### PR TITLE
fix(questura-client): correct article page metadata (hreflang, SEO title, Twitter Card, OG, robots)

### DIFF
--- a/apps/questura/apps/client/src/features/articles/lib/buildArticleMetadata.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/buildArticleMetadata.ts
@@ -3,7 +3,7 @@ import { fetchArticle } from './fetchArticle'
 import { fetchArticleByCanonicalPath } from './fetchArticleByCanonicalPath'
 import type { ArticleScope, ArticleTypeKey } from './articleScope'
 import { articleHrefForScope } from './articleScope'
-import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/lib/i18n/locales'
+import { DEFAULT_LOCALE } from '@/lib/i18n/locales'
 
 const PUBLIC_BASE_URL =
   process.env.NEXT_PUBLIC_FRONTEND_URL ?? 'http://localhost:3000'
@@ -11,11 +11,83 @@ const PUBLIC_BASE_URL =
 type ArticleLikeDoc = {
   title?: string
   seoSection?: {
-    metaTitle?: string
+    seoTitle?: string
     metaDescription?: string
-    openGraph?: { imageUrl?: string }
+    openGraph?: { title?: string; description?: string; imageUrl?: string }
+    twitterCard?: {
+      card?: 'summary' | 'summary_large_image'
+      title?: string
+      description?: string
+      imageUrl?: string
+    }
+    robots?: {
+      index?: 'index' | 'noindex'
+      follow?: 'follow' | 'nofollow'
+    }
   }
   header?: { featuredImage?: { url?: string; alt_text?: string } }
+}
+
+/**
+ * hreflang alternates: only the language this article actually exists in,
+ * plus x-default. Do not emit an alternate per supported locale — they would
+ * all point at the same URL, which is invalid hreflang.
+ */
+function buildLanguageAlternates(lang: string, canonical: string): Record<string, string> {
+  return {
+    [lang]: canonical,
+    'x-default': canonical,
+  }
+}
+
+function buildMetadataFromArticle(
+  article: ArticleLikeDoc,
+  canonical: string,
+  lang: string,
+): Metadata {
+  const seo = article.seoSection
+  const title = seo?.seoTitle ?? article.title ?? ''
+  const description = seo?.metaDescription ?? undefined
+  const fallbackImage = seo?.openGraph?.imageUrl ?? article.header?.featuredImage?.url ?? null
+
+  const ogTitle = seo?.openGraph?.title ?? title
+  const ogDescription = seo?.openGraph?.description ?? description
+
+  const twitter = seo?.twitterCard
+  const twitterTitle = twitter?.title ?? ogTitle
+  const twitterDescription = twitter?.description ?? ogDescription
+  const twitterImage = twitter?.imageUrl ?? fallbackImage
+
+  const robots = seo?.robots
+
+  return {
+    title: title || undefined,
+    description,
+    alternates: {
+      canonical,
+      languages: buildLanguageAlternates(lang, canonical),
+    },
+    openGraph: {
+      title: ogTitle || undefined,
+      description: ogDescription,
+      url: canonical,
+      ...(fallbackImage ? { images: [{ url: fallbackImage }] } : {}),
+    },
+    twitter: {
+      card: twitter?.card ?? 'summary_large_image',
+      title: twitterTitle || undefined,
+      description: twitterDescription,
+      ...(twitterImage ? { images: [twitterImage] } : {}),
+    },
+    ...(robots
+      ? {
+          robots: {
+            index: robots.index !== 'noindex',
+            follow: robots.follow !== 'nofollow',
+          },
+        }
+      : {}),
+  }
 }
 
 type BuildParams = {
@@ -43,31 +115,7 @@ export async function buildArticleMetadata({
       : articleHrefForScope(scope, type, slug)
   const canonical = `${base}${path}`
 
-  const title = article.seoSection?.metaTitle ?? article.title ?? ''
-  const description = article.seoSection?.metaDescription ?? undefined
-  const image =
-    article.seoSection?.openGraph?.imageUrl ?? article.header?.featuredImage?.url ?? null
-
-  const languages: Record<string, string> = {}
-  for (const locale of SUPPORTED_LOCALES) {
-    languages[locale] = canonical
-  }
-  languages['x-default'] = canonical
-
-  return {
-    title: title || undefined,
-    description,
-    alternates: {
-      canonical,
-      languages,
-    },
-    openGraph: {
-      title: title || undefined,
-      description,
-      url: canonical,
-      ...(image ? { images: [{ url: image }] } : {}),
-    },
-  }
+  return buildMetadataFromArticle(article, canonical, lang)
 }
 
 type BuildByPathParams = {
@@ -85,31 +133,7 @@ export async function buildArticleMetadataByPath({
   const base = PUBLIC_BASE_URL.replace(/\/+$/, '')
   const canonical = `${base}${path}`
 
-  const title = article.seoSection?.metaTitle ?? article.title ?? ''
-  const description = article.seoSection?.metaDescription ?? undefined
-  const image =
-    article.seoSection?.openGraph?.imageUrl ?? article.header?.featuredImage?.url ?? null
-
-  const languages: Record<string, string> = {}
-  for (const locale of SUPPORTED_LOCALES) {
-    languages[locale] = canonical
-  }
-  languages['x-default'] = canonical
-
-  return {
-    title: title || undefined,
-    description,
-    alternates: {
-      canonical,
-      languages,
-    },
-    openGraph: {
-      title: title || undefined,
-      description,
-      url: canonical,
-      ...(image ? { images: [{ url: image }] } : {}),
-    },
-  }
+  return buildMetadataFromArticle(article, canonical, lang)
 }
 
 type BuildIndexParams = {
@@ -135,16 +159,10 @@ export function buildArticleIndexMetadata({
   })()
   const canonical = `${base}${path}`
 
-  const languages: Record<string, string> = {}
-  for (const locale of SUPPORTED_LOCALES) {
-    languages[locale] = canonical
-  }
-  languages['x-default'] = canonical
-
   return {
     alternates: {
       canonical,
-      languages,
+      languages: buildLanguageAlternates(DEFAULT_LOCALE, canonical),
     },
   }
 }


### PR DESCRIPTION
## Summary

Five metadata issues fixed in `buildArticleMetadata.ts`, all in one file so this PR is independent of the JSON-LD rendering PR (#44) and mergeable in any order.

1. **SEO title bug (new find)**: the code read `seoSection.metaTitle`, but the Payload field is named `seoTitle` — CMS-authored SEO titles were silently never used; every page fell back to the raw article title.
2. **hreflang bug**: alternates looped over every entry in `SUPPORTED_LOCALES`, all pointing at the same URL. Now only the article's actual language plus `x-default` are emitted (invalid-hreflang shape gone, and it stays correct when more locales are added).
3. **Twitter Card**: the stored `twitterCard` group was dropped entirely. Now mapped to `Metadata.twitter`, falling back to OG values and the featured image; card type defaults to `summary_large_image`.
4. **OG overrides**: `openGraph.title` / `openGraph.description` were stored but ignored (only `imageUrl` was read). Now honored, falling back to the page title/description.
5. **robots**: the CMS noindex/nofollow setting was never rendered. Now mapped to `Metadata.robots` when present.

## Verification

- `tsc --noEmit` clean
- `next lint` clean (only pre-existing warnings)