### PR TITLE
refactor: extract types, predicates, selectors from usePayloadSyncFilters

### DIFF
--- a/apps/location-manager/packages/client/src/features/admin/hooks/usePayloadSyncFilters.ts
+++ b/apps/location-manager/packages/client/src/features/admin/hooks/usePayloadSyncFilters.ts
@@ -2,111 +2,55 @@ import { useEffect, useMemo, useState } from "react";
 import { formatLocationName } from "@questurian/lm-shared";
 import type { Category } from "@client/shared/services/api/types";
 import type { SyncStatusResponse } from "@client/shared/services/api/types/payload.types";
+import { buildFacetOptions } from "@client/features/admin/utils/payload-sync-filter-utils";
 import {
-  buildFacetOptions,
-  extractPayloadSyncLocationScope,
-  isPayloadSyncCategory,
-  matchesFacetFilter,
-} from "@client/features/admin/utils/payload-sync-filter-utils";
+  UNSPECIFIED_CITY_FILTER,
+  UNSPECIFIED_COUNTRY_FILTER,
+  UNSPECIFIED_NEIGHBORHOOD_FILTER,
+  UNSPECIFIED_TYPE_FILTER,
+  type CityFilter,
+  type CountryFilter,
+  type LocationTypeFilter,
+  type LocationsBasicData,
+  type NeighborhoodFilter,
+  type StatusFilter,
+} from "@client/features/admin/utils/payload-sync-filter.types";
+import {
+  formatActiveScopePart,
+  formatLabel,
+  matchesCityFilter,
+  matchesCountryFilter,
+} from "@client/features/admin/utils/payload-sync-filter-predicates";
+import {
+  applyLocationTypeFilter,
+  applyScopeFilters,
+  applyStatusAndCategoryFilters,
+  buildLocationsWithStatus,
+  buildSyncStatusMap,
+  computeSyncStats,
+} from "@client/features/admin/utils/payload-sync-selectors";
 
