### PR TITLE
feat(abw-frontend): use structured SEO endpoint in single-type listicle builder

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
@@ -1,4 +1,4 @@
-import { convertMarkdownToLexical, generateListicleContentWithAi, generateTitleWithAi, rewriteBlockWithAi } from '../staging/api'
+import { convertMarkdownToLexical, generateListicleContentWithAi, generateSeoMetadataWithAi, generateTitleWithAi, rewriteBlockWithAi } from '../staging/api'
 import { appendScopedLocationWhere, getArticleLocationScope } from '../../shared/locationScope/scope'
 import { normalizeRelatedItems } from '../../shared/related-items/normalizeRelatedItems'
 import type { LocationScope } from '../../shared/locationScope/types'
@@ -144,4 +144,4 @@ export async function markdownToLexical(markdown: string): Promise<Record<string
   return result.data as Record<string, unknown>
 }
 
-export { generateListicleContentWithAi, generateTitleWithAi, rewriteBlockWithAi }
+export { generateListicleContentWithAi, generateSeoMetadataWithAi, generateTitleWithAi, rewriteBlockWithAi }

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx
@@ -50,7 +50,7 @@ import {
   buildSingleTypeListicleStructuredDataTemplate,
   serializeStructuredDataTemplate,
 } from '../builder/services/structured-data-template.service'
-import { generateListicleContentWithAi, generateTitleWithAi, rewriteBlockWithAi } from '../api'
+import { generateListicleContentWithAi, generateSeoMetadataWithAi, generateTitleWithAi, rewriteBlockWithAi } from '../api'
 import { saveDraft } from '../storage'
 import { buildArticleOgUrl } from '../../../shared/seo/utils/buildArticleOgUrl'
 import '../styles.css'
@@ -649,7 +649,7 @@ export default function SingleTypeListicleBuilderPage() {
     setIsGeneratingSeoTarget(target)
 
     try {
-      const response = await rewriteBlockWithAi({
+      const response = await generateSeoMetadataWithAi({
         prompt: buildSeoAiPrompt({
           articleType: draft.listicleType
             ? `single-type-listicle (${draft.listicleType})`
@@ -660,18 +660,19 @@ export default function SingleTypeListicleBuilderPage() {
             ? structuredDataTemplate
             : undefined,
         }),
-        blockContent: buildSeoAiSeed(draft.seoSection),
+        seed: buildSeoAiSeed(draft.seoSection),
         modelName: resolveEditorAssistModelName(draft.editorModelName),
         articleTitle,
         articleContext: articleContext || undefined,
       })
 
-      const aiText = response.rewritten_content?.trim()
-      if (!aiText) {
-        throw new Error('AI returned empty SEO content.')
+      if (!response.seo_patch || Object.keys(response.seo_patch).length === 0) {
+        throw new Error('AI returned an empty SEO patch.')
       }
 
-      const seoPatch = parseSeoAiPatch(aiText)
+      // The patch arrives schema-validated from the forced tool call; parse
+      // still applies length clipping and URL validation.
+      const seoPatch = parseSeoAiPatch(JSON.stringify(response.seo_patch))
       setDraft((current) => {
         if (!current) return current
         return {


### PR DESCRIPTION
## Summary
PR #38 moved the listicle-itinerary builder's step 4 SEO generation off the generic `/rewrite-block` endpoint onto the new `/editor-assist/generate-seo-metadata` endpoint (Anthropic forced tool use, schema-validated patch). The single-type listicle builder has the same step 4 flow and was still on the old free-text path.

This ports the identical change:
- `SingleTypeListicleBuilderPage` now calls `generateSeoMetadataWithAi` instead of `rewriteBlockWithAi` for SEO generation
- The prompt builder and `parseSeoAiPatch`/`applySeoAiPatch` normalization (length clipping, URL validation, target filtering) are unchanged — only the transport and trust in the response shape change
- `rewriteBlockWithAi` remains in use for the builder's other free-text rewrites

## Testing
- `tsc --noEmit`, eslint, and vitest for the feature: no new failures (the one failing test and lint error pre-exist on main)