### PR TITLE
feat(questura-client): render JSON-LD structured data, breadcrumbs, and Organization node

### DIFF
--- a/apps/questura/apps/client/src/app/(public)/layout.tsx
+++ b/apps/questura/apps/client/src/app/(public)/layout.tsx
@@ -1,6 +1,8 @@
 import Footer from "@/components/layout/Footer";
 import { ClientInteractionProvider } from "@/components/providers/ClientInteractionProvider";
+import { JsonLd } from "@/components/seo/JsonLd";
 import { Navbar } from "@/features/Navigation";
+import { buildOrganizationJsonLd } from "@/lib/seo/organizationJsonLd";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -12,6 +14,7 @@ export default function PublicLayout({
 }>) {
   return (
     <>
+      <JsonLd data={buildOrganizationJsonLd()} />
       <ClientInteractionProvider>
         <Navbar />
       </ClientInteractionProvider>

--- a/apps/questura/apps/client/src/components/seo/JsonLd.tsx
+++ b/apps/questura/apps/client/src/components/seo/JsonLd.tsx
@@ -1,0 +1,20 @@
+type JsonLdProps = {
+  data: unknown
+}
+
+/**
+ * Renders a schema.org JSON-LD script tag. `<` is escaped so stored content
+ * can never break out of the script element.
+ */
+export function JsonLd({ data }: JsonLdProps) {
+  if (!data || typeof data !== 'object') return null
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+      }}
+    />
+  )
+}

--- a/apps/questura/apps/client/src/features/articles/lib/articleBreadcrumbJsonLd.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/articleBreadcrumbJsonLd.ts
@@ -1,0 +1,49 @@
+const PUBLIC_BASE_URL =
+  process.env.NEXT_PUBLIC_FRONTEND_URL ?? 'http://localhost:3000'
+
+function humanizeSegment(segment: string): string {
+  return segment
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+type BuildBreadcrumbParams = {
+  /** Canonical article path, e.g. /italy/rome/maps/best-bars-in-trastevere */
+  path: string
+  articleTitle: string
+}
+
+/**
+ * BreadcrumbList derived from the article's URL segments: Home, then one
+ * crumb per intermediate segment (humanized slug), then the article title.
+ */
+export function buildArticleBreadcrumbJsonLd({
+  path,
+  articleTitle,
+}: BuildBreadcrumbParams): Record<string, unknown> {
+  const base = PUBLIC_BASE_URL.replace(/\/+$/, '')
+  const segments = path.split('/').filter(Boolean)
+
+  const itemListElement: Array<Record<string, unknown>> = [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: `${base}/` },
+  ]
+
+  let cumulativePath = ''
+  segments.forEach((segment, index) => {
+    cumulativePath += `/${segment}`
+    const isLast = index === segments.length - 1
+    itemListElement.push({
+      '@type': 'ListItem',
+      position: itemListElement.length + 1,
+      name: isLast ? articleTitle : humanizeSegment(segment),
+      item: `${base}${cumulativePath}`,
+    })
+  })
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement,
+  }
+}

--- a/apps/questura/apps/client/src/features/articles/routes/renderItineraryArticleRoute.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderItineraryArticleRoute.tsx
@@ -1,5 +1,8 @@
 import { notFound } from 'next/navigation'
+import { JsonLd } from '@/components/seo/JsonLd'
 import { ItineraryListicleArticlePage } from '@/features/articles/ItineraryListicleArticlePage'
+import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
+import { articleHrefForScope } from '@/features/articles/lib/articleScope'
 import { fetchArticle } from '@/features/articles/lib/fetchArticle'
 import { fetchRelatedMapsArticles } from '@/features/articles/lib/fetchRelatedMapsArticles'
 import { ListicleArticleLayout } from '@/features/articles/layouts/ListicleArticleLayout'
