### PR TITLE
Enforce Author profile policy in Payload Users

### DIFF
--- a/apps/questura/apps/server/src/app/api/public/authors/[slug]/route.ts
+++ b/apps/questura/apps/server/src/app/api/public/authors/[slug]/route.ts
@@ -6,6 +6,7 @@ import type { User } from '@/payload-types'
 import { DEFAULT_LANG, isSupportedLang } from '@/shared/i18n/languageField'
 import { serializeIndexItem, type IndexItem } from '@/features/articles/public/indexItem'
 import { TYPE_TO_COLLECTION, type ArticleTypeKey } from '@/features/articles/public/scope'
+import { hasPublishedAuthorContent } from '@/features/articles/public/authorVisibility'
 
 const ARTICLE_TYPES: ArticleTypeKey[] = ['articles', 'maps', 'itineraries']
 const MAX_ARTICLES_PER_COLLECTION = 100
@@ -56,6 +57,13 @@ export async function GET(
     }
 
     if (!user) {
+      return NextResponse.json({ message: 'Author not found.' }, { status: 404 })
+    }
+
+    // Byline implies visibility: staff without published work have no public
+    // author page, so they are not enumerable through this route.
+    const isVisible = await hasPublishedAuthorContent(payload, user.id, ARTICLE_TYPES)
+    if (!isVisible) {
       return NextResponse.json({ message: 'Author not found.' }, { status: 404 })
     }
 

--- a/apps/questura/apps/server/src/features/articles/public/authorVisibility.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/authorVisibility.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { hasPublishedAuthorContent, type AuthorContentCounter } from './authorVisibility'
+
+const ALL_TYPES = ['articles', 'maps', 'itineraries'] as const
+
+function createPayload(countsByCollection: Record<string, number>) {
+  const count = vi.fn(async (args: { collection: string }) => ({
+    totalDocs: countsByCollection[args.collection] ?? 0,
+  }))
+  return { count, payload: { count } as unknown as AuthorContentCounter }
+}
+
+describe('hasPublishedAuthorContent', () => {
+  it('is visible with published work in any collection', async () => {
+    const { payload } = createPayload({ 'listicle-itineraries': 1 })
+
+    await expect(hasPublishedAuthorContent(payload, 7, [...ALL_TYPES])).resolves.toBe(true)
+  })
+
+  it('is not visible with no published work anywhere', async () => {
+    const { count, payload } = createPayload({})
+
+    await expect(hasPublishedAuthorContent(payload, 7, [...ALL_TYPES])).resolves.toBe(false)
+    expect(count).toHaveBeenCalledTimes(ALL_TYPES.length)
+  })
+
+  it('only counts published items by the given author', async () => {
+    const { count, payload } = createPayload({ articles: 1 })
+
+    await hasPublishedAuthorContent(payload, 42, [...ALL_TYPES])
+
+    for (const [args] of count.mock.calls as Array<[Record<string, unknown>]>) {
+      expect(args.where).toEqual({
+        and: [
+          { author: { equals: 42 } },
+          { status: { equals: 'published' } },
+        ],
+      })
+      expect(args.overrideAccess).toBe(true)
+    }
+  })
+})

--- a/apps/questura/apps/server/src/features/articles/public/authorVisibility.ts
+++ b/apps/questura/apps/server/src/features/articles/public/authorVisibility.ts
@@ -1,0 +1,34 @@
+import type { Payload } from 'payload'
+
+import { TYPE_TO_COLLECTION, type ArticleTypeKey } from './scope'
+
+export type AuthorContentCounter = Pick<Payload, 'count'>
+
+/**
+ * Byline implies visibility: an author page is publicly visible iff the Staff
+ * identity has at least one published editorial item in ANY language. There is
+ * no opt-in flag (the legacy `isPublic` checkbox is retired) — see the Domain
+ * Rules in apps/questura/CONTEXT.md.
+ */
+export async function hasPublishedAuthorContent(
+  payload: AuthorContentCounter,
+  authorId: number | string,
+  types: ArticleTypeKey[],
+): Promise<boolean> {
+  const counts = await Promise.all(
+    types.map((type) =>
+      payload.count({
+        collection: TYPE_TO_COLLECTION[type],
+        where: {
+          and: [
+            { author: { equals: authorId } },
+            { status: { equals: 'published' } },
+          ],
+        },
+        overrideAccess: true,
+      }),
+    ),
+  )
+
+  return counts.some((result) => result.totalDocs > 0)
+}

--- a/apps/questura/apps/server/src/features/auth/collections/Users.ts
+++ b/apps/questura/apps/server/src/features/auth/collections/Users.ts
@@ -1,5 +1,6 @@
 import { CollectionConfig } from 'payload'
 import { collectionAccess } from './access/collectionLevel'
