### PR TITLE
refactor: extract useAddUploadFilesForm from AddUploadFilesForm

### DIFF
--- a/apps/location-manager/packages/client/src/shared/components/location-media/forms/AddUploadFilesForm.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/forms/AddUploadFilesForm.tsx
@@ -1,23 +1,12 @@
-import { useState, useRef, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Upload, Clock3, ShieldCheck } from 'lucide-react';
-import { VARIANT_SPECS } from '@questurian/lm-shared';
 import { FormInput } from '@client/shared/components/forms';
 import { Button } from '@client/components/ui/button';
-import { useToast } from '@client/shared/hooks/useToast';
-import { useAddUploadImageSet } from '@client/shared/services/api/hooks/useAddUploadImageSet';
-import { useGenerateAltText } from '@client/shared/services/api/hooks/useGenerateAltText';
-import { useLocationById } from '@client/shared/services/api/hooks/useLocationById';
 import type { Category } from '@client/shared/services/api/types';
-import type { ImageVariantUploadFile, QueuedImageSetPayload } from '@client/shared/types/location-media.types';
+import type { QueuedImageSetPayload } from '@client/shared/types/location-media.types';
 import { ImagePreviewGrid } from '../ui/ImagePreviewGrid';
 import { MultiVariantCropperModal } from '../modals/MultiVariantCropperModal';
 import { AltTextReviewModal } from '../modals/AltTextReviewModal';