@@ -26,13 +29,19 @@ export async function renderItineraryArticleRoute({
     notFound()
   }
 
+  const path = articleHrefForScope(scope, 'itineraries', slug)
+
   return (
-    <ListicleArticleLayout
-      relatedArticles={relatedArticles}
-      country={scope.country}
-      city={scope.city}
-    >
-      <ItineraryListicleArticlePage article={article} />
-    </ListicleArticleLayout>
+    <>
+      <JsonLd data={article.seoSection?.structuredData} />
+      <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
+      <ListicleArticleLayout
+        relatedArticles={relatedArticles}
+        country={scope.country}
+        city={scope.city}
+      >
+        <ItineraryListicleArticlePage article={article} />
+      </ListicleArticleLayout>
+    </>
   )
 }

--- a/apps/questura/apps/client/src/features/articles/routes/renderMapsArticleRoute.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderMapsArticleRoute.tsx
@@ -1,4 +1,7 @@
 import { notFound } from 'next/navigation'
+import { JsonLd } from '@/components/seo/JsonLd'
+import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
+import { articleHrefForScope } from '@/features/articles/lib/articleScope'
 import { fetchArticle } from '@/features/articles/lib/fetchArticle'
 import { fetchRelatedMapsArticles } from '@/features/articles/lib/fetchRelatedMapsArticles'
 import { MapsArticleLayout } from '@/features/articles/layouts/MapsArticleLayout'
@@ -25,12 +28,18 @@ export async function renderMapsArticleRoute({
     notFound()
   }
 
+  const path = articleHrefForScope(scope, 'maps', slug)
+
   return (
-    <MapsArticleLayout
-      article={article}
-      relatedArticles={relatedArticles}
-      country={scope.country}
-      city={scope.city}
-    />
+    <>
+      <JsonLd data={article.seoSection?.structuredData} />
+      <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
+      <MapsArticleLayout
+        article={article}
+        relatedArticles={relatedArticles}
+        country={scope.country}
+        city={scope.city}
+      />
+    </>
   )
 }

--- a/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleByPath.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleByPath.tsx
@@ -1,6 +1,8 @@
 import { notFound, permanentRedirect } from 'next/navigation'
+import { JsonLd } from '@/components/seo/JsonLd'
 import { ArticlePage } from '@/features/articles/ArticlePage'
 import { isStandardArticle } from '@/features/articles/lib/articleGuards'
