### PR TITLE
fix(abw-backend): harden SQLite for concurrent access (WAL + busy timeout + rollback)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/core/database.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/database.py
@@ -11,21 +11,35 @@ from typing import Generator
 from app.config import DATA_DIR, DB_PATH
 
 
+# Wait up to 5s for a competing writer instead of failing immediately
+# with "database is locked". Pipelines write status from background
+# threads while API requests read/write concurrently.
+_BUSY_TIMEOUT_SECONDS = 5.0
+
+
 @contextmanager
 def get_db_connection() -> Generator[sqlite3.Connection, None, None]:
     """
     Get a database connection with auto-commit.
+
+    Commits on clean exit, rolls back if the block raises. Connections
+    use WAL journal mode so readers don't block the single writer.
 
     Usage:
         with get_db_connection() as conn:
             conn.execute("SELECT * FROM runs")
     """
     DATA_DIR.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(DB_PATH))
+    conn = sqlite3.connect(str(DB_PATH), timeout=_BUSY_TIMEOUT_SECONDS)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
     try:
         yield conn
         conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
     finally:
         conn.close()
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_database_concurrency.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_database_concurrency.py
@@ -1,0 +1,64 @@
+import sqlite3
+import threading
+
+import pytest
+
+import app.core.database as database
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, 'DATA_DIR', tmp_path)
+    monkeypatch.setattr(database, 'DB_PATH', tmp_path / 'pipeline.db')
+    with database.get_db_connection() as conn:
+        conn.execute(
+            'CREATE TABLE IF NOT EXISTS kv (k TEXT PRIMARY KEY, v TEXT)'
+        )
+    return tmp_path / 'pipeline.db'
+
+
+def test_connection_uses_wal_mode(temp_db):
+    with database.get_db_connection() as conn:
+        mode = conn.execute('PRAGMA journal_mode').fetchone()[0]
+    assert mode == 'wal'
+
+
+def test_rolls_back_on_exception(temp_db):
+    with pytest.raises(RuntimeError):
+        with database.get_db_connection() as conn:
+            conn.execute("INSERT INTO kv (k, v) VALUES ('a', '1')")
+            raise RuntimeError('boom')
+
+    with database.get_db_connection() as conn:
+        rows = conn.execute('SELECT * FROM kv').fetchall()
+    assert rows == []
+
+
+def test_concurrent_writers_do_not_raise_locked(temp_db):
+    errors: list[Exception] = []
+
+    def write_many(worker: int) -> None:
+        try:
+            for i in range(50):
+                with database.get_db_connection() as conn:
+                    conn.execute(
+                        'INSERT OR REPLACE INTO kv (k, v) VALUES (?, ?)',
+                        (f'{worker}-{i}', 'x'),
+                    )
+        except sqlite3.OperationalError as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=write_many, args=(worker,))
+        for worker in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+
+    with database.get_db_connection() as conn:
+        count = conn.execute('SELECT COUNT(*) FROM kv').fetchone()[0]
+    assert count == 200


### PR DESCRIPTION
## Problem
`get_db_connection` opened SQLite with defaults: rollback journal, 0ms busy timeout, and no rollback on error. ABW pipelines write status from FastAPI background-task threads while API requests hit the same file concurrently — with two overlapping runs this starts throwing `sqlite3.OperationalError: database is locked`. It works fine in solo testing and fails exactly when the tool gets real use.

## Fix (all in `app/core/database.py`)
- `PRAGMA journal_mode=WAL` — readers no longer block the writer and vice versa.
- `sqlite3.connect(..., timeout=5)` — competing writers wait up to 5s instead of failing instantly.
- `PRAGMA synchronous=NORMAL` — the standard durability/perf pairing with WAL.
- Roll back explicitly when the `with` block raises, instead of closing a connection with a dangling uncommitted transaction.

Deliberately **not** included: `PRAGMA foreign_keys=ON` — that's a behavior change (existing data may contain orphans; some code paths may rely on lax ordering) and belongs in its own change if wanted.

## Testing
New `tests/test_database_concurrency.py`:
- WAL mode is active on connections ✅
- exception inside the context manager rolls the write back ✅
- 4 threads × 50 writes each complete with zero `database is locked` errors and all 200 rows present ✅

Part 2/4 of the ABW high-impact fixes.