-export type StatusFilter = "all" | "synced" | "ready" | "incomplete" | "needs_resync" | "failed" | "unsupported";
-
-export const UNSPECIFIED_COUNTRY_FILTER = "__unspecified_country__";
-export const UNSPECIFIED_CITY_FILTER = "__unspecified_city__";
-export const UNSPECIFIED_NEIGHBORHOOD_FILTER = "__unspecified_neighborhood__";
-export const UNSPECIFIED_TYPE_FILTER = "__unspecified_type__";
-
-export type CountryFilter = "all" | typeof UNSPECIFIED_COUNTRY_FILTER | string;
-export type CityFilter = "all" | typeof UNSPECIFIED_CITY_FILTER | string;
-export type NeighborhoodFilter = "all" | typeof UNSPECIFIED_NEIGHBORHOOD_FILTER | string;
-export type LocationTypeFilter = "all" | typeof UNSPECIFIED_TYPE_FILTER | string;
-
-export interface LocationWithSyncStatus {
-  locationId: number;
-  title: string;
-  location: string | null;
-  locationKey: string | null;
-  country: string | null;
-  city: string | null;
-  neighborhood: string | null;
-  category: Category;
-  type: string | null;
-  isComplete: boolean;
-  synced: boolean;
-  needsResync: boolean;
-  syncState?: SyncStatusResponse["syncState"];
-}
-
-interface LocationBasic {
-  id: number;
-  title?: string | null;
-  name: string;
-  location: string | null;
-  locationKey: string | null;
-  country: string | null;
-  category: Category;
-  type?: string | null;
-  isComplete: boolean;
-}
-
-interface LocationsBasicData {
-  locations?: LocationBasic[];
-}
-
-export function matchesStatusFilter(item: LocationWithSyncStatus, filter: StatusFilter): boolean {
-  const supported = isPayloadSyncCategory(item.category);
-
-  switch (filter) {
-    case "all":
-      return true;
-    case "synced":
-      return supported && item.synced && !item.needsResync;
-    case "ready":
-      return supported &&
-        item.isComplete &&
-        !item.synced &&
-        item.syncState?.sync_status !== "failed" &&
-        item.syncState?.sync_status !== "pending";
-    case "incomplete":
-      return !item.isComplete;
-    case "needs_resync":
-      return supported && item.needsResync;
-    case "failed":
-      return item.syncState?.sync_status === "failed";
-    case "unsupported":
-      return !supported;
-    default:
-      return true;
-  }
-}
-
-export function formatLabel(value: string): string {
-  return value
-    .split(/[_-]+/g)
-    .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join(" ");
-}
-
-function matchesCountryFilter(country: string | null, filter: CountryFilter): boolean {
-  return matchesFacetFilter(country, filter, UNSPECIFIED_COUNTRY_FILTER);
-}
-
-function matchesCityFilter(city: string | null, filter: CityFilter): boolean {
-  return matchesFacetFilter(city, filter, UNSPECIFIED_CITY_FILTER);
-}
-
-function matchesNeighborhoodFilter(neighborhood: string | null, filter: NeighborhoodFilter): boolean {
-  return matchesFacetFilter(neighborhood, filter, UNSPECIFIED_NEIGHBORHOOD_FILTER);
-}
-
-function formatActiveScopePart(value: string, unspecifiedValue: string, unspecifiedLabel: string): string {
-  if (value === unspecifiedValue) {
-    return unspecifiedLabel;
-  }
-
-  return formatLocationName(value);
-}
+// Re-exported so existing importers of this module keep working unchanged.
+export {
+  UNSPECIFIED_CITY_FILTER,
+  UNSPECIFIED_COUNTRY_FILTER,
+  UNSPECIFIED_NEIGHBORHOOD_FILTER,
+  UNSPECIFIED_TYPE_FILTER,
+} from "@client/features/admin/utils/payload-sync-filter.types";
+export type {
+  CityFilter,
+  CountryFilter,
+  LocationBasic,
+  LocationTypeFilter,
+  LocationWithSyncStatus,
+  LocationsBasicData,
+  NeighborhoodFilter,
+  StatusFilter,
+} from "@client/features/admin/utils/payload-sync-filter.types";
+export {
+  formatLabel,
+  matchesStatusFilter,
+} from "@client/features/admin/utils/payload-sync-filter-predicates";
 
 export function usePayloadSyncFilters(
   statusData: SyncStatusResponse[] | undefined,
@@ -119,57 +63,18 @@ export function usePayloadSyncFilters(
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [locationTypeFilter, setLocationTypeFilter] = useState<LocationTypeFilter>("all");
 
-  const syncStatusMap = useMemo(() => {
-    const map = new Map<number, SyncStatusResponse>();
-    (statusData ?? []).forEach((item) => {
-      map.set(item.locationId, item);
-    });
-    return map;
-  }, [statusData]);
+  const syncStatusMap = useMemo(() => buildSyncStatusMap(statusData), [statusData]);
 
-  const allLocationsWithStatus = useMemo<LocationWithSyncStatus[]>(() => {
-    return (locationsBasicData?.locations ?? []).map((location) => {
-      const syncStatus = syncStatusMap.get(location.id);
-      const locationScope = extractPayloadSyncLocationScope({
-        location: location.location,
-        locationKey: location.locationKey,
-        country: location.country,
-      });
-
-      return {
-        locationId: location.id,
-        title: location.title || location.name,
-        location: locationScope.location,
-        locationKey: locationScope.locationKey,
-        country: locationScope.country,
-        city: locationScope.city,
-        neighborhood: locationScope.neighborhood,
-        category: location.category,
-        type: location.type?.trim() || null,
-        isComplete: location.isComplete,
-        synced: !!syncStatus && syncStatus.synced,
-        needsResync: !!syncStatus && syncStatus.needsResync,
-        syncState: syncStatus?.syncState,
-      };
-    });
-  }, [locationsBasicData, syncStatusMap]);
+  const allLocationsWithStatus = useMemo(
+    () => buildLocationsWithStatus(locationsBasicData, syncStatusMap),
+    [locationsBasicData, syncStatusMap]
+  );
 
   const locationHierarchyBaseData = useMemo(() => {
-    let filtered = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, statusFilter));
-
-    if (categoryFilter !== "all") {
-      filtered = filtered.filter((item) => item.category === categoryFilter);
-    }
-
-    if (locationTypeFilter !== "all") {
-      if (locationTypeFilter === UNSPECIFIED_TYPE_FILTER) {
-        filtered = filtered.filter((item) => !item.type);
-      } else {
-        filtered = filtered.filter((item) => item.type === locationTypeFilter);
-      }
-    }
-
-    return filtered;
+    return applyLocationTypeFilter(
+      applyStatusAndCategoryFilters(allLocationsWithStatus, statusFilter, categoryFilter),
+      locationTypeFilter
+    );
   }, [allLocationsWithStatus, categoryFilter, locationTypeFilter, statusFilter]);
 
   const countryOptions = useMemo(() => {
@@ -284,17 +189,12 @@ export function usePayloadSyncFilters(
   }, [isNeighborhoodFilterEnabled, neighborhoodFilter, neighborhoodOptions]);
 
   const locationTypeBaseData = useMemo(() => {
-    let filtered = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, statusFilter));
-
-    if (categoryFilter !== "all") {
-      filtered = filtered.filter((item) => item.category === categoryFilter);
-    }
-
-    filtered = filtered.filter((item) => matchesCountryFilter(item.country, countryFilter));
-    filtered = filtered.filter((item) => matchesCityFilter(item.city, cityFilter));
-    filtered = filtered.filter((item) => matchesNeighborhoodFilter(item.neighborhood, neighborhoodFilter));
-
-    return filtered;
+    return applyScopeFilters(
+      applyStatusAndCategoryFilters(allLocationsWithStatus, statusFilter, categoryFilter),
+      countryFilter,
+      cityFilter,
+      neighborhoodFilter
+    );
   }, [
     allLocationsWithStatus,
     categoryFilter,
@@ -331,25 +231,15 @@ export function usePayloadSyncFilters(
   }, [locationTypeFilter, locationTypeOptions]);
 
   const filteredData = useMemo(() => {
-    let filtered = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, statusFilter));
-
-    if (categoryFilter !== "all") {
-      filtered = filtered.filter((item) => item.category === categoryFilter);
-    }
-
-    filtered = filtered.filter((item) => matchesCountryFilter(item.country, countryFilter));
-    filtered = filtered.filter((item) => matchesCityFilter(item.city, cityFilter));
-    filtered = filtered.filter((item) => matchesNeighborhoodFilter(item.neighborhood, neighborhoodFilter));
-
-    if (locationTypeFilter !== "all") {
-      if (locationTypeFilter === UNSPECIFIED_TYPE_FILTER) {
-        filtered = filtered.filter((item) => !item.type);
-      } else {
-        filtered = filtered.filter((item) => item.type === locationTypeFilter);
-      }
-    }
-
-    return filtered;
+    return applyLocationTypeFilter(
+      applyScopeFilters(
+        applyStatusAndCategoryFilters(allLocationsWithStatus, statusFilter, categoryFilter),
+        countryFilter,
+        cityFilter,
+        neighborhoodFilter
+      ),
+      locationTypeFilter
+    );
   }, [
     allLocationsWithStatus,
     categoryFilter,
@@ -365,17 +255,7 @@ export function usePayloadSyncFilters(
     [filteredData]
   );
 
-  const stats = useMemo(() => {
-    const total = allLocationsWithStatus.length;
-    const synced = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, "synced")).length;
-    const ready = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, "ready")).length;
-    const incomplete = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, "incomplete")).length;
-    const needsResync = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, "needs_resync")).length;
-    const failed = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, "failed")).length;
-    const unsupported = allLocationsWithStatus.filter((item) => matchesStatusFilter(item, "unsupported")).length;
-
-    return { total, synced, ready, incomplete, needsResync, failed, unsupported };
-  }, [allLocationsWithStatus]);
+  const stats = useMemo(() => computeSyncStats(allLocationsWithStatus), [allLocationsWithStatus]);
 
   const hasActiveFilters =
     statusFilter !== "all" ||

