### PR TITLE
validate referral ID before forwarding to Stripe metadata

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -8,6 +8,22 @@ import {
   updateVisitorProfileByAuthUserId,
 } from '@/features/visitor-auth/lib/visitor-profile'
 
+// Referral IDs are opaque tokens from the Endorsely script; anything else in
+// the body must not reach Stripe metadata. Stripe caps metadata values at 500
+// chars — bound well below that.
+const REFERRAL_ID_MAX_LENGTH = 100
+
+function sanitizeReferralId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0 || trimmed.length > REFERRAL_ID_MAX_LENGTH) {
+    return null
+  }
+  return trimmed
+}
+
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
 
@@ -38,7 +54,7 @@ export async function POST(req: NextRequest) {
     if (APP_CONFIG.features.endorselyAffiliates) {
       try {
         const body = await req.json()
-        referralId = body.referralId || null
+        referralId = sanitizeReferralId(body?.referralId)
       } catch {
         // Body is optional, continue without it
       }

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  requireVisitorPrincipal: vi.fn(),
+  findVisitorProfileByAuthUserId: vi.fn(),
+  updateVisitorProfileByAuthUserId: vi.fn(),
+  stripeCustomerCreate: vi.fn(),
+  stripeCheckoutCreate: vi.fn(),
+}))
+
+vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
+  requireVisitorPrincipal: mocks.requireVisitorPrincipal,
+}))
+
+vi.mock('@/features/visitor-auth/lib/visitor-profile', () => ({
+  findVisitorProfileByAuthUserId: mocks.findVisitorProfileByAuthUserId,
+  updateVisitorProfileByAuthUserId: mocks.updateVisitorProfileByAuthUserId,
+}))
+
+vi.mock('@/payments/lib/stripe', () => ({
+  stripe: {
+    customers: {
+      create: mocks.stripeCustomerCreate,
+    },
+    checkout: {
+      sessions: {
+        create: mocks.stripeCheckoutCreate,
+      },
+    },
+  },
+}))
+
+vi.mock('@/shared/config', () => ({
+  APP_CONFIG: {
+    CORS_ORIGINS: ['http://localhost:3000'],
+    features: {
+      endorselyAffiliates: true,
+    },
+    stripe: {
+      priceId: 'price_123',
+    },
+  },
+  APP_URLS: {
+    frontend: 'http://localhost:3000',
+    frontendUrl: (path: string) => `http://localhost:3000${path}`,
+  },
+}))
+
+import { POST } from '@/app/api/payments/create-checkout-session/route'
+
+let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
+
+function createRequest(body: unknown) {
+  return new Request('http://localhost:4000/api/payments/create-checkout-session', {
+    method: 'POST',
+    headers: {
+      origin: 'http://localhost:3000',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  }) as any
+}
+
+describe('create checkout session referral ID validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      result: { authenticated: true },
+      principal: {
+        kind: 'visitor',
+        id: 'visitor_123',
+        email: 'visitor@example.com',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        profileId: 10,
+        emailVerified: true,
+      },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'none',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeCheckoutCreate.mockResolvedValue({
+      id: 'cs_123',
+      url: 'https://checkout.stripe.test/session',
+    })
+  })
+
+  afterEach(() => {
+    consoleLogSpy?.mockRestore()
+    consoleLogSpy = null
+  })
+
+  async function metadataForBody(body: unknown) {
+    const response = await POST(createRequest(body))
+    expect(response.status).toBe(200)
+    return mocks.stripeCheckoutCreate.mock.calls[0][0].metadata
+  }
+
+  it('forwards a valid referral ID into Stripe metadata', async () => {
+    const metadata = await metadataForBody({ referralId: '  ref_abc123  ' })
+
+    expect(metadata.endorsely_referral).toBe('ref_abc123')
+  })
+
+  it('drops non-string referral IDs', async () => {
+    const metadata = await metadataForBody({ referralId: { $gt: '' } })
+
+    expect(metadata).not.toHaveProperty('endorsely_referral')
+  })
+
+  it('drops referral IDs longer than 100 characters', async () => {
+    const metadata = await metadataForBody({ referralId: 'x'.repeat(101) })
+
+    expect(metadata).not.toHaveProperty('endorsely_referral')
+  })
+
+  it('drops empty referral IDs', async () => {
+    const metadata = await metadataForBody({ referralId: '   ' })
+
+    expect(metadata).not.toHaveProperty('endorsely_referral')
+  })
+})


### PR DESCRIPTION
`body.referralId` was accepted with no type or length check before being forwarded into Stripe checkout/subscription metadata. It is now coerced to a trimmed, non-empty string bounded at 100 chars (Stripe caps metadata values at 500); non-strings, empty values, and oversized values are dropped. Adds route tests with the affiliate feature enabled covering valid, non-string, oversized, and empty referral IDs.

From code review finding: [input-validation] create-checkout-session referralId.