### PR TITLE
refactor(abw-frontend): make Robots controls deterministic in SEO panel

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/seo/components/SeoEditorPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/seo/components/SeoEditorPanel.tsx
@@ -458,53 +458,57 @@ export function SeoEditorPanel({
                 <h3>Robots</h3>
                 <p>Indexing controls for search crawlers.</p>
               </div>
-              {renderAiButton('robots', 'AI Fill Section')}
+              <button
+                type="button"
+                className="stl-btn stl-btn-secondary"
+                onClick={() =>
+                  updateSeo((current) => ({
+                    ...current,
+                    robots: { index: 'index', follow: 'follow' },
+                  }))
+                }
+                disabled={isSeoActionRunning}
+              >
+                Reset to index/follow
+              </button>
             </div>
 
             <label className="stl-field">
               <span>robots:index</span>
-              <div className="stl-seo-input-wrap">
-                <select
-                  className="stl-seo-input-with-ai"
-                  value={seoSection.robots.index}
-                  onChange={(event) =>
-                    updateSeo((current) => ({
-                      ...current,
-                      robots: {
-                        ...current.robots,
-                        index: event.target.value === 'noindex' ? 'noindex' : 'index',
-                      },
-                    }))
-                  }
-                >
-                  <option value="index">index</option>
-                  <option value="noindex">noindex</option>
-                </select>
-                <span className="stl-seo-ai-trigger-wrap">{renderAiButton('robotsIndex')}</span>
-              </div>
+              <select
+                value={seoSection.robots.index}
+                onChange={(event) =>
+                  updateSeo((current) => ({
+                    ...current,
+                    robots: {
+                      ...current.robots,
+                      index: event.target.value === 'noindex' ? 'noindex' : 'index',
+                    },
+                  }))
+                }
+              >
+                <option value="index">index</option>
+                <option value="noindex">noindex</option>
+              </select>
             </label>
 
             <label className="stl-field">
               <span>robots:follow</span>
-              <div className="stl-seo-input-wrap">
-                <select
-                  className="stl-seo-input-with-ai"
-                  value={seoSection.robots.follow}
-                  onChange={(event) =>
-                    updateSeo((current) => ({
-                      ...current,
-                      robots: {
-                        ...current.robots,
-                        follow: event.target.value === 'nofollow' ? 'nofollow' : 'follow',
-                      },
-                    }))
-                  }
-                >
-                  <option value="follow">follow</option>
-                  <option value="nofollow">nofollow</option>
-                </select>
-                <span className="stl-seo-ai-trigger-wrap">{renderAiButton('robotsFollow')}</span>
-              </div>
+              <select
+                value={seoSection.robots.follow}
+                onChange={(event) =>
+                  updateSeo((current) => ({
+                    ...current,
+                    robots: {
+                      ...current.robots,
+                      follow: event.target.value === 'nofollow' ? 'nofollow' : 'follow',
+                    },
+                  }))
+                }
+              >
+                <option value="follow">follow</option>
+                <option value="nofollow">nofollow</option>
+              </select>
             </label>
           </section>
         </div>


### PR DESCRIPTION
## Problem
The Robots section of the shared `SeoEditorPanel` (Step 4 in the itinerary builder) rendered three AI buttons — an "AI Fill Section" plus per-field buttons on `robots:index` and `robots:follow`. Each one sent the full article context to the writer model to pick between two enum values, and the prompt itself said the answer should "usually be index/follow". A deterministic default pretending to be an AI feature — wasted latency and tokens.

## Fix
Replace the three AI buttons with a single deterministic **Reset to index/follow** button. The selects remain editable for deliberate `noindex`/`nofollow` cases.

The `robots`/`robotsIndex`/`robotsFollow` AI targets remain in the shared service since `all` still fills them as part of a full generate.

## Testing
- Shared SEO panel/staging builder tests pass.
- Frontend typecheck introduces no new errors (existing failures on main are unrelated test-file type debt).