+import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
 import {
   fetchArticleByCanonicalPath,
   fetchRedirectByPath,
@@ -15,7 +17,13 @@ export async function renderStandardArticleByPath({ path, lang }: Params) {
   const article = await fetchArticleByCanonicalPath({ path, lang })
 
   if (article && isStandardArticle(article)) {
-    return <ArticlePage article={article} />
+    return (
+      <>
+        <JsonLd data={article.seoSection?.structuredData} />
+        <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
+        <ArticlePage article={article} />
+      </>
+    )
   }
 
   const redirect = await fetchRedirectByPath(path)

--- a/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleRoute.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleRoute.tsx
@@ -1,7 +1,10 @@
 import { notFound } from 'next/navigation'
+import { JsonLd } from '@/components/seo/JsonLd'
 import { ArticlePage } from '@/features/articles/ArticlePage'
 import { isStandardArticle } from '@/features/articles/lib/articleGuards'
+import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
 import { fetchArticle } from '@/features/articles/lib/fetchArticle'
+import { articleHrefForScope } from '@/features/articles/lib/articleScope'
 import type { ArticleScope } from '@/features/articles/lib/articleScope'
 
 type RenderStandardArticleRouteParams = {
@@ -21,5 +24,17 @@ export async function renderStandardArticleRoute({
     notFound()
   }
 
-  return <ArticlePage article={article} />
+  const canonicalPath = (article as { canonicalPath?: string | null }).canonicalPath
+  const path =
+    typeof canonicalPath === 'string' && canonicalPath.length > 0
+      ? canonicalPath
+      : articleHrefForScope(scope, 'articles', slug)
+
+  return (
+    <>
+      <JsonLd data={article.seoSection?.structuredData} />
+      <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
+      <ArticlePage article={article} />
+    </>
+  )
 }

--- a/apps/questura/apps/client/src/features/articles/types/index.ts
+++ b/apps/questura/apps/client/src/features/articles/types/index.ts
@@ -59,6 +59,18 @@ export type SeoSection = {
     title?: string
     description?: string
     imageUrl?: string
+    url?: string
+  }
+  twitterCard?: {
+    card?: 'summary' | 'summary_large_image'
+    title?: string
+    description?: string
+    imageUrl?: string
+  }
+  structuredData?: unknown
+  robots?: {
+    index?: 'index' | 'noindex'
+    follow?: 'follow' | 'nofollow'
   }
 }
 

--- a/apps/questura/apps/client/src/features/articles/types/mapsListicle.ts
+++ b/apps/questura/apps/client/src/features/articles/types/mapsListicle.ts
@@ -1,5 +1,5 @@
 /** Public API payload for `single-type-listicles` (served under `/maps/[slug]`). */
-import type { ArticleAuthor } from '@/features/articles/types'
+import type { ArticleAuthor, SeoSection } from '@/features/articles/types'
 
 export type MediaVariant = {
   url?: string
@@ -74,10 +74,7 @@ export type MapsListicleArticle = {
   author?: ArticleAuthor | null
   header?: MapsListicleHeader | null
   items?: ListicleItemRow[]
-  seoSection?: {
-    metaDescription?: string
-    seoTitle?: string
-  }
+  seoSection?: SeoSection
 }
 
 export function isMapsListicleArticle(

--- a/apps/questura/apps/client/src/lib/seo/organizationJsonLd.ts
+++ b/apps/questura/apps/client/src/lib/seo/organizationJsonLd.ts
@@ -1,0 +1,21 @@
+const PUBLIC_BASE_URL =
+  process.env.NEXT_PUBLIC_FRONTEND_URL ?? 'http://localhost:3000'
+
+/**
+ * Official Questura social profiles for the Organization `sameAs` links.
+ * Add profile URLs here as they exist; `sameAs` is omitted while empty.
+ */
+const SOCIAL_PROFILE_URLS: string[] = []
+
+export function buildOrganizationJsonLd(): Record<string, unknown> {
+  const base = PUBLIC_BASE_URL.replace(/\/+$/, '')
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': `${base}/#organization`,
+    name: 'Questura',
+    url: `${base}/`,
+    ...(SOCIAL_PROFILE_URLS.length > 0 ? { sameAs: SOCIAL_PROFILE_URLS } : {}),
+  }
+}


### PR DESCRIPTION
## Summary

The Questura client stores rich JSON-LD in `seoSection.structuredData` (built by the ABW structured SEO pipeline) but never rendered it — search engines saw none of it. This PR wires up rendering:

- **`JsonLd` component** (`components/seo/JsonLd.tsx`): renders `<script type="application/ld+json">` with `<` escaped as `\u003c` so stored content can never break out of the script element.
- **Stored structured data** is now emitted on all four article route renderers (standard scope-based, standard by-canonical-path, maps listicle, itinerary listicle).
- **BreadcrumbList** per article, generated from the URL segments (Home → humanized country/city/type crumbs → article title).
- **Site-wide Organization node** in the public layout with a stable `@id`; `sameAs` is ready to be populated in `lib/seo/organizationJsonLd.ts` once official social profile URLs exist (none are in the codebase today).
- **Type alignment**: client `SeoSection` type extended with `structuredData`, `twitterCard`, `openGraph.url`, and `robots` to match the Payload schema; the maps listicle type now reuses the shared `SeoSection` instead of a narrower inline copy.

Author-page URLs on Person nodes were considered but skipped — the client has no author routes to link to.

## Verification

- `tsc --noEmit` clean
- `next lint` clean (only pre-existing warnings)

Independent of the metadata-fixes PR (no file overlap); mergeable in any order.