### PR TITLE
NOJIRA: Decompose the multi-variant cropper

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/MultiVariantCropper.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/MultiVariantCropper.tsx
@@ -1,53 +1,15 @@
-import { useState, useCallback, useEffect } from 'react';
-import Cropper, { type Point, type Area } from 'react-easy-crop';
-import {
-  VARIANT_SPECS,
-  VARIANT_SEQUENCE,
-  initializeCropStates,
-  createMultiVariantImages,
-  loadImage,
-  type ImageVariantType,
-  type CropStates,
-} from '../utils/imageProcessing';
+import { VARIANT_SEQUENCE, type ImageVariantType } from '../utils/imageProcessing'
+import { CropperFooter } from './multi-variant-cropper/CropperFooter'
+import { CropperViewport } from './multi-variant-cropper/CropperViewport'
+import { VariantProgress } from './multi-variant-cropper/VariantProgress'
+import { useMultiVariantCropper } from './multi-variant-cropper/useMultiVariantCropper'
 
 interface MultiVariantCropperProps {
-  file: File;
-  fileNamePrefix?: string;
-  onConfirm: (variantFiles: { type: ImageVariantType; file: File }[]) => void;
-  onCancel: () => void;
+  file: File
+  fileNamePrefix?: string
+  onConfirm: (variantFiles: { type: ImageVariantType; file: File }[]) => void
+  onCancel: () => void
 }
