### PR TITLE
refactor: split core completeness field editors and save strategies

### DIFF
--- a/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-completeness-fields.tsx
+++ b/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-completeness-fields.tsx
@@ -1,32 +1,35 @@
-import type { ReactNode } from "react";
-import type { LocationResponse, UpdateMapsRequest } from "@client/shared/services/api/types";
-import { Input } from "@client/components/ui";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "@client/components/ui/select";
-import { TaxonomyLocationEditor } from "@client/shared/components/forms";
-import { isValidLocationKey } from "@client/shared/lib/taxonomy-location";
-import { DINING_ESTABLISHMENT_TYPE_GROUPS } from "@shared/types/dining-taxonomy";
-import type { FieldDef } from "./completeness-field-edit.types";
-import type { CompletenessFieldDraft } from "./drafts/use-completeness-field-draft";
 import { PRICE_LEVELS, TIMEZONE_OPTIONS } from "./field-options";
-import { withAttractionContactDetail } from "./completeness-detail-fields";
-import { parseCoordinateInput } from "./field-value-utils";
-import { buildOperationHoursJson } from "./operation-hours/operation-hours-utils";
-import { OperationHoursFieldEditor } from "./operation-hours/OperationHoursFieldEditor";
-import { CoordinatesFieldEditor } from "./fields/CoordinatesFieldEditor";
-import { CuisinesFieldEditor } from "./fields/CuisinesFieldEditor";
-import { IdealForFieldEditor } from "./fields/IdealForFieldEditor";
-import { NeighborhoodDescriptionFieldEditor } from "./fields/NeighborhoodDescriptionFieldEditor";
-import { RawJsonFieldInput } from "./fields/RawJsonFieldInput";
-import type { SaveStrategy } from "./submission/save-strategy";
+import type { CoreFieldConfig } from "./core-field.types";
+import {
+  coordinatesEditor,
+  cuisinesEditor,
+  idealForEditor,
+  neighborhoodDescriptionEditor,
+  operationHoursEditor,
+  phoneEditor,
+  rawJsonEditor,
+  selectEditor,
+  taxonomyEditor,
+  textEditor,
+  typeEditor,
+} from "./core-field-editors";
+import {
+  contactUrlStrategy,
+  coordinatesStrategy,
+  cuisinesStrategy,
+  detailsJson,
+  idealForStrategy,
+  mediaStrategy,
+  operationHoursStrategy,
+  phoneStrategy,
+  rawJsonStrategy,
+  simpleValueStrategy,
+  taxonomyStrategy,
+  websiteStrategy,
+} from "./core-field-save-strategies";
+
+export type { CoreFieldConfig, CoreFieldEditorContext } from "./core-field.types";
+export { defaultFieldEditor } from "./core-field-editors";
 
 /**
  * Single source of truth for the "core" completeness fields — every field that
@@ -34,157 +37,10 @@ import type { SaveStrategy } from "./submission/save-strategy";
  * detail field (see completeness-detail-fields.ts). Adding a field means adding
  * one entry here with its `draftInit`, `editor`, and `saveStrategy`, instead of
  * editing three separate behaviour maps (draft init / render switch / save).
+ *
+ * Editors live in ./core-field-editors, save strategies in
+ * ./core-field-save-strategies, so this stays a readable table.
  */
