### PR TITLE
feat(url2blog): tiered article fetching + trafilatura extraction

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -60,3 +60,28 @@ LM_API_URL=http://localhost:4002
 # Anthropic — required when the listicle writer model is set to claude-opus-4-8.
 # Get a key at https://console.anthropic.com/settings/keys.
 ANTHROPIC_API_KEY=
+
+# URL2Blog tiered article fetch (stage 1). All optional — tiers without
+# config are skipped and the fetch falls back to a direct request.
+# Tier 2: IPRoyal residential proxy (same account as location-manager's
+# Viator tour import).
+IPROYAL_HOST=
+IPROYAL_PORT=
+IPROYAL_USER=
+IPROYAL_PASS=
+PROXY_COUNTRY=us
+# Tier 3: location-manager's rendered-fetch endpoint (stealth Chromium).
+# Requires the location-manager server running (default port 4002).
+URL2BLOG_RENDERED_FETCH_URL=http://localhost:4002/api/scrape/rendered-fetch
+
+# URL2Blog article fetching — tiered fallback (see url2blog/content/fetching.py).
+# Tier 2 (residential proxy): same IPRoyal credentials as location-manager.
+# Leave blank to skip the proxy tier.
+IPROYAL_HOST=
+IPROYAL_PORT=
+IPROYAL_USER=
+IPROYAL_PASS=
+PROXY_COUNTRY=us
+# Tier 3 (JS rendering): location-manager's rendered-fetch endpoint.
+# e.g. http://localhost:4002/api/scrape/rendered-fetch — leave blank to skip.
+URL2BLOG_RENDERED_FETCH_URL=

