### PR TITLE
fix(abw-frontend): stop SEO AI aggregate targets from overwriting og:url

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/seo-ai.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/seo-ai.service.ts
@@ -63,7 +63,7 @@ function buildTargetShape(target: SeoAiTarget): string {
     case 'metaDescription':
       return '{"metaDescription":"string"}'
     case 'openGraph':
-      return '{"openGraph":{"title":"string","description":"string","url":"https://example.com/path"}}'
+      return '{"openGraph":{"title":"string","description":"string"}}'
     case 'openGraphTitle':
       return '{"openGraph":{"title":"string"}}'
     case 'openGraphDescription':
@@ -94,8 +94,7 @@ function buildTargetShape(target: SeoAiTarget): string {
         '  "metaDescription": "string",',
         '  "openGraph": {',
         '    "title": "string",',
-        '    "description": "string",',
-        '    "url": "https://example.com/path"',
+        '    "description": "string"',
         '  },',
         '  "twitterCard": {',
         '    "card": "summary or summary_large_image",',

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/seo-ai.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/seo-ai.service.ts
@@ -68,7 +68,7 @@ function buildTargetShape(target: SeoAiTarget): string {
     case 'metaDescription':
       return '{"metaDescription":"string"}'
     case 'openGraph':
-      return '{"openGraph":{"title":"string","description":"string","url":"https://example.com/path"}}'
+      return '{"openGraph":{"title":"string","description":"string"}}'
     case 'openGraphTitle':
       return '{"openGraph":{"title":"string"}}'
     case 'openGraphDescription':
@@ -99,7 +99,6 @@ function buildTargetShape(target: SeoAiTarget): string {
         openGraph: {
           title: 'string',
           description: 'string',
-          url: 'https://example.com/path',
         },
         twitterCard: {
           card: 'summary or summary_large_image',

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/standard-article-seo.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/standard-article-seo.service.ts
@@ -295,7 +295,7 @@ function buildTargetShape(target: SeoAiTarget): string {
     case 'metaDescription':
       return '{"metaDescription":"string"}'
     case 'openGraph':
-      return '{"openGraph":{"title":"string","description":"string","url":"https://example.com/article"}}'
+      return '{"openGraph":{"title":"string","description":"string"}}'
     case 'openGraphTitle':
       return '{"openGraph":{"title":"string"}}'
     case 'openGraphDescription':
@@ -326,7 +326,6 @@ function buildTargetShape(target: SeoAiTarget): string {
         openGraph: {
           title: 'string',
           description: 'string',
-          url: 'https://example.com/article',
         },
         twitterCard: {
           card: 'summary or summary_large_image',

--- a/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { SeoSection } from '../types'
+import { applySeoAiPatch, parseSeoAiPatch } from './seo-ai.service'
+
+function buildSeoSection(overrides: Partial<SeoSection> = {}): SeoSection {
+  return {
+    seoTitle: 'Two Days in Lima',
+    metaDescription: 'A two-day Lima itinerary.',
+    openGraph: {
+      title: 'Two Days in Lima',
+      description: 'A two-day Lima itinerary.',
+      imageUrl: 'https://cdn.example.com/lima.jpg',
+      url: 'https://www.questurian.com/peru/lima/itinerary/two-days-lima',
+    },
+    twitterCard: {
+      card: 'summary_large_image',
+      title: 'Two Days in Lima',
+      description: 'A two-day Lima itinerary.',
+      imageUrl: 'https://cdn.example.com/lima.jpg',
+    },
+    structuredData: '',
+    robots: { index: 'index', follow: 'follow' },
+    ...overrides,
+  }
+}
+
+describe('applySeoAiPatch og:url protection', () => {
+  const hallucinatedPatch = parseSeoAiPatch(JSON.stringify({
+    seoTitle: 'New Title',
+    metaDescription: 'New description.',
+    openGraph: {
+      title: 'New OG Title',
+      description: 'New OG description.',
+      url: 'https://example.com/made-up-path',
+    },
+  }))
+
+  it('does not overwrite og:url on the "all" target', () => {
+    const current = buildSeoSection()
+    const next = applySeoAiPatch(current, hallucinatedPatch, 'all')
+
+    expect(next.seoTitle).toBe('New Title')
+    expect(next.openGraph.title).toBe('New OG Title')
+    expect(next.openGraph.url).toBe(current.openGraph.url)
+  })
+
+  it('does not overwrite og:url on the "openGraph" section target', () => {
+    const current = buildSeoSection()
+    const next = applySeoAiPatch(current, hallucinatedPatch, 'openGraph')
+
+    expect(next.openGraph.title).toBe('New OG Title')
+    expect(next.openGraph.description).toBe('New OG description.')
+    expect(next.openGraph.url).toBe(current.openGraph.url)
+  })
+
+  it('still applies og:url on the explicit single-field target', () => {
+    const current = buildSeoSection()
+    const next = applySeoAiPatch(current, hallucinatedPatch, 'openGraphUrl')
+
+    expect(next.openGraph.url).toBe('https://example.com/made-up-path')
+    expect(next.seoTitle).toBe(current.seoTitle)
+    expect(next.openGraph.title).toBe(current.openGraph.title)
+  })
+
+  it('rejects non-absolute og:url values during parsing', () => {
+    const patch = parseSeoAiPatch(JSON.stringify({ openGraph: { url: '/relative/path' } }))
+    const next = applySeoAiPatch(buildSeoSection(), patch, 'openGraphUrl')
+
+    expect(next.openGraph.url).toBe(buildSeoSection().openGraph.url)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.ts
@@ -51,12 +51,15 @@ type SeoAiPatch = {
   }
 }
 
+// og:url is deliberately excluded from the aggregate targets: the canonical URL
+// is derived deterministically (slug + location), and letting the model write it
+// during an "all"/section fill risks replacing a correct URL with an invented one.
+// It stays writable only through the explicit single-field `openGraphUrl` target.
 const ALL_FIELDS: SeoFieldKey[] = [
   'seoTitle',
   'metaDescription',
   'openGraphTitle',
   'openGraphDescription',
-  'openGraphUrl',
   'twitterCardCard',
   'twitterCardTitle',
   'twitterCardDescription',
@@ -69,7 +72,7 @@ const TARGET_FIELDS: Record<SeoAiTarget, SeoFieldKey[]> = {
   all: ALL_FIELDS,
   seoTitle: ['seoTitle'],
   metaDescription: ['metaDescription'],
-  openGraph: ['openGraphTitle', 'openGraphDescription', 'openGraphUrl'],
+  openGraph: ['openGraphTitle', 'openGraphDescription'],
   openGraphTitle: ['openGraphTitle'],
   openGraphDescription: ['openGraphDescription'],
   openGraphUrl: ['openGraphUrl'],


### PR DESCRIPTION
## Problem
In the Step 4 SEO panel, **Generate SEO (AI)** (`all` target) and the Open Graph **AI Fill Section** button (`openGraph` target) ask the model to output `openGraph.url`, seeded with an `https://example.com/...` example. `parseSeoAiPatch` only checks that the returned value is an absolute http(s) URL, so a hallucinated URL passes validation and silently replaces a correct canonical og:url.

The canonical URL is already built deterministically (`buildArticleOgUrl` via Fill URL / the slug generator), so the model has no business writing it during aggregate fills.

## Fix
- `shared/seo/services/seo-ai.service.ts`: remove `openGraphUrl` from the `all` and `openGraph` target field sets (belt).
- Drop the `url` key from the `all`/`openGraph` prompt shapes in all three builders that construct SEO prompts (listicle itineraries, single-type listicles, staging standard article) so the model isn't asked for it (suspenders).
- The explicit single-field `openGraphUrl` target is unchanged, for panels without a deterministic fill.

## Testing
- New `seo-ai.service.test.ts`: `all`/`openGraph` patches preserve og:url, single-field target still applies, relative URLs rejected — 4/4 pass.
- Feature suites for listicleItineraries / singleTypeListicles / staging pass, except `useBuilderDraftActions.test.ts` (singleTypeListicles) which **also fails on clean main** — pre-existing, unrelated.