-export interface CoreFieldEditorContext {
-  field: FieldDef;
-  category: string;
-  draft: CompletenessFieldDraft;
-  isPending: boolean;
-}
-
-export interface CoreFieldConfig {
-  /** Seeds the shared `value` draft slice when the editor opens. */
-  draftInit?: (location: LocationResponse) => string;
-  /** Renders the field editor. Omitted for fields rendered by the modal shell
-   *  itself (e.g. `media`, `contactUrl`). */
-  editor?: (context: CoreFieldEditorContext) => ReactNode;
-  /** Whether the draft is saveable and how it persists. */
-  saveStrategy: SaveStrategy;
-}
-
-// --- Editor helpers -------------------------------------------------------
-
-function textEditor(type: "text" | "url" = "text") {
-  return ({ field, draft }: CoreFieldEditorContext) => (
-    <Input
-      value={draft.value}
-      onChange={(event) => draft.setValue(event.target.value)}
-      placeholder={`Enter ${field.label.toLowerCase()}`}
-      type={type}
-    />
-  );
-}
-
-function selectEditor(
-  options: ReadonlyArray<{ value: string; label: string }>,
-  placeholder: string
-) {
-  return ({ draft }: CoreFieldEditorContext) => (
-    <Select value={draft.value || undefined} onValueChange={draft.setValue}>
-      <SelectTrigger>
-        <SelectValue placeholder={placeholder} />
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((option) => (
-          <SelectItem key={option.value} value={option.value}>
-            {option.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
-
-function rawJsonEditor({ field, draft }: CoreFieldEditorContext) {
-  return <RawJsonFieldInput fieldKey={field.key} value={draft.value} onChange={draft.setValue} />;
-}
-
-// --- Save-strategy helpers ------------------------------------------------
-
-/**
- * Strategy for plain string-backed fields. `buildPayload` returns the update
- * payload for the trimmed draft value, or `null` when the value cannot be
- * saved (which also disables the Save button).
- */
-function simpleValueStrategy(
-  buildPayload: (trimmed: string) => Partial<UpdateMapsRequest> | null
-): SaveStrategy {
-  return {
-    canSave: ({ draft }) => buildPayload(draft.value.trim()) !== null,
-    save: ({ field, draft, save }) => {
-      const payload = buildPayload(draft.value.trim());
-      if (payload) {
-        save(payload as UpdateMapsRequest, `${field.label} saved`, `Failed to save ${field.label}`);
-      }
-    },
-  };
-}
-
-function getCoordinateValidation(
-  draft: CompletenessFieldDraft
-): { valid: true; lat: number; lng: number } | { valid: false; message: string } {
-  const lat = parseCoordinateInput(draft.coordinateDraft.lat);
-  const lng = parseCoordinateInput(draft.coordinateDraft.lng);
-  if (lat == null || lng == null) return { valid: false, message: "Latitude and longitude are required" };
-  if (lat < -90 || lat > 90) return { valid: false, message: "Latitude must be between -90 and 90" };
-  if (lng < -180 || lng > 180) return { valid: false, message: "Longitude must be between -180 and 180" };
-  return { valid: true, lat, lng };
-}
-
-const taxonomyStrategy: SaveStrategy = {
-  canSave: ({ draft }) => {
-    const locationKey = draft.taxonomyLocationKey.trim();
-    return !locationKey || isValidLocationKey(locationKey);
-  },
-  save: ({ draft, save, showValidationError }) => {
-    const locationKey = draft.taxonomyLocationKey.trim();
-    if (locationKey && !isValidLocationKey(locationKey)) {
-      showValidationError("Location Key must be lowercase kebab-case (country|city|neighborhood)");
-      return;
-    }
-    save(
-      {
-        locationKey: locationKey || undefined,
-        district: draft.taxonomyDistrict.trim() || null,
-        autoApproveTaxonomy: true,
-      },
-      "Location taxonomy saved",
-      "Failed to save location taxonomy"
-    );
-  },
-};
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function parseRawJsonDraft(
-  value: string
-): { valid: true; value: Record<string, unknown> | null } | { valid: false; message: string } {
-  const trimmed = value.trim();
-  if (!trimmed) return { valid: true, value: null };
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (parsed === null) return { valid: true, value: null };
-    if (!isPlainRecord(parsed)) return { valid: false, message: "JSON must be an object" };
-    return { valid: true, value: parsed };
-  } catch {
-    return { valid: false, message: "Enter valid JSON before saving" };
-  }
-}
-
-function rawJsonStrategy(
-  fieldKey: "nightlifeDetails" | "accommodationsDetails" | "attractionsDetails" | "keyLocationsDetails"
-): SaveStrategy {
-  return {
-    canSave: ({ draft }) => parseRawJsonDraft(draft.value).valid,
-    save: ({ field, draft, save, showValidationError }) => {
-      const parsed = parseRawJsonDraft(draft.value);
-      if (!parsed.valid) {
-        showValidationError(parsed.message);
-        return;
-      }
-      save({ [fieldKey]: parsed.value }, `${field.label} saved`, `Failed to save ${field.label}`);
-    },
-  };
-}
-
-function detailsJson(value: unknown): string {
-  return value ? JSON.stringify(value, null, 2) : "";
-}
-
-// --- Registry -------------------------------------------------------------
-
 const CORE_FIELD_REGISTRY = {
   title: {
     draftInit: (l) => l.title?.trim() ?? "",
@@ -203,42 +59,7 @@ const CORE_FIELD_REGISTRY = {
   },
   type: {
     draftInit: (l) => l.type?.trim() ?? "",
-    editor: ({ category, draft }) => (
-      <Select value={draft.value || undefined} onValueChange={draft.setValue} disabled={draft.isLoadingTypes}>
-        <SelectTrigger>
-          <SelectValue
-            placeholder={
-              draft.isLoadingTypes
-                ? "Loading types..."
-                : category === "dining"
-                  ? "Select establishment type"
-                  : "Select a type"
-            }
-          />
-        </SelectTrigger>
-        <SelectContent>
-          {category === "dining"
-            ? DINING_ESTABLISHMENT_TYPE_GROUPS.map((group, groupIndex) => (
-                <SelectGroup key={group.label}>
-                  <SelectLabel className="pl-2 pr-2 py-1 text-[11px] uppercase tracking-wide text-muted-foreground">
-                    {group.label}
-                  </SelectLabel>
-                  {group.options.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                  {groupIndex < DINING_ESTABLISHMENT_TYPE_GROUPS.length - 1 && <SelectSeparator />}
-                </SelectGroup>
-              ))
-            : draft.locationTypes.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-        </SelectContent>
-      </Select>
-    ),
+    editor: typeEditor,
     saveStrategy: simpleValueStrategy((t) => ({ type: t || undefined })),
   },
   locationKey: {
@@ -252,20 +73,8 @@ const CORE_FIELD_REGISTRY = {
     saveStrategy: taxonomyStrategy,
   },
   coordinates: {
-    editor: ({ draft }) => (
-      <CoordinatesFieldEditor value={draft.coordinateDraft} onChange={draft.setCoordinateDraft} onCopy={draft.copyText} />
-    ),
-    saveStrategy: {
-      canSave: ({ draft }) => getCoordinateValidation(draft).valid,
-      save: ({ draft, save, showValidationError }) => {
-        const validation = getCoordinateValidation(draft);
-        if (!validation.valid) {
-          showValidationError(validation.message);
-          return;
-        }
-        save({ lat: validation.lat, lng: validation.lng }, "Coordinates saved", "Failed to save coordinates");
-      },
-    },
+    editor: coordinatesEditor,
+    saveStrategy: coordinatesStrategy,
   },
   ianaTimeId: {
     draftInit: (l) => l.ianaTimeId?.trim() ?? "",
@@ -279,59 +88,13 @@ const CORE_FIELD_REGISTRY = {
   },
   phone: {
     draftInit: (l) => l.contact?.phoneNumber?.trim() ?? "",
-    editor: ({ draft }) => (
-      <div className="space-y-2">
-        <Input
-          value={draft.value}
-          onChange={(event) => draft.setValue(event.target.value)}
-          placeholder="Enter phone"
-          disabled={draft.phoneNotAvailable}
-        />
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={draft.phoneNotAvailable}
-            onChange={(event) => {
-              const checked = event.target.checked;
-              draft.setPhoneNotAvailable(checked);
-              if (checked) draft.setValue("");
-            }}
-          />
-          Phone not available
-        </label>
-      </div>
-    ),
-    saveStrategy: {
-      canSave: () => true,
-      save: ({ locationDetail, draft, save }) => {
-        const phoneNumber = draft.phoneNotAvailable ? "" : draft.value.trim();
-        save(
-          withAttractionContactDetail(
-            locationDetail,
-            { phoneNumber, phoneUnavailable: draft.phoneNotAvailable },
-            "phone",
-            phoneNumber
-          ),
-          "Phone saved",
-          "Failed to save phone"
-        );
-      },
-    },
+    editor: phoneEditor,
+    saveStrategy: phoneStrategy,
   },
   website: {
     draftInit: (l) => l.contact?.website?.trim() ?? "",
     editor: textEditor("url"),
-    saveStrategy: {
-      canSave: () => true,
-      save: ({ locationDetail, draft, save }) => {
-        const website = draft.value.trim();
-        save(
-          withAttractionContactDetail(locationDetail, { website }, "website", website),
-          "Website saved",
-          "Failed to save Website"
-        );
-      },
-    },
+    saveStrategy: websiteStrategy,
   },
   bookingUrl: {
     draftInit: (l) => l.bookingUrl?.trim() ?? "",
@@ -340,19 +103,7 @@ const CORE_FIELD_REGISTRY = {
   },
   contactUrl: {
     draftInit: (l) => l.contact?.url?.trim() ?? "",
-    saveStrategy: {
-      canSave: ({ locationDetail }) =>
-        Boolean(locationDetail.source?.name?.trim() && locationDetail.source?.address?.trim()),
-      save: ({ locationDetail, save, showValidationError }) => {
-        const name = locationDetail.source?.name?.trim();
-        const address = locationDetail.source?.address?.trim();
-        if (!name || !address) {
-          showValidationError("Name and Source Address are required to generate Google URL");
-          return;
-        }
-        save({ name, address }, "Google URL regenerated", "Failed to regenerate Google URL");
-      },
-    },
+    saveStrategy: contactUrlStrategy,
   },
   tripadvisorUrl: {
     draftInit: (l) => l.tripadvisorUrl?.trim() ?? "",
@@ -361,59 +112,18 @@ const CORE_FIELD_REGISTRY = {
   },
   neighborhoodDescription: {
     draftInit: (l) => l.neighborhoodDescription?.trim() ?? "",
-    editor: ({ draft, isPending }) => (
-      <NeighborhoodDescriptionFieldEditor
-        value={draft.value}
-        canGenerate={draft.canGenerateNeighborhoodDescription}
-        locationHierarchyLabel={draft.locationHierarchyLabel}
-        isPending={isPending}
-        isGenerating={draft.isGeneratingNeighborhoodDescription}
-        onChange={draft.setValue}
-        onGenerate={() => draft.generateNeighborhoodDescription()}
-      />
-    ),
+    editor: neighborhoodDescriptionEditor,
     saveStrategy: simpleValueStrategy((t) => ({ neighborhoodDescription: t || undefined })),
   },
   idealFor: {
     draftInit: (l) => (Array.isArray(l.idealFor) ? l.idealFor.join(", ") : ""),
-    editor: ({ draft }) => (
-      <IdealForFieldEditor
-        value={draft.idealForDraft}
-        availableGroups={draft.availableIdealForGroups}
-        onAdd={draft.addIdealForTag}
-        onRemove={draft.removeIdealForTag}
-      />
-    ),
-    saveStrategy: {
-      canSave: ({ draft }) => draft.idealForDraft.length > 0,
-      save: ({ draft, save, showValidationError }) => {
-        if (!draft.idealForDraft.length) {
-          showValidationError("Select at least one Ideal For tag");
-          return;
-        }
-        save({ idealFor: draft.idealForDraft }, "Ideal For saved", "Failed to save Ideal For");
-      },
-    },
+    editor: idealForEditor,
+    saveStrategy: idealForStrategy,
   },
   cuisines: {
     draftInit: (l) => (Array.isArray(l.tripadvisorCuisines) ? l.tripadvisorCuisines.join(", ") : ""),
-    editor: ({ draft }) => (
-      <CuisinesFieldEditor
-        value={draft.cuisinesDraft}
-        availableOptions={draft.availableCuisineOptions}
-        availableGroups={draft.availableCuisineGroups}
-        onChange={draft.setCuisinesDraft}
-      />
-    ),
-    saveStrategy: {
-      canSave: () => true,
-      save: ({ draft, save }) =>
-        save(
-          { tripadvisorCuisines: draft.cuisinesDraft.length ? draft.cuisinesDraft : null },
-          "Cuisines saved",
-          "Failed to save cuisines"
-        ),
-    },
+    editor: cuisinesEditor,
+    saveStrategy: cuisinesStrategy,
   },
   priceLevel: {
     draftInit: (l) => l.priceLevel?.trim() ?? "",
@@ -422,18 +132,11 @@ const CORE_FIELD_REGISTRY = {
   },
   operationHours: {
     draftInit: (l) => detailsJson(l.operationHours),
-    editor: ({ draft }) => <OperationHoursFieldEditor dayEntries={draft.dayEntries} onChange={draft.setDayEntries} />,
-    saveStrategy: {
-      canSave: () => true,
-      save: ({ draft, save }) =>
-        save({ operationHours: buildOperationHoursJson(draft.dayEntries) }, "Hours saved", "Failed to save hours"),
-    },
+    editor: operationHoursEditor,
+    saveStrategy: operationHoursStrategy,
   },
   media: {
-    saveStrategy: {
-      canSave: () => true,
-      save: ({ close }) => close(),
-    },
+    saveStrategy: mediaStrategy,
   },
   nightlifeDetails: {
     draftInit: (l) => detailsJson(l.nightlifeDetails),
@@ -459,39 +162,10 @@ const CORE_FIELD_REGISTRY = {
 
 export type CompletenessFieldKey = keyof typeof CORE_FIELD_REGISTRY;
 
-function taxonomyEditor({ draft, isPending }: CoreFieldEditorContext) {
-  return (
-    <TaxonomyLocationEditor
-      locationKey={draft.taxonomyLocationKey}
-      district={draft.taxonomyDistrict}
-      onLocationKeyChange={draft.setTaxonomyLocationKey}
-      onDistrictChange={draft.setTaxonomyDistrict}
-      locationKeyError={
-        draft.taxonomyLocationKey.trim().length > 0 && !isValidLocationKey(draft.taxonomyLocationKey.trim())
-          ? "Location Key must be lowercase kebab-case (country|city|neighborhood)."
-          : undefined
-      }
-      disabled={isPending}
-    />
-  );
-}
-
 export function getCoreFieldConfig(fieldKey: string): CoreFieldConfig | undefined {
   return (CORE_FIELD_REGISTRY as Record<string, CoreFieldConfig>)[fieldKey];
 }
 
 export function isCoreFieldKey(fieldKey: string): fieldKey is CompletenessFieldKey {
   return fieldKey in CORE_FIELD_REGISTRY;
-}
-
-/** Fallback editor for any field key without a bespoke editor (keeps the modal
- *  resilient if a new completeness key is surfaced before its editor lands). */
-export function defaultFieldEditor({ field, draft }: CoreFieldEditorContext) {
-  return (
-    <Input
-      value={draft.value}
-      onChange={(event) => draft.setValue(event.target.value)}
-      placeholder={`Enter ${field.label.toLowerCase()}`}
-    />
-  );
 }

--- a/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-field-editors.tsx
+++ b/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-field-editors.tsx
@@ -1,0 +1,197 @@
+import { Input } from "@client/components/ui";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@client/components/ui/select";
+import { TaxonomyLocationEditor } from "@client/shared/components/forms";
+import { isValidLocationKey } from "@client/shared/lib/taxonomy-location";
+import { DINING_ESTABLISHMENT_TYPE_GROUPS } from "@shared/types/dining-taxonomy";
+import { OperationHoursFieldEditor } from "./operation-hours/OperationHoursFieldEditor";
+import { CoordinatesFieldEditor } from "./fields/CoordinatesFieldEditor";
+import { CuisinesFieldEditor } from "./fields/CuisinesFieldEditor";
+import { IdealForFieldEditor } from "./fields/IdealForFieldEditor";
+import { NeighborhoodDescriptionFieldEditor } from "./fields/NeighborhoodDescriptionFieldEditor";
+import { RawJsonFieldInput } from "./fields/RawJsonFieldInput";
+import type { CoreFieldEditorContext } from "./core-field.types";
+
+export function textEditor(type: "text" | "url" = "text") {
+  return ({ field, draft }: CoreFieldEditorContext) => (
+    <Input
+      value={draft.value}
+      onChange={(event) => draft.setValue(event.target.value)}
+      placeholder={`Enter ${field.label.toLowerCase()}`}
+      type={type}
+    />
+  );
+}
+
+export function selectEditor(
+  options: ReadonlyArray<{ value: string; label: string }>,
+  placeholder: string
+) {
+  return ({ draft }: CoreFieldEditorContext) => (
+    <Select value={draft.value || undefined} onValueChange={draft.setValue}>
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function rawJsonEditor({ field, draft }: CoreFieldEditorContext) {
+  return <RawJsonFieldInput fieldKey={field.key} value={draft.value} onChange={draft.setValue} />;
+}
+
+export function taxonomyEditor({ draft, isPending }: CoreFieldEditorContext) {
+  return (
+    <TaxonomyLocationEditor
+      locationKey={draft.taxonomyLocationKey}
+      district={draft.taxonomyDistrict}
+      onLocationKeyChange={draft.setTaxonomyLocationKey}
+      onDistrictChange={draft.setTaxonomyDistrict}
+      locationKeyError={
+        draft.taxonomyLocationKey.trim().length > 0 && !isValidLocationKey(draft.taxonomyLocationKey.trim())
+          ? "Location Key must be lowercase kebab-case (country|city|neighborhood)."
+          : undefined
+      }
+      disabled={isPending}
+    />
+  );
+}
+
+/** Dining uses grouped establishment types; every other category uses the flat
+ *  list loaded into the draft. */
+export function typeEditor({ category, draft }: CoreFieldEditorContext) {
+  return (
+    <Select value={draft.value || undefined} onValueChange={draft.setValue} disabled={draft.isLoadingTypes}>
+      <SelectTrigger>
+        <SelectValue
+          placeholder={
+            draft.isLoadingTypes
+              ? "Loading types..."
+              : category === "dining"
+                ? "Select establishment type"
+                : "Select a type"
+          }
+        />
+      </SelectTrigger>
+      <SelectContent>
+        {category === "dining"
+          ? DINING_ESTABLISHMENT_TYPE_GROUPS.map((group, groupIndex) => (
+              <SelectGroup key={group.label}>
+                <SelectLabel className="pl-2 pr-2 py-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  {group.label}
+                </SelectLabel>
+                {group.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+                {groupIndex < DINING_ESTABLISHMENT_TYPE_GROUPS.length - 1 && <SelectSeparator />}
+              </SelectGroup>
+            ))
+          : draft.locationTypes.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function phoneEditor({ draft }: CoreFieldEditorContext) {
+  return (
+    <div className="space-y-2">
+      <Input
+        value={draft.value}
+        onChange={(event) => draft.setValue(event.target.value)}
+        placeholder="Enter phone"
+        disabled={draft.phoneNotAvailable}
+      />
+      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={draft.phoneNotAvailable}
+          onChange={(event) => {
+            const checked = event.target.checked;
+            draft.setPhoneNotAvailable(checked);
+            if (checked) draft.setValue("");
+          }}
+        />
+        Phone not available
+      </label>
+    </div>
+  );
+}
+
+export function coordinatesEditor({ draft }: CoreFieldEditorContext) {
+  return (
+    <CoordinatesFieldEditor value={draft.coordinateDraft} onChange={draft.setCoordinateDraft} onCopy={draft.copyText} />
+  );
+}
+
+export function neighborhoodDescriptionEditor({ draft, isPending }: CoreFieldEditorContext) {
+  return (
+    <NeighborhoodDescriptionFieldEditor
+      value={draft.value}
+      canGenerate={draft.canGenerateNeighborhoodDescription}
+      locationHierarchyLabel={draft.locationHierarchyLabel}
+      isPending={isPending}
+      isGenerating={draft.isGeneratingNeighborhoodDescription}
+      onChange={draft.setValue}
+      onGenerate={() => draft.generateNeighborhoodDescription()}
+    />
+  );
+}
+
+export function idealForEditor({ draft }: CoreFieldEditorContext) {
+  return (
+    <IdealForFieldEditor
+      value={draft.idealForDraft}
+      availableGroups={draft.availableIdealForGroups}
+      onAdd={draft.addIdealForTag}
+      onRemove={draft.removeIdealForTag}
+    />
+  );
+}
+
+export function cuisinesEditor({ draft }: CoreFieldEditorContext) {
+  return (
+    <CuisinesFieldEditor
+      value={draft.cuisinesDraft}
+      availableOptions={draft.availableCuisineOptions}
+      availableGroups={draft.availableCuisineGroups}
+      onChange={draft.setCuisinesDraft}
+    />
+  );
+}
+
+export function operationHoursEditor({ draft }: CoreFieldEditorContext) {
+  return <OperationHoursFieldEditor dayEntries={draft.dayEntries} onChange={draft.setDayEntries} />;
+}
+
+/** Fallback editor for any field key without a bespoke editor (keeps the modal
+ *  resilient if a new completeness key is surfaced before its editor lands). */
+export function defaultFieldEditor({ field, draft }: CoreFieldEditorContext) {
+  return (
+    <Input
+      value={draft.value}
+      onChange={(event) => draft.setValue(event.target.value)}
+      placeholder={`Enter ${field.label.toLowerCase()}`}
+    />
+  );
+}

--- a/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-field-save-strategies.ts
+++ b/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-field-save-strategies.ts
@@ -1,0 +1,187 @@
+import type { UpdateMapsRequest } from "@client/shared/services/api/types";
+import { isValidLocationKey } from "@client/shared/lib/taxonomy-location";
+import type { CompletenessFieldDraft } from "./drafts/use-completeness-field-draft";
+import { withAttractionContactDetail } from "./completeness-detail-fields";
+import { parseCoordinateInput } from "./field-value-utils";
+import { buildOperationHoursJson } from "./operation-hours/operation-hours-utils";
+import type { SaveStrategy } from "./submission/save-strategy";
+
+/**
+ * Strategy for plain string-backed fields. `buildPayload` returns the update
+ * payload for the trimmed draft value, or `null` when the value cannot be
+ * saved (which also disables the Save button).
+ */
+export function simpleValueStrategy(
+  buildPayload: (trimmed: string) => Partial<UpdateMapsRequest> | null
+): SaveStrategy {
+  return {
+    canSave: ({ draft }) => buildPayload(draft.value.trim()) !== null,
+    save: ({ field, draft, save }) => {
+      const payload = buildPayload(draft.value.trim());
+      if (payload) {
+        save(payload as UpdateMapsRequest, `${field.label} saved`, `Failed to save ${field.label}`);
+      }
+    },
+  };
+}
+
+function getCoordinateValidation(
+  draft: CompletenessFieldDraft
+): { valid: true; lat: number; lng: number } | { valid: false; message: string } {
+  const lat = parseCoordinateInput(draft.coordinateDraft.lat);
+  const lng = parseCoordinateInput(draft.coordinateDraft.lng);
+  if (lat == null || lng == null) return { valid: false, message: "Latitude and longitude are required" };
+  if (lat < -90 || lat > 90) return { valid: false, message: "Latitude must be between -90 and 90" };
+  if (lng < -180 || lng > 180) return { valid: false, message: "Longitude must be between -180 and 180" };
+  return { valid: true, lat, lng };
+}
+
+export const coordinatesStrategy: SaveStrategy = {
+  canSave: ({ draft }) => getCoordinateValidation(draft).valid,
+  save: ({ draft, save, showValidationError }) => {
+    const validation = getCoordinateValidation(draft);
+    if (!validation.valid) {
+      showValidationError(validation.message);
+      return;
+    }
+    save({ lat: validation.lat, lng: validation.lng }, "Coordinates saved", "Failed to save coordinates");
+  },
+};
+
+export const taxonomyStrategy: SaveStrategy = {
+  canSave: ({ draft }) => {
+    const locationKey = draft.taxonomyLocationKey.trim();
+    return !locationKey || isValidLocationKey(locationKey);
+  },
+  save: ({ draft, save, showValidationError }) => {
+    const locationKey = draft.taxonomyLocationKey.trim();
+    if (locationKey && !isValidLocationKey(locationKey)) {
+      showValidationError("Location Key must be lowercase kebab-case (country|city|neighborhood)");
+      return;
+    }
+    save(
+      {
+        locationKey: locationKey || undefined,
+        district: draft.taxonomyDistrict.trim() || null,
+        autoApproveTaxonomy: true,
+      },
+      "Location taxonomy saved",
+      "Failed to save location taxonomy"
+    );
+  },
+};
+
+export const phoneStrategy: SaveStrategy = {
+  canSave: () => true,
+  save: ({ locationDetail, draft, save }) => {
+    const phoneNumber = draft.phoneNotAvailable ? "" : draft.value.trim();
+    save(
+      withAttractionContactDetail(
+        locationDetail,
+        { phoneNumber, phoneUnavailable: draft.phoneNotAvailable },
+        "phone",
+        phoneNumber
+      ),
+      "Phone saved",
+      "Failed to save phone"
+    );
+  },
+};
+
+export const websiteStrategy: SaveStrategy = {
+  canSave: () => true,
+  save: ({ locationDetail, draft, save }) => {
+    const website = draft.value.trim();
+    save(
+      withAttractionContactDetail(locationDetail, { website }, "website", website),
+      "Website saved",
+      "Failed to save Website"
+    );
+  },
+};
+
+export const contactUrlStrategy: SaveStrategy = {
+  canSave: ({ locationDetail }) =>
+    Boolean(locationDetail.source?.name?.trim() && locationDetail.source?.address?.trim()),
+  save: ({ locationDetail, save, showValidationError }) => {
+    const name = locationDetail.source?.name?.trim();
+    const address = locationDetail.source?.address?.trim();
+    if (!name || !address) {
+      showValidationError("Name and Source Address are required to generate Google URL");
+      return;
+    }
+    save({ name, address }, "Google URL regenerated", "Failed to regenerate Google URL");
+  },
+};
+
+export const idealForStrategy: SaveStrategy = {
+  canSave: ({ draft }) => draft.idealForDraft.length > 0,
+  save: ({ draft, save, showValidationError }) => {
+    if (!draft.idealForDraft.length) {
+      showValidationError("Select at least one Ideal For tag");
+      return;
+    }
+    save({ idealFor: draft.idealForDraft }, "Ideal For saved", "Failed to save Ideal For");
+  },
+};
+
+export const cuisinesStrategy: SaveStrategy = {
+  canSave: () => true,
+  save: ({ draft, save }) =>
+    save(
+      { tripadvisorCuisines: draft.cuisinesDraft.length ? draft.cuisinesDraft : null },
+      "Cuisines saved",
+      "Failed to save cuisines"
+    ),
+};
+
+export const operationHoursStrategy: SaveStrategy = {
+  canSave: () => true,
+  save: ({ draft, save }) =>
+    save({ operationHours: buildOperationHoursJson(draft.dayEntries) }, "Hours saved", "Failed to save hours"),
+};
+
+/** `media` is rendered by the modal shell; saving just closes it. */
+export const mediaStrategy: SaveStrategy = {
+  canSave: () => true,
+  save: ({ close }) => close(),
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRawJsonDraft(
+  value: string
+): { valid: true; value: Record<string, unknown> | null } | { valid: false; message: string } {
+  const trimmed = value.trim();
+  if (!trimmed) return { valid: true, value: null };
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed === null) return { valid: true, value: null };
+    if (!isPlainRecord(parsed)) return { valid: false, message: "JSON must be an object" };
+    return { valid: true, value: parsed };
+  } catch {
+    return { valid: false, message: "Enter valid JSON before saving" };
+  }
+}
+
+export function rawJsonStrategy(
+  fieldKey: "nightlifeDetails" | "accommodationsDetails" | "attractionsDetails" | "keyLocationsDetails"
+): SaveStrategy {
+  return {
+    canSave: ({ draft }) => parseRawJsonDraft(draft.value).valid,
+    save: ({ field, draft, save, showValidationError }) => {
+      const parsed = parseRawJsonDraft(draft.value);
+      if (!parsed.valid) {
+        showValidationError(parsed.message);
+        return;
+      }
+      save({ [fieldKey]: parsed.value }, `${field.label} saved`, `Failed to save ${field.label}`);
+    },
+  };
+}
+
+export function detailsJson(value: unknown): string {
+  return value ? JSON.stringify(value, null, 2) : "";
+}

--- a/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-field.types.ts
+++ b/apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-field.types.ts
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import type { LocationResponse } from "@client/shared/services/api/types";
+import type { FieldDef } from "./completeness-field-edit.types";
+import type { CompletenessFieldDraft } from "./drafts/use-completeness-field-draft";
+import type { SaveStrategy } from "./submission/save-strategy";
+
+export interface CoreFieldEditorContext {
+  field: FieldDef;
+  category: string;
+  draft: CompletenessFieldDraft;
+  isPending: boolean;
+}
+
+export interface CoreFieldConfig {
+  /** Seeds the shared `value` draft slice when the editor opens. */
+  draftInit?: (location: LocationResponse) => string;
+  /** Renders the field editor. Omitted for fields rendered by the modal shell
+   *  itself (e.g. `media`, `contactUrl`). */
+  editor?: (context: CoreFieldEditorContext) => ReactNode;
+  /** Whether the draft is saveable and how it persists. */
+  saveStrategy: SaveStrategy;
+}


### PR DESCRIPTION
Refactor of `apps/location-manager/packages/client/src/features/location-browse/components/detail/completeness-field-edit/core-completeness-fields.tsx`, flagged at **497 LOC / 7 concerns** ("many functions and imports").

## Problem

The file's own doc comment describes the registry as the place where you add "one entry with its `draftInit`, `editor`, and `saveStrategy`" — but inline editor JSX and inline save strategies had grown it to 497 lines. Answering "what fields exist?" meant scrolling past dining establishment-type groups and raw-JSON parsing.

## Change

| Module | LOC | Responsibility |
| --- | --- | --- |
| `core-field.types.ts` | 22 | `CoreFieldConfig`, `CoreFieldEditorContext` |
| `core-field-editors.tsx` | 197 | All editors, including the previously-inline `type`, `phone`, `coordinates`, `idealFor`, `cuisines`, `operationHours`, `neighborhoodDescription` |
| `core-field-save-strategies.ts` | 187 | All strategies, including the previously-inline ones |
| `core-completeness-fields.tsx` | 171 | The registry + accessors |

The registry now reads as the table it was designed to be — every entry is three references, no inline bodies.

## Behavior

Pure extraction. Verified mechanically that the registry's **24 keys are identical** to `main` and that each entry's `draftInit`/`editor` presence is unchanged (the `satisfies Record<string, CoreFieldConfig>` plus `CompletenessFieldKey = keyof typeof CORE_FIELD_REGISTRY` mean a dropped key would silently narrow a public type). Types and `defaultFieldEditor` are re-exported, so the 3 consumers are untouched.

## 🔍 Incidental finding: these tests actually run

The two colocated test files here (`core-completeness-fields.test.ts`, `completeness-detail-fields.test.ts`) **do execute under `bun test`** — 9 tests, 30 assertions — despite `lm-client`'s `package.json` claiming "No tests configured yet" and the test files declaring their own `describe`/`test`/`expect` stubs (a workaround for missing vitest types).

They pass **9/9 identically on this branch and on `main`**, so this PR has real test coverage behind it, unlike the other `lm-client` PRs in this batch.

That suggests `lm-client` has runnable test coverage that CI is simply not executing. Wiring `bun test` into that package's `test` script looks like cheap, worthwhile follow-up — I left it out of scope here since it changes build config rather than the flagged file.

## Verification

- `bun test` (both colocated files) → **9 pass / 0 fail**, identical to `main`
- `tsc --noEmit -p tsconfig.app.json` → **0 errors**, matching baseline
- registry key set → identical, 24/24; per-field shape → identical
