### PR TITLE
refactor(abw-frontend): show static label when only one editor model exists

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/builder/components/BuilderSidebar.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/builder/components/BuilderSidebar.tsx
@@ -143,13 +143,21 @@ export function BuilderSidebar({
         <h3>Quick Actions</h3>
         <label className="stl-field">
           <span>AI Model</span>
-          <select value={editorModelName} onChange={(event) => onEditorModelChange(event.target.value)}>
-            {EDITOR_ASSIST_MODEL_OPTIONS.map((modelOption) => (
-              <option key={modelOption.value} value={modelOption.value}>
-                {modelOption.label}
-              </option>
-            ))}
-          </select>
+          {EDITOR_ASSIST_MODEL_OPTIONS.length > 1 ? (
+            <select value={editorModelName} onChange={(event) => onEditorModelChange(event.target.value)}>
+              {EDITOR_ASSIST_MODEL_OPTIONS.map((modelOption) => (
+                <option key={modelOption.value} value={modelOption.value}>
+                  {modelOption.label}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              value={EDITOR_ASSIST_MODEL_OPTIONS.find((modelOption) => modelOption.value === editorModelName)?.label ?? editorModelName}
+              disabled
+              readOnly
+            />
+          )}
         </label>
         <div className="stl-summary-actions">
           {renderAutoWriteButton()}


### PR DESCRIPTION
## Problem
The builder sidebar's **AI Model** dropdown has exactly one option (`claude-opus-4-8`), and `resolveEditorAssistModelName` ignores the stored value entirely — the control is pure decoration and implies a choice that doesn't exist.

## Fix
When `EDITOR_ASSIST_MODEL_OPTIONS` has a single entry, render a disabled read-only input showing the model label instead of a select. If a second model option is ever added, the select reappears with no further changes.

Kept the prop plumbing (`editorModelName`/`onEditorModelChange`) intact so drafts keep persisting the model name and multi-model support stays one constants change away.

## Testing
Shared builder + listicle builder component tests pass (12/12).