### PR TITLE
Refactor: dedupe payments period-end/renewal helpers, single splitDisplayName, remove dead code

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -9,7 +9,7 @@ import config from '@/payload.config'
 import Stripe from 'stripe'
 import type { StripeSubscriptionExpanded } from '@/payments/types'
 import { APP_CONFIG } from '@/shared/config'
-import { findVisitorProfileByStripeCustomerId } from '@/features/visitor-auth/lib/visitor-profile'
+import { findVisitorProfileByStripeCustomerId, splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
 import { logger } from '@/shared/utils/logger'
 
 export async function POST(req: NextRequest) {
@@ -128,6 +128,36 @@ export async function POST(req: NextRequest) {
 }
 
 /**
+ * Resolve the subscription's current period end as an ISO string, preferring
+ * the timestamp on the webhook payload and falling back to the Stripe API
+ * when the payload doesn't carry a usable value.
+ */
+async function resolveRenewalDate(subscription: Stripe.Subscription): Promise<string | null> {
+  const expandedSubscription = subscription as StripeSubscriptionExpanded
+
+  if (expandedSubscription.current_period_end) {
+    const convertedDate = convertStripeTimestamp(expandedSubscription.current_period_end)
+    if (convertedDate) {
+      return convertedDate.toISOString()
+    }
+  }
+
+  try {
+    const subscriptionDetails = await getStripeSubscriptionDetails(subscription.id)
+    if (subscriptionDetails?.currentPeriodEnd) {
+      return subscriptionDetails.currentPeriodEnd.toISOString()
+    }
+  } catch (error) {
+    logger.error('Error fetching subscription details from Stripe', {
+      subscriptionId: subscription.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return null
+}
+
+/**
  * Extract the subscription ID from subscription lifecycle events.
  * Used for the ordering guard — only these events carry full subscription
  * state that a stale delivery could overwrite.
@@ -220,9 +250,9 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
   if (billingName) {
     const profile = await findVisitorProfileByStripeCustomerId(customerId)
     if (profile && !profile.firstName && !profile.lastName) {
-      const parts = billingName.split(/\s+/).filter(Boolean)
-      updateData.firstName = parts[0] ?? ''
-      updateData.lastName = parts.slice(1).join(' ')
+      const { firstName, lastName } = splitDisplayName(billingName)
+      updateData.firstName = firstName
+      updateData.lastName = lastName
     }
   }
 
@@ -248,41 +278,9 @@ async function handleSubscriptionCreated(subscription: Stripe.Subscription) {
   const customerId = subscription.customer as string
 
   const status = mapStripeStatusToInternal(subscription.status)
-  const expandedSubscription = subscription as StripeSubscriptionExpanded
 
   // Get renewal date for active subscriptions
-  let subscriptionRenewsAt: string | null = null
-  if (status === 'active') {
-    // Try to get renewal date from webhook event data first
-    if (expandedSubscription.current_period_end) {
-      try {
-        const convertedDate = convertStripeTimestamp(expandedSubscription.current_period_end)
-        if (convertedDate) {
-          subscriptionRenewsAt = convertedDate.toISOString()
-        }
-      } catch (error) {
-        logger.error('Error converting current_period_end from webhook', {
-          subscriptionId: subscription.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-
-    // Fallback to Stripe API if webhook data failed
-    if (!subscriptionRenewsAt) {
-      try {
-        const subscriptionDetails = await getStripeSubscriptionDetails(subscription.id)
-        if (subscriptionDetails?.currentPeriodEnd) {
-          subscriptionRenewsAt = subscriptionDetails.currentPeriodEnd.toISOString()
-        }
-      } catch (error) {
-        logger.error('Error fetching subscription details from Stripe', {
-          subscriptionId: subscription.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-  }
+  const subscriptionRenewsAt = status === 'active' ? await resolveRenewalDate(subscription) : null
 
   await updateUserSubscription(customerId, {
     stripeSubscriptionId: subscription.id,
@@ -316,79 +314,20 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   const cancelAtPeriodEnd = expandedSubscription.cancel_at_period_end || false
 
   // Get renewal date for active subscriptions, clear for inactive ones
-  let subscriptionRenewsAt: string | null = null
-  if (status === 'active') {
-    // Try to get renewal date from webhook event data first
-    if (expandedSubscription.current_period_end) {
-      try {
-        const convertedDate = convertStripeTimestamp(expandedSubscription.current_period_end)
-        if (convertedDate) {
-          subscriptionRenewsAt = convertedDate.toISOString()
-        }
-      } catch (error) {
-        logger.error('Error converting current_period_end from webhook', {
-          subscriptionId: subscription.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-
-    // Fallback to Stripe API if webhook data failed
-    if (!subscriptionRenewsAt) {
-      try {
-        const subscriptionDetails = await getStripeSubscriptionDetails(subscription.id)
-        if (subscriptionDetails?.currentPeriodEnd) {
-          subscriptionRenewsAt = subscriptionDetails.currentPeriodEnd.toISOString()
-        }
-      } catch (error) {
-        logger.error('Error fetching subscription details from Stripe', {
-          subscriptionId: subscription.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-  }
+  const subscriptionRenewsAt = status === 'active' ? await resolveRenewalDate(subscription) : null
 
   // Set membershipExpiration when subscription is cancelled but still active
-  // Clear it when subscription is reactivated or renewed
+  // (the paid period runs to the same current-period-end a renewal would use).
+  // Stays null when the subscription is renewing, which clears any previous value.
   let membershipExpiration: string | null = null
   if (cancelAtPeriodEnd && status === 'active') {
-    // Subscription cancelled but still active until period end
-    if (expandedSubscription.current_period_end) {
-      try {
-        const convertedDate = convertStripeTimestamp(expandedSubscription.current_period_end)
-        if (convertedDate) {
-          membershipExpiration = convertedDate.toISOString()
-        }
-      } catch (error) {
-        logger.error('Error converting expiration date from webhook event', {
-          subscriptionId: subscription.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    } else {
-      // Fetch subscription details from Stripe API to get the period end date
-      try {
-        const subscriptionDetails = await getStripeSubscriptionDetails(subscription.id)
-        if (subscriptionDetails?.currentPeriodEnd) {
-          membershipExpiration = subscriptionDetails.currentPeriodEnd.toISOString()
-        }
-      } catch (error) {
-        logger.error('Error fetching subscription details from Stripe', {
-          subscriptionId: subscription.id,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
+    membershipExpiration = subscriptionRenewsAt
     if (membershipExpiration) {
       logger.info('Subscription cancelled but active until period end', {
         subscriptionId: subscription.id,
         membershipExpiration,
       })
     }
-  } else if (!cancelAtPeriodEnd && status === 'active') {
-    // Subscription was reactivated or renewed - clear expiration and cancel flag
-    membershipExpiration = null
   }
 
   await updateUserSubscription(customerId, {

--- a/apps/questura/apps/server/src/features/media/lib/index.ts
+++ b/apps/questura/apps/server/src/features/media/lib/index.ts
@@ -4,13 +4,11 @@
  */
 
 export {
-  initializeBunnyService,
   formatBytes,
   isValidContentType,
   isAllowedMimeType,
   isFileSizeValid,
   getMaxFileSizeDisplay,
-  buildMediaUrl,
   isBunnyEnabled,
   getCostThreshold,
 } from './media-utils'

--- a/apps/questura/apps/server/src/features/media/lib/media-utils.ts
+++ b/apps/questura/apps/server/src/features/media/lib/media-utils.ts
@@ -52,18 +52,6 @@ export function getMaxFileSizeDisplay(): string {
 }
 
 /**
- * Build a CDN URL for a media asset
- */
-export function buildMediaUrl(
-  filename: string,
-  variant?: string
-): string {
-  const cdnUrl = process.env.BUNNY_STORAGE_HOSTNAME || 'https://questurian-cdn.b-cdn.net'
-  const path = variant ? `${filename}?v=${variant}` : filename
-  return `${cdnUrl}/${path}`
-}
-
-/**
  * Check if Bunny.net is enabled
  */
 export function isBunnyEnabled(): boolean {
@@ -75,27 +63,4 @@ export function isBunnyEnabled(): boolean {
  */
 export function getCostThreshold(): number {
   return 30
-}
-
-/**
- * Initialize BunnyService with app configuration
- * @deprecated Use @seshuk/payload-storage-bunny plugin instead
- */
-export function initializeBunnyService(): any {
-  const apiKey = process.env.BUNNY_STORAGE_API_KEY
-  const hostname = process.env.BUNNY_STORAGE_HOSTNAME
-  const zoneName = process.env.BUNNY_STORAGE_ZONE_NAME
-
-  if (!apiKey) {
-    throw new Error(
-      'BUNNY_STORAGE_API_KEY not configured. Set BUNNY_STORAGE_API_KEY environment variable.'
-    )
-  }
-
-  // Return config object instead of BunnyService since it's no longer used
-  return {
-    apiKey,
-    hostname,
-    zoneName,
-  }
 }

--- a/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
@@ -11,6 +11,27 @@ import {
 } from '@/features/visitor-auth/lib/visitor-profile'
 
 /**
+ * Stripe returns current_period_end/start on the first subscription item,
+ * not at the subscription root.
+ */
+function getFirstSubscriptionItem(
+  subscription: StripeSubscriptionExpanded
+): { current_period_end?: number | null; current_period_start?: number | null } | null {
+  if (subscription.items && Array.isArray(subscription.items.data) && subscription.items.data.length > 0) {
+    return subscription.items.data[0] as any
+  }
+  return null
+}
+
+/**
+ * Extract the subscription's current period end from items.data[0] and
+ * convert it to a Date. Returns null when it can't be determined.
+ */
+export function getCurrentPeriodEnd(subscription: StripeSubscriptionExpanded): Date | null {
+  return convertStripeTimestamp(getFirstSubscriptionItem(subscription)?.current_period_end || null)
+}
+
+/**
  * Updates a VisitorProfile subscription based on Stripe customer ID.
  */
 export async function updateUserSubscription(
@@ -59,25 +80,13 @@ export async function getStripeSubscriptionDetails(subscriptionId: string) {
 
     const expanded = subscription as unknown as StripeSubscriptionExpanded
 
-    // CRITICAL: Stripe returns the period dates in the subscription items, not at the root level
-    // Access them from subscription.items.data[0].current_period_end/start
-    let currentPeriodEnd: number | null = null
-    let currentPeriodStart: number | null = null
-
-    if (expanded.items && Array.isArray(expanded.items.data) && expanded.items.data.length > 0) {
-      const firstItem = expanded.items.data[0] as any
-      currentPeriodEnd = firstItem.current_period_end || null
-      currentPeriodStart = firstItem.current_period_start || null
-    }
-
-    const result = {
+    return {
       status: expanded.status,
-      currentPeriodEnd: convertStripeTimestamp(currentPeriodEnd),
-      currentPeriodStart: convertStripeTimestamp(currentPeriodStart),
+      currentPeriodEnd: getCurrentPeriodEnd(expanded),
+      currentPeriodStart: convertStripeTimestamp(getFirstSubscriptionItem(expanded)?.current_period_start || null),
       cancelAtPeriodEnd: expanded.cancel_at_period_end,
       customerId: expanded.customer as string
     }
-    return result
   } catch (error) {
     logger.error('Error retrieving Stripe subscription', {
       subscriptionId,
@@ -113,13 +122,8 @@ export async function cancelUserSubscription(authUserId: string): Promise<{
       cancel_at_period_end: true
     }) as unknown as StripeSubscriptionExpanded
 
-    // Calculate when membership will actually expire (extract from nested items.data[0] location)
-    let membershipExpiresAt: Date | null = null
-    if (cancelledSubscription.items && Array.isArray(cancelledSubscription.items.data) && cancelledSubscription.items.data.length > 0) {
-      const firstItem = cancelledSubscription.items.data[0] as any
-      const currentPeriodEnd = firstItem.current_period_end || null
-      membershipExpiresAt = convertStripeTimestamp(currentPeriodEnd)
-    }
+    // Calculate when membership will actually expire
+    const membershipExpiresAt = getCurrentPeriodEnd(cancelledSubscription)
 
     await payload.update({
       collection: 'visitor-profiles',
@@ -211,13 +215,8 @@ export async function reactivateUserSubscription(authUserId: string): Promise<{
       cancel_at_period_end: false
     }) as unknown as StripeSubscriptionExpanded
 
-    // Get the new renewal date from the nested items.data[0] location (same as retrieve)
-    let renewsAt: Date | null = null
-    if (updatedSubscription.items && Array.isArray(updatedSubscription.items.data) && updatedSubscription.items.data.length > 0) {
-      const firstItem = updatedSubscription.items.data[0] as any
-      const currentPeriodEnd = firstItem.current_period_end || null
-      renewsAt = convertStripeTimestamp(currentPeriodEnd)
-    }
+    // Get the new renewal date
+    const renewsAt = getCurrentPeriodEnd(updatedSubscription)
 
     if (!renewsAt) {
       return {

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
@@ -10,7 +10,7 @@ import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { redisSecondaryStorage } from './redis-secondary-storage'
 import { auditVisitorAuthSecurityEvent } from './security-audit'
 import { isStaffEmail, normalizeEmail } from './staff-email-guard'
-import { ensureVisitorProfileForAuthUser, updateVisitorProfileByAuthUserId } from './visitor-profile'
+import { ensureVisitorProfileForAuthUser, splitDisplayName, updateVisitorProfileByAuthUserId } from './visitor-profile'
 
 const databaseUrl = APP_CONFIG.database.uri
 
@@ -24,16 +24,6 @@ if (APP_CONFIG.isProduction && !APP_CONFIG.redis.url) {
 
 if (APP_CONFIG.isProduction && APP_CONFIG.turnstile.enabled && !APP_CONFIG.turnstile.secretKey) {
   throw new Error('TURNSTILE_SECRET_KEY is required when Visitor auth bot protection is enabled')
-}
-
-function splitDisplayName(name: string | null | undefined): { firstName: string; lastName: string } {
-  const parts = (name ?? '').trim().split(/\s+/).filter(Boolean)
-  if (parts.length === 0) return { firstName: '', lastName: '' }
-  if (parts.length === 1) return { firstName: parts[0], lastName: '' }
-  return {
-    firstName: parts[0],
-    lastName: parts.slice(1).join(' '),
-  }
 }
 
 const googleProvider =

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.ts
@@ -9,7 +9,7 @@ type BetterAuthUser = {
   name?: string | null
 }
 
-function splitDisplayName(name: string | null | undefined): { firstName: string; lastName: string } {
+export function splitDisplayName(name: string | null | undefined): { firstName: string; lastName: string } {
   const parts = (name ?? '').trim().split(/\s+/).filter(Boolean)
   if (parts.length === 0) return { firstName: '', lastName: '' }
   if (parts.length === 1) return { firstName: parts[0], lastName: '' }

--- a/apps/questura/apps/server/src/shared/config/index.ts
+++ b/apps/questura/apps/server/src/shared/config/index.ts
@@ -19,12 +19,12 @@ export const APP_CONFIG = {
   // Security & Authentication
   payloadSecret: process.env.PAYLOAD_SECRET || '',
 
-  // Google OAuth Configuration (redirectUri set below after backendUrl is computed)
+  // Google OAuth Configuration (the redirect URI is built where the provider
+  // is configured, in visitor-auth/lib/better-auth.ts)
   google: {
     clientId: process.env.GOOGLE_CLIENT_ID || '',
     clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-    redirectUri: '', // Set dynamically below
-  } as any,
+  },
 
   // Stripe Configuration
   stripe: {
@@ -74,16 +74,6 @@ export const APP_CONFIG = {
   isProduction: process.env.NODE_ENV === 'production',
   nodeEnv: (process.env.NODE_ENV || 'development') as 'development' | 'production' | 'test',
 } as const
-
-// Set Google redirect URI to use ngrok (external service requirement)
-// Google OAuth requires a real URL, not localhost
-export const APP_CONFIG_WITH_GOOGLE = {
-  ...APP_CONFIG,
-  google: {
-    ...APP_CONFIG.google,
-    redirectUri: `${APP_CONFIG.backendUrl}/api/visitor-auth/callback/google`,
-  },
-}
 
 // Re-export URL utilities for convenience
 export { APP_URLS }


### PR DESCRIPTION
Addresses the [redundant]/[duplicate-logic]/[dead-code] items from the code review:

- **`resolveRenewalDate(subscription)`** extracted in the Stripe webhook route — replaces the ~30-line copy-pasted "renewal date from webhook, fall back to Stripe API" blocks in `handleSubscriptionCreated` and `handleSubscriptionUpdated`. Also reused for `membershipExpiration` in the cancel-at-period-end path, which has the same period-end semantics (minor improvement: that path now also falls back to the API when the webhook timestamp is present but unparseable, matching the renewal path).
- **`getCurrentPeriodEnd(subscription)`** extracted in `payment-service.ts` — replaces the three inline `items.data[0].current_period_end` extractions (subscription details, cancel, reactivate).
- **`splitDisplayName`** now exported once from `visitor-auth/lib/visitor-profile.ts`; the identical copy in `better-auth.ts` and the inline re-implementation in the webhook route are gone.
- **Dead code removed:** `APP_CONFIG_WITH_GOOGLE` (never imported) and the stale `google.redirectUri: ''` + "set dynamically below" comment (the real redirect URI is built in `better-auth.ts`); `buildMediaUrl` and the `@deprecated` `initializeBunnyService` plus their barrel exports (only referenced from the barrel, never called — `buildMediaUrl` also disagreed with the rest of the codebase on whether `BUNNY_STORAGE_HOSTNAME` is a URL or a hostname).

Net −119 lines. Tests: 288/288 pass. Lint clean; no new typecheck errors.