### PR TITLE
ABW: self-service Author profile page

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/App.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import {
 import { ImageRecreationPromptsPage } from './features/imageRecreationPrompts'
 import { MediaLibraryPage } from './features/mediaLibrary'
 import BatchImageRecreationPage from './features/batchImageRecreation/BatchImageRecreationPage'
+import { MyProfilePage } from './features/staff'
 import './styles.css'
 
 const queryClient = new QueryClient()
@@ -123,6 +124,9 @@ export default function App() {
 
               {/* Batch Image Recreation */}
               <Route path="batch-image-recreation" element={<BatchImageRecreationPage />} />
+
+              {/* Staff management */}
+              <Route path="profile" element={<MyProfilePage />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/apps/ai-blog-writer/apps/frontend/src/app/layout/Layout.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/app/layout/Layout.tsx
@@ -116,6 +116,14 @@ export default function Layout() {
               {isUserMenuOpen ? (
                 <div className="nav-user-menu-dropdown" role="menu">
                   <div className="nav-user-menu-email">{user?.email ?? 'Unknown user'}</div>
+                  <Link
+                    to="/profile"
+                    className="nav-user-menu-link"
+                    role="menuitem"
+                    onClick={() => setIsUserMenuOpen(false)}
+                  >
+                    My Profile
+                  </Link>
                   <button type="button" className="nav-user-menu-logout" onClick={handleLogout}>
                     Log out
                   </button>
@@ -137,6 +145,9 @@ export default function Layout() {
             <p className="nav-mobile-connection-error">{connectionError}</p>
           )}
           <span className="nav-mobile-user">{user?.email}</span>
+          <Link to="/profile" className="nav-mobile-profile-link">
+            My Profile
+          </Link>
           <button type="button" className="nav-mobile-logout" onClick={handleLogout}>
             Log out
           </button>

--- a/apps/ai-blog-writer/apps/frontend/src/css/staff.css
+++ b/apps/ai-blog-writer/apps/frontend/src/css/staff.css
@@ -1,0 +1,251 @@
+/* Staff management & Author profile styles */
+
+/* User-menu entries (rendered in the Layout nav) */
+.nav-user-menu-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  color: var(--ink);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  transition: all var(--transition-base);
+}
+
+.nav-user-menu-link:hover {
+  background: var(--cream-dark);
+}
+
+.nav-mobile-profile-link {
+  display: block;
+  padding: var(--space-3) var(--space-4);
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: var(--font-body);
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  text-align: center;
+}
+
+.nav-mobile-profile-link:hover {
+  background: var(--cream-dark);
+}
+
+.staff-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+}
+
+.staff-page-header {
+  margin-bottom: var(--space-6);
+}
+
+.staff-page-header h1 {
+  font-family: var(--font-display);
+  color: var(--ink);
+  margin: 0 0 var(--space-2);
+}
+
+.staff-muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.staff-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  box-shadow: 0 2px 8px var(--shadow-soft);
+}
+
+.staff-section {
+  padding-bottom: var(--space-5);
+  margin-bottom: var(--space-5);
+  border-bottom: 1px solid var(--border);
+}
+
+.staff-section h2 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  color: var(--ink);
+  margin: 0 0 var(--space-3);
+}
+
+.staff-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+  flex: 1;
+}
+
+.staff-field span {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ink-light);
+}
+
+.staff-field input,
+.staff-field textarea {
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  color: var(--ink);
+  background: #fff;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.staff-field input:focus,
+.staff-field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.staff-field-row {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.staff-add-row {
+  align-items: center;
+}
+
+.staff-add-row input {
+  flex: 1;
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+}
+
+.staff-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.staff-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  border: 1px solid var(--border-strong);
+}
+
+.staff-avatar-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+}
+
+.staff-file-input {
+  display: none;
+}
+
+.staff-hint {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  margin: var(--space-2) 0 0;
+}
+
+.staff-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.staff-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: var(--accent-softer);
+  border: 1px solid var(--accent-soft);
+  color: var(--ink);
+  font-size: 0.8125rem;
+  border-radius: var(--radius-full);
+  padding: var(--space-1) var(--space-2) var(--space-1) var(--space-3);
+}
+
+.staff-chip button {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 var(--space-1);
+}
+
+.staff-chip button:hover {
+  color: var(--error);
+}
+
+.staff-form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+.staff-button-primary {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.9375rem;
+  color: #fff;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-5);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.staff-button-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.staff-button-primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.staff-button-secondary {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--ink);
+  background: #fff;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+}
+
+.staff-button-secondary:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.staff-success {
+  color: var(--success);
+  font-size: 0.875rem;
+}
+
+.staff-error {
+  color: var(--error);
+  font-size: 0.875rem;
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { avatarUrl, fetchStaffUser, updateStaffUser, uploadAvatarAsset } from './staff.api'
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }
+}
+
+describe('staff.api', () => {
+  it('fetches the staff user with depth=1 and auth header', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 3, email: 'w@questurian.com', role: 'writer' }))
+
+    const user = await fetchStaffUser(3, 'token-1')
+
+    expect(user.id).toBe(3)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/api/users/3?depth=1')
+    expect(init.headers.Authorization).toBe('Bearer token-1')
+  })
+
+  it('updates the staff user and unwraps the doc', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ doc: { id: 3, email: 'w@questurian.com', role: 'writer', firstName: 'Ana' } }))
+
+    const user = await updateStaffUser(3, { firstName: 'Ana' }, 'token-1')
+
+    expect(user.firstName).toBe('Ana')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/api/users/3')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(init.body)).toEqual({ firstName: 'Ana' })
+  })
+
+  it('throws when update returns no doc', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}))
+
+    await expect(updateStaffUser(3, {}, 'token-1')).rejects.toThrow('no updated user document')
+  })
+
+  it('uploads an avatar as multipart form data', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ doc: { id: 9, url: 'https://cdn/avatar.jpg' } }))
+
+    const asset = await uploadAvatarAsset(new File(['x'], 'a.jpg', { type: 'image/jpeg' }), 'token-1')
+
+    expect(asset.id).toBe(9)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain('/api/media-assets')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeInstanceOf(FormData)
+    expect(init.headers.Authorization).toBe('Bearer token-1')
+  })
+
+  it('surfaces upload failures with status and body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ errors: [{ message: 'nope' }] }, false, 403))
+
+    await expect(
+      uploadAvatarAsset(new File(['x'], 'a.jpg', { type: 'image/jpeg' }), 'token-1'),
+    ).rejects.toThrow('Avatar upload failed: 403')
+  })
+
+  it('resolves avatar URLs from doc url, filename, or not at all', () => {
+    expect(avatarUrl({ id: 1, url: 'https://cdn/x.jpg' })).toBe('https://cdn/x.jpg')
+    expect(avatarUrl({ id: 1, filename: 'x.jpg' })).toContain('/api/media-assets/file/x.jpg')
+    expect(avatarUrl(5)).toBeNull()
+    expect(avatarUrl(null)).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
@@ -1,0 +1,59 @@
+import { PAYLOAD_API_URL } from '../../../shared/api/client/config'
+import { payloadMutation, payloadRequest } from '../../../shared/api/client/http'
+import type { AvatarAsset, StaffUser, StaffUserPatch } from '../types'
+
+export async function fetchStaffUser(id: number | string, token: string): Promise<StaffUser> {
+  // depth=1 populates the avatar upload relationship for preview
+  return payloadRequest(`/api/users/${id}?depth=1`, token)
+}
+
+export async function updateStaffUser(
+  id: number | string,
+  patch: StaffUserPatch,
+  token: string,
+): Promise<StaffUser> {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', patch, token)) as {
+    doc?: StaffUser
+  }
+  if (!response.doc) {
+    throw new Error('Payload returned no updated user document.')
+  }
+  return response.doc
+}
+
+/**
+ * Direct MediaAsset upload for profile avatars. Questura's domain rules
+ * explicitly reserve direct media-asset uploads for internal profile images,
+ * so this does not go through the MediaSet workflow.
+ */
+export async function uploadAvatarAsset(file: File, token: string): Promise<AvatarAsset> {
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('_payload', JSON.stringify({ alt_text: 'Author profile avatar' }))
+
+  const response = await fetch(`${PAYLOAD_API_URL}/api/media-assets`, {
+    method: 'POST',
+    mode: 'cors',
+    credentials: 'omit',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`Avatar upload failed: ${response.status}${text ? ` — ${text}` : ''}`)
+  }
+
+  const data = (await response.json()) as { doc?: AvatarAsset }
+  if (!data.doc?.id) {
+    throw new Error('Avatar upload returned no media asset document.')
+  }
+  return data.doc
+}
+
+export function avatarUrl(avatar: AvatarAsset | number | null | undefined): string | null {
+  if (!avatar || typeof avatar === 'number') return null
+  if (avatar.url) return avatar.url
+  if (avatar.filename) return `${PAYLOAD_API_URL}/api/media-assets/file/${avatar.filename}`
+  return null
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/index.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/index.ts
@@ -1,0 +1,1 @@
+export { default as MyProfilePage } from './pages/MyProfilePage'

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/pages/MyProfilePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/pages/MyProfilePage.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '../../auth'
+import { avatarUrl, fetchStaffUser, updateStaffUser, uploadAvatarAsset } from '../api/staff.api'
+import type { SocialLinks, StaffUser } from '../types'
+
+type ProfileFormState = {
+  firstName: string
+  lastName: string
+  displayName: string
+  bio: string
+  expertise: string[]
+  socialLinks: Required<{ [K in keyof SocialLinks]: string }>
+}
+
+function formStateFromUser(user: StaffUser): ProfileFormState {
+  return {
+    firstName: user.firstName ?? '',
+    lastName: user.lastName ?? '',
+    displayName: user.publicProfile?.displayName ?? '',
+    bio: user.publicProfile?.bio ?? '',
+    expertise: (user.publicProfile?.expertise ?? []).map((entry) => entry.area),
+    socialLinks: {
+      instagram: user.publicProfile?.socialLinks?.instagram ?? '',
+      twitter: user.publicProfile?.socialLinks?.twitter ?? '',
+      website: user.publicProfile?.socialLinks?.website ?? '',
+    },
+  }
+}
+
+export default function MyProfilePage() {
+  const { user: authUser, token } = useAuth()
+  const queryClient = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const [form, setForm] = useState<ProfileFormState | null>(null)
+  const [newExpertise, setNewExpertise] = useState('')
+  const [pendingAvatarId, setPendingAvatarId] = useState<number | null>(null)
+  const [pendingAvatarPreview, setPendingAvatarPreview] = useState<string | null>(null)
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const userId = authUser?.id
+  const profileQuery = useQuery({
+    queryKey: ['staff', 'me', userId],
+    queryFn: () => fetchStaffUser(userId as string, token as string),
+    enabled: Boolean(userId && token),
+  })
+
+  useEffect(() => {
+    if (profileQuery.data && form === null) {
+      setForm(formStateFromUser(profileQuery.data))
+    }
+  }, [profileQuery.data, form])
+
+  const avatarUpload = useMutation({
+    mutationFn: (file: File) => uploadAvatarAsset(file, token as string),
+    onSuccess: (asset) => {
+      setPendingAvatarId(asset.id)
+      setPendingAvatarPreview(avatarUrl(asset))
+      setErrorMessage(null)
+    },
+    onError: (error: Error) => setErrorMessage(error.message),
+  })
+
+  const saveProfile = useMutation({
+    mutationFn: (state: ProfileFormState) =>
+      updateStaffUser(
+        userId as string,
+        {
+          firstName: state.firstName.trim(),
+          lastName: state.lastName.trim(),
+          publicProfile: {
+            ...(pendingAvatarId !== null ? { avatar: pendingAvatarId } : {}),
+            displayName: state.displayName.trim(),
+            bio: state.bio.trim(),
+            expertise: state.expertise
+              .map((area) => area.trim())
+              .filter(Boolean)
+              .map((area) => ({ area })),
+            socialLinks: {
+              instagram: state.socialLinks.instagram.trim() || null,
+              twitter: state.socialLinks.twitter.trim() || null,
+              website: state.socialLinks.website.trim() || null,
+            },
+          },
+        },
+        token as string,
+      ),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['staff', 'me', userId], updated)
+      setForm(formStateFromUser(updated))
+      setPendingAvatarId(null)
+      setPendingAvatarPreview(null)
+      setStatusMessage('Profile saved.')
+      setErrorMessage(null)
+    },
+    onError: (error: Error) => {
+      setStatusMessage(null)
+      setErrorMessage(error.message)
+    },
+  })
+
+  if (!userId || !token) return null
+
+  if (profileQuery.isLoading || form === null) {
+    return (
+      <div className="staff-page">
+        <p className="staff-muted">Loading your profile…</p>
+      </div>
+    )
+  }
+
+  if (profileQuery.isError) {
+    return (
+      <div className="staff-page">
+        <p className="staff-error">Could not load your profile: {(profileQuery.error as Error).message}</p>
+      </div>
+    )
+  }
+
+  const profile = profileQuery.data as StaffUser
+  const currentAvatar = pendingAvatarPreview ?? avatarUrl(profile.publicProfile?.avatar)
+
+  function update<K extends keyof ProfileFormState>(key: K, value: ProfileFormState[K]) {
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev))
+    setStatusMessage(null)
+  }
+
+  function addExpertise() {
+    const area = newExpertise.trim()
+    if (!area || !form) return
+    if (form.expertise.some((existing) => existing.toLowerCase() === area.toLowerCase())) {
+      setNewExpertise('')
+      return
+    }
+    update('expertise', [...form.expertise, area])
+    setNewExpertise('')
+  }
+
+  return (
+    <div className="staff-page">
+      <header className="staff-page-header">
+        <h1>My Profile</h1>
+        <p className="staff-muted">
+          How you appear as an author on the public site. Your author page goes live automatically
+          once you have published work.
+        </p>
+      </header>
+
+      <form
+        className="staff-card"
+        onSubmit={(event) => {
+          event.preventDefault()
+          saveProfile.mutate(form)
+        }}
+      >
+        <section className="staff-section">
+          <h2>Avatar</h2>
+          <div className="staff-avatar-row">
+            {currentAvatar ? (
+              <img className="staff-avatar" src={currentAvatar} alt="Profile avatar" />
+            ) : (
+              <div className="staff-avatar staff-avatar-empty" aria-hidden="true">
+                {(form.displayName || form.firstName || profile.email).slice(0, 1).toUpperCase()}
+              </div>
+            )}
+            <div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="staff-file-input"
+                onChange={(event) => {
+                  const file = event.target.files?.[0]
+                  if (file) avatarUpload.mutate(file)
+                }}
+              />
+              <button
+                type="button"
+                className="staff-button-secondary"
+                disabled={avatarUpload.isPending}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {avatarUpload.isPending ? 'Uploading…' : 'Upload new avatar'}
+              </button>
+              {pendingAvatarId !== null ? (
+                <p className="staff-hint">New avatar is applied when you save.</p>
+              ) : null}
+            </div>
+          </div>
+        </section>
+
+        <section className="staff-section">
+          <h2>Name</h2>
+          <div className="staff-field-row">
+            <label className="staff-field">
+              <span>First name</span>
+              <input
+                type="text"
+                value={form.firstName}
+                onChange={(event) => update('firstName', event.target.value)}
+              />
+            </label>
+            <label className="staff-field">
+              <span>Last name</span>
+              <input
+                type="text"
+                value={form.lastName}
+                onChange={(event) => update('lastName', event.target.value)}
+              />
+            </label>
+          </div>
+          <label className="staff-field">
+            <span>Display name (byline)</span>
+            <input
+              type="text"
+              value={form.displayName}
+              placeholder={`${form.firstName} ${form.lastName}`.trim() || 'Shown to readers'}
+              onChange={(event) => update('displayName', event.target.value)}
+            />
+          </label>
+          {profile.slug ? (
+            <p className="staff-hint">
+              Author page: <code>/authors/{profile.slug}</code> — the URL is managed by admins.
+            </p>
+          ) : (
+            <p className="staff-hint">Your author URL is generated the first time your profile is saved.</p>
+          )}
+        </section>
+
+        <section className="staff-section">
+          <h2>Bio</h2>
+          <label className="staff-field">
+            <span>Travel expert biography</span>
+            <textarea
+              rows={5}
+              value={form.bio}
+              onChange={(event) => update('bio', event.target.value)}
+            />
+          </label>
+        </section>
+
+        <section className="staff-section">
+          <h2>Expertise</h2>
+          <div className="staff-chip-row">
+            {form.expertise.map((area) => (
+              <span key={area} className="staff-chip">
+                {area}
+                <button
+                  type="button"
+                  aria-label={`Remove ${area}`}
+                  onClick={() =>
+                    update(
+                      'expertise',
+                      form.expertise.filter((existing) => existing !== area),
+                    )
+                  }
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+            {form.expertise.length === 0 ? (
+              <span className="staff-muted">No areas yet — e.g. “Southeast Asia”, “Budget Travel”.</span>
+            ) : null}
+          </div>
+          <div className="staff-field-row staff-add-row">
+            <input
+              type="text"
+              value={newExpertise}
+              placeholder="Add an area of expertise"
+              onChange={(event) => setNewExpertise(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  addExpertise()
+                }
+              }}
+            />
+            <button type="button" className="staff-button-secondary" onClick={addExpertise}>
+              Add
+            </button>
+          </div>
+        </section>
+
+        <section className="staff-section">
+          <h2>Social links</h2>
+          <label className="staff-field">
+            <span>Instagram URL</span>
+            <input
+              type="url"
+              value={form.socialLinks.instagram}
+              placeholder="https://instagram.com/…"
+              onChange={(event) =>
+                update('socialLinks', { ...form.socialLinks, instagram: event.target.value })
+              }
+            />
+          </label>
+          <label className="staff-field">
+            <span>Twitter / X URL</span>
+            <input
+              type="url"
+              value={form.socialLinks.twitter}
+              placeholder="https://x.com/…"
+              onChange={(event) =>
+                update('socialLinks', { ...form.socialLinks, twitter: event.target.value })
+              }
+            />
+          </label>
+          <label className="staff-field">
+            <span>Website URL</span>
+            <input
+              type="url"
+              value={form.socialLinks.website}
+              placeholder="https://…"
+              onChange={(event) =>
+                update('socialLinks', { ...form.socialLinks, website: event.target.value })
+              }
+            />
+          </label>
+        </section>
+
+        <footer className="staff-form-footer">
+          {statusMessage ? <span className="staff-success">{statusMessage}</span> : null}
+          {errorMessage ? <span className="staff-error">{errorMessage}</span> : null}
+          <button type="submit" className="staff-button-primary" disabled={saveProfile.isPending}>
+            {saveProfile.isPending ? 'Saving…' : 'Save profile'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/types.ts
@@ -1,0 +1,51 @@
+export type StaffRole = 'admin' | 'editor' | 'writer'
+
+export type AvatarAsset = {
+  id: number
+  url?: string | null
+  filename?: string | null
+  alt_text?: string | null
+}
+
+export type ExpertiseEntry = {
+  id?: string | null
+  area: string
+}
+
+export type SocialLinks = {
+  instagram?: string | null
+  twitter?: string | null
+  website?: string | null
+}
+
+export type PublicProfile = {
+  avatar?: AvatarAsset | number | null
+  displayName?: string | null
+  bio?: string | null
+  expertise?: ExpertiseEntry[] | null
+  socialLinks?: SocialLinks | null
+}
+
+export type StaffUser = {
+  id: number
+  email: string
+  role: StaffRole
+  firstName?: string | null
+  lastName?: string | null
+  slug?: string | null
+  createdAt?: string
+  updatedAt?: string
+  publicProfile?: PublicProfile | null
+}
+
+export type StaffUserPatch = {
+  firstName?: string
+  lastName?: string
+  publicProfile?: {
+    avatar?: number | null
+    displayName?: string
+    bio?: string
+    expertise?: { area: string }[]
+    socialLinks?: SocialLinks
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/styles.css
+++ b/apps/ai-blog-writer/apps/frontend/src/styles.css
@@ -2,3 +2,4 @@
 @import './css/base.css';
 @import './css/landing.css';
 @import './css/auth.css';
+@import './css/staff.css';


### PR DESCRIPTION
## Summary
Slice 2 of the staff-management plan (policy landed in #48):

- New `features/staff` in the ABW frontend with a **My Profile** page: every logged-in Staff identity edits their own names, display name (byline), bio, expertise chips, social links, and avatar
- Direct Payload CRUD with the staff JWT (`GET/PATCH /api/users/:id`) per ADR-0001/ADR-0023 — no ABW backend changes, Payload access rules are the enforcement point
- Avatar uploads `POST /api/media-assets` directly (Questura domain rules reserve direct MediaAsset uploads for internal profile images)
- Author page URL displayed read-only with a note that admins manage the slug
- "My Profile" entry in the nav user menu (desktop dropdown + mobile)

## Testing
- Unit tests for the staff API client (auth headers, PATCH body, multipart upload, error surfacing, avatar URL resolution)
- Auth feature tests still pass; `tsc` reports no errors in touched files (pre-existing model-selector test errors unchanged)