### PR TITLE
NOJIRA: Decompose the location homepage picker

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationPickerModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationPickerModal.tsx
@@ -1,234 +1,35 @@
-import { useEffect, useMemo, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { LocationPickerResults } from './location-picker/LocationPickerResults'
+import { useLocationPicker } from './location-picker/useLocationPicker'
 
-import { fetchLocationsIndex } from '../locationDocuments/api'
-import type { LocationIndexRow } from '../locationDocuments/types'
-
-const LOCATION_COLLATOR = new Intl.Collator('en', {
-  numeric: true,
-  sensitivity: 'base',
-})
-
-type ModalCityGroup = {
-  key: string
-  cityLabel: string
-  city: LocationIndexRow | null
-  neighborhoods: LocationIndexRow[]
-}
-
-type ModalCountryGroup = {
-  key: string
-  countryLabel: string
-  cityGroups: ModalCityGroup[]
-}
-
-type Props = {
+type LocationPickerModalProps = {
   token: string
   existingLocationIds: number[]
   onSelect: (locationId: number) => Promise<void>
   onClose: () => void
 }
 
-function getLocationDisplayLabel(loc: LocationIndexRow): string {
-  if (loc.level === 'neighborhood' && loc.neighborhoodName) {
-    return loc.cityName ? `${loc.neighborhoodName}, ${loc.cityName}` : loc.neighborhoodName
-  }
-
-  return loc.cityName ?? loc.countryName ?? loc.locationKey ?? String(loc.id)
-}
-
-function normalizeGroupValue(...values: Array<string | null | undefined>): string {
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim()
-    }
-  }
-
-  return ''
-}
-
-function getCountryLabel(loc: LocationIndexRow): string {
-  const keyParts = loc.locationKey?.split('|') ?? []
-  return normalizeGroupValue(loc.countryName, loc.country, keyParts[0]) || 'Unassigned country'
-}
-
-function getCityLabel(loc: LocationIndexRow): string {
-  const keyParts = loc.locationKey?.split('|') ?? []
-  return normalizeGroupValue(loc.cityName, loc.city, keyParts[1]) || 'Unassigned city'
-}
-
-function getLocationSearchText(loc: LocationIndexRow): string {
-  return [
-    getLocationDisplayLabel(loc),
-    loc.countryName,
-    loc.cityName,
-    loc.neighborhoodName,
-    loc.locationKey,
-    loc.level,
-  ]
-    .filter((value): value is string => Boolean(value?.trim()))
-    .join(' ')
-    .toLowerCase()
-}
-
-export function LocationPickerModal({ token, existingLocationIds, onSelect, onClose }: Props) {
-  const [searchValue, setSearchValue] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const cityQuery = useQuery({
-    queryKey: ['locations-city', token],
-    queryFn: () => fetchLocationsIndex(token, { level: 'city' }),
-    staleTime: 60_000,
+export function LocationPickerModal({
+  token,
+  existingLocationIds,
+  onSelect,
+  onClose,
+}: LocationPickerModalProps) {
+  const picker = useLocationPicker({
+    token,
+    existingLocationIds,
+    onSelect,
+    onClose,
   })
-
-  const neighborhoodQuery = useQuery({
-    queryKey: ['locations-neighborhood', token],
-    queryFn: () => fetchLocationsIndex(token, { level: 'neighborhood' }),
-    staleTime: 60_000,
-  })
-
-  const groupedLocations = useMemo(() => {
-    const existingSet = new Set(existingLocationIds)
-    const q = searchValue.trim().toLowerCase()
-    const countryMap = new Map<
-      string,
-      ModalCountryGroup & { cityMap: Map<string, ModalCityGroup> }
-    >()
-
-    const insertCity = (loc: LocationIndexRow) => {
-      const countryLabel = getCountryLabel(loc)
-      const cityLabel = getCityLabel(loc)
-      const countryKey = countryLabel.toLowerCase()
-      const cityKey = `${countryKey}::${cityLabel.toLowerCase()}`
-
-      let countryGroup = countryMap.get(countryKey)
-      if (!countryGroup) {
-        countryGroup = {
-          key: countryKey,
-          countryLabel,
-          cityGroups: [],
-          cityMap: new Map<string, ModalCityGroup>(),
-        }
-        countryMap.set(countryKey, countryGroup)
-      }
-
-      let cityGroup = countryGroup.cityMap.get(cityKey)
-      if (!cityGroup) {
-        cityGroup = {
-          key: cityKey,
-          cityLabel,
-          city: null,
-          neighborhoods: [],
-        }
-        countryGroup.cityMap.set(cityKey, cityGroup)
-        countryGroup.cityGroups.push(cityGroup)
-      }
-
-      if (loc.level === 'city') {
-        cityGroup.city = loc
-      } else {
-        cityGroup.neighborhoods.push(loc)
-      }
-    }
-
-    for (const city of cityQuery.data ?? []) {
-      if (existingSet.has(city.id)) continue
-      insertCity(city)
-    }
-
-    for (const neighborhood of neighborhoodQuery.data ?? []) {
-      if (existingSet.has(neighborhood.id)) continue
-      insertCity(neighborhood)
-    }
-
-    return Array.from(countryMap.values())
-      .map((countryGroup) => {
-        const cityGroups = countryGroup.cityGroups
-          .map((cityGroup) => {
-            const cityMatches = q.length === 0
-              || [
-                countryGroup.countryLabel,
-                cityGroup.cityLabel,
-                cityGroup.city?.locationKey,
-              ]
-                .filter((value): value is string => Boolean(value?.trim()))
-                .join(' ')
-                .toLowerCase()
-                .includes(q)
-
-            const matchingNeighborhoods = q.length === 0 || cityMatches
-              ? cityGroup.neighborhoods
-              : cityGroup.neighborhoods.filter((loc) => getLocationSearchText(loc).includes(q))
-
-            if (!cityMatches && matchingNeighborhoods.length === 0) {
-              return null
-            }
-
-            return {
-              ...cityGroup,
-              neighborhoods: [...matchingNeighborhoods].sort((left, right) =>
-                LOCATION_COLLATOR.compare(
-                  getLocationDisplayLabel(left),
-                  getLocationDisplayLabel(right),
-                ),
-              ),
-            }
-          })
-          .filter((group): group is ModalCityGroup => group !== null)
-          .sort((left, right) => LOCATION_COLLATOR.compare(left.cityLabel, right.cityLabel))
-
-        if (cityGroups.length === 0) return null
-
-        return {
-          key: countryGroup.key,
-          countryLabel: countryGroup.countryLabel,
-          cityGroups,
-        }
-      })
-      .filter((group): group is ModalCountryGroup => group !== null)
-      .sort((left, right) => LOCATION_COLLATOR.compare(left.countryLabel, right.countryLabel))
-  }, [cityQuery.data, neighborhoodQuery.data, existingLocationIds, searchValue])
-
-  const isLoading = cityQuery.isLoading || neighborhoodQuery.isLoading
-  const totalResults = groupedLocations.reduce(
-    (total, countryGroup) => total + countryGroup.cityGroups.reduce(
-      (cityTotal, cityGroup) => cityTotal + (cityGroup.city ? 1 : 0) + cityGroup.neighborhoods.length,
-      0,
-    ),
-    0,
-  )
-
-  async function handleSelect(locationId: number) {
-    setIsSubmitting(true)
-    setError(null)
-
-    try {
-      await onSelect(locationId)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create location homepage.')
-      setIsSubmitting(false)
-    }
-  }
-
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [onClose])
 
   return (
     <div className="hf-modal-backdrop" onClick={onClose}>
       <div
         className="hf-modal"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-label="Add Location Homepage"
       >
-        {/* ── Header ─────────────────────────────────────── */}
         <div className="hf-modal-top">
           <div className="hf-modal-title-row">
             <h2>Add Location Homepage</h2>
@@ -247,87 +48,24 @@ export function LocationPickerModal({ token, existingLocationIds, onSelect, onCl
             <input
               type="search"
               placeholder="Search cities or neighborhoods…"
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.target.value)}
+              value={picker.searchValue}
+              onChange={(event) => picker.setSearchValue(event.target.value)}
               autoFocus
             />
           </div>
 
-          {error && <p className="hf-modal-error">{error}</p>}
+          {picker.error && <p className="hf-modal-error">{picker.error}</p>}
         </div>
 
-        {/* ── Body ───────────────────────────────────────── */}
         <div className="hf-modal-body">
-          {isLoading ? (
-            <p className="hf-modal-empty">Loading locations…</p>
-          ) : totalResults === 0 ? (
-            <p className="hf-modal-empty">
-              {searchValue.trim()
-                ? 'No locations matched your search.'
-                : 'All available cities and neighborhoods already have a homepage.'}
-            </p>
-          ) : (
-            groupedLocations.map((countryGroup) => (
-              <section key={countryGroup.key} className="hf-modal-country-group">
-                <div className="hf-modal-group">{countryGroup.countryLabel}</div>
-
-                {countryGroup.cityGroups.map((cityGroup) => (
-                  <div key={cityGroup.key} className="hf-modal-city-group">
-                    <div className="hf-modal-city-group-header">
-                      <div>
-                        <p className="hf-modal-city-group-kicker">City</p>
-                        <h3>{cityGroup.cityLabel}</h3>
-                      </div>
-                    </div>
-
-                    {cityGroup.city ? (
-                      <button
-                        type="button"
-                        className="hf-modal-row hf-modal-row-city"
-                        onClick={() => handleSelect(cityGroup.city!.id)}
-                        disabled={isSubmitting}
-                      >
-                        <span className="hf-modal-row-copy">
-                          <span className="hf-modal-row-name">{getLocationDisplayLabel(cityGroup.city)}</span>
-                        </span>
-                        <span className="hf-modal-row-meta">
-                          {cityGroup.city.locationKey && (
-                            <span className="hf-modal-row-key">{cityGroup.city.locationKey}</span>
-                          )}
-                          <span className="hf-level-tag">city</span>
-                        </span>
-                      </button>
-                    ) : null}
-
-                    {cityGroup.neighborhoods.length > 0 ? (
-                      <div className="hf-modal-neighborhood-stack">
-                        <div className="hf-modal-neighborhood-label">Neighborhoods</div>
-                        {cityGroup.neighborhoods.map((loc) => (
-                          <button
-                            key={loc.id}
-                            type="button"
-                            className="hf-modal-row hf-modal-row-child"
-                            onClick={() => handleSelect(loc.id)}
-                            disabled={isSubmitting}
-                          >
-                            <span className="hf-modal-row-copy">
-                              <span className="hf-modal-row-name">{getLocationDisplayLabel(loc)}</span>
-                            </span>
-                            <span className="hf-modal-row-meta">
-                              {loc.locationKey && (
-                                <span className="hf-modal-row-key">{loc.locationKey}</span>
-                              )}
-                              <span className="hf-level-tag">neighborhood</span>
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    ) : null}
-                  </div>
-                ))}
-              </section>
-            ))
-          )}
+          <LocationPickerResults
+            groups={picker.groupedLocations}
+            isLoading={picker.isLoading}
+            totalResults={picker.totalResults}
+            searchValue={picker.searchValue}
+            isSubmitting={picker.isSubmitting}
+            onSelect={(locationId) => void picker.selectLocation(locationId)}
+          />
         </div>
       </div>
     </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/LocationPickerResults.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/LocationPickerResults.tsx
@@ -1,0 +1,104 @@
+import {
+  getLocationDisplayLabel,
+  type ModalCountryGroup,
+} from './location-groups'
+
+type LocationPickerResultsProps = {
+  groups: ModalCountryGroup[]
+  isLoading: boolean
+  totalResults: number
+  searchValue: string
+  isSubmitting: boolean
+  onSelect: (locationId: number) => void
+}
+
+export function LocationPickerResults({
+  groups,
+  isLoading,
+  totalResults,
+  searchValue,
+  isSubmitting,
+  onSelect,
+}: LocationPickerResultsProps) {
+  if (isLoading) {
+    return <p className="hf-modal-empty">Loading locations…</p>
+  }
+  if (totalResults === 0) {
+    return (
+      <p className="hf-modal-empty">
+        {searchValue.trim()
+          ? 'No locations matched your search.'
+          : 'All available cities and neighborhoods already have a homepage.'}
+      </p>
+    )
+  }
+
+  return groups.map((countryGroup) => (
+    <section key={countryGroup.key} className="hf-modal-country-group">
+      <div className="hf-modal-group">{countryGroup.countryLabel}</div>
+
+      {countryGroup.cityGroups.map((cityGroup) => (
+        <div key={cityGroup.key} className="hf-modal-city-group">
+          <div className="hf-modal-city-group-header">
+            <div>
+              <p className="hf-modal-city-group-kicker">City</p>
+              <h3>{cityGroup.cityLabel}</h3>
+            </div>
+          </div>
+
+          {cityGroup.city ? (
+            <button
+              type="button"
+              className="hf-modal-row hf-modal-row-city"
+              onClick={() => onSelect(cityGroup.city!.id)}
+              disabled={isSubmitting}
+            >
+              <span className="hf-modal-row-copy">
+                <span className="hf-modal-row-name">
+                  {getLocationDisplayLabel(cityGroup.city)}
+                </span>
+              </span>
+              <span className="hf-modal-row-meta">
+                {cityGroup.city.locationKey && (
+                  <span className="hf-modal-row-key">
+                    {cityGroup.city.locationKey}
+                  </span>
+                )}
+                <span className="hf-level-tag">city</span>
+              </span>
+            </button>
+          ) : null}
+
+          {cityGroup.neighborhoods.length > 0 ? (
+            <div className="hf-modal-neighborhood-stack">
+              <div className="hf-modal-neighborhood-label">Neighborhoods</div>
+              {cityGroup.neighborhoods.map((location) => (
+                <button
+                  key={location.id}
+                  type="button"
+                  className="hf-modal-row hf-modal-row-child"
+                  onClick={() => onSelect(location.id)}
+                  disabled={isSubmitting}
+                >
+                  <span className="hf-modal-row-copy">
+                    <span className="hf-modal-row-name">
+                      {getLocationDisplayLabel(location)}
+                    </span>
+                  </span>
+                  <span className="hf-modal-row-meta">
+                    {location.locationKey && (
+                      <span className="hf-modal-row-key">
+                        {location.locationKey}
+                      </span>
+                    )}
+                    <span className="hf-level-tag">neighborhood</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </section>
+  ))
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/location-groups.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/location-groups.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { LocationIndexRow } from '../../locationDocuments/types'
+import { countGroupedLocations, groupLocationOptions } from './location-groups'
+
+const city = {
+  id: 1,
+  level: 'city',
+  countryName: 'Peru',
+  cityName: 'Lima',
+  locationKey: 'peru|lima',
+} as LocationIndexRow
+
+const barranco = {
+  id: 2,
+  level: 'neighborhood',
+  countryName: 'Peru',
+  cityName: 'Lima',
+  neighborhoodName: 'Barranco',
+  locationKey: 'peru|lima|barranco',
+} as LocationIndexRow
+
+const miraflores = {
+  id: 3,
+  level: 'neighborhood',
+  countryName: 'Peru',
+  cityName: 'Lima',
+  neighborhoodName: 'Miraflores',
+  locationKey: 'peru|lima|miraflores',
+} as LocationIndexRow
+
+describe('groupLocationOptions', () => {
+  it('excludes existing locations and keeps deterministic neighborhood order', () => {
+    const groups = groupLocationOptions(
+      [city],
+      [miraflores, barranco],
+      [miraflores.id],
+      '',
+    )
+
+    expect(groups[0]?.cityGroups[0]?.city?.id).toBe(city.id)
+    expect(groups[0]?.cityGroups[0]?.neighborhoods.map((row) => row.id)).toEqual([
+      barranco.id,
+    ])
+    expect(countGroupedLocations(groups)).toBe(2)
+  })
+
+  it('keeps the parent city record when only a neighborhood matches search', () => {
+    const groups = groupLocationOptions(
+      [city],
+      [barranco, miraflores],
+      [],
+      'Barranco',
+    )
+
+    expect(groups[0]?.cityGroups[0]?.city?.id).toBe(city.id)
+    expect(groups[0]?.cityGroups[0]?.neighborhoods.map((row) => row.id)).toEqual([
+      barranco.id,
+    ])
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/location-groups.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/location-groups.ts
@@ -1,0 +1,195 @@
+import type { LocationIndexRow } from '../../locationDocuments/types'
+
+const LOCATION_COLLATOR = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+export type ModalCityGroup = {
+  key: string
+  cityLabel: string
+  city: LocationIndexRow | null
+  neighborhoods: LocationIndexRow[]
+}
+
+export type ModalCountryGroup = {
+  key: string
+  countryLabel: string
+  cityGroups: ModalCityGroup[]
+}
+
+export function getLocationDisplayLabel(loc: LocationIndexRow): string {
+  if (loc.level === 'neighborhood' && loc.neighborhoodName) {
+    return loc.cityName
+      ? `${loc.neighborhoodName}, ${loc.cityName}`
+      : loc.neighborhoodName
+  }
+  return loc.cityName ?? loc.countryName ?? loc.locationKey ?? String(loc.id)
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function getCountryLabel(loc: LocationIndexRow): string {
+  const keyParts = loc.locationKey?.split('|') ?? []
+  return (
+    firstNonEmpty(loc.countryName, loc.country, keyParts[0]) ||
+    'Unassigned country'
+  )
+}
+
+function getCityLabel(loc: LocationIndexRow): string {
+  const keyParts = loc.locationKey?.split('|') ?? []
+  return (
+    firstNonEmpty(loc.cityName, loc.city, keyParts[1]) || 'Unassigned city'
+  )
+}
+
+function getLocationSearchText(loc: LocationIndexRow): string {
+  return [
+    getLocationDisplayLabel(loc),
+    loc.countryName,
+    loc.cityName,
+    loc.neighborhoodName,
+    loc.locationKey,
+    loc.level,
+  ]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(' ')
+    .toLowerCase()
+}
+
+export function groupLocationOptions(
+  cities: LocationIndexRow[],
+  neighborhoods: LocationIndexRow[],
+  existingLocationIds: number[],
+  searchValue: string,
+): ModalCountryGroup[] {
+  const existingSet = new Set(existingLocationIds)
+  const query = searchValue.trim().toLowerCase()
+  const countryMap = new Map<
+    string,
+    ModalCountryGroup & { cityMap: Map<string, ModalCityGroup> }
+  >()
+
+  const insertLocation = (location: LocationIndexRow) => {
+    const countryLabel = getCountryLabel(location)
+    const cityLabel = getCityLabel(location)
+    const countryKey = countryLabel.toLowerCase()
+    const cityKey = `${countryKey}::${cityLabel.toLowerCase()}`
+
+    let countryGroup = countryMap.get(countryKey)
+    if (!countryGroup) {
+      countryGroup = {
+        key: countryKey,
+        countryLabel,
+        cityGroups: [],
+        cityMap: new Map<string, ModalCityGroup>(),
+      }
+      countryMap.set(countryKey, countryGroup)
+    }
+
+    let cityGroup = countryGroup.cityMap.get(cityKey)
+    if (!cityGroup) {
+      cityGroup = {
+        key: cityKey,
+        cityLabel,
+        city: null,
+        neighborhoods: [],
+      }
+      countryGroup.cityMap.set(cityKey, cityGroup)
+      countryGroup.cityGroups.push(cityGroup)
+    }
+
+    if (location.level === 'city') cityGroup.city = location
+    else cityGroup.neighborhoods.push(location)
+  }
+
+  for (const city of cities) {
+    if (!existingSet.has(city.id)) insertLocation(city)
+  }
+  for (const neighborhood of neighborhoods) {
+    if (!existingSet.has(neighborhood.id)) insertLocation(neighborhood)
+  }
+
+  return Array.from(countryMap.values())
+    .map((countryGroup) => filterCountryGroup(countryGroup, query))
+    .filter((group): group is ModalCountryGroup => group !== null)
+    .sort((left, right) =>
+      LOCATION_COLLATOR.compare(left.countryLabel, right.countryLabel),
+    )
+}
+
+function filterCountryGroup(
+  countryGroup: ModalCountryGroup,
+  query: string,
+): ModalCountryGroup | null {
+  const cityGroups = countryGroup.cityGroups
+    .map((cityGroup) => filterCityGroup(countryGroup, cityGroup, query))
+    .filter((group): group is ModalCityGroup => group !== null)
+    .sort((left, right) =>
+      LOCATION_COLLATOR.compare(left.cityLabel, right.cityLabel),
+    )
+
+  return cityGroups.length > 0
+    ? {
+        key: countryGroup.key,
+        countryLabel: countryGroup.countryLabel,
+        cityGroups,
+      }
+    : null
+}
+
+function filterCityGroup(
+  countryGroup: ModalCountryGroup,
+  cityGroup: ModalCityGroup,
+  query: string,
+): ModalCityGroup | null {
+  const cityMatches =
+    query.length === 0 ||
+    [
+      countryGroup.countryLabel,
+      cityGroup.cityLabel,
+      cityGroup.city?.locationKey,
+    ]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join(' ')
+      .toLowerCase()
+      .includes(query)
+  const matchingNeighborhoods =
+    query.length === 0 || cityMatches
+      ? cityGroup.neighborhoods
+      : cityGroup.neighborhoods.filter((location) =>
+          getLocationSearchText(location).includes(query),
+        )
+
+  if (!cityMatches && matchingNeighborhoods.length === 0) return null
+  return {
+    ...cityGroup,
+    neighborhoods: [...matchingNeighborhoods].sort((left, right) =>
+      LOCATION_COLLATOR.compare(
+        getLocationDisplayLabel(left),
+        getLocationDisplayLabel(right),
+      ),
+    ),
+  }
+}
+
+export function countGroupedLocations(groups: ModalCountryGroup[]): number {
+  return groups.reduce(
+    (total, countryGroup) =>
+      total +
+      countryGroup.cityGroups.reduce(
+        (cityTotal, cityGroup) =>
+          cityTotal +
+          (cityGroup.city ? 1 : 0) +
+          cityGroup.neighborhoods.length,
+        0,
+      ),
+    0,
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/useLocationPicker.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/useLocationPicker.ts
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchLocationsIndex } from '../../locationDocuments/api'
+import {
+  countGroupedLocations,
+  groupLocationOptions,
+} from './location-groups'
+
+type UseLocationPickerOptions = {
+  token: string
+  existingLocationIds: number[]
+  onSelect: (locationId: number) => Promise<void>
+  onClose: () => void
+}
+
+export function useLocationPicker({
+  token,
+  existingLocationIds,
+  onSelect,
+  onClose,
+}: UseLocationPickerOptions) {
+  const [searchValue, setSearchValue] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const cityQuery = useQuery({
+    queryKey: ['locations-city', token],
+    queryFn: () => fetchLocationsIndex(token, { level: 'city' }),
+    staleTime: 60_000,
+  })
+  const neighborhoodQuery = useQuery({
+    queryKey: ['locations-neighborhood', token],
+    queryFn: () => fetchLocationsIndex(token, { level: 'neighborhood' }),
+    staleTime: 60_000,
+  })
+
+  const groupedLocations = useMemo(
+    () =>
+      groupLocationOptions(
+        cityQuery.data ?? [],
+        neighborhoodQuery.data ?? [],
+        existingLocationIds,
+        searchValue,
+      ),
+    [
+      cityQuery.data,
+      neighborhoodQuery.data,
+      existingLocationIds,
+      searchValue,
+    ],
+  )
+
+  const selectLocation = async (locationId: number) => {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await onSelect(locationId)
+    } catch (selectionError) {
+      setError(
+        selectionError instanceof Error
+          ? selectionError.message
+          : 'Failed to create location homepage.',
+      )
+      setIsSubmitting(false)
+    }
+  }
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  return {
+    searchValue,
+    setSearchValue,
+    isSubmitting,
+    error,
+    groupedLocations,
+    isLoading: cityQuery.isLoading || neighborhoodQuery.isLoading,
+    totalResults: countGroupedLocations(groupedLocations),
+    selectLocation,
+  }
+}


### PR DESCRIPTION
## Summary
- reduce `LocationPickerModal.tsx` from 335 lines to a 73-line dialog composition shell
- isolate location querying and selection workflow in a dedicated hook
- extract deterministic grouping, search, counting, and result rendering from the modal
- add regression coverage for exclusions, ordering, counts, and neighborhood-only search

## Validation
- `pnpm exec nx run @questurian/abw-client:test` (90 files, 349 tests)
- `pnpm exec nx run @questurian/abw-client:lint`
- `pnpm exec nx run @questurian/abw-client:build`