+import { isAdminFieldLevel } from './access/fieldLevel'
 import { userCollectionHooks } from './hooks'
 import { basicFields, profileFields } from './fields'
 
@@ -133,10 +134,16 @@ export const Users: CollectionConfig = {
       type: 'text',
       unique: true,
       index: true,
+      access: {
+        // Author URLs are public and un-redirected once a slug changes, so
+        // only admins may rename a slug. Auto-generation via the beforeChange
+        // hook is unaffected (hook-set values bypass field access).
+        update: isAdminFieldLevel,
+      },
       admin: {
         position: 'sidebar',
         description:
-          'URL slug for the public author page (/authors/<slug>). Auto-generated from the display name if left empty.',
+          'URL slug for the public author page (/authors/<slug>). Auto-generated from the display name if left empty. Admin-only: changing it breaks inbound author URLs.',
       },
     },
 
@@ -170,11 +177,11 @@ export const Users: CollectionConfig = {
           ],
         },
         {
+          // Any Staff identity may have an Author profile, regardless of role
+          // (writers receive bylines on published articles). Visibility of the
+          // public author page is derived from published work, not a flag.
           label: 'Public Profile',
           fields: profileFields,
-          admin: {
-            condition: (data) => data?.role === 'editor',
-          },
         },
       ],
     },

--- a/apps/questura/apps/server/src/features/auth/collections/fields/profile.ts
+++ b/apps/questura/apps/server/src/features/auth/collections/fields/profile.ts
@@ -17,14 +17,6 @@ export const profileFields: Field[] = [
         },
       },
       {
-        name: 'isPublic',
-        type: 'checkbox',
-        defaultValue: false,
-        admin: {
-          description: 'Make this profile visible on the website frontend',
-        },
-      },
-      {
         name: 'displayName',
         type: 'text',
         admin: {

--- a/apps/questura/apps/server/src/migrations/20260717_000000_retire_users_public_profile_is_public.ts
+++ b/apps/questura/apps/server/src/migrations/20260717_000000_retire_users_public_profile_is_public.ts
@@ -1,0 +1,18 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+// Byline implies visibility: the public authors route never read this flag,
+// and author-page visibility is now derived from published work. Retire the
+// column instead of leaving a dead control.
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`ALTER TABLE "users" DROP COLUMN IF EXISTS "public_profile_is_public";`),
+  )
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(
+    sql.raw(
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "public_profile_is_public" boolean DEFAULT false;`,
+    ),
+  )
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -12,6 +12,7 @@ import * as migration_20260703_132643_add_itinerary_tour_agency_block_storage fr
 import * as migration_20260704_000000_add_article_source_fields from './20260704_000000_add_article_source_fields';
 import * as migration_20260708_060450_reference_grid_registry_cleanup from './20260708_060450_reference_grid_registry_cleanup';
 import * as migration_20260711_000000_add_users_author_slug from './20260711_000000_add_users_author_slug';
+import * as migration_20260717_000000_retire_users_public_profile_is_public from './20260717_000000_retire_users_public_profile_is_public';
 
 export const migrations = [
   {
@@ -83,5 +84,10 @@ export const migrations = [
     up: migration_20260711_000000_add_users_author_slug.up,
     down: migration_20260711_000000_add_users_author_slug.down,
     name: '20260711_000000_add_users_author_slug',
+  },
+  {
+    up: migration_20260717_000000_retire_users_public_profile_is_public.up,
+    down: migration_20260717_000000_retire_users_public_profile_is_public.down,
+    name: '20260717_000000_retire_users_public_profile_is_public',
   },
 ];


### PR DESCRIPTION
## Summary
Implements Slice 1 of the staff-management plan (per Domain Rules added in #47):

- **Any Staff identity gets an Author profile**: removes the editor-only condition on the Public Profile tab (writers already receive bylines on published articles)
- **Slug is admin-controlled**: adds field-level access so only admins can rename an author URL (auto-generation via the beforeChange hook is unaffected)
- **Retires `publicProfile.isPublic`**: the public route never read it; field removed + migration `20260717_000000` drops the column (down re-adds it)
- **Byline implies visibility**: `/api/public/authors/[slug]` now 404s unless the Staff identity has ≥1 published item in any language, via a new `hasPublishedAuthorContent` helper — staff without published work are no longer enumerable

## Testing
- New unit tests for `hasPublishedAuthorContent` (visibility across collections, author/status filtering)
- Existing `collectionLevel` access tests still pass
- `tsc --noEmit`: no errors in touched files (pre-existing script/@types errors unchanged)
- `payload generate:types` regenerated cleanly without `isPublic` (file is gitignored)