### PR TITLE
fix(abw-frontend): clip AI-generated SEO titles at word boundaries

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.test.ts
@@ -69,3 +69,23 @@ describe('applySeoAiPatch og:url protection', () => {
     expect(next.openGraph.url).toBe(buildSeoSection().openGraph.url)
   })
 })
+
+describe('parseSeoAiPatch seoTitle clipping', () => {
+  it('keeps titles within the limit untouched', () => {
+    const patch = parseSeoAiPatch(JSON.stringify({ seoTitle: 'Two Days in Lima: Food, Art & Coastline' }))
+    expect(patch.seoTitle).toBe('Two Days in Lima: Food, Art & Coastline')
+  })
+
+  it('clips overlong titles at a word boundary instead of mid-word', () => {
+    const original = 'The Ultimate Two Day Lima Itinerary for Foodies and Architecture Lovers'
+    const patch = parseSeoAiPatch(JSON.stringify({ seoTitle: original }))
+
+    expect(patch.seoTitle).toBeDefined()
+    expect(patch.seoTitle!.length).toBeLessThanOrEqual(60)
+    // No mid-word cut: the clipped title must be a prefix of the original
+    // ending exactly at a word boundary.
+    const nextChar = original.charAt(patch.seoTitle!.length)
+    expect(original.startsWith(patch.seoTitle!)).toBe(true)
+    expect(nextChar === ' ' || nextChar === '').toBe(true)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/seo/services/seo-ai.service.ts
@@ -118,11 +118,6 @@ const normalizeText = (value: unknown): string | undefined => {
   return normalized ? normalized : undefined
 }
 
-const withMaxLength = (value: string | undefined, maxLength: number): string | undefined => {
-  if (!value) return value
-  return value.length > maxLength ? value.slice(0, maxLength) : value
-}
-
 const withReadableMaxLength = (
   value: string | undefined,
   maxLength: number,
@@ -303,7 +298,7 @@ export function parseSeoAiPatch(response: string): SeoAiPatch {
   const normalizedOpenGraphUrl = openGraphUrl && isValidAbsoluteUrl(openGraphUrl) ? openGraphUrl : undefined
 
   return {
-    seoTitle: withMaxLength(normalizeText(parsed.seoTitle), 60),
+    seoTitle: withReadableMaxLength(normalizeText(parsed.seoTitle), 60),
     metaDescription: withReadableMaxLength(normalizeText(parsed.metaDescription), 160),
     openGraph: {
       title: normalizeText(openGraph.title),


### PR DESCRIPTION
## Problem
`parseSeoAiPatch` hard-sliced overlong AI `seoTitle` values at 60 characters (`withMaxLength`), so a title could ship cut mid-word ("...for Foodies and Architec"). Meta descriptions already used the readable sentence/word-boundary clipper.

## Fix
Use `withReadableMaxLength` for `seoTitle` too, and remove the now-unused `withMaxLength` helper.

## Notes
Stacked on #34 (touches the same file + test suite). Merge #34 first; this PR then retargets to main.

## Testing
Added clipping tests to `seo-ai.service.test.ts` — 6/6 pass.