--- a/apps/location-manager/packages/client/src/features/admin/utils/payload-sync-filter-predicates.ts
+++ b/apps/location-manager/packages/client/src/features/admin/utils/payload-sync-filter-predicates.ts
@@ -1,0 +1,70 @@
+import { formatLocationName } from "@questurian/lm-shared";
+import {
+  isPayloadSyncCategory,
+  matchesFacetFilter,
+} from "@client/features/admin/utils/payload-sync-filter-utils";
+import {
+  UNSPECIFIED_CITY_FILTER,
+  UNSPECIFIED_COUNTRY_FILTER,
+  UNSPECIFIED_NEIGHBORHOOD_FILTER,
+  type CityFilter,
+  type CountryFilter,
+  type LocationWithSyncStatus,
+  type NeighborhoodFilter,
+  type StatusFilter,
+} from "./payload-sync-filter.types";
+
+export function matchesStatusFilter(item: LocationWithSyncStatus, filter: StatusFilter): boolean {
+  const supported = isPayloadSyncCategory(item.category);
+
+  switch (filter) {
+    case "all":
+      return true;
+    case "synced":
+      return supported && item.synced && !item.needsResync;
+    case "ready":
+      return supported &&
+        item.isComplete &&
+        !item.synced &&
+        item.syncState?.sync_status !== "failed" &&
+        item.syncState?.sync_status !== "pending";
+    case "incomplete":
+      return !item.isComplete;
+    case "needs_resync":
+      return supported && item.needsResync;
+    case "failed":
+      return item.syncState?.sync_status === "failed";
+    case "unsupported":
+      return !supported;
+    default:
+      return true;
+  }
+}
+
+export function formatLabel(value: string): string {
+  return value
+    .split(/[_-]+/g)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function matchesCountryFilter(country: string | null, filter: CountryFilter): boolean {
+  return matchesFacetFilter(country, filter, UNSPECIFIED_COUNTRY_FILTER);
+}
+
+export function matchesCityFilter(city: string | null, filter: CityFilter): boolean {
+  return matchesFacetFilter(city, filter, UNSPECIFIED_CITY_FILTER);
+}
+
+export function matchesNeighborhoodFilter(neighborhood: string | null, filter: NeighborhoodFilter): boolean {
+  return matchesFacetFilter(neighborhood, filter, UNSPECIFIED_NEIGHBORHOOD_FILTER);
+}
+
+export function formatActiveScopePart(value: string, unspecifiedValue: string, unspecifiedLabel: string): string {
+  if (value === unspecifiedValue) {
+    return unspecifiedLabel;
+  }
+
+  return formatLocationName(value);
+}

--- a/apps/location-manager/packages/client/src/features/admin/utils/payload-sync-filter.types.ts
+++ b/apps/location-manager/packages/client/src/features/admin/utils/payload-sync-filter.types.ts
@@ -1,0 +1,46 @@
+import type { Category } from "@client/shared/services/api/types";
+import type { SyncStatusResponse } from "@client/shared/services/api/types/payload.types";
+
+export type StatusFilter = "all" | "synced" | "ready" | "incomplete" | "needs_resync" | "failed" | "unsupported";
+
+export const UNSPECIFIED_COUNTRY_FILTER = "__unspecified_country__";
+export const UNSPECIFIED_CITY_FILTER = "__unspecified_city__";
+export const UNSPECIFIED_NEIGHBORHOOD_FILTER = "__unspecified_neighborhood__";
+export const UNSPECIFIED_TYPE_FILTER = "__unspecified_type__";
+
+export type CountryFilter = "all" | typeof UNSPECIFIED_COUNTRY_FILTER | string;
+export type CityFilter = "all" | typeof UNSPECIFIED_CITY_FILTER | string;
+export type NeighborhoodFilter = "all" | typeof UNSPECIFIED_NEIGHBORHOOD_FILTER | string;
+export type LocationTypeFilter = "all" | typeof UNSPECIFIED_TYPE_FILTER | string;
+
+export interface LocationWithSyncStatus {
+  locationId: number;
+  title: string;
+  location: string | null;
+  locationKey: string | null;
+  country: string | null;
+  city: string | null;
+  neighborhood: string | null;
+  category: Category;
+  type: string | null;
+  isComplete: boolean;
+  synced: boolean;
+  needsResync: boolean;
+  syncState?: SyncStatusResponse["syncState"];
+}
+
+export interface LocationBasic {
+  id: number;
+  title?: string | null;
+  name: string;
+  location: string | null;
+  locationKey: string | null;
+  country: string | null;
+  category: Category;
+  type?: string | null;
+  isComplete: boolean;
+}
+
+export interface LocationsBasicData {
+  locations?: LocationBasic[];
+}

--- a/apps/location-manager/packages/client/src/features/admin/utils/payload-sync-selectors.ts
+++ b/apps/location-manager/packages/client/src/features/admin/utils/payload-sync-selectors.ts
@@ -1,0 +1,115 @@
+import type { SyncStatusResponse } from "@client/shared/services/api/types/payload.types";
+import type { Category } from "@client/shared/services/api/types";
+import { extractPayloadSyncLocationScope } from "@client/features/admin/utils/payload-sync-filter-utils";
+import {
+  UNSPECIFIED_TYPE_FILTER,
+  type CityFilter,
+  type CountryFilter,
+  type LocationTypeFilter,
+  type LocationWithSyncStatus,
+  type LocationsBasicData,
+  type NeighborhoodFilter,
+  type StatusFilter,
+} from "./payload-sync-filter.types";
+import {
+  matchesCityFilter,
+  matchesCountryFilter,
+  matchesNeighborhoodFilter,
+  matchesStatusFilter,
+} from "./payload-sync-filter-predicates";
+
+export function buildSyncStatusMap(
+  statusData: SyncStatusResponse[] | undefined
+): Map<number, SyncStatusResponse> {
+  const map = new Map<number, SyncStatusResponse>();
+  (statusData ?? []).forEach((item) => {
+    map.set(item.locationId, item);
+  });
+  return map;
+}
+
+export function buildLocationsWithStatus(
+  locationsBasicData: LocationsBasicData | undefined,
+  syncStatusMap: Map<number, SyncStatusResponse>
+): LocationWithSyncStatus[] {
+  return (locationsBasicData?.locations ?? []).map((location) => {
+    const syncStatus = syncStatusMap.get(location.id);
+    const locationScope = extractPayloadSyncLocationScope({
+      location: location.location,
+      locationKey: location.locationKey,
+      country: location.country,
+    });
+
+    return {
+      locationId: location.id,
+      title: location.title || location.name,
+      location: locationScope.location,
+      locationKey: locationScope.locationKey,
+      country: locationScope.country,
+      city: locationScope.city,
+      neighborhood: locationScope.neighborhood,
+      category: location.category,
+      type: location.type?.trim() || null,
+      isComplete: location.isComplete,
+      synced: !!syncStatus && syncStatus.synced,
+      needsResync: !!syncStatus && syncStatus.needsResync,
+      syncState: syncStatus?.syncState,
+    };
+  });
+}
+
+/**
+ * Status + category narrowing, the common base every derived list starts from.
+ */
+export function applyStatusAndCategoryFilters(
+  items: LocationWithSyncStatus[],
+  statusFilter: StatusFilter,
+  categoryFilter: Category | "all"
+): LocationWithSyncStatus[] {
+  let filtered = items.filter((item) => matchesStatusFilter(item, statusFilter));
+
+  if (categoryFilter !== "all") {
+    filtered = filtered.filter((item) => item.category === categoryFilter);
+  }
+
+  return filtered;
+}
+
+export function applyLocationTypeFilter(
+  items: LocationWithSyncStatus[],
+  locationTypeFilter: LocationTypeFilter
+): LocationWithSyncStatus[] {
+  if (locationTypeFilter === "all") {
+    return items;
+  }
+
+  if (locationTypeFilter === UNSPECIFIED_TYPE_FILTER) {
+    return items.filter((item) => !item.type);
+  }
+
+  return items.filter((item) => item.type === locationTypeFilter);
+}
+
+export function applyScopeFilters(
+  items: LocationWithSyncStatus[],
+  countryFilter: CountryFilter,
+  cityFilter: CityFilter,
+  neighborhoodFilter: NeighborhoodFilter
+): LocationWithSyncStatus[] {
+  return items
+    .filter((item) => matchesCountryFilter(item.country, countryFilter))
+    .filter((item) => matchesCityFilter(item.city, cityFilter))
+    .filter((item) => matchesNeighborhoodFilter(item.neighborhood, neighborhoodFilter));
+}
+
+export function computeSyncStats(items: LocationWithSyncStatus[]) {
+  const total = items.length;
+  const synced = items.filter((item) => matchesStatusFilter(item, "synced")).length;
+  const ready = items.filter((item) => matchesStatusFilter(item, "ready")).length;
+  const incomplete = items.filter((item) => matchesStatusFilter(item, "incomplete")).length;
+  const needsResync = items.filter((item) => matchesStatusFilter(item, "needs_resync")).length;
+  const failed = items.filter((item) => matchesStatusFilter(item, "failed")).length;
+  const unsupported = items.filter((item) => matchesStatusFilter(item, "unsupported")).length;
+
+  return { total, synced, ready, incomplete, needsResync, failed, unsupported };
+}


### PR DESCRIPTION
Refactor of `apps/location-manager/packages/client/src/features/admin/hooks/usePayloadSyncFilters.ts`, flagged at **456 LOC / 7 concerns** ("broad hook/export surface").

## Problem

The hook was also the module that defined the feature's filter types, sentinel constants, pure predicates, and all list/stat derivation — hence the broad export surface. Five other modules import types and values from it.

## Change

| Module | LOC | Responsibility |
| --- | --- | --- |
| `payload-sync-filter.types.ts` | 46 | Filter types + `UNSPECIFIED_*` sentinels |
| `payload-sync-filter-predicates.ts` | 70 | `matchesStatusFilter`, `formatLabel`, facet matchers |
| `payload-sync-selectors.ts` | 115 | List building, filter composition, stats |
| `usePayloadSyncFilters.ts` | 336 | State, memos, the four cascade auto-reset effects |

The hook **re-exports** the constants, types, `formatLabel` and `matchesStatusFilter` it previously defined, so all 5 importing modules (`PayloadSync`, `useBulkPayloadSync`, `PayloadSyncStats`, `PayloadSyncTable`, `PayloadSyncFilters`) are untouched.

## The risky part, and how it was verified

Three derived lists — `locationHierarchyBaseData`, `locationTypeBaseData`, `filteredData` — each repeated the same status/category/scope/type filtering inline with slightly different subsets. Collapsing them onto shared selectors is exactly where an off-by-one-predicate bug would hide, and it would show up as *silently wrong filter results*, not an error.

So this was checked differentially rather than by reading. A harness ran the **original inline memo bodies** (copied verbatim from `main`) against the new selector composition over every combination of all six filters, on 400 generated locations spanning null/blank/whitespace countries, cities, neighborhoods and types:

```
ran 24193 comparisons across 400 items
✓ ALL IDENTICAL — selectors reproduce original composition
```

The `stats` block was compared the same way.

## Verification

- differential harness → **24,193 comparisons, 0 mismatches**
- `tsc --noEmit -p tsconfig.app.json` → **0 errors**, matching baseline
- returned object keys → identical, 25/25

(As with the other `lm-client` PRs: `lint` and `test` are stubbed out in that package, so the differential harness is doing the real work here.)
