### PR TITLE
NOJIRA: Decompose standard article stage builder

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { StandardArticleStageBuilder } from './StandardArticleStageBuilder'
@@ -235,6 +235,20 @@ describe('StandardArticleStageBuilder', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Continue to Step 2' }))
 
     expect(screen.getByText('Step 1 requires an article title.')).toBeInTheDocument()
+  })
+
+  it('applies an AI-generated slug through the staged Draft update boundary', async () => {
+    mockedViewModel = buildViewModel()
+
+    renderBuilder()
+
+    fireEvent.click(screen.getByRole('button', { name: 'AI' }))
+
+    await waitFor(() => {
+      expect(mockedViewModel.sidebarProps.onUpdateStagedArticle).toHaveBeenCalledWith({
+        payloadSlug: 'rewritten',
+      })
+    })
   })
 
   it('allows Step 2 to pass without a featured image', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.tsx
@@ -1,46 +1,25 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useCallback, useState } from 'react'
 import { useAuth, usePermissions } from '../../auth'
-import {
-  generateSocialImageFromFeatured as requestGenerateSocialImageFromFeatured,
-  uploadSocialImage as requestUploadSocialImage,
-} from '../../../shared/images'
 import { SeoEditorPanel } from '../../../shared/seo/components/SeoEditorPanel'
-import { getSchemaPublisherConfig } from '../../../shared/seo/services/schema-publisher-config.service'
-import { buildArticleOgUrl } from '../../../shared/seo/utils/buildArticleOgUrl'
-import {
-  applySeoAiPatch,
-  buildSeoAiSeed,
-  parseSeoAiPatch,
-  type SeoAiTarget,
-} from '../../../shared/seo/services/seo-ai.service'
+import type { SeoSection } from '../../../shared/seo/types'
 import { createEmptySeoSection } from '../../../shared/seo/services/seo-section.service'
-import { resolveEditorAssistModelName } from '../api'
 import type { EditorialStageArticleApi, EditorialStageRoutes } from '../features/editorial-stage-article/types'
 import { useEditorialStageArticleScreenViewModel } from '../features/editorial-stage-article/hooks/useEditorialStageArticleScreenViewModel'
-import { EDITOR_MODEL_OPTIONS, resolveEditorModelName } from '../features/editorial-stage-article/constants'
-import { getLocationDisplayName } from '../features/editorial-stage-article/utils/editorial-stage-view.utils'
-import {
-  buildStandardArticleContext,
-  buildLegacyStandardArticleStructuredDataTemplate,
-  buildStandardArticleSeoAiPrompt,
-  shouldAutoManageStandardArticleStructuredData,
-  buildStandardArticleStructuredDataTemplate,
-  isSeoCoreComplete,
-  serializeStandardArticleStructuredDataTemplate,
-  validateStandardArticleSeoSection,
-} from '../features/editorial-stage-article/services/standard-article-seo.service'
-import {
-  buildPrimaryLocationUpdate,
-  getSharedNeighborhoodOptions,
-  sanitizeSharedNeighborhoods,
-} from '../features/editorial-stage-article/utils/sharedNeighborhoods'
+import { useStandardArticleDerivedState } from '../features/editorial-stage-article/hooks/useStandardArticleDerivedState'
+import { useStandardArticleExpansion } from '../features/editorial-stage-article/hooks/useStandardArticleExpansion'
+import { useStandardArticlePermalink } from '../features/editorial-stage-article/hooks/useStandardArticlePermalink'
+import { useStandardArticleSeoActions } from '../features/editorial-stage-article/hooks/useStandardArticleSeoActions'
+import { useStandardArticleStageActions } from '../features/editorial-stage-article/hooks/useStandardArticleStageActions'
+import { useStandardArticleStructuredData } from '../features/editorial-stage-article/hooks/useStandardArticleStructuredData'
 import { FeaturedImageModal } from './editorial-stage/FeaturedImageModal'
 import { BlockImageModal } from './editorial-stage/BlockImageModal'
-import { EditorialTimelineList } from './editorial-stage/EditorialTimelineList'
 import { ArticleExpansionModal } from '../../youtube2blog/components/ArticleExpansionModal'
-import { useArticleExpansion } from '../../youtube2blog/hooks/useArticleExpansion'
-import { parseMarkdownToBlocks } from '../features/editorial-stage-article/workflow.service'
+import { StandardArticleBuilderSidebar } from './standard-article-stage/StandardArticleBuilderSidebar'
+import { StandardArticleContentPanel } from './standard-article-stage/StandardArticleContentPanel'
+import { StandardArticleFeaturedImagePanel } from './standard-article-stage/StandardArticleFeaturedImagePanel'
+import { StandardArticleSetupPanel } from './standard-article-stage/StandardArticleSetupPanel'
+import { StandardArticleStageHero } from './standard-article-stage/StandardArticleStageHero'
+import { StandardArticleStatusBanners } from './standard-article-stage/StandardArticleStatusBanners'
 import '../../singleTypeListicles/styles.css'
 import './standard-article-stage-builder.css'
 
@@ -54,33 +33,6 @@ type StandardArticleStageBuilderProps = {
   syncBehavior?: 'finalize' | 'draft-sync'
   backToStageLabel?: string
 }
