### PR TITLE
type webhook subscription update payload with UserSubscriptionUpdate

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -7,7 +7,7 @@ import { sendMembershipConfirmationEmail, sendSubscriptionCancelledEmail } from 
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import Stripe from 'stripe'
-import type { StripeSubscriptionExpanded } from '@/payments/types'
+import type { StripeSubscriptionExpanded, UserSubscriptionUpdate } from '@/payments/types'
 import { APP_CONFIG } from '@/shared/config'
 import { findVisitorProfileByStripeCustomerId, splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
 import { logger } from '@/shared/utils/logger'
@@ -227,7 +227,7 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
   }
 
   // Extract affiliate referral ID from metadata if present (and feature enabled)
-  const updateData: any = {
+  const updateData: UserSubscriptionUpdate = {
     stripeSubscriptionId: subscriptionId,
     subscriptionStatus: 'active',
     subscriptionRenewsAt
@@ -239,7 +239,7 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
       logger.info('Subscription created via affiliate referral', { referralId, subscriptionId })
       // Store affiliate referral info
       updateData.affiliateReferralId = referralId
-      updateData.affiliateReferredAt = new Date()
+      updateData.affiliateReferredAt = new Date().toISOString()
     }
   }
 

--- a/apps/questura/apps/server/src/features/payments/types/payment-service.types.ts
+++ b/apps/questura/apps/server/src/features/payments/types/payment-service.types.ts
@@ -6,6 +6,8 @@ export interface UserSubscriptionUpdate {
   cancelAtPeriodEnd?: boolean
   firstName?: string
   lastName?: string
+  affiliateReferralId?: string
+  affiliateReferredAt?: string
 }
 
 export interface StripeCleanupResult {


### PR DESCRIPTION
Replaces the `updateData: any` cast in the Stripe webhook checkout handler with the existing `UserSubscriptionUpdate` type, extending it with the affiliate fields (`affiliateReferralId`, `affiliateReferredAt`). `affiliateReferredAt` now stores an ISO string, matching the payload-types field (`string | null`).

From code review finding: [naming] `updateData: any` on the subscription update payload.