### PR TITLE
refactor: split ImageStorageService into composed modules

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/services/storage/image-orphan-cleanup.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/storage/image-orphan-cleanup.ts
@@ -1,0 +1,273 @@
+import { existsSync } from "node:fs";
+import { rm, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { ImagePathResolver } from "./image-path-resolver";
+import type { DeletionResult, OrphanedFileScanResult } from "./image-storage.types";
+
+/**
+ * Delete timestamp folder and all contents
+ * Example: data/images/coco_bambu/instagram/1766982300989/
+ */
+export async function deleteTimestampFolder(timestampDir: string): Promise<void> {
+  try {
+    if (!existsSync(timestampDir)) {
+      console.info("Timestamp folder already deleted", { timestampDir });
+      return;
+    }
+
+    await rm(timestampDir, { recursive: true, force: true });
+    console.info("Deleted timestamp folder", { timestampDir });
+  } catch (error) {
+    console.error("Failed to delete timestamp folder", { timestampDir, error });
+    // Don't throw - graceful degradation
+  }
+}
+
+/**
+ * Delete entire location folder
+ * Example: data/images/coco_bambu/
+ */
+export async function deleteLocationFolder(
+  paths: ImagePathResolver,
+  locationName: string
+): Promise<void> {
+  try {
+    const locationFolder = join(paths.baseImagesDir, locationName);
+
+    if (!existsSync(locationFolder)) {
+      console.info("Location folder already deleted", { locationFolder });
+      return;
+    }
+
+    await rm(locationFolder, { recursive: true, force: true });
+    console.info("Deleted location folder", { locationFolder });
+  } catch (error) {
+    console.error("Failed to delete location folder", { locationName, error });
+    // Don't throw - graceful degradation
+  }
+}
+
+/**
+ * Cleanup empty parent folders recursively (bottom-up)
+ * Deletes timestamp → storageType → location if empty
+ */
+export async function cleanupEmptyFolders(paths: ImagePathResolver, startPath: string): Promise<void> {
+  try {
+    let currentPath = startPath;
+    const baseDir = paths.baseImagesDir;
+
+    // Traverse up to 3 levels: timestamp → storageType → location
+    for (let i = 0; i < 3; i++) {
+      // Stop if we've reached the base images directory
+      if (currentPath === baseDir || !currentPath.startsWith(baseDir)) {
+        break;
+      }
+
+      // Check if directory exists
+      if (!existsSync(currentPath)) {
+        // Already deleted, move up
+        currentPath = join(currentPath, "..");
+        continue;
+      }
+
+      // Check if directory is empty
+      const entries = await readdir(currentPath);
+      if (entries.length === 0) {
+        console.info("Deleting empty folder", { currentPath });
+        await rm(currentPath, { recursive: true, force: true });
+      } else {
+        // Directory not empty, stop cleanup
+        break;
+      }
+
+      // Move up one level
+      currentPath = join(currentPath, "..");
+    }
+  } catch (error) {
+    console.error("Error during empty folder cleanup", { startPath, error });
+    // Don't throw - best effort cleanup
+  }
+}
+
+/**
+ * Get all image paths from database
+ * This is a helper method to scan all tables for image paths
+ */
+async function getAllDatabaseImagePaths(): Promise<string[]> {
+  const paths: string[] = [];
+
+  try {
+    // Import getDb here to avoid circular dependencies
+    const { getDb } = await import("@server/shared/db/client");
+    const db = getDb();
+
+    // Get paths from instagram_embeds table
+    const instagramEmbeds = db.query("SELECT images FROM instagram_embeds WHERE images IS NOT NULL").all() as Array<{ images: string }>;
+    for (const embed of instagramEmbeds) {
+      if (embed.images) {
+        const images = JSON.parse(embed.images);
+        paths.push(...images);
+      }
+    }
+
+    // Get paths from uploads table (legacy format)
+    const uploads = db.query("SELECT images, imageSets FROM uploads WHERE images IS NOT NULL OR imageSets IS NOT NULL").all() as Array<{ images: string | null; imageSets: string | null }>;
+    for (const upload of uploads) {
+      // Legacy format
+      if (upload.images) {
+        const images = JSON.parse(upload.images);
+        paths.push(...images);
+      }
+
+      // ImageSet format
+      if (upload.imageSets) {
+        const imageSet = JSON.parse(upload.imageSets);
+        // Add source image
+        if (imageSet.sourceImage?.path) {
+          paths.push(imageSet.sourceImage.path);
+        }
+        // Add variants
+        if (imageSet.variants) {
+          for (const variant of imageSet.variants) {
+            if (variant.path) {
+              paths.push(variant.path);
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error("Error fetching database image paths", { error });
+  }
+
+  return paths;
+}
+
+/**
+ * Scan filesystem for files not referenced in database
+ */
+export async function scanOrphanedFiles(resolver: ImagePathResolver): Promise<OrphanedFileScanResult> {
+  const orphanedByLocation = new Map<string, { paths: string[]; sizeBytes: number }>();
+  let totalOrphanedFiles = 0;
+  let totalSizeBytes = 0;
+
+  try {
+    // Get all database image paths
+    const dbPaths = await getAllDatabaseImagePaths();
+    const dbPathSet = new Set(dbPaths);
+
+    // Scan filesystem
+    if (!existsSync(resolver.baseImagesDir)) {
+      return { totalOrphanedFiles: 0, totalSizeBytes: 0, orphanedByLocation };
+    }
+
+    const locationDirs = await readdir(resolver.baseImagesDir);
+
+    for (const locationName of locationDirs) {
+      const locationPath = join(resolver.baseImagesDir, locationName);
+      const locationStat = await stat(locationPath);
+
+      if (!locationStat.isDirectory()) continue;
+
+      // Scan storage types (instagram/uploads)
+      const storageTypes = await readdir(locationPath);
+
+      for (const storageType of storageTypes) {
+        if (storageType !== "instagram" && storageType !== "uploads") continue;
+
+        const storageTypePath = join(locationPath, storageType);
+        const storageTypeStat = await stat(storageTypePath);
+
+        if (!storageTypeStat.isDirectory()) continue;
+
+        // Scan timestamp folders
+        const timestamps = await readdir(storageTypePath);
+
+        for (const timestamp of timestamps) {
+          const timestampPath = join(storageTypePath, timestamp);
+          const timestampStat = await stat(timestampPath);
+
+          if (!timestampStat.isDirectory()) continue;
+
+          // Scan files in timestamp folder
+          const files = await readdir(timestampPath);
+
+          for (const file of files) {
+            const filePath = join(timestampPath, file);
+            const fileStat = await stat(filePath);
+
+            if (!fileStat.isFile()) continue;
+
+            // Convert to relative path
+            const relativePath = resolver.toStoredPath(filePath);
+
+            // Check if path exists in database
+            if (!dbPathSet.has(relativePath)) {
+              // Orphaned file found
+              const existing = orphanedByLocation.get(locationName) || { paths: [], sizeBytes: 0 };
+              existing.paths.push(relativePath);
+              existing.sizeBytes += fileStat.size;
+              orphanedByLocation.set(locationName, existing);
+
+              totalOrphanedFiles++;
+              totalSizeBytes += fileStat.size;
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error("Error scanning for orphaned files", { error });
+  }
+
+  return {
+    totalOrphanedFiles,
+    totalSizeBytes,
+    orphanedByLocation
+  };
+}
+
+/**
+ * Delete orphaned files
+ */
+export async function deleteOrphanedFiles(
+  resolver: ImagePathResolver,
+  paths: string[]
+): Promise<DeletionResult> {
+  const result: DeletionResult = {
+    deletedCount: 0,
+    failedCount: 0,
+    errors: []
+  };
+
+  for (const relativePath of paths) {
+    try {
+      const absolutePath = resolver.toAbsolutePath(relativePath);
+
+      if (!existsSync(absolutePath)) {
+        console.warn("File already deleted", { relativePath });
+        result.deletedCount++;
+        continue;
+      }
+
+      await rm(absolutePath, { force: true });
+      console.info("Deleted orphaned file", { relativePath });
+      result.deletedCount++;
+
+      // Extract metadata and cleanup empty folders
+      const metadata = resolver.extractPathMetadata(relativePath);
+      if (metadata) {
+        await cleanupEmptyFolders(resolver, metadata.timestampDir);
+      }
+    } catch (error) {
+      console.error("Failed to delete orphaned file", { relativePath, error });
+      result.failedCount++;
+      result.errors.push({
+        path: relativePath,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/storage/image-path-resolver.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/storage/image-path-resolver.ts
@@ -1,0 +1,169 @@
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import type { ImageStorageConfig, PathMetadata } from "./image-storage.types";
+
+/**
+ * Owns the root directories images live under and every translation between
+ * stored (repo-relative) paths and absolute filesystem paths.
+ *
+ * Stored paths are relative to the server package root so database rows stay
+ * portable across checkouts; absolute paths are what the filesystem calls need.
+ */
+export class ImagePathResolver {
+  readonly serverRoot: string;
+  readonly repoRoot: string;
+  readonly baseImagesDir: string;
+
+  constructor(currentDir: string, baseImagesDir?: string) {
+    this.serverRoot = resolve(currentDir, "../../../../../");
+    this.repoRoot = resolve(this.serverRoot, "../../../..");
+    this.baseImagesDir = this.resolveImagesBaseDir(baseImagesDir);
+  }
+
+  private resolveImagesBaseDir(rawPath?: string): string {
+    const defaultImagesPath = join(this.serverRoot, "data/images");
+    if (!rawPath) {
+      return defaultImagesPath;
+    }
+
+    if (isAbsolute(rawPath)) {
+      return rawPath;
+    }
+
+    const normalized = rawPath.replace(/^\.\//, "");
+    if (
+      normalized.startsWith("packages/") ||
+      normalized.startsWith("apps/")
+    ) {
+      if (normalized === "packages/server/data/images") {
+        return join(this.serverRoot, "data/images");
+      }
+      return resolve(this.repoRoot, normalized);
+    }
+
+    return resolve(this.serverRoot, normalized);
+  }
+
+  toStoredPath(absolutePath: string): string {
+    const relativePath = relative(this.serverRoot, absolutePath).replace(/\\/g, "/");
+    if (relativePath.startsWith("..")) {
+      return absolutePath;
+    }
+    return relativePath;
+  }
+
+  toAbsolutePath(pathValue: string): string {
+    if (pathValue.startsWith("/")) {
+      return pathValue;
+    }
+
+    const normalized = pathValue.replace(/^\.\//, "");
+    if (normalized.startsWith("data/")) {
+      return resolve(this.serverRoot, normalized);
+    }
+    if (normalized.startsWith("packages/") || normalized.startsWith("apps/")) {
+      if (normalized === "packages/server/data/images") {
+        return join(this.serverRoot, "data/images");
+      }
+      return resolve(this.repoRoot, normalized);
+    }
+    return resolve(this.serverRoot, normalized);
+  }
+
+  /**
+   * Generate a clean, filesystem-safe name from location name
+   */
+  sanitizeLocationName(locationName: string): string {
+    return locationName
+      .replace(/[^a-z0-9]/gi, "_")
+      .toLowerCase()
+      .substring(0, 30);
+  }
+
+  /**
+   * Generate full storage path for a given configuration
+   */
+  generateStoragePath(config: ImageStorageConfig): string {
+    const cleanName = this.sanitizeLocationName(config.locationName);
+    return join(
+      config.baseDir || this.baseImagesDir,
+      cleanName,
+      config.storageType,
+      config.timestamp.toString()
+    );
+  }
+
+  /**
+   * Ensure directory structure exists
+   */
+  async ensureDirectoryExists(path: string): Promise<void> {
+    const parts = path.replace(this.baseImagesDir, "").split("/").filter(Boolean);
+    let current = this.baseImagesDir;
+
+    // Ensure base directory exists
+    if (!existsSync(current)) {
+      await mkdir(current, { recursive: true });
+    }
+
+    // Create each subdirectory
+    for (const part of parts) {
+      current = join(current, part);
+      if (!existsSync(current)) {
+        await mkdir(current, { recursive: true });
+      }
+    }
+  }
+
+  /**
+   * Extract location name, storage type, and timestamp from path
+   * Input: "packages/server/data/images/coco_bambu/instagram/1766982300989/image_0.jpg"
+   * Output: { locationName: "coco_bambu", storageType: "instagram", timestamp: "1766982300989", timestampDir: "..." }
+   */
+  extractPathMetadata(relativePath: string): PathMetadata | null {
+    try {
+      // Normalize path separators
+      const normalizedPath = relativePath.replace(/\\/g, "/");
+      const parts = normalizedPath.split("/");
+
+      // Find the "images" directory in the path
+      const imagesIndex = parts.indexOf("images");
+      if (imagesIndex === -1 || imagesIndex + 3 >= parts.length) {
+        console.warn("Invalid path format - missing images directory or insufficient parts", { relativePath });
+        return null;
+      }
+
+      const locationName = parts[imagesIndex + 1];
+      const storageType = parts[imagesIndex + 2];
+      const timestamp = parts[imagesIndex + 3];
+
+      // Validate extracted parts
+      if (!locationName || !storageType || !timestamp) {
+        console.warn("Invalid path format - missing required parts", { relativePath });
+        return null;
+      }
+
+      // Validate storage type
+      if (storageType !== "instagram" && storageType !== "uploads") {
+        console.warn("Invalid storage type", { storageType, relativePath });
+        return null;
+      }
+
+      // Build absolute path to timestamp directory
+      const timestampDir = join(
+        this.serverRoot,
+        parts.slice(0, imagesIndex + 4).join("/")
+      );
+
+      return {
+        locationName,
+        storageType,
+        timestamp,
+        timestampDir
+      };
+    } catch (error) {
+      console.error("Error extracting path metadata", { relativePath, error });
+      return null;
+    }
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/storage/image-storage.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/storage/image-storage.service.ts
@@ -1,132 +1,61 @@
-import { existsSync } from "node:fs";
-import { mkdir, rm, readdir, stat } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { sanitizeUploadedImageBuffer } from "../../utils/image-upload-sanitizer";
-import { extractImageMetadata } from "../../utils/image-metadata-extractor";
+import { ImagePathResolver } from "./image-path-resolver";
+import * as writer from "./image-writer";
+import * as cleanup from "./image-orphan-cleanup";
+import type {
+  ImageStorageConfig,
+  OrphanedFileScanResult,
+  DeletionResult,
+  SaveImageResult,
+  SavedImageSource,
+  PathMetadata,
+} from "./image-storage.types";
 
-export interface ImageStorageConfig {
-  baseDir: string;
-  locationName: string;
-  storageType: "instagram" | "uploads";
-  timestamp: number | string;
-}
+export type {
+  ImageStorageConfig,
+  SaveImageResult,
+  SavedImageSource,
+  PathMetadata,
+  OrphanedFileScanResult,
+  DeletionResult,
+};
 
-export interface SaveImageResult {
-  savedPaths: string[];
-  errors: Array<{ index: number; error: string }>;
-}
-
-export interface SavedImageSource {
-  path: string;
-  metadata: { width: number; height: number; size: number; format: string };
-}
-
-export interface PathMetadata {
-  locationName: string;
-  storageType: "instagram" | "uploads";
-  timestamp: string;
-  timestampDir: string; // Full path to timestamp folder
-}
-
-export interface OrphanedFileScanResult {
-  totalOrphanedFiles: number;
-  totalSizeBytes: number;
-  orphanedByLocation: Map<string, {
-    paths: string[];
-    sizeBytes: number;
-  }>;
-}
-
-export interface DeletionResult {
-  deletedCount: number;
-  failedCount: number;
-  errors: Array<{ path: string; error: string }>;
-}
-
+/**
+ * Filesystem storage for location images.
+ *
+ * Path translation lives in {@link ImagePathResolver}, writing in
+ * `./image-writer`, and orphan scanning/deletion in `./image-orphan-cleanup`.
+ * This class composes them behind the service interface the DI container and
+ * consuming services expect.
+ */
 export class ImageStorageService {
-  private readonly serverRoot: string;
-  private readonly repoRoot: string;
+  private readonly paths: ImagePathResolver;
+
+  /**
+   * Retained as instance members because `uploads.service.ts` and
+   * `instagram.service.ts` reach past `private` via bracket indexing
+   * (`imageStorage["baseImagesDir"]`, `imageStorage["cleanupEmptyFolders"]`).
+   * Dropping them would resolve to `undefined` at runtime, not fail to compile.
+   */
   private readonly baseImagesDir: string;
 
   constructor(baseImagesDir?: string) {
     const currentDir = dirname(fileURLToPath(import.meta.url));
-    this.serverRoot = resolve(currentDir, "../../../../../");
-    this.repoRoot = resolve(this.serverRoot, "../../../..");
-    this.baseImagesDir = this.resolveImagesBaseDir(baseImagesDir ?? process.env.IMAGES_PATH);
+    this.paths = new ImagePathResolver(currentDir, baseImagesDir ?? process.env.IMAGES_PATH);
+    this.baseImagesDir = this.paths.baseImagesDir;
   }
 
-  private resolveImagesBaseDir(rawPath?: string): string {
-    const defaultImagesPath = join(this.serverRoot, "data/images");
-    if (!rawPath) {
-      return defaultImagesPath;
-    }
-
-    if (isAbsolute(rawPath)) {
-      return rawPath;
-    }
-
-    const normalized = rawPath.replace(/^\.\//, "");
-    if (
-      normalized.startsWith("packages/") ||
-      normalized.startsWith("apps/")
-    ) {
-      if (normalized === "packages/server/data/images") {
-        return join(this.serverRoot, "data/images");
-      }
-      return resolve(this.repoRoot, normalized);
-    }
-
-    return resolve(this.serverRoot, normalized);
+  private async cleanupEmptyFolders(startPath: string): Promise<void> {
+    return cleanup.cleanupEmptyFolders(this.paths, startPath);
   }
 
-  private toStoredPath(absolutePath: string): string {
-    const relativePath = relative(this.serverRoot, absolutePath).replace(/\\/g, "/");
-    if (relativePath.startsWith("..")) {
-      return absolutePath;
-    }
-    return relativePath;
-  }
-
-  private toAbsolutePath(pathValue: string): string {
-    if (pathValue.startsWith("/")) {
-      return pathValue;
-    }
-
-    const normalized = pathValue.replace(/^\.\//, "");
-    if (normalized.startsWith("data/")) {
-      return resolve(this.serverRoot, normalized);
-    }
-    if (normalized.startsWith("packages/") || normalized.startsWith("apps/")) {
-      if (normalized === "packages/server/data/images") {
-        return join(this.serverRoot, "data/images");
-      }
-      return resolve(this.repoRoot, normalized);
-    }
-    return resolve(this.serverRoot, normalized);
-  }
-
-  /**
-   * Generate a clean, filesystem-safe name from location name
-   */
   sanitizeLocationName(locationName: string): string {
-    return locationName
-      .replace(/[^a-z0-9]/gi, "_")
-      .toLowerCase()
-      .substring(0, 30);
+    return this.paths.sanitizeLocationName(locationName);
   }
 
-  /**
-   * Generate full storage path for a given configuration
-   */
   generateStoragePath(config: ImageStorageConfig): string {
-    const cleanName = this.sanitizeLocationName(config.locationName);
-    return join(
-      config.baseDir || this.baseImagesDir,
-      cleanName,
-      config.storageType,
-      config.timestamp.toString()
-    );
+    return this.paths.generateStoragePath(config);
   }
 
   createStoragePath(
@@ -135,499 +64,58 @@ export class ImageStorageService {
     timestamp: ImageStorageConfig["timestamp"],
   ): string {
     return this.generateStoragePath({
-      baseDir: this.baseImagesDir,
+      baseDir: this.paths.baseImagesDir,
       locationName,
       storageType,
       timestamp,
     });
   }
 
-  /**
-   * Ensure directory structure exists
-   */
   async ensureDirectoryExists(path: string): Promise<void> {
-    const parts = path.replace(this.baseImagesDir, "").split("/").filter(Boolean);
-    let current = this.baseImagesDir;
-
-    // Ensure base directory exists
-    if (!existsSync(current)) {
-      await mkdir(current, { recursive: true });
-    }
-
-    // Create each subdirectory
-    for (const part of parts) {
-      current = join(current, part);
-      if (!existsSync(current)) {
-        await mkdir(current, { recursive: true });
-      }
-    }
+    return this.paths.ensureDirectoryExists(path);
   }
 
-  /**
-   * Save images from URLs to filesystem
-   */
+  extractPathMetadata(relativePath: string): PathMetadata | null {
+    return this.paths.extractPathMetadata(relativePath);
+  }
+
   async saveImagesFromUrls(
     imageUrls: string[],
     storagePath: string,
     fileExtension: string = "jpg"
   ): Promise<SaveImageResult> {
-    await this.ensureDirectoryExists(storagePath);
-
-    const savedPaths: string[] = [];
-    const errors: Array<{ index: number; error: string }> = [];
-
-    const fetchWithRetry = async (url: string): Promise<Response> => {
-      // First attempt: plain fetch
-      let res = await fetch(url);
-      if (res.ok) return res;
-
-      // Retry once with browser-like headers (helps with some Instagram CDN URLs)
-      res = await fetch(url, {
-        headers: {
-          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-          "Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
-          "Referer": "https://www.instagram.com/",
-        },
-      });
-      return res;
-    };
-
-    for (let i = 0; i < imageUrls.length; i++) {
-      const imgUrl = imageUrls[i];
-      try {
-        const imgRes = await fetchWithRetry(imgUrl!);
-        if (!imgRes.ok) {
-          throw new Error(`HTTP ${imgRes.status}`);
-        }
-
-        const filename = `image_${i}.${fileExtension}`;
-        const filePath = join(storagePath, filename);
-        await Bun.write(filePath, await imgRes.blob());
-
-        savedPaths.push(this.toStoredPath(filePath));
-      } catch (err) {
-        errors.push({
-          index: i,
-          error: err instanceof Error ? err.message : String(err)
-        });
-      }
-    }
-
-    return { savedPaths, errors };
+    return writer.saveImagesFromUrls(this.paths, imageUrls, storagePath, fileExtension);
   }
 
   async saveSanitizedImageFromUrl(url: string, storagePath: string): Promise<SavedImageSource> {
-    await this.ensureDirectoryExists(storagePath);
-    let response = await fetch(url);
-    if (!response.ok) {
-      response = await fetch(url, {
-        headers: {
-          "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36",
-          Accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
-          Referer: "https://www.instagram.com/",
-        },
-      });
-    }
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-
-    const raw = Buffer.from(await response.arrayBuffer());
-    const sanitized = await sanitizeUploadedImageBuffer(raw);
-    const absolutePath = join(storagePath, "source_0.webp");
-    await Bun.write(absolutePath, sanitized);
-    return {
-      path: this.toStoredPath(absolutePath),
-      metadata: await extractImageMetadata(absolutePath),
-    };
+    return writer.saveSanitizedImageFromUrl(this.paths, url, storagePath);
   }
 
-  /**
-   * Stage a StagedSource from an image already on disk (relative `data/...`
-   * or absolute path), re-encoding it into an independent `source_0.webp` under
-   * `storagePath`. Mirrors {@link saveSanitizedImageFromUrl} without a network
-   * fetch — used to backfill Instagram staging from previously-downloaded bytes.
-   */
   async saveSanitizedImageFromFile(localPath: string, storagePath: string): Promise<SavedImageSource> {
-    await this.ensureDirectoryExists(storagePath);
-    const raw = await this.readImage(localPath);
-    const sanitized = await sanitizeUploadedImageBuffer(raw);
-    const absolutePath = join(storagePath, "source_0.webp");
-    await Bun.write(absolutePath, sanitized);
-    return {
-      path: this.toStoredPath(absolutePath),
-      metadata: await extractImageMetadata(absolutePath),
-    };
+    return writer.saveSanitizedImageFromFile(this.paths, localPath, storagePath);
   }
 
-  /**
-   * Save uploaded File objects to filesystem, converting to WebP format
-   */
-  async saveUploadedFiles(
-    files: File[],
-    storagePath: string
-  ): Promise<SaveImageResult> {
-    await this.ensureDirectoryExists(storagePath);
-
-    const savedPaths: string[] = [];
-    const errors: Array<{ index: number; error: string }> = [];
-
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      if (!file) {
-        errors.push({
-          index: i,
-          error: "File is undefined"
-        });
-        continue;
-      }
-
-      try {
-        const buffer = Buffer.from(await file.arrayBuffer());
-        const webpBuffer = await sanitizeUploadedImageBuffer(buffer);
-
-        const filename = `image_${i}.webp`;
-        const filePath = join(storagePath, filename);
-        await Bun.write(filePath, webpBuffer);
-
-        savedPaths.push(this.toStoredPath(filePath));
-      } catch (err) {
-        errors.push({
-          index: i,
-          error: err instanceof Error ? err.message : String(err)
-        });
-      }
-    }
-
-    return { savedPaths, errors };
+  async saveUploadedFiles(files: File[], storagePath: string): Promise<SaveImageResult> {
+    return writer.saveUploadedFiles(this.paths, files, storagePath);
   }
 
-  /**
-   * Read image file and return as Buffer
-   */
   async readImage(filePath: string): Promise<Buffer> {
-    // Handle both relative and absolute paths
-    const absolutePath = this.toAbsolutePath(filePath);
-
-    const file = Bun.file(absolutePath);
-
-    if (!await file.exists()) {
-      throw new Error(`Image file not found: ${filePath}`);
-    }
-
-    const arrayBuffer = await file.arrayBuffer();
-    return Buffer.from(arrayBuffer);
+    return writer.readImage(this.paths, filePath);
   }
 
-  /**
-   * Extract location name, storage type, and timestamp from path
-   * Input: "packages/server/data/images/coco_bambu/instagram/1766982300989/image_0.jpg"
-   * Output: { locationName: "coco_bambu", storageType: "instagram", timestamp: "1766982300989", timestampDir: "..." }
-   */
-  extractPathMetadata(relativePath: string): PathMetadata | null {
-    try {
-      // Normalize path separators
-      const normalizedPath = relativePath.replace(/\\/g, "/");
-      const parts = normalizedPath.split("/");
-
-      // Find the "images" directory in the path
-      const imagesIndex = parts.indexOf("images");
-      if (imagesIndex === -1 || imagesIndex + 3 >= parts.length) {
-        console.warn("Invalid path format - missing images directory or insufficient parts", { relativePath });
-        return null;
-      }
-
-      const locationName = parts[imagesIndex + 1];
-      const storageType = parts[imagesIndex + 2];
-      const timestamp = parts[imagesIndex + 3];
-
-      // Validate extracted parts
-      if (!locationName || !storageType || !timestamp) {
-        console.warn("Invalid path format - missing required parts", { relativePath });
-        return null;
-      }
-
-      // Validate storage type
-      if (storageType !== "instagram" && storageType !== "uploads") {
-        console.warn("Invalid storage type", { storageType, relativePath });
-        return null;
-      }
-
-      // Build absolute path to timestamp directory
-      const timestampDir = join(
-        this.serverRoot,
-        parts.slice(0, imagesIndex + 4).join("/")
-      );
-
-      return {
-        locationName,
-        storageType,
-        timestamp,
-        timestampDir
-      };
-    } catch (error) {
-      console.error("Error extracting path metadata", { relativePath, error });
-      return null;
-    }
-  }
-
-  /**
-   * Delete timestamp folder and all contents
-   * Example: data/images/coco_bambu/instagram/1766982300989/
-   */
   async deleteTimestampFolder(timestampDir: string): Promise<void> {
-    try {
-      if (!existsSync(timestampDir)) {
-        console.info("Timestamp folder already deleted", { timestampDir });
-        return;
-      }
-
-      await rm(timestampDir, { recursive: true, force: true });
-      console.info("Deleted timestamp folder", { timestampDir });
-    } catch (error) {
-      console.error("Failed to delete timestamp folder", { timestampDir, error });
-      // Don't throw - graceful degradation
-    }
+    return cleanup.deleteTimestampFolder(timestampDir);
   }
 
-  /**
-   * Delete entire location folder
-   * Example: data/images/coco_bambu/
-   */
   async deleteLocationFolder(locationName: string): Promise<void> {
-    try {
-      const locationFolder = join(this.baseImagesDir, locationName);
-
-      if (!existsSync(locationFolder)) {
-        console.info("Location folder already deleted", { locationFolder });
-        return;
-      }
-
-      await rm(locationFolder, { recursive: true, force: true });
-      console.info("Deleted location folder", { locationFolder });
-    } catch (error) {
-      console.error("Failed to delete location folder", { locationName, error });
-      // Don't throw - graceful degradation
-    }
+    return cleanup.deleteLocationFolder(this.paths, locationName);
   }
 
-  /**
-   * Cleanup empty parent folders recursively (bottom-up)
-   * Deletes timestamp → storageType → location if empty
-   */
-  private async cleanupEmptyFolders(startPath: string): Promise<void> {
-    try {
-      let currentPath = startPath;
-      const baseDir = this.baseImagesDir;
-
-      // Traverse up to 3 levels: timestamp → storageType → location
-      for (let i = 0; i < 3; i++) {
-        // Stop if we've reached the base images directory
-        if (currentPath === baseDir || !currentPath.startsWith(baseDir)) {
-          break;
-        }
-
-        // Check if directory exists
-        if (!existsSync(currentPath)) {
-          // Already deleted, move up
-          currentPath = join(currentPath, "..");
-          continue;
-        }
-
-        // Check if directory is empty
-        const entries = await readdir(currentPath);
-        if (entries.length === 0) {
-          console.info("Deleting empty folder", { currentPath });
-          await rm(currentPath, { recursive: true, force: true });
-        } else {
-          // Directory not empty, stop cleanup
-          break;
-        }
-
-        // Move up one level
-        currentPath = join(currentPath, "..");
-      }
-    } catch (error) {
-      console.error("Error during empty folder cleanup", { startPath, error });
-      // Don't throw - best effort cleanup
-    }
-  }
-
-  /**
-   * Scan filesystem for files not referenced in database
-   */
   async scanOrphanedFiles(): Promise<OrphanedFileScanResult> {
-    const orphanedByLocation = new Map<string, { paths: string[]; sizeBytes: number }>();
-    let totalOrphanedFiles = 0;
-    let totalSizeBytes = 0;
-
-    try {
-      // Get all database image paths
-      const dbPaths = await this.getAllDatabaseImagePaths();
-      const dbPathSet = new Set(dbPaths);
-
-      // Scan filesystem
-      if (!existsSync(this.baseImagesDir)) {
-        return { totalOrphanedFiles: 0, totalSizeBytes: 0, orphanedByLocation };
-      }
-
-      const locationDirs = await readdir(this.baseImagesDir);
-
-      for (const locationName of locationDirs) {
-        const locationPath = join(this.baseImagesDir, locationName);
-        const locationStat = await stat(locationPath);
-
-        if (!locationStat.isDirectory()) continue;
-
-        // Scan storage types (instagram/uploads)
-        const storageTypes = await readdir(locationPath);
-
-        for (const storageType of storageTypes) {
-          if (storageType !== "instagram" && storageType !== "uploads") continue;
-
-          const storageTypePath = join(locationPath, storageType);
-          const storageTypeStat = await stat(storageTypePath);
-
-          if (!storageTypeStat.isDirectory()) continue;
-
-          // Scan timestamp folders
-          const timestamps = await readdir(storageTypePath);
-
-          for (const timestamp of timestamps) {
-            const timestampPath = join(storageTypePath, timestamp);
-            const timestampStat = await stat(timestampPath);
-
-            if (!timestampStat.isDirectory()) continue;
-
-            // Scan files in timestamp folder
-            const files = await readdir(timestampPath);
-
-            for (const file of files) {
-              const filePath = join(timestampPath, file);
-              const fileStat = await stat(filePath);
-
-              if (!fileStat.isFile()) continue;
-
-              // Convert to relative path
-              const relativePath = this.toStoredPath(filePath);
-
-              // Check if path exists in database
-              if (!dbPathSet.has(relativePath)) {
-                // Orphaned file found
-                const existing = orphanedByLocation.get(locationName) || { paths: [], sizeBytes: 0 };
-                existing.paths.push(relativePath);
-                existing.sizeBytes += fileStat.size;
-                orphanedByLocation.set(locationName, existing);
-
-                totalOrphanedFiles++;
-                totalSizeBytes += fileStat.size;
-              }
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Error scanning for orphaned files", { error });
-    }
-
-    return {
-      totalOrphanedFiles,
-      totalSizeBytes,
-      orphanedByLocation
-    };
+    return cleanup.scanOrphanedFiles(this.paths);
   }
 
-  /**
-   * Delete orphaned files
-   */
   async deleteOrphanedFiles(paths: string[]): Promise<DeletionResult> {
-    const result: DeletionResult = {
-      deletedCount: 0,
-      failedCount: 0,
-      errors: []
-    };
-
-    for (const relativePath of paths) {
-      try {
-        const absolutePath = this.toAbsolutePath(relativePath);
-
-        if (!existsSync(absolutePath)) {
-          console.warn("File already deleted", { relativePath });
-          result.deletedCount++;
-          continue;
-        }
-
-        await rm(absolutePath, { force: true });
-        console.info("Deleted orphaned file", { relativePath });
-        result.deletedCount++;
-
-        // Extract metadata and cleanup empty folders
-        const metadata = this.extractPathMetadata(relativePath);
-        if (metadata) {
-          await this.cleanupEmptyFolders(metadata.timestampDir);
-        }
-      } catch (error) {
-        console.error("Failed to delete orphaned file", { relativePath, error });
-        result.failedCount++;
-        result.errors.push({
-          path: relativePath,
-          error: error instanceof Error ? error.message : String(error)
-        });
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Get all image paths from database
-   * This is a helper method to scan all tables for image paths
-   */
-  private async getAllDatabaseImagePaths(): Promise<string[]> {
-    const paths: string[] = [];
-
-    try {
-      // Import getDb here to avoid circular dependencies
-      const { getDb } = await import("@server/shared/db/client");
-      const db = getDb();
-
-      // Get paths from instagram_embeds table
-      const instagramEmbeds = db.query("SELECT images FROM instagram_embeds WHERE images IS NOT NULL").all() as Array<{ images: string }>;
-      for (const embed of instagramEmbeds) {
-        if (embed.images) {
-          const images = JSON.parse(embed.images);
-          paths.push(...images);
-        }
-      }
-
-      // Get paths from uploads table (legacy format)
-      const uploads = db.query("SELECT images, imageSets FROM uploads WHERE images IS NOT NULL OR imageSets IS NOT NULL").all() as Array<{ images: string | null; imageSets: string | null }>;
-      for (const upload of uploads) {
-        // Legacy format
-        if (upload.images) {
-          const images = JSON.parse(upload.images);
-          paths.push(...images);
-        }
-
-        // ImageSet format
-        if (upload.imageSets) {
-          const imageSet = JSON.parse(upload.imageSets);
-          // Add source image
-          if (imageSet.sourceImage?.path) {
-            paths.push(imageSet.sourceImage.path);
-          }
-          // Add variants
-          if (imageSet.variants) {
-            for (const variant of imageSet.variants) {
-              if (variant.path) {
-                paths.push(variant.path);
-              }
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Error fetching database image paths", { error });
-    }
-
-    return paths;
+    return cleanup.deleteOrphanedFiles(this.paths, paths);
   }
 }

--- a/apps/location-manager/packages/server/src/features/locations/services/storage/image-storage.types.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/storage/image-storage.types.ts
@@ -1,0 +1,38 @@
+export interface ImageStorageConfig {
+  baseDir: string;
+  locationName: string;
+  storageType: "instagram" | "uploads";
+  timestamp: number | string;
+}
+
+export interface SaveImageResult {
+  savedPaths: string[];
+  errors: Array<{ index: number; error: string }>;
+}
+
+export interface SavedImageSource {
+  path: string;
+  metadata: { width: number; height: number; size: number; format: string };
+}
+
+export interface PathMetadata {
+  locationName: string;
+  storageType: "instagram" | "uploads";
+  timestamp: string;
+  timestampDir: string; // Full path to timestamp folder
+}
+
+export interface OrphanedFileScanResult {
+  totalOrphanedFiles: number;
+  totalSizeBytes: number;
+  orphanedByLocation: Map<string, {
+    paths: string[];
+    sizeBytes: number;
+  }>;
+}
+
+export interface DeletionResult {
+  deletedCount: number;
+  failedCount: number;
+  errors: Array<{ path: string; error: string }>;
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/storage/image-writer.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/storage/image-writer.ts
@@ -1,0 +1,169 @@
+import { join } from "node:path";
+import { sanitizeUploadedImageBuffer } from "../../utils/image-upload-sanitizer";
+import { extractImageMetadata } from "../../utils/image-metadata-extractor";
+import type { ImagePathResolver } from "./image-path-resolver";
+import type { SaveImageResult, SavedImageSource } from "./image-storage.types";
+
+/**
+ * Read image file and return as Buffer
+ */
+export async function readImage(paths: ImagePathResolver, filePath: string): Promise<Buffer> {
+  // Handle both relative and absolute paths
+  const absolutePath = paths.toAbsolutePath(filePath);
+
+  const file = Bun.file(absolutePath);
+
+  if (!await file.exists()) {
+    throw new Error(`Image file not found: ${filePath}`);
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+/**
+ * Save images from URLs to filesystem
+ */
+export async function saveImagesFromUrls(
+  paths: ImagePathResolver,
+  imageUrls: string[],
+  storagePath: string,
+  fileExtension: string = "jpg"
+): Promise<SaveImageResult> {
+  await paths.ensureDirectoryExists(storagePath);
+
+  const savedPaths: string[] = [];
+  const errors: Array<{ index: number; error: string }> = [];
+
+  const fetchWithRetry = async (url: string): Promise<Response> => {
+    // First attempt: plain fetch
+    let res = await fetch(url);
+    if (res.ok) return res;
+
+    // Retry once with browser-like headers (helps with some Instagram CDN URLs)
+    res = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+        "Referer": "https://www.instagram.com/",
+      },
+    });
+    return res;
+  };
+
+  for (let i = 0; i < imageUrls.length; i++) {
+    const imgUrl = imageUrls[i];
+    try {
+      const imgRes = await fetchWithRetry(imgUrl!);
+      if (!imgRes.ok) {
+        throw new Error(`HTTP ${imgRes.status}`);
+      }
+
+      const filename = `image_${i}.${fileExtension}`;
+      const filePath = join(storagePath, filename);
+      await Bun.write(filePath, await imgRes.blob());
+
+      savedPaths.push(paths.toStoredPath(filePath));
+    } catch (err) {
+      errors.push({
+        index: i,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+  }
+
+  return { savedPaths, errors };
+}
+
+export async function saveSanitizedImageFromUrl(
+  paths: ImagePathResolver,
+  url: string,
+  storagePath: string
+): Promise<SavedImageSource> {
+  await paths.ensureDirectoryExists(storagePath);
+  let response = await fetch(url);
+  if (!response.ok) {
+    response = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36",
+        Accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+        Referer: "https://www.instagram.com/",
+      },
+    });
+  }
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+  const raw = Buffer.from(await response.arrayBuffer());
+  const sanitized = await sanitizeUploadedImageBuffer(raw);
+  const absolutePath = join(storagePath, "source_0.webp");
+  await Bun.write(absolutePath, sanitized);
+  return {
+    path: paths.toStoredPath(absolutePath),
+    metadata: await extractImageMetadata(absolutePath),
+  };
+}
+
+/**
+ * Stage a StagedSource from an image already on disk (relative `data/...`
+ * or absolute path), re-encoding it into an independent `source_0.webp` under
+ * `storagePath`. Mirrors {@link saveSanitizedImageFromUrl} without a network
+ * fetch — used to backfill Instagram staging from previously-downloaded bytes.
+ */
+export async function saveSanitizedImageFromFile(
+  paths: ImagePathResolver,
+  localPath: string,
+  storagePath: string
+): Promise<SavedImageSource> {
+  await paths.ensureDirectoryExists(storagePath);
+  const raw = await readImage(paths, localPath);
+  const sanitized = await sanitizeUploadedImageBuffer(raw);
+  const absolutePath = join(storagePath, "source_0.webp");
+  await Bun.write(absolutePath, sanitized);
+  return {
+    path: paths.toStoredPath(absolutePath),
+    metadata: await extractImageMetadata(absolutePath),
+  };
+}
+
+/**
+ * Save uploaded File objects to filesystem, converting to WebP format
+ */
+export async function saveUploadedFiles(
+  paths: ImagePathResolver,
+  files: File[],
+  storagePath: string
+): Promise<SaveImageResult> {
+  await paths.ensureDirectoryExists(storagePath);
+
+  const savedPaths: string[] = [];
+  const errors: Array<{ index: number; error: string }> = [];
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (!file) {
+      errors.push({
+        index: i,
+        error: "File is undefined"
+      });
+      continue;
+    }
+
+    try {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const webpBuffer = await sanitizeUploadedImageBuffer(buffer);
+
+      const filename = `image_${i}.webp`;
+      const filePath = join(storagePath, filename);
+      await Bun.write(filePath, webpBuffer);
+
+      savedPaths.push(paths.toStoredPath(filePath));
+    } catch (err) {
+      errors.push({
+        index: i,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+  }
+
+  return { savedPaths, errors };
+}


### PR DESCRIPTION
Refactor of `apps/location-manager/packages/server/src/features/locations/services/storage/image-storage.service.ts`, flagged at **633 LOC / 7 concerns** ("large, multi-concern service").

## Problem

One class mixed four concerns: repo-relative ↔ absolute path translation, image writing (URL fetch / file / upload), directory lifecycle, and orphaned-file scanning against the database.

## Change

| Module | LOC | Responsibility |
| --- | --- | --- |
| `image-path-resolver.ts` | 169 | Root dirs, stored↔absolute translation, storage paths, path metadata |
| `image-writer.ts` | 169 | URL / file / upload saving, sanitization, reads |
| `image-orphan-cleanup.ts` | 273 | Orphan scan vs DB, deletion, empty-folder cleanup |
| `image-storage.types.ts` | 38 | The six shared interfaces |

`ImageStorageService`: **633 → 121 LOC**, composing the three modules. All **14 public methods** retained with identical signatures (verified by diffing the extracted method list against `main`), and the type exports are re-exported so existing import paths keep working.

## ⚠️ One finding worth reviewer attention

Two consumers reach past `private` using bracket indexing:

```ts
uploads.service.ts:73,188   this.imageStorage["baseImagesDir"]
uploads.service.ts:665      this.imageStorage["cleanupEmptyFolders"](...)
instagram.service.ts:127    this.imageStorage["cleanupEmptyFolders"](...)
```

Moving these into the extracted modules left all four call sites resolving to **`undefined` at runtime**. `bun test` passed unchanged — those paths aren't covered — so this surfaced only through `tsc`. Both are deliberately retained as instance members on the service, with a comment explaining why they can't be moved.

This is pre-existing coupling, not something this PR introduces. Converting those four sites to a real public API is a reasonable follow-up, but it's a behavior-affecting change so it's out of scope here.

Also preserved deliberately: the two URL-fetch retry paths send **different** `User-Agent` strings (`...(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36` vs `...Chrome/120 Safari/537.36`). They look like duplication begging to be unified, but collapsing them would change what those requests send, so they're left alone.

## Verification

- `bun test` → **213 pass / 4 fail**, identical to baseline on `main` (the 4 failures are pre-existing, incl. `DistrictExtractionService > getAllMappings`)
- `tsc --noEmit` → error list **identical to baseline** (8 pre-existing config errors)
- Runtime smoke test exercising the public surface *and* both bracket-accessed privates → **byte-identical output** vs `main`
