### PR TITLE
NOJIRA: Decompose the shared image picker

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/ImagePicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/ImagePicker.tsx
@@ -1,384 +1,127 @@
-import { type MouseEvent, type ReactNode, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import {
-  ImageUpload,
-  type ImageVariantType,
-  type UploadImageResponse,
-} from '..'
-import { fetchMediaAssets } from '../../api/payload/payload.api'
-import type { MediaAsset, MediaSet } from '../../api/payload/payload.types'
-import { searchPexelsImages, searchUnsplashImages } from '../external/external-images.api'
 import type { PexelsPhoto, UnsplashPhoto } from '../external/external-images.types'
-import { getPexelsPhotoImportUrl, getUnsplashPhotoImportUrl } from '../external/external-import.utils'
-import type { ImagePickerQuery, ImagePickerResult, ImagePickerSelectionMode } from './imagePicker.types'
-import { pickUploadedAssetId } from './mediaSet.utils'
-import { useExternalImageImport } from './useExternalImageImport'
-import { useImagePickerData } from './useImagePickerData'
-import { useProviderImageSearch } from './useProviderImageSearch'
-import { useImagePickerSelectionBuffer } from './useImagePickerSelectionBuffer'
-import { buildUploadIdentity } from './imagePicker.utils'
-import { ImagePickerGrid } from './ImagePickerGrid'
-import { ExternalImagePanel, MultiSelectFooter } from './ExternalImagePanel'
+import {
+  getPexelsPhotoImportUrl,
+  getUnsplashPhotoImportUrl,
+} from '../external/external-import.utils'
+import { ExternalImagePanel } from './ExternalImagePanel'
+import { ImagePickerChrome } from './ImagePickerChrome'
+import { PayloadImagePanel } from './PayloadImagePanel'
+import { UploadImagePanel } from './UploadImagePanel'
+import type { ImagePickerProps } from './imagePicker.types'
+import { useImagePickerController } from './useImagePickerController'
+import { useImagePickerModalLifecycle } from './useImagePickerModalLifecycle'
 import './imagePicker.css'
 
-type ActiveTab = 'payload' | 'upload' | 'unsplash' | 'pexels'
+export type { ImagePickerProps } from './imagePicker.types'
 
-export type ImagePickerProps = {
-  isOpen: boolean
-  token?: string
-  /** Required for uploads/imports; when null those tabs show a notice. */
-  locationRef: number | null
-  /** Reactive filter that drives the Payload fetch (ADR 0020). */
-  query: ImagePickerQuery
-  /** Single (default) or exact-N multi-select. */
-  selection?: ImagePickerSelectionMode
-  /** Currently-persisted id, kept highlighted/hydrated. Single-select only. */
-  selectedId?: number | null
-  uploadExternalRefBase?: string
-  uploadFileNameTitle?: string
-  importExternalRefBase?: string
-  importFileNameTitle?: string
-  importAltContextLabel?: string
-  /** Caller-owned controls (caption, trio toggle) rendered above the grid. */
-  aboveGrid?: ReactNode
-  /** Hide upload/provider tabs; useful when only existing Payload records are valid inputs. */
-  payloadOnly?: boolean
-  /** Confirm-button label in multi mode, e.g. 'Add Img Trio'. */
-  confirmLabel?: string
-  onSelect: (result: ImagePickerResult) => void
-  onClose: () => void
-}
-
-export function ImagePicker({
-  isOpen,
-  token,
-  locationRef,
-  query,
-  selection = { mode: 'single' },
-  selectedId = null,
-  uploadExternalRefBase = 'image-picker',
-  uploadFileNameTitle = 'image',
-  importExternalRefBase,
-  importFileNameTitle,
-  importAltContextLabel = 'Image',
-  aboveGrid,
-  payloadOnly = false,
-  confirmLabel = 'Add selected',
-  onSelect,
-  onClose,
-}: ImagePickerProps) {
-  const isMulti = selection.mode === 'multiple'
-  const requiredCount = isMulti ? selection.count : 1
-  const uploadAvailable = !isMulti && !payloadOnly
-
-  const [activeTab, setActiveTab] = useState<ActiveTab>('payload')
-  const [search, setSearch] = useState('')
-  const [uploadIdentity, setUploadIdentity] = useState(() =>
-    buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle),
-  )
-
-  const buffer = useImagePickerSelectionBuffer(requiredCount)
-
-  const overlayRef = useRef<HTMLDivElement>(null)
-
-  const data = useImagePickerData({ isOpen, token, query, search, selectedId })
-  const unsplash = useProviderImageSearch<UnsplashPhoto>(searchUnsplashImages)
-  const pexels = useProviderImageSearch<PexelsPhoto>(searchPexelsImages)
-  const importer = useExternalImageImport({
+export function ImagePicker(props: ImagePickerProps) {
+  const {
+    isOpen,
     token,
     locationRef,
-    externalRefBase: importExternalRefBase ?? uploadExternalRefBase,
-    fileNameTitle: importFileNameTitle ?? uploadFileNameTitle,
-    altContextLabel: importAltContextLabel,
+    query,
+    selection = { mode: 'single' },
+    selectedId = null,
+    aboveGrid,
+    payloadOnly = false,
+    confirmLabel = 'Add selected',
+    onClose,
+  } = props
+  const controller = useImagePickerController({
+    ...props,
+    selection,
+    selectedId,
+    payloadOnly,
+    confirmLabel,
   })
-
-  // Reset transient UI each time the picker opens/closes.
-  useEffect(() => {
-    if (!isOpen) return
-    setActiveTab('payload')
-    setSearch('')
-    buffer.reset()
-    setUploadIdentity(buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle))
-    unsplash.reset()
-    pexels.reset()
-    importer.reset()
-    // Intentionally only on open transition.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
-
-  // Escape to close + lock background scroll while open.
-  useEffect(() => {
-    if (!isOpen) return
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        onClose()
-      }
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      document.body.style.overflow = previousOverflow
-    }
-  }, [isOpen, onClose])
+  const modal = useImagePickerModalLifecycle(isOpen, onClose)
 
   if (!isOpen) return null
 
-  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === overlayRef.current) onClose()
-  }
-
-  const switchTab = (next: ActiveTab) => {
-    if (payloadOnly && next !== 'payload') return
-    if (next !== activeTab) importer.reset()
-    if (next === 'upload') setUploadIdentity(buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle))
-    setActiveTab(next)
-  }
-
-  const emitAssets = (assets: MediaAsset[]) => onSelect({ kind: 'assets', assets })
-
-  const handlePayloadAssetClick = (asset: MediaAsset) => {
-    if (isMulti) {
-      buffer.addToBuffer(asset.id, asset, 'toggle')
-      return
-    }
-    emitAssets([asset])
-    onClose()
-  }
-
-  const handleMediaSetClick = (mediaSet: (typeof data.mediaSets)[number]) => {
-    if (isMulti) {
-      buffer.addMediaSetToBuffer(mediaSet)
-      return
-    }
-    onSelect({ kind: 'mediaSets', mediaSets: [mediaSet] })
-    onClose()
-  }
-
-  const handleUploadComplete = (response: UploadImageResponse) => {
-    onSelect({ kind: 'upload', response })
-    onClose()
-  }
-
-  const handleConfirmMulti = () => {
-    if (query.browseUnit === 'mediaSets') {
-      const mediaSets = buffer.bufferIds
-        .map((id) => buffer.bufferMediaSets.get(id))
-        .filter((mediaSet): mediaSet is MediaSet => Boolean(mediaSet))
-      if (mediaSets.length !== requiredCount) return
-      onSelect({ kind: 'mediaSets', mediaSets })
-      onClose()
-      return
-    }
-
-    const assets = buffer.bufferIds
-      .map((id) => buffer.bufferAssets.get(id))
-      .filter((asset): asset is MediaAsset => Boolean(asset))
-    if (assets.length !== requiredCount) return
-    emitAssets(assets)
-    onClose()
-  }
-
-  const handleExternalCropConfirm = async (
-    variantFiles: Array<{ type: ImageVariantType; file: File }>,
-  ) => {
-    const response = await importer.confirmUpload(variantFiles)
-    if (!response) return
-    if (!isMulti) {
-      onSelect({ kind: 'upload', response })
-      onClose()
-      return
-    }
-    // Multi: resolve the imported asset and push it into the shared buffer.
-    const assetId = pickUploadedAssetId(response, query.variant ?? undefined)
-    if (assetId === null || !token) return
-    try {
-      const res = await fetchMediaAssets(token, { limit: 1, id: assetId })
-      buffer.addToBuffer(assetId, res.docs[0] ?? null, 'rolling')
-    } catch {
-      // Import succeeded but resolution failed; the asset is still in Payload.
-    }
-  }
-
-  const tabTitle =
-    activeTab === 'payload'
-      ? 'Select from Payload Library'
-      : activeTab === 'upload'
-        ? 'Upload Image'
-        : activeTab === 'unsplash'
-          ? 'Search Unsplash'
-          : 'Search Pexels'
-
   return createPortal(
-    <div className="ip-overlay" ref={overlayRef} onClick={handleOverlayClick} role="presentation">
-      <div
-        className="ip-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Image picker"
-        onClick={(event) => event.stopPropagation()}
+    <div
+      className="ip-overlay"
+      ref={modal.overlayRef}
+      onClick={modal.handleOverlayClick}
+      role="presentation"
+    >
+      <ImagePickerChrome
+        activeTab={controller.activeTab}
+        payloadOnly={payloadOnly}
+        uploadAvailable={controller.uploadAvailable}
+        locationRef={locationRef}
+        query={query}
+        onTabChange={controller.switchTab}
+        onClose={onClose}
       >
-        <div className="ip-modal__header">
-          <h3>{tabTitle}</h3>
-          <button type="button" className="ip-modal__close" onClick={onClose} aria-label="Close">
-            ×
-          </button>
-        </div>
-
-        <div className="ip-tabs">
-          <button
-            type="button"
-            className={`ip-tab${activeTab === 'payload' ? ' ip-tab--active' : ''}`}
-            onClick={() => switchTab('payload')}
-          >
-            Payload Library
-          </button>
-          {!payloadOnly ? (
-            <>
-              <button
-                type="button"
-                className={`ip-tab${activeTab === 'upload' ? ' ip-tab--active' : ''}`}
-                onClick={() => switchTab('upload')}
-                disabled={!uploadAvailable || locationRef === null}
-                title={
-                  !uploadAvailable
-                    ? 'Upload is available for single-image selection only.'
-                    : locationRef === null
-                      ? 'Set a location to enable uploads.'
-                      : undefined
-                }
-              >
-                Upload
-              </button>
-              <button
-                type="button"
-                className={`ip-tab${activeTab === 'unsplash' ? ' ip-tab--active' : ''}`}
-                onClick={() => switchTab('unsplash')}
-              >
-                Unsplash
-              </button>
-              <button
-                type="button"
-                className={`ip-tab${activeTab === 'pexels' ? ' ip-tab--active' : ''}`}
-                onClick={() => switchTab('pexels')}
-              >
-                Pexels
-              </button>
-            </>
-          ) : null}
-        </div>
-
-        {query.requirementLabel && activeTab === 'payload' && (
-          <div className="ip-context-bar">
-            <span className="ip-context-chip">{query.browseUnit === 'mediaSets' ? 'Media Set' : 'Image'}</span>
-            <div className="ip-context-copy">
-              <span className="ip-context-label">Requirement</span>
-              <strong className="ip-context-value">{query.requirementLabel}</strong>
-            </div>
-          </div>
+        {controller.activeTab === 'payload' && (
+          <PayloadImagePanel
+            aboveGrid={aboveGrid}
+            query={query}
+            search={controller.search}
+            data={controller.data}
+            selectedId={selectedId}
+            bufferIds={
+              controller.isMulti ? controller.buffer.bufferIds : null
+            }
+            requiredCount={controller.requiredCount}
+            confirmLabel={confirmLabel}
+            onSearchChange={controller.setSearch}
+            onAssetClick={controller.handlePayloadAssetClick}
+            onMediaSetClick={controller.handleMediaSetClick}
+            onConfirmMulti={controller.handleConfirmMulti}
+          />
         )}
 
-        <div className="ip-body">
-          {activeTab === 'payload' && (
-            <>
-              {aboveGrid && <div className="ip-above-grid">{aboveGrid}</div>}
+        {controller.activeTab === 'upload' && (
+          <UploadImagePanel
+            locationRef={locationRef}
+            token={token}
+            uploadIdentity={controller.uploadIdentity}
+            onComplete={controller.handleUploadComplete}
+            onCancel={() => controller.switchTab('payload')}
+          />
+        )}
 
-              <div className="ip-search-row">
-                <input
-                  type="text"
-                  className="ip-search-input"
-                  placeholder={
-                    query.browseUnit === 'mediaSets'
-                      ? 'Search by title, location, or alt text...'
-                      : 'Search by filename or alt text...'
-                  }
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                />
-              </div>
+        {controller.activeTab === 'unsplash' && (
+          <ExternalImagePanel
+            provider="unsplash"
+            controller={controller.unsplash}
+            importUrl={(photo) =>
+              getUnsplashPhotoImportUrl(photo as UnsplashPhoto)
+            }
+            importer={controller.importer}
+            locationRef={locationRef}
+            isMulti={controller.isMulti}
+            bufferIds={controller.buffer.bufferIds}
+            requiredCount={controller.requiredCount}
+            confirmLabel={confirmLabel}
+            onConfirmMulti={controller.handleConfirmMulti}
+            onCropConfirm={(variantFiles) => {
+              void controller.handleExternalCropConfirm(variantFiles)
+            }}
+          />
+        )}
 
-              {data.error && <p className="ip-error">{data.error}</p>}
-
-              {data.isBootstrapping ? (
-                <p className="ip-empty">Loading image library...</p>
-              ) : (
-                <ImagePickerGrid
-                  data={data}
-                  browseUnit={query.browseUnit}
-                  selectedId={selectedId}
-                  bufferIds={isMulti ? buffer.bufferIds : null}
-                  onAssetClick={handlePayloadAssetClick}
-                  onMediaSetClick={handleMediaSetClick}
-                />
-              )}
-
-              {isMulti && (
-                <MultiSelectFooter
-                  selectedCount={buffer.bufferIds.length}
-                  requiredCount={requiredCount}
-                  confirmLabel={confirmLabel}
-                  onConfirm={handleConfirmMulti}
-                />
-              )}
-            </>
-          )}
-
-          {activeTab === 'upload' && (
-            <div className="ip-upload-pane">
-              {locationRef === null ? (
-                <p className="ip-notice">A location must be set before you can upload images.</p>
-              ) : (
-                <ImageUpload
-                  className="ip-upload-flow"
-                  externalRef={uploadIdentity.externalRef}
-                  fileNamePrefix={uploadIdentity.fileNamePrefix}
-                  locationRef={locationRef}
-                  token={token ?? ''}
-                  onComplete={handleUploadComplete}
-                  onCancel={() => switchTab('payload')}
-                />
-              )}
-            </div>
-          )}
-
-          {activeTab === 'unsplash' && (
-            <ExternalImagePanel
-              provider="unsplash"
-              controller={unsplash}
-              importUrl={(photo) => getUnsplashPhotoImportUrl(photo as UnsplashPhoto)}
-              importer={importer}
-              locationRef={locationRef}
-              isMulti={isMulti}
-              bufferIds={buffer.bufferIds}
-              requiredCount={requiredCount}
-              confirmLabel={confirmLabel}
-              onConfirmMulti={handleConfirmMulti}
-              onCropConfirm={(variantFiles) => {
-                void handleExternalCropConfirm(variantFiles)
-              }}
-            />
-          )}
-          {activeTab === 'pexels' && (
-            <ExternalImagePanel
-              provider="pexels"
-              controller={pexels}
-              importUrl={(photo) => getPexelsPhotoImportUrl(photo as PexelsPhoto)}
-              importer={importer}
-              locationRef={locationRef}
-              isMulti={isMulti}
-              bufferIds={buffer.bufferIds}
-              requiredCount={requiredCount}
-              confirmLabel={confirmLabel}
-              onConfirmMulti={handleConfirmMulti}
-              onCropConfirm={(variantFiles) => {
-                void handleExternalCropConfirm(variantFiles)
-              }}
-            />
-          )}
-        </div>
-      </div>
+        {controller.activeTab === 'pexels' && (
+          <ExternalImagePanel
+            provider="pexels"
+            controller={controller.pexels}
+            importUrl={(photo) => getPexelsPhotoImportUrl(photo as PexelsPhoto)}
+            importer={controller.importer}
+            locationRef={locationRef}
+            isMulti={controller.isMulti}
+            bufferIds={controller.buffer.bufferIds}
+            requiredCount={controller.requiredCount}
+            confirmLabel={confirmLabel}
+            onConfirmMulti={controller.handleConfirmMulti}
+            onCropConfirm={(variantFiles) => {
+              void controller.handleExternalCropConfirm(variantFiles)
+            }}
+          />
+        )}
+      </ImagePickerChrome>
     </div>,
     document.body,
   )

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/ImagePickerChrome.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/ImagePickerChrome.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react'
+import type { ImagePickerQuery, ImagePickerTab } from './imagePicker.types'
+
+type ImagePickerChromeProps = {
+  activeTab: ImagePickerTab
+  payloadOnly: boolean
+  uploadAvailable: boolean
+  locationRef: number | null
+  query: ImagePickerQuery
+  children: ReactNode
+  onTabChange: (tab: ImagePickerTab) => void
+  onClose: () => void
+}
+
+const tabTitles: Record<ImagePickerTab, string> = {
+  payload: 'Select from Payload Library',
+  upload: 'Upload Image',
+  unsplash: 'Search Unsplash',
+  pexels: 'Search Pexels',
+}
+
+export function ImagePickerChrome({
+  activeTab,
+  payloadOnly,
+  uploadAvailable,
+  locationRef,
+  query,
+  children,
+  onTabChange,
+  onClose,
+}: ImagePickerChromeProps) {
+  return (
+    <div
+      className="ip-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image picker"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="ip-modal__header">
+        <h3>{tabTitles[activeTab]}</h3>
+        <button
+          type="button"
+          className="ip-modal__close"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="ip-tabs">
+        <TabButton
+          label="Payload Library"
+          isActive={activeTab === 'payload'}
+          onClick={() => onTabChange('payload')}
+        />
+        {!payloadOnly ? (
+          <>
+            <TabButton
+              label="Upload"
+              isActive={activeTab === 'upload'}
+              onClick={() => onTabChange('upload')}
+              disabled={!uploadAvailable || locationRef === null}
+              title={
+                !uploadAvailable
+                  ? 'Upload is available for single-image selection only.'
+                  : locationRef === null
+                    ? 'Set a location to enable uploads.'
+                    : undefined
+              }
+            />
+            <TabButton
+              label="Unsplash"
+              isActive={activeTab === 'unsplash'}
+              onClick={() => onTabChange('unsplash')}
+            />
+            <TabButton
+              label="Pexels"
+              isActive={activeTab === 'pexels'}
+              onClick={() => onTabChange('pexels')}
+            />
+          </>
+        ) : null}
+      </div>
+
+      {query.requirementLabel && activeTab === 'payload' && (
+        <div className="ip-context-bar">
+          <span className="ip-context-chip">
+            {query.browseUnit === 'mediaSets' ? 'Media Set' : 'Image'}
+          </span>
+          <div className="ip-context-copy">
+            <span className="ip-context-label">Requirement</span>
+            <strong className="ip-context-value">{query.requirementLabel}</strong>
+          </div>
+        </div>
+      )}
+
+      <div className="ip-body">{children}</div>
+    </div>
+  )
+}
+
+function TabButton({
+  label,
+  isActive,
+  ...buttonProps
+}: {
+  label: string
+  isActive: boolean
+  onClick: () => void
+  disabled?: boolean
+  title?: string
+}) {
+  return (
+    <button
+      type="button"
+      className={`ip-tab${isActive ? ' ip-tab--active' : ''}`}
+      {...buttonProps}
+    >
+      {label}
+    </button>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/PayloadImagePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/PayloadImagePanel.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react'
+import type { MediaAsset, MediaSet } from '../../api/payload/payload.types'
+import type { ImagePickerQuery } from './imagePicker.types'
+import type { ImagePickerData } from './useImagePickerData'
+import { ImagePickerGrid } from './ImagePickerGrid'
+import { MultiSelectFooter } from './ExternalImagePanel'
+
+type PayloadImagePanelProps = {
+  aboveGrid?: ReactNode
+  query: ImagePickerQuery
+  search: string
+  data: ImagePickerData
+  selectedId: number | null
+  bufferIds: number[] | null
+  requiredCount: number
+  confirmLabel: string
+  onSearchChange: (search: string) => void
+  onAssetClick: (asset: MediaAsset) => void
+  onMediaSetClick: (mediaSet: MediaSet) => void
+  onConfirmMulti: () => void
+}
+
+export function PayloadImagePanel({
+  aboveGrid,
+  query,
+  search,
+  data,
+  selectedId,
+  bufferIds,
+  requiredCount,
+  confirmLabel,
+  onSearchChange,
+  onAssetClick,
+  onMediaSetClick,
+  onConfirmMulti,
+}: PayloadImagePanelProps) {
+  return (
+    <>
+      {aboveGrid && <div className="ip-above-grid">{aboveGrid}</div>}
+      <div className="ip-search-row">
+        <input
+          type="text"
+          className="ip-search-input"
+          placeholder={
+            query.browseUnit === 'mediaSets'
+              ? 'Search by title, location, or alt text...'
+              : 'Search by filename or alt text...'
+          }
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </div>
+
+      {data.error && <p className="ip-error">{data.error}</p>}
+      {data.isBootstrapping ? (
+        <p className="ip-empty">Loading image library...</p>
+      ) : (
+        <ImagePickerGrid
+          data={data}
+          browseUnit={query.browseUnit}
+          selectedId={selectedId}
+          bufferIds={bufferIds}
+          onAssetClick={onAssetClick}
+          onMediaSetClick={onMediaSetClick}
+        />
+      )}
+
+      {bufferIds && (
+        <MultiSelectFooter
+          selectedCount={bufferIds.length}
+          requiredCount={requiredCount}
+          confirmLabel={confirmLabel}
+          onConfirm={onConfirmMulti}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/UploadImagePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/UploadImagePanel.tsx
@@ -1,0 +1,38 @@
+import { ImageUpload } from '../components/ImageUpload'
+import type { UploadImageResponse } from '../api/imagesApi'
+
+type UploadImagePanelProps = {
+  locationRef: number | null
+  token?: string
+  uploadIdentity: { externalRef: string; fileNamePrefix: string }
+  onComplete: (response: UploadImageResponse) => void
+  onCancel: () => void
+}
+
+export function UploadImagePanel({
+  locationRef,
+  token,
+  uploadIdentity,
+  onComplete,
+  onCancel,
+}: UploadImagePanelProps) {
+  return (
+    <div className="ip-upload-pane">
+      {locationRef === null ? (
+        <p className="ip-notice">
+          A location must be set before you can upload images.
+        </p>
+      ) : (
+        <ImageUpload
+          className="ip-upload-flow"
+          externalRef={uploadIdentity.externalRef}
+          fileNamePrefix={uploadIdentity.fileNamePrefix}
+          locationRef={locationRef}
+          token={token ?? ''}
+          onComplete={onComplete}
+          onCancel={onCancel}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/imagePicker.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/imagePicker.types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { MediaAsset, MediaSet } from '../../api/payload/payload.types'
 import type { UploadImageResponse } from '../api/imagesApi'
 
@@ -44,3 +45,31 @@ export type ImagePickerResult =
   | { kind: 'assets'; assets: MediaAsset[] }
   | { kind: 'mediaSets'; mediaSets: MediaSet[] }
   | { kind: 'upload'; response: UploadImageResponse }
+
+export type ImagePickerProps = {
+  isOpen: boolean
+  token?: string
+  /** Required for uploads/imports; when null those tabs show a notice. */
+  locationRef: number | null
+  /** Reactive filter that drives the Payload fetch. */
+  query: ImagePickerQuery
+  /** Single (default) or exact-N multi-select. */
+  selection?: ImagePickerSelectionMode
+  /** Currently persisted id, kept highlighted/hydrated in single mode. */
+  selectedId?: number | null
+  uploadExternalRefBase?: string
+  uploadFileNameTitle?: string
+  importExternalRefBase?: string
+  importFileNameTitle?: string
+  importAltContextLabel?: string
+  /** Caller-owned controls rendered above the Payload grid. */
+  aboveGrid?: ReactNode
+  /** Restrict the picker to existing Payload records. */
+  payloadOnly?: boolean
+  /** Confirm-button label in exact-N multi mode. */
+  confirmLabel?: string
+  onSelect: (result: ImagePickerResult) => void
+  onClose: () => void
+}
+
+export type ImagePickerTab = 'payload' | 'upload' | 'unsplash' | 'pexels'

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerController.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerController.ts
@@ -1,0 +1,164 @@
+import { useEffect, useState } from 'react'
+import { fetchMediaAssets } from '../../api/payload/payload.api'
+import type { MediaAsset, MediaSet } from '../../api/payload/payload.types'
+import { searchPexelsImages, searchUnsplashImages } from '../external/external-images.api'
+import type { PexelsPhoto, UnsplashPhoto } from '../external/external-images.types'
+import type { UploadImageResponse } from '../api/imagesApi'
+import type { ImageVariantType } from '../utils/imageProcessing'
+import type {
+  ImagePickerProps,
+  ImagePickerTab,
+} from './imagePicker.types'
+import { buildUploadIdentity } from './imagePicker.utils'
+import { pickUploadedAssetId } from './mediaSet.utils'
+import { useExternalImageImport } from './useExternalImageImport'
+import { useImagePickerData } from './useImagePickerData'
+import { useImagePickerSelectionBuffer } from './useImagePickerSelectionBuffer'
+import { useProviderImageSearch } from './useProviderImageSearch'
+
+export function useImagePickerController({
+  isOpen,
+  token,
+  locationRef,
+  query,
+  selection = { mode: 'single' },
+  selectedId = null,
+  uploadExternalRefBase = 'image-picker',
+  uploadFileNameTitle = 'image',
+  importExternalRefBase,
+  importFileNameTitle,
+  importAltContextLabel = 'Image',
+  payloadOnly = false,
+  onSelect,
+  onClose,
+}: ImagePickerProps) {
+  const isMulti = selection.mode === 'multiple'
+  const requiredCount = isMulti ? selection.count : 1
+  const [activeTab, setActiveTab] = useState<ImagePickerTab>('payload')
+  const [search, setSearch] = useState('')
+  const [uploadIdentity, setUploadIdentity] = useState(() =>
+    buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle),
+  )
+  const buffer = useImagePickerSelectionBuffer(requiredCount)
+  const data = useImagePickerData({ isOpen, token, query, search, selectedId })
+  const unsplash = useProviderImageSearch<UnsplashPhoto>(searchUnsplashImages)
+  const pexels = useProviderImageSearch<PexelsPhoto>(searchPexelsImages)
+  const importer = useExternalImageImport({
+    token,
+    locationRef,
+    externalRefBase: importExternalRefBase ?? uploadExternalRefBase,
+    fileNameTitle: importFileNameTitle ?? uploadFileNameTitle,
+    altContextLabel: importAltContextLabel,
+  })
+
+  useEffect(() => {
+    if (!isOpen) return
+    setActiveTab('payload')
+    setSearch('')
+    buffer.reset()
+    setUploadIdentity(
+      buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle),
+    )
+    unsplash.reset()
+    pexels.reset()
+    importer.reset()
+    // Reset only on the open transition; controller methods are intentionally
+    // omitted because their identities follow transient state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
+  const switchTab = (next: ImagePickerTab) => {
+    if (payloadOnly && next !== 'payload') return
+    if (next !== activeTab) importer.reset()
+    if (next === 'upload') {
+      setUploadIdentity(
+        buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle),
+      )
+    }
+    setActiveTab(next)
+  }
+
+  const handlePayloadAssetClick = (asset: MediaAsset) => {
+    if (isMulti) {
+      buffer.addToBuffer(asset.id, asset, 'toggle')
+      return
+    }
+    onSelect({ kind: 'assets', assets: [asset] })
+    onClose()
+  }
+
+  const handleMediaSetClick = (mediaSet: MediaSet) => {
+    if (isMulti) {
+      buffer.addMediaSetToBuffer(mediaSet)
+      return
+    }
+    onSelect({ kind: 'mediaSets', mediaSets: [mediaSet] })
+    onClose()
+  }
+
+  const handleUploadComplete = (response: UploadImageResponse) => {
+    onSelect({ kind: 'upload', response })
+    onClose()
+  }
+
+  const handleConfirmMulti = () => {
+    if (query.browseUnit === 'mediaSets') {
+      const mediaSets = buffer.bufferIds
+        .map((id) => buffer.bufferMediaSets.get(id))
+        .filter((mediaSet): mediaSet is MediaSet => Boolean(mediaSet))
+      if (mediaSets.length !== requiredCount) return
+      onSelect({ kind: 'mediaSets', mediaSets })
+      onClose()
+      return
+    }
+
+    const assets = buffer.bufferIds
+      .map((id) => buffer.bufferAssets.get(id))
+      .filter((asset): asset is MediaAsset => Boolean(asset))
+    if (assets.length !== requiredCount) return
+    onSelect({ kind: 'assets', assets })
+    onClose()
+  }
+
+  const handleExternalCropConfirm = async (
+    variantFiles: Array<{ type: ImageVariantType; file: File }>,
+  ) => {
+    const response = await importer.confirmUpload(variantFiles)
+    if (!response) return
+    if (!isMulti) {
+      onSelect({ kind: 'upload', response })
+      onClose()
+      return
+    }
+
+    const assetId = pickUploadedAssetId(response, query.variant ?? undefined)
+    if (assetId === null || !token) return
+    try {
+      const result = await fetchMediaAssets(token, { limit: 1, id: assetId })
+      buffer.addToBuffer(assetId, result.docs[0] ?? null, 'rolling')
+    } catch {
+      // Import succeeded but resolution failed; the asset remains in Payload.
+    }
+  }
+
+  return {
+    activeTab,
+    search,
+    setSearch,
+    uploadIdentity,
+    isMulti,
+    requiredCount,
+    uploadAvailable: !isMulti && !payloadOnly,
+    data,
+    buffer,
+    unsplash,
+    pexels,
+    importer,
+    switchTab,
+    handlePayloadAssetClick,
+    handleMediaSetClick,
+    handleUploadComplete,
+    handleConfirmMulti,
+    handleExternalCropConfirm,
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerModalLifecycle.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerModalLifecycle.ts
@@ -1,0 +1,31 @@
+import { type MouseEvent, useEffect, useRef } from 'react'
+
+export function useImagePickerModalLifecycle(
+  isOpen: boolean,
+  onClose: () => void,
+) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [isOpen, onClose])
+
+  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === overlayRef.current) onClose()
+  }
+
+  return { overlayRef, handleOverlayClick }
+}


### PR DESCRIPTION
## Summary
- reduce ImagePicker from 385 lines to a 128-line composition layer
- isolate picker selection/import workflow in a controller hook and modal lifecycle in a focused hook
- separate modal chrome/tabs, Payload library browsing, and upload rendering
- retain the documented public props/result contract, reactive query behavior, exact-N selection, external imports, Escape/backdrop close, and scroll locking

## Validation
- frontend boundary check and ESLint passed
- all 89 frontend test files / 347 tests passed, including the eight picker data tests
- production Vite build passed
- git diff check passed