### PR TITLE
fix(abw-frontend): correct listicle itinerary JSON-LD schema types and properties

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/seo-ai.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/seo-ai.service.test.ts
@@ -10,7 +10,7 @@ describe('listicleItineraries seo ai service', () => {
         '@context': 'https://schema.org',
         '@graph': [
           { '@type': 'BlogPosting' },
-          { '@type': 'Trip' },
+          { '@type': 'TouristTrip' },
           {
             '@type': 'ItemList',
             itemListElement: [{ '@type': 'ListItem', position: 1 }],
@@ -19,7 +19,7 @@ describe('listicleItineraries seo ai service', () => {
       }),
     })
 
-    expect(prompt).toContain('keep @graph nodes for BlogPosting + Trip + ItemList')
+    expect(prompt).toContain('keep @graph nodes for BlogPosting + TouristTrip + ItemList')
     expect(prompt).toContain('preserve BlogPosting author, publisher, image, datePublished, dateModified, url, and mainEntityOfPage when present')
     expect(prompt).toContain('Structured data stop count to preserve: 1')
   })
@@ -33,7 +33,7 @@ describe('listicleItineraries seo ai service', () => {
             '@type': 'BlogPosting',
             description: 'Discover this full-day itinerary with endless amazing highlights and top-rated experiences that make it one of the best possible days in the city for absolutely everyone looking for unforgettable moments all day long.',
           },
-          { '@type': 'Trip' },
+          { '@type': 'TouristTrip' },
           {
             '@type': 'ItemList',
             itemListElement: [
@@ -84,7 +84,7 @@ describe('listicleItineraries seo ai service', () => {
             "headline": "One Day in Lima"
           }
           {
-            "@type": "Trip"
+            "@type": "TouristTrip"
           }
           {
             "@type": "ItemList",

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/seo-ai.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/seo-ai.service.ts
@@ -79,7 +79,7 @@ function buildTargetShape(target: SeoAiTarget): string {
     case 'twitterCardDescription':
       return '{"twitterCard":{"description":"string"}}'
     case 'structuredData':
-      return '{"structuredData":{"@context":"https://schema.org","@graph":[{"@type":"BlogPosting","headline":"string","description":"string","datePublished":"2026-03-07T21:54:32.290Z","dateModified":"2026-03-07T22:16:16.572Z","author":{"@type":"Person","name":"string"},"publisher":{"@type":"Organization","name":"string"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://example.com/path"}},{"@type":"Trip"},{"@type":"ItemList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@type":"Place","name":"string"}}]}]}}'
+      return '{"structuredData":{"@context":"https://schema.org","@graph":[{"@type":"BlogPosting","headline":"string","description":"string","datePublished":"2026-03-07T21:54:32.290Z","dateModified":"2026-03-07T22:16:16.572Z","author":{"@type":"Person","name":"string"},"publisher":{"@type":"Organization","name":"string"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://example.com/path"}},{"@type":"TouristTrip"},{"@type":"ItemList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@type":"Place","name":"string"}}]}]}}'
     case 'robots':
       return '{"robots":{"index":"index|noindex","follow":"follow|nofollow"}}'
     case 'robotsIndex':
@@ -149,9 +149,9 @@ export function buildSeoAiPrompt(input: {
     lines.push(
       '- structuredData must be a JSON object (JSON-LD style).',
       '- If structuredData is requested, preserve the existing structuredData shape from input block content.',
-      '- If structuredData is requested, keep @graph nodes for BlogPosting + Trip + ItemList and preserve stop order.',
+      '- If structuredData is requested, keep @graph nodes for BlogPosting + TouristTrip + ItemList and preserve stop order.',
       '- If structuredData is requested, preserve BlogPosting author, publisher, image, datePublished, dateModified, url, and mainEntityOfPage when present.',
-      '- If structuredData is requested, preserve canonical @id relationships between BlogPosting, Trip, and ItemList.',
+      '- If structuredData is requested, preserve canonical @id relationships between BlogPosting, TouristTrip, and ItemList.',
       '- If structuredData is requested, do not invent new stop entity types; keep existing item @type values unless explicitly required by context.',
       `- If structuredData is requested, keep every "description" concise and factual (max ${STRUCTURED_DATA_DESCRIPTION_MAX_LENGTH} chars).`,
       '- If structuredData is requested, avoid marketing tone, keyword stuffing, and sales language.',

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/structured-data-template.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/structured-data-template.service.test.ts
@@ -148,7 +148,7 @@ describe('listicleItineraries structured data template', () => {
       node && typeof node === 'object' && (node as Record<string, unknown>)['@type'] === 'BlogPosting'
     )) as Record<string, unknown> | undefined
     const tripNode = graph.find((node) => (
-      node && typeof node === 'object' && (node as Record<string, unknown>)['@type'] === 'Trip'
+      node && typeof node === 'object' && (node as Record<string, unknown>)['@type'] === 'TouristTrip'
     )) as Record<string, unknown> | undefined
     const itemListNode = graph.find((node) => (
       node && typeof node === 'object' && (node as Record<string, unknown>)['@type'] === 'ItemList'
@@ -195,6 +195,9 @@ describe('listicleItineraries structured data template', () => {
 
     expect(firstEntity?.['@type']).toBe('Restaurant')
     expect(secondEntity?.['@type']).toBe('TouristAttraction')
+    expect(firstEntity?.category).toBeUndefined()
+    expect(typeof firstEntity?.keywords === 'string' ? firstEntity.keywords : '').toContain('Dining')
+    expect(blogPostingNode?.inLanguage).toBe('en')
 
     const shapeIssues = validateListicleItineraryStructuredDataShape({
       structuredData,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/structured-data-template.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/structured-data-template.service.ts
@@ -297,6 +297,12 @@ function buildStopEntity(input: {
   const keyLocationKeywords = keyLocationEntities
     .map((location) => normalizeText(location.name))
     .filter((location): location is string => Boolean(location))
+  // schema.org has no `category` on Place subtypes, so the stop type label rides in `keywords`.
+  const stopTypeKeyword = itemTypeLabel || getStopTypeLabel(itineraryItem.blockType)
+  const keywordParts = [
+    ...(isManualStop ? keyLocationKeywords : idealFor),
+    stopTypeKeyword,
+  ].filter(Boolean)
 
   const entity: Record<string, unknown> = {
     '@type': schemaType,
@@ -311,12 +317,7 @@ function buildStopEntity(input: {
     geo: itemGeo,
     priceRange: itemPriceRange,
     servesCuisine: cuisines.length > 0 ? cuisines : undefined,
-    keywords: isManualStop
-      ? keyLocationKeywords.join(', ') || undefined
-      : idealFor.length > 0
-        ? idealFor.join(', ')
-        : undefined,
-    category: itemTypeLabel || getStopTypeLabel(itineraryItem.blockType),
+    keywords: keywordParts.length > 0 ? keywordParts.join(', ') : undefined,
     provider: isManualStop && providerName
       ? {
           '@type': 'Organization',
@@ -411,7 +412,7 @@ export function buildListicleItineraryStructuredDataTemplate(input: {
   }
 
   const tripNode: Record<string, unknown> = {
-    '@type': 'Trip',
+    '@type': 'TouristTrip',
     '@id': tripId,
     name: articleTitle,
     description: intro || 'AI_FILL_TRIP_DESCRIPTION',
@@ -428,6 +429,7 @@ export function buildListicleItineraryStructuredDataTemplate(input: {
     name: articleTitle,
     description: intro || 'AI_FILL_ARTICLE_DESCRIPTION',
     articleSection: 'Itinerary',
+    inLanguage: 'en',
     contentLocation: contentLocationName
       ? {
           '@type': 'Place',
@@ -438,7 +440,7 @@ export function buildListicleItineraryStructuredDataTemplate(input: {
       '@id': tripId,
     },
     mainEntity: {
-      '@type': 'Trip',
+      '@type': 'TouristTrip',
       '@id': tripId,
     },
     url: canonicalUrl,
@@ -535,7 +537,10 @@ export function validateListicleItineraryStructuredDataShape(input: {
     .filter((node): node is Record<string, unknown> => Boolean(node))
 
   const blogPostingNode = graphNodes.find((node) => getNodeType(node['@type']) === 'BlogPosting')
-  const tripNode = graphNodes.find((node) => getNodeType(node['@type']) === 'Trip')
+  const tripNode = graphNodes.find((node) => {
+    const nodeType = getNodeType(node['@type'])
+    return nodeType === 'TouristTrip' || nodeType === 'Trip'
+  })
   const itemListNode = graphNodes.find((node) => getNodeType(node['@type']) === 'ItemList')
 
   if (!blogPostingNode) {
@@ -543,7 +548,7 @@ export function validateListicleItineraryStructuredDataShape(input: {
   }
 
   if (!tripNode) {
-    issues.push('Structured Data "@graph" must include a Trip node.')
+    issues.push('Structured Data "@graph" must include a TouristTrip node.')
   }
 
   if (!itemListNode) {


### PR DESCRIPTION
## Why
Audit of the Step 4 SEO structured data found schema.org type/property issues in the listicle itinerary JSON-LD template.

## Changes
- **`Trip` → `TouristTrip`** for the trip node and the BlogPosting `mainEntity` reference. TouristTrip is the specific schema.org type for travel itineraries (it's what schema.org's own itinerary examples use). The shape validator accepts both `TouristTrip` and legacy `Trip`, so structured data stored before this change still validates.
- **Remove invalid `category` property from stop entities.** schema.org does not define `category` on Place subtypes (Restaurant, LodgingBusiness, TouristAttraction, NightClub, Place). The stop type label is now folded into `keywords`, which *is* valid on Place, so no signal is lost.
- **Add `inLanguage: "en"`** to the BlogPosting node.
- Updated the structured-data AI prompt (target shape + guardrail rules) to reference TouristTrip.

## Testing
- `vitest run` over `apps/frontend/src/features/listicleItineraries` — 17 files, 78 tests pass, including new assertions for TouristTrip, no `category`, keywords carrying the stop type label, and `inLanguage`.