-
-// Inline SVG icons
-const CheckIcon = () => (
-  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="20 6 9 17 4 12"/>
-  </svg>
-);
-
-const ChevronLeftIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="15 18 9 12 15 6"/>
-  </svg>
-);
-
-const ChevronRightIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="9 18 15 12 9 6"/>
-  </svg>
-);
-
-const LoaderIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="animate-spin">
-    <line x1="12" y1="2" x2="12" y2="6"/>
-    <line x1="12" y1="18" x2="12" y2="22"/>
-    <line x1="4.93" y1="4.93" x2="7.76" y2="7.76"/>
-    <line x1="16.24" y1="16.24" x2="19.07" y2="19.07"/>
-    <line x1="2" y1="12" x2="6" y2="12"/>
-    <line x1="18" y1="12" x2="22" y2="12"/>
-    <line x1="4.93" y1="19.07" x2="7.76" y2="16.24"/>
-    <line x1="16.24" y1="7.76" x2="19.07" y2="4.93"/>
-  </svg>
-);
 
 export function MultiVariantCropper({
   file,
@@ -55,365 +17,82 @@ export function MultiVariantCropper({
   onConfirm,
   onCancel,
 }: MultiVariantCropperProps) {
-  const [previewUrl, setPreviewUrl] = useState<string>('');
-  const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(null);
-  const [currentVariantIndex, setCurrentVariantIndex] = useState(0);
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [cropStates, setCropStates] = useState<CropStates>(initializeCropStates());
-  const [errorMsg, setErrorMsg] = useState<string>('');
+  const cropper = useMultiVariantCropper({ file, fileNamePrefix, onConfirm })
 
-  const currentVariantType = VARIANT_SEQUENCE[currentVariantIndex];
-  const currentState = cropStates[currentVariantType];
-  const currentSpec = VARIANT_SPECS[currentVariantType];
-  const formatVariantLabel = (variantType: ImageVariantType) =>
-    variantType
-      .split('_')
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(' ');
-
-  // Create preview URL and load image dimensions when file changes
-  useEffect(() => {
-    let cancelled = false;
-    const url = URL.createObjectURL(file);
-    setPreviewUrl(url);
-    setImageDimensions(null);
-    setCropStates(initializeCropStates());
-    setCurrentVariantIndex(0);
-    setErrorMsg('');
-
-    const loadAndInit = async () => {
-      const img = await loadImage(url);
-      if (cancelled) return;
-      const dimensions = { width: img.naturalWidth, height: img.naturalHeight };
-
-      setImageDimensions(dimensions);
-      setCropStates(initializeCropStates(dimensions.width, dimensions.height));
-    };
-
-    loadAndInit().catch((error) => {
-      if (!cancelled) {
-        setErrorMsg(error instanceof Error ? error.message : 'Failed to load image');
-      }
-    });
-
-    return () => {
-      cancelled = true;
-      URL.revokeObjectURL(url);
-    };
-  }, [file]);
-
-  const onCropChange = useCallback((crop: Point) => {
-    setCropStates(prev => ({
-      ...prev,
-      [currentVariantType]: {
-        ...prev[currentVariantType],
-        crop,
-        croppedAreaPixels: null,
-        completed: false,
-      }
-    }));
-  }, [currentVariantType]);
-
-  const onZoomChange = useCallback((zoom: number) => {
-    setCropStates(prev => ({
-      ...prev,
-      [currentVariantType]: {
-        ...prev[currentVariantType],
-        zoom,
-        croppedAreaPixels: null,
-        completed: false,
-      }
-    }));
-  }, [currentVariantType]);
-
-  // Track the draft crop area separately from the confirmed upload crop.
-  const onCropComplete = useCallback((_croppedArea: Area, croppedAreaPixels: Area) => {
-    setCropStates(prev => ({
-      ...prev,
-      [currentVariantType]: { ...prev[currentVariantType], draftAreaPixels: croppedAreaPixels }
-    }));
-  }, [currentVariantType]);
-
-  const handlePrevious = () => {
-    if (currentVariantIndex > 0) {
-      setCurrentVariantIndex(currentVariantIndex - 1);
+  const showPrevious = () => {
+    if (cropper.currentVariantIndex > 0) {
+      cropper.setCurrentVariantIndex(cropper.currentVariantIndex - 1)
     }
-  };
-
-  const handleNext = () => {
-    if (currentVariantIndex < VARIANT_SEQUENCE.length - 1) {
-      setCurrentVariantIndex(currentVariantIndex + 1);
+  }
+  const showNext = () => {
+    if (cropper.currentVariantIndex < VARIANT_SEQUENCE.length - 1) {
+      cropper.setCurrentVariantIndex(cropper.currentVariantIndex + 1)
     }
-  };
-
-  const jumpToVariant = (index: number) => {
-    setCurrentVariantIndex(index);
-  };
-
-  const handleSaveCurrentCrop = () => {
-    setErrorMsg('');
-    const draftCrop = cropStates[currentVariantType].draftAreaPixels;
-    if (!draftCrop || draftCrop.width <= 0 || draftCrop.height <= 0) {
-      setErrorMsg(`Crop area is not ready for ${formatVariantLabel(currentVariantType)}.`);
-      return false;
-    }
-
-    setCropStates(prev => ({
-      ...prev,
-      [currentVariantType]: {
-        ...prev[currentVariantType],
-        croppedAreaPixels: draftCrop,
-        completed: true,
-      }
-    }));
-    return true;
-  };
-
-  const handleSaveAndNext = () => {
-    const saved = handleSaveCurrentCrop();
-    if (saved && currentVariantIndex < VARIANT_SEQUENCE.length - 1) {
-      setCurrentVariantIndex(currentVariantIndex + 1);
-    }
-  };
-
-  const handleConfirmAll = async () => {
-    setErrorMsg('');
-    
-    // Check each variant
-    const missingCrops = VARIANT_SEQUENCE.filter(type => !cropStates[type].completed || !cropStates[type].croppedAreaPixels);
-    if (missingCrops.length > 0) {
-      setErrorMsg(`Missing crops for: ${missingCrops.join(', ')}`);
-      return;
-    }
-
-    setIsProcessing(true);
-    setErrorMsg('Creating image files...');
-
-    try {
-      const variantFiles = await createMultiVariantImages(
-        previewUrl,
-        cropStates,
-        file.name,
-        fileNamePrefix
-      );
-      onConfirm(variantFiles);
-    } catch (error) {
-      console.error('Error processing variants:', error);
-      const msg = error instanceof Error ? error.message : 'Unknown error';
-      setErrorMsg(`Error: ${msg}`);
-      alert('Failed to process image variants: ' + msg);
-      setIsProcessing(false);
-    }
-  };
-
-  const completedCount = VARIANT_SEQUENCE.filter(type => {
-    const state = cropStates[type];
-    return state.completed && state.croppedAreaPixels !== null && state.croppedAreaPixels.width > 0;
-  }).length;
-  const totalVariants = VARIANT_SEQUENCE.length;
-  const allCropsSaved = completedCount === totalVariants;
-  const currentCropSaved = currentState.completed && currentState.croppedAreaPixels !== null;
+  }
 
   return (
     <div className="stage-article-cropper-container">
-      {/* Header */}
-      <div style={{ 
-        padding: '1rem 1.25rem', 
-        borderBottom: '1px solid #27272a',
-        flexShrink: 0
-      }}>
-        <h3 style={{ fontSize: '1.125rem', fontWeight: 600, color: '#f4f4f5', margin: 0 }}>
-          Crop: {formatVariantLabel(currentVariantType)}
-        </h3>
-        <p style={{ fontSize: '0.875rem', color: '#71717a', margin: '0.25rem 0 0 0' }}>
-          Step {currentVariantIndex + 1} of {totalVariants} • Target: {currentSpec.width}×{currentSpec.height}px ({currentSpec.label})
-          {imageDimensions && ` • Source: ${imageDimensions.width}×${imageDimensions.height}`}
-        </p>
-      </div>
+      <CropperViewport
+        previewUrl={cropper.previewUrl}
+        imageDimensions={cropper.imageDimensions}
+        currentVariantIndex={cropper.currentVariantIndex}
+        currentVariantType={cropper.currentVariantType}
+        currentState={cropper.currentState}
+        onCropChange={cropper.onCropChange}
+        onZoomChange={cropper.onZoomChange}
+        onCropComplete={cropper.onCropComplete}
+      />
 
-      {/* Cropper area - Fixed height */}
-      <div className="stage-article-cropper-area" style={{ height: '280px' }}>
-        {previewUrl && (
-          <Cropper
-            image={previewUrl}
-            crop={currentState.crop}
-            zoom={currentState.zoom}
-            aspect={currentSpec.ratio}
-            onCropChange={onCropChange}
-            onZoomChange={onZoomChange}
-            onCropComplete={onCropComplete}
-            restrictPosition={true}
-            cropShape="rect"
-            showGrid={true}
-            style={{
-              containerStyle: { background: '#000', height: '100%' },
-              cropAreaStyle: { border: '2px solid #f36f2b' }
-            }}
-          />
-        )}
-      </div>
+      <div
+        className="stage-article-cropper-controls"
+        style={{ flexShrink: 0 }}
+      >
+        <VariantProgress
+          cropStates={cropper.cropStates}
+          currentVariantIndex={cropper.currentVariantIndex}
+          isProcessing={cropper.isProcessing}
+          onSelect={cropper.setCurrentVariantIndex}
+        />
 
-      {/* Controls */}
-      <div className="stage-article-cropper-controls" style={{ flexShrink: 0 }}>
-        {/* Variant progress badges */}
-        <div className="stage-article-cropper-variants">
-          {VARIANT_SEQUENCE.map((type, idx) => {
-            const isActive = idx === currentVariantIndex;
-            const isCompleted = cropStates[type].completed && cropStates[type].croppedAreaPixels !== null && cropStates[type].croppedAreaPixels!.width > 0;
-
-            return (
-              <button
-                key={type}
-                onClick={() => jumpToVariant(idx)}
-                disabled={isProcessing}
-                className={`stage-article-cropper-variant-btn ${isActive ? 'active' : isCompleted ? 'completed' : 'pending'}`}
-              >
-                {isCompleted && <CheckIcon />}
-                <span>{formatVariantLabel(type)}</span>
-                <span style={{ fontSize: '10px', opacity: 0.7 }}>({VARIANT_SPECS[type].label})</span>
-              </button>
-            );
-          })}
+        <div
+          style={{
+            fontSize: '0.75rem',
+            color: '#71717a',
+            textAlign: 'center',
+            marginBottom: '0.75rem',
+          }}
+        >
+          Zoom: {Math.round(cropper.currentState.zoom * 100)}% • Scroll or pinch
+          to zoom • Drag to move
         </div>
 
-        {/* Zoom info */}
-        <div style={{ fontSize: '0.75rem', color: '#71717a', textAlign: 'center', marginBottom: '0.75rem' }}>
-          Zoom: {Math.round(currentState.zoom * 100)}% • Scroll or pinch to zoom • Drag to move
-        </div>
-
-        {/* Error/Status message */}
-        {errorMsg && (
-          <div style={{ fontSize: '0.75rem', color: '#f36f2b', textAlign: 'center', marginBottom: '0.75rem' }}>
-            {errorMsg}
-          </div>
-        )}
-
-        {/* Footer buttons */}
-        <div className="stage-article-cropper-footer">
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <button
-              type="button"
-              onClick={handlePrevious}
-              disabled={currentVariantIndex === 0 || isProcessing}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.25rem',
-                padding: '0.5rem 0.75rem',
-                background: '#3f3f46',
-                color: '#d4d4d8',
-                border: 'none',
-                borderRadius: '0.5rem',
-                fontSize: '0.875rem',
-                cursor: currentVariantIndex === 0 || isProcessing ? 'not-allowed' : 'pointer',
-                opacity: currentVariantIndex === 0 || isProcessing ? 0.5 : 1
-              }}
-            >
-              <ChevronLeftIcon />
-              Previous
-            </button>
-            <button
-              type="button"
-              onClick={handleNext}
-              disabled={currentVariantIndex === VARIANT_SEQUENCE.length - 1 || isProcessing}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.25rem',
-                padding: '0.5rem 0.75rem',
-                background: '#3f3f46',
-                color: '#d4d4d8',
-                border: 'none',
-                borderRadius: '0.5rem',
-                fontSize: '0.875rem',
-                cursor: currentVariantIndex === VARIANT_SEQUENCE.length - 1 || isProcessing ? 'not-allowed' : 'pointer',
-                opacity: currentVariantIndex === VARIANT_SEQUENCE.length - 1 || isProcessing ? 0.5 : 1
-              }}
-            >
-              Next
-              <ChevronRightIcon />
-            </button>
-          </div>
-
-          <button
-            type="button"
-            onClick={handleSaveAndNext}
-            disabled={isProcessing || !currentState.draftAreaPixels}
+        {cropper.errorMsg && (
+          <div
             style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.5rem',
-              padding: '0.5rem 0.75rem',
-              background: currentCropSaved ? '#2f6f48' : '#f36f2b',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '0.5rem',
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              cursor: isProcessing || !currentState.draftAreaPixels ? 'not-allowed' : 'pointer',
-              opacity: isProcessing || !currentState.draftAreaPixels ? 0.5 : 1
+              fontSize: '0.75rem',
+              color: '#f36f2b',
+              textAlign: 'center',
+              marginBottom: '0.75rem',
             }}
           >
-            <CheckIcon />
-            {currentVariantIndex === VARIANT_SEQUENCE.length - 1 ? 'Save crop' : 'Save & Next'}
-          </button>
-
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <button
-              type="button"
-              onClick={onCancel}
-              disabled={isProcessing}
-              style={{
-                padding: '0.5rem 1rem',
-                background: '#3f3f46',
-                color: '#d4d4d8',
-                border: 'none',
-                borderRadius: '0.5rem',
-                fontSize: '0.875rem',
-                fontWeight: 500,
-                cursor: isProcessing ? 'not-allowed' : 'pointer',
-                opacity: isProcessing ? 0.5 : 1
-              }}
-            >
-              Cancel
-            </button>
-
-            <button
-              type="button"
-              onClick={handleConfirmAll}
-              disabled={isProcessing || !allCropsSaved}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.5rem',
-                padding: '0.5rem 1rem',
-                background: allCropsSaved ? '#f36f2b' : '#3f3f46',
-                color: allCropsSaved ? '#fff' : '#71717a',
-                border: 'none',
-                borderRadius: '0.5rem',
-                fontSize: '0.875rem',
-                fontWeight: 500,
-                cursor: isProcessing || !allCropsSaved ? 'not-allowed' : 'pointer',
-                opacity: isProcessing ? 0.5 : 1
-              }}
-            >
-              {isProcessing ? (
-                <>
-                  <LoaderIcon />
-                  Processing...
-                </>
-              ) : (
-                <>
-                  <CheckIcon />
-                  {allCropsSaved
-                    ? 'Generate crops'
-                    : `Saved ${completedCount}/${totalVariants}`}
-                </>
-              )}
-            </button>
+            {cropper.errorMsg}
           </div>
