### PR TITLE
NOJIRA: Split location payload mapping by collection

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload.mapper.ts
@@ -1,562 +1,27 @@
-import type { LocationResponse, LocationCategory } from "../../../models/location";
 import { BadRequestError } from "@shared/errors/http-error";
-import type { UploadedImagesResult } from "../types";
 import type {
-  PayloadEntryData,
-  PayloadNightlifeDetails,
-  PayloadRelationshipId,
-} from "../clients/payload-api.client";
-import { extractPhoneNumber, convertIsoToPhoneCountryCode } from "../utils";
+  LocationCategory,
+  LocationResponse,
+} from "../../../models/location";
+import type { PayloadEntryData } from "../clients/payload-api.client";
+import type { UploadedImagesResult } from "../types";
+import { mapAccommodationsPayload } from "./location-payload/accommodations.mapper";
+import { mapAttractionsPayload } from "./location-payload/attractions.mapper";
+import { mapDiningPayload } from "./location-payload/dining.mapper";
+import { mapKeyLocationsPayload } from "./location-payload/key-locations.mapper";
+import { mapNightlifePayload } from "./location-payload/nightlife.mapper";
+import { stripLegacyLmFields } from "./location-payload/shared-fields.mapper";
 
-export type PayloadCollection = "dining" | "accommodations" | "attractions" | "nightlife" | "key-locations";
-
-const LEGACY_LM_ONLY_FIELDS = [
-  "neighborhoodDescription",
-  "tripadvisorUrl",
-  "tripadvisorLocationId",
-  "placeId",
-  "contactAddress",
-  "sourceAddress",
-  "locationKey",
-  "district",
-] as const;
-
-// App stores $, $$, $$$, $$$$ — Payload expects "1", "2", "3", "4"
-const PRICE_LEVEL_TO_PAYLOAD: Record<string, string> = {
-  "$": "1",
-  "$$": "2",
-  "$$$": "3",
-  "$$$$": "4",
-  "free": "1",
-  "budget": "1",
-  "inexpensive": "1",
-  "mid-range": "2",
-  "moderate": "2",
-  "expensive": "3",
-  "very expensive": "4",
-  "luxury": "4",
-};
-
-const WEEKDAY_LABELS: Record<string, string> = {
-  monday: "Monday",
-  tuesday: "Tuesday",
-  wednesday: "Wednesday",
-  thursday: "Thursday",
-  friday: "Friday",
-  saturday: "Saturday",
-  sunday: "Sunday",
-};
-
-const MAX_ATTRACTION_GALLERY_ITEMS = 20;
-
-/** Questura `accommodations` multi-selects — LM also stores "none" for absent amenities, which Payload rejects. */
-const PAYLOAD_ACCOMMODATIONS_PARKING = new Set(["onsite", "valet", "street", "garage"]);
-const PAYLOAD_ACCOMMODATIONS_JACUZZI = new Set(["private", "shared", "rooftop"]);
-const PAYLOAD_ACCOMMODATIONS_POOL = new Set(["indoor", "outdoor", "rooftop", "infinity"]);
-const PAYLOAD_ACCOMMODATIONS_WORKSPACE = new Set([
-  "None",
-  "Shared Lounge",
-  "Dedicated Desk",
-  "Co-working Space",
-]);
-
-function filterPayloadMultiSelect(
-  values: string[] | undefined,
-  allowed: Set<string>
-): string[] | undefined {
-  if (!values?.length) return undefined;
-  const filtered = values.filter((v) => allowed.has(v));
-  return filtered.length > 0 ? filtered : undefined;
-}
-
-function normalizeWorkspaceForPayload(raw: unknown): string | undefined {
-  if (typeof raw === "string") {
-    const trimmed = raw.trim();
-    return PAYLOAD_ACCOMMODATIONS_WORKSPACE.has(trimmed) ? trimmed : undefined;
-  }
-  if (Array.isArray(raw)) {
-    for (const item of raw) {
-      if (typeof item !== "string") continue;
-      const trimmed = item.trim();
-      if (PAYLOAD_ACCOMMODATIONS_WORKSPACE.has(trimmed)) {
-        return trimmed;
-      }
-    }
-  }
-  return undefined;
-}
-
-function dedupePreservingOrder(ids: string[]): string[] {
-  return Array.from(new Set(ids));
-}
-
-function toPayloadRelationshipId(id: string | number): PayloadRelationshipId {
-  if (typeof id === "number") {
-    return id;
-  }
-
-  const trimmed = id.trim();
-  if (/^\d+$/.test(trimmed)) {
-    return Number(trimmed);
-  }
-
-  return trimmed;
-}
-
-function getGalleryImageIds(location: LocationResponse, uploadedImages: UploadedImagesResult): string[] {
-  const uploadedGalleryIds = uploadedImages.galleryImageIds;
-
-  if (location.category !== "attractions") {
-    return uploadedGalleryIds;
-  }
-
-  const selectedPayloadMediaSetIds = location.selectedPayloadMediaSetIds ?? [];
-  const combinedGalleryIds = dedupePreservingOrder([
-    ...uploadedGalleryIds,
-    ...selectedPayloadMediaSetIds,
-  ]);
-
-  if (combinedGalleryIds.length > MAX_ATTRACTION_GALLERY_ITEMS) {
-    throw new BadRequestError(
-      `Attractions gallery exceeds Payload max of ${MAX_ATTRACTION_GALLERY_ITEMS} items`
-    );
-  }
-
-  return combinedGalleryIds;
-}
-
-function normalizeOperationHoursForPayload(
-  operationHours: Record<string, unknown> | null
-): { hours: Array<{ day: string; hours: string }> } | undefined {
-  if (!operationHours) return undefined;
-
-  const rawHours = operationHours.hours;
-  if (Array.isArray(rawHours)) {
-    const normalizedRows = rawHours
-      .map((row) => {
-        if (!row || typeof row !== "object" || Array.isArray(row)) return null;
-        const day = typeof (row as { day?: unknown }).day === "string"
-          ? (row as { day: string }).day.trim()
-          : "";
-        const hours = typeof (row as { hours?: unknown }).hours === "string"
-          ? (row as { hours: string }).hours.trim()
-          : "";
-        if (!day || !hours) return null;
-        return { day, hours };
-      })
-      .filter((row): row is { day: string; hours: string } => row !== null);
-
-    return normalizedRows.length > 0 ? { hours: normalizedRows } : undefined;
-  }
-
-  // Backward compatibility: convert day-key maps into canonical array format.
-  const normalizedRows = Object.entries(operationHours)
-    .filter(([key]) => key !== "currently_open" && key !== "hours")
-    .map(([key, value]) => {
-      const dayLabel = WEEKDAY_LABELS[key.toLowerCase()] ?? key;
-      const hours = typeof value === "string" ? value.trim() : "";
-      if (!hours) return null;
-      return { day: dayLabel, hours };
-    })
-    .filter((row): row is { day: string; hours: string } => row !== null);
-
-  return normalizedRows.length > 0 ? { hours: normalizedRows } : undefined;
-}
-
-function parseKeyLocationStatus(location: LocationResponse): string | undefined {
-  const details = location.keyLocationsDetails;
-  if (!details || typeof details !== "object") return undefined;
-
-  const detailsRecord = details as Record<string, unknown>;
-  const status =
-    detailsRecord.status
-    ?? asRecord(detailsRecord.core)?.status
-    ?? asRecord(detailsRecord.core)?.["status"];
-  return typeof status === "string" && status.trim().length > 0 ? status.trim() : undefined;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
-
-function asString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function asStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const normalized = value
-    .filter((item): item is string => typeof item === "string")
-    .map((item) => item.trim())
-    .filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") {
-    if (value === 1) return true;
-    if (value === 0) return false;
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true" || normalized === "yes" || normalized === "1") return true;
-    if (normalized === "false" || normalized === "no" || normalized === "0") return false;
-  }
-  return undefined;
-}
-
-function unwrapLabeledValue(value: unknown): unknown {
-  const record = asRecord(value);
-  if (!record) return value;
-  if (Object.prototype.hasOwnProperty.call(record, "value")) {
-    return record.value;
-  }
-  return value;
-}
-
-function getNightlifeSectionValue(
-  details: Record<string, unknown>,
-  section: "theSpace" | "theScene" | "theDetails",
-  key: string
-): unknown {
-  const newSchemaSection = asRecord(details[section]);
-  const oldSchemaDetails = asRecord(details.details);
-  const oldSchemaSection = asRecord(oldSchemaDetails?.[section]);
-  const candidate = newSchemaSection?.[key] ?? oldSchemaSection?.[key];
-  return unwrapLabeledValue(candidate);
-}
-
-function getNightlifeDetailsPayload(location: LocationResponse): PayloadNightlifeDetails {
-  const details = asRecord(location.nightlifeDetails) ?? {};
-  const core = asRecord(details.core);
-  const sectionDetails = asRecord(details.theDetails);
-
-  const coreName = asString(core?.name) ?? asString(details.name) ?? location.title ?? location.source.name ?? "";
-  const clubType = asString(core?.clubType) ?? asString(details.club_type) ?? asString(location.type) ?? null;
-  const priceTier = asString(core?.priceTier) ?? asString(details.price_tier) ?? asString(location.priceLevel) ?? null;
-  const music = asStringArray(core?.music ?? details.music) ?? [];
-  const idealFor = asStringArray(core?.idealFor ?? location.idealFor) ?? [];
-
-  const operationHours =
-    asRecord(sectionDetails?.operationHours)
-    ?? asRecord(getNightlifeSectionValue(details, "theDetails", "operationHours"))
-    ?? location.operationHours
-    ?? null;
-  const bookingUrl = location.bookingUrl
-    ?? asString(sectionDetails?.bookingUrl)
-    ?? asString(details.booking_url)
-    ?? asString(getNightlifeSectionValue(details, "theDetails", "bookingUrl"))
-    ?? asString(details.reserve_url) // legacy pre-ADR-0009 JSON key
-    ?? null;
-  const daytimeRestaurant = asBoolean(sectionDetails?.daytimeRestaurant)
-    ?? asBoolean(details.daytime_restaurant)
-    ?? asBoolean(getNightlifeSectionValue(details, "theDetails", "daytimeRestaurant"))
-    ?? false;
-
-  return {
-    core: {
-      name: coreName,
-      clubType,
-      priceTier,
-      music,
-      idealFor,
-    },
-    theSpace: {
-      venueType: asString(getNightlifeSectionValue(details, "theSpace", "venueType")) ?? null,
-      venueSize: asString(getNightlifeSectionValue(details, "theSpace", "venueSize")) ?? null,
-      spaceLayout: asStringArray(getNightlifeSectionValue(details, "theSpace", "spaceLayout")) ?? [],
-      vibe: asStringArray(getNightlifeSectionValue(details, "theSpace", "vibe")) ?? [],
-      peakHours: asString(getNightlifeSectionValue(details, "theSpace", "peakHours")) ?? null,
-    },
-    theScene: {
-      musicFormat: asStringArray(getNightlifeSectionValue(details, "theScene", "musicFormat")) ?? [],
-      touristPresence: asString(getNightlifeSectionValue(details, "theScene", "touristPresence")) ?? null,
-      dressCode: asStringArray(getNightlifeSectionValue(details, "theScene", "dressCode")) ?? [],
-      energyLevel: asString(getNightlifeSectionValue(details, "theScene", "energyLevel")) ?? null,
-      vipAndBottleService: asString(getNightlifeSectionValue(details, "theScene", "vipAndBottleService")) ?? null,
-      crowdProfile: asString(getNightlifeSectionValue(details, "theScene", "crowdProfile")) ?? null,
-    },
-    theDetails: {
-      operationHours,
-      bookingUrl,
-      daytimeRestaurant,
-    },
-  };
-}
-
-function getAttractionsDetailsPayload(location: LocationResponse): Record<string, unknown> {
-  const details = asRecord(location.attractionsDetails) ?? {};
-  const core = asRecord(details.core);
-  const visit = asRecord(details.visit);
-  const attractionType = asString(core?.attraction_type) ?? asString(location.type);
-  const pricing = asString(core?.pricing) ?? asString(location.priceLevel);
-  const bookingRequired = asBoolean(visit?.booking_required);
-  return {
-    core: {
-      attractionType: attractionType ?? null,
-      pricing: pricing ?? null,
-    },
-    visit: {
-      bookingRequired: bookingRequired ?? false,
-      bookingUrl: asString(location.bookingUrl) ?? null,
-    },
-  };
-}
-
-function getKeyLocationsDetailsPayload(location: LocationResponse): Record<string, unknown> {
-  const details = asRecord(location.keyLocationsDetails) ?? {};
-  const core = asRecord(details.core);
-
-  const locationType =
-    asString(details.location_type)
-    ?? asString(core?.locationType)
-    ?? asString(core?.location_type)
-    ?? asString(location.type);
-  const status = asString(details.status) ?? asString(core?.status);
-  const neighborhood = asString(details.neighborhood) ?? asString(core?.neighborhood);
-
-  return {
-    core: {
-      locationType: locationType ?? null,
-      status: status ?? null,
-      neighborhood: neighborhood ?? null,
-    },
-  };
-}
-
-function parseAccommodationsGroups(location: LocationResponse): Record<string, unknown> {
-  const details = asRecord(location.accommodationsDetails) ?? {};
-
-  const core = asRecord(details.core);
-  const theStay = asRecord(details.the_stay);
-  const theExperience = asRecord(details.the_experience);
-  const theDetails = asRecord(details.the_details);
-
-  const payloadCore = {
-    name: asString(core?.name) ?? null,
-    price: asString(core?.price) ?? null,
-    district: asString(core?.district) ?? null,
-    type: asString(core?.type) ?? null,
-  };
-
-  const parkingForPayload = filterPayloadMultiSelect(
-    asStringArray(theStay?.parking),
-    PAYLOAD_ACCOMMODATIONS_PARKING
-  );
-  const poolForPayload = filterPayloadMultiSelect(
-    asStringArray(theExperience?.pool),
-    PAYLOAD_ACCOMMODATIONS_POOL
-  );
-  const jacuzziForPayload = filterPayloadMultiSelect(
-    asStringArray(theExperience?.jacuzzi),
-    PAYLOAD_ACCOMMODATIONS_JACUZZI
-  );
-  const workspaceForPayload = normalizeWorkspaceForPayload(theExperience?.workspace);
-
-  const payloadStay = {
-    perfectFor: asStringArray(theStay?.perfect_for) ?? [],
-    kidFriendly: asBoolean(theStay?.kid_friendly) ?? false,
-    ac: asBoolean(theStay?.ac) ?? false,
-    wifi: asBoolean(theStay?.wifi) ?? false,
-    extraGuestFee: asBoolean(theStay?.extra_guest_fee) ?? false,
-    parking: parkingForPayload ?? [],
-    breakfastServed: asBoolean(theStay?.breakfast_served) ?? false,
-  };
-
-  const payloadExperience = {
-    vibe: asStringArray(theExperience?.vibe) ?? [],
-    workspace: workspaceForPayload ?? null,
-    restaurant: asBoolean(theExperience?.restaurant) ?? false,
-    pool: poolForPayload ?? [],
-    rooftopLounge: asBoolean(theExperience?.rooftop_lounge) ?? false,
-    jacuzzi: jacuzziForPayload ?? [],
-    gym: asString(theExperience?.gym) ?? null,
-  };
-
-  const payloadDetails = {
-    address: asString(theDetails?.address) ?? null,
-    walkability: asString(theDetails?.walkability) ?? null,
-    checkInTime: asString(theDetails?.check_in_time) ?? null,
-    checkOutTime: asString(theDetails?.check_out_time) ?? null,
-    phone: asString(theDetails?.phone) ?? null,
-    websiteUrl: asString(theDetails?.website_url) ?? null,
-    bookingUrl: asString(location.bookingUrl) ?? asString(theDetails?.booking_url) ?? null,
-    googleMapsUrl: asString(theDetails?.google_maps_url) ?? null,
-  };
-
-  return {
-    core: payloadCore,
-    theStay: payloadStay,
-    theExperience: payloadExperience,
-    theDetails: payloadDetails,
-  };
-}
-
-function mapSharedPayloadFields(
-  location: LocationResponse,
-  uploadedImages: UploadedImagesResult,
-  locationRef: string
-): Pick<
-  PayloadEntryData,
-  | "title"
-  | "locationRef"
-  | "gallery"
-  | "instagramGallery"
-  | "address"
-  | "countryCode"
-  | "phoneNumber"
-  | "website"
-  | "latitude"
-  | "longitude"
-  | "status"
-  | "email"
-  | "countryCodeIso"
-  | "sourceName"
-> {
-  const galleryImageIds = getGalleryImageIds(location, uploadedImages);
-  const payloadCountryCode = convertIsoToPhoneCountryCode(location.contact.countryCode || undefined);
-  const phoneNumber = extractPhoneNumber(location.contact.phoneNumber || undefined);
-
-  return {
-    title: location.title || location.source.name,
-    locationRef,
-    gallery: galleryImageIds.map(id => ({
-      image: toPayloadRelationshipId(id),
-      altText: "",
-      caption: "",
-    })),
-    instagramGallery: uploadedImages.instagramPostIds.map(id => ({
-      post: toPayloadRelationshipId(id),
-    })),
-    address: location.contact.url || "",
-    countryCode: payloadCountryCode ?? null,
-    phoneNumber: phoneNumber ?? null,
-    website: asString(location.contact.website) ?? null,
-    latitude: location.coordinates.lat ?? null,
-    longitude: location.coordinates.lng ?? null,
-    status: "published" as const,
-    email: asString(location.contact.email) ?? null,
-    countryCodeIso: asString(location.contact.countryCode) ?? null,
-    sourceName: asString(location.source.name) ?? null,
-  };
-}
-
-function mapCategoryCommonPayloadFields(location: LocationResponse) {
-  const mappedPriceLevel = location.priceLevel
-    ? PRICE_LEVEL_TO_PAYLOAD[location.priceLevel.toLowerCase()]
-    : undefined;
-  return {
-    type: asString(location.type) ?? null,
-    priceLevel: mappedPriceLevel ?? null,
-    ianaTimeId: asString(location.ianaTimeId) ?? null,
-  };
-}
-
-function mapDiningPayload(
-  location: LocationResponse,
-  uploadedImages: UploadedImagesResult,
-  locationRef: string
-): PayloadEntryData {
-  const sharedFields = mapSharedPayloadFields(location, uploadedImages, locationRef);
-  const { countryCodeIso, sourceName, ...diningSharedFields } = sharedFields;
-  const operationHours = normalizeOperationHoursForPayload(location.operationHours);
-
-  return {
-    ...diningSharedFields,
-    ...mapCategoryCommonPayloadFields(location),
-    operationHours: operationHours ?? null,
-    idealFor: location.idealFor ?? [],
-    cuisines: location.tripadvisorCuisines ?? [],
-    menuUrl: asString(location.menuUrl) ?? null,
-    bookingUrl: asString(location.bookingUrl) ?? null,
-  };
-}
-
-function mapAccommodationsPayload(
-  location: LocationResponse,
-  uploadedImages: UploadedImagesResult,
-  locationRef: string
-): PayloadEntryData {
-  return {
-    ...mapSharedPayloadFields(location, uploadedImages, locationRef),
-    ...mapCategoryCommonPayloadFields(location),
-    ...parseAccommodationsGroups(location),
-  };
-}
-
-function mapAttractionsPayload(
-  location: LocationResponse,
-  uploadedImages: UploadedImagesResult,
-  locationRef: string,
-  tourPayloadIds?: string[]
-): PayloadEntryData {
-  const sharedFields = mapSharedPayloadFields(location, uploadedImages, locationRef);
-  const operationHours = normalizeOperationHoursForPayload(location.operationHours);
-  const attractionsDetails = getAttractionsDetailsPayload(location);
-
-  return {
-    ...sharedFields,
-    ...mapCategoryCommonPayloadFields(location),
-    ...(location.locationKey ? { location: location.locationKey } : {}),
-    operationHours: operationHours ?? null,
-    attractionsDetails,
-    ...(tourPayloadIds ? { tours: tourPayloadIds.map(toPayloadRelationshipId) } : {}),
-  };
-}
-
-function mapNightlifePayload(
-  location: LocationResponse,
-  uploadedImages: UploadedImagesResult,
-  locationRef: string
-): PayloadEntryData {
-  const sharedFields = mapSharedPayloadFields(location, uploadedImages, locationRef);
-  const { countryCodeIso, sourceName, ...nightlifeSharedFields } = sharedFields;
-  return {
-    ...nightlifeSharedFields,
-    ...mapCategoryCommonPayloadFields(location),
-    location: location.locationKey ?? "",
-    nightlifeDetails: getNightlifeDetailsPayload(location),
-  };
-}
-
-function mapKeyLocationsPayload(
-  location: LocationResponse,
-  uploadedImages: UploadedImagesResult,
-  locationRef: string
-): PayloadEntryData {
-  const operationHours = normalizeOperationHoursForPayload(location.operationHours);
-  const keyLocationsDetails = getKeyLocationsDetailsPayload(location);
-  const keyLocationStatus = parseKeyLocationStatus(location);
-  const { type, ianaTimeId } = mapCategoryCommonPayloadFields(location);
-
-  return {
-    ...mapSharedPayloadFields(location, uploadedImages, locationRef),
-    type,
-    ianaTimeId,
-    ...(location.locationKey ? { location: location.locationKey } : {}),
-    operationHours: operationHours ?? null,
-    keyLocationsDetails,
-    keyLocationStatus: keyLocationStatus ?? null,
-  };
-}
-
-function stripLegacyLmFields(payload: PayloadEntryData): PayloadEntryData {
-  const mutable = payload as PayloadEntryData & Record<string, unknown>;
-  for (const field of LEGACY_LM_ONLY_FIELDS) {
-    delete mutable[field];
-  }
-  return mutable;
-}
+export type PayloadCollection =
+  | "dining"
+  | "accommodations"
+  | "attractions"
+  | "nightlife"
+  | "key-locations";
 
 /**
- * Map url-util location to Payload format
- * @param locationRef - REQUIRED by Payload CMS, guaranteed to be present by caller
+ * Map a Location Manager location to the owning Questura collection contract.
+ * locationRef is required by Payload and guaranteed to be present by the caller.
  */
 export function mapLocationToPayloadFormat(
   location: LocationResponse,
@@ -565,6 +30,7 @@ export function mapLocationToPayloadFormat(
   options: { tourPayloadIds?: string[] } = {}
 ): PayloadEntryData {
   let mapped: PayloadEntryData;
+
   switch (location.category) {
     case "dining":
       mapped = mapDiningPayload(location, uploadedImages, locationRef);
@@ -573,7 +39,12 @@ export function mapLocationToPayloadFormat(
       mapped = mapAccommodationsPayload(location, uploadedImages, locationRef);
       break;
     case "attractions":
-      mapped = mapAttractionsPayload(location, uploadedImages, locationRef, options.tourPayloadIds);
+      mapped = mapAttractionsPayload(
+        location,
+        uploadedImages,
+        locationRef,
+        options.tourPayloadIds
+      );
       break;
     case "nightlife":
       mapped = mapNightlifePayload(location, uploadedImages, locationRef);
@@ -581,18 +52,16 @@ export function mapLocationToPayloadFormat(
     case "key_locations":
       mapped = mapKeyLocationsPayload(location, uploadedImages, locationRef);
       break;
-    default: {
-      const exhaustiveCheck: never = location.category;
-      throw new BadRequestError(`Unsupported payload category: ${String(exhaustiveCheck)}`);
-    }
+    default:
+      throw unsupportedCategory(location.category);
   }
+
   return stripLegacyLmFields(mapped);
 }
 
-/**
- * Map category to Payload collection name
- */
-export function mapCategoryToCollection(category: LocationCategory): PayloadCollection {
+export function mapCategoryToCollection(
+  category: LocationCategory
+): PayloadCollection {
   switch (category) {
     case "dining":
     case "accommodations":
@@ -601,19 +70,14 @@ export function mapCategoryToCollection(category: LocationCategory): PayloadColl
       return category;
     case "key_locations":
       return "key-locations";
-    default: {
-      const exhaustiveCheck: never = category;
-      throw new BadRequestError(`Unsupported payload category: ${String(exhaustiveCheck)}`);
-    }
+    default:
+      throw unsupportedCategory(category);
   }
 }
 
-/**
- * Map locationKey to Payload location identifier
- * url-util: "colombia|bogota|chapinero"
- * Payload: "bogota-colombia" (or similar format)
- */
-export function mapLocationKeyToPayloadLocation(locationKey?: string): string | undefined {
+export function mapLocationKeyToPayloadLocation(
+  locationKey?: string
+): string | undefined {
   if (!locationKey) return undefined;
 
   const parts = locationKey.split("|");
@@ -621,4 +85,8 @@ export function mapLocationKeyToPayloadLocation(locationKey?: string): string | 
 
   const [country, city] = parts;
   return `${city}-${country}`.toLowerCase();
+}
+
+function unsupportedCategory(category: never): BadRequestError {
+  return new BadRequestError(`Unsupported payload category: ${String(category)}`);
 }

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/accommodations.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/accommodations.mapper.ts
@@ -1,0 +1,100 @@
+import type { LocationResponse } from "../../../../models/location";
+import type { PayloadEntryData } from "../../clients/payload-api.client";
+import type { UploadedImagesResult } from "../../types";
+import { mapSharedPayloadFields } from "./shared-fields.mapper";
+import {
+  asBoolean,
+  asRecord,
+  asString,
+  asStringArray,
+  mapCategoryCommonPayloadFields,
+} from "./value-normalizers";
+
+const ALLOWED_PARKING = new Set(["onsite", "valet", "street", "garage"]);
+const ALLOWED_JACUZZI = new Set(["private", "shared", "rooftop"]);
+const ALLOWED_POOL = new Set(["indoor", "outdoor", "rooftop", "infinity"]);
+const ALLOWED_WORKSPACE = new Set([
+  "None",
+  "Shared Lounge",
+  "Dedicated Desk",
+  "Co-working Space",
+]);
+
+function filterMultiSelect(
+  values: string[] | undefined,
+  allowed: Set<string>
+): string[] | undefined {
+  if (!values?.length) return undefined;
+  const filtered = values.filter((value) => allowed.has(value));
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function normalizeWorkspace(raw: unknown): string | undefined {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return ALLOWED_WORKSPACE.has(trimmed) ? trimmed : undefined;
+  }
+  if (!Array.isArray(raw)) return undefined;
+  return raw
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .find((item) => ALLOWED_WORKSPACE.has(item));
+}
+
+function mapAccommodationsGroups(location: LocationResponse): Record<string, unknown> {
+  const details = asRecord(location.accommodationsDetails) ?? {};
+  const core = asRecord(details.core);
+  const stay = asRecord(details.the_stay);
+  const experience = asRecord(details.the_experience);
+  const detailFields = asRecord(details.the_details);
+
+  return {
+    core: {
+      name: asString(core?.name) ?? null,
+      price: asString(core?.price) ?? null,
+      district: asString(core?.district) ?? null,
+      type: asString(core?.type) ?? null,
+    },
+    theStay: {
+      perfectFor: asStringArray(stay?.perfect_for) ?? [],
+      kidFriendly: asBoolean(stay?.kid_friendly) ?? false,
+      ac: asBoolean(stay?.ac) ?? false,
+      wifi: asBoolean(stay?.wifi) ?? false,
+      extraGuestFee: asBoolean(stay?.extra_guest_fee) ?? false,
+      parking: filterMultiSelect(asStringArray(stay?.parking), ALLOWED_PARKING) ?? [],
+      breakfastServed: asBoolean(stay?.breakfast_served) ?? false,
+    },
+    theExperience: {
+      vibe: asStringArray(experience?.vibe) ?? [],
+      workspace: normalizeWorkspace(experience?.workspace) ?? null,
+      restaurant: asBoolean(experience?.restaurant) ?? false,
+      pool: filterMultiSelect(asStringArray(experience?.pool), ALLOWED_POOL) ?? [],
+      rooftopLounge: asBoolean(experience?.rooftop_lounge) ?? false,
+      jacuzzi: filterMultiSelect(asStringArray(experience?.jacuzzi), ALLOWED_JACUZZI) ?? [],
+      gym: asString(experience?.gym) ?? null,
+    },
+    theDetails: {
+      address: asString(detailFields?.address) ?? null,
+      walkability: asString(detailFields?.walkability) ?? null,
+      checkInTime: asString(detailFields?.check_in_time) ?? null,
+      checkOutTime: asString(detailFields?.check_out_time) ?? null,
+      phone: asString(detailFields?.phone) ?? null,
+      websiteUrl: asString(detailFields?.website_url) ?? null,
+      bookingUrl:
+        asString(location.bookingUrl) ?? asString(detailFields?.booking_url) ?? null,
+      googleMapsUrl: asString(detailFields?.google_maps_url) ?? null,
+    },
+  };
+}
+
+export function mapAccommodationsPayload(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult,
+  locationRef: string
+): PayloadEntryData {
+  return {
+    ...mapSharedPayloadFields(location, uploadedImages, locationRef),
+    ...mapCategoryCommonPayloadFields(location),
+    ...mapAccommodationsGroups(location),
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/attractions.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/attractions.mapper.ts
@@ -1,0 +1,45 @@
+import type { LocationResponse } from "../../../../models/location";
+import type { PayloadEntryData } from "../../clients/payload-api.client";
+import type { UploadedImagesResult } from "../../types";
+import { mapSharedPayloadFields } from "./shared-fields.mapper";
+import {
+  asBoolean,
+  asRecord,
+  asString,
+  mapCategoryCommonPayloadFields,
+  normalizeOperationHoursForPayload,
+  toPayloadRelationshipId,
+} from "./value-normalizers";
+
+function getAttractionsDetailsPayload(location: LocationResponse): Record<string, unknown> {
+  const details = asRecord(location.attractionsDetails) ?? {};
+  const core = asRecord(details.core);
+  const visit = asRecord(details.visit);
+
+  return {
+    core: {
+      attractionType: asString(core?.attraction_type) ?? asString(location.type) ?? null,
+      pricing: asString(core?.pricing) ?? asString(location.priceLevel) ?? null,
+    },
+    visit: {
+      bookingRequired: asBoolean(visit?.booking_required) ?? false,
+      bookingUrl: asString(location.bookingUrl) ?? null,
+    },
+  };
+}
+
+export function mapAttractionsPayload(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult,
+  locationRef: string,
+  tourPayloadIds?: string[]
+): PayloadEntryData {
+  return {
+    ...mapSharedPayloadFields(location, uploadedImages, locationRef),
+    ...mapCategoryCommonPayloadFields(location),
+    ...(location.locationKey ? { location: location.locationKey } : {}),
+    operationHours: normalizeOperationHoursForPayload(location.operationHours) ?? null,
+    attractionsDetails: getAttractionsDetailsPayload(location),
+    ...(tourPayloadIds ? { tours: tourPayloadIds.map(toPayloadRelationshipId) } : {}),
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/dining.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/dining.mapper.ts
@@ -1,0 +1,28 @@
+import type { LocationResponse } from "../../../../models/location";
+import type { PayloadEntryData } from "../../clients/payload-api.client";
+import type { UploadedImagesResult } from "../../types";
+import { mapSharedPayloadFields } from "./shared-fields.mapper";
+import {
+  asString,
+  mapCategoryCommonPayloadFields,
+  normalizeOperationHoursForPayload,
+} from "./value-normalizers";
+
+export function mapDiningPayload(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult,
+  locationRef: string
+): PayloadEntryData {
+  const sharedFields = mapSharedPayloadFields(location, uploadedImages, locationRef);
+  const { countryCodeIso, sourceName, ...diningSharedFields } = sharedFields;
+
+  return {
+    ...diningSharedFields,
+    ...mapCategoryCommonPayloadFields(location),
+    operationHours: normalizeOperationHoursForPayload(location.operationHours) ?? null,
+    idealFor: location.idealFor ?? [],
+    cuisines: location.tripadvisorCuisines ?? [],
+    menuUrl: asString(location.menuUrl) ?? null,
+    bookingUrl: asString(location.bookingUrl) ?? null,
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/key-locations.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/key-locations.mapper.ts
@@ -1,0 +1,53 @@
+import type { LocationResponse } from "../../../../models/location";
+import type { PayloadEntryData } from "../../clients/payload-api.client";
+import type { UploadedImagesResult } from "../../types";
+import { mapSharedPayloadFields } from "./shared-fields.mapper";
+import {
+  asRecord,
+  asString,
+  mapCategoryCommonPayloadFields,
+  normalizeOperationHoursForPayload,
+} from "./value-normalizers";
+
+function getKeyLocationStatus(location: LocationResponse): string | undefined {
+  const details = asRecord(location.keyLocationsDetails);
+  if (!details) return undefined;
+  const status = details.status ?? asRecord(details.core)?.status;
+  return asString(status);
+}
+
+function getKeyLocationsDetailsPayload(location: LocationResponse): Record<string, unknown> {
+  const details = asRecord(location.keyLocationsDetails) ?? {};
+  const core = asRecord(details.core);
+
+  return {
+    core: {
+      locationType:
+        asString(details.location_type) ??
+        asString(core?.locationType) ??
+        asString(core?.location_type) ??
+        asString(location.type) ??
+        null,
+      status: asString(details.status) ?? asString(core?.status) ?? null,
+      neighborhood: asString(details.neighborhood) ?? asString(core?.neighborhood) ?? null,
+    },
+  };
+}
+
+export function mapKeyLocationsPayload(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult,
+  locationRef: string
+): PayloadEntryData {
+  const { type, ianaTimeId } = mapCategoryCommonPayloadFields(location);
+
+  return {
+    ...mapSharedPayloadFields(location, uploadedImages, locationRef),
+    type,
+    ianaTimeId,
+    ...(location.locationKey ? { location: location.locationKey } : {}),
+    operationHours: normalizeOperationHoursForPayload(location.operationHours) ?? null,
+    keyLocationsDetails: getKeyLocationsDetailsPayload(location),
+    keyLocationStatus: getKeyLocationStatus(location) ?? null,
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/nightlife.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/nightlife.mapper.ts
@@ -1,0 +1,107 @@
+import type { LocationResponse } from "../../../../models/location";
+import type {
+  PayloadEntryData,
+  PayloadNightlifeDetails,
+} from "../../clients/payload-api.client";
+import type { UploadedImagesResult } from "../../types";
+import { mapSharedPayloadFields } from "./shared-fields.mapper";
+import {
+  asBoolean,
+  asRecord,
+  asString,
+  asStringArray,
+  mapCategoryCommonPayloadFields,
+  unwrapLabeledValue,
+} from "./value-normalizers";
+
+function getSectionValue(
+  details: Record<string, unknown>,
+  section: "theSpace" | "theScene" | "theDetails",
+  key: string
+): unknown {
+  const currentSection = asRecord(details[section]);
+  const legacySection = asRecord(asRecord(details.details)?.[section]);
+  return unwrapLabeledValue(currentSection?.[key] ?? legacySection?.[key]);
+}
+
+function getNightlifeDetailsPayload(location: LocationResponse): PayloadNightlifeDetails {
+  const details = asRecord(location.nightlifeDetails) ?? {};
+  const core = asRecord(details.core);
+  const detailFields = asRecord(details.theDetails);
+  const operationHours =
+    asRecord(detailFields?.operationHours) ??
+    asRecord(getSectionValue(details, "theDetails", "operationHours")) ??
+    location.operationHours ??
+    null;
+  const bookingUrl =
+    location.bookingUrl ??
+    asString(detailFields?.bookingUrl) ??
+    asString(details.booking_url) ??
+    asString(getSectionValue(details, "theDetails", "bookingUrl")) ??
+    asString(details.reserve_url) ??
+    null;
+
+  return {
+    core: {
+      name:
+        asString(core?.name) ??
+        asString(details.name) ??
+        location.title ??
+        location.source.name ??
+        "",
+      clubType:
+        asString(core?.clubType) ??
+        asString(details.club_type) ??
+        asString(location.type) ??
+        null,
+      priceTier:
+        asString(core?.priceTier) ??
+        asString(details.price_tier) ??
+        asString(location.priceLevel) ??
+        null,
+      music: asStringArray(core?.music ?? details.music) ?? [],
+      idealFor: asStringArray(core?.idealFor ?? location.idealFor) ?? [],
+    },
+    theSpace: {
+      venueType: asString(getSectionValue(details, "theSpace", "venueType")) ?? null,
+      venueSize: asString(getSectionValue(details, "theSpace", "venueSize")) ?? null,
+      spaceLayout: asStringArray(getSectionValue(details, "theSpace", "spaceLayout")) ?? [],
+      vibe: asStringArray(getSectionValue(details, "theSpace", "vibe")) ?? [],
+      peakHours: asString(getSectionValue(details, "theSpace", "peakHours")) ?? null,
+    },
+    theScene: {
+      musicFormat: asStringArray(getSectionValue(details, "theScene", "musicFormat")) ?? [],
+      touristPresence:
+        asString(getSectionValue(details, "theScene", "touristPresence")) ?? null,
+      dressCode: asStringArray(getSectionValue(details, "theScene", "dressCode")) ?? [],
+      energyLevel: asString(getSectionValue(details, "theScene", "energyLevel")) ?? null,
+      vipAndBottleService:
+        asString(getSectionValue(details, "theScene", "vipAndBottleService")) ?? null,
+      crowdProfile: asString(getSectionValue(details, "theScene", "crowdProfile")) ?? null,
+    },
+    theDetails: {
+      operationHours,
+      bookingUrl,
+      daytimeRestaurant:
+        asBoolean(detailFields?.daytimeRestaurant) ??
+        asBoolean(details.daytime_restaurant) ??
+        asBoolean(getSectionValue(details, "theDetails", "daytimeRestaurant")) ??
+        false,
+    },
+  };
+}
+
+export function mapNightlifePayload(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult,
+  locationRef: string
+): PayloadEntryData {
+  const sharedFields = mapSharedPayloadFields(location, uploadedImages, locationRef);
+  const { countryCodeIso, sourceName, ...nightlifeSharedFields } = sharedFields;
+  return {
+    ...nightlifeSharedFields,
+    ...mapCategoryCommonPayloadFields(location),
+    location: location.locationKey ?? "",
+    nightlifeDetails: getNightlifeDetailsPayload(location),
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/shared-fields.mapper.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/shared-fields.mapper.ts
@@ -1,0 +1,96 @@
+import { BadRequestError } from "@shared/errors/http-error";
+import type { LocationResponse } from "../../../../models/location";
+import type { PayloadEntryData } from "../../clients/payload-api.client";
+import type { UploadedImagesResult } from "../../types";
+import { extractPhoneNumber, convertIsoToPhoneCountryCode } from "../../utils";
+import { asString, toPayloadRelationshipId } from "./value-normalizers";
+
+const LEGACY_LM_ONLY_FIELDS = [
+  "neighborhoodDescription",
+  "tripadvisorUrl",
+  "tripadvisorLocationId",
+  "placeId",
+  "contactAddress",
+  "sourceAddress",
+  "locationKey",
+  "district",
+] as const;
+
+const MAX_ATTRACTION_GALLERY_ITEMS = 20;
+
+function getGalleryImageIds(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult
+): string[] {
+  if (location.category !== "attractions") return uploadedImages.galleryImageIds;
+
+  const galleryIds = Array.from(
+    new Set([
+      ...uploadedImages.galleryImageIds,
+      ...(location.selectedPayloadMediaSetIds ?? []),
+    ])
+  );
+
+  if (galleryIds.length > MAX_ATTRACTION_GALLERY_ITEMS) {
+    throw new BadRequestError(
+      `Attractions gallery exceeds Payload max of ${MAX_ATTRACTION_GALLERY_ITEMS} items`
+    );
+  }
+  return galleryIds;
+}
+
+export function mapSharedPayloadFields(
+  location: LocationResponse,
+  uploadedImages: UploadedImagesResult,
+  locationRef: string
+): Pick<
+  PayloadEntryData,
+  | "title"
+  | "locationRef"
+  | "gallery"
+  | "instagramGallery"
+  | "address"
+  | "countryCode"
+  | "phoneNumber"
+  | "website"
+  | "latitude"
+  | "longitude"
+  | "status"
+  | "email"
+  | "countryCodeIso"
+  | "sourceName"
+> {
+  const payloadCountryCode = convertIsoToPhoneCountryCode(
+    location.contact.countryCode || undefined
+  );
+  const phoneNumber = extractPhoneNumber(location.contact.phoneNumber || undefined);
+
+  return {
+    title: location.title || location.source.name,
+    locationRef,
+    gallery: getGalleryImageIds(location, uploadedImages).map((id) => ({
+      image: toPayloadRelationshipId(id),
+      altText: "",
+      caption: "",
+    })),
+    instagramGallery: uploadedImages.instagramPostIds.map((id) => ({
+      post: toPayloadRelationshipId(id),
+    })),
+    address: location.contact.url || "",
+    countryCode: payloadCountryCode ?? null,
+    phoneNumber: phoneNumber ?? null,
+    website: asString(location.contact.website) ?? null,
+    latitude: location.coordinates.lat ?? null,
+    longitude: location.coordinates.lng ?? null,
+    status: "published",
+    email: asString(location.contact.email) ?? null,
+    countryCodeIso: asString(location.contact.countryCode) ?? null,
+    sourceName: asString(location.source.name) ?? null,
+  };
+}
+
+export function stripLegacyLmFields(payload: PayloadEntryData): PayloadEntryData {
+  const mutable = payload as PayloadEntryData & Record<string, unknown>;
+  for (const field of LEGACY_LM_ONLY_FIELDS) delete mutable[field];
+  return mutable;
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/value-normalizers.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/mappers/location-payload/value-normalizers.ts
@@ -1,0 +1,117 @@
+import type { LocationResponse } from "../../../../models/location";
+import type { PayloadRelationshipId } from "../../clients/payload-api.client";
+
+const PRICE_LEVEL_TO_PAYLOAD: Record<string, string> = {
+  "$": "1",
+  "$$": "2",
+  "$$$": "3",
+  "$$$$": "4",
+  free: "1",
+  budget: "1",
+  inexpensive: "1",
+  "mid-range": "2",
+  moderate: "2",
+  expensive: "3",
+  "very expensive": "4",
+  luxury: "4",
+};
+
+const WEEKDAY_LABELS: Record<string, string> = {
+  monday: "Monday",
+  tuesday: "Tuesday",
+  wednesday: "Wednesday",
+  thursday: "Thursday",
+  friday: "Friday",
+  saturday: "Saturday",
+  sunday: "Sunday",
+};
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+export function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const normalized = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "yes" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "no" || normalized === "0") return false;
+  }
+  return undefined;
+}
+
+export function unwrapLabeledValue(value: unknown): unknown {
+  const record = asRecord(value);
+  return record && Object.prototype.hasOwnProperty.call(record, "value")
+    ? record.value
+    : value;
+}
+
+export function toPayloadRelationshipId(id: string | number): PayloadRelationshipId {
+  if (typeof id === "number") return id;
+  const trimmed = id.trim();
+  return /^\d+$/.test(trimmed) ? Number(trimmed) : trimmed;
+}
+
+export function normalizeOperationHoursForPayload(
+  operationHours: Record<string, unknown> | null
+): { hours: Array<{ day: string; hours: string }> } | undefined {
+  if (!operationHours) return undefined;
+
+  if (Array.isArray(operationHours.hours)) {
+    const hours = operationHours.hours
+      .map(normalizeHoursRow)
+      .filter((row): row is { day: string; hours: string } => row !== null);
+    return hours.length > 0 ? { hours } : undefined;
+  }
+
+  const hours = Object.entries(operationHours)
+    .filter(([key]) => key !== "currently_open" && key !== "hours")
+    .map(([key, value]) => {
+      const day = WEEKDAY_LABELS[key.toLowerCase()] ?? key;
+      const hoursValue = typeof value === "string" ? value.trim() : "";
+      return hoursValue ? { day, hours: hoursValue } : null;
+    })
+    .filter((row): row is { day: string; hours: string } => row !== null);
+
+  return hours.length > 0 ? { hours } : undefined;
+}
+
+function normalizeHoursRow(row: unknown): { day: string; hours: string } | null {
+  const record = asRecord(row);
+  if (!record) return null;
+  const day = typeof record.day === "string" ? record.day.trim() : "";
+  const hours = typeof record.hours === "string" ? record.hours.trim() : "";
+  return day && hours ? { day, hours } : null;
+}
+
+export function mapCategoryCommonPayloadFields(location: LocationResponse) {
+  const mappedPriceLevel = location.priceLevel
+    ? PRICE_LEVEL_TO_PAYLOAD[location.priceLevel.toLowerCase()]
+    : undefined;
+  return {
+    type: asString(location.type) ?? null,
+    priceLevel: mappedPriceLevel ?? null,
+    ianaTimeId: asString(location.ianaTimeId) ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- reduce location-payload.mapper.ts from 624 lines to a 92-line public dispatch facade
- give dining, accommodations, attractions, nightlife, and key locations dedicated outbound mappers
- isolate shared Payload fields, relationship normalization, legacy-field stripping, hours normalization, and scalar coercion
- retain the existing public exports and every collection-specific clear/fallback rule

## Validation
- all 225 lm-server tests passed across 48 files, including all 20 mapper contract tests
- configured lm-server lint completed (repository explicitly skips lint for the current baseline)
- configured lm-server build completed (Bun service declares no build step)
- git diff check passed