--- a/apps/ai-blog-writer/apps/backend/app/features/url2blog/content/fetching.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/url2blog/content/fetching.py
@@ -1,0 +1,211 @@
+"""Tiered article fetching for URL2Blog.
+
+Escalates through three tiers until one yields usable article text:
+
+1. direct   — plain httpx with realistic desktop-Chrome headers
+2. proxy    — same request through an IPRoyal residential proxy
+              (skipped when IPROYAL_* env vars are absent)
+3. rendered — POST to a headless-browser fetch service that executes JS
+              (skipped when URL2BLOG_RENDERED_FETCH_URL is absent)
+
+A tier "fails" on network error, block-page status, challenge markers in
+the visible text, or too little extracted text (JS-rendered shells).
+"""
+
+import logging
+import os
+import secrets
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from app.core import resolve_httpx_verify
+
+from .text_cleanup import extract_article_text
+
+logger = logging.getLogger(__name__)
+
+DIRECT_TIMEOUT_SECONDS = 30.0
+RENDERED_TIMEOUT_SECONDS = 120.0
+MIN_ARTICLE_TEXT_CHARS = 50
+PROXY_SESSION_LIFETIME_MINUTES = 10
+
+RENDERED_FETCH_URL_ENV = "URL2BLOG_RENDERED_FETCH_URL"
+
+# Full desktop-Chrome header set. The previous UA
+# ("Mozilla/5.0 (compatible; Questurian/1.0)") self-identified as a bot
+# and was rejected outright by Cloudflare/Akamai/DataDome fronts.
+BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+    "Sec-Ch-Ua": '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": '"Windows"',
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
+}
+
+BLOCK_STATUS_CODES = {401, 403, 407, 429, 503}
+
+# Only checked against short pages (real articles can legitimately mention
+# "captcha"); a challenge interstitial has very little visible text.
+CHALLENGE_MARKERS = (
+    "just a moment",
+    "please enable js",
+    "enable javascript",
+    "verify you are human",
+    "are you a robot",
+    "access denied",
+    "attention required",
+    "captcha",
+    "datadome",
+)
+CHALLENGE_TEXT_MAX_CHARS = 2_000
+
+
+class ArticleFetchError(Exception):
+    """All fetch tiers failed; `attempts` records each tier's outcome."""
+
+    def __init__(self, url: str, attempts: list[dict[str, Any]]):
+        self.url = url
+        self.attempts = attempts
+        summary = "; ".join(
+            f"{a['tier']}: {a.get('error') or a.get('skip_reason')}" for a in attempts
+        )
+        super().__init__(f"All fetch tiers failed for {url} ({summary})")
+
+
+@dataclass
+class FetchOutcome:
+    html: str
+    text: str
+    tier: str
+    attempts: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _residential_proxy_url() -> str | None:
+    """Build an IPRoyal proxy URL with a fresh sticky session, or None."""
+    host = os.getenv("IPROYAL_HOST")
+    port = os.getenv("IPROYAL_PORT")
+    user = os.getenv("IPROYAL_USER")
+    password = os.getenv("IPROYAL_PASS")
+    if not all((host, port, user, password)):
+        return None
+    country = os.getenv("PROXY_COUNTRY", "us")
+    session_id = secrets.token_hex(5)
+    full_password = (
+        f"{password}_country-{country}_session-{session_id}"
+        f"_lifetime-{PROXY_SESSION_LIFETIME_MINUTES}m"
+    )
+    return f"http://{quote(user, safe='')}:{quote(full_password, safe='')}@{host}:{port}"
+
+
+def _rendered_fetch_url() -> str | None:
+    return os.getenv(RENDERED_FETCH_URL_ENV) or None
+
+
+def _rejection_reason(status: int, text: str) -> str | None:
+    """Return why a response is unusable as article content, or None if OK."""
+    if status in BLOCK_STATUS_CODES:
+        return f"blocked (HTTP {status})"
+    if status >= 400:
+        return f"HTTP {status}"
+    if len(text) < MIN_ARTICLE_TEXT_CHARS:
+        return f"too little text ({len(text)} chars); likely JS-rendered or empty"
+    if len(text) <= CHALLENGE_TEXT_MAX_CHARS:
+        lowered = text.lower()
+        for marker in CHALLENGE_MARKERS:
+            if marker in lowered:
+                return f"challenge page (matched {marker!r})"
+    return None
+
+
+async def _httpx_get(url: str, proxy: str | None) -> tuple[int, str]:
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        timeout=DIRECT_TIMEOUT_SECONDS,
+        verify=resolve_httpx_verify(),
+        headers=BROWSER_HEADERS,
+        proxy=proxy,
+    ) as client:
+        resp = await client.get(url)
+        return resp.status_code, resp.text
+
+
+async def _rendered_get(url: str, service_url: str) -> tuple[int, str]:
+    """Fetch fully rendered HTML from the browser-fetch service."""
+    async with httpx.AsyncClient(
+        timeout=RENDERED_TIMEOUT_SECONDS,
+        verify=resolve_httpx_verify(),
+    ) as client:
+        resp = await client.post(service_url, json={"url": url})
+        resp.raise_for_status()
+        payload = resp.json()
+    data = payload.get("data") or payload
+    html = data.get("html") or ""
+    status = int(data.get("status") or 200)
+    return status, html
+
+
+async def fetch_article_html(url: str) -> FetchOutcome:
+    """Fetch `url` through the tier ladder; raise ArticleFetchError if all fail."""
+    attempts: list[dict[str, Any]] = []
+    proxy = _residential_proxy_url()
+    rendered = _rendered_fetch_url()
+
+    tiers: list[tuple[str, Any, str | None]] = [
+        ("direct", lambda: _httpx_get(url, None), None),
+        (
+            "proxy",
+            lambda: _httpx_get(url, proxy),
+            None if proxy else "IPROYAL_* env vars not configured",
+        ),
+        (
+            "rendered",
+            lambda: _rendered_get(url, rendered or ""),
+            None if rendered else f"{RENDERED_FETCH_URL_ENV} not configured",
+        ),
+    ]
+
+    for tier, fetcher, skip_reason in tiers:
+        if skip_reason:
+            attempts.append({"tier": tier, "skipped": True, "skip_reason": skip_reason})
+            logger.info("URL2Blog fetch: skipping tier %s (%s)", tier, skip_reason)
+            continue
+        try:
+            status, html = await fetcher()
+        except httpx.HTTPError as exc:
+            attempts.append({"tier": tier, "error": f"request failed: {exc}"})
+            logger.warning("URL2Blog fetch: tier %s failed for %s: %s", tier, url, exc)
+            continue
+
+        text = extract_article_text(html)
+        reason = _rejection_reason(status, text)
+        if reason is None:
+            attempts.append({"tier": tier, "ok": True, "status": status})
+            logger.info("URL2Blog fetch: tier %s succeeded for %s", tier, url)
+            return FetchOutcome(html=html, text=text, tier=tier, attempts=attempts)
+
+        attempts.append({"tier": tier, "error": reason, "status": status})
+        logger.warning("URL2Blog fetch: tier %s rejected for %s: %s", tier, url, reason)
+
+    raise ArticleFetchError(url, attempts)
+
+
+__all__ = [
+    "ArticleFetchError",
+    "FetchOutcome",
+    "fetch_article_html",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/url2blog/content/text_cleanup.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/url2blog/content/text_cleanup.py
@@ -4,6 +4,8 @@ import logging
 import re
 from typing import Any
 
+import trafilatura
+
 from ..config import (
     URL2BLOG_TEXT_CLEANUP_CHUNKING_CHAR_THRESHOLD,
     URL2BLOG_TEXT_CLEANUP_CHUNK_TARGET_CHARS,
@@ -43,6 +45,34 @@ def _strip_html(html: str) -> str:
     # Restore some paragraph breaks at block boundaries
     text = re.sub(r"\s{2,}", "\n\n", text)
     return text.strip()
+
+
+def extract_article_text(html: str) -> str:
+    """Extract the main article text from a full HTML document.
+
+    Uses trafilatura (boilerplate removal: nav, footers, cookie banners,
+    related-article rails) and falls back to the regex tag-stripper when
+    trafilatura finds no main content — e.g. non-article pages or HTML
+    fragments where the readability heuristics don't apply.
+    """
+    if not html:
+        return ""
+    try:
+        extracted = trafilatura.extract(
+            html,
+            include_comments=False,
+            include_tables=True,
+            favor_precision=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — never let extraction crash the fetch
+        logger.warning("trafilatura extraction raised; using regex fallback: %s", exc)
+        extracted = None
+
+    if extracted and len(extracted.strip()) >= 50:
+        return extracted.strip()
+
+    logger.info("trafilatura returned no usable content; using regex fallback")
+    return _strip_html(html)
 
 
 def _preclean_pasted_text(raw_text: str) -> str:

--- a/apps/ai-blog-writer/apps/backend/app/features/url2blog/stages/stage1.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/url2blog/stages/stage1.py
@@ -3,11 +3,8 @@
 import logging
 from typing import Any
 
-import httpx
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
-
-from app.core import resolve_httpx_verify
 
 from ..config import (
     URL2BLOG_INPUT_CHAR_LIMIT_DEFAULT,
@@ -15,7 +12,7 @@ from ..config import (
     _read_int_env,
     _resolve_url2blog_model,
 )
-from ..content.text_cleanup import _strip_html
+from ..content.fetching import ArticleFetchError, fetch_article_html
 from ..models import ExtractRequest
 from ..prompts import EXTRACT_PROMPT, TRANSLATE_PROMPT
 
@@ -37,39 +34,15 @@ async def extract_article(request: ExtractRequest) -> JSONResponse:
             status_code=400, detail="URL must start with http:// or https://"
         )
 
-    # Fetch the page
+    # Fetch the page through the tier ladder: direct -> residential proxy
+    # -> rendered browser (see content/fetching.py).
     logger.info("URL2Blog: fetching %s", url)
     try:
-        async with httpx.AsyncClient(
-            follow_redirects=True,
-            timeout=30.0,
-            verify=resolve_httpx_verify(),
-            headers={
-                "User-Agent": "Mozilla/5.0 (compatible; Questurian/1.0)",
-                "Accept": "text/html,application/xhtml+xml",
-            },
-        ) as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to fetch URL (HTTP {exc.response.status_code})",
-        ) from exc
-    except httpx.RequestError as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to fetch URL: {exc}",
-        ) from exc
+        fetched = await fetch_article_html(url)
+    except ArticleFetchError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
-    raw_html = resp.text
-    raw_text = _strip_html(raw_html)
-
-    if not raw_text or len(raw_text) < 50:
-        raise HTTPException(
-            status_code=422,
-            detail="Page returned too little text content to extract an article.",
-        )
+    raw_text = fetched.text
 
     max_chars = _read_int_env(
         URL2BLOG_INPUT_CHAR_LIMIT_ENV,
@@ -108,6 +81,8 @@ async def extract_article(request: ExtractRequest) -> JSONResponse:
                     "url": url,
                     "raw_text": raw_text,
                     "raw_text_length": len(raw_text),
+                    "fetch_tier": fetched.tier,
+                    "fetch_attempts": fetched.attempts,
                 },
                 "prompt": prompt,
                 "raw_response": raw_response,
@@ -193,6 +168,7 @@ async def extract_article(request: ExtractRequest) -> JSONResponse:
     payload: dict[str, Any] = {
         "message": "URL2Blog stage 1 completed",
         "source_url": url,
+        "fetch_tier": fetched.tier,
         "raw_text_length": len(raw_text),
         "raw_response": raw_response,
         "parsed": parsed,

--- a/apps/ai-blog-writer/apps/backend/requirements.txt
+++ b/apps/ai-blog-writer/apps/backend/requirements.txt
@@ -14,3 +14,4 @@ pillow==10.4.0
 httpx==0.28.1
 youtube-transcript-api>=1.0.0
 anthropic>=0.42.0
+trafilatura==2.1.0

--- a/apps/location-manager/packages/server/.env.example
+++ b/apps/location-manager/packages/server/.env.example
@@ -31,3 +31,13 @@ IMAGES_PATH=packages/server/data/images
 PAYLOAD_API_URL=http://localhost:4000
 PAYLOAD_SERVICE_EMAIL=service-account@questurian.com
 PAYLOAD_SERVICE_PASSWORD=your-strong-password
+
+# IPRoyal residential proxy — used by tour-import (Viator) and the generic
+# rendered-fetch scrape service. Leave blank to run the browser unproxied.
+IPROYAL_HOST=
+IPROYAL_PORT=
+IPROYAL_USER=
+IPROYAL_PASS=
+PROXY_COUNTRY=us
+# Set to "false" to run the rendered-fetch browser headful (debugging).
+RENDERED_FETCH_HEADLESS=true

--- a/apps/location-manager/packages/server/src/features/scrape/routes/scrape.routes.ts
+++ b/apps/location-manager/packages/server/src/features/scrape/routes/scrape.routes.ts
@@ -1,0 +1,24 @@
+import type { Context } from "hono";
+import { app } from "@server/shared/http/server";
+import { successResponse } from "@shared/types/api-response";
+import { BadRequestError } from "@shared/errors/http-error";
+import { fetchRenderedHtml } from "../services/rendered-fetch.service";
+
+/**
+ * POST /api/scrape/rendered-fetch  { url }
+ * Returns fully rendered HTML via stealth Chromium (+ residential proxy
+ * when IPROYAL_* env vars are set). Tier-3 fallback for ai-blog-writer's
+ * url2blog article fetch.
+ */
+async function postRenderedFetch(c: Context) {
+  const body = await c.req.json().catch(() => null);
+  const url = typeof body?.url === "string" ? body.url.trim() : "";
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    throw new BadRequestError("url must start with http:// or https://");
+  }
+
+  const { html, status } = await fetchRenderedHtml(url);
+  return c.json(successResponse({ url, html, status }));
+}
+
+app.post("/api/scrape/rendered-fetch", postRenderedFetch);

--- a/apps/location-manager/packages/server/src/features/scrape/services/rendered-fetch.service.ts
+++ b/apps/location-manager/packages/server/src/features/scrape/services/rendered-fetch.service.ts
@@ -1,0 +1,189 @@
+import { chromium } from "patchright";
+import type { Browser, BrowserContext } from "patchright";
+
+/**
+ * Generic rendered-HTML fetcher: stealth Chromium (patchright), optionally
+ * routed through IPRoyal residential sticky-session proxies. Generalized
+ * from tour-import/providers/viator-session.ts, minus the Viator-specific
+ * warmup. Consumed by ai-blog-writer's url2blog tier-3 fetch fallback.
+ *
+ * Without IPROYAL_* env vars the browser runs unproxied — still useful,
+ * since JS rendering alone fixes SPA article pages.
+ */
+
+type ProxyConfig = {
+  server: string;
+  username: string;
+  password: string;
+  sessionId: string;
+};
+
+type Session = {
+  browser: Browser;
+  context: BrowserContext;
+  proxy: ProxyConfig | null;
+  createdAt: number;
+  pageCount: number;
+};
+
+const PAGE_LIMIT = 50;
+const AGE_LIMIT_MS = 25 * 60 * 1000;
+const STICKY_LIFETIME_MIN = 30;
+const NAV_TIMEOUT_MS = 30_000;
+const POST_NAV_SETTLE_MS = 2500;
+
+const CHALLENGE_TEXT_MAX_CHARS = 2000;
+const CHALLENGE_MARKERS = [
+  "just a moment",
+  "please enable js",
+  "enable javascript",
+  "verify you are human",
+  "are you a robot",
+  "access denied",
+  "attention required",
+];
+
+let current: Session | null = null;
+let inFlight: Promise<Session> | null = null;
+
+export class RenderedFetchBlockedError extends Error {
+  constructor(public readonly reason: string) {
+    super(`Rendered fetch blocked: ${reason}`);
+    this.name = "RenderedFetchBlockedError";
+  }
+}
+
+function newSessionId(): string {
+  return Math.random().toString(36).slice(2, 12);
+}
+
+function buildProxy(sessionId: string): ProxyConfig | null {
+  const host = Bun.env.IPROYAL_HOST;
+  const port = Bun.env.IPROYAL_PORT;
+  const user = Bun.env.IPROYAL_USER;
+  const pass = Bun.env.IPROYAL_PASS;
+  if (!host || !port || !user || !pass) return null;
+  const country = Bun.env.PROXY_COUNTRY ?? "us";
+  return {
+    server: `http://${host}:${port}`,
+    username: user,
+    password: `${pass}_country-${country}_session-${sessionId}_lifetime-${STICKY_LIFETIME_MIN}m`,
+    sessionId,
+  };
+}
+
+async function closeSession(session: Session): Promise<void> {
+  try {
+    await session.context.close();
+  } catch {}
+  try {
+    await session.browser.close();
+  } catch {}
+}
+
+function isExpired(session: Session): boolean {
+  return session.pageCount >= PAGE_LIMIT || Date.now() - session.createdAt >= AGE_LIMIT_MS;
+}
+
+async function createSession(): Promise<Session> {
+  const proxy = buildProxy(newSessionId());
+  const headless = Bun.env.RENDERED_FETCH_HEADLESS !== "false";
+  console.log(
+    `[scrape:rendered-fetch] starting session ${proxy?.sessionId ?? "no-proxy"} (headless=${headless})`,
+  );
+  const browser = await chromium.launch({
+    headless,
+    ...(proxy
+      ? {
+          proxy: {
+            server: proxy.server,
+            username: proxy.username,
+            password: proxy.password,
+          },
+        }
+      : {}),
+  });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    locale: "en-US",
+    timezoneId: "America/New_York",
+  });
+  return { browser, context, proxy, createdAt: Date.now(), pageCount: 0 };
+}
+
+async function getSession(): Promise<Session> {
+  if (current && !isExpired(current)) return current;
+  if (current && isExpired(current)) {
+    await closeSession(current);
+    current = null;
+  }
+  if (inFlight) return inFlight;
+  inFlight = createSession()
+    .then((session) => {
+      current = session;
+      return session;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+async function markBlocked(session: Session): Promise<void> {
+  if (current === session) {
+    current = null;
+    await closeSession(session);
+  }
+}
+
+function challengeMarker(innerText: string): string | null {
+  if (innerText.length > CHALLENGE_TEXT_MAX_CHARS) return null;
+  const lowered = innerText.toLowerCase();
+  for (const marker of CHALLENGE_MARKERS) {
+    if (lowered.includes(marker)) return marker;
+  }
+  return null;
+}
+
+type AttemptResult = { html: string; status: number } | { blocked: string };
+
+async function attempt(url: string): Promise<AttemptResult> {
+  const session = await getSession();
+  const page = await session.context.newPage();
+  let topStatus: number | null = null;
+  page.on("response", (response) => {
+    if (topStatus === null && response.url() === url) topStatus = response.status();
+  });
+
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+    await page.waitForTimeout(POST_NAV_SETTLE_MS);
+    const html = await page.content();
+    const innerText = (await page.textContent("body").catch(() => "")) ?? "";
+    session.pageCount += 1;
+
+    if (topStatus !== null && topStatus >= 400 && topStatus !== 404) {
+      await markBlocked(session);
+      return { blocked: `HTTP ${topStatus}` };
+    }
+    const marker = challengeMarker(innerText);
+    if (marker) {
+      await markBlocked(session);
+      return { blocked: `challenge page (matched "${marker}")` };
+    }
+    return { html, status: topStatus ?? 200 };
+  } finally {
+    await page.close();
+  }
+}
+
+export async function fetchRenderedHtml(url: string): Promise<{ html: string; status: number }> {
+  const first = await attempt(url);
+  if ("html" in first) return first;
+
+  console.log(`[scrape:rendered-fetch] blocked (${first.blocked}); retrying with fresh session`);
+  const second = await attempt(url);
+  if ("html" in second) return second;
+
+  throw new RenderedFetchBlockedError(`${first.blocked}, then ${second.blocked}`);
+}

--- a/apps/location-manager/packages/server/src/server/main.ts
+++ b/apps/location-manager/packages/server/src/server/main.ts
@@ -1,6 +1,7 @@
 import { initDb } from "../shared/db/client";
 import { app } from "../shared/http/server";
 import "../features/locations/routes/location.routes";
+import "../features/scrape/routes/scrape.routes";
 
 export function startServer(port = Number(process.env.PORT || 4317)) {
   initDb();


### PR DESCRIPTION
## What

Replaces the single plain-`httpx` GET in url2blog (self-identifying bot UA, no proxy, no JS, one attempt) with a **fallback ladder** that stops at the first tier returning usable article text:

1. **direct** — `httpx` with realistic desktop-Chrome headers
2. **proxy** — same request via IPRoyal residential sticky session
3. **rendered** — stealth-Chromium fetch service (executes JS)

Tiers 2/3 auto-skip when their env vars are unset, so the default path is still a strict upgrade over the old direct fetch. Block/challenge pages, JS-rendered shells, and network errors each fail a tier and escalate.

Article text now comes from **trafilatura** (boilerplate removal) with the former regex tag-stripper as fallback for non-article/fragment pages. The pasted-text path keeps the regex, since trafilatura expects a full HTML document.

Tier 3 lives in **location-manager** (patchright + IPRoyal already there), generalized from tour-import's Viator session into a reusable `POST /api/scrape/rendered-fetch` endpoint.

## Config

New env vars (all optional, documented in the `.env.example` files):
- `IPROYAL_HOST/PORT/USER/PASS`, `PROXY_COUNTRY` — tier 2
- `URL2BLOG_RENDERED_FETCH_URL` — tier 3

Adds `trafilatura==2.1.0` to backend requirements (pulls in `lxml`).

## Verified

- Full ladder against real articles -> tier `direct`, clean extraction
- JS-only page -> direct rejected, escalates to `rendered`
- Block page (403) -> ladder exhausts with per-tier error report
- `POST /api/scrape/rendered-fetch` returns rendered HTML
- Trafilatura vs regex: Wikipedia article 151k->103k chars (drops nav/reference boilerplate, keeps tables)
- 29/29 url2blog tests pass