### PR TITLE
refactor: extract alt-text review from usePhotoImportPanel

### DIFF
--- a/apps/location-manager/packages/client/src/shared/components/location-media/photoImportPanel.utils.ts
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/photoImportPanel.utils.ts
@@ -1,6 +1,7 @@
 import type { ImageVariantType } from "@questurian/lm-shared";
 import { VARIANT_SPECS } from "@questurian/lm-shared";
 import type { CropState } from "@client/shared/types/location-media.types";
+import type { StagedSourceSnapshot } from "@client/shared/services/api";
 
 export const PHOTO_IMPORT_VARIANT_TYPES: ImageVariantType[] = [
   "thumbnail",
@@ -73,4 +74,22 @@ export function toImageApiPath(path: string): string {
 export function getFileNameFromPath(path: string, fallback: string): string {
   const fileName = path.split("/").pop();
   return fileName?.trim() ? fileName : fallback;
+}
+
+/**
+ * Download a staged source image as a File so it can be fed to the cropper or
+ * the alt-text model. The `?v=` cache-buster keeps a re-staged source from
+ * resolving to a stale cached response at the same path.
+ */
+export async function fetchSourceFile(source: StagedSourceSnapshot): Promise<File> {
+  if (!source.sourcePath) throw new Error("Missing source image");
+  const url = `${toImageApiPath(source.sourcePath)}?v=${source.uploadId}-${Date.now()}`;
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to load source (${response.status})`);
+  const blob = await response.blob();
+  return new File(
+    [blob],
+    getFileNameFromPath(source.sourcePath, `${source.origin}-${source.uploadId}.webp`),
+    { type: blob.type || "image/webp" }
+  );
 }

--- a/apps/location-manager/packages/client/src/shared/components/location-media/useAltTextReview.ts
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/useAltTextReview.ts
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import type { StagedSourceSnapshot } from "@client/shared/services/api";
+import { useGenerateAltText } from "@client/shared/services/api/hooks/useGenerateAltText";
+import { useToast } from "@client/shared/hooks/useToast";
+import { fetchSourceFile } from "./photoImportPanel.utils";
+
+type AltReviewState = {
+  isOpen: boolean;
+  uploadId: number | null;
+  file: File | null;
+  generatedText: string;
+  error: string | null;
+};
+
+const CLOSED_ALT_REVIEW_STATE: AltReviewState = {
+  isOpen: false,
+  uploadId: null,
+  file: null,
+  generatedText: "",
+  error: null,
+};
+
+type UseAltTextReviewOptions = {
+  /**
+   * Called when the operator approves an alt text. The panel uses this to hand
+   * the source and its approved alt text on to the cropper.
+   */
+  onApproved: (uploadId: number, file: File, altText: string) => void;
+};
+
+/**
+ * The alt-text review step of the photo-import flow.
+ *
+ * Opening a review downloads the staged source, then generates alt text unless
+ * a value is already cached for that upload (either from a previous generation
+ * in this session or from the source itself). Generated text is cached per
+ * uploadId so reopening a review does not re-bill the model.
+ */
+export function useAltTextReview({ onApproved }: UseAltTextReviewOptions) {
+  const { showToast } = useToast();
+  const [altReviewState, setAltReviewState] = useState<AltReviewState>(CLOSED_ALT_REVIEW_STATE);
+  const [cachedAltTexts, setCachedAltTexts] = useState<Record<number, string>>({});
+  const [loadingSourceId, setLoadingSourceId] = useState<number | null>(null);
+  const generateAltText = useGenerateAltText();
+
+  async function generateAltTextForReview(file: File, uploadId: number) {
+    try {
+      const result = await generateAltText.mutateAsync({ imageFile: file, uploadId });
+      setCachedAltTexts((current) => ({ ...current, [uploadId]: result.altText }));
+      setAltReviewState((state) => state.uploadId === uploadId
+        ? { ...state, generatedText: result.altText, error: null }
+        : state);
+    } catch (error) {
+      setAltReviewState((state) => state.uploadId === uploadId
+        ? { ...state, error: error instanceof Error ? error.message : "Alt-text generation failed" }
+        : state);
+    }
+  }
+
+  async function handleOpenReview(source: StagedSourceSnapshot) {
+    if (!source.sourcePath) return;
+    setLoadingSourceId(source.uploadId);
+    try {
+      const file = await fetchSourceFile(source);
+      const cachedAltText = cachedAltTexts[source.uploadId] ?? source.altText ?? "";
+      setAltReviewState({
+        isOpen: true,
+        uploadId: source.uploadId,
+        file,
+        generatedText: cachedAltText,
+        error: null,
+      });
+      if (!cachedAltText) await generateAltTextForReview(file, source.uploadId);
+    } catch (err) {
+      const center = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast(err instanceof Error ? err.message : "Failed to load source", center);
+    } finally {
+      setLoadingSourceId((current) => (current === source.uploadId ? null : current));
+    }
+  }
+
+  function closeAltReview() {
+    setAltReviewState(CLOSED_ALT_REVIEW_STATE);
+  }
+
+  function confirmAltText(altText: string) {
+    if (!altReviewState.uploadId || !altReviewState.file) return;
+    onApproved(altReviewState.uploadId, altReviewState.file, altText);
+    closeAltReview();
+  }
+
+  function regenerateAltText() {
+    if (altReviewState.file && altReviewState.uploadId) {
+      void generateAltTextForReview(altReviewState.file, altReviewState.uploadId);
+    }
+  }
+
+  return {
+    altReviewState,
+    loadingSourceId,
+    handleOpenReview,
+    closeAltReview,
+    confirmAltText,
+    regenerateAltText,
+    isGeneratingAltText: generateAltText.isPending,
+  };
+}

--- a/apps/location-manager/packages/client/src/shared/components/location-media/usePhotoImportPanel.ts
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/usePhotoImportPanel.ts
@@ -8,11 +8,10 @@ import {
 } from "@client/shared/services/api";
 import { useGooglePhotoImportEnabled } from "@client/shared/services/api/hooks";
 import { useReplaceUploadVariants } from "@client/shared/services/api/hooks/useReplaceUploadVariants";
-import { useGenerateAltText } from "@client/shared/services/api/hooks/useGenerateAltText";
 import { useToast } from "@client/shared/hooks/useToast";
 import type { ImageVariantUploadFile } from "@client/shared/types/location-media.types";
 import type { LocationCategory, PhotoImportStartPhoto } from "@questurian/lm-shared";
-import { getFileNameFromPath, toImageApiPath } from "./photoImportPanel.utils";
+import { useAltTextReview } from "./useAltTextReview";
 
 type CropModalState = {
   isOpen: boolean;
@@ -28,22 +27,6 @@ const CLOSED_CROP_STATE: CropModalState = {
   altText: undefined,
 };
 
-type AltReviewState = {
-  isOpen: boolean;
-  uploadId: number | null;
-  file: File | null;
-  generatedText: string;
-  error: string | null;
-};
-
-const CLOSED_ALT_REVIEW_STATE: AltReviewState = {
-  isOpen: false,
-  uploadId: null,
-  file: null,
-  generatedText: "",
-  error: null,
-};
-
 type UsePhotoImportPanelOptions = {
   locationId: number;
   category: LocationCategory;
@@ -55,9 +38,6 @@ export function usePhotoImportPanel({ locationId, category, hasActiveInstagramSt
   const { enabled: photoImportEnabled } = useGooglePhotoImportEnabled();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [cropState, setCropState] = useState<CropModalState>(CLOSED_CROP_STATE);
-  const [altReviewState, setAltReviewState] = useState<AltReviewState>(CLOSED_ALT_REVIEW_STATE);
-  const [cachedAltTexts, setCachedAltTexts] = useState<Record<number, string>>({});
-  const [loadingSourceId, setLoadingSourceId] = useState<number | null>(null);
   const [deleteConfirmSource, setDeleteConfirmSource] = useState<StagedSourceSnapshot | null>(null);
   const [previewSource, setPreviewSource] = useState<StagedSourceSnapshot | null>(null);
 
@@ -65,7 +45,13 @@ export function usePhotoImportPanel({ locationId, category, hasActiveInstagramSt
   const startImport = useStartPhotoImport();
   const retryStaged = useRetryStagedSource();
   const deleteStaged = useDeleteStagedSource();
-  const generateAltText = useGenerateAltText();
+
+  // Approving an alt text advances straight into the cropper for that source.
+  const altReview = useAltTextReview({
+    onApproved: (uploadId, file, altText) => {
+      setCropState({ isOpen: true, uploadId, file, altText });
+    },
+  });
 
   const replaceVariants = useReplaceUploadVariants({
     category,
@@ -108,76 +94,6 @@ export function usePhotoImportPanel({ locationId, category, hasActiveInstagramSt
     );
   }
 
-  async function fetchSourceFile(source: StagedSourceSnapshot): Promise<File> {
-    if (!source.sourcePath) throw new Error("Missing source image");
-    const url = `${toImageApiPath(source.sourcePath)}?v=${source.uploadId}-${Date.now()}`;
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`Failed to load source (${response.status})`);
-    const blob = await response.blob();
-    return new File(
-      [blob],
-      getFileNameFromPath(source.sourcePath, `${source.origin}-${source.uploadId}.webp`),
-      { type: blob.type || "image/webp" }
-    );
-  }
-
-  async function handleOpenReview(source: StagedSourceSnapshot) {
-    if (!source.sourcePath) return;
-    setLoadingSourceId(source.uploadId);
-    try {
-      const file = await fetchSourceFile(source);
-      const cachedAltText = cachedAltTexts[source.uploadId] ?? source.altText ?? "";
-      setAltReviewState({
-        isOpen: true,
-        uploadId: source.uploadId,
-        file,
-        generatedText: cachedAltText,
-        error: null,
-      });
-      if (!cachedAltText) await generateAltTextForReview(file, source.uploadId);
-    } catch (err) {
-      const center = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast(err instanceof Error ? err.message : "Failed to load source", center);
-    } finally {
-      setLoadingSourceId((current) => (current === source.uploadId ? null : current));
-    }
-  }
-
-  async function generateAltTextForReview(file: File, uploadId: number) {
-    try {
-      const result = await generateAltText.mutateAsync({ imageFile: file, uploadId });
-      setCachedAltTexts((current) => ({ ...current, [uploadId]: result.altText }));
-      setAltReviewState((state) => state.uploadId === uploadId
-        ? { ...state, generatedText: result.altText, error: null }
-        : state);
-    } catch (error) {
-      setAltReviewState((state) => state.uploadId === uploadId
-        ? { ...state, error: error instanceof Error ? error.message : "Alt-text generation failed" }
-        : state);
-    }
-  }
-
-  function closeAltReview() {
-    setAltReviewState(CLOSED_ALT_REVIEW_STATE);
-  }
-
-  function confirmAltText(altText: string) {
-    if (!altReviewState.uploadId || !altReviewState.file) return;
-    setCropState({
-      isOpen: true,
-      uploadId: altReviewState.uploadId,
-      file: altReviewState.file,
-      altText,
-    });
-    closeAltReview();
-  }
-
-  function regenerateAltText() {
-    if (altReviewState.file && altReviewState.uploadId) {
-      void generateAltTextForReview(altReviewState.file, altReviewState.uploadId);
-    }
-  }
-
   function handleCropConfirm(sourceFile: File, variantFiles: ImageVariantUploadFile[]) {
     if (!cropState.uploadId) return;
     replaceVariants.mutate({
@@ -204,7 +120,7 @@ export function usePhotoImportPanel({ locationId, category, hasActiveInstagramSt
     if (!previewSource) return;
     const source = previewSource;
     setPreviewSource(null);
-    void handleOpenReview(source);
+    void altReview.handleOpenReview(source);
   }
 
   // From the preview, hand off to the delete-confirmation flow.
@@ -237,24 +153,24 @@ export function usePhotoImportPanel({ locationId, category, hasActiveInstagramSt
     photoImportEnabled,
     pickerOpen,
     cropState,
-    altReviewState,
-    loadingSourceId,
+    altReviewState: altReview.altReviewState,
+    loadingSourceId: altReview.loadingSourceId,
     startImport,
     retryPending: retryStaged.isPending,
     pendingSources,
     setPickerOpen,
     closeCropper,
-    closeAltReview,
+    closeAltReview: altReview.closeAltReview,
     handleConfirmPick,
-    handleOpenReview,
+    handleOpenReview: altReview.handleOpenReview,
     previewSource,
     openPreview,
     closePreview,
     reviewFromPreview,
     deleteFromPreview,
-    confirmAltText,
-    regenerateAltText,
-    isGeneratingAltText: generateAltText.isPending,
+    confirmAltText: altReview.confirmAltText,
+    regenerateAltText: altReview.regenerateAltText,
+    isGeneratingAltText: altReview.isGeneratingAltText,
     handleCropConfirm,
     handleDelete,
     handleRetry,


### PR DESCRIPTION
Refactor of `apps/location-manager/packages/client/src/shared/components/location-media/usePhotoImportPanel.ts`, flagged at **266 LOC / 7 concerns** ("18 functions; many concerns").

## Problem

One hook drove four distinct flows — Google picker, alt-text review, cropper handoff, and preview/delete — with their state interleaved.

## Change

| Module | LOC | Responsibility |
| --- | --- | --- |
| `useAltTextReview.ts` | 107 | Review state, AI generation, per-upload caching |
| `photoImportPanel.utils.ts` | 95 (+22) | Gains `fetchSourceFile` |
| `usePhotoImportPanel.ts` | 182 | Picker, cropper, preview/delete orchestration |

`fetchSourceFile` moved next to the two helpers it already calls (`toImageApiPath`, `getFileNameFromPath`) rather than staying inline in the hook.

The review hook takes an `onApproved(uploadId, file, altText)` callback instead of writing the cropper's state directly. Extracting it the obvious way would have made the two hooks mutually dependent — `confirmAltText` set `cropState`, while `reviewFromPreview` called `handleOpenReview` — so the callback keeps the handoff one-directional.

## Behavior

Pure extraction. The returned object has the **same 28 keys** under the same names (verified by diffing the key sets against `main`), so the consuming components need no changes. Alt-text caching semantics are preserved: generated text is still cached per `uploadId` so reopening a review doesn't re-bill the model, and `openPreview` still deliberately avoids triggering the AI.

## Verification

- `tsc --noEmit -p tsconfig.app.json` → **0 errors**, matching baseline
- returned key set diff → identical, 28/28
- `fetchSourceFile` body → identical modulo indentation

⚠️ **Note on test coverage:** there is a `photoImportPanel.utils.test.ts` sitting next to the file I added a function to, but it **cannot currently run** — `vitest` isn't a dependency of `lm-client`, and the `npx` fallback fails on this environment's Node 18.19.1 (`rolldown` needs `styleText`, Node 20+). Combined with `lint` and `test` both being stubbed in `lm-client`'s `package.json`, typecheck is the only working automated gate. Getting that test file running again is worth a separate issue.
