### PR TITLE
chore(abw): bump Anthropic writer model to Claude Opus 4.8

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -57,6 +57,6 @@ BFL_MODEL_ID=flux-2-pro-preview
 # prompts with canonical venue facts and the Reviews Digest.
 LM_API_URL=http://localhost:4002
 
-# Anthropic — required when the listicle writer model is set to claude-opus-4-7.
+# Anthropic — required when the listicle writer model is set to claude-opus-4-8.
 # Get a key at https://console.anthropic.com/settings/keys.
 ANTHROPIC_API_KEY=

--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
@@ -23,7 +23,7 @@ from .shell_library import (
 router = APIRouter(prefix="/itineraries-pipeline", tags=["itineraries-pipeline"])
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_MODEL = "claude-opus-4-8"
 MAX_PROMPT_CHARS = 120_000
 
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/constants/titleModel.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/constants/titleModel.constants.ts
@@ -1,13 +1,13 @@
 /** Model selection for the itineraries title generator. Runs on Claude (Anthropic);
  * the backend routes `claude*` names to Anthropic via the writer-model router. */
-export type ItineraryTitleModelName = 'claude-opus-4-7'
+export type ItineraryTitleModelName = 'claude-opus-4-8'
 
-export const DEFAULT_ITINERARY_TITLE_MODEL: ItineraryTitleModelName = 'claude-opus-4-7'
+export const DEFAULT_ITINERARY_TITLE_MODEL: ItineraryTitleModelName = 'claude-opus-4-8'
 
 export const ITINERARY_TITLE_MODEL_OPTIONS: Array<{
   value: ItineraryTitleModelName
   label: string
-}> = [{ value: 'claude-opus-4-7', label: 'Claude Opus 4.7' }]
+}> = [{ value: 'claude-opus-4-8', label: 'Claude Opus 4.8' }]
 
 export function resolveItineraryTitleModelName(_value?: string): ItineraryTitleModelName {
   return DEFAULT_ITINERARY_TITLE_MODEL

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/mappers/autobuild-plan.mapper.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/mappers/autobuild-plan.mapper.test.ts
@@ -9,7 +9,7 @@ const ids = (kind: string, day: number, slot: number) => `${kind}-${day}-${slot}
 function baseDraft(): ListicleItineraryDraft {
   return {
     draftId: 'd1',
-    editorModelName: 'claude-opus-4-7',
+    editorModelName: 'claude-opus-4-8',
     listTone: 'elevated',
     generationBrief: 'luxury foodie day',
     title: 'Luxury Foodie Day',

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.test.ts
@@ -43,7 +43,7 @@ function buildItem(overrides: Partial<ItineraryItemBlock> & { id: string }): Iti
 function buildDraft(overrides: Partial<ListicleItineraryDraft> = {}): ListicleItineraryDraft {
   return {
     draftId: 'draft-1',
-    editorModelName: 'claude-opus-4-7',
+    editorModelName: 'claude-opus-4-8',
     listTone: 'elevated',
     title: 'Two Days in Lima',
     location: 'peru|lima',
@@ -190,7 +190,7 @@ describe('day-blurb composer service', () => {
       dayIndex: 0,
       relatedByBlockType: buildRelatedByBlockType(),
       locations: buildLocations(),
-      modelName: 'claude-opus-4-7',
+      modelName: 'claude-opus-4-8',
     })
 
     expect(request.articleTitle).toBe('Two Days in Lima')
@@ -210,7 +210,7 @@ describe('day-blurb composer service', () => {
       dayIndex: 1,
       relatedByBlockType: buildRelatedByBlockType(),
       locations: buildLocations(),
-      modelName: 'claude-opus-4-7',
+      modelName: 'claude-opus-4-8',
     })
     expect(request.prevDayLastStop).toEqual({ title: 'Mérito', category: 'Dining' })
     expect(request.nextDayFirstStop).toBeUndefined()
@@ -218,7 +218,7 @@ describe('day-blurb composer service', () => {
 
   it('applies only generated blurbs, only to the target day', () => {
     const response: ComposeDayBlurbsResponse = {
-      model_used: 'claude-opus-4-7',
+      model_used: 'claude-opus-4-8',
       results: {
         'stop-1_blurb': { target_id: 'stop-1_blurb', status: 'generated', markdown: 'Fresh dining prose.', validation_errors: [] },
         'ws-1_blurb': { target_id: 'ws-1_blurb', status: 'error', validation_errors: ['missing'] },
@@ -242,7 +242,7 @@ describe('day-blurb composer service', () => {
       dayIndex: 0,
       relatedByBlockType: buildRelatedByBlockType(),
       locations: buildLocations(),
-      modelName: 'claude-opus-4-7',
+      modelName: 'claude-opus-4-8',
       writeTargetIds: ['ws-1_blurb'],
     })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/constants.ts
@@ -24,7 +24,7 @@ export const IMG_TRIO_DEFAULT_FORMAT: ImgTrioFormat = 'square'
 export const DEFAULT_EDITOR_MODEL_NAME: EditorModelName = 'gemini-2.5-flash'
 
 export const EDITOR_MODEL_OPTIONS: Array<{ value: EditorModelName; label: string }> = [
-  { value: 'claude-opus-4-7', label: 'Claude Opus 4.7 (premier writer)' },
+  { value: 'claude-opus-4-8', label: 'Claude Opus 4.8 (premier writer)' },
   { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (Preview — best Gemini quality)' },
   { value: 'gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash Lite (Preview — fast & cheap)' },
   { value: 'gemini-3.1-flash-image-preview', label: 'Gemini 3.1 Flash Image (Preview — multimodal)' },
@@ -115,7 +115,7 @@ export function getEditorialComponentDefaultLabel(component: string): string {
 }
 
 export function resolveEditorModelName(value?: string): EditorModelName {
-  if (value === 'claude-opus-4-7') return value
+  if (value === 'claude-opus-4-8') return value
   if (value === 'gemini-3.1-pro-preview') return value
   if (value === 'gemini-3.1-flash-lite-preview') return value
   if (value === 'gemini-3.1-flash-image-preview') return value

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/types.ts
@@ -24,7 +24,7 @@ export type ImgTrioFormat = 'square' | 'landscape'
 export type PexelsOrientationOption = PexelsOrientation | ''
 export type ImageSourceOption = 'payload' | 'upload' | 'unsplash' | 'pexels'
 export type EditorModelName =
-  | 'claude-opus-4-7'
+  | 'claude-opus-4-8'
   | 'gemini-3.1-pro-preview'
   | 'gemini-3.1-flash-lite-preview'
   | 'gemini-3.1-flash-image-preview'

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/ai/models.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/ai/models.ts
@@ -1,11 +1,11 @@
-export type EditorAssistModelName = 'claude-opus-4-7'
+export type EditorAssistModelName = 'claude-opus-4-8'
 
-export const DEFAULT_EDITOR_ASSIST_MODEL: EditorAssistModelName = 'claude-opus-4-7'
+export const DEFAULT_EDITOR_ASSIST_MODEL: EditorAssistModelName = 'claude-opus-4-8'
 
 export const EDITOR_ASSIST_MODEL_OPTIONS: Array<{ value: EditorAssistModelName; label: string }> = [
   {
-    value: 'claude-opus-4-7',
-    label: 'Claude Opus 4.7 (writer; Evidence Profile runs on Gemini)',
+    value: 'claude-opus-4-8',
+    label: 'Claude Opus 4.8 (writer; Evidence Profile runs on Gemini)',
   },
 ]
 


### PR DESCRIPTION
## Summary
Completes the in-flight Opus 4.7 → 4.8 migration that was sitting uncommitted in the working tree.

- Editor-assist writer default (`EditorAssistModelName`) → `claude-opus-4-8`
- Itineraries pipeline `DEFAULT_MODEL` and title-generator model → `claude-opus-4-8`
- Editorial stage article model option/type renamed
- `.env.example` comment updated
- Test fixtures updated to the new id

No behavioral change beyond the model id — the backend writer router (`writer_models.py`) routes by the `claude*` prefix either way. Grep confirms no remaining `opus-4-7` references.

## Testing
- `vitest run` on the two touched test files: 21/21 pass