### PR TITLE
fix(abw-frontend): correct single-type listicle JSON-LD schema properties

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/structured-data-template.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/structured-data-template.service.test.ts
@@ -153,6 +153,8 @@ describe('singleTypeListicles structured data template', () => {
     expect((blogPosting?.mainEntityOfPage as Record<string, unknown> | undefined)?.['@id']).toBe(
       'https://example.com/best-gelato-lima',
     )
+    expect(blogPosting?.inLanguage).toBe('en')
+    expect(firstEntity?.category).toBeUndefined()
 
     const validationIssues = validateSingleTypeListicleStructuredDataShape({
       structuredData: template,

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/structured-data-template.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/structured-data-template.service.ts
@@ -90,6 +90,8 @@ function buildRankedItemEntity(input: {
   const itemInstagram = relatedItem ? resolveSelectedInstagramPermalink(listicleItem, relatedItem) : undefined
   const cuisines = source ? pickStringArray(source, [['cuisines']]) : []
   const idealFor = source ? pickStringArray(source, [['idealFor'], ['nightlifeDetails', 'core', 'idealFor']]) : []
+  // schema.org has no `category` on Place subtypes, so the venue type label rides in `keywords`.
+  const keywordParts = [...idealFor, ...(itemTypeLabel ? [itemTypeLabel] : [])]
 
   const entity: Record<string, unknown> = {
     '@type': schemaType,
@@ -104,8 +106,7 @@ function buildRankedItemEntity(input: {
     geo: itemGeo,
     priceRange: itemPriceRange,
     servesCuisine: cuisines.length > 0 ? cuisines : undefined,
-    keywords: idealFor.length > 0 ? idealFor.join(', ') : undefined,
-    category: itemTypeLabel,
+    keywords: keywordParts.length > 0 ? keywordParts.join(', ') : undefined,
   }
 
   if (includeUrlFields && !entity.url && itemInstagram && isValidAbsoluteHttpUrl(itemInstagram)) {
@@ -185,6 +186,7 @@ export function buildSingleTypeListicleStructuredDataTemplate(input: {
     name: articleTitle,
     description: intro || 'AI_FILL_ARTICLE_DESCRIPTION',
     articleSection: listicleLabel,
+    inLanguage: 'en',
     contentLocation: draft.location.trim()
       ? {
           '@type': 'Place',


### PR DESCRIPTION
## Why
Audit of the Step 4 SEO structured data found an invalid schema.org property in the single-type listicle JSON-LD template.

## Changes
- **Remove `category` from ranked item entities.** schema.org does not define `category` on Place subtypes (Restaurant, LodgingBusiness, TouristAttraction, NightClub) — validators flag it and Google ignores it. The venue type label is now folded into `keywords`, which *is* valid on Place, so no signal is lost.
- **Add `inLanguage: "en"`** to the BlogPosting node.

## Testing
- `vitest run` over `apps/frontend/src/features/singleTypeListicles` — structured-data template tests pass, including new assertions that `category` is gone and `inLanguage` is present.
- Note: `useBuilderDraftActions.test.ts` has one pre-existing failure on `main` (confirm-dialog spy), unrelated to this change.