-
-function validateSetupStep(title: string, locationId?: number): string[] {
-  const issues: string[] = []
-  if (!title.trim()) issues.push('Step 1 requires an article title.')
-  if (!locationId) issues.push('Step 1 requires a location.')
-  return issues
-}
-
-function validateFeaturedImageStep(featuredImageId?: number): string[] {
-  return featuredImageId ? [] : ['Select a featured image before syncing to Payload.']
-}
-
-function validateContentStep(input: {
-  bodyMarkdown: string
-  editorialBlockingMessages: string[]
-}): string[] {
-  const issues: string[] = []
-  if (!input.bodyMarkdown.trim()) {
-    issues.push('Step 3 requires at least one text block with content.')
-  }
-  if (input.editorialBlockingMessages.length > 0) {
-    issues.push(input.editorialBlockingMessages[0])
-  }
-  return issues
-}
-
-const schemaPublisherConfig = getSchemaPublisherConfig()
 
 export function StandardArticleStageBuilder({
   storageKey,
@@ -96,13 +48,6 @@ export function StandardArticleStageBuilder({
   const { canManagePublished, role } = usePermissions()
   const [localError, setLocalError] = useState<string | null>(null)
   const [localResult, setLocalResult] = useState<string | null>(null)
-  const [isGeneratingSeoTarget, setIsGeneratingSeoTarget] = useState<SeoAiTarget | null>(null)
-  const [isGeneratingSeoImage, setIsGeneratingSeoImage] = useState(false)
-  const [isUploadingOgImage, setIsUploadingOgImage] = useState(false)
-  const [isGeneratingSlug, setIsGeneratingSlug] = useState(false)
-  const lastAutoStructuredDataRef = useRef<string>('')
-
-  const [isExpansionModalOpen, setIsExpansionModalOpen] = useState(false)
 
   const viewModel = useEditorialStageArticleScreenViewModel({
     storageKey,
@@ -111,132 +56,20 @@ export function StandardArticleStageBuilder({
     api,
     token,
   })
-
-  const { status, layout, timelineListProps, sidebarProps, featuredModalProps, blockModalProps } = viewModel
+  const {
+    status,
+    layout,
+    timelineListProps,
+    sidebarProps,
+    featuredModalProps,
+    blockModalProps,
+  } = viewModel
   const stagedArticle = layout?.stagedArticle
-  const seoSection = stagedArticle?.seoSection ?? createEmptySeoSection()
-  const selectedLocation = useMemo(
-    () => sidebarProps?.locations.find((location) => location.id === stagedArticle?.locationId),
-    [sidebarProps?.locations, stagedArticle?.locationId],
-  )
-  const sharedNeighborhoodOptions = useMemo(
-    () => getSharedNeighborhoodOptions(sidebarProps?.locations ?? [], stagedArticle?.locationId),
-    [sidebarProps?.locations, stagedArticle?.locationId],
-  )
-  const selectedSharedNeighborhoods = useMemo(
-    () => sanitizeSharedNeighborhoods(
-      stagedArticle?.sharedNeighborhoods ?? [],
-      sidebarProps?.locations ?? [],
-      stagedArticle?.locationId
-    ),
-    [sidebarProps?.locations, stagedArticle?.locationId, stagedArticle?.sharedNeighborhoods],
-  )
-  const selectedLocationLabel = useMemo(
-    () => getLocationDisplayName(selectedLocation),
-    [selectedLocation],
-  )
-  const bodyMarkdown = useMemo(
-    () => (stagedArticle ? buildStandardArticleContext(stagedArticle) : ''),
-    [stagedArticle],
-  )
+  const derived = useStandardArticleDerivedState(stagedArticle, sidebarProps)
 
-  const step1Issues = useMemo(
-    () => validateSetupStep(stagedArticle?.title || '', stagedArticle?.locationId),
-    [stagedArticle?.title, stagedArticle?.locationId],
-  )
-  const step2Issues = useMemo(
-    () => validateFeaturedImageStep(stagedArticle?.featuredImageId),
-    [stagedArticle?.featuredImageId],
-  )
-  const step3Issues = useMemo(
-    () => validateContentStep({
-      bodyMarkdown,
-      editorialBlockingMessages: sidebarProps?.editorialBlockingMessages || [],
-    }),
-    [bodyMarkdown, sidebarProps?.editorialBlockingMessages],
-  )
-  const seoIssues = useMemo(
-    () => validateStandardArticleSeoSection({
-      seoSection,
-      locationLabel: selectedLocationLabel || undefined,
-    }),
-    [seoSection, selectedLocationLabel],
-  )
-  const featuredImageId = stagedArticle?.featuredImageId
-  const featuredImagePreviewUrl = sidebarProps?.selectedFeaturedImage
-    ? sidebarProps.getImageUrl(sidebarProps.selectedFeaturedImage)
-    : undefined
-  const featuredImageTriggerLabel = featuredImageId
-    ? sidebarProps?.selectedFeaturedImage?.filename || `Image #${featuredImageId} selected`
-    : 'Select Featured Image...'
-  const headerPreviewTitle = stagedArticle?.title.trim() || 'Your article headline will appear here'
-  const isFeaturedImagePlaceholder = !featuredImageId
-  const isPublished = stagedArticle?.payloadStatus === 'published'
-  const isCityPrimaryLocation = selectedLocation?.level === 'city'
-
-  const isStep1Locked = Boolean(stagedArticle?.step1_complete && !stagedArticle?.in_update_mode)
-  const isStep2Locked = Boolean(stagedArticle?.step2_complete && !stagedArticle?.step2_in_update_mode)
-  const isStep3Locked = Boolean(stagedArticle?.step3_complete && !stagedArticle?.step3_in_update_mode)
-  const isSynced = Boolean(stagedArticle?.publishedToPayload)
-  const hasUnsyncedPayloadChanges = Boolean(isSynced && stagedArticle?.hasUnsyncedPayloadChanges)
-  const seoCoreComplete = isSeoCoreComplete(seoSection)
-  const completionPercent = Math.round(([
-    isStep1Locked,
-    isStep3Locked,
-    seoCoreComplete,
-  ].filter(Boolean).length / 3) * 100)
-
-  const syncIssues = useMemo(() => {
-    const issues: string[] = []
-    if (isSynced) {
-      if (step1Issues.length > 0) issues.push(step1Issues[0])
-      if (!stagedArticle?.payloadSlug?.trim()) issues.push('Slug is required before syncing to Payload.')
-      if (step2Issues.length > 0) issues.push(step2Issues[0])
-      if (step3Issues.length > 0) issues.push(step3Issues[0])
-      if (!seoCoreComplete) issues.push('Add SEO title and meta description before syncing to Payload.')
-      if (seoIssues.length > 0) issues.push(seoIssues[0])
-    } else {
-      if (!isStep1Locked) issues.push('Lock Step 1 before syncing to Payload.')
-      if (!stagedArticle?.payloadSlug?.trim()) issues.push('Slug is required before syncing to Payload.')
-      if (step2Issues.length > 0) issues.push(step2Issues[0])
-      if (!isStep3Locked) issues.push('Lock Step 3 before syncing to Payload.')
-      if (!seoCoreComplete) issues.push('Add SEO title and meta description before syncing to Payload.')
-      if (step3Issues.length > 0) issues.push(step3Issues[0])
-      if (seoIssues.length > 0) issues.push(seoIssues[0])
-    }
-    return issues
-  }, [isSynced, isStep1Locked, isStep3Locked, seoCoreComplete, seoIssues, stagedArticle?.payloadSlug, step1Issues, step2Issues, step3Issues])
-
-  const setStageArticle = useCallback((updates: Partial<NonNullable<typeof stagedArticle>>) => {
-    sidebarProps?.onUpdateStagedArticle(updates)
-  }, [sidebarProps])
-
-  const expansion = useArticleExpansion(stagedArticle?.runId ?? null)
-
-  const handleOpenDeepExpand = useCallback(() => {
-    if (!stagedArticle) return
-    expansion.reset()
-    expansion.startExpansion(
-      stagedArticle.content,
-      stagedArticle.originalType,
-      stagedArticle.title || stagedArticle.originalTitle,
-    )
-    setIsExpansionModalOpen(true)
-  }, [expansion, stagedArticle])
-
-  const handleAcceptExpansion = useCallback((expandedMarkdown: string) => {
-    const blocks = parseMarkdownToBlocks(expandedMarkdown)
-    setStageArticle({ blocks, content: expandedMarkdown, lexicalConverted: false })
-    expansion.reset()
-    setIsExpansionModalOpen(false)
-  }, [expansion, setStageArticle])
-
-  const handleCloseExpansion = useCallback(() => {
-    expansion.reset()
-    setIsExpansionModalOpen(false)
-  }, [expansion])
-
-  const updateSeoSection = useCallback((next: typeof seoSection | ((current: typeof seoSection) => typeof seoSection)) => {
+  const updateSeoSection = useCallback((
+    next: SeoSection | ((current: SeoSection) => SeoSection),
+  ) => {
     if (!stagedArticle || !sidebarProps) return
     const resolved = typeof next === 'function'
       ? next(stagedArticle.seoSection ?? createEmptySeoSection())
@@ -244,271 +77,57 @@ export function StandardArticleStageBuilder({
     sidebarProps.onUpdateStagedArticle({ seoSection: resolved })
   }, [sidebarProps, stagedArticle])
 
-  useEffect(() => {
-    if (!stagedArticle || !isStep3Locked) return
-
-    const nextStructuredData = serializeStandardArticleStructuredDataTemplate(
-      buildStandardArticleStructuredDataTemplate({
-        stagedArticle: {
-          ...stagedArticle,
-          seoSection,
-        },
-        locationLabel: selectedLocationLabel || undefined,
-        publisherConfig: schemaPublisherConfig,
-      }),
-    )
-    const legacyStructuredData = serializeStandardArticleStructuredDataTemplate(
-      buildLegacyStandardArticleStructuredDataTemplate({
-        stagedArticle: {
-          ...stagedArticle,
-          seoSection,
-        },
-        locationLabel: selectedLocationLabel || undefined,
-      }),
-    )
-
-    const existingStructuredData = seoSection.structuredData.trim()
-    const lastAutoStructuredData = lastAutoStructuredDataRef.current.trim()
-    const isAutoManaged = shouldAutoManageStandardArticleStructuredData({
-      existingStructuredData,
-      lastAutoStructuredData,
-      nextStructuredData,
-      legacyStructuredData,
-    })
-
-    if (!isAutoManaged) return
-    if (existingStructuredData === nextStructuredData) {
-      lastAutoStructuredDataRef.current = nextStructuredData
-      return
-    }
-
-    lastAutoStructuredDataRef.current = nextStructuredData
-    updateSeoSection((current) => ({
-      ...current,
-      structuredData: nextStructuredData,
-    }))
-  }, [
-    isStep3Locked,
-    seoSection,
-    selectedLocationLabel,
+  const actions = useStandardArticleStageActions({
     stagedArticle,
+    sidebarProps,
+    step1Issues: derived.step1Issues,
+    step3Issues: derived.step3Issues,
+    syncIssues: derived.syncIssues,
+    setLocalError,
+    setLocalResult,
+  })
+  const permalink = useStandardArticlePermalink({
+    api,
+    stagedArticle,
+    selectedLocation: derived.selectedLocation,
     updateSeoSection,
-  ])
+    setLocalError,
+  })
+  const seo = useStandardArticleSeoActions({
+    api,
+    token,
+    stagedArticle,
+    featureLabel,
+    selectedLocationLabel: derived.selectedLocationLabel,
+    seoSection: derived.seoSection,
+    updateSeoSection,
+    setLocalError,
+    setLocalResult,
+  })
+  const expansion = useStandardArticleExpansion(stagedArticle, actions.setStageArticle)
 
-  const handleAutoFillOgUrl = useCallback(() => {
-    const slug = stagedArticle?.payloadSlug?.trim()
-    const country = selectedLocation?.country
-    const city = selectedLocation?.city
-    if (!slug || !country) return
-    const url = buildArticleOgUrl(country, city, null, slug)
-    if (!url) return
-    updateSeoSection((current) => ({ ...current, openGraph: { ...current.openGraph, url } }))
-  }, [stagedArticle?.payloadSlug, selectedLocation, updateSeoSection])
+  useStandardArticleStructuredData({
+    stagedArticle,
+    seoSection: derived.seoSection,
+    selectedLocationLabel: derived.selectedLocationLabel,
+    enabled: derived.isStep3Locked,
+    updateSeoSection,
+  })
 
-  const handleContinueSetup = useCallback(() => {
-    if (!stagedArticle || !sidebarProps) return
-    if (step1Issues.length > 0) {
-      setLocalError(step1Issues[0])
-      return
-    }
-    if (!stagedArticle.payloadSlug?.trim()) {
-      setLocalError('Slug is required before continuing.')
-      return
-    }
-    setLocalError(null)
-    setLocalResult(null)
-    sidebarProps.onUpdateStagedArticle({
-      step1_complete: true,
-      in_update_mode: false,
-      step2_complete: false,
-      step2_in_update_mode: false,
-      step3_complete: false,
-      step3_in_update_mode: false,
-    })
-  }, [sidebarProps, stagedArticle, step1Issues])
+  const generateSlug = useCallback(async () => {
+    const slug = await permalink.generateSlug()
+    if (slug) actions.setStageArticle({ payloadSlug: slug })
+  }, [actions, permalink])
 
-  const handleGenerateSlugWithAi = useCallback(async () => {
-    if (!stagedArticle?.title.trim() || !sidebarProps) return
-    setIsGeneratingSlug(true)
-    try {
-      const response = await api.rewriteBlockWithAi({
-        prompt: `Generate a clean SEO-friendly URL slug for this article title:\n\nTitle: ${stagedArticle.title.trim()}\n\nRules:\n- Think like a real user searching Google.\n- Keep the most important search keywords.\n- Remove filler words like "the," "a," "an," "in," "of," "to," and "for" unless they are needed.\n- Keep it short, readable, and specific.\n- Use lowercase only.\n- Use hyphens between words.\n- Do not keyword-stuff.\n- Do not add words that are not strongly related to the title.\n- Prefer search-intent wording over matching the title exactly.\n- Return only the slug, no explanation.\n\nExample:\nTitle: The Best Steakhouses in Las Vegas\nSlug: best-steakhouses-las-vegas`,
-        blockContent: stagedArticle.title.trim(),
-        articleTitle: stagedArticle.title.trim(),
-      })
-      const slug = response.rewritten_content?.trim()
-      if (slug) {
-        sidebarProps.onUpdateStagedArticle({ payloadSlug: slug })
-      }
-    } catch (err) {
-      setLocalError(err instanceof Error ? err.message : 'Failed to generate slug with AI.')
-    } finally {
-      setIsGeneratingSlug(false)
-    }
-  }, [api, sidebarProps, stagedArticle])
-
-  const handleContinueFeaturedImage = useCallback(() => {
-    if (!sidebarProps) return
-    setLocalError(null)
-    setLocalResult(null)
-    sidebarProps.onUpdateStagedArticle({
-      step2_complete: true,
-      step2_in_update_mode: false,
-    })
-  }, [sidebarProps])
-
-  const handleContinueContent = useCallback(() => {
-    if (!sidebarProps) return
-    if (step3Issues.length > 0) {
-      setLocalError(step3Issues[0])
-      return
-    }
-    setLocalError(null)
-    setLocalResult(null)
-    sidebarProps.onUpdateStagedArticle({
-      step3_complete: true,
-      step3_in_update_mode: false,
-    })
-  }, [sidebarProps, step3Issues])
-
-  const handleGenerateSeoWithAi = useCallback(async (target: SeoAiTarget = 'all') => {
-    if (!stagedArticle) return
-
-    const articleContext = buildStandardArticleContext(stagedArticle).trim()
-    const articleTitle = stagedArticle.title.trim()
-    const hasSourceContent = Boolean(articleTitle || articleContext)
-    if (!hasSourceContent) {
-      setLocalError('Add article content before generating SEO with AI.')
-      return
-    }
-
-    setLocalError(null)
-    setLocalResult(null)
-    setIsGeneratingSeoTarget(target)
-
-    try {
-      const response = await api.generateSeoMetadataWithAi({
-        prompt: buildStandardArticleSeoAiPrompt({
-          location: selectedLocationLabel || undefined,
-          target,
-        }),
-        seed: buildSeoAiSeed(seoSection),
-        modelName: resolveEditorAssistModelName(stagedArticle.editorModelName),
-        articleTitle,
-        articleContext: articleContext || undefined,
-      })
-
-      if (!response.seo_patch || Object.keys(response.seo_patch).length === 0) {
-        throw new Error('AI returned an empty SEO patch.')
-      }
-
-      // The patch arrives schema-validated from the forced tool call; parse
-      // still applies length clipping and URL validation.
-      const seoPatch = parseSeoAiPatch(JSON.stringify(response.seo_patch))
-      updateSeoSection((current) => applySeoAiPatch(current, seoPatch, target))
-      setLocalResult(`Updated ${target === 'all' ? 'SEO metadata' : target} with AI.`)
-    } catch (err) {
-      setLocalError(err instanceof Error ? err.message : 'Failed to generate SEO with AI.')
-    } finally {
-      setIsGeneratingSeoTarget(null)
-    }
-  }, [api, seoSection, selectedLocationLabel, stagedArticle, updateSeoSection])
-
-  const handleGenerateSeoImageFromFeatured = useCallback(async () => {
-    if (!token || !stagedArticle?.featuredImageId) {
-      setLocalError('Select a featured image before generating an OG image.')
-      return
-    }
-
-    setLocalError(null)
-    setLocalResult(null)
-    setIsGeneratingSeoImage(true)
-
-    try {
-      const response = await requestGenerateSocialImageFromFeatured(
-        { featuredAssetId: stagedArticle.featuredImageId },
-        token,
-      )
-      const socialImageUrl = response.generatedImageUrl.trim()
-      if (!socialImageUrl) {
-        throw new Error('Social image generation did not return a usable URL.')
-      }
-
-      updateSeoSection((current) => ({
-        ...current,
-        openGraph: {
-          ...current.openGraph,
-          imageUrl: socialImageUrl,
-        },
-        twitterCard: {
-          ...current.twitterCard,
-          imageUrl: socialImageUrl,
-        },
-      }))
-      setLocalResult('Generated a 1200x630 social image from the featured image.')
-    } catch (err) {
-      setLocalError(err instanceof Error ? err.message : 'Failed to generate social image.')
-    } finally {
-      setIsGeneratingSeoImage(false)
-    }
-  }, [stagedArticle?.featuredImageId, token, updateSeoSection])
-
-  const handleUploadOgImageFile = useCallback(async (file: File) => {
-    if (!token || !stagedArticle?.locationId) {
-      throw new Error('Select a location before uploading an OG image.')
-    }
-
-    setLocalError(null)
-    setLocalResult(null)
-    setIsUploadingOgImage(true)
-
-    try {
-      const uploadResponse = await requestUploadSocialImage(
-        file,
-        stagedArticle.title.trim() || `${featureLabel} social image`,
-        stagedArticle.locationId,
-        token,
-        '',
-      )
-
-      const socialImageUrl = uploadResponse.generatedImageUrl.trim()
-      if (!socialImageUrl) {
-        throw new Error('OG image upload did not return a usable URL.')
-      }
-
-      updateSeoSection((current) => ({
-        ...current,
-        openGraph: {
-          ...current.openGraph,
-          imageUrl: socialImageUrl,
-        },
-        twitterCard: {
-          ...current.twitterCard,
-          imageUrl: socialImageUrl,
-        },
-      }))
-      setLocalResult('Uploaded and applied a custom OG image.')
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to upload OG image.'
-      setLocalError(message)
-      throw err instanceof Error ? err : new Error(message)
-    } finally {
-      setIsUploadingOgImage(false)
-    }
-  }, [featureLabel, stagedArticle?.locationId, stagedArticle?.title, token, updateSeoSection])
-
-  const handlePayloadSubmit = useCallback((targetStatus: 'draft' | 'published') => {
-    if (!sidebarProps) return
-    if (syncIssues.length > 0) {
-      setLocalError(syncIssues[0])
-      return
-    }
-    setLocalError(null)
-    setLocalResult(null)
-    sidebarProps.onPublish(targetStatus)
-  }, [sidebarProps, syncIssues])
-
-  if (status.isLoading || !stagedArticle || !layout || !timelineListProps || !sidebarProps || !featuredModalProps || !blockModalProps) {
+  if (
+    status.isLoading
+    || !stagedArticle
+    || !layout
+    || !timelineListProps
+    || !sidebarProps
+    || !featuredModalProps
+    || !blockModalProps
+  ) {
     return (
       <div className="stl-page stl-single-type-page sab-stage-page">
         <p className="stl-placeholder">{status.error ? status.error : 'Loading builder...'}</p>
@@ -516,472 +135,130 @@ export function StandardArticleStageBuilder({
     )
   }
 
+  const featuredImagePreviewUrl = sidebarProps.selectedFeaturedImage
+    ? sidebarProps.getImageUrl(sidebarProps.selectedFeaturedImage)
+    : undefined
+  const featuredImageTriggerLabel = stagedArticle.featuredImageId
+    ? sidebarProps.selectedFeaturedImage?.filename || `Image #${stagedArticle.featuredImageId} selected`
+    : 'Select Featured Image...'
+
   return (
     <>
       <div className="stl-page stl-single-type-page sab-stage-page">
-        <header className="stl-hero sab-stage-hero">
-          <div>
-            <p className="stl-eyebrow">{heroEyebrow}</p>
-            <h1>{stagedArticle.payloadArticleId ? `Sync Draft #${stagedArticle.payloadArticleId}` : 'Stage Article'}</h1>
-            <p className="stl-lede">{heroDescription}</p>
-            <div className="sab-stage-hero-meta">
-              {stagedArticle.originalType ? <span className="sab-stage-pill">{stagedArticle.originalType}</span> : null}
-              {stagedArticle.payloadArticleId ? <span className="sab-stage-pill">Linked Payload #{stagedArticle.payloadArticleId}</span> : null}
-              {!isSynced ? <span className="sab-stage-pill">{completionPercent}% ready</span> : null}
-            </div>
-          </div>
-          <div className="stl-hero-actions">
-            <Link to={layout.stagePath} className="stl-btn stl-btn-secondary">{backToStageLabel}</Link>
-            <button type="button" className="stl-btn stl-btn-danger" onClick={layout.onDelete}>
-              Delete Staged Article
-            </button>
-          </div>
-        </header>
+        <StandardArticleStageHero
+          stagedArticle={stagedArticle}
+          eyebrow={heroEyebrow}
+          description={heroDescription}
+          backLabel={backToStageLabel}
+          stagePath={layout.stagePath}
+          completionPercent={derived.completionPercent}
+          isSynced={derived.isSynced}
+          onDelete={layout.onDelete}
+        />
 
         <div className="stl-builder-layout">
           <main className="stl-builder-main">
-            {status.saveConflict ? (
-              <div className="stl-summary-warning" role="alert">
-                <strong>Draft changed elsewhere.</strong>
-                <p>
-                  This draft was modified
-                  {status.saveConflict.current?.lastEditedBy?.email
-                    ? ` by ${status.saveConflict.current.lastEditedBy.email}`
-                    : status.saveConflict.current === null
-                      ? ' (it was deleted)'
-                      : ' by another user'}
-                  {' '}since you opened it. Autosave is paused — reload to continue; unsynced local changes will be lost.
-                </p>
-                <button type="button" className="stl-btn stl-btn-secondary" onClick={() => window.location.reload()}>
-                  Reload draft
-                </button>
-              </div>
-            ) : null}
-            {localError ? <p className="stl-error">{localError}</p> : null}
-            {localResult ? <p className="stl-success">{localResult}</p> : null}
+            <StandardArticleStatusBanners
+              status={status}
+              localError={localError}
+              localResult={localResult}
+              hasUnsyncedPayloadChanges={derived.hasUnsyncedPayloadChanges}
+              isPublished={derived.isPublished}
+              isPublishing={sidebarProps.isPublishing}
+              syncIssues={derived.syncIssues}
+              onSubmit={actions.submitToPayload}
+            />
 
-            {hasUnsyncedPayloadChanges ? (
-              <div className="stl-out-of-sync-banner" role="status">
-                <span className="stl-out-of-sync-banner__dot" aria-hidden="true" />
-                <span className="stl-out-of-sync-banner__text">
-                  Out of sync — you have local changes. Sync to Payload to apply them to the live article.
-                </span>
-                <button
-                  type="button"
-                  className="stl-btn stl-out-of-sync-banner__btn"
-                  onClick={() => handlePayloadSubmit(isPublished ? 'published' : 'draft')}
-                  disabled={sidebarProps.isPublishing || syncIssues.length > 0}
-                >
-                  {sidebarProps.isPublishing ? 'Syncing...' : 'Save & Sync'}
-                </button>
-              </div>
-            ) : null}
+            <StandardArticleSetupPanel
+              stagedArticle={stagedArticle}
+              locations={sidebarProps.locations}
+              sharedNeighborhoodOptions={derived.sharedNeighborhoodOptions}
+              selectedSharedNeighborhoods={derived.selectedSharedNeighborhoods}
+              isCityPrimaryLocation={derived.selectedLocation?.level === 'city'}
+              isSynced={derived.isSynced}
+              isStep1Locked={derived.isStep1Locked}
+              isGeneratingSlug={permalink.isGeneratingSlug}
+              onUpdateTitle={layout.onUpdateTitle}
+              onUpdateArticle={actions.setStageArticle}
+              onContinue={actions.continueSetup}
+              onGenerateSlug={generateSlug}
+            />
 
-            <section className="stl-panel sab-stage-panel">
-              <div className="stl-panel-header">
-                <h2>{!isSynced ? <span className="stl-kicker">Step 1</span> : null} Setup</h2>
-                {!isSynced ? (
-                  <div className="stl-inline-actions">
-                    {isStep1Locked ? (
-                      stagedArticle.in_update_mode ? (
-                        <>
-                          <button type="button" className="stl-btn stl-btn-secondary" onClick={() => setStageArticle({ in_update_mode: false })}>
-                            Cancel
-                          </button>
-                          <button type="button" className="stl-btn" onClick={handleContinueSetup}>
-                            Save Setup
-                          </button>
-                        </>
-                      ) : (
-                        <button type="button" className="stl-btn stl-btn-secondary" onClick={() => setStageArticle({ in_update_mode: true })}>
-                          Update Setup
-                        </button>
-                      )
-                    ) : (
-                      <button type="button" className="stl-btn" onClick={handleContinueSetup}>
-                        Continue to Step 2
-                      </button>
-                    )}
-                  </div>
-                ) : null}
-              </div>
-
-              <div className="sab-stage-field-grid">
-                <label className="stl-field">
-                  <span>Article Title</span>
-                  <input
-                    value={stagedArticle.title}
-                    onChange={(event) => layout.onUpdateTitle(event.target.value)}
-                    placeholder="Title the article draft"
-                  />
-                </label>
-
-                <label className="stl-field">
-                  <span>Location</span>
-                  <select
-                    value={stagedArticle.locationId || ''}
-                    onChange={(event) => {
-                      const nextLocationId = Number(event.target.value) || undefined
-                      sidebarProps.onUpdateStagedArticle(buildPrimaryLocationUpdate({
-                        locations: sidebarProps.locations,
-                        nextLocationId,
-                        sharedNeighborhoods: stagedArticle.sharedNeighborhoods,
-                      }))
-                    }}
-                  >
-                    <option value="">Select location</option>
-                    {sidebarProps.locations.map((location) => (
-                      <option key={location.id} value={location.id}>
-                        {getLocationDisplayName(location)}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                {isCityPrimaryLocation ? (
-                  <label className="stl-field">
-                    <span>Shared Neighborhoods</span>
-                    <small>Optional. Exact neighborhood scoping only.</small>
-                    <select
-                      multiple
-                      value={selectedSharedNeighborhoods.map(String)}
-                      onChange={(event) => {
-                        const nextSharedNeighborhoods = Array.from(
-                          event.currentTarget.selectedOptions,
-                          (option) => Number(option.value)
-                        ).filter((value) => Number.isFinite(value) && value > 0)
-
-                        sidebarProps.onUpdateStagedArticle({
-                          sharedNeighborhoods: sanitizeSharedNeighborhoods(
-                            nextSharedNeighborhoods,
-                            sidebarProps.locations,
-                            stagedArticle.locationId
-                          ),
-                        })
-                      }}
-                      style={{ minHeight: '8rem' }}
-                      disabled={sharedNeighborhoodOptions.length === 0}
-                    >
-                      {sharedNeighborhoodOptions.map((location) => (
-                        <option key={location.id} value={location.id}>
-                          {getLocationDisplayName(location)}
-                        </option>
-                      ))}
-                    </select>
-                    {sharedNeighborhoodOptions.length === 0 ? (
-                      <small>No neighborhoods are available for this city yet.</small>
-                    ) : null}
-                  </label>
-                ) : null}
-
-                <label className="stl-field">
-                  <span>AI Model</span>
-                  <select
-                    value={resolveEditorModelName(stagedArticle.editorModelName)}
-                    onChange={(event) => sidebarProps.onUpdateStagedArticle({
-                      editorModelName: resolveEditorModelName(event.target.value),
-                    })}
-                  >
-                    {EDITOR_MODEL_OPTIONS.map((modelOption) => (
-                      <option key={modelOption.value} value={modelOption.value}>
-                        {modelOption.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                <label className="stl-field">
-                  <span>Slug *</span>
-                  <small>URL-friendly identifier (e.g. medellin-digital-nomad-guide-2026)</small>
-                  <div className="stl-seo-input-wrap">
-                    <input
-                      className="stl-seo-input-with-ai"
-                      value={stagedArticle.payloadSlug || ''}
-                      onChange={(event) => {
-                        const slug = event.target.value
-                        sidebarProps.onUpdateStagedArticle({ payloadSlug: slug })
-                      }}
-                      placeholder="e.g. best-steakhouses-las-vegas"
-                      disabled={!isSynced && isStep1Locked}
-                    />
-                    {(isSynced || !isStep1Locked) ? (
-                      <span className="stl-seo-ai-trigger-wrap">
-                        <button
-                          type="button"
-                          className="stl-btn stl-btn-secondary stl-seo-ai-btn"
-                          onClick={() => void handleGenerateSlugWithAi()}
-                          disabled={isGeneratingSlug || !stagedArticle.title.trim()}
-                        >
-                          {isGeneratingSlug ? 'Generating...' : 'AI'}
-                        </button>
-                      </span>
-                    ) : null}
-                  </div>
-                </label>
-              </div>
-
-              {isStep1Locked && !isSynced ? (
-                <p className="sab-stage-summary">
-                  Locked with title, primary location, optional shared neighborhoods, and AI model. Updating setup will unlock later steps.
-                </p>
-              ) : null}
-            </section>
-
-            {(isStep1Locked || isSynced) ? (
-              <section className="stl-panel sab-stage-panel">
-                <div className="stl-panel-header">
-                  <h2>{!isSynced ? <span className="stl-kicker">Step 2</span> : null} Featured Image</h2>
-                  {!isSynced ? (
-                    <div className="stl-inline-actions">
-                      {isStep2Locked ? (
-                        stagedArticle.step2_in_update_mode ? (
-                          <>
-                            <button type="button" className="stl-btn stl-btn-secondary" onClick={() => setStageArticle({ step2_in_update_mode: false })}>
-                              Cancel
-                            </button>
-                            <button type="button" className="stl-btn" onClick={handleContinueFeaturedImage}>
-                              Save Featured Image
-                            </button>
-                          </>
-                        ) : (
-                          <button type="button" className="stl-btn stl-btn-secondary" onClick={() => setStageArticle({ step2_in_update_mode: true })}>
-                            Update Featured Image
-                          </button>
-                        )
-                      ) : (
-                        <button type="button" className="stl-btn" onClick={handleContinueFeaturedImage}>
-                          Continue to Step 3
-                        </button>
-                      )}
-                    </div>
-                  ) : null}
-                </div>
-
-                <fieldset className="stl-panel-fieldset" disabled={!isSynced && isStep2Locked}>
-                  <div className="stl-field">
-                    <span>Featured Image</span>
-                    {!featuredImageId ? (
-                      <button
-                        type="button"
-                        className="stl-picker-trigger"
-                        onClick={sidebarProps.onOpenFeaturedImageModal}
-                      >
-                        <span className="stl-picker-trigger__preview">
-                          <span className={`stl-picker-trigger__label${isFeaturedImagePlaceholder ? ' stl-picker-trigger__label--placeholder' : ''}`}>
-                            {featuredImageTriggerLabel}
-                          </span>
-                        </span>
-                        <span className="stl-picker-trigger__caret">▼</span>
-                      </button>
-                    ) : (
-                      <div className="stl-featured-header-preview">
-                        <button
-                          type="button"
-                          className="stl-featured-header-preview__media"
-                          onClick={sidebarProps.onOpenFeaturedImageModal}
-                        >
-                          {featuredImagePreviewUrl ? (
-                            <img src={featuredImagePreviewUrl} alt="" />
-                          ) : (
-                            <div className="stl-featured-header-preview__fallback">Image selected</div>
-                          )}
-                          <div className="stl-featured-header-preview__overlay">
-                            <p className="stl-featured-header-preview__title">{headerPreviewTitle}</p>
-                          </div>
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                </fieldset>
-              </section>
+            {(derived.isStep1Locked || derived.isSynced) ? (
+              <StandardArticleFeaturedImagePanel
+                stagedArticle={stagedArticle}
+                isSynced={derived.isSynced}
+                isStep2Locked={derived.isStep2Locked}
+                featuredImagePreviewUrl={featuredImagePreviewUrl}
+                featuredImageTriggerLabel={featuredImageTriggerLabel}
+                onUpdateArticle={actions.setStageArticle}
+                onContinue={actions.continueFeaturedImage}
+                onOpenFeaturedImageModal={sidebarProps.onOpenFeaturedImageModal}
+              />
             ) : null}
 
-            {isStep1Locked || isSynced ? (
-              <section className="stl-panel sab-stage-panel sab-stage-panel-content">
-                <div className="stl-panel-header">
-                  <h2>{!isSynced ? <span className="stl-kicker">Step 3</span> : null} Content Blocks</h2>
-                  <div className="stl-inline-actions">
-                    <button type="button" className="stl-btn stl-btn-secondary" onClick={layout.onResetToOriginalBlocks}>
-                      Reset to Original
-                    </button>
-                    <button type="button" className="stl-btn stl-btn-secondary" onClick={handleOpenDeepExpand}>
-                      Deep Expand
-                    </button>
-                    {!isSynced ? (
-                      isStep3Locked ? (
-                        stagedArticle.step3_in_update_mode ? (
-                          <>
-                            <button type="button" className="stl-btn stl-btn-secondary" onClick={() => setStageArticle({ step3_in_update_mode: false })}>
-                              Cancel
-                            </button>
-                            <button type="button" className="stl-btn" onClick={handleContinueContent}>
-                              Save Step 3
-                            </button>
-                          </>
-                        ) : (
-                          <button type="button" className="stl-btn stl-btn-secondary" onClick={() => setStageArticle({ step3_in_update_mode: true })}>
-                            Update Step 3
-                          </button>
-                        )
-                      ) : (
-                        <button type="button" className="stl-btn" onClick={handleContinueContent}>
-                          Continue to Step 4
-                        </button>
-                      )
-                    ) : null}
-                  </div>
-                </div>
-
-                <div className="sab-stage-content-shell">
-                  <EditorialTimelineList {...timelineListProps} />
-                </div>
-              </section>
+            {(derived.isStep1Locked || derived.isSynced) ? (
+              <StandardArticleContentPanel
+                stagedArticle={stagedArticle}
+                timelineListProps={timelineListProps}
+                isSynced={derived.isSynced}
+                isStep3Locked={derived.isStep3Locked}
+                onUpdateArticle={actions.setStageArticle}
+                onContinue={actions.continueContent}
+                onResetToOriginalBlocks={layout.onResetToOriginalBlocks}
+                onOpenDeepExpand={expansion.open}
+              />
             ) : null}
 
-            {(isStep1Locked && isStep3Locked) || isSynced ? (
+            {((derived.isStep1Locked && derived.isStep3Locked) || derived.isSynced) ? (
               <SeoEditorPanel
-                seoSection={seoSection}
+                seoSection={derived.seoSection}
                 setSeoSection={updateSeoSection}
-                onGenerateSeoWithAi={handleGenerateSeoWithAi}
-                isGeneratingSeoTarget={isGeneratingSeoTarget}
-                onGenerateSeoImageFromFeatured={handleGenerateSeoImageFromFeatured}
-                isGeneratingSeoImage={isGeneratingSeoImage}
-                onUploadOgImageFile={handleUploadOgImageFile}
-                isUploadingOgImage={isUploadingOgImage}
-                onAutoFillOgUrl={handleAutoFillOgUrl}
+                onGenerateSeoWithAi={seo.generateSeo}
+                isGeneratingSeoTarget={seo.isGeneratingSeoTarget}
+                onGenerateSeoImageFromFeatured={seo.generateImageFromFeatured}
+                isGeneratingSeoImage={seo.isGeneratingSeoImage}
+                onUploadOgImageFile={seo.uploadOgImageFile}
+                isUploadingOgImage={seo.isUploadingOgImage}
+                onAutoFillOgUrl={permalink.autoFillOgUrl}
                 title="SEO & Sync"
               />
             ) : null}
           </main>
 
-          <aside className="stl-builder-sidebar">
-            {isSynced ? (
-              <section className="stl-summary-card">
-                <h3>Article Status</h3>
-                {syncIssues.length > 0 ? (
-                  <ul className="stl-summary-list">
-                    {syncIssues.map((issue) => <li key={issue}>{issue}</li>)}
-                  </ul>
-                ) : (
-                  <p className="stl-summary-note">All fields complete.</p>
-                )}
-              </section>
-            ) : (
-              <section className="stl-summary-card">
-                <h3>Build Progress</h3>
-                <div className="stl-progress-track" aria-hidden="true">
-                  <span className="stl-progress-bar" style={{ width: `${completionPercent}%` }} />
-                </div>
-                <p className="stl-summary-percent">{completionPercent}% ready</p>
-                <ul className="stl-summary-list">
-                  <li className={isStep1Locked ? 'done' : ''}>
-                    Setup: {isStep1Locked ? 'Locked' : stagedArticle.in_update_mode ? 'Editing' : 'Incomplete'}
-                  </li>
-                  <li className="done">
-                    Featured image: {isStep2Locked ? 'Saved' : stagedArticle.step2_in_update_mode ? 'Editing' : 'Skippable'}
-                  </li>
-                  <li className={isStep3Locked ? 'done' : ''}>
-                    Content blocks: {isStep3Locked ? 'Locked' : stagedArticle.step3_in_update_mode ? 'Editing' : isStep1Locked ? 'Ready' : 'Blocked'}
-                  </li>
-                  <li className={seoCoreComplete ? 'done' : ''}>
-                    SEO core: {seoCoreComplete ? 'Complete' : 'Missing SEO title or meta description'}
-                  </li>
-                </ul>
-              </section>
-            )}
-
-            <section className="stl-summary-card stl-summary-card--quick-actions">
-              <h3>Sync</h3>
-              <div className="stl-summary-actions">
-                {!isPublished ? (
-                  <button
-                    type="button"
-                    className="stl-btn stl-btn-success"
-                    onClick={() => handlePayloadSubmit('draft')}
-                    disabled={sidebarProps.isPublishing || syncIssues.length > 0}
-                  >
-                    {sidebarProps.isPublishing ? 'Saving...' : 'Save Draft to Payload'}
-                  </button>
-                ) : null}
-
-                <button
-                  type="button"
-                  className="stl-btn"
-                  onClick={() => handlePayloadSubmit('published')}
-                  disabled={sidebarProps.isPublishing || syncIssues.length > 0 || !canManagePublished}
-                >
-                  {sidebarProps.isPublishing
-                    ? 'Publishing...'
-                    : isPublished
-                      ? 'Update Published'
-                      : 'Publish'}
-                </button>
-              </div>
-
-              {stagedArticle.payloadArticleId ? (
-                <p className="stl-summary-note">
-                  {isPublished
-                    ? `Published Payload article: #${stagedArticle.payloadArticleId}`
-                    : `Linked Payload draft: #${stagedArticle.payloadArticleId}`}
-                </p>
-              ) : (
-                <p className="stl-summary-note">First sync will create a draft article in Payload.</p>
-              )}
-
-              {!canManagePublished ? (
-                <p className="stl-summary-note">
-                  Publishing requires an editor or admin role (you are signed in as {role ?? 'unknown'}).
-                </p>
-              ) : null}
-
-              {sidebarProps.publishResult ? (
-                <div className={`sab-stage-sync-result ${sidebarProps.publishResult.success ? 'success' : 'error'}`}>
-                  {sidebarProps.publishResult.message}
-                </div>
-              ) : null}
-
-              {syncIssues.length > 0 ? (
-                <div className="stl-summary-warning">
-                  <strong>Sync needs attention:</strong>
-                  <p>{syncIssues[0]}</p>
-                </div>
-              ) : null}
-            </section>
-
-            <section className="stl-summary-card">
-              <h3>Draft Details</h3>
-              <div className="sab-stage-meta-list">
-                <p><strong>Run ID:</strong> {stagedArticle.runId || 'n/a'}</p>
-                <p><strong>Location:</strong> {selectedLocationLabel || 'Not set'}</p>
-                {stagedArticle.createdBy ? (
-                  <p><strong>Created by:</strong> {stagedArticle.createdBy.name || stagedArticle.createdBy.email}</p>
-                ) : null}
-                {stagedArticle.lastEditedBy ? (
-                  <p><strong>Last edited by:</strong> {stagedArticle.lastEditedBy.name || stagedArticle.lastEditedBy.email}</p>
-                ) : null}
-                <p><strong>Created:</strong> {stagedArticle.createdAt ? new Date(stagedArticle.createdAt).toLocaleDateString() : 'n/a'}</p>
-                <p><strong>Updated:</strong> {stagedArticle.updatedAt ? new Date(stagedArticle.updatedAt).toLocaleDateString() : 'n/a'}</p>
-              </div>
-            </section>
-          </aside>
+          <StandardArticleBuilderSidebar
+            stagedArticle={stagedArticle}
+            sidebarProps={sidebarProps}
+            selectedLocationLabel={derived.selectedLocationLabel}
+            syncIssues={derived.syncIssues}
+            completionPercent={derived.completionPercent}
+            isSynced={derived.isSynced}
+            isPublished={derived.isPublished}
+            isStep1Locked={derived.isStep1Locked}
+            isStep2Locked={derived.isStep2Locked}
+            isStep3Locked={derived.isStep3Locked}
+            seoCoreComplete={derived.seoCoreComplete}
+            canManagePublished={canManagePublished}
+            role={role}
+            onSubmit={actions.submitToPayload}
+          />
         </div>
       </div>
 
       <FeaturedImageModal {...featuredModalProps} />
       <BlockImageModal {...blockModalProps} />
-
       <ArticleExpansionModal
-        isOpen={isExpansionModalOpen}
+        isOpen={expansion.isOpen}
         phase={expansion.phase}
         expandedArticle={expansion.expandedArticle}
         expansionPlan={expansion.expansionPlan}
         error={expansion.error}
-        originalArticle={stagedArticle?.content ?? ''}
-        articleType={stagedArticle?.originalType ?? ''}
-        title={stagedArticle?.title || stagedArticle?.originalTitle || ''}
+        originalArticle={stagedArticle.content}
+        articleType={stagedArticle.originalType}
+        title={stagedArticle.title || stagedArticle.originalTitle}
         listicleDetection={expansion.listicleDetection}
-        onAccept={handleAcceptExpansion}
-        onClose={handleCloseExpansion}
+        onAccept={expansion.accept}
+        onClose={expansion.close}
         onProceed={expansion.proceedWithExpansion}
       />
     </>

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleBuilderSidebar.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleBuilderSidebar.tsx
@@ -1,0 +1,149 @@
+import type { SidebarViewProps } from '../../features/editorial-stage-article/selectors'
+import type { StagedArticle } from '../../types'
+
+type StandardArticleBuilderSidebarProps = {
+  stagedArticle: StagedArticle
+  sidebarProps: SidebarViewProps
+  selectedLocationLabel: string
+  syncIssues: string[]
+  completionPercent: number
+  isSynced: boolean
+  isPublished: boolean
+  isStep1Locked: boolean
+  isStep2Locked: boolean
+  isStep3Locked: boolean
+  seoCoreComplete: boolean
+  canManagePublished: boolean
+  role: string | null | undefined
+  onSubmit: (targetStatus: 'draft' | 'published') => void
+}
+
+export function StandardArticleBuilderSidebar({
+  stagedArticle,
+  sidebarProps,
+  selectedLocationLabel,
+  syncIssues,
+  completionPercent,
+  isSynced,
+  isPublished,
+  isStep1Locked,
+  isStep2Locked,
+  isStep3Locked,
+  seoCoreComplete,
+  canManagePublished,
+  role,
+  onSubmit,
+}: StandardArticleBuilderSidebarProps) {
+  return (
+    <aside className="stl-builder-sidebar">
+      {isSynced ? (
+        <section className="stl-summary-card">
+          <h3>Article Status</h3>
+          {syncIssues.length > 0 ? (
+            <ul className="stl-summary-list">
+              {syncIssues.map((issue) => <li key={issue}>{issue}</li>)}
+            </ul>
+          ) : (
+            <p className="stl-summary-note">All fields complete.</p>
+          )}
+        </section>
+      ) : (
+        <section className="stl-summary-card">
+          <h3>Build Progress</h3>
+          <div className="stl-progress-track" aria-hidden="true">
+            <span className="stl-progress-bar" style={{ width: `${completionPercent}%` }} />
+          </div>
+          <p className="stl-summary-percent">{completionPercent}% ready</p>
+          <ul className="stl-summary-list">
+            <li className={isStep1Locked ? 'done' : ''}>
+              Setup: {isStep1Locked ? 'Locked' : stagedArticle.in_update_mode ? 'Editing' : 'Incomplete'}
+            </li>
+            <li className="done">
+              Featured image: {isStep2Locked ? 'Saved' : stagedArticle.step2_in_update_mode ? 'Editing' : 'Skippable'}
+            </li>
+            <li className={isStep3Locked ? 'done' : ''}>
+              Content blocks: {isStep3Locked ? 'Locked' : stagedArticle.step3_in_update_mode ? 'Editing' : isStep1Locked ? 'Ready' : 'Blocked'}
+            </li>
+            <li className={seoCoreComplete ? 'done' : ''}>
+              SEO core: {seoCoreComplete ? 'Complete' : 'Missing SEO title or meta description'}
+            </li>
+          </ul>
+        </section>
+      )}
+
+      <section className="stl-summary-card stl-summary-card--quick-actions">
+        <h3>Sync</h3>
+        <div className="stl-summary-actions">
+          {!isPublished ? (
+            <button
+              type="button"
+              className="stl-btn stl-btn-success"
+              onClick={() => onSubmit('draft')}
+              disabled={sidebarProps.isPublishing || syncIssues.length > 0}
+            >
+              {sidebarProps.isPublishing ? 'Saving...' : 'Save Draft to Payload'}
+            </button>
+          ) : null}
+
+          <button
+            type="button"
+            className="stl-btn"
+            onClick={() => onSubmit('published')}
+            disabled={sidebarProps.isPublishing || syncIssues.length > 0 || !canManagePublished}
+          >
+            {sidebarProps.isPublishing
+              ? 'Publishing...'
+              : isPublished
+                ? 'Update Published'
+                : 'Publish'}
+          </button>
+        </div>
+
+        {stagedArticle.payloadArticleId ? (
+          <p className="stl-summary-note">
+            {isPublished
+              ? `Published Payload article: #${stagedArticle.payloadArticleId}`
+              : `Linked Payload draft: #${stagedArticle.payloadArticleId}`}
+          </p>
+        ) : (
+          <p className="stl-summary-note">First sync will create a draft article in Payload.</p>
+        )}
+
+        {!canManagePublished ? (
+          <p className="stl-summary-note">
+            Publishing requires an editor or admin role (you are signed in as {role ?? 'unknown'}).
+          </p>
+        ) : null}
+
+        {sidebarProps.publishResult ? (
+          <div className={`sab-stage-sync-result ${sidebarProps.publishResult.success ? 'success' : 'error'}`}>
+            {sidebarProps.publishResult.message}
+          </div>
+        ) : null}
+
+        {syncIssues.length > 0 ? (
+          <div className="stl-summary-warning">
+            <strong>Sync needs attention:</strong>
+            <p>{syncIssues[0]}</p>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="stl-summary-card">
+        <h3>Draft Details</h3>
+        <div className="sab-stage-meta-list">
+          <p><strong>Run ID:</strong> {stagedArticle.runId || 'n/a'}</p>
+          <p><strong>Location:</strong> {selectedLocationLabel || 'Not set'}</p>
+          {stagedArticle.createdBy ? (
+            <p><strong>Created by:</strong> {stagedArticle.createdBy.name || stagedArticle.createdBy.email}</p>
+          ) : null}
+          {stagedArticle.lastEditedBy ? (
+            <p><strong>Last edited by:</strong> {stagedArticle.lastEditedBy.name || stagedArticle.lastEditedBy.email}</p>
+          ) : null}
+          <p><strong>Created:</strong> {stagedArticle.createdAt ? new Date(stagedArticle.createdAt).toLocaleDateString() : 'n/a'}</p>
+          <p><strong>Updated:</strong> {stagedArticle.updatedAt ? new Date(stagedArticle.updatedAt).toLocaleDateString() : 'n/a'}</p>
+        </div>
+      </section>
+    </aside>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleContentPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleContentPanel.tsx
@@ -1,0 +1,75 @@
+import type { TimelineListViewProps } from '../../features/editorial-stage-article/selectors'
+import type { StagedArticle } from '../../types'
+import { EditorialTimelineList } from '../editorial-stage/EditorialTimelineList'
+
+type StandardArticleContentPanelProps = {
+  stagedArticle: StagedArticle
+  timelineListProps: TimelineListViewProps
+  isSynced: boolean
+  isStep3Locked: boolean
+  onUpdateArticle: (updates: Partial<StagedArticle>) => void
+  onContinue: () => void
+  onResetToOriginalBlocks: () => void
+  onOpenDeepExpand: () => void
+}
+
+export function StandardArticleContentPanel({
+  stagedArticle,
+  timelineListProps,
+  isSynced,
+  isStep3Locked,
+  onUpdateArticle,
+  onContinue,
+  onResetToOriginalBlocks,
+  onOpenDeepExpand,
+}: StandardArticleContentPanelProps) {
+  return (
+    <section className="stl-panel sab-stage-panel sab-stage-panel-content">
+      <div className="stl-panel-header">
+        <h2>{!isSynced ? <span className="stl-kicker">Step 3</span> : null} Content Blocks</h2>
+        <div className="stl-inline-actions">
+          <button type="button" className="stl-btn stl-btn-secondary" onClick={onResetToOriginalBlocks}>
+            Reset to Original
+          </button>
+          <button type="button" className="stl-btn stl-btn-secondary" onClick={onOpenDeepExpand}>
+            Deep Expand
+          </button>
+          {!isSynced ? (
+            isStep3Locked ? (
+              stagedArticle.step3_in_update_mode ? (
+                <>
+                  <button
+                    type="button"
+                    className="stl-btn stl-btn-secondary"
+                    onClick={() => onUpdateArticle({ step3_in_update_mode: false })}
+                  >
+                    Cancel
+                  </button>
+                  <button type="button" className="stl-btn" onClick={onContinue}>
+                    Save Step 3
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  className="stl-btn stl-btn-secondary"
+                  onClick={() => onUpdateArticle({ step3_in_update_mode: true })}
+                >
+                  Update Step 3
+                </button>
+              )
+            ) : (
+              <button type="button" className="stl-btn" onClick={onContinue}>
+                Continue to Step 4
+              </button>
+            )
+          ) : null}
+        </div>
+      </div>
+
+      <div className="sab-stage-content-shell">
+        <EditorialTimelineList {...timelineListProps} />
+      </div>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleFeaturedImagePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleFeaturedImagePanel.tsx
@@ -1,0 +1,103 @@
+import type { StagedArticle } from '../../types'
+
+type StandardArticleFeaturedImagePanelProps = {
+  stagedArticle: StagedArticle
+  isSynced: boolean
+  isStep2Locked: boolean
+  featuredImagePreviewUrl?: string
+  featuredImageTriggerLabel: string
+  onUpdateArticle: (updates: Partial<StagedArticle>) => void
+  onContinue: () => void
+  onOpenFeaturedImageModal: () => void
+}
+
+export function StandardArticleFeaturedImagePanel({
+  stagedArticle,
+  isSynced,
+  isStep2Locked,
+  featuredImagePreviewUrl,
+  featuredImageTriggerLabel,
+  onUpdateArticle,
+  onContinue,
+  onOpenFeaturedImageModal,
+}: StandardArticleFeaturedImagePanelProps) {
+  const featuredImageId = stagedArticle.featuredImageId
+  const headerPreviewTitle = stagedArticle.title.trim() || 'Your article headline will appear here'
+
+  return (
+    <section className="stl-panel sab-stage-panel">
+      <div className="stl-panel-header">
+        <h2>{!isSynced ? <span className="stl-kicker">Step 2</span> : null} Featured Image</h2>
+        {!isSynced ? (
+          <div className="stl-inline-actions">
+            {isStep2Locked ? (
+              stagedArticle.step2_in_update_mode ? (
+                <>
+                  <button
+                    type="button"
+                    className="stl-btn stl-btn-secondary"
+                    onClick={() => onUpdateArticle({ step2_in_update_mode: false })}
+                  >
+                    Cancel
+                  </button>
+                  <button type="button" className="stl-btn" onClick={onContinue}>
+                    Save Featured Image
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  className="stl-btn stl-btn-secondary"
+                  onClick={() => onUpdateArticle({ step2_in_update_mode: true })}
+                >
+                  Update Featured Image
+                </button>
+              )
+            ) : (
+              <button type="button" className="stl-btn" onClick={onContinue}>
+                Continue to Step 3
+              </button>
+            )}
+          </div>
+        ) : null}
+      </div>
+
+      <fieldset className="stl-panel-fieldset" disabled={!isSynced && isStep2Locked}>
+        <div className="stl-field">
+          <span>Featured Image</span>
+          {!featuredImageId ? (
+            <button
+              type="button"
+              className="stl-picker-trigger"
+              onClick={onOpenFeaturedImageModal}
+            >
+              <span className="stl-picker-trigger__preview">
+                <span className="stl-picker-trigger__label stl-picker-trigger__label--placeholder">
+                  {featuredImageTriggerLabel}
+                </span>
+              </span>
+              <span className="stl-picker-trigger__caret">▼</span>
+            </button>
+          ) : (
+            <div className="stl-featured-header-preview">
+              <button
+                type="button"
+                className="stl-featured-header-preview__media"
+                onClick={onOpenFeaturedImageModal}
+              >
+                {featuredImagePreviewUrl ? (
+                  <img src={featuredImagePreviewUrl} alt="" />
+                ) : (
+                  <div className="stl-featured-header-preview__fallback">Image selected</div>
+                )}
+                <div className="stl-featured-header-preview__overlay">
+                  <p className="stl-featured-header-preview__title">{headerPreviewTitle}</p>
+                </div>
+              </button>
+            </div>
+          )}
+        </div>
+      </fieldset>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleSetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleSetupPanel.tsx
@@ -1,0 +1,195 @@
+import type { StagedArticle } from '../../types'
+import type { Location } from '../../api'
+import { EDITOR_MODEL_OPTIONS, resolveEditorModelName } from '../../features/editorial-stage-article/constants'
+import { getLocationDisplayName } from '../../features/editorial-stage-article/utils/editorial-stage-view.utils'
+import {
+  buildPrimaryLocationUpdate,
+  sanitizeSharedNeighborhoods,
+} from '../../features/editorial-stage-article/utils/sharedNeighborhoods'
+
+type StandardArticleSetupPanelProps = {
+  stagedArticle: StagedArticle
+  locations: Location[]
+  sharedNeighborhoodOptions: Location[]
+  selectedSharedNeighborhoods: number[]
+  isCityPrimaryLocation: boolean
+  isSynced: boolean
+  isStep1Locked: boolean
+  isGeneratingSlug: boolean
+  onUpdateTitle: (title: string) => void
+  onUpdateArticle: (updates: Partial<StagedArticle>) => void
+  onContinue: () => void
+  onGenerateSlug: () => Promise<void>
+}
+
+export function StandardArticleSetupPanel({
+  stagedArticle,
+  locations,
+  sharedNeighborhoodOptions,
+  selectedSharedNeighborhoods,
+  isCityPrimaryLocation,
+  isSynced,
+  isStep1Locked,
+  isGeneratingSlug,
+  onUpdateTitle,
+  onUpdateArticle,
+  onContinue,
+  onGenerateSlug,
+}: StandardArticleSetupPanelProps) {
+  return (
+    <section className="stl-panel sab-stage-panel">
+      <div className="stl-panel-header">
+        <h2>{!isSynced ? <span className="stl-kicker">Step 1</span> : null} Setup</h2>
+        {!isSynced ? (
+          <div className="stl-inline-actions">
+            {isStep1Locked ? (
+              stagedArticle.in_update_mode ? (
+                <>
+                  <button
+                    type="button"
+                    className="stl-btn stl-btn-secondary"
+                    onClick={() => onUpdateArticle({ in_update_mode: false })}
+                  >
+                    Cancel
+                  </button>
+                  <button type="button" className="stl-btn" onClick={onContinue}>
+                    Save Setup
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  className="stl-btn stl-btn-secondary"
+                  onClick={() => onUpdateArticle({ in_update_mode: true })}
+                >
+                  Update Setup
+                </button>
+              )
+            ) : (
+              <button type="button" className="stl-btn" onClick={onContinue}>
+                Continue to Step 2
+              </button>
+            )}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="sab-stage-field-grid">
+        <label className="stl-field">
+          <span>Article Title</span>
+          <input
+            value={stagedArticle.title}
+            onChange={(event) => onUpdateTitle(event.target.value)}
+            placeholder="Title the article draft"
+          />
+        </label>
+
+        <label className="stl-field">
+          <span>Location</span>
+          <select
+            value={stagedArticle.locationId || ''}
+            onChange={(event) => {
+              const nextLocationId = Number(event.target.value) || undefined
+              onUpdateArticle(buildPrimaryLocationUpdate({
+                locations,
+                nextLocationId,
+                sharedNeighborhoods: stagedArticle.sharedNeighborhoods,
+              }))
+            }}
+          >
+            <option value="">Select location</option>
+            {locations.map((location) => (
+              <option key={location.id} value={location.id}>
+                {getLocationDisplayName(location)}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {isCityPrimaryLocation ? (
+          <label className="stl-field">
+            <span>Shared Neighborhoods</span>
+            <small>Optional. Exact neighborhood scoping only.</small>
+            <select
+              multiple
+              value={selectedSharedNeighborhoods.map(String)}
+              onChange={(event) => {
+                const nextSharedNeighborhoods = Array.from(
+                  event.currentTarget.selectedOptions,
+                  (option) => Number(option.value),
+                ).filter((value) => Number.isFinite(value) && value > 0)
+
+                onUpdateArticle({
+                  sharedNeighborhoods: sanitizeSharedNeighborhoods(
+                    nextSharedNeighborhoods,
+                    locations,
+                    stagedArticle.locationId,
+                  ),
+                })
+              }}
+              style={{ minHeight: '8rem' }}
+              disabled={sharedNeighborhoodOptions.length === 0}
+            >
+              {sharedNeighborhoodOptions.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {getLocationDisplayName(location)}
+                </option>
+              ))}
+            </select>
+            {sharedNeighborhoodOptions.length === 0 ? (
+              <small>No neighborhoods are available for this city yet.</small>
+            ) : null}
+          </label>
+        ) : null}
+
+        <label className="stl-field">
+          <span>AI Model</span>
+          <select
+            value={resolveEditorModelName(stagedArticle.editorModelName)}
+            onChange={(event) => onUpdateArticle({
+              editorModelName: resolveEditorModelName(event.target.value),
+            })}
+          >
+            {EDITOR_MODEL_OPTIONS.map((modelOption) => (
+              <option key={modelOption.value} value={modelOption.value}>
+                {modelOption.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="stl-field">
+          <span>Slug *</span>
+          <small>URL-friendly identifier (e.g. medellin-digital-nomad-guide-2026)</small>
+          <div className="stl-seo-input-wrap">
+            <input
+              className="stl-seo-input-with-ai"
+              value={stagedArticle.payloadSlug || ''}
+              onChange={(event) => onUpdateArticle({ payloadSlug: event.target.value })}
+              placeholder="e.g. best-steakhouses-las-vegas"
+              disabled={!isSynced && isStep1Locked}
+            />
+            {(isSynced || !isStep1Locked) ? (
+              <span className="stl-seo-ai-trigger-wrap">
+                <button
+                  type="button"
+                  className="stl-btn stl-btn-secondary stl-seo-ai-btn"
+                  onClick={() => void onGenerateSlug()}
+                  disabled={isGeneratingSlug || !stagedArticle.title.trim()}
+                >
+                  {isGeneratingSlug ? 'Generating...' : 'AI'}
+                </button>
+              </span>
+            ) : null}
+          </div>
+        </label>
+      </div>
+
+      {isStep1Locked && !isSynced ? (
+        <p className="sab-stage-summary">
+          Locked with title, primary location, optional shared neighborhoods, and AI model. Updating setup will unlock later steps.
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleStageHero.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleStageHero.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom'
+import type { StagedArticle } from '../../types'
+
+type StandardArticleStageHeroProps = {
+  stagedArticle: StagedArticle
+  eyebrow: string
+  description: string
+  backLabel: string
+  stagePath: string
+  completionPercent: number
+  isSynced: boolean
+  onDelete: () => void
+}
+
+export function StandardArticleStageHero({
+  stagedArticle,
+  eyebrow,
+  description,
+  backLabel,
+  stagePath,
+  completionPercent,
+  isSynced,
+  onDelete,
+}: StandardArticleStageHeroProps) {
+  return (
+    <header className="stl-hero sab-stage-hero">
+      <div>
+        <p className="stl-eyebrow">{eyebrow}</p>
+        <h1>{stagedArticle.payloadArticleId ? `Sync Draft #${stagedArticle.payloadArticleId}` : 'Stage Article'}</h1>
+        <p className="stl-lede">{description}</p>
+        <div className="sab-stage-hero-meta">
+          {stagedArticle.originalType ? <span className="sab-stage-pill">{stagedArticle.originalType}</span> : null}
+          {stagedArticle.payloadArticleId ? <span className="sab-stage-pill">Linked Payload #{stagedArticle.payloadArticleId}</span> : null}
+          {!isSynced ? <span className="sab-stage-pill">{completionPercent}% ready</span> : null}
+        </div>
+      </div>
+      <div className="stl-hero-actions">
+        <Link to={stagePath} className="stl-btn stl-btn-secondary">{backLabel}</Link>
+        <button type="button" className="stl-btn stl-btn-danger" onClick={onDelete}>
+          Delete Staged Article
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleStatusBanners.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleStatusBanners.tsx
@@ -1,0 +1,68 @@
+import type { EditorialStageStatusView } from '../../features/editorial-stage-article/view-model/types'
+
+type StandardArticleStatusBannersProps = {
+  status: EditorialStageStatusView
+  localError: string | null
+  localResult: string | null
+  hasUnsyncedPayloadChanges: boolean
+  isPublished: boolean
+  isPublishing: boolean
+  syncIssues: string[]
+  onSubmit: (targetStatus: 'draft' | 'published') => void
+}
+
+export function StandardArticleStatusBanners({
+  status,
+  localError,
+  localResult,
+  hasUnsyncedPayloadChanges,
+  isPublished,
+  isPublishing,
+  syncIssues,
+  onSubmit,
+}: StandardArticleStatusBannersProps) {
+  return (
+    <>
+      {status.saveConflict ? (
+        <div className="stl-summary-warning" role="alert">
+          <strong>Draft changed elsewhere.</strong>
+          <p>
+            This draft was modified
+            {status.saveConflict.current?.lastEditedBy?.email
+              ? ` by ${status.saveConflict.current.lastEditedBy.email}`
+              : status.saveConflict.current === null
+                ? ' (it was deleted)'
+                : ' by another user'}
+            {' '}since you opened it. Autosave is paused — reload to continue; unsynced local changes will be lost.
+          </p>
+          <button
+            type="button"
+            className="stl-btn stl-btn-secondary"
+            onClick={() => window.location.reload()}
+          >
+            Reload draft
+          </button>
+        </div>
+      ) : null}
+      {localError ? <p className="stl-error">{localError}</p> : null}
+      {localResult ? <p className="stl-success">{localResult}</p> : null}
+
+      {hasUnsyncedPayloadChanges ? (
+        <div className="stl-out-of-sync-banner" role="status">
+          <span className="stl-out-of-sync-banner__dot" aria-hidden="true" />
+          <span className="stl-out-of-sync-banner__text">
+            Out of sync — you have local changes. Sync to Payload to apply them to the live article.
+          </span>
+          <button
+            type="button"
+            className="stl-btn stl-out-of-sync-banner__btn"
+            onClick={() => onSubmit(isPublished ? 'published' : 'draft')}
+            disabled={isPublishing || syncIssues.length > 0}
+          >
+            {isPublishing ? 'Syncing...' : 'Save & Sync'}
+          </button>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleDerivedState.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleDerivedState.ts
@@ -1,0 +1,155 @@
+import { useMemo } from 'react'
+import { createEmptySeoSection } from '../../../../../shared/seo/services/seo-section.service'
+import type { StagedArticle } from '../../../types'
+import type { SidebarViewProps } from '../selectors'
+import {
+  buildStandardArticleContext,
+  isSeoCoreComplete,
+  validateStandardArticleSeoSection,
+} from '../services/standard-article-seo.service'
+import { getLocationDisplayName } from '../utils/editorial-stage-view.utils'
+import {
+  getSharedNeighborhoodOptions,
+  sanitizeSharedNeighborhoods,
+} from '../utils/sharedNeighborhoods'
+
+function validateSetupStep(title: string, locationId?: number): string[] {
+  const issues: string[] = []
+  if (!title.trim()) issues.push('Step 1 requires an article title.')
+  if (!locationId) issues.push('Step 1 requires a location.')
+  return issues
+}
+
+function validateFeaturedImageStep(featuredImageId?: number): string[] {
+  return featuredImageId ? [] : ['Select a featured image before syncing to Payload.']
+}
+
+function validateContentStep(input: {
+  bodyMarkdown: string
+  editorialBlockingMessages: string[]
+}): string[] {
+  const issues: string[] = []
+  if (!input.bodyMarkdown.trim()) {
+    issues.push('Step 3 requires at least one text block with content.')
+  }
+  if (input.editorialBlockingMessages.length > 0) {
+    issues.push(input.editorialBlockingMessages[0])
+  }
+  return issues
+}
+
+export function useStandardArticleDerivedState(
+  stagedArticle: StagedArticle | undefined,
+  sidebarProps: SidebarViewProps | null,
+) {
+  const seoSection = stagedArticle?.seoSection ?? createEmptySeoSection()
+  const selectedLocation = useMemo(
+    () => sidebarProps?.locations.find((location) => location.id === stagedArticle?.locationId),
+    [sidebarProps?.locations, stagedArticle?.locationId],
+  )
+  const sharedNeighborhoodOptions = useMemo(
+    () => getSharedNeighborhoodOptions(sidebarProps?.locations ?? [], stagedArticle?.locationId),
+    [sidebarProps?.locations, stagedArticle?.locationId],
+  )
+  const selectedSharedNeighborhoods = useMemo(
+    () => sanitizeSharedNeighborhoods(
+      stagedArticle?.sharedNeighborhoods ?? [],
+      sidebarProps?.locations ?? [],
+      stagedArticle?.locationId,
+    ),
+    [sidebarProps?.locations, stagedArticle?.locationId, stagedArticle?.sharedNeighborhoods],
+  )
+  const selectedLocationLabel = useMemo(
+    () => getLocationDisplayName(selectedLocation),
+    [selectedLocation],
+  )
+  const bodyMarkdown = useMemo(
+    () => (stagedArticle ? buildStandardArticleContext(stagedArticle) : ''),
+    [stagedArticle],
+  )
+  const step1Issues = useMemo(
+    () => validateSetupStep(stagedArticle?.title || '', stagedArticle?.locationId),
+    [stagedArticle?.locationId, stagedArticle?.title],
+  )
+  const step2Issues = useMemo(
+    () => validateFeaturedImageStep(stagedArticle?.featuredImageId),
+    [stagedArticle?.featuredImageId],
+  )
+  const step3Issues = useMemo(
+    () => validateContentStep({
+      bodyMarkdown,
+      editorialBlockingMessages: sidebarProps?.editorialBlockingMessages || [],
+    }),
+    [bodyMarkdown, sidebarProps?.editorialBlockingMessages],
+  )
+  const seoIssues = useMemo(
+    () => validateStandardArticleSeoSection({
+      seoSection,
+      locationLabel: selectedLocationLabel || undefined,
+    }),
+    [seoSection, selectedLocationLabel],
+  )
+
+  const isStep1Locked = Boolean(stagedArticle?.step1_complete && !stagedArticle?.in_update_mode)
+  const isStep2Locked = Boolean(stagedArticle?.step2_complete && !stagedArticle?.step2_in_update_mode)
+  const isStep3Locked = Boolean(stagedArticle?.step3_complete && !stagedArticle?.step3_in_update_mode)
+  const isSynced = Boolean(stagedArticle?.publishedToPayload)
+  const isPublished = stagedArticle?.payloadStatus === 'published'
+  const hasUnsyncedPayloadChanges = Boolean(isSynced && stagedArticle?.hasUnsyncedPayloadChanges)
+  const seoCoreComplete = isSeoCoreComplete(seoSection)
+  const completionPercent = Math.round(([
+    isStep1Locked,
+    isStep3Locked,
+    seoCoreComplete,
+  ].filter(Boolean).length / 3) * 100)
+
+  const syncIssues = useMemo(() => {
+    const issues: string[] = []
+    if (isSynced) {
+      if (step1Issues.length > 0) issues.push(step1Issues[0])
+      if (!stagedArticle?.payloadSlug?.trim()) issues.push('Slug is required before syncing to Payload.')
+      if (step2Issues.length > 0) issues.push(step2Issues[0])
+      if (step3Issues.length > 0) issues.push(step3Issues[0])
+      if (!seoCoreComplete) issues.push('Add SEO title and meta description before syncing to Payload.')
+      if (seoIssues.length > 0) issues.push(seoIssues[0])
+    } else {
+      if (!isStep1Locked) issues.push('Lock Step 1 before syncing to Payload.')
+      if (!stagedArticle?.payloadSlug?.trim()) issues.push('Slug is required before syncing to Payload.')
+      if (step2Issues.length > 0) issues.push(step2Issues[0])
+      if (!isStep3Locked) issues.push('Lock Step 3 before syncing to Payload.')
+      if (!seoCoreComplete) issues.push('Add SEO title and meta description before syncing to Payload.')
+      if (step3Issues.length > 0) issues.push(step3Issues[0])
+      if (seoIssues.length > 0) issues.push(seoIssues[0])
+    }
+    return issues
+  }, [
+    isStep1Locked,
+    isStep3Locked,
+    isSynced,
+    seoCoreComplete,
+    seoIssues,
+    stagedArticle?.payloadSlug,
+    step1Issues,
+    step2Issues,
+    step3Issues,
+  ])
+
+  return {
+    seoSection,
+    selectedLocation,
+    selectedLocationLabel,
+    sharedNeighborhoodOptions,
+    selectedSharedNeighborhoods,
+    step1Issues,
+    step3Issues,
+    syncIssues,
+    isStep1Locked,
+    isStep2Locked,
+    isStep3Locked,
+    isSynced,
+    isPublished,
+    hasUnsyncedPayloadChanges,
+    seoCoreComplete,
+    completionPercent,
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleExpansion.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleExpansion.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react'
+import type { StagedArticle } from '../../../types'
+import { useArticleExpansion } from '../../../../youtube2blog/hooks/useArticleExpansion'
+import { parseMarkdownToBlocks } from '../workflow.service'
+
+export function useStandardArticleExpansion(
+  stagedArticle: StagedArticle | undefined,
+  setStageArticle: (updates: Partial<StagedArticle>) => void,
+) {
+  const [isOpen, setIsOpen] = useState(false)
+  const expansion = useArticleExpansion(stagedArticle?.runId ?? null)
+
+  const open = useCallback(() => {
+    if (!stagedArticle) return
+    expansion.reset()
+    expansion.startExpansion(
+      stagedArticle.content,
+      stagedArticle.originalType,
+      stagedArticle.title || stagedArticle.originalTitle,
+    )
+    setIsOpen(true)
+  }, [expansion, stagedArticle])
+
+  const accept = useCallback((expandedMarkdown: string) => {
+    const blocks = parseMarkdownToBlocks(expandedMarkdown)
+    setStageArticle({ blocks, content: expandedMarkdown, lexicalConverted: false })
+    expansion.reset()
+    setIsOpen(false)
+  }, [expansion, setStageArticle])
+
+  const close = useCallback(() => {
+    expansion.reset()
+    setIsOpen(false)
+  }, [expansion])
+
+  return {
+    ...expansion,
+    isOpen,
+    open,
+    accept,
+    close,
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticlePermalink.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticlePermalink.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import type { SeoSection } from '../../../../../shared/seo/types'
+import { buildArticleOgUrl } from '../../../../../shared/seo/utils/buildArticleOgUrl'
+import type { Location } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import type { EditorialStageArticleApi } from '../types'
+
+type SetSeoSection = (
+  next: SeoSection | ((current: SeoSection) => SeoSection)
+) => void
+
+type UseStandardArticlePermalinkParams = {
+  api: EditorialStageArticleApi
+  stagedArticle?: StagedArticle
+  selectedLocation?: Location
+  updateSeoSection: SetSeoSection
+  setLocalError: Dispatch<SetStateAction<string | null>>
+}
+
+export function useStandardArticlePermalink({
+  api,
+  stagedArticle,
+  selectedLocation,
+  updateSeoSection,
+  setLocalError,
+}: UseStandardArticlePermalinkParams) {
+  const [isGeneratingSlug, setIsGeneratingSlug] = useState(false)
+
+  const generateSlug = useCallback(async () => {
+    if (!stagedArticle?.title.trim()) return
+    setIsGeneratingSlug(true)
+    try {
+      const response = await api.rewriteBlockWithAi({
+        prompt: `Generate a clean SEO-friendly URL slug for this article title:\n\nTitle: ${stagedArticle.title.trim()}\n\nRules:\n- Think like a real user searching Google.\n- Keep the most important search keywords.\n- Remove filler words like "the," "a," "an," "in," "of," "to," and "for" unless they are needed.\n- Keep it short, readable, and specific.\n- Use lowercase only.\n- Use hyphens between words.\n- Do not keyword-stuff.\n- Do not add words that are not strongly related to the title.\n- Prefer search-intent wording over matching the title exactly.\n- Return only the slug, no explanation.\n\nExample:\nTitle: The Best Steakhouses in Las Vegas\nSlug: best-steakhouses-las-vegas`,
+        blockContent: stagedArticle.title.trim(),
+        articleTitle: stagedArticle.title.trim(),
+      })
+      const slug = response.rewritten_content?.trim()
+      if (slug) {
+        // The shell's update callback is the authoritative staged Draft writer.
+        return slug
+      }
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Failed to generate slug with AI.')
+    } finally {
+      setIsGeneratingSlug(false)
+    }
+    return undefined
+  }, [api, setLocalError, stagedArticle])
+
+  const autoFillOgUrl = useCallback(() => {
+    const slug = stagedArticle?.payloadSlug?.trim()
+    const country = selectedLocation?.country
+    if (!slug || !country) return
+    const url = buildArticleOgUrl(country, selectedLocation.city, null, slug)
+    if (!url) return
+    updateSeoSection((current) => ({
+      ...current,
+      openGraph: { ...current.openGraph, url },
+    }))
+  }, [selectedLocation, stagedArticle?.payloadSlug, updateSeoSection])
+
+  return {
+    generateSlug,
+    isGeneratingSlug,
+    autoFillOgUrl,
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleSeoActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleSeoActions.ts
@@ -1,0 +1,180 @@
+import { useCallback, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import {
+  generateSocialImageFromFeatured,
+  uploadSocialImage,
+} from '../../../../../shared/images'
+import type { SeoSection } from '../../../../../shared/seo/types'
+import {
+  applySeoAiPatch,
+  buildSeoAiSeed,
+  parseSeoAiPatch,
+  type SeoAiTarget,
+} from '../../../../../shared/seo/services/seo-ai.service'
+import { resolveEditorAssistModelName } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import {
+  buildStandardArticleContext,
+  buildStandardArticleSeoAiPrompt,
+} from '../services/standard-article-seo.service'
+import type { EditorialStageArticleApi } from '../types'
+
+type UseStandardArticleSeoActionsParams = {
+  api: EditorialStageArticleApi
+  token?: string | null
+  stagedArticle?: StagedArticle
+  featureLabel: string
+  selectedLocationLabel: string
+  seoSection: SeoSection
+  updateSeoSection: (
+    next: SeoSection | ((current: SeoSection) => SeoSection)
+  ) => void
+  setLocalError: Dispatch<SetStateAction<string | null>>
+  setLocalResult: Dispatch<SetStateAction<string | null>>
+}
+
+export function useStandardArticleSeoActions({
+  api,
+  token,
+  stagedArticle,
+  featureLabel,
+  selectedLocationLabel,
+  seoSection,
+  updateSeoSection,
+  setLocalError,
+  setLocalResult,
+}: UseStandardArticleSeoActionsParams) {
+  const [isGeneratingSeoTarget, setIsGeneratingSeoTarget] = useState<SeoAiTarget | null>(null)
+  const [isGeneratingSeoImage, setIsGeneratingSeoImage] = useState(false)
+  const [isUploadingOgImage, setIsUploadingOgImage] = useState(false)
+
+  const generateSeo = useCallback(async (target: SeoAiTarget = 'all') => {
+    if (!stagedArticle) return
+
+    const articleContext = buildStandardArticleContext(stagedArticle).trim()
+    const articleTitle = stagedArticle.title.trim()
+    if (!articleTitle && !articleContext) {
+      setLocalError('Add article content before generating SEO with AI.')
+      return
+    }
+
+    setLocalError(null)
+    setLocalResult(null)
+    setIsGeneratingSeoTarget(target)
+
+    try {
+      const response = await api.generateSeoMetadataWithAi({
+        prompt: buildStandardArticleSeoAiPrompt({
+          location: selectedLocationLabel || undefined,
+          target,
+        }),
+        seed: buildSeoAiSeed(seoSection),
+        modelName: resolveEditorAssistModelName(stagedArticle.editorModelName),
+        articleTitle,
+        articleContext: articleContext || undefined,
+      })
+      if (!response.seo_patch || Object.keys(response.seo_patch).length === 0) {
+        throw new Error('AI returned an empty SEO patch.')
+      }
+
+      const seoPatch = parseSeoAiPatch(JSON.stringify(response.seo_patch))
+      updateSeoSection((current) => applySeoAiPatch(current, seoPatch, target))
+      setLocalResult(`Updated ${target === 'all' ? 'SEO metadata' : target} with AI.`)
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Failed to generate SEO with AI.')
+    } finally {
+      setIsGeneratingSeoTarget(null)
+    }
+  }, [
+    api,
+    seoSection,
+    selectedLocationLabel,
+    setLocalError,
+    setLocalResult,
+    stagedArticle,
+    updateSeoSection,
+  ])
+
+  const generateImageFromFeatured = useCallback(async () => {
+    if (!token || !stagedArticle?.featuredImageId) {
+      setLocalError('Select a featured image before generating an OG image.')
+      return
+    }
+
+    setLocalError(null)
+    setLocalResult(null)
+    setIsGeneratingSeoImage(true)
+    try {
+      const response = await generateSocialImageFromFeatured(
+        { featuredAssetId: stagedArticle.featuredImageId },
+        token,
+      )
+      const socialImageUrl = response.generatedImageUrl.trim()
+      if (!socialImageUrl) {
+        throw new Error('Social image generation did not return a usable URL.')
+      }
+      updateSeoSection((current) => ({
+        ...current,
+        openGraph: { ...current.openGraph, imageUrl: socialImageUrl },
+        twitterCard: { ...current.twitterCard, imageUrl: socialImageUrl },
+      }))
+      setLocalResult('Generated a 1200x630 social image from the featured image.')
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Failed to generate social image.')
+    } finally {
+      setIsGeneratingSeoImage(false)
+    }
+  }, [setLocalError, setLocalResult, stagedArticle?.featuredImageId, token, updateSeoSection])
+
+  const uploadOgImageFile = useCallback(async (file: File) => {
+    if (!token || !stagedArticle?.locationId) {
+      throw new Error('Select a location before uploading an OG image.')
+    }
+
+    setLocalError(null)
+    setLocalResult(null)
+    setIsUploadingOgImage(true)
+    try {
+      const response = await uploadSocialImage(
+        file,
+        stagedArticle.title.trim() || `${featureLabel} social image`,
+        stagedArticle.locationId,
+        token,
+        '',
+      )
+      const socialImageUrl = response.generatedImageUrl.trim()
+      if (!socialImageUrl) {
+        throw new Error('OG image upload did not return a usable URL.')
+      }
+      updateSeoSection((current) => ({
+        ...current,
+        openGraph: { ...current.openGraph, imageUrl: socialImageUrl },
+        twitterCard: { ...current.twitterCard, imageUrl: socialImageUrl },
+      }))
+      setLocalResult('Uploaded and applied a custom OG image.')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to upload OG image.'
+      setLocalError(message)
+      throw error instanceof Error ? error : new Error(message)
+    } finally {
+      setIsUploadingOgImage(false)
+    }
+  }, [
+    featureLabel,
+    setLocalError,
+    setLocalResult,
+    stagedArticle?.locationId,
+    stagedArticle?.title,
+    token,
+    updateSeoSection,
+  ])
+
+  return {
+    generateSeo,
+    isGeneratingSeoTarget,
+    generateImageFromFeatured,
+    isGeneratingSeoImage,
+    uploadOgImageFile,
+    isUploadingOgImage,
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleStageActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleStageActions.ts
@@ -1,0 +1,93 @@
+import { useCallback } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import type { StagedArticle } from '../../../types'
+import type { SidebarViewProps } from '../selectors'
+
+type UseStandardArticleStageActionsParams = {
+  stagedArticle?: StagedArticle
+  sidebarProps: SidebarViewProps | null
+  step1Issues: string[]
+  step3Issues: string[]
+  syncIssues: string[]
+  setLocalError: Dispatch<SetStateAction<string | null>>
+  setLocalResult: Dispatch<SetStateAction<string | null>>
+}
+
+export function useStandardArticleStageActions({
+  stagedArticle,
+  sidebarProps,
+  step1Issues,
+  step3Issues,
+  syncIssues,
+  setLocalError,
+  setLocalResult,
+}: UseStandardArticleStageActionsParams) {
+  const setStageArticle = useCallback((updates: Partial<StagedArticle>) => {
+    sidebarProps?.onUpdateStagedArticle(updates)
+  }, [sidebarProps])
+
+  const continueSetup = useCallback(() => {
+    if (!stagedArticle || !sidebarProps) return
+    if (step1Issues.length > 0) {
+      setLocalError(step1Issues[0])
+      return
+    }
+    if (!stagedArticle.payloadSlug?.trim()) {
+      setLocalError('Slug is required before continuing.')
+      return
+    }
+    setLocalError(null)
+    setLocalResult(null)
+    sidebarProps.onUpdateStagedArticle({
+      step1_complete: true,
+      in_update_mode: false,
+      step2_complete: false,
+      step2_in_update_mode: false,
+      step3_complete: false,
+      step3_in_update_mode: false,
+    })
+  }, [setLocalError, setLocalResult, sidebarProps, stagedArticle, step1Issues])
+
+  const continueFeaturedImage = useCallback(() => {
+    if (!sidebarProps) return
+    setLocalError(null)
+    setLocalResult(null)
+    sidebarProps.onUpdateStagedArticle({
+      step2_complete: true,
+      step2_in_update_mode: false,
+    })
+  }, [setLocalError, setLocalResult, sidebarProps])
+
+  const continueContent = useCallback(() => {
+    if (!sidebarProps) return
+    if (step3Issues.length > 0) {
+      setLocalError(step3Issues[0])
+      return
+    }
+    setLocalError(null)
+    setLocalResult(null)
+    sidebarProps.onUpdateStagedArticle({
+      step3_complete: true,
+      step3_in_update_mode: false,
+    })
+  }, [setLocalError, setLocalResult, sidebarProps, step3Issues])
+
+  const submitToPayload = useCallback((targetStatus: 'draft' | 'published') => {
+    if (!sidebarProps) return
+    if (syncIssues.length > 0) {
+      setLocalError(syncIssues[0])
+      return
+    }
+    setLocalError(null)
+    setLocalResult(null)
+    sidebarProps.onPublish(targetStatus)
+  }, [setLocalError, setLocalResult, sidebarProps, syncIssues])
+
+  return {
+    setStageArticle,
+    continueSetup,
+    continueFeaturedImage,
+    continueContent,
+    submitToPayload,
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleStructuredData.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleStructuredData.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react'
+import type { SeoSection } from '../../../../../shared/seo/types'
+import { getSchemaPublisherConfig } from '../../../../../shared/seo/services/schema-publisher-config.service'
+import type { StagedArticle } from '../../../types'
+import {
+  buildLegacyStandardArticleStructuredDataTemplate,
+  buildStandardArticleStructuredDataTemplate,
+  serializeStandardArticleStructuredDataTemplate,
+  shouldAutoManageStandardArticleStructuredData,
+} from '../services/standard-article-seo.service'
+
+const schemaPublisherConfig = getSchemaPublisherConfig()
+
+type UseStandardArticleStructuredDataParams = {
+  stagedArticle?: StagedArticle
+  seoSection: SeoSection
+  selectedLocationLabel: string
+  enabled: boolean
+  updateSeoSection: (
+    next: SeoSection | ((current: SeoSection) => SeoSection)
+  ) => void
+}
+
+export function useStandardArticleStructuredData({
+  stagedArticle,
+  seoSection,
+  selectedLocationLabel,
+  enabled,
+  updateSeoSection,
+}: UseStandardArticleStructuredDataParams) {
+  const lastAutoStructuredDataRef = useRef('')
+
+  useEffect(() => {
+    if (!stagedArticle || !enabled) return
+
+    const article = { ...stagedArticle, seoSection }
+    const nextStructuredData = serializeStandardArticleStructuredDataTemplate(
+      buildStandardArticleStructuredDataTemplate({
+        stagedArticle: article,
+        locationLabel: selectedLocationLabel || undefined,
+        publisherConfig: schemaPublisherConfig,
+      }),
+    )
+    const legacyStructuredData = serializeStandardArticleStructuredDataTemplate(
+      buildLegacyStandardArticleStructuredDataTemplate({
+        stagedArticle: article,
+        locationLabel: selectedLocationLabel || undefined,
+      }),
+    )
+    const existingStructuredData = seoSection.structuredData.trim()
+    const lastAutoStructuredData = lastAutoStructuredDataRef.current.trim()
+    const isAutoManaged = shouldAutoManageStandardArticleStructuredData({
+      existingStructuredData,
+      lastAutoStructuredData,
+      nextStructuredData,
+      legacyStructuredData,
+    })
+
+    if (!isAutoManaged) return
+    if (existingStructuredData === nextStructuredData) {
+      lastAutoStructuredDataRef.current = nextStructuredData
+      return
+    }
+
+    lastAutoStructuredDataRef.current = nextStructuredData
+    updateSeoSection((current) => ({
+      ...current,
+      structuredData: nextStructuredData,
+    }))
+  }, [
+    enabled,
+    seoSection,
+    selectedLocationLabel,
+    stagedArticle,
+    updateSeoSection,
+  ])
+}


### PR DESCRIPTION
## Summary

- reduce `StandardArticleStageBuilder` from 989 lines to a 266-line composition shell
- isolate derived validation/sync state, step transitions, permalink generation, structured-data management, SEO/media actions, and article expansion
- split setup, featured-image, content, status, hero, and sidebar rendering into presentation-only components
- preserve the staged Draft, step locking, save-conflict, explicit Payload Sync, role-gated publish, and deep-expansion behavior

## Architecture

The existing editorial-stage feature services and view model remain authoritative. The builder now consumes those seams through focused hooks and panels instead of recomputing workflow state and rendering every surface in one component. No extracted module exceeds 195 lines.

## Validation

- added regression coverage for applying an AI-generated slug through the staged Draft update boundary
- `nx run @questurian/abw-client:lint`
- `nx run @questurian/abw-client:test` (89 files, 347 tests)
- `nx run @questurian/abw-client:build`