### PR TITLE
omit CORS headers for disallowed origins

### DIFF
--- a/apps/questura/apps/server/src/shared/utils/cors.test.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/shared/config', () => ({
+  APP_CONFIG: {
+    CORS_ORIGINS: ['http://localhost:3000', 'https://app.example.com'],
+  },
+}))
+
+import { getCorsHeaders } from './cors'
+
+function requestWithOrigin(origin?: string) {
+  return new NextRequest('http://localhost:4000/api/health', {
+    headers: origin ? { origin } : {},
+  })
+}
+
+describe('getCorsHeaders', () => {
+  it('reflects an allowed origin with credentials', () => {
+    const headers = getCorsHeaders(requestWithOrigin('https://app.example.com'))
+
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://app.example.com')
+    expect(headers['Access-Control-Allow-Credentials']).toBe('true')
+    expect(headers['Vary']).toBe('Origin')
+  })
+
+  it('omits Access-Control-Allow-Origin for disallowed origins', () => {
+    const headers = getCorsHeaders(requestWithOrigin('https://evil.example.com'))
+
+    expect(headers).not.toHaveProperty('Access-Control-Allow-Origin')
+    expect(headers).not.toHaveProperty('Access-Control-Allow-Credentials')
+  })
+
+  it('omits Access-Control-Allow-Origin when no origin header is present', () => {
+    const headers = getCorsHeaders(requestWithOrigin())
+
+    expect(headers).not.toHaveProperty('Access-Control-Allow-Origin')
+    expect(headers).not.toHaveProperty('Access-Control-Allow-Credentials')
+  })
+})

--- a/apps/questura/apps/server/src/shared/utils/cors.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.ts
@@ -1,18 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { APP_CONFIG, APP_URLS } from '@/shared/config'
+import { APP_CONFIG } from '@/shared/config'
 
 const ALLOWED_ORIGINS = APP_CONFIG.CORS_ORIGINS
 
-export function getCorsHeaders(req: NextRequest) {
+export function getCorsHeaders(req: NextRequest): Record<string, string> {
   const origin = req.headers.get('origin')
-  const corsOrigin = ALLOWED_ORIGINS.includes(origin || '') ? origin : APP_URLS.frontend
 
-  return {
-    'Access-Control-Allow-Origin': corsOrigin!,
-    'Access-Control-Allow-Credentials': 'true',
+  const headers: Record<string, string> = {
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, Cookie, ngrok-skip-browser-warning, x-captcha-response',
+    'Vary': 'Origin',
   }
+
+  // Only reflect origins on the allowlist; disallowed origins get no
+  // Access-Control-Allow-Origin header at all (the browser then blocks them).
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin
+    headers['Access-Control-Allow-Credentials'] = 'true'
+  }
+
+  return headers
 }
 
 export function handleCorsOptions(req: NextRequest) {


### PR DESCRIPTION
Previously `getCorsHeaders` fell back to `Access-Control-Allow-Origin: <frontend>` with `Access-Control-Allow-Credentials: true` for any unknown origin. Now only allowlisted origins are reflected (with credentials); disallowed or absent origins get no ACAO/credentials headers, so browsers block cross-origin reads outright. Adds `Vary: Origin` and unit tests.

From code review finding: [input-validation] cors.ts unknown-origin fallback.