### PR TITLE
Document staff management decisions (glossary, domain rules, ADR-0023)

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/frontend/CONTEXT.md
@@ -8,6 +8,7 @@ React SPA for operators. Lets a human:
 - watch a Running Pipeline by polling status.
 - edit the resulting Draft locally.
 - Sync the Draft to a Payload entity (Questura).
+- manage editorial staffing (Staff management): admins create writer/editor Staff identities and promote writers; every Staff identity edits its own Author profile.
 
 ## Out of Scope
 
@@ -34,6 +35,12 @@ Operators need a tactile UI: pick inputs, watch progress, hand-edit before pushi
 
 Definition: one top-level UI per pipeline. Lives in `src/features/<featureCamelCase>/`.
 Examples: `Prompt2BlogPage`, `YouTube2BlogPage`, `Url2BlogPage`, `LocationDocumentsPage`, `ItinerariesPipelinePage`, `ListicleItinerariesPage`, `SingleTypeListiclesPage`, `BatchUploadPage`, `BatchImageRecreationPage`, `HomepageFeaturedContentPage`, `StagingPage`.
+
+### Staff management
+
+Definition: the admin-gated feature for editorial staffing — creating `writer`/`editor` Staff identities (invite-style, no shared passwords), promoting a writer to editor, and self-service Author profile editing for every logged-in Staff identity. Deliberately narrower than the Payload admin panel; see `docs/adr/0023`.
+Related terms: Staff identity, Author profile (both defined in Questura's CONTEXT.md — Payload owns the records; this is only a surface over them).
+Do not confuse with: Visitor accounts (BetterAuth, public site) — never touched here.
 
 ### Saved Articles Page
 

--- a/apps/ai-blog-writer/docs/adr/0023-staff-management-surface-in-abw-frontend.md
+++ b/apps/ai-blog-writer/docs/adr/0023-staff-management-surface-in-abw-frontend.md
@@ -1,0 +1,9 @@
+# Staff management surface in ABW frontend over direct Payload Users CRUD
+
+Editorial staffing (creating writers/editors, promoting a writer to editor, self-service Author profile editing) gets a curated surface in the ABW frontend, even though the Payload admin panel already offers user management. ABW is where Staff identities already work and log in (Payload staff JWT), so day-to-day staffing lives there; the Payload admin panel remains the deliberate, rarely used surface for high-stakes acts. The ABW surface calls Payload's `/api/users` REST API directly with the operator's staff JWT, extending ADR-0001's split (AI work → ABW backend; CRUD → Payload direct) — Payload's existing access rules stay the single enforcement point, and ABW adds no backend proxy and no second user store.
+
+## Consequences
+
+- The ABW surface is deliberately narrower than what Payload permits: it creates only `writer` and `editor` roles (never `admin`), offers exactly one role change (admin promotes writer → editor, mirroring the server's only legal transition), and has no delete/offboarding controls in v1. These omissions are on purpose; do not "complete" them without revisiting this ADR.
+- New Staff identities are onboarded invite-style: created with a random password that is never displayed, followed by Payload's `forgot-password` email (Resend) so the hire sets their own credentials. No temporary passwords are shared out-of-band.
+- Role gating in the ABW UI derives from Payload's `/api/access` response (as `usePermissions` already does for publishing), not from client-side role checks alone.

--- a/apps/questura/CONTEXT.md
+++ b/apps/questura/CONTEXT.md
@@ -160,6 +160,11 @@ _Avoid_: account, customer, member
 Role-derived Membership entitlement for a Staff identity.
 _Avoid_: Stripe subscription, manual subscription status
 
+### Author profile
+
+The public presentation (display name, bio, avatar, slug, author page) of a Staff identity; not a separate record or role.
+_Avoid_: author account, author role, guest author
+
 ### Visitor account
 
 Authenticated public-site identity for end visitors using login, signup, profile, saved content, and checkout flows.
@@ -226,6 +231,7 @@ _Avoid_: public auth, visitor auth
 - **`PerfectForTag.applicableTypes`** scopes a tag to one or more of dining/attractions/nightlife/accommodations.
 - A **Visitor account** may have an active **Membership entitlement**.
 - A **Staff identity** may have a **Staff grant**, but it is not exposed through public account APIs.
+- A **Staff identity** has at most one **Author profile**; an Author profile never exists without a Staff identity.
 - A **Visitor account** has exactly one **Visitor profile**.
 - A **Staff identity** is separate from a **Visitor account**.
 - A **Staff identity** enters through a **Staff entry point**, not a **Visitor entry point**.
@@ -287,6 +293,9 @@ _Avoid_: public auth, visitor auth
 - New public uploads enter through a MediaSet creation/selection workflow. Direct `MediaAsset` uploads are reserved for internal profile images, inline article body images (until placement-aware serving is needed), migration tooling, and external non-first-class images.
 - Editorial body images may remain direct `MediaAsset` references until they need variant-aware serving.
 - For synced location content, **LM owns variant file generation**; Questura owns variant attachment validation, MediaPlacement requirements, and public serving.
+- Any Staff identity may have an Author profile, regardless of role. Role governs editorial capability; the Author profile governs public presentation. (Resolved 2026-07: the editor-only public-profile gate contradicted writers receiving bylines on published articles.)
+- **Byline implies visibility**: an Author page is publicly visible iff its Staff identity has at least one published editorial item. There is no separate opt-in flag; the legacy `isPublic` checkbox is retired, not left as a dead control.
+- A Staff identity edits its own Author profile presentation (names, display name, bio, expertise, social links, avatar). The author-page slug is admin-controlled: it auto-generates once and never changes without an admin, because author URLs are public and un-redirected.
 
 ## Naming Conventions
 
@@ -319,6 +328,7 @@ See `docs/adr/` for current ADRs.
 
 ## Open Questions
 
+- Staff offboarding is unmodeled: a Staff identity can only be deleted (admin-only), which would orphan required `author` relationships on published editorial content. A deactivated state that blocks login but preserves bylines has been discussed and deferred (2026-07).
 - Long-form article body comes in as LexicalJSON from AI Blog Writer — what is the contract? Today it's implicit.
 - `homepage-featured-content` is one of the largest feature folders; should it have its own CONTEXT.md? See suggestion in the meta-root.
 - Should the LM-side variant-generation responsibilities be documented in a parallel ADR (LM-side mirror of 0001)?


### PR DESCRIPTION
## Summary
- Adds **Author profile** to Questura's glossary: the public presentation of a Staff identity, not a separate record or role
- New Domain Rules: any Staff identity may have an Author profile; **byline implies visibility** (author page resolves iff ≥1 published item, `isPublic` retired); slug is admin-controlled
- Records staff offboarding as an Open Question (deletion would orphan required `author` relationships)
- ABW frontend CONTEXT.md: adds Staff management to scope + glossary
- New ABW ADR-0023: staff management surface lives in the ABW frontend over direct Payload Users CRUD (extends ADR-0001's pattern)

Decisions resolved in a grill-with-docs session; implementation follows in three PRs (Payload policy, ABW My Profile, ABW staffing tools).