### PR TITLE
fix(abw-backend): optional API-key auth + safe CORS policy

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -13,6 +13,18 @@ PAYLOAD_API_URL=http://localhost:4000
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
 
+# API access control. When ABW_API_KEY is set, every request (except
+# /health and CORS preflight) must send a matching X-API-Key header.
+# Leave empty for local development. REQUIRED for any deployment
+# reachable beyond localhost: without it the API is fully open —
+# anyone can start Vertex AI pipeline runs or wipe run history.
+ABW_API_KEY=
+
+# Comma-separated list of allowed browser origins, e.g.
+# http://localhost:3003,https://abw.example.com
+# Empty means wildcard (*), which also disables credentialed CORS.
+ABW_ALLOWED_ORIGINS=
+
 # Expose raw exception text in API error responses (dev/debug only).
 # Keep false in production to avoid leaking internals.
 API_EXPOSE_ERROR_DETAILS=false

--- a/apps/ai-blog-writer/apps/backend/app/main.py
+++ b/apps/ai-blog-writer/apps/backend/app/main.py
@@ -1,3 +1,4 @@
+import hmac
 import os
 import sys
 import logging
@@ -41,6 +42,10 @@ from app.api import router  # noqa: E402
 app = FastAPI(title="AI Blog Writer")
 logger = logging.getLogger(__name__)
 
+# Paths reachable without an API key when ABW_API_KEY is set.
+AUTH_EXEMPT_PATHS = {"/health"}
+API_KEY_HEADER = "X-API-Key"
+
 
 def _read_bool_env(key: str, default: bool = False) -> bool:
     raw = os.getenv(key)
@@ -48,10 +53,52 @@ def _read_bool_env(key: str, default: bool = False) -> bool:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
+
+def _allowed_origins() -> list[str]:
+    """Comma-separated ABW_ALLOWED_ORIGINS, or wildcard when unset."""
+    raw = os.getenv("ABW_ALLOWED_ORIGINS", "").strip()
+    if not raw:
+        return ["*"]
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+@app.middleware("http")
+async def require_api_key(request: Request, call_next):
+    """Reject requests without the configured API key.
+
+    Disabled unless ABW_API_KEY is set, so local development keeps
+    working with no configuration. Preflight requests and /health stay
+    open: browsers send OPTIONS without custom headers, and health
+    checks must not need credentials.
+    """
+    expected_key = os.getenv("ABW_API_KEY", "").strip()
+    if (
+        not expected_key
+        or request.method == "OPTIONS"
+        or request.url.path in AUTH_EXEMPT_PATHS
+    ):
+        return await call_next(request)
+
+    provided_key = request.headers.get(API_KEY_HEADER, "")
+    if not hmac.compare_digest(provided_key, expected_key):
+        return JSONResponse(
+            status_code=401,
+            content={"detail": f"Missing or invalid {API_KEY_HEADER} header"},
+        )
+
+    return await call_next(request)
+
+
+_cors_origins = _allowed_origins()
+_cors_wildcard = "*" in _cors_origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=_cors_origins,
+    # Credentialed CORS with a wildcard origin is rejected by browsers and
+    # would require reflecting arbitrary origins, which defeats the origin
+    # check. Only allow credentials when origins are pinned.
+    allow_credentials=not _cors_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -72,13 +119,19 @@ async def handle_unexpected_exception(
 
     expose_details = _read_bool_env("API_EXPOSE_ERROR_DETAILS", default=False)
     detail = str(exc) if expose_details else "Internal server error"
+    # This handler runs outside CORSMiddleware, so browser clients only see
+    # the error payload if we add CORS headers here — following the same
+    # origin policy as the middleware, never reflecting arbitrary origins
+    # with credentials.
     response_headers: dict[str, str] = {}
     origin = request.headers.get("origin")
     if origin:
-        # Ensure browser clients can read error payloads for unhandled exceptions.
-        response_headers["Access-Control-Allow-Origin"] = origin
-        response_headers["Access-Control-Allow-Credentials"] = "true"
-        response_headers["Vary"] = "Origin"
+        if _cors_wildcard:
+            response_headers["Access-Control-Allow-Origin"] = "*"
+        elif origin in _cors_origins:
+            response_headers["Access-Control-Allow-Origin"] = origin
+            response_headers["Access-Control-Allow-Credentials"] = "true"
+            response_headers["Vary"] = "Origin"
     return JSONResponse(
         status_code=500,
         headers=response_headers,

--- a/apps/ai-blog-writer/apps/backend/tests/test_api_key_auth.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_api_key_auth.py
@@ -1,0 +1,83 @@
+import httpx
+import pytest
+
+import app.main as main_module
+
+
+def _client() -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(
+        app=main_module.app, raise_app_exceptions=False
+    )
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+async def test_requests_pass_when_no_api_key_configured(monkeypatch):
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+
+    async with _client() as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_request_without_key_is_rejected(monkeypatch):
+    monkeypatch.setenv("ABW_API_KEY", "secret-key")
+
+    async with _client() as client:
+        response = await client.get("/article-types")
+
+    assert response.status_code == 401
+    assert "X-API-Key" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_request_with_wrong_key_is_rejected(monkeypatch):
+    monkeypatch.setenv("ABW_API_KEY", "secret-key")
+
+    async with _client() as client:
+        response = await client.get(
+            "/article-types", headers={"X-API-Key": "wrong-key"}
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_request_with_correct_key_passes(monkeypatch):
+    monkeypatch.setenv("ABW_API_KEY", "secret-key")
+
+    async with _client() as client:
+        response = await client.get(
+            "/article-types", headers={"X-API-Key": "secret-key"}
+        )
+
+    assert response.status_code != 401
+
+
+@pytest.mark.asyncio
+async def test_health_stays_open_with_key_configured(monkeypatch):
+    monkeypatch.setenv("ABW_API_KEY", "secret-key")
+
+    async with _client() as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_preflight_stays_open_with_key_configured(monkeypatch):
+    monkeypatch.setenv("ABW_API_KEY", "secret-key")
+
+    async with _client() as client:
+        response = await client.options(
+            "/article-types",
+            headers={
+                "Origin": "http://localhost:3003",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-api-key",
+            },
+        )
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Problem
The ABW backend has zero authentication and `allow_origins=["*"]` with `allow_credentials=True`. Anyone who can reach port 4003 can start LLM pipeline runs (Vertex AI spend), read all generated content, and call the destructive clear/cleanup routes. Separately, the global exception handler reflected **any** `Origin` header back with `Access-Control-Allow-Credentials: true` — a CORS bypass that would undermine credential protection the moment auth exists.

## Fix (`app/main.py`)
- **API-key gate, off by default**: when `ABW_API_KEY` is set, every request must send a matching `X-API-Key` header (constant-time compare via `hmac.compare_digest`). Exempt: `/health` and `OPTIONS` preflight. When unset, behavior is unchanged — local dev needs no configuration.
- **Configurable CORS**: `ABW_ALLOWED_ORIGINS` (comma-separated) pins allowed origins; empty means wildcard. Credentialed CORS is only enabled when origins are pinned — wildcard + credentials is rejected by browsers anyway and forced the old reflect-anything hack.
- **Exception handler** (which runs outside `CORSMiddleware`, hence the manual headers) now applies the same origin policy: `*` in wildcard mode, reflect + credentials only for pinned origins.
- `.env.example` documents both variables and warns that `ABW_API_KEY` is required for any non-localhost deployment.

## Follow-up (not in this PR)
Frontend calls to the backend are scattered per-feature with no shared fetch wrapper, so wiring `X-API-Key` (e.g. from `VITE_ABW_API_KEY`) client-side is a separate change. Until then, enable the key only where the frontend is co-located or fronted by a proxy that injects the header.

## Testing
- New `tests/test_api_key_auth.py` (6 tests): open when unset, 401 on missing/wrong key, pass on correct key, /health and preflight exempt. ✅
- Existing `test_cors_error_responses.py` still passes (wildcard mode keeps `Access-Control-Allow-Origin` on 500s). ✅
- Full backend suite: only pre-existing failures (4 youtube2blog tests, verified failing on `main` before this change).

Part 4/4 of the ABW high-impact fixes.