### PR TITLE
refactor: split MultiVariantCropperModal into hook, dial, geometry

### DIFF
--- a/apps/location-manager/packages/client/src/shared/components/location-media/modals/MultiVariantCropperModal.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/modals/MultiVariantCropperModal.tsx
@@ -1,5 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
-import Cropper, { type Point, type Area } from "react-easy-crop";
+import Cropper from "react-easy-crop";
 import {
   Dialog,
   DialogContent,
@@ -9,16 +8,17 @@ import {
 } from "@client/components/ui/dialog";
 import { Button } from "@client/components/ui/button";
 import { Check, ChevronLeft, RotateCcw, RotateCw, Sparkles } from "lucide-react";
-import { type ImageVariantType, VARIANT_SPECS } from "@questurian/lm-shared";
-import { useToast } from "@client/shared/hooks/useToast";
+import { VARIANT_SPECS } from "@questurian/lm-shared";
+import type { ImageVariantUploadFile } from "@client/shared/types/location-media.types";
+import { StraightenDial } from "./StraightenDial";
+import { useMultiVariantCropper } from "./useMultiVariantCropper";
 import {
-  createMultiVariantImages,
-  createRotatedSourceImage,
-} from "@client/shared/lib/image-processing";
-import type {
-  CropState,
-  ImageVariantUploadFile,
-} from "@client/shared/types/location-media.types";
+  STRAIGHTEN_MAX,
+  STRAIGHTEN_MIN,
+  STRAIGHTEN_STEP,
+  formatDegrees,
+  variantSequence,
+} from "./multiVariantCropper.geometry";
 
 interface MultiVariantCropperModalProps {
   file: File;
@@ -39,175 +39,6 @@ interface MultiVariantCropperModalProps {
   initialPhotographerCredit?: string;
 }
 
-const variantSequence: ImageVariantType[] = ['thumbnail', 'square', 'wide', 'open_graph', 'editorial', 'portrait', 'hero'];
-const STRAIGHTEN_MIN = -20;
-const STRAIGHTEN_MAX = 20;
-const STRAIGHTEN_STEP = 0.1;
-
-function clampStraightenAngle(angle: number): number {
-  return Math.min(STRAIGHTEN_MAX, Math.max(STRAIGHTEN_MIN, Number(angle.toFixed(1))));
-}
-
-function normalizeDegrees(angle: number): number {
-  return ((angle % 360) + 360) % 360;
-}
-
-/**
- * Dimensions of the axis-aligned bounding box after rotating a width×height
- * rectangle. Mirrors the `rotateSize` used in image-processing so auto-crop
- * areas land in the same coordinate space that `createCroppedImage` consumes.
- */
-function rotatedBoundingBox(width: number, height: number, degrees: number) {
-  const radians = (degrees * Math.PI) / 180;
-  return {
-    width: Math.abs(Math.cos(radians) * width) + Math.abs(Math.sin(radians) * height),
-    height: Math.abs(Math.sin(radians) * width) + Math.abs(Math.cos(radians) * height),
-  };
-}
-
-/**
- * Largest centered rectangle of the target aspect ratio that fits inside a
- * width×height box. Matches react-easy-crop's default (`objectFit: contain`)
- * crop area at zoom 1 with the image centered, so a manually-cropped variant
- * and an auto-cropped one resolve to the same pixels.
- */
-function centeredCropArea(width: number, height: number, ratio: number): Area {
-  let cropWidth = width;
-  let cropHeight = width / ratio;
-
-  if (cropHeight > height) {
-    cropHeight = height;
-    cropWidth = height * ratio;
-  }
-
-  return {
-    x: Math.round((width - cropWidth) / 2),
-    y: Math.round((height - cropHeight) / 2),
-    width: Math.round(cropWidth),
-    height: Math.round(cropHeight),
-  };
-}
-
-function loadImageSize(src: string): Promise<{ width: number; height: number }> {
-  return new Promise((resolve, reject) => {
-    const image = new Image();
-    image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
-    image.onerror = () => reject(new Error("Failed to load image"));
-    image.src = src;
-  });
-}
-
-function formatDegrees(angle: number): string {
-  if (Math.abs(angle) < 0.05) {
-    return "0°";
-  }
-
-  return `${angle > 0 ? "+" : ""}${angle.toFixed(1)}°`;
-}
-
-interface StraightenDialProps {
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  disabled?: boolean;
-  onChange: (value: number) => void;
-}
-
-function StraightenDial({
-  value,
-  min,
-  max,
-  step,
-  disabled = false,
-  onChange,
-}: StraightenDialProps) {
-  const tickValues = Array.from({ length: max - min + 1 }, (_, index) => min + index);
-  const progress = ((value - min) / (max - min)) * 100;
-  const activeLeft = value >= 0 ? 50 : progress;
-  const activeWidth = Math.abs(progress - 50);
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-end justify-between gap-3 text-xs">
-        <div className="space-y-1">
-          <p className="font-medium text-foreground">Straighten</p>
-          <p className="text-muted-foreground">Fine tune the horizon with small angle adjustments.</p>
-        </div>
-        <span className="rounded-full border border-border bg-background px-2.5 py-1 font-semibold text-foreground tabular-nums">
-          {formatDegrees(value)}
-        </span>
-      </div>
-
-      <div className="rounded-xl border border-border bg-background/80 px-3 py-4">
-        <div className="relative h-16">
-          <div className="pointer-events-none absolute inset-x-3 top-1/2 h-1 -translate-y-1/2">
-            <div className="absolute inset-0 rounded-full bg-border/70" />
-            <div
-              className="absolute top-0 h-full rounded-full bg-blue-500/80"
-              style={{
-                left: `${activeLeft}%`,
-                width: `${activeWidth}%`,
-              }}
-            />
-          </div>
-          <div className="pointer-events-none absolute left-1/2 top-1/2 h-7 w-px -translate-x-1/2 -translate-y-1/2 bg-foreground/70" />
-
-          <div className="pointer-events-none absolute inset-x-3 top-1/2 flex -translate-y-1/2 justify-between">
-            {tickValues.map((tickValue) => {
-              const isCenter = tickValue === 0;
-              const isMajor = tickValue % 5 === 0;
-
-              return (
-                <span
-                  key={tickValue}
-                  className={`block w-px rounded-full ${
-                    isCenter
-                      ? "h-7 bg-foreground/80"
-                      : isMajor
-                        ? "h-5 bg-foreground/45"
-                        : "h-3 bg-foreground/20"
-                  }`}
-                />
-              );
-            })}
-          </div>
-
-          <input
-            type="range"
-            min={min}
-            max={max}
-            step={step}
-            value={value}
-            onChange={(event) => onChange(Number(event.target.value))}
-            disabled={disabled}
-            aria-label="Straighten image"
-            className="absolute inset-0 z-10 h-full w-full cursor-ew-resize appearance-none bg-transparent focus:outline-none disabled:cursor-not-allowed [&::-webkit-slider-runnable-track]:bg-transparent [&::-webkit-slider-thumb]:mt-0 [&::-webkit-slider-thumb]:h-6 [&::-webkit-slider-thumb]:w-6 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:bg-blue-500 [&::-webkit-slider-thumb]:shadow-[0_0_0_5px_rgba(59,130,246,0.2)] [&::-moz-range-thumb]:h-6 [&::-moz-range-thumb]:w-6 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:bg-blue-500 [&::-moz-range-thumb]:shadow-[0_0_0_5px_rgba(59,130,246,0.2)] [&::-moz-range-track]:bg-transparent"
-          />
-        </div>
-
-        <div className="mt-2 flex items-center justify-between text-[11px] text-muted-foreground">
-          <span>{min}°</span>
-          <span className="rounded-full border border-border px-2 py-0.5 text-foreground/80">Level</span>
-          <span>{max}°</span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function createInitialCropStates(): Record<ImageVariantType, CropState> {
-  return {
-    thumbnail: { variantType: 'thumbnail', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-    square: { variantType: 'square', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-    wide: { variantType: 'wide', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-    open_graph: { variantType: 'open_graph', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-    editorial: { variantType: 'editorial', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-    portrait: { variantType: 'portrait', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-    hero: { variantType: 'hero', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
-  };
-}
-
 export function MultiVariantCropperModal({
   file,
   isOpen,
@@ -215,233 +46,36 @@ export function MultiVariantCropperModal({
   onConfirm,
   initialPhotographerCredit,
 }: MultiVariantCropperModalProps) {
-  const { showToast } = useToast();
-  const [previewUrl, setPreviewUrl] = useState<string>("");
-  const [currentVariantIndex, setCurrentVariantIndex] = useState(0);
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [isAutoCropping, setIsAutoCropping] = useState(false);
-  const [baseRotation, setBaseRotation] = useState(0);
-  const [straightenAngle, setStraightenAngle] = useState(0);
-  const showCreditField = initialPhotographerCredit !== undefined;
-  const [photographerCredit, setPhotographerCredit] = useState(initialPhotographerCredit ?? "");
-
-  useEffect(() => {
-    setPhotographerCredit(initialPhotographerCredit ?? "");
-  }, [initialPhotographerCredit, file]);
-
-  // Initialize crop states for all variants
-  const [cropStates, setCropStates] = useState<Record<ImageVariantType, CropState>>(() => createInitialCropStates());
-
-  const currentVariantType = variantSequence[currentVariantIndex];
-  const currentState = cropStates[currentVariantType];
-  const currentSpec = VARIANT_SPECS[currentVariantType];
-  const totalVariants = variantSequence.length;
-  const fileIdentity = `${file.name}:${file.lastModified}:${file.size}`;
-  const rotation = baseRotation + straightenAngle;
-
-  // Create preview URL when file changes
-  useEffect(() => {
-    if (file) {
-      const url = URL.createObjectURL(file);
-      setPreviewUrl(url);
-      return () => URL.revokeObjectURL(url);
-    }
-  }, [file]);
-
-  // Reset cropper progress when switching to a different source file.
-  useEffect(() => {
-    setCurrentVariantIndex(0);
-    setIsProcessing(false);
-    setIsAutoCropping(false);
-    setBaseRotation(0);
-    setStraightenAngle(0);
-    setCropStates(createInitialCropStates());
-  }, [file]);
-
-  const updateVariantState = useCallback(
-    (variantType: ImageVariantType, updates: Partial<CropState>) => {
-      setCropStates((prev) => ({
-        ...prev,
-        [variantType]: { ...prev[variantType], ...updates },
-      }));
-    },
-    []
-  );
-
-  // Update crop position for current variant
-  const onCropChange = useCallback((crop: Point) => {
-    updateVariantState(currentVariantType, { crop });
-  }, [currentVariantType, updateVariantState]);
-
-  // Update zoom for current variant
-  const onZoomChange = useCallback((zoom: number) => {
-    updateVariantState(currentVariantType, { zoom });
-  }, [currentVariantType, updateVariantState]);
-
-  // Persist the pixel crop continuously to avoid stale area when switching tabs quickly.
-  const onCropAreaChange = useCallback((_croppedArea: Area, croppedAreaPixels: Area) => {
-    updateVariantState(currentVariantType, { croppedAreaPixels, completed: true });
-  }, [currentVariantType, updateVariantState]);
-
-  const applyOrientation = useCallback((nextBaseRotation: number, nextStraightenAngle: number) => {
-    const normalizedStraightenAngle = clampStraightenAngle(nextStraightenAngle);
-
-    if (
-      Math.abs(nextBaseRotation - baseRotation) < 0.001 &&
-      Math.abs(normalizedStraightenAngle - straightenAngle) < 0.001
-    ) {
-      return;
-    }
-
-    const shouldNotifyReset = currentVariantIndex > 0 || variantSequence.some(
-      (type, index) => index !== currentVariantIndex && cropStates[type].croppedAreaPixels !== null
-    );
-
-    setBaseRotation(nextBaseRotation);
-    setStraightenAngle(normalizedStraightenAngle);
-    setCropStates(createInitialCropStates());
-    setCurrentVariantIndex(0);
-
-    if (shouldNotifyReset) {
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast("Orientation changed. Existing crop selections were reset.", centerPosition);
-    }
-  }, [baseRotation, cropStates, currentVariantIndex, showToast, straightenAngle]);
-
-  const handleRotate = (direction: "left" | "right") => {
-    const delta = direction === "left" ? -90 : 90;
-    applyOrientation(baseRotation + delta, straightenAngle);
-  };
-
-  const handleStraightenChange = (nextAngle: number) => {
-    applyOrientation(baseRotation, nextAngle);
-  };
-
-  // Fill every variant with a centered crop so the operator can confirm in one
-  // step. Each area is the largest centered rect of the variant's aspect ratio,
-  // computed in the rotated image's coordinate space to match manual crops.
-  const applyAutoCrop = useCallback(async () => {
-    if (!previewUrl || isProcessing || isAutoCropping) {
-      return;
-    }
-
-    setIsAutoCropping(true);
-
-    try {
-      const { width, height } = await loadImageSize(previewUrl);
-      const box = rotatedBoundingBox(width, height, normalizeDegrees(rotation));
-
-      setCropStates((prev) => {
-        const next = { ...prev };
-        for (const type of variantSequence) {
-          next[type] = {
-            ...prev[type],
-            crop: { x: 0, y: 0 },
-            zoom: 1,
-            croppedAreaPixels: centeredCropArea(box.width, box.height, VARIANT_SPECS[type].ratio),
-            completed: true,
-          };
-        }
-        return next;
-      });
-    } catch (error) {
-      console.error("Auto-crop failed:", error);
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast("Could not auto-crop this image", centerPosition);
-    } finally {
-      setIsAutoCropping(false);
-    }
-  }, [previewUrl, isProcessing, isAutoCropping, rotation, showToast]);
-
-  const saveCurrentCrop = () => {
-    if (!currentState.croppedAreaPixels) {
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast("Please adjust the crop area before continuing", centerPosition);
-      return false;
-    }
-
-    updateVariantState(currentVariantType, { completed: true });
-    return true;
-  };
-
-  // Navigate to previous variant
-  const handlePrevious = () => {
-    if (currentVariantIndex > 0 && saveCurrentCrop()) {
-      setCurrentVariantIndex((prev) => prev - 1);
-    }
-  };
-
-  // Navigate to next variant
-  const handleNext = () => {
-    if (currentVariantIndex < variantSequence.length - 1 && saveCurrentCrop()) {
-      setCurrentVariantIndex((prev) => prev + 1);
-    }
-  };
-
-  // Jump to specific variant
-  const jumpToVariant = (index: number) => {
-    if (index === currentVariantIndex) {
-      return;
-    }
-
-    if (saveCurrentCrop()) {
-      setCurrentVariantIndex(index);
-    }
-  };
-
-  // Check if all crops have been defined
-  const allCropsComplete = () => {
-    return variantSequence.every(type => cropStates[type].croppedAreaPixels !== null);
-  };
-
-  // Process all crops and return variant files
-  const handleConfirmAll = async () => {
-    if (!saveCurrentCrop()) {
-      return;
-    }
-
-    if (!allCropsComplete()) {
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast(`Please complete all ${totalVariants} variant crops`, centerPosition);
-      return;
-    }
-
-    setIsProcessing(true);
-
-    try {
-      const normalizedRotation = normalizeDegrees(rotation);
-      const [sourceFile, variantFiles] = await Promise.all([
-        normalizedRotation === 0
-          ? Promise.resolve(file)
-          : createRotatedSourceImage(previewUrl, file.name, normalizedRotation),
-        createMultiVariantImages(previewUrl, cropStates, file.name, normalizedRotation),
-      ]);
-
-      onConfirm(
-        sourceFile,
-        variantFiles,
-        showCreditField ? photographerCredit.trim() : undefined
-      );
-    } catch (error) {
-      console.error("Error processing variants:", error);
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast("Failed to process image variants", centerPosition);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
-
-  const completedCount = variantSequence.filter(type => cropStates[type].completed).length;
-  const isLastVariant = currentVariantIndex === variantSequence.length - 1;
-
-  const handlePrimaryAction = async () => {
-    if (isLastVariant) {
-      await handleConfirmAll();
-      return;
-    }
-
-    handleNext();
-  };
+  const {
+    previewUrl,
+    currentVariantIndex,
+    currentVariantType,
+    currentState,
+    currentSpec,
+    cropStates,
+    totalVariants,
+    completedCount,
+    isLastVariant,
+    fileIdentity,
+    isProcessing,
+    isAutoCropping,
+    baseRotation,
+    straightenAngle,
+    rotation,
+    showCreditField,
+    photographerCredit,
+    setPhotographerCredit,
+    onCropChange,
+    onZoomChange,
+    onCropAreaChange,
+    applyOrientation,
+    handleRotate,
+    handleStraightenChange,
+    applyAutoCrop,
+    handlePrevious,
+    jumpToVariant,
+    handlePrimaryAction,
+  } = useMultiVariantCropper({ file, onConfirm, initialPhotographerCredit });
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/apps/location-manager/packages/client/src/shared/components/location-media/modals/StraightenDial.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/modals/StraightenDial.tsx
@@ -1,0 +1,92 @@
+import { formatDegrees } from "./multiVariantCropper.geometry";
+
+interface StraightenDialProps {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  disabled?: boolean;
+  onChange: (value: number) => void;
+}
+
+export function StraightenDial({
+  value,
+  min,
+  max,
+  step,
+  disabled = false,
+  onChange,
+}: StraightenDialProps) {
+  const tickValues = Array.from({ length: max - min + 1 }, (_, index) => min + index);
+  const progress = ((value - min) / (max - min)) * 100;
+  const activeLeft = value >= 0 ? 50 : progress;
+  const activeWidth = Math.abs(progress - 50);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end justify-between gap-3 text-xs">
+        <div className="space-y-1">
+          <p className="font-medium text-foreground">Straighten</p>
+          <p className="text-muted-foreground">Fine tune the horizon with small angle adjustments.</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2.5 py-1 font-semibold text-foreground tabular-nums">
+          {formatDegrees(value)}
+        </span>
+      </div>
+
+      <div className="rounded-xl border border-border bg-background/80 px-3 py-4">
+        <div className="relative h-16">
+          <div className="pointer-events-none absolute inset-x-3 top-1/2 h-1 -translate-y-1/2">
+            <div className="absolute inset-0 rounded-full bg-border/70" />
+            <div
+              className="absolute top-0 h-full rounded-full bg-blue-500/80"
+              style={{
+                left: `${activeLeft}%`,
+                width: `${activeWidth}%`,
+              }}
+            />
+          </div>
+          <div className="pointer-events-none absolute left-1/2 top-1/2 h-7 w-px -translate-x-1/2 -translate-y-1/2 bg-foreground/70" />
+
+          <div className="pointer-events-none absolute inset-x-3 top-1/2 flex -translate-y-1/2 justify-between">
+            {tickValues.map((tickValue) => {
+              const isCenter = tickValue === 0;
+              const isMajor = tickValue % 5 === 0;
+
+              return (
+                <span
+                  key={tickValue}
+                  className={`block w-px rounded-full ${
+                    isCenter
+                      ? "h-7 bg-foreground/80"
+                      : isMajor
+                        ? "h-5 bg-foreground/45"
+                        : "h-3 bg-foreground/20"
+                  }`}
+                />
+              );
+            })}
+          </div>
+
+          <input
+            type="range"
+            min={min}
+            max={max}
+            step={step}
+            value={value}
+            onChange={(event) => onChange(Number(event.target.value))}
+            disabled={disabled}
+            aria-label="Straighten image"
+            className="absolute inset-0 z-10 h-full w-full cursor-ew-resize appearance-none bg-transparent focus:outline-none disabled:cursor-not-allowed [&::-webkit-slider-runnable-track]:bg-transparent [&::-webkit-slider-thumb]:mt-0 [&::-webkit-slider-thumb]:h-6 [&::-webkit-slider-thumb]:w-6 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:bg-blue-500 [&::-webkit-slider-thumb]:shadow-[0_0_0_5px_rgba(59,130,246,0.2)] [&::-moz-range-thumb]:h-6 [&::-moz-range-thumb]:w-6 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:bg-blue-500 [&::-moz-range-thumb]:shadow-[0_0_0_5px_rgba(59,130,246,0.2)] [&::-moz-range-track]:bg-transparent"
+          />
+        </div>
+
+        <div className="mt-2 flex items-center justify-between text-[11px] text-muted-foreground">
+          <span>{min}°</span>
+          <span className="rounded-full border border-border px-2 py-0.5 text-foreground/80">Level</span>
+          <span>{max}°</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/location-manager/packages/client/src/shared/components/location-media/modals/multiVariantCropper.geometry.ts
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/modals/multiVariantCropper.geometry.ts
@@ -1,0 +1,81 @@
+import type { Area } from "react-easy-crop";
+import type { ImageVariantType } from "@questurian/lm-shared";
+import type { CropState } from "@client/shared/types/location-media.types";
+
+export const variantSequence: ImageVariantType[] = ['thumbnail', 'square', 'wide', 'open_graph', 'editorial', 'portrait', 'hero'];
+export const STRAIGHTEN_MIN = -20;
+export const STRAIGHTEN_MAX = 20;
+export const STRAIGHTEN_STEP = 0.1;
+
+export function clampStraightenAngle(angle: number): number {
+  return Math.min(STRAIGHTEN_MAX, Math.max(STRAIGHTEN_MIN, Number(angle.toFixed(1))));
+}
+
+export function normalizeDegrees(angle: number): number {
+  return ((angle % 360) + 360) % 360;
+}
+
+/**
+ * Dimensions of the axis-aligned bounding box after rotating a width×height
+ * rectangle. Mirrors the `rotateSize` used in image-processing so auto-crop
+ * areas land in the same coordinate space that `createCroppedImage` consumes.
+ */
+export function rotatedBoundingBox(width: number, height: number, degrees: number) {
+  const radians = (degrees * Math.PI) / 180;
+  return {
+    width: Math.abs(Math.cos(radians) * width) + Math.abs(Math.sin(radians) * height),
+    height: Math.abs(Math.sin(radians) * width) + Math.abs(Math.cos(radians) * height),
+  };
+}
+
+/**
+ * Largest centered rectangle of the target aspect ratio that fits inside a
+ * width×height box. Matches react-easy-crop's default (`objectFit: contain`)
+ * crop area at zoom 1 with the image centered, so a manually-cropped variant
+ * and an auto-cropped one resolve to the same pixels.
+ */
+export function centeredCropArea(width: number, height: number, ratio: number): Area {
+  let cropWidth = width;
+  let cropHeight = width / ratio;
+
+  if (cropHeight > height) {
+    cropHeight = height;
+    cropWidth = height * ratio;
+  }
+
+  return {
+    x: Math.round((width - cropWidth) / 2),
+    y: Math.round((height - cropHeight) / 2),
+    width: Math.round(cropWidth),
+    height: Math.round(cropHeight),
+  };
+}
+
+export function loadImageSize(src: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
+    image.onerror = () => reject(new Error("Failed to load image"));
+    image.src = src;
+  });
+}
+
+export function formatDegrees(angle: number): string {
+  if (Math.abs(angle) < 0.05) {
+    return "0°";
+  }
+
+  return `${angle > 0 ? "+" : ""}${angle.toFixed(1)}°`;
+}
+
+export function createInitialCropStates(): Record<ImageVariantType, CropState> {
+  return {
+    thumbnail: { variantType: 'thumbnail', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+    square: { variantType: 'square', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+    wide: { variantType: 'wide', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+    open_graph: { variantType: 'open_graph', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+    editorial: { variantType: 'editorial', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+    portrait: { variantType: 'portrait', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+    hero: { variantType: 'hero', crop: { x: 0, y: 0 }, zoom: 1, croppedAreaPixels: null, completed: false },
+  };
+}

--- a/apps/location-manager/packages/client/src/shared/components/location-media/modals/useMultiVariantCropper.ts
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/modals/useMultiVariantCropper.ts
@@ -1,0 +1,304 @@
+import { useState, useCallback, useEffect } from "react";
+import type { Point, Area } from "react-easy-crop";
+import { type ImageVariantType, VARIANT_SPECS } from "@questurian/lm-shared";
+import { useToast } from "@client/shared/hooks/useToast";
+import {
+  createMultiVariantImages,
+  createRotatedSourceImage,
+} from "@client/shared/lib/image-processing";
+import type {
+  CropState,
+  ImageVariantUploadFile,
+} from "@client/shared/types/location-media.types";
+import {
+  clampStraightenAngle,
+  centeredCropArea,
+  createInitialCropStates,
+  loadImageSize,
+  normalizeDegrees,
+  rotatedBoundingBox,
+  variantSequence,
+} from "./multiVariantCropper.geometry";
+
+interface UseMultiVariantCropperArgs {
+  file: File;
+  onConfirm: (
+    sourceFile: File,
+    variantFiles: ImageVariantUploadFile[],
+    photographerCredit?: string
+  ) => void;
+  initialPhotographerCredit?: string;
+}
+
+/**
+ * Crop state, orientation, and confirmation flow for the multi-variant cropper.
+ *
+ * Holds one {@link CropState} per variant in `variantSequence` and keeps the
+ * active variant's crop in sync with react-easy-crop. Changing orientation
+ * resets every crop, since existing pixel areas no longer map to the rotated
+ * image's coordinate space.
+ */
+export function useMultiVariantCropper({
+  file,
+  onConfirm,
+  initialPhotographerCredit,
+}: UseMultiVariantCropperArgs) {
+  const { showToast } = useToast();
+  const [previewUrl, setPreviewUrl] = useState<string>("");
+  const [currentVariantIndex, setCurrentVariantIndex] = useState(0);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [isAutoCropping, setIsAutoCropping] = useState(false);
+  const [baseRotation, setBaseRotation] = useState(0);
+  const [straightenAngle, setStraightenAngle] = useState(0);
+  const showCreditField = initialPhotographerCredit !== undefined;
+  const [photographerCredit, setPhotographerCredit] = useState(initialPhotographerCredit ?? "");
+
+  useEffect(() => {
+    setPhotographerCredit(initialPhotographerCredit ?? "");
+  }, [initialPhotographerCredit, file]);
+
+  // Initialize crop states for all variants
+  const [cropStates, setCropStates] = useState<Record<ImageVariantType, CropState>>(() => createInitialCropStates());
+
+  const currentVariantType = variantSequence[currentVariantIndex];
+  const currentState = cropStates[currentVariantType];
+  const currentSpec = VARIANT_SPECS[currentVariantType];
+  const totalVariants = variantSequence.length;
+  const fileIdentity = `${file.name}:${file.lastModified}:${file.size}`;
+  const rotation = baseRotation + straightenAngle;
+
+  // Create preview URL when file changes
+  useEffect(() => {
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setPreviewUrl(url);
+      return () => URL.revokeObjectURL(url);
+    }
+  }, [file]);
+
+  // Reset cropper progress when switching to a different source file.
+  useEffect(() => {
+    setCurrentVariantIndex(0);
+    setIsProcessing(false);
+    setIsAutoCropping(false);
+    setBaseRotation(0);
+    setStraightenAngle(0);
+    setCropStates(createInitialCropStates());
+  }, [file]);
+
+  const updateVariantState = useCallback(
+    (variantType: ImageVariantType, updates: Partial<CropState>) => {
+      setCropStates((prev) => ({
+        ...prev,
+        [variantType]: { ...prev[variantType], ...updates },
+      }));
+    },
+    []
+  );
+
+  // Update crop position for current variant
+  const onCropChange = useCallback((crop: Point) => {
+    updateVariantState(currentVariantType, { crop });
+  }, [currentVariantType, updateVariantState]);
+
+  // Update zoom for current variant
+  const onZoomChange = useCallback((zoom: number) => {
+    updateVariantState(currentVariantType, { zoom });
+  }, [currentVariantType, updateVariantState]);
+
+  // Persist the pixel crop continuously to avoid stale area when switching tabs quickly.
+  const onCropAreaChange = useCallback((_croppedArea: Area, croppedAreaPixels: Area) => {
+    updateVariantState(currentVariantType, { croppedAreaPixels, completed: true });
+  }, [currentVariantType, updateVariantState]);
+
+  const applyOrientation = useCallback((nextBaseRotation: number, nextStraightenAngle: number) => {
+    const normalizedStraightenAngle = clampStraightenAngle(nextStraightenAngle);
+
+    if (
+      Math.abs(nextBaseRotation - baseRotation) < 0.001 &&
+      Math.abs(normalizedStraightenAngle - straightenAngle) < 0.001
+    ) {
+      return;
+    }
+
+    const shouldNotifyReset = currentVariantIndex > 0 || variantSequence.some(
+      (type, index) => index !== currentVariantIndex && cropStates[type].croppedAreaPixels !== null
+    );
+
+    setBaseRotation(nextBaseRotation);
+    setStraightenAngle(normalizedStraightenAngle);
+    setCropStates(createInitialCropStates());
+    setCurrentVariantIndex(0);
+
+    if (shouldNotifyReset) {
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast("Orientation changed. Existing crop selections were reset.", centerPosition);
+    }
+  }, [baseRotation, cropStates, currentVariantIndex, showToast, straightenAngle]);
+
+  const handleRotate = (direction: "left" | "right") => {
+    const delta = direction === "left" ? -90 : 90;
+    applyOrientation(baseRotation + delta, straightenAngle);
+  };
+
+  const handleStraightenChange = (nextAngle: number) => {
+    applyOrientation(baseRotation, nextAngle);
+  };
+
+  // Fill every variant with a centered crop so the operator can confirm in one
+  // step. Each area is the largest centered rect of the variant's aspect ratio,
+  // computed in the rotated image's coordinate space to match manual crops.
+  const applyAutoCrop = useCallback(async () => {
+    if (!previewUrl || isProcessing || isAutoCropping) {
+      return;
+    }
+
+    setIsAutoCropping(true);
+
+    try {
+      const { width, height } = await loadImageSize(previewUrl);
+      const box = rotatedBoundingBox(width, height, normalizeDegrees(rotation));
+
+      setCropStates((prev) => {
+        const next = { ...prev };
+        for (const type of variantSequence) {
+          next[type] = {
+            ...prev[type],
+            crop: { x: 0, y: 0 },
+            zoom: 1,
+            croppedAreaPixels: centeredCropArea(box.width, box.height, VARIANT_SPECS[type].ratio),
+            completed: true,
+          };
+        }
+        return next;
+      });
+    } catch (error) {
+      console.error("Auto-crop failed:", error);
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast("Could not auto-crop this image", centerPosition);
+    } finally {
+      setIsAutoCropping(false);
+    }
+  }, [previewUrl, isProcessing, isAutoCropping, rotation, showToast]);
+
+  const saveCurrentCrop = () => {
+    if (!currentState.croppedAreaPixels) {
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast("Please adjust the crop area before continuing", centerPosition);
+      return false;
+    }
+
+    updateVariantState(currentVariantType, { completed: true });
+    return true;
+  };
+
+  // Navigate to previous variant
+  const handlePrevious = () => {
+    if (currentVariantIndex > 0 && saveCurrentCrop()) {
+      setCurrentVariantIndex((prev) => prev - 1);
+    }
+  };
+
+  // Navigate to next variant
+  const handleNext = () => {
+    if (currentVariantIndex < variantSequence.length - 1 && saveCurrentCrop()) {
+      setCurrentVariantIndex((prev) => prev + 1);
+    }
+  };
+
+  // Jump to specific variant
+  const jumpToVariant = (index: number) => {
+    if (index === currentVariantIndex) {
+      return;
+    }
+
+    if (saveCurrentCrop()) {
+      setCurrentVariantIndex(index);
+    }
+  };
+
+  // Check if all crops have been defined
+  const allCropsComplete = () => {
+    return variantSequence.every(type => cropStates[type].croppedAreaPixels !== null);
+  };
+
+  // Process all crops and return variant files
+  const handleConfirmAll = async () => {
+    if (!saveCurrentCrop()) {
+      return;
+    }
+
+    if (!allCropsComplete()) {
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast(`Please complete all ${totalVariants} variant crops`, centerPosition);
+      return;
+    }
+
+    setIsProcessing(true);
+
+    try {
+      const normalizedRotation = normalizeDegrees(rotation);
+      const [sourceFile, variantFiles] = await Promise.all([
+        normalizedRotation === 0
+          ? Promise.resolve(file)
+          : createRotatedSourceImage(previewUrl, file.name, normalizedRotation),
+        createMultiVariantImages(previewUrl, cropStates, file.name, normalizedRotation),
+      ]);
+
+      onConfirm(
+        sourceFile,
+        variantFiles,
+        showCreditField ? photographerCredit.trim() : undefined
+      );
+    } catch (error) {
+      console.error("Error processing variants:", error);
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast("Failed to process image variants", centerPosition);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const completedCount = variantSequence.filter(type => cropStates[type].completed).length;
+  const isLastVariant = currentVariantIndex === variantSequence.length - 1;
+
+  const handlePrimaryAction = async () => {
+    if (isLastVariant) {
+      await handleConfirmAll();
+      return;
+    }
+
+    handleNext();
+  };
+
+  return {
+    previewUrl,
+    currentVariantIndex,
+    currentVariantType,
+    currentState,
+    currentSpec,
+    cropStates,
+    totalVariants,
+    completedCount,
+    isLastVariant,
+    fileIdentity,
+    isProcessing,
+    isAutoCropping,
+    baseRotation,
+    straightenAngle,
+    rotation,
+    showCreditField,
+    photographerCredit,
+    setPhotographerCredit,
+    onCropChange,
+    onZoomChange,
+    onCropAreaChange,
+    applyOrientation,
+    handleRotate,
+    handleStraightenChange,
+    applyAutoCrop,
+    handlePrevious,
+    jumpToVariant,
+    handlePrimaryAction,
+  };
+}


### PR DESCRIPTION
Refactor of `apps/location-manager/packages/client/src/shared/components/location-media/modals/MultiVariantCropperModal.tsx`, flagged at **681 LOC / 9 concerns** ("very large; too many concerns") — the highest concern count in the audit.

## Problem

One file held four unrelated things: trigonometric crop geometry, a standalone straighten-dial UI component, all cropper state and handlers, and ~230 lines of modal JSX.

## Change

| Module | LOC | Responsibility |
| --- | --- | --- |
| `multiVariantCropper.geometry.ts` | 81 | Angle clamping, rotated bounding box, centered crop area, variant sequence |
| `StraightenDial.tsx` | 92 | The dial component — was file-private, now independently viewable |
| `useMultiVariantCropper.ts` | 304 | Per-variant crop state, orientation, auto-crop, confirm flow |
| `MultiVariantCropperModal.tsx` | 315 | JSX only |

## Behavior

Pure extraction. The hook preserves the original hook call order exactly (7 `useState`, then the credit-reset effect, then `cropStates`, the preview-URL and file-reset effects, then the 5 `useCallback`s) — reordering any of those would change render behavior, so the sequence is deliberately unchanged.

Verified mechanically rather than by eye:
- the modal's `<Dialog>` JSX is **byte-identical** to `main` (233 lines, zero diff)
- the `StraightenDial` body is **byte-identical** to `main`
- geometry function bodies moved verbatim

Export name and file path are unchanged, so all **5 consumers** (`TourImageUploadPanel`, `AddUploadFilesForm`, `PhotoImportPanel`, `LocationMediaGallery`, `PhotoImportPhase`) need no edits.

## Verification

- `tsc --noEmit -p tsconfig.app.json` → **0 errors**, matching baseline

Worth flagging: `lm-client` has both `lint` and `test` stubbed out in `package.json` ("TypeScript/React baseline not yet clean"), so typecheck is the only automated gate available here. The byte-identical JSX/component diffs above are what carry the confidence.