-import {
-  addUploadFilesSchema,
-  type AddUploadFilesFormData,
-} from '../validation/add-upload-files.schema';
+import { useAddUploadFilesForm } from './useAddUploadFilesForm';
 
 interface AddUploadFilesFormProps {
   category?: Category;
@@ -26,270 +15,48 @@ interface AddUploadFilesFormProps {
   onQueueImageSet?: (payload: QueuedImageSetPayload) => void;
 }
 
-interface ProcessedImageSet {
-  sourceFile: File;
-  variantFiles: ImageVariantUploadFile[];
-  altText?: string;
-}
-
 export function AddUploadFilesForm({
   category,
   locationId,
   defaultPhotographerCredit,
   onQueueImageSet,
 }: AddUploadFilesFormProps) {
-  const { showToast } = useToast();
-  const variantCount = Object.keys(VARIANT_SPECS).length;
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const [processedImageSets, setProcessedImageSets] = useState<(ProcessedImageSet | null)[]>([]);
-  const [cropModalState, setCropModalState] = useState<{
-    isOpen: boolean;
-    fileIndex: number | null;
-  }>({ isOpen: false, fileIndex: null });
-  const [altTextModalState, setAltTextModalState] = useState<{
-    isOpen: boolean;
-    fileIndex: number | null;
-    aiGeneratedText: string;
-  }>({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
-  const [altTextGenerationError, setAltTextGenerationError] = useState<string | null>(null);
-  const [confirmedAltTexts, setConfirmedAltTexts] = useState<(string | undefined)[]>([]);
-  const [isDragging, setIsDragging] = useState(false);
-  const [showMetadataCleanedBadge, setShowMetadataCleanedBadge] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const { data: location } = useLocationById(locationId ?? null, category ?? null);
-
-  const form = useForm<AddUploadFilesFormData>({
-    resolver: zodResolver(addUploadFilesSchema),
-    defaultValues: {
-      photographerCredit: '',
-    },
+  const {
+    form,
+    fileInputRef,
+    variantCount,
+    isUploadMode,
+    isPending,
+    uploadProgress,
+    isGeneratingAltText,
+    selectedFiles,
+    processedImageSets,
+    cropModalState,
+    setCropModalState,
+    altTextModalState,
+    altTextGenerationError,
+    isDragging,
+    showMetadataCleanedBadge,
+    hasValidPhotographerCredit,
+    handleFileSelect,
+    handleRemoveFile,
+    handleReset,
+    handleCropImage,
+    handleCropConfirm,
+    handleAltTextConfirm,
+    handleAltTextCancel,
+    areAllFilesCropped,
+    hasCroppedImages,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleFormSubmit,
+  } = useAddUploadFilesForm({
+    category,
+    locationId,
+    defaultPhotographerCredit,
+    onQueueImageSet,
   });
-
-  useEffect(() => {
-    const preferredCredit = location?.title || defaultPhotographerCredit || '';
-    if (preferredCredit && !form.getValues('photographerCredit')) {
-      form.setValue('photographerCredit', preferredCredit);
-    }
-  }, [location?.title, defaultPhotographerCredit, form]);
-
-  const { mutate: generateAltText, isPending: isGeneratingAltText } = useGenerateAltText({
-    onSuccess: (data) => {
-      setAltTextGenerationError(null);
-      if (altTextModalState.fileIndex !== null) {
-        setAltTextModalState((prev) => ({
-          ...prev,
-          aiGeneratedText: data.altText,
-        }));
-      }
-    },
-    onError: (error) => {
-      console.warn('Failed to generate alt text:', error);
-      setAltTextGenerationError('AI alt text unavailable. Enter alt text manually.');
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast('AI alt text unavailable. Enter alt text manually.', centerPosition);
-      if (altTextModalState.fileIndex !== null) {
-        setAltTextModalState((prev) => ({
-          ...prev,
-          aiGeneratedText: '',
-        }));
-      }
-    },
-  });
-
-  const { mutate, isPending, uploadProgress } = useAddUploadImageSet(category ?? null, locationId ?? 0, {
-    onSuccess: () => {
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast(`Image set uploaded. Image metadata cleaned. (${variantCount} variants)`, centerPosition);
-      handleReset();
-      setShowMetadataCleanedBadge(true);
-    },
-    onError: (error: Error) => {
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast(error.message || 'Failed to upload image set', centerPosition);
-    },
-  });
-
-  const isUploadMode = typeof locationId === 'number' && !!category;
-  const photographerCreditValue = form.watch('photographerCredit') || '';
-  const hasValidPhotographerCredit = photographerCreditValue.trim().length > 0;
-
-  function handleFileSelect(files: FileList | null) {
-    if (!files) return;
-    const fileArray = Array.from(files);
-    const startIndex = selectedFiles.length;
-
-    setShowMetadataCleanedBadge(false);
-    setSelectedFiles((prev) => [...prev, ...fileArray]);
-    setProcessedImageSets((prev) => [...prev, ...new Array(fileArray.length).fill(null)]);
-    setConfirmedAltTexts((prev) => [...prev, ...new Array(fileArray.length).fill(undefined)]);
-
-    setAltTextModalState({
-      isOpen: true,
-      fileIndex: startIndex,
-      aiGeneratedText: '',
-    });
-    setAltTextGenerationError(null);
-
-    if (fileArray.length > 0) {
-      generateAltText(fileArray[0]);
-    }
-
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-  }
-
-  function handleRemoveFile(index: number) {
-    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
-    setProcessedImageSets((prev) => prev.filter((_, i) => i !== index));
-    setConfirmedAltTexts((prev) => prev.filter((_, i) => i !== index));
-
-    if (cropModalState.fileIndex === index) {
-      setCropModalState({ isOpen: false, fileIndex: null });
-    }
-    if (altTextModalState.fileIndex === index) {
-      setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
-    }
-  }
-
-  function handleReset() {
-    setSelectedFiles([]);
-    setProcessedImageSets([]);
-    setConfirmedAltTexts([]);
-    setCropModalState({ isOpen: false, fileIndex: null });
-    setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
-    setAltTextGenerationError(null);
-    form.reset();
-
-    const preferredCredit = location?.title || defaultPhotographerCredit || '';
-    if (preferredCredit) {
-      form.setValue('photographerCredit', preferredCredit);
-    }
-
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-  }
-
-  function handleSubmit(data: AddUploadFilesFormData) {
-    if (!areAllFilesCropped()) return;
-    const normalizedPhotographerCredit = data.photographerCredit.trim();
-    if (!normalizedPhotographerCredit) return;
-
-    const imageSet = processedImageSets[0];
-    if (!imageSet) return;
-
-    const altText = confirmedAltTexts[0];
-    const payload: QueuedImageSetPayload = {
-      sourceFile: imageSet.sourceFile,
-      variantFiles: imageSet.variantFiles,
-      photographerCredit: normalizedPhotographerCredit,
-      altText,
-    };
-
-    if (!isUploadMode) {
-      if (!onQueueImageSet) {
-        const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-        showToast('Unable to queue image set before document creation.', centerPosition);
-        return;
-      }
-
-      onQueueImageSet(payload);
-      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-      showToast('Image set queued. It will upload after document creation.', centerPosition);
-      handleReset();
-      return;
-    }
-
-    mutate(payload);
-  }
-
-  function handleCropImage(index: number) {
-    setCropModalState({ isOpen: true, fileIndex: index });
-  }
-
-  function handleCropConfirm(
-    sourceFile: File,
-    variantFiles: ImageVariantUploadFile[]
-  ) {
-    if (cropModalState.fileIndex === null) return;
-
-    setProcessedImageSets((prev) => {
-      const updated = [...prev];
-      updated[cropModalState.fileIndex!] = { sourceFile, variantFiles };
-      return updated;
-    });
-
-    const nextUncropped = findNextUncroppedIndex(cropModalState.fileIndex + 1);
-    if (nextUncropped !== null) {
-      setCropModalState({ isOpen: true, fileIndex: nextUncropped });
-    } else {
-      setCropModalState({ isOpen: false, fileIndex: null });
-    }
-  }
-
-  function findNextUncroppedIndex(startIndex: number): number | null {
-    for (let i = startIndex; i < selectedFiles.length; i++) {
-      if (!processedImageSets[i]) return i;
-    }
-    return null;
-  }
-
-  function handleAltTextConfirm(altText: string) {
-    if (altTextModalState.fileIndex === null) return;
-
-    setConfirmedAltTexts((prev) => {
-      const updated = [...prev];
-      updated[altTextModalState.fileIndex!] = altText;
-      return updated;
-    });
-
-    setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
-    setAltTextGenerationError(null);
-    setCropModalState({ isOpen: true, fileIndex: altTextModalState.fileIndex });
-  }
-
-  function handleAltTextCancel() {
-    if (altTextModalState.fileIndex !== null) {
-      handleRemoveFile(altTextModalState.fileIndex);
-    }
-    setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
-    setAltTextGenerationError(null);
-  }
-
-  function areAllFilesCropped(): boolean {
-    return (
-      selectedFiles.length > 0 &&
-      selectedFiles.every((_, i) => processedImageSets[i] !== null)
-    );
-  }
-
-  function hasCroppedImages(): boolean {
-    return processedImageSets.some((set) => set !== null);
-  }
-
-  function handleDragOver(e: React.DragEvent) {
-    e.preventDefault();
-    setIsDragging(true);
-  }
-
-  function handleDragLeave(e: React.DragEvent) {
-    e.preventDefault();
-    setIsDragging(false);
-  }
-
-  function handleDrop(e: React.DragEvent) {
-    e.preventDefault();
-    setIsDragging(false);
-    const files = e.dataTransfer.files;
-    handleFileSelect(files);
-  }
-
-  function handleFormSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    void form.handleSubmit(handleSubmit)(event);
-  }
 
   return (
     <div className="border rounded-lg p-4 bg-muted/50 space-y-3 min-h-[368px]">

--- a/apps/location-manager/packages/client/src/shared/components/location-media/forms/useAddUploadFilesForm.ts
+++ b/apps/location-manager/packages/client/src/shared/components/location-media/forms/useAddUploadFilesForm.ts
@@ -1,0 +1,331 @@
+import { useState, useRef, useEffect } from 'react';
+import type React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { VARIANT_SPECS } from '@questurian/lm-shared';
+import { useToast } from '@client/shared/hooks/useToast';
+import { useAddUploadImageSet } from '@client/shared/services/api/hooks/useAddUploadImageSet';
+import { useGenerateAltText } from '@client/shared/services/api/hooks/useGenerateAltText';
+import { useLocationById } from '@client/shared/services/api/hooks/useLocationById';
+import type { Category } from '@client/shared/services/api/types';
+import type { ImageVariantUploadFile, QueuedImageSetPayload } from '@client/shared/types/location-media.types';
+import {
+  addUploadFilesSchema,
+  type AddUploadFilesFormData,
+} from '../validation/add-upload-files.schema';
+
+interface ProcessedImageSet {
+  sourceFile: File;
+  variantFiles: ImageVariantUploadFile[];
+  altText?: string;
+}
+
+interface UseAddUploadFilesFormArgs {
+  category?: Category;
+  locationId?: number;
+  defaultPhotographerCredit?: string;
+  onQueueImageSet?: (payload: QueuedImageSetPayload) => void;
+}
+
+/**
+ * Drives the add/queue image-set form.
+ *
+ * Selecting files starts a per-file pipeline: alt-text review, then cropping
+ * into every variant. Both are tracked as index-parallel arrays alongside
+ * `selectedFiles`, so removing a file has to splice all three together.
+ *
+ * With a locationId + category the form uploads directly; without them it
+ * hands the finished image set to `onQueueImageSet` to upload after the parent
+ * document is created.
+ */
+export function useAddUploadFilesForm({
+  category,
+  locationId,
+  defaultPhotographerCredit,
+  onQueueImageSet,
+}: UseAddUploadFilesFormArgs) {
+  const { showToast } = useToast();
+  const variantCount = Object.keys(VARIANT_SPECS).length;
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [processedImageSets, setProcessedImageSets] = useState<(ProcessedImageSet | null)[]>([]);
+  const [cropModalState, setCropModalState] = useState<{
+    isOpen: boolean;
+    fileIndex: number | null;
+  }>({ isOpen: false, fileIndex: null });
+  const [altTextModalState, setAltTextModalState] = useState<{
+    isOpen: boolean;
+    fileIndex: number | null;
+    aiGeneratedText: string;
+  }>({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
+  const [altTextGenerationError, setAltTextGenerationError] = useState<string | null>(null);
+  const [confirmedAltTexts, setConfirmedAltTexts] = useState<(string | undefined)[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [showMetadataCleanedBadge, setShowMetadataCleanedBadge] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { data: location } = useLocationById(locationId ?? null, category ?? null);
+
+  const form = useForm<AddUploadFilesFormData>({
+    resolver: zodResolver(addUploadFilesSchema),
+    defaultValues: {
+      photographerCredit: '',
+    },
+  });
+
+  useEffect(() => {
+    const preferredCredit = location?.title || defaultPhotographerCredit || '';
+    if (preferredCredit && !form.getValues('photographerCredit')) {
+      form.setValue('photographerCredit', preferredCredit);
+    }
+  }, [location?.title, defaultPhotographerCredit, form]);
+
+  const { mutate: generateAltText, isPending: isGeneratingAltText } = useGenerateAltText({
+    onSuccess: (data) => {
+      setAltTextGenerationError(null);
+      if (altTextModalState.fileIndex !== null) {
+        setAltTextModalState((prev) => ({
+          ...prev,
+          aiGeneratedText: data.altText,
+        }));
+      }
+    },
+    onError: (error) => {
+      console.warn('Failed to generate alt text:', error);
+      setAltTextGenerationError('AI alt text unavailable. Enter alt text manually.');
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast('AI alt text unavailable. Enter alt text manually.', centerPosition);
+      if (altTextModalState.fileIndex !== null) {
+        setAltTextModalState((prev) => ({
+          ...prev,
+          aiGeneratedText: '',
+        }));
+      }
+    },
+  });
+
+  const { mutate, isPending, uploadProgress } = useAddUploadImageSet(category ?? null, locationId ?? 0, {
+    onSuccess: () => {
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast(`Image set uploaded. Image metadata cleaned. (${variantCount} variants)`, centerPosition);
+      handleReset();
+      setShowMetadataCleanedBadge(true);
+    },
+    onError: (error: Error) => {
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast(error.message || 'Failed to upload image set', centerPosition);
+    },
+  });
+
+  const isUploadMode = typeof locationId === 'number' && !!category;
+  const photographerCreditValue = form.watch('photographerCredit') || '';
+  const hasValidPhotographerCredit = photographerCreditValue.trim().length > 0;
+
+  function handleFileSelect(files: FileList | null) {
+    if (!files) return;
+    const fileArray = Array.from(files);
+    const startIndex = selectedFiles.length;
+
+    setShowMetadataCleanedBadge(false);
+    setSelectedFiles((prev) => [...prev, ...fileArray]);
+    setProcessedImageSets((prev) => [...prev, ...new Array(fileArray.length).fill(null)]);
+    setConfirmedAltTexts((prev) => [...prev, ...new Array(fileArray.length).fill(undefined)]);
+
+    setAltTextModalState({
+      isOpen: true,
+      fileIndex: startIndex,
+      aiGeneratedText: '',
+    });
+    setAltTextGenerationError(null);
+
+    if (fileArray.length > 0) {
+      generateAltText(fileArray[0]);
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  function handleRemoveFile(index: number) {
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+    setProcessedImageSets((prev) => prev.filter((_, i) => i !== index));
+    setConfirmedAltTexts((prev) => prev.filter((_, i) => i !== index));
+
+    if (cropModalState.fileIndex === index) {
+      setCropModalState({ isOpen: false, fileIndex: null });
+    }
+    if (altTextModalState.fileIndex === index) {
+      setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
+    }
+  }
+
+  function handleReset() {
+    setSelectedFiles([]);
+    setProcessedImageSets([]);
+    setConfirmedAltTexts([]);
+    setCropModalState({ isOpen: false, fileIndex: null });
+    setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
+    setAltTextGenerationError(null);
+    form.reset();
+
+    const preferredCredit = location?.title || defaultPhotographerCredit || '';
+    if (preferredCredit) {
+      form.setValue('photographerCredit', preferredCredit);
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  function handleSubmit(data: AddUploadFilesFormData) {
+    if (!areAllFilesCropped()) return;
+    const normalizedPhotographerCredit = data.photographerCredit.trim();
+    if (!normalizedPhotographerCredit) return;
+
+    const imageSet = processedImageSets[0];
+    if (!imageSet) return;
+
+    const altText = confirmedAltTexts[0];
+    const payload: QueuedImageSetPayload = {
+      sourceFile: imageSet.sourceFile,
+      variantFiles: imageSet.variantFiles,
+      photographerCredit: normalizedPhotographerCredit,
+      altText,
+    };
+
+    if (!isUploadMode) {
+      if (!onQueueImageSet) {
+        const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+        showToast('Unable to queue image set before document creation.', centerPosition);
+        return;
+      }
+
+      onQueueImageSet(payload);
+      const centerPosition = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+      showToast('Image set queued. It will upload after document creation.', centerPosition);
+      handleReset();
+      return;
+    }
+
+    mutate(payload);
+  }
+
+  function handleCropImage(index: number) {
+    setCropModalState({ isOpen: true, fileIndex: index });
+  }
+
+  function handleCropConfirm(
+    sourceFile: File,
+    variantFiles: ImageVariantUploadFile[]
+  ) {
+    if (cropModalState.fileIndex === null) return;
+
+    setProcessedImageSets((prev) => {
+      const updated = [...prev];
+      updated[cropModalState.fileIndex!] = { sourceFile, variantFiles };
+      return updated;
+    });
+
+    const nextUncropped = findNextUncroppedIndex(cropModalState.fileIndex + 1);
+    if (nextUncropped !== null) {
+      setCropModalState({ isOpen: true, fileIndex: nextUncropped });
+    } else {
+      setCropModalState({ isOpen: false, fileIndex: null });
+    }
+  }
+
+  function findNextUncroppedIndex(startIndex: number): number | null {
+    for (let i = startIndex; i < selectedFiles.length; i++) {
+      if (!processedImageSets[i]) return i;
+    }
+    return null;
+  }
+
+  function handleAltTextConfirm(altText: string) {
+    if (altTextModalState.fileIndex === null) return;
+
+    setConfirmedAltTexts((prev) => {
+      const updated = [...prev];
+      updated[altTextModalState.fileIndex!] = altText;
+      return updated;
+    });
+
+    setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
+    setAltTextGenerationError(null);
+    setCropModalState({ isOpen: true, fileIndex: altTextModalState.fileIndex });
+  }
+
+  function handleAltTextCancel() {
+    if (altTextModalState.fileIndex !== null) {
+      handleRemoveFile(altTextModalState.fileIndex);
+    }
+    setAltTextModalState({ isOpen: false, fileIndex: null, aiGeneratedText: '' });
+    setAltTextGenerationError(null);
+  }
+
+  function areAllFilesCropped(): boolean {
+    return (
+      selectedFiles.length > 0 &&
+      selectedFiles.every((_, i) => processedImageSets[i] !== null)
+    );
+  }
+
+  function hasCroppedImages(): boolean {
+    return processedImageSets.some((set) => set !== null);
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(true);
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+    const files = e.dataTransfer.files;
+    handleFileSelect(files);
+  }
+
+  function handleFormSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void form.handleSubmit(handleSubmit)(event);
+  }
+
+  return {
+    form,
+    fileInputRef,
+    variantCount,
+    isUploadMode,
+    isPending,
+    uploadProgress,
+    isGeneratingAltText,
+    selectedFiles,
+    processedImageSets,
+    cropModalState,
+    setCropModalState,
+    altTextModalState,
+    altTextGenerationError,
+    isDragging,
+    showMetadataCleanedBadge,
+    hasValidPhotographerCredit,
+    handleFileSelect,
+    handleRemoveFile,
+    handleReset,
+    handleCropImage,
+    handleCropConfirm,
+    handleAltTextConfirm,
+    handleAltTextCancel,
+    areAllFilesCropped,
+    hasCroppedImages,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleFormSubmit,
+  };
+}


### PR DESCRIPTION
Refactor of `apps/location-manager/packages/client/src/shared/components/location-media/forms/AddUploadFilesForm.tsx`, flagged at **423 LOC / 6 concerns** ("16 functions; heavy imports").

## Problem

One component held the full per-file pipeline (alt-text review → multi-variant cropping), two mutations, drag-and-drop handling, credit prefill, and ~130 lines of JSX.

## Change

| Module | LOC | Responsibility |
| --- | --- | --- |
| `useAddUploadFilesForm.ts` | 331 | State, mutations, the 16 handlers |
| `AddUploadFilesForm.tsx` | 190 | JSX only |

## Behavior

Pure extraction. Two things preserved on purpose:

1. **`handleReset` stays a `function` declaration.** The `useAddUploadImageSet` `onSuccess` callback is defined *above* `handleReset` but calls it, which only works because function declarations hoist. Tidying the handlers into `const` arrow functions — the natural instinct when moving code into a hook — would turn that into a TDZ error the moment an upload succeeded. Left as-is.

2. **Hook call order is unchanged**, so render behavior is identical.

The component's JSX is **byte-identical** to `main` (128 lines, zero diff), verified mechanically. Props interface and export name unchanged.

Also documented in the hook: `selectedFiles`, `processedImageSets` and `confirmedAltTexts` are index-parallel arrays, which is why `handleRemoveFile` has to splice all three together — non-obvious and easy to break later.

## Verification

- form JSX diff vs `main` → **identical, 128/128 lines**
- `tsc --noEmit -p tsconfig.app.json` → **0 errors**, matching baseline
