### PR TITLE
fix(abw-backend): persist SQLite data across container redeploys

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -1,6 +1,9 @@
 WEAVIATE_URL=http://weaviate:8080
 WEAVIATE_VECTORIZER_MODULE=none
 PIPELINE_VERSION=0.1.0
+# SQLite home for ALL run history, stage results, and generated articles
+# (data/pipeline.db lives here). In Docker this must point at a mounted
+# volume (docker-compose pins it to /data) or a redeploy wipes everything.
 DATA_DIR=data/runs
 OUTPUT_DIR=output
 

--- a/apps/ai-blog-writer/apps/backend/Dockerfile
+++ b/apps/ai-blog-writer/apps/backend/Dockerfile
@@ -7,6 +7,13 @@ RUN pip install --no-cache-dir -r /app/apps/backend/requirements.txt
 COPY . /app
 
 ENV PYTHONPATH=/app/apps/backend:/app/packages/shared/src:/app/packages/utils/src
+
+# All run history, stage results, and generated articles live in a single
+# SQLite file under DATA_DIR. Keep it on a named volume so a redeploy or
+# container rebuild doesn't wipe it.
+ENV DATA_DIR=/data
+VOLUME ["/data"]
+
 EXPOSE 4003
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "4003"]

--- a/apps/ai-blog-writer/docker-compose.yml
+++ b/apps/ai-blog-writer/docker-compose.yml
@@ -7,8 +7,13 @@ services:
       - apps/backend/.env
     environment:
       - PAYLOAD_API_URL=http://host.docker.internal:4000
+      # Pin the SQLite data dir to the named volume below so run history
+      # and generated articles survive container rebuilds (overrides any
+      # DATA_DIR in apps/backend/.env).
+      - DATA_DIR=/data
     volumes:
       - ./:/app
+      - backend_data:/data
       - ~/.config/gcloud:/root/.config/gcloud:ro  # Mount GCloud credentials
     ports:
       - '4003:4003'
@@ -42,3 +47,4 @@ services:
 volumes:
   frontend_node_modules:
   converter_node_modules:
+  backend_data:


### PR DESCRIPTION
## Problem
All ABW state — run history, stage results, generated articles, Payload sync records — lives in one SQLite file (`data/pipeline.db`) under `DATA_DIR`. The backend Dockerfile declared no volume and defaulted `DATA_DIR` to a path inside the image, so a container rebuild/redeploy wipes everything unless whoever deploys remembers to mount a volume by hand. The dev compose file only survives because it bind-mounts the whole repo.

## Fix
- **Dockerfile**: `ENV DATA_DIR=/data` + `VOLUME ["/data"]` — any runtime (compose, plain `docker run`, orchestrators) now gets an anonymous volume at worst instead of silently writing into the container layer.
- **docker-compose.yml**: named `backend_data` volume mounted at `/data`, and `DATA_DIR=/data` pinned in `environment` so it overrides any stale value in `apps/backend/.env` (env-file entries would otherwise win over the image ENV).
- **.env.example**: documents what lives in `DATA_DIR` and why it must be durable.

## Migration note
Existing deployments that already have data inside the container should copy `pipeline.db` into the new volume before switching (`docker cp` out, then into the `/data` mount). Dev compose users are unaffected.

## Testing
Config-only change; `app/config.py` already reads `DATA_DIR` from the environment. **Not validated with `docker compose config`** — Docker isn't installed on the machine this was authored on. Please run `docker compose up` once before merging.

Part 3/4 of the ABW high-impact fixes.