### PR TITLE
NOJIRA: Decompose the form tag multi-select

### DIFF
--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select.tsx
@@ -1,200 +1,16 @@
-import * as React from "react";
-import { type Control, type FieldValues, type Path } from "react-hook-form";
-import { X } from "lucide-react";
-import {
-  Button,
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-  Textarea,
-} from "@client/components/ui";
+import type { FieldValues } from "react-hook-form";
 import { FormBase } from "./form-base";
+import { DirectTagArrayInput } from "./form-tag-multi-select/DirectTagArrayInput";
+import { SelectedTagChips } from "./form-tag-multi-select/SelectedTagChips";
+import { TagSelectMenu } from "./form-tag-multi-select/TagSelectMenu";
+import { buildTagOptionsView } from "./form-tag-multi-select/tag-options";
+import type { FormTagMultiSelectProps } from "./form-tag-multi-select.types";
 
-export interface TagSelectOption {
-  value: string;
-  label: string;
-}
-
-export interface TagSelectGroup {
-  label: string;
-  options: readonly TagSelectOption[];
-}
-
-export interface FormTagMultiSelectProps<T extends FieldValues = FieldValues> {
-  name: Path<T>;
-  label: string;
-  control: Control<T>;
-  options?: readonly TagSelectOption[];
-  optionGroups?: readonly TagSelectGroup[];
-  maxSelections?: number;
-  placeholder?: string;
-  description?: string;
-  allowDirectTagArrayInput?: boolean;
-}
-
-interface ParsedTagInputSuccess {
-  ok: true;
-  tags: string[];
-}
-
-interface ParsedTagInputFailure {
-  ok: false;
-  error: string;
-}
-
-type ParsedTagInputResult = ParsedTagInputSuccess | ParsedTagInputFailure;
-
-function normalizeTagText(value: string): string {
-  return value.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-function stripWrappingQuotes(value: string): string {
-  return value.trim().replace(/^['"`]+|['"`]+$/g, "").trim();
-}
-
-function tokenizeTagInput(rawInput: string): string[] {
-  const trimmed = rawInput.trim();
-
-  if (!trimmed) {
-    return [];
-  }
-
-  const withoutBrackets =
-    trimmed.startsWith("[") && trimmed.endsWith("]")
-      ? trimmed.slice(1, -1)
-      : trimmed;
-
-  return withoutBrackets
-    .split(/[\n,;]+/)
-    .map((token) => stripWrappingQuotes(token))
-    .filter((token) => token.length > 0);
-}
-
-function buildNormalizedValueMap(options: readonly TagSelectOption[]): Map<string, string> {
-  const normalizedValueMap = new Map<string, string>();
-
-  options.forEach((option) => {
-    normalizedValueMap.set(normalizeTagText(option.value), option.value);
-    normalizedValueMap.set(normalizeTagText(option.label), option.value);
-  });
-
-  return normalizedValueMap;
-}
-
-function levenshteinDistance(a: string, b: string): number {
-  if (a === b) return 0;
-  if (!a.length) return b.length;
-  if (!b.length) return a.length;
-
-  const previousRow = Array.from({ length: b.length + 1 }, (_, index) => index);
-  const currentRow = new Array<number>(b.length + 1).fill(0);
-
-  for (let i = 0; i < a.length; i += 1) {
-    currentRow[0] = i + 1;
-
-    for (let j = 0; j < b.length; j += 1) {
-      const cost = a[i] === b[j] ? 0 : 1;
-      currentRow[j + 1] = Math.min(
-        currentRow[j] + 1,
-        previousRow[j + 1] + 1,
-        previousRow[j] + cost
-      );
-    }
-
-    for (let j = 0; j < previousRow.length; j += 1) {
-      previousRow[j] = currentRow[j];
-    }
-  }
-
-  return previousRow[b.length];
-}
-
-function getClosestTagSuggestion(token: string, optionValues: readonly string[]): string | null {
-  const normalizedToken = normalizeTagText(token);
-  let bestMatch: string | null = null;
-  let bestDistance = Number.POSITIVE_INFINITY;
-
-  optionValues.forEach((option) => {
-    const distance = levenshteinDistance(normalizedToken, normalizeTagText(option));
-    if (distance < bestDistance) {
-      bestDistance = distance;
-      bestMatch = option;
-    }
-  });
-
-  const maxDistance = Math.max(2, Math.floor(normalizedToken.length * 0.35));
-
-  return bestDistance <= maxDistance ? bestMatch : null;
-}
-
-function parseDirectTagArrayInput(params: {
-  rawInput: string;
-  maxSelections: number;
-  normalizedValueMap: Map<string, string>;
-  optionValues: readonly string[];
-}): ParsedTagInputResult {
-  const { rawInput, maxSelections, normalizedValueMap, optionValues } = params;
-  const parsedTokens = tokenizeTagInput(rawInput);
-
-  if (parsedTokens.length === 0) {
-    return { ok: false, error: "Enter at least one tag before applying." };
-  }
-
-  const resolvedValues: string[] = [];
-  const unknownTokens: string[] = [];
-
-  parsedTokens.forEach((token) => {
-    const normalizedToken = normalizeTagText(token);
-    const resolvedValue = normalizedValueMap.get(normalizedToken);
-    if (resolvedValue) {
-      resolvedValues.push(resolvedValue);
-    } else {
-      unknownTokens.push(token);
-    }
-  });
-
-  if (unknownTokens.length > 0) {
-    const unknownTokenMessage = unknownTokens
-      .map((token) => {
-        const suggestion = getClosestTagSuggestion(token, optionValues);
-        return suggestion
-          ? `"${token}" (did you mean "${suggestion}"?)`
-          : `"${token}"`;
-      })
-      .join(", ");
-    return { ok: false, error: `Check spelling for: ${unknownTokenMessage}.` };
-  }
-
-  const duplicateValues = resolvedValues.filter(
-    (value, index) => resolvedValues.indexOf(value) !== index
-  );
-
-  if (duplicateValues.length > 0) {
-    const uniqueDuplicates = Array.from(new Set(duplicateValues));
-    return { ok: false, error: `Remove duplicate tags: ${uniqueDuplicates.join(", ")}.` };
-  }
-
-  if (resolvedValues.length > maxSelections) {
-    return {
-      ok: false,
-      error: `You can only apply up to ${maxSelections} tags at once.`,
-    };
-  }
-
-  return {
-    ok: true,
-    tags: resolvedValues,
-  };
-}
-
-function formatTagsAsArray(tags: readonly string[]): string {
-  return `[${tags.map((tag) => `"${tag}"`).join(", ")}]`;
-}
+export type {
+  FormTagMultiSelectProps,
+  TagSelectGroup,
+  TagSelectOption,
+} from "./form-tag-multi-select.types";
 
 export function FormTagMultiSelect<T extends FieldValues = FieldValues>({
   name,
@@ -207,11 +23,6 @@ export function FormTagMultiSelect<T extends FieldValues = FieldValues>({
   description,
   allowDirectTagArrayInput = false,
 }: FormTagMultiSelectProps<T>) {
-  const [isDirectArrayInputEnabled, setIsDirectArrayInputEnabled] = React.useState(false);
-  const [directArrayInputValue, setDirectArrayInputValue] = React.useState("");
-  const [directArrayInputError, setDirectArrayInputError] = React.useState<string | null>(null);
-  const [directArrayInputFeedback, setDirectArrayInputFeedback] = React.useState<string | null>(null);
-
   return (
     <FormBase
       name={name}
@@ -223,193 +34,54 @@ export function FormTagMultiSelect<T extends FieldValues = FieldValues>({
         const selectedValues = Array.isArray(field.value)
           ? (field.value as string[])
           : [];
-        const allOptions = optionGroups
-          ? optionGroups.flatMap((group) => group.options)
-          : options;
-        const optionLabelByValue = new Map(
-          allOptions.map((option) => [option.value, option.label])
-        );
-        const normalizedValueMap = buildNormalizedValueMap(allOptions);
-        const optionValues = allOptions.map((option) => option.value);
-        const availableOptions = allOptions.filter(
-          (option) => !selectedValues.includes(option.value)
-        );
-        const availableOptionGroups = optionGroups?.map((group) => ({
-          ...group,
-          options: group.options.filter(
-            (option) => !selectedValues.includes(option.value)
-          ),
-        })).filter((group) => group.options.length > 0);
+        const {
+          allOptions,
+          availableOptions,
+          availableOptionGroups,
+          optionLabelByValue,
+        } = buildTagOptionsView(options, optionGroups, selectedValues);
         const isAtLimit = selectedValues.length >= maxSelections;
 
         const addTag = (nextValue: string) => {
           if (selectedValues.includes(nextValue) || isAtLimit) return;
           field.onChange([...selectedValues, nextValue]);
         };
-
         const removeTag = (valueToRemove: string) => {
           field.onChange(
             selectedValues.filter((value) => value !== valueToRemove)
           );
         };
 
-        const handleDirectInputToggle = (isEnabled: boolean) => {
-          setIsDirectArrayInputEnabled(isEnabled);
-          setDirectArrayInputError(null);
-          setDirectArrayInputFeedback(null);
-
-          if (isEnabled && directArrayInputValue.trim().length === 0 && selectedValues.length > 0) {
-            setDirectArrayInputValue(formatTagsAsArray(selectedValues));
-          }
-        };
-
-        const handleApplyDirectInput = () => {
-          const parseResult = parseDirectTagArrayInput({
-            rawInput: directArrayInputValue,
-            maxSelections,
-            normalizedValueMap,
-            optionValues,
-          });
-
-          if (!parseResult.ok) {
-            setDirectArrayInputError(parseResult.error);
-            setDirectArrayInputFeedback(null);
-            return;
-          }
-
-          field.onChange(parseResult.tags);
-          setDirectArrayInputValue(formatTagsAsArray(parseResult.tags));
-          setDirectArrayInputError(null);
-          setDirectArrayInputFeedback(
-            `Applied ${parseResult.tags.length} tag${parseResult.tags.length === 1 ? "" : "s"}.`
-          );
-        };
-
         return (
           <div className="space-y-2">
-            <Select
-              key={selectedValues.join("|") || "empty"}
-              value={undefined}
-              onValueChange={addTag}
-              disabled={
-                (optionGroups
-                  ? (availableOptionGroups?.length ?? 0) === 0
-                  : availableOptions.length === 0) || isAtLimit
-              }
-            >
-              <SelectTrigger
-                id={field.name}
-                onBlur={field.onBlur}
-                aria-invalid={fieldState.invalid}
-              >
-                <SelectValue
-                  placeholder={
-                    isAtLimit
-                      ? `Maximum ${maxSelections} tags selected`
-                      : placeholder
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {optionGroups ? (
-                  availableOptionGroups?.map((group, groupIndex) => (
-                    <SelectGroup key={group.label}>
-                      <SelectLabel className="pl-2 pr-2 py-1 text-[11px] uppercase tracking-wide text-muted-foreground">
-                        {group.label}
-                      </SelectLabel>
-                      {group.options.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                      {groupIndex < availableOptionGroups.length - 1 && (
-                        <SelectSeparator />
-                      )}
-                    </SelectGroup>
-                  ))
-                ) : (
-                  availableOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
+            <TagSelectMenu
+              fieldName={field.name}
+              selectedValues={selectedValues}
+              availableOptions={availableOptions}
+              availableOptionGroups={availableOptionGroups}
+              usesOptionGroups={Boolean(optionGroups)}
+              isAtLimit={isAtLimit}
+              maxSelections={maxSelections}
+              placeholder={placeholder}
+              isInvalid={fieldState.invalid}
+              onBlur={field.onBlur}
+              onAdd={addTag}
+            />
 
             {allowDirectTagArrayInput && (
-              <div className="rounded-md border border-dashed border-border/80 bg-muted/20 p-3 space-y-3">
-                <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <input
-                    type="checkbox"
-                    className="h-3.5 w-3.5 accent-primary"
-                    checked={isDirectArrayInputEnabled}
-                    onChange={(event) => handleDirectInputToggle(event.target.checked)}
-                  />
-                  Paste an Ideal For array directly
-                </label>
-
-                {isDirectArrayInputEnabled && (
-                  <div className="space-y-2">
-                    <Textarea
-                      value={directArrayInputValue}
-                      onChange={(event) => {
-                        setDirectArrayInputValue(event.target.value);
-                        setDirectArrayInputError(null);
-                        setDirectArrayInputFeedback(null);
-                      }}
-                      rows={3}
-                      placeholder='["Casual Dining", "Coffee & Light Bites"] or Casual Dining, Coffee & Light Bites'
-                      aria-invalid={Boolean(directArrayInputError)}
-                    />
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <p className="text-[11px] text-muted-foreground">
-                        Brackets are optional. Tags must match the approved names exactly.
-                      </p>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={handleApplyDirectInput}
-                      >
-                        Apply array
-                      </Button>
-                    </div>
-                    {directArrayInputError && (
-                      <p className="text-xs font-medium text-destructive">
-                        {directArrayInputError}
-                      </p>
-                    )}
-                    {directArrayInputFeedback && !directArrayInputError && (
-                      <p className="text-xs font-medium text-green-600">
-                        {directArrayInputFeedback}
-                      </p>
-                    )}
-                  </div>
-                )}
-              </div>
+              <DirectTagArrayInput
+                selectedValues={selectedValues}
+                options={allOptions}
+                maxSelections={maxSelections}
+                onApply={field.onChange}
+              />
             )}
 
-            {selectedValues.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {selectedValues.map((value) => (
-                  <span
-                    key={value}
-                    className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs text-foreground"
-                  >
-                    {optionLabelByValue.get(value) ?? value}
-                    <button
-                      type="button"
-                      className="rounded-sm text-muted-foreground hover:text-foreground"
-                      onClick={() => removeTag(value)}
-                      aria-label={`Remove ${optionLabelByValue.get(value) ?? value}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            )}
+            <SelectedTagChips
+              selectedValues={selectedValues}
+              optionLabelByValue={optionLabelByValue}
+              onRemove={removeTag}
+            />
 
             <p className="text-xs text-muted-foreground">
               {selectedValues.length}/{maxSelections} selected

--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select.types.ts
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select.types.ts
@@ -1,0 +1,23 @@
+import type { Control, FieldValues, Path } from "react-hook-form";
+
+export interface TagSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface TagSelectGroup {
+  label: string;
+  options: readonly TagSelectOption[];
+}
+
+export interface FormTagMultiSelectProps<T extends FieldValues = FieldValues> {
+  name: Path<T>;
+  label: string;
+  control: Control<T>;
+  options?: readonly TagSelectOption[];
+  optionGroups?: readonly TagSelectGroup[];
+  maxSelections?: number;
+  placeholder?: string;
+  description?: string;
+  allowDirectTagArrayInput?: boolean;
+}

--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/DirectTagArrayInput.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/DirectTagArrayInput.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import { Button, Textarea } from "@client/components/ui";
+import type { TagSelectOption } from "../form-tag-multi-select.types";
+import {
+  formatTagsAsArray,
+  parseDirectTagArrayInput,
+} from "./tag-input-parser";
+
+interface DirectTagArrayInputProps {
+  selectedValues: string[];
+  options: readonly TagSelectOption[];
+  maxSelections: number;
+  onApply: (tags: string[]) => void;
+}
+
+export function DirectTagArrayInput({
+  selectedValues,
+  options,
+  maxSelections,
+  onApply,
+}: DirectTagArrayInputProps) {
+  const [isEnabled, setIsEnabled] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+  const [feedback, setFeedback] = React.useState<string | null>(null);
+
+  const handleToggle = (nextEnabled: boolean) => {
+    setIsEnabled(nextEnabled);
+    setError(null);
+    setFeedback(null);
+    if (nextEnabled && !inputValue.trim() && selectedValues.length > 0) {
+      setInputValue(formatTagsAsArray(selectedValues));
+    }
+  };
+
+  const handleApply = () => {
+    const result = parseDirectTagArrayInput({
+      rawInput: inputValue,
+      maxSelections,
+      options,
+    });
+    if (!result.ok) {
+      setError(result.error);
+      setFeedback(null);
+      return;
+    }
+
+    onApply(result.tags);
+    setInputValue(formatTagsAsArray(result.tags));
+    setError(null);
+    setFeedback(
+      `Applied ${result.tags.length} tag${result.tags.length === 1 ? "" : "s"}.`
+    );
+  };
+
+  return (
+    <div className="rounded-md border border-dashed border-border/80 bg-muted/20 p-3 space-y-3">
+      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          className="h-3.5 w-3.5 accent-primary"
+          checked={isEnabled}
+          onChange={(event) => handleToggle(event.target.checked)}
+        />
+        Paste an Ideal For array directly
+      </label>
+
+      {isEnabled && (
+        <div className="space-y-2">
+          <Textarea
+            value={inputValue}
+            onChange={(event) => {
+              setInputValue(event.target.value);
+              setError(null);
+              setFeedback(null);
+            }}
+            rows={3}
+            placeholder='["Casual Dining", "Coffee & Light Bites"] or Casual Dining, Coffee & Light Bites'
+            aria-invalid={Boolean(error)}
+          />
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-[11px] text-muted-foreground">
+              Brackets are optional. Tags must match the approved names exactly.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleApply}
+            >
+              Apply array
+            </Button>
+          </div>
+          {error && (
+            <p className="text-xs font-medium text-destructive">{error}</p>
+          )}
+          {feedback && !error && (
+            <p className="text-xs font-medium text-green-600">{feedback}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/SelectedTagChips.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/SelectedTagChips.tsx
@@ -1,0 +1,39 @@
+import { X } from "lucide-react";
+
+interface SelectedTagChipsProps {
+  selectedValues: string[];
+  optionLabelByValue: Map<string, string>;
+  onRemove: (value: string) => void;
+}
+
+export function SelectedTagChips({
+  selectedValues,
+  optionLabelByValue,
+  onRemove,
+}: SelectedTagChipsProps) {
+  if (selectedValues.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {selectedValues.map((value) => {
+        const label = optionLabelByValue.get(value) ?? value;
+        return (
+          <span
+            key={value}
+            className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs text-foreground"
+          >
+            {label}
+            <button
+              type="button"
+              className="rounded-sm text-muted-foreground hover:text-foreground"
+              onClick={() => onRemove(value)}
+              aria-label={`Remove ${label}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/TagSelectMenu.tsx
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/TagSelectMenu.tsx
@@ -1,0 +1,90 @@
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@client/components/ui";
+import type {
+  TagSelectGroup,
+  TagSelectOption,
+} from "../form-tag-multi-select.types";
+
+interface TagSelectMenuProps {
+  fieldName: string;
+  selectedValues: string[];
+  availableOptions: readonly TagSelectOption[];
+  availableOptionGroups?: readonly TagSelectGroup[];
+  usesOptionGroups: boolean;
+  isAtLimit: boolean;
+  maxSelections: number;
+  placeholder: string;
+  isInvalid: boolean;
+  onBlur: () => void;
+  onAdd: (value: string) => void;
+}
+
+export function TagSelectMenu({
+  fieldName,
+  selectedValues,
+  availableOptions,
+  availableOptionGroups,
+  usesOptionGroups,
+  isAtLimit,
+  maxSelections,
+  placeholder,
+  isInvalid,
+  onBlur,
+  onAdd,
+}: TagSelectMenuProps) {
+  const hasAvailableOptions = usesOptionGroups
+    ? (availableOptionGroups?.length ?? 0) > 0
+    : availableOptions.length > 0;
+
+  return (
+    <Select
+      key={selectedValues.join("|") || "empty"}
+      value={undefined}
+      onValueChange={onAdd}
+      disabled={!hasAvailableOptions || isAtLimit}
+    >
+      <SelectTrigger
+        id={fieldName}
+        onBlur={onBlur}
+        aria-invalid={isInvalid}
+      >
+        <SelectValue
+          placeholder={
+            isAtLimit ? `Maximum ${maxSelections} tags selected` : placeholder
+          }
+        />
+      </SelectTrigger>
+      <SelectContent>
+        {usesOptionGroups
+          ? availableOptionGroups?.map((group, groupIndex) => (
+              <SelectGroup key={group.label}>
+                <SelectLabel className="pl-2 pr-2 py-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  {group.label}
+                </SelectLabel>
+                {group.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+                {groupIndex < (availableOptionGroups?.length ?? 0) - 1 && (
+                  <SelectSeparator />
+                )}
+              </SelectGroup>
+            ))
+          : availableOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/tag-input-parser.ts
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/tag-input-parser.ts
@@ -1,0 +1,145 @@
+import type { TagSelectOption } from "../form-tag-multi-select.types";
+
+type ParsedTagInputResult =
+  | { ok: true; tags: string[] }
+  | { ok: false; error: string };
+
+function normalizeTagText(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function tokenizeTagInput(rawInput: string): string[] {
+  const trimmed = rawInput.trim();
+  if (!trimmed) return [];
+
+  const withoutBrackets =
+    trimmed.startsWith("[") && trimmed.endsWith("]")
+      ? trimmed.slice(1, -1)
+      : trimmed;
+
+  return withoutBrackets
+    .split(/[\n,;]+/)
+    .map((token) => token.trim().replace(/^['"`]+|['"`]+$/g, "").trim())
+    .filter(Boolean);
+}
+
+function buildNormalizedValueMap(
+  options: readonly TagSelectOption[]
+): Map<string, string> {
+  const normalizedValueMap = new Map<string, string>();
+  options.forEach((option) => {
+    normalizedValueMap.set(normalizeTagText(option.value), option.value);
+    normalizedValueMap.set(normalizeTagText(option.label), option.value);
+  });
+  return normalizedValueMap;
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+
+  const previousRow = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const currentRow = new Array<number>(b.length + 1).fill(0);
+
+  for (let i = 0; i < a.length; i += 1) {
+    currentRow[0] = i + 1;
+    for (let j = 0; j < b.length; j += 1) {
+      const cost = a[i] === b[j] ? 0 : 1;
+      currentRow[j + 1] = Math.min(
+        currentRow[j] + 1,
+        previousRow[j + 1] + 1,
+        previousRow[j] + cost
+      );
+    }
+    for (let j = 0; j < previousRow.length; j += 1) {
+      previousRow[j] = currentRow[j];
+    }
+  }
+
+  return previousRow[b.length];
+}
+
+function getClosestTagSuggestion(
+  token: string,
+  optionValues: readonly string[]
+): string | null {
+  const normalizedToken = normalizeTagText(token);
+  let bestMatch: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  optionValues.forEach((option) => {
+    const distance = levenshteinDistance(
+      normalizedToken,
+      normalizeTagText(option)
+    );
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = option;
+    }
+  });
+
+  const maxDistance = Math.max(2, Math.floor(normalizedToken.length * 0.35));
+  return bestDistance <= maxDistance ? bestMatch : null;
+}
+
+export function parseDirectTagArrayInput(params: {
+  rawInput: string;
+  maxSelections: number;
+  options: readonly TagSelectOption[];
+}): ParsedTagInputResult {
+  const { rawInput, maxSelections, options } = params;
+  const parsedTokens = tokenizeTagInput(rawInput);
+  if (parsedTokens.length === 0) {
+    return { ok: false, error: "Enter at least one tag before applying." };
+  }
+
+  const normalizedValueMap = buildNormalizedValueMap(options);
+  const optionValues = options.map((option) => option.value);
+  const resolvedValues: string[] = [];
+  const unknownTokens: string[] = [];
+
+  parsedTokens.forEach((token) => {
+    const resolvedValue = normalizedValueMap.get(normalizeTagText(token));
+    if (resolvedValue) resolvedValues.push(resolvedValue);
+    else unknownTokens.push(token);
+  });
+
+  if (unknownTokens.length > 0) {
+    const unknownTokenMessage = unknownTokens
+      .map((token) => {
+        const suggestion = getClosestTagSuggestion(token, optionValues);
+        return suggestion
+          ? `"${token}" (did you mean "${suggestion}"?)`
+          : `"${token}"`;
+      })
+      .join(", ");
+    return { ok: false, error: `Check spelling for: ${unknownTokenMessage}.` };
+  }
+
+  const duplicates = Array.from(
+    new Set(
+      resolvedValues.filter(
+        (value, index) => resolvedValues.indexOf(value) !== index
+      )
+    )
+  );
+  if (duplicates.length > 0) {
+    return {
+      ok: false,
+      error: `Remove duplicate tags: ${duplicates.join(", ")}.`,
+    };
+  }
+
+  if (resolvedValues.length > maxSelections) {
+    return {
+      ok: false,
+      error: `You can only apply up to ${maxSelections} tags at once.`,
+    };
+  }
+  return { ok: true, tags: resolvedValues };
+}
+
+export function formatTagsAsArray(tags: readonly string[]): string {
+  return `[${tags.map((tag) => `"${tag}"`).join(", ")}]`;
+}

--- a/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/tag-options.ts
+++ b/apps/location-manager/packages/client/src/shared/components/forms/form-tag-multi-select/tag-options.ts
@@ -1,0 +1,34 @@
+import type {
+  TagSelectGroup,
+  TagSelectOption,
+} from "../form-tag-multi-select.types";
+
+export function buildTagOptionsView(
+  options: readonly TagSelectOption[],
+  optionGroups: readonly TagSelectGroup[] | undefined,
+  selectedValues: string[]
+) {
+  const allOptions = optionGroups
+    ? optionGroups.flatMap((group) => group.options)
+    : options;
+  const availableOptions = allOptions.filter(
+    (option) => !selectedValues.includes(option.value)
+  );
+  const availableOptionGroups = optionGroups
+    ?.map((group) => ({
+      ...group,
+      options: group.options.filter(
+        (option) => !selectedValues.includes(option.value)
+      ),
+    }))
+    .filter((group) => group.options.length > 0);
+
+  return {
+    allOptions,
+    availableOptions,
+    availableOptionGroups,
+    optionLabelByValue: new Map(
+      allOptions.map((option) => [option.value, option.label])
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- reduce form-tag-multi-select.tsx from 422 lines to a 94-line form adapter
- isolate direct-array parsing and spelling suggestions as pure utilities
- separate option availability, grouped select rendering, direct-array editing, and selected chips
- retain the existing public component and type exports, selection limits, labels, feedback, and React Hook Form behavior

## Validation
- targeted ESLint passed across every changed module
- lm-client TypeScript and production Vite build passed
- configured lint and test scripts completed (both are explicitly skipped by repository configuration)
- git diff check passed