### PR TITLE
fix(abw-frontend): correct standard article JSON-LD schema semantics

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/standard-article-seo.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/standard-article-seo.service.test.ts
@@ -116,7 +116,8 @@ function runStructuredDataTemplateTest() {
   assert((blogPosting?.mainEntityOfPage as Record<string, unknown> | undefined)?.['@id'] === 'https://example.com/weekend-in-lima', 'Expected mainEntityOfPage to use canonical URL.')
   assert((blogPosting?.contentLocation as Record<string, unknown> | undefined)?.['@id'] === place?.['@id'], 'Expected contentLocation to reference the Place @id.')
   assert((blogPosting?.about as Record<string, unknown> | undefined)?.['@id'] === place?.['@id'], 'Expected about to reference the Place @id.')
-  assert((blogPosting?.mainEntity as Record<string, unknown> | undefined)?.['@id'] === place?.['@id'], 'Expected mainEntity to reference the Place @id.')
+  assert(blogPosting?.mainEntity === undefined, 'Expected mainEntity to be omitted; the article is the main entity of the page.')
+  assert(blogPosting?.inLanguage === 'en', 'Expected inLanguage on BlogPosting.')
 
   const author = blogPosting?.author as Record<string, unknown> | undefined
   const publisher = blogPosting?.publisher as Record<string, unknown> | undefined
@@ -211,7 +212,7 @@ function runPromptRulesTest() {
     'Expected prompt to preserve the BlogPosting graph node.',
   )
   assert(
-    prompt.includes('preserve the Place node plus BlogPosting contentLocation/about/mainEntity references to the Place @id'),
+    prompt.includes('preserve the Place node plus BlogPosting contentLocation/about references to the Place @id'),
     'Expected prompt to preserve linked Place references.',
   )
   assert(

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/standard-article-seo.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/standard-article-seo.service.ts
@@ -244,7 +244,7 @@ export function buildStandardArticleStructuredDataTemplate(input: StandardArticl
     articleSection: normalizeText(stagedArticle.originalType),
     contentLocation: locationNode ? { '@id': placeId } : undefined,
     about: locationNode ? { '@id': placeId } : undefined,
-    mainEntity: locationNode ? { '@id': placeId } : undefined,
+    inLanguage: 'en',
     url: canonicalUrl,
     image: articleImageUrl,
     dateModified: schemaDateModified,
@@ -379,7 +379,8 @@ export function buildStandardArticleSeoAiPrompt(input: {
     '- structuredData must be a JSON object (JSON-LD style).',
     '- If structuredData is requested, preserve the existing structuredData shape from input block content.',
     '- If structuredData is requested, keep @graph with BlogPosting as the primary node.',
-    '- If structuredData is requested and location data exists, preserve the Place node plus BlogPosting contentLocation/about/mainEntity references to the Place @id.',
+    '- If structuredData is requested and location data exists, preserve the Place node plus BlogPosting contentLocation/about references to the Place @id.',
+    '- If structuredData is requested, do not add a mainEntity reference to the Place; the article itself is the main entity of the page.',
     '- If structuredData is requested, do not add articleBody or wordCount to BlogPosting.',
     '- If structuredData is requested, preserve author and publisher nodes when present.',
     `- If structuredData is requested, keep every "description" concise and factual (max ${STRUCTURED_DATA_DESCRIPTION_MAX_LENGTH} chars).`,
@@ -482,7 +483,6 @@ export function validateStandardArticleSeoSection(input: {
 
       const contentLocationId = getReferenceId(blogPostingNode?.contentLocation)
       const aboutId = getReferenceId(blogPostingNode?.about)
-      const mainEntityId = getReferenceId(blogPostingNode?.mainEntity)
 
       if (!contentLocationId) {
         issues.push('Structured Data BlogPosting.contentLocation must reference the Place @id.')
@@ -492,20 +492,12 @@ export function validateStandardArticleSeoSection(input: {
         issues.push('Structured Data BlogPosting.about must reference the Place @id.')
       }
 
-      if (!mainEntityId) {
-        issues.push('Structured Data BlogPosting.mainEntity must reference the Place @id.')
-      }
-
       if (placeId && contentLocationId && contentLocationId !== placeId) {
         issues.push('Structured Data BlogPosting.contentLocation must reference the Place @id.')
       }
 
       if (placeId && aboutId && aboutId !== placeId) {
         issues.push('Structured Data BlogPosting.about must reference the Place @id.')
-      }
-
-      if (placeId && mainEntityId && mainEntityId !== placeId) {
-        issues.push('Structured Data BlogPosting.mainEntity must reference the Place @id.')
       }
     }
   } catch {


### PR DESCRIPTION
## Why
Audit of the Step 4 SEO structured data found two schema.org semantics issues in the standard article JSON-LD template.

## Changes
- **Drop `BlogPosting.mainEntity` → Place reference.** A blog post's main entity is the article itself (already expressed via `mainEntityOfPage`), not the location it covers. The Place node stays linked through `about` and `contentLocation`, which is the correct relationship.
- **Add `inLanguage: "en"`** to the BlogPosting node (recommended Article property, relevant with the multi-locale site setup).
- Updated the structured-data AI prompt rules and the publish-time validator (`validateStandardArticleSeoSection`) to match — the validator no longer requires `mainEntity`, and existing stored data that still has it continues to pass.

## Testing
- `vitest run` over `apps/frontend/src/features/staging` — 9 files, 31 tests pass.