-        </div>
+        )}
+
+        <CropperFooter
+          currentVariantIndex={cropper.currentVariantIndex}
+          isProcessing={cropper.isProcessing}
+          currentCropReady={Boolean(cropper.currentState.draftAreaPixels)}
+          currentCropSaved={cropper.currentCropSaved}
+          allCropsSaved={cropper.allCropsSaved}
+          completedCount={cropper.completedCount}
+          onPrevious={showPrevious}
+          onNext={showNext}
+          onSaveAndNext={cropper.saveAndNext}
+          onCancel={onCancel}
+          onConfirm={() => void cropper.confirmAll()}
+        />
       </div>
     </div>
-  );
+  )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/CropperFooter.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/CropperFooter.tsx
@@ -1,0 +1,167 @@
+import { VARIANT_SEQUENCE } from '../../utils/imageProcessing'
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  LoaderIcon,
+} from './CropperIcons'
+
+type CropperFooterProps = {
+  currentVariantIndex: number
+  isProcessing: boolean
+  currentCropReady: boolean
+  currentCropSaved: boolean
+  allCropsSaved: boolean
+  completedCount: number
+  onPrevious: () => void
+  onNext: () => void
+  onSaveAndNext: () => void
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export function CropperFooter({
+  currentVariantIndex,
+  isProcessing,
+  currentCropReady,
+  currentCropSaved,
+  allCropsSaved,
+  completedCount,
+  onPrevious,
+  onNext,
+  onSaveAndNext,
+  onCancel,
+  onConfirm,
+}: CropperFooterProps) {
+  const isFirst = currentVariantIndex === 0
+  const isLast = currentVariantIndex === VARIANT_SEQUENCE.length - 1
+
+  return (
+    <div className="stage-article-cropper-footer">
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={onPrevious}
+          disabled={isFirst || isProcessing}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            padding: '0.5rem 0.75rem',
+            background: '#3f3f46',
+            color: '#d4d4d8',
+            border: 'none',
+            borderRadius: '0.5rem',
+            fontSize: '0.875rem',
+            cursor: isFirst || isProcessing ? 'not-allowed' : 'pointer',
+            opacity: isFirst || isProcessing ? 0.5 : 1,
+          }}
+        >
+          <ChevronLeftIcon />
+          Previous
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={isLast || isProcessing}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            padding: '0.5rem 0.75rem',
+            background: '#3f3f46',
+            color: '#d4d4d8',
+            border: 'none',
+            borderRadius: '0.5rem',
+            fontSize: '0.875rem',
+            cursor: isLast || isProcessing ? 'not-allowed' : 'pointer',
+            opacity: isLast || isProcessing ? 0.5 : 1,
+          }}
+        >
+          Next
+          <ChevronRightIcon />
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={onSaveAndNext}
+        disabled={isProcessing || !currentCropReady}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          padding: '0.5rem 0.75rem',
+          background: currentCropSaved ? '#2f6f48' : '#f36f2b',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '0.5rem',
+          fontSize: '0.875rem',
+          fontWeight: 500,
+          cursor:
+            isProcessing || !currentCropReady ? 'not-allowed' : 'pointer',
+          opacity: isProcessing || !currentCropReady ? 0.5 : 1,
+        }}
+      >
+        <CheckIcon />
+        {isLast ? 'Save crop' : 'Save & Next'}
+      </button>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isProcessing}
+          style={{
+            padding: '0.5rem 1rem',
+            background: '#3f3f46',
+            color: '#d4d4d8',
+            border: 'none',
+            borderRadius: '0.5rem',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            cursor: isProcessing ? 'not-allowed' : 'pointer',
+            opacity: isProcessing ? 0.5 : 1,
+          }}
+        >
+          Cancel
+        </button>
+
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={isProcessing || !allCropsSaved}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.5rem 1rem',
+            background: allCropsSaved ? '#f36f2b' : '#3f3f46',
+            color: allCropsSaved ? '#fff' : '#71717a',
+            border: 'none',
+            borderRadius: '0.5rem',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            cursor:
+              isProcessing || !allCropsSaved ? 'not-allowed' : 'pointer',
+            opacity: isProcessing ? 0.5 : 1,
+          }}
+        >
+          {isProcessing ? (
+            <>
+              <LoaderIcon />
+              Processing...
+            </>
+          ) : (
+            <>
+              <CheckIcon />
+              {allCropsSaved
+                ? 'Generate crops'
+                : `Saved ${completedCount}/${VARIANT_SEQUENCE.length}`}
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/CropperIcons.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/CropperIcons.tsx
@@ -1,0 +1,30 @@
+export const CheckIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+)
+
+export const ChevronLeftIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="15 18 9 12 15 6" />
+  </svg>
+)
+
+export const ChevronRightIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="9 18 15 12 9 6" />
+  </svg>
+)
+
+export const LoaderIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="animate-spin">
+    <line x1="12" y1="2" x2="12" y2="6" />
+    <line x1="12" y1="18" x2="12" y2="22" />
+    <line x1="4.93" y1="4.93" x2="7.76" y2="7.76" />
+    <line x1="16.24" y1="16.24" x2="19.07" y2="19.07" />
+    <line x1="2" y1="12" x2="6" y2="12" />
+    <line x1="18" y1="12" x2="22" y2="12" />
+    <line x1="4.93" y1="19.07" x2="7.76" y2="16.24" />
+    <line x1="16.24" y1="7.76" x2="19.07" y2="4.93" />
+  </svg>
+)

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/CropperViewport.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/CropperViewport.tsx
@@ -1,0 +1,88 @@
+import Cropper, { type Area, type Point } from 'react-easy-crop'
+import {
+  VARIANT_SPECS,
+  VARIANT_SEQUENCE,
+  type CropStates,
+  type ImageVariantType,
+} from '../../utils/imageProcessing'
+import { formatVariantLabel } from './cropper.utils'
+
+type CropperViewportProps = {
+  previewUrl: string
+  imageDimensions: { width: number; height: number } | null
+  currentVariantIndex: number
+  currentVariantType: ImageVariantType
+  currentState: CropStates[ImageVariantType]
+  onCropChange: (crop: Point) => void
+  onZoomChange: (zoom: number) => void
+  onCropComplete: (croppedArea: Area, croppedAreaPixels: Area) => void
+}
+
+export function CropperViewport({
+  previewUrl,
+  imageDimensions,
+  currentVariantIndex,
+  currentVariantType,
+  currentState,
+  onCropChange,
+  onZoomChange,
+  onCropComplete,
+}: CropperViewportProps) {
+  const spec = VARIANT_SPECS[currentVariantType]
+
+  return (
+    <>
+      <div
+        style={{
+          padding: '1rem 1.25rem',
+          borderBottom: '1px solid #27272a',
+          flexShrink: 0,
+        }}
+      >
+        <h3
+          style={{
+            fontSize: '1.125rem',
+            fontWeight: 600,
+            color: '#f4f4f5',
+            margin: 0,
+          }}
+        >
+          Crop: {formatVariantLabel(currentVariantType)}
+        </h3>
+        <p
+          style={{
+            fontSize: '0.875rem',
+            color: '#71717a',
+            margin: '0.25rem 0 0 0',
+          }}
+        >
+          Step {currentVariantIndex + 1} of {VARIANT_SEQUENCE.length} • Target:{' '}
+          {spec.width}×{spec.height}px ({spec.label})
+          {imageDimensions &&
+            ` • Source: ${imageDimensions.width}×${imageDimensions.height}`}
+        </p>
+      </div>
+
+      <div className="stage-article-cropper-area" style={{ height: '280px' }}>
+        {previewUrl && (
+          <Cropper
+            image={previewUrl}
+            crop={currentState.crop}
+            zoom={currentState.zoom}
+            aspect={spec.ratio}
+            onCropChange={onCropChange}
+            onZoomChange={onZoomChange}
+            onCropComplete={onCropComplete}
+            restrictPosition
+            cropShape="rect"
+            showGrid
+            style={{
+              containerStyle: { background: '#000', height: '100%' },
+              cropAreaStyle: { border: '2px solid #f36f2b' },
+            }}
+          />
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/VariantProgress.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/VariantProgress.tsx
@@ -1,0 +1,46 @@
+import {
+  VARIANT_SEQUENCE,
+  VARIANT_SPECS,
+  type CropStates,
+} from '../../utils/imageProcessing'
+import { CheckIcon } from './CropperIcons'
+import { formatVariantLabel, isVariantCropSaved } from './cropper.utils'
+
+type VariantProgressProps = {
+  cropStates: CropStates
+  currentVariantIndex: number
+  isProcessing: boolean
+  onSelect: (index: number) => void
+}
+
+export function VariantProgress({
+  cropStates,
+  currentVariantIndex,
+  isProcessing,
+  onSelect,
+}: VariantProgressProps) {
+  return (
+    <div className="stage-article-cropper-variants">
+      {VARIANT_SEQUENCE.map((type, index) => {
+        const isActive = index === currentVariantIndex
+        const isCompleted = isVariantCropSaved(cropStates, type)
+        return (
+          <button
+            key={type}
+            onClick={() => onSelect(index)}
+            disabled={isProcessing}
+            className={`stage-article-cropper-variant-btn ${
+              isActive ? 'active' : isCompleted ? 'completed' : 'pending'
+            }`}
+          >
+            {isCompleted && <CheckIcon />}
+            <span>{formatVariantLabel(type)}</span>
+            <span style={{ fontSize: '10px', opacity: 0.7 }}>
+              ({VARIANT_SPECS[type].label})
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/cropper.utils.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/cropper.utils.ts
@@ -1,0 +1,20 @@
+import type { CropStates, ImageVariantType } from '../../utils/imageProcessing'
+
+export function formatVariantLabel(variantType: ImageVariantType): string {
+  return variantType
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function isVariantCropSaved(
+  cropStates: CropStates,
+  variantType: ImageVariantType,
+): boolean {
+  const state = cropStates[variantType]
+  return Boolean(
+    state.completed &&
+      state.croppedAreaPixels &&
+      state.croppedAreaPixels.width > 0,
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/useMultiVariantCropper.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/multi-variant-cropper/useMultiVariantCropper.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Area, Point } from 'react-easy-crop'
+import {
+  VARIANT_SEQUENCE,
+  createMultiVariantImages,
+  initializeCropStates,
+  loadImage,
+  type CropStates,
+  type ImageVariantType,
+} from '../../utils/imageProcessing'
+import { formatVariantLabel, isVariantCropSaved } from './cropper.utils'
+
+type UseMultiVariantCropperOptions = {
+  file: File
+  fileNamePrefix?: string
+  onConfirm: (variantFiles: { type: ImageVariantType; file: File }[]) => void
+}
+
+export function useMultiVariantCropper({
+  file,
+  fileNamePrefix,
+  onConfirm,
+}: UseMultiVariantCropperOptions) {
+  const [previewUrl, setPreviewUrl] = useState('')
+  const [imageDimensions, setImageDimensions] = useState<{
+    width: number
+    height: number
+  } | null>(null)
+  const [currentVariantIndex, setCurrentVariantIndex] = useState(0)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [cropStates, setCropStates] = useState<CropStates>(initializeCropStates())
+  const [errorMsg, setErrorMsg] = useState('')
+  const currentVariantType = VARIANT_SEQUENCE[currentVariantIndex]
+  const currentState = cropStates[currentVariantType]
+
+  useEffect(() => {
+    let cancelled = false
+    const url = URL.createObjectURL(file)
+    setPreviewUrl(url)
+    setImageDimensions(null)
+    setCropStates(initializeCropStates())
+    setCurrentVariantIndex(0)
+    setErrorMsg('')
+
+    loadImage(url)
+      .then((image) => {
+        if (cancelled) return
+        const dimensions = {
+          width: image.naturalWidth,
+          height: image.naturalHeight,
+        }
+        setImageDimensions(dimensions)
+        setCropStates(initializeCropStates(dimensions.width, dimensions.height))
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setErrorMsg(error instanceof Error ? error.message : 'Failed to load image')
+        }
+      })
+
+    return () => {
+      cancelled = true
+      URL.revokeObjectURL(url)
+    }
+  }, [file])
+
+  const onCropChange = useCallback(
+    (crop: Point) => {
+      setCropStates((previous) => ({
+        ...previous,
+        [currentVariantType]: {
+          ...previous[currentVariantType],
+          crop,
+          croppedAreaPixels: null,
+          completed: false,
+        },
+      }))
+    },
+    [currentVariantType],
+  )
+
+  const onZoomChange = useCallback(
+    (zoom: number) => {
+      setCropStates((previous) => ({
+        ...previous,
+        [currentVariantType]: {
+          ...previous[currentVariantType],
+          zoom,
+          croppedAreaPixels: null,
+          completed: false,
+        },
+      }))
+    },
+    [currentVariantType],
+  )
+
+  const onCropComplete = useCallback(
+    (_croppedArea: Area, croppedAreaPixels: Area) => {
+      setCropStates((previous) => ({
+        ...previous,
+        [currentVariantType]: {
+          ...previous[currentVariantType],
+          draftAreaPixels: croppedAreaPixels,
+        },
+      }))
+    },
+    [currentVariantType],
+  )
+
+  const saveCurrentCrop = () => {
+    setErrorMsg('')
+    const draftCrop = cropStates[currentVariantType].draftAreaPixels
+    if (!draftCrop || draftCrop.width <= 0 || draftCrop.height <= 0) {
+      setErrorMsg(
+        `Crop area is not ready for ${formatVariantLabel(currentVariantType)}.`,
+      )
+      return false
+    }
+
+    setCropStates((previous) => ({
+      ...previous,
+      [currentVariantType]: {
+        ...previous[currentVariantType],
+        croppedAreaPixels: draftCrop,
+        completed: true,
+      },
+    }))
+    return true
+  }
+
+  const saveAndNext = () => {
+    if (
+      saveCurrentCrop() &&
+      currentVariantIndex < VARIANT_SEQUENCE.length - 1
+    ) {
+      setCurrentVariantIndex(currentVariantIndex + 1)
+    }
+  }
+
+  const confirmAll = async () => {
+    setErrorMsg('')
+    const missingCrops = VARIANT_SEQUENCE.filter(
+      (type) =>
+        !cropStates[type].completed || !cropStates[type].croppedAreaPixels,
+    )
+    if (missingCrops.length > 0) {
+      setErrorMsg(`Missing crops for: ${missingCrops.join(', ')}`)
+      return
+    }
+
+    setIsProcessing(true)
+    setErrorMsg('Creating image files...')
+    try {
+      onConfirm(
+        await createMultiVariantImages(
+          previewUrl,
+          cropStates,
+          file.name,
+          fileNamePrefix,
+        ),
+      )
+    } catch (error) {
+      console.error('Error processing variants:', error)
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      setErrorMsg(`Error: ${message}`)
+      alert(`Failed to process image variants: ${message}`)
+      setIsProcessing(false)
+    }
+  }
+
+  const completedCount = VARIANT_SEQUENCE.filter((type) =>
+    isVariantCropSaved(cropStates, type),
+  ).length
+
+  return {
+    previewUrl,
+    imageDimensions,
+    currentVariantIndex,
+    setCurrentVariantIndex,
+    currentVariantType,
+    currentState,
+    isProcessing,
+    cropStates,
+    errorMsg,
+    completedCount,
+    allCropsSaved: completedCount === VARIANT_SEQUENCE.length,
+    currentCropSaved:
+      currentState.completed && currentState.croppedAreaPixels !== null,
+    onCropChange,
+    onZoomChange,
+    onCropComplete,
+    saveAndNext,
+    confirmAll,
+  }
+}


### PR DESCRIPTION
## Summary
- reduce MultiVariantCropper from 419 lines to a 98-line composition shell
- isolate file loading and crop workflow state in a dedicated hook
- separate viewport, variant progress, navigation/generation footer, icons, and crop-state helpers
- preserve per-variant crop positions, explicit save semantics, seven-variant completion gating, object URL cleanup, and error handling

## Validation
- cropper interaction tests passed
- frontend boundary check and ESLint passed
- all 89 frontend test files / 347 tests passed
- production Vite build passed
- git diff check passed