### PR TITLE
feat(abw-frontend): use structured SEO endpoint in standard article stage builder

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
@@ -48,6 +48,7 @@ export {
   fetchExternalImageSource,
   fetchLocations,
   fetchMediaAssets,
+  generateSeoMetadataWithAi,
   importExternalImage,
   rewriteBlockWithAi,
   searchPexelsImages,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/StageArticlePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/StageArticlePage.tsx
@@ -7,6 +7,7 @@ import {
   fetchLocations,
   fetchMediaAssets,
   fetchResult,
+  generateSeoMetadataWithAi,
   getArticleSyncStatus,
   importExternalImage,
   markArticleSynced,
@@ -46,6 +47,7 @@ export default function StageArticlePage() {
         searchPexelsImages,
         searchUnsplashImages,
         rewriteBlockWithAi,
+        generateSeoMetadataWithAi,
       }}
       featureLabel="Prompt2Blog"
       heroDescription="Step through setup, featured image selection, article content blocks, and SEO before saving drafts or publishing to Payload."

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.test.tsx
@@ -170,6 +170,7 @@ const api = {
   searchPexelsImages: vi.fn(async () => ({ photos: [] })),
   searchUnsplashImages: vi.fn(async () => ({ photos: [] })),
   rewriteBlockWithAi: vi.fn(async () => ({ rewritten_content: 'rewritten' })),
+  generateSeoMetadataWithAi: vi.fn(async () => ({ seo_patch: { metaTitle: 'AI title' }, model_used: 'claude-opus-4-8' })),
 }
 
 function renderBuilder() {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.tsx
@@ -393,23 +393,24 @@ export function StandardArticleStageBuilder({
     setIsGeneratingSeoTarget(target)
 
     try {
-      const response = await api.rewriteBlockWithAi({
+      const response = await api.generateSeoMetadataWithAi({
         prompt: buildStandardArticleSeoAiPrompt({
           location: selectedLocationLabel || undefined,
           target,
         }),
-        blockContent: buildSeoAiSeed(seoSection),
+        seed: buildSeoAiSeed(seoSection),
         modelName: resolveEditorAssistModelName(stagedArticle.editorModelName),
         articleTitle,
         articleContext: articleContext || undefined,
       })
 
-      const aiText = response.rewritten_content?.trim()
-      if (!aiText) {
-        throw new Error('AI returned empty SEO content.')
+      if (!response.seo_patch || Object.keys(response.seo_patch).length === 0) {
+        throw new Error('AI returned an empty SEO patch.')
       }
 
-      const seoPatch = parseSeoAiPatch(aiText)
+      // The patch arrives schema-validated from the forced tool call; parse
+      // still applies length clipping and URL validation.
+      const seoPatch = parseSeoAiPatch(JSON.stringify(response.seo_patch))
       updateSeoSection((current) => applySeoAiPatch(current, seoPatch, target))
       setLocalResult(`Updated ${target === 'all' ? 'SEO metadata' : target} with AI.`)
     } catch (err) {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/types.ts
@@ -1,3 +1,4 @@
+import type { EditorAssistModelName } from '../../../../shared/api/ai/models'
 import type { UploadImageResponse } from '../../../../shared/images'
 import type { PayloadArticleDoc } from '../../../api/articles/articles.types'
 import type {
@@ -131,6 +132,15 @@ export type EditorialStageArticleApi = {
       articleContext?: string
     }
   ) => Promise<{ rewritten_content: string }>
+  generateSeoMetadataWithAi: (
+    input: {
+      prompt: string
+      seed: string
+      modelName?: EditorAssistModelName
+      articleTitle?: string
+      articleContext?: string
+    }
+  ) => Promise<{ seo_patch: Record<string, unknown>; model_used: string }>
 }
 
 export type EditorialStageRoutes = {

--- a/apps/ai-blog-writer/apps/frontend/src/features/url2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/url2blog/api.ts
@@ -30,6 +30,7 @@ export {
   fetchExternalImageSource,
   fetchLocations,
   fetchMediaAssets,
+  generateSeoMetadataWithAi,
   importExternalImage,
   rewriteBlockWithAi,
   searchPexelsImages,

--- a/apps/ai-blog-writer/apps/frontend/src/features/url2blog/pages/StageArticlePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/url2blog/pages/StageArticlePage.tsx
@@ -7,6 +7,7 @@ import {
   fetchLocations,
   fetchMediaAssets,
   fetchResult,
+  generateSeoMetadataWithAi,
   getArticleSyncStatus,
   importExternalImage,
   markArticleSynced,
@@ -46,6 +47,7 @@ export default function StageArticlePage() {
         searchPexelsImages,
         searchUnsplashImages,
         rewriteBlockWithAi,
+        generateSeoMetadataWithAi,
       }}
       featureLabel="URL2Blog"
       heroDescription="Step through setup, featured image selection, article content blocks, and SEO before saving drafts or publishing to Payload."

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api.ts
@@ -49,6 +49,7 @@ export {
   fetchExternalImageSource,
   fetchLocations,
   fetchMediaAssets,
+  generateSeoMetadataWithAi,
   importExternalImage,
   rewriteBlockWithAi,
   searchPexelsImages,

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/pages/StageArticlePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/pages/StageArticlePage.tsx
@@ -13,6 +13,7 @@ import {
   searchPexelsImages,
   searchUnsplashImages,
   rewriteBlockWithAi,
+  generateSeoMetadataWithAi,
 } from '../api'
 
 export type {
@@ -45,6 +46,7 @@ export default function StageArticlePage() {
         searchPexelsImages,
         searchUnsplashImages,
         rewriteBlockWithAi,
+        generateSeoMetadataWithAi,
       }}
       featureLabel="YouTube2Blog"
       heroDescription="Step through setup, featured image selection, article content blocks, and SEO before saving drafts or publishing to Payload."


### PR DESCRIPTION
## Summary
PR #38 moved the listicle-itinerary builder's step 4 SEO generation off the generic `/rewrite-block` endpoint onto `/editor-assist/generate-seo-metadata` (Anthropic forced tool use, schema-validated patch). The shared `StandardArticleStageBuilder` — which provides the same step 4 SEO flow to **url2blog**, **youtube2blog**, and **prompt2blog** — was still on the old free-text path.

This ports the identical change:
- Added `generateSeoMetadataWithAi` to `EditorialStageArticleApi` and switched the builder's SEO handler to it
- Wired the new api method through each flow's staging re-export and `StageArticlePage`
- `rewriteBlockWithAi` stays for the genuinely free-text uses (AI slug generation, editorial block rewrites)
- The prompt builder and `parseSeoAiPatch`/`applySeoAiPatch` normalization are unchanged — only the transport and trust in the response shape change
- The new api member is typed `EditorAssistModelName` to match the actual request type, instead of repeating the `EditorModelName` mismatch the `rewriteBlockWithAi` member carries

## Testing
- `tsc --noEmit` (31 errors, identical to main baseline), eslint (11 errors, identical to main baseline), vitest across staging/url2blog/youtube2blog/prompt2blog: 22/22 files, 68/68 tests pass
- `StandardArticleStageBuilder.test.tsx` api mock updated with the new member

Sibling PR: #39 does the same for the single-type listicle builder.