### PR TITLE
NOJIRA: Split editorial stage screen view model

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleMediaController.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleMediaController.ts
@@ -1,0 +1,90 @@
+import {
+  useCallback,
+  useEffect,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
+import type { EditorialStageArticleApi } from '../types'
+import { getImageTimelineItemId } from '../workflow.service'
+import type { EditorialStageArticleWorkspace } from './useEditorialStageArticleWorkspace'
+import { useEditorialStageMedia } from './useEditorialStageMedia'
+
+type UseEditorialStageArticleMediaControllerParams = {
+  token: string | null | undefined
+  api: EditorialStageArticleApi
+  workspace: EditorialStageArticleWorkspace
+}
+
+export function useEditorialStageArticleMediaController({
+  token,
+  api,
+  workspace,
+}: UseEditorialStageArticleMediaControllerParams) {
+  const media = useEditorialStageMedia({
+    token,
+    stagedArticle: workspace.page.stagedArticle,
+    locations: workspace.page.locations,
+    mediaAssets: workspace.page.mediaAssets,
+    mergeMediaAssetsIntoState: workspace.page.mergeMediaAssetsIntoState,
+    fetchMediaAssets: api.fetchMediaAssets,
+    fetchExternalImageSource: api.fetchExternalImageSource,
+    searchPexelsImages: api.searchPexelsImages,
+    searchUnsplashImages: api.searchUnsplashImages,
+    updateStagedArticle: workspace.page.updateStagedArticle,
+    setPublishResult: workspace.setPublishResult,
+    setActiveEditingTimelineItemId: workspace.timeline.setActiveEditingTimelineItemId,
+    getImageTimelineItemId,
+    addImageAfterBlock: workspace.blocks.addImageAfterBlock,
+    clearOpenImagePickerTarget: () => workspace.dispatchUi({ type: 'CLOSE_IMAGE_PICKER' }),
+  })
+  const { dispatchUi } = workspace
+  const { showImageModal, setShowImageModal } = media.featured
+  const {
+    blockImageModal,
+    openBlockImageModal,
+    closeBlockImageModal,
+  } = media.block
+
+  useEffect(() => {
+    dispatchUi({
+      type: 'SYNC_MODAL_FLAGS',
+      featuredOpen: showImageModal,
+      blockOpen: Boolean(blockImageModal?.show),
+      cropOpen: false,
+    })
+  }, [
+    showImageModal,
+    blockImageModal?.show,
+    dispatchUi,
+  ])
+
+  const setShowImageModalTracked: Dispatch<SetStateAction<boolean>> = useCallback((next) => {
+    const resolved = typeof next === 'function'
+      ? next(showImageModal)
+      : next
+    setShowImageModal(resolved)
+  }, [showImageModal, setShowImageModal])
+
+  const openBlockImageModalTracked = useCallback((
+    blockId: string,
+    mode: Parameters<typeof openBlockImageModal>[1],
+    options?: Parameters<typeof openBlockImageModal>[2],
+  ) => {
+    openBlockImageModal(blockId, mode, options)
+  }, [openBlockImageModal])
+
+  const closeBlockImageModalTracked = useCallback(() => {
+    closeBlockImageModal()
+  }, [closeBlockImageModal])
+
+  return {
+    ...media,
+    setShowImageModalTracked,
+    openBlockImageModalTracked,
+    closeBlockImageModalTracked,
+  }
+}
+
+export type EditorialStageArticleMediaController = ReturnType<
+  typeof useEditorialStageArticleMediaController
+>

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticlePublishing.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticlePublishing.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react'
+import type { EditorialStageArticleApi, EditorialStageRoutes } from '../types'
+import type { EditorialStageArticleMediaController } from './useEditorialStageArticleMediaController'
+import type { EditorialStageArticleWorkspace } from './useEditorialStageArticleWorkspace'
+import { useEditorialStagePublishWorkflow } from './useEditorialStagePublishWorkflow'
+
+type UseEditorialStageArticlePublishingParams = {
+  token: string | null | undefined
+  routes: EditorialStageRoutes
+  api: EditorialStageArticleApi
+  workspace: EditorialStageArticleWorkspace
+  media: EditorialStageArticleMediaController
+}
+
+export function useEditorialStageArticlePublishing({
+  token,
+  routes,
+  api,
+  workspace,
+  media,
+}: UseEditorialStageArticlePublishingParams) {
+  const publishWorkflow = useEditorialStagePublishWorkflow({
+    token,
+    // Route prefixes double as feature keys ('/url2blog/stage-article' -> 'url2blog'),
+    // matching the backend API prefixes for each blog-writer pipeline.
+    sourceFeature: routes.stageArticlePath.split('/')[1] ?? '',
+    stagedArticle: workspace.page.stagedArticle,
+    locations: workspace.page.locations,
+    mediaAssets: workspace.page.mediaAssets,
+    timelineItems: workspace.timeline.timelineItems,
+    editorialPublishAnalysis: workspace.editorialPublishAnalysis,
+    convertMarkdownToLexical: api.convertMarkdownToLexical,
+    createArticle: api.createArticle,
+    updateArticle: api.updateArticle,
+    markArticleSynced: api.markArticleSynced,
+    findPreferredVariantAsset: media.shared.findPreferredVariantAsset,
+    updateStagedArticle: workspace.page.updateStagedArticle,
+    dispatchUi: workspace.dispatchUi,
+    publishPhase: workspace.uiState.publishPhase,
+    publishResult: workspace.uiState.publishResult,
+  })
+  const { flushStagedArticleSaves } = workspace.page
+  const { handlePublish: handlePublishInner } = publishWorkflow
+
+  const handlePublish = useCallback(async (targetStatus: 'draft' | 'published') => {
+    await flushStagedArticleSaves()
+    await handlePublishInner(targetStatus)
+  }, [flushStagedArticleSaves, handlePublishInner])
+
+  return {
+    isPublishing: publishWorkflow.isPublishing,
+    isConverting: publishWorkflow.isConverting,
+    publishResult: publishWorkflow.publishResult,
+    handlePublish,
+  }
+}
+
+export type EditorialStageArticlePublishing = ReturnType<
+  typeof useEditorialStageArticlePublishing
+>

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleScreenViewModel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleScreenViewModel.tsx
@@ -1,71 +1,17 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  type Dispatch,
-  type SetStateAction,
-} from 'react'
-import type { StagedArticle } from '../../../types'
-import { createEmptySeoSection } from '../../../../../shared/seo/services/seo-section.service'
-import {
-  createInitialEditorialStageUiState,
-  editorialStageUiReducer,
-} from '../state/editorialStageUiMachine'
+import { useMemo } from 'react'
+import type { EditorialStageArticlePageProps } from '../types'
 import type {
-  EditorialStageArticlePageProps,
-  SupportedEditorialComponent,
-} from '../types'
-import { buildEditorialPublishAnalysis } from '../editorial-markdown.service'
-import { getImageTimelineItemId } from '../workflow.service'
-import { useEditorialStageBlocks } from './useEditorialStageBlocks'
-import { useEditorialStageMedia } from './useEditorialStageMedia'
-import { useEditorialStagePageData } from './useEditorialStagePageData'
-import { useEditorialStagePublishWorkflow } from './useEditorialStagePublishWorkflow'
-import { useEditorialStageTimeline } from './useEditorialStageTimeline'
+  EditorialStageArticleScreenViewModel,
+  EditorialStageStatusView,
+} from '../view-model/types'
+import { EMPTY_STAGED_ARTICLE } from '../view-model/empty-staged-article'
+import { useEditorialStageArticleMediaController } from './useEditorialStageArticleMediaController'
+import { useEditorialStageArticlePublishing } from './useEditorialStageArticlePublishing'
+import { useEditorialStageArticleWorkspace } from './useEditorialStageArticleWorkspace'
 import { useEditorialStageLoadedArticleViews } from './useEditorialStageLoadedArticleViews'
-import type { EditorialStageArticleScreenViewModel, EditorialStageStatusView } from '../view-model/types'
-import type { PublishResult } from '../selectors'
 
 type UseEditorialStageArticleScreenViewModelParams = EditorialStageArticlePageProps & {
   token: string | null | undefined
-}
-
-const EMPTY_STAGED_ARTICLE: StagedArticle = {
-  id: '',
-  runId: '',
-  originalTitle: '',
-  originalContent: '',
-  originalType: '',
-  title: '',
-  content: '',
-  blocks: [],
-  editorialBlocks: [],
-  sharedNeighborhoods: [],
-  seoSection: createEmptySeoSection(),
-  syncBehavior: 'finalize',
-  lexicalConverted: false,
-  publishedToPayload: false,
-  hasUnsyncedPayloadChanges: false,
-  payloadStatus: undefined,
-  payloadSlug: undefined,
-  payloadPublishedAt: undefined,
-  payloadUpdatedAt: undefined,
-  payloadAuthorName: undefined,
-  createdAt: '',
-  updatedAt: '',
-}
-
-function useSetPublishResult(
-  currentResult: PublishResult,
-  dispatchUi: (event: { type: 'SET_PUBLISH_RESULT'; result: PublishResult }) => void
-): Dispatch<SetStateAction<PublishResult>> {
-  return useCallback((next) => {
-    const result = typeof next === 'function'
-      ? next(currentResult)
-      : next
-    dispatchUi({ type: 'SET_PUBLISH_RESULT', result })
-  }, [currentResult, dispatchUi])
 }
 
 export function useEditorialStageArticleScreenViewModel({
@@ -75,408 +21,46 @@ export function useEditorialStageArticleScreenViewModel({
   token,
   syncBehavior,
 }: UseEditorialStageArticleScreenViewModelParams): EditorialStageArticleScreenViewModel {
-  const {
-    fetchLocations,
-    fetchMediaAssets,
-    createArticle,
-    updateArticle,
-    getArticleById,
-    convertMarkdownToLexical,
-    fetchResult,
-    markArticleSynced,
-    getArticleSyncStatus,
-    fetchExternalImageSource,
-    searchPexelsImages,
-    searchUnsplashImages,
-    rewriteBlockWithAi,
-  } = api
-
-  const [uiState, dispatchUi] = useReducer(editorialStageUiReducer, undefined, createInitialEditorialStageUiState)
-  const setPublishResult = useSetPublishResult(uiState.publishResult, dispatchUi)
-
-  const {
-    locations,
-    mediaAssets,
-    isLoading,
-    error,
-    stagedArticle,
-    saveConflict,
-    updateStagedArticle,
-    flushStagedArticleSaves,
-    handleDelete,
-    mergeMediaAssetsIntoState,
-  } = useEditorialStagePageData({
+  const workspace = useEditorialStageArticleWorkspace({
     storageKey,
-    stageArticlePath: routes.stageArticlePath,
-    stagePath: routes.stagePath,
+    routes,
+    api,
     token,
     syncBehavior,
-    api: {
-      fetchResult,
-      fetchLocations,
-      fetchMediaAssets,
-      getArticleSyncStatus,
-      getArticleById,
-    },
   })
-
-  const {
-    activeEditingTimelineItemId,
-    setActiveEditingTimelineItemId,
-    timelineItems,
-    toggleTimelineItemEdit,
-    moveTimelineItem,
-    draggedTimelineItemId,
-    dragOverTimelineItemId,
-    handleDragStart,
-    handleDragEnd,
-    handleDragOver,
-    handleDragLeave,
-    handleDrop,
-  } = useEditorialStageTimeline({
-    stagedArticle,
-    updateStagedArticle,
-  })
-
-  const editorialPublishAnalysis = useMemo(
-    () => buildEditorialPublishAnalysis(stagedArticle?.editorialBlocks || []),
-    [stagedArticle?.editorialBlocks]
-  )
-
-  const {
-    fixEditorialBlock,
-    updateEditorialBlockMarkdown,
-    removeEditorialBlock,
-    updateBlockContent,
-    rewriteTextBlockWithAi,
-    addImageAfterBlock,
-    addImgPairAfterBlock,
-    addImgTrioAfterBlock,
-    updateMediaGroupCaption,
-    removeImageAfterBlock,
-    removeImgPairAfterBlock,
-    removeImgTrioAfterBlock,
-    mergeWithNextBlock,
-    resetToOriginalBlocks,
-    findHeaderSplitPoints,
-    splitBlockAtHeader,
-    addNewBlock,
-    addNewEditorialBlock,
-    deleteBlock,
-  } = useEditorialStageBlocks({
-    stagedArticle,
-    timelineItems,
-    updateStagedArticle,
-    setPublishResult,
-    setActiveEditingTimelineItemId,
-    rewriteBlockWithAi,
-  })
-
-  const toggleEditorialPicker = useCallback((target: string) => {
-    dispatchUi({ type: 'TOGGLE_EDITORIAL_PICKER', target })
-  }, [])
-
-  const toggleImagePicker = useCallback((target: string) => {
-    dispatchUi({ type: 'TOGGLE_IMAGE_PICKER', target })
-  }, [])
-
-  const addEditorialFromPicker = useCallback((
-    component: SupportedEditorialComponent,
-    afterBlockId?: string,
-    placeAfterImage?: boolean
-  ) => {
-    void placeAfterImage
-    addNewEditorialBlock(component, afterBlockId)
-    dispatchUi({ type: 'CLOSE_EDITORIAL_PICKER' })
-  }, [addNewEditorialBlock])
-
-  const {
-    featured: {
-      featuredImageUploadExternalRef,
-      featuredImageFileNamePrefix,
-      showImageModal,
-      setShowImageModal,
-      featuredImageSource,
-      setFeaturedImageSource,
-      imageSearch,
-      setImageSearch,
-      unsplashFeaturedQuery,
-      setUnsplashFeaturedQuery,
-      unsplashFeaturedResults,
-      isSearchingUnsplashFeatured,
-      unsplashFeaturedError,
-      unsplashFeaturedOrientation,
-      setUnsplashFeaturedOrientation,
-      unsplashFeaturedPerPage,
-      setUnsplashFeaturedPerPage,
-      pexelsFeaturedQuery,
-      setPexelsFeaturedQuery,
-      pexelsFeaturedResults,
-      isSearchingPexelsFeatured,
-      pexelsFeaturedError,
-      pexelsFeaturedOrientation,
-      setPexelsFeaturedOrientation,
-      pexelsFeaturedPerPage,
-      setPexelsFeaturedPerPage,
-      isImportingFeaturedExternalImage,
-      runFeaturedUnsplashSearch,
-      runFeaturedPexelsSearch,
-    },
-    block: {
-      blockImageModal,
-      blockImageSource,
-      setBlockImageSource,
-      blockImageSearch,
-      setBlockImageSearch,
-      imgBlockAssets,
-      isLoadingImgBlockAssets,
-      imgBlockAssetsError,
-      hasMoreImgBlockAssets,
-      loadMoreImgBlockAssets,
-      selectedImgBlockAssetIds,
-      toggleImgBlockAssetSelection,
-      imgBlockCaption,
-      setImgBlockCaption,
-      imgTrioFormat,
-      setImgTrioFormat,
-      unsplashBlockQuery,
-      setUnsplashBlockQuery,
-      unsplashBlockResults,
-      isSearchingUnsplashBlock,
-      unsplashBlockError,
-      unsplashBlockOrientation,
-      setUnsplashBlockOrientation,
-      unsplashBlockPerPage,
-      setUnsplashBlockPerPage,
-      pexelsBlockQuery,
-      setPexelsBlockQuery,
-      pexelsBlockResults,
-      isSearchingPexelsBlock,
-      pexelsBlockError,
-      pexelsBlockOrientation,
-      setPexelsBlockOrientation,
-      pexelsBlockPerPage,
-      setPexelsBlockPerPage,
-      openBlockImageModal,
-      closeBlockImageModal,
-      isImportingBlockExternalImage,
-      runBlockUnsplashSearch,
-      runBlockPexelsSearch,
-    },
-    shared: {
-      findPreferredVariantAsset,
-    },
-  } = useEditorialStageMedia({
+  const media = useEditorialStageArticleMediaController({ token, api, workspace })
+  const publishing = useEditorialStageArticlePublishing({
     token,
-    stagedArticle,
-    locations,
-    mediaAssets,
-    mergeMediaAssetsIntoState,
-    fetchMediaAssets,
-    fetchExternalImageSource,
-    searchPexelsImages,
-    searchUnsplashImages,
-    updateStagedArticle,
-    setPublishResult,
-    setActiveEditingTimelineItemId,
-    getImageTimelineItemId,
-    addImageAfterBlock,
-    clearOpenImagePickerTarget: () => dispatchUi({ type: 'CLOSE_IMAGE_PICKER' }),
+    routes,
+    api,
+    workspace,
+    media,
   })
-
-  useEffect(() => {
-    dispatchUi({
-      type: 'SYNC_MODAL_FLAGS',
-      featuredOpen: showImageModal,
-      blockOpen: Boolean(blockImageModal?.show),
-      cropOpen: false,
-    })
-  }, [showImageModal, blockImageModal?.show, dispatchUi])
-
-  const setShowImageModalTracked: Dispatch<SetStateAction<boolean>> = useCallback((next) => {
-    const resolved = typeof next === 'function'
-      ? next(showImageModal)
-      : next
-    setShowImageModal(resolved)
-  }, [showImageModal, setShowImageModal])
-
-  const openBlockImageModalTracked = useCallback((
-    blockId: string,
-    mode: Parameters<typeof openBlockImageModal>[1],
-    options?: Parameters<typeof openBlockImageModal>[2]
-  ) => {
-    openBlockImageModal(blockId, mode, options)
-  }, [openBlockImageModal])
-
-  const closeBlockImageModalTracked = useCallback(() => {
-    closeBlockImageModal()
-  }, [closeBlockImageModal])
-
-  const {
-    handlePublish: handlePublishInner,
-    isPublishing,
-    isConverting,
-    publishResult,
-  } = useEditorialStagePublishWorkflow({
-    token,
-    // Route prefixes double as feature keys ('/url2blog/stage-article' -> 'url2blog'),
-    // matching the backend API prefixes for each blog-writer pipeline.
-    sourceFeature: routes.stageArticlePath.split('/')[1] ?? '',
-    stagedArticle,
-    locations,
-    mediaAssets,
-    timelineItems,
-    editorialPublishAnalysis,
-    convertMarkdownToLexical,
-    createArticle,
-    updateArticle,
-    markArticleSynced,
-    findPreferredVariantAsset,
-    updateStagedArticle,
-    dispatchUi,
-    publishPhase: uiState.publishPhase,
-    publishResult: uiState.publishResult,
-  })
-
-  // Ensure any pending debounced draft save lands before publishing so the
-  // published document reflects the latest local edits.
-  const handlePublish = useCallback(async (targetStatus: 'draft' | 'published') => {
-    await flushStagedArticleSaves()
-    await handlePublishInner(targetStatus)
-  }, [flushStagedArticleSaves, handlePublishInner])
 
   const status: EditorialStageStatusView = useMemo(() => ({
-    isLoading,
-    error,
-    stagedArticle,
+    isLoading: workspace.page.isLoading,
+    error: workspace.page.error,
+    stagedArticle: workspace.page.stagedArticle,
     articlesPath: routes.articlesPath,
-    saveConflict,
-  }), [isLoading, error, stagedArticle, routes.articlesPath, saveConflict])
-
-  const resolvedStagedArticle = stagedArticle ?? EMPTY_STAGED_ARTICLE
+    saveConflict: workspace.page.saveConflict,
+  }), [
+    workspace.page.isLoading,
+    workspace.page.error,
+    workspace.page.stagedArticle,
+    workspace.page.saveConflict,
+    routes.articlesPath,
+  ])
 
   const loadedViews = useEditorialStageLoadedArticleViews({
-    stagedArticle: resolvedStagedArticle,
+    stagedArticle: workspace.page.stagedArticle ?? EMPTY_STAGED_ARTICLE,
     stagePath: routes.stagePath,
     token,
-    locations,
-    mediaAssets,
-    timelineItems,
-    activeEditingTimelineItemId,
-    setActiveEditingTimelineItemId,
-    draggedTimelineItemId,
-    dragOverTimelineItemId,
-    handleDragStart,
-    handleDragEnd,
-    handleDragOver,
-    handleDragLeave,
-    handleDrop,
-    moveTimelineItem,
-    toggleTimelineItemEdit,
-    editorialPublishAnalysis,
-    fixEditorialBlock,
-    updateEditorialBlockMarkdown,
-    removeEditorialBlock,
-    updateBlockContent,
-    rewriteTextBlockWithAi,
-    addImageAfterBlock,
-    addImgPairAfterBlock,
-    addImgTrioAfterBlock,
-    updateMediaGroupCaption,
-    removeImageAfterBlock,
-    removeImgPairAfterBlock,
-    removeImgTrioAfterBlock,
-    mergeWithNextBlock,
-    resetToOriginalBlocks,
-    findHeaderSplitPoints,
-    splitBlockAtHeader,
-    addNewBlock,
-    addNewEditorialBlock: addEditorialFromPicker,
-    deleteBlock,
-    updateStagedArticle,
-    handleDelete,
-    isConverting,
-    isPublishing,
-    publishResult,
-    setPublishResult,
-    openImagePickerTarget: uiState.pickers.openImageTarget,
-    openEditorialPickerTarget: uiState.pickers.openEditorialTarget,
-    toggleImagePicker,
-    toggleEditorialPicker,
-    showImageModal,
-    setShowImageModalTracked,
-    featuredImageUploadExternalRef,
-    featuredImageFileNamePrefix,
-    featuredImageSource,
-    setFeaturedImageSource,
-    imageSearch,
-    setImageSearch,
-    unsplashFeaturedQuery,
-    setUnsplashFeaturedQuery,
-    unsplashFeaturedResults,
-    isSearchingUnsplashFeatured,
-    unsplashFeaturedError,
-    unsplashFeaturedOrientation,
-    setUnsplashFeaturedOrientation,
-    unsplashFeaturedPerPage,
-    setUnsplashFeaturedPerPage,
-    pexelsFeaturedQuery,
-    setPexelsFeaturedQuery,
-    pexelsFeaturedResults,
-    isSearchingPexelsFeatured,
-    pexelsFeaturedError,
-    pexelsFeaturedOrientation,
-    setPexelsFeaturedOrientation,
-    pexelsFeaturedPerPage,
-    setPexelsFeaturedPerPage,
-    isImportingFeaturedExternalImage,
-    runFeaturedUnsplashSearch,
-    runFeaturedPexelsSearch,
-    blockImageModal,
-    blockImageSource,
-    setBlockImageSource,
-    blockImageSearch,
-    setBlockImageSearch,
-    imgBlockAssets,
-    isLoadingImgBlockAssets,
-    imgBlockAssetsError,
-    hasMoreImgBlockAssets,
-    loadMoreImgBlockAssets,
-    selectedImgBlockAssetIds,
-    toggleImgBlockAssetSelection,
-    imgBlockCaption,
-    setImgBlockCaption,
-    imgTrioFormat,
-    setImgTrioFormat,
-    unsplashBlockQuery,
-    setUnsplashBlockQuery,
-    unsplashBlockResults,
-    isSearchingUnsplashBlock,
-    unsplashBlockError,
-    unsplashBlockOrientation,
-    setUnsplashBlockOrientation,
-    unsplashBlockPerPage,
-    setUnsplashBlockPerPage,
-    pexelsBlockQuery,
-    setPexelsBlockQuery,
-    pexelsBlockResults,
-    isSearchingPexelsBlock,
-    pexelsBlockError,
-    pexelsBlockOrientation,
-    setPexelsBlockOrientation,
-    pexelsBlockPerPage,
-    setPexelsBlockPerPage,
-    openBlockImageModalTracked,
-    closeBlockImageModalTracked,
-    isImportingBlockExternalImage,
-    runBlockUnsplashSearch,
-    runBlockPexelsSearch,
-    mergeMediaAssetsIntoState,
-    findPreferredVariantAsset,
-    handlePublish,
+    workspace,
+    media,
+    publishing,
   })
 
-  if (isLoading || !stagedArticle || error) {
+  if (workspace.page.isLoading || !workspace.page.stagedArticle || workspace.page.error) {
     return {
       status,
       layout: null,
@@ -489,10 +73,6 @@ export function useEditorialStageArticleScreenViewModel({
 
   return {
     status,
-    layout: loadedViews.layout,
-    timelineListProps: loadedViews.timelineListProps,
-    sidebarProps: loadedViews.sidebarProps,
-    featuredModalProps: loadedViews.featuredModalProps,
-    blockModalProps: loadedViews.blockModalProps,
+    ...loadedViews,
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleWorkspace.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleWorkspace.ts
@@ -1,0 +1,116 @@
+import {
+  useCallback,
+  useMemo,
+  useReducer,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
+import type { EditorialStageArticlePageProps, SupportedEditorialComponent } from '../types'
+import { buildEditorialPublishAnalysis } from '../editorial-markdown.service'
+import type { PublishResult } from '../selectors'
+import {
+  createInitialEditorialStageUiState,
+  editorialStageUiReducer,
+} from '../state/editorialStageUiMachine'
+import { useEditorialStageBlocks } from './useEditorialStageBlocks'
+import { useEditorialStagePageData } from './useEditorialStagePageData'
+import { useEditorialStageTimeline } from './useEditorialStageTimeline'
+
+type UseEditorialStageArticleWorkspaceParams = EditorialStageArticlePageProps & {
+  token: string | null | undefined
+}
+
+function useSetPublishResult(
+  currentResult: PublishResult,
+  dispatchUi: (event: { type: 'SET_PUBLISH_RESULT'; result: PublishResult }) => void,
+): Dispatch<SetStateAction<PublishResult>> {
+  return useCallback((next) => {
+    const result = typeof next === 'function' ? next(currentResult) : next
+    dispatchUi({ type: 'SET_PUBLISH_RESULT', result })
+  }, [currentResult, dispatchUi])
+}
+
+export function useEditorialStageArticleWorkspace({
+  storageKey,
+  routes,
+  api,
+  token,
+  syncBehavior,
+}: UseEditorialStageArticleWorkspaceParams) {
+  const [uiState, dispatchUi] = useReducer(
+    editorialStageUiReducer,
+    undefined,
+    createInitialEditorialStageUiState,
+  )
+  const setPublishResult = useSetPublishResult(uiState.publishResult, dispatchUi)
+
+  const page = useEditorialStagePageData({
+    storageKey,
+    stageArticlePath: routes.stageArticlePath,
+    stagePath: routes.stagePath,
+    token,
+    syncBehavior,
+    api: {
+      fetchResult: api.fetchResult,
+      fetchLocations: api.fetchLocations,
+      fetchMediaAssets: api.fetchMediaAssets,
+      getArticleSyncStatus: api.getArticleSyncStatus,
+      getArticleById: api.getArticleById,
+    },
+  })
+
+  const timeline = useEditorialStageTimeline({
+    stagedArticle: page.stagedArticle,
+    updateStagedArticle: page.updateStagedArticle,
+  })
+
+  const editorialPublishAnalysis = useMemo(
+    () => buildEditorialPublishAnalysis(page.stagedArticle?.editorialBlocks || []),
+    [page.stagedArticle?.editorialBlocks],
+  )
+
+  const blocks = useEditorialStageBlocks({
+    stagedArticle: page.stagedArticle,
+    timelineItems: timeline.timelineItems,
+    updateStagedArticle: page.updateStagedArticle,
+    setPublishResult,
+    setActiveEditingTimelineItemId: timeline.setActiveEditingTimelineItemId,
+    rewriteBlockWithAi: api.rewriteBlockWithAi,
+  })
+
+  const toggleEditorialPicker = useCallback((target: string) => {
+    dispatchUi({ type: 'TOGGLE_EDITORIAL_PICKER', target })
+  }, [])
+
+  const toggleImagePicker = useCallback((target: string) => {
+    dispatchUi({ type: 'TOGGLE_IMAGE_PICKER', target })
+  }, [])
+
+  const { addNewEditorialBlock } = blocks
+  const addEditorialFromPicker = useCallback((
+    component: SupportedEditorialComponent,
+    afterBlockId?: string,
+    placeAfterImage?: boolean,
+  ) => {
+    void placeAfterImage
+    addNewEditorialBlock(component, afterBlockId)
+    dispatchUi({ type: 'CLOSE_EDITORIAL_PICKER' })
+  }, [addNewEditorialBlock])
+
+  return {
+    page,
+    timeline,
+    blocks,
+    editorialPublishAnalysis,
+    uiState,
+    dispatchUi,
+    setPublishResult,
+    toggleEditorialPicker,
+    toggleImagePicker,
+    addEditorialFromPicker,
+  }
+}
+
+export type EditorialStageArticleWorkspace = ReturnType<
+  typeof useEditorialStageArticleWorkspace
+>

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageLoadedArticleViews.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageLoadedArticleViews.tsx
@@ -1,7 +1,4 @@
-import { type Dispatch, type SetStateAction } from 'react'
 import type { StagedArticle } from '../../../types'
-import type { Location, MediaAsset } from '../../../api'
-import type { TimelineItem } from '../workflow.service'
 import { getMediaAssetUrl } from '../utils/editorial-stage-view.utils'
 import {
   buildBlockModalView,
@@ -12,7 +9,6 @@ import {
   type FeaturedModalViewProps,
   type SidebarViewProps,
   type TimelineListViewProps,
-  type PublishResult,
 } from '../selectors'
 import { getImageTimelineItemId } from '../workflow.service'
 import { useEditorialStageDerivedState } from './useEditorialStageDerivedState'
@@ -20,165 +16,17 @@ import { useEditorialStageImageBlockAction } from './useEditorialStageImageBlock
 import type {
   EditorialStageLayoutView,
 } from '../view-model/types'
-import type {
-  BlockImageModalState,
-  ImgTrioFormat,
-  MediaVariant,
-  SupportedEditorialComponent,
-  OpenBlockImageModalOptions,
-  PexelsOrientationOption,
-  ImageSourceOption,
-} from '../types'
-import type { PexelsPhoto, UnsplashPhoto } from '../../../api'
-import type { EditorialPublishAnalysis } from '../editorial-markdown.service'
+import type { EditorialStageArticleWorkspace } from './useEditorialStageArticleWorkspace'
+import type { EditorialStageArticleMediaController } from './useEditorialStageArticleMediaController'
+import type { EditorialStageArticlePublishing } from './useEditorialStageArticlePublishing'
 
 type UseEditorialStageLoadedArticleViewsParams = {
   stagedArticle: StagedArticle
   stagePath: string
   token: string | null | undefined
-  locations: Location[]
-  mediaAssets: MediaAsset[]
-  timelineItems: TimelineItem[]
-  activeEditingTimelineItemId: string | null
-  setActiveEditingTimelineItemId: Dispatch<SetStateAction<string | null>>
-  draggedTimelineItemId: string | null
-  dragOverTimelineItemId: string | null
-  handleDragStart: (e: React.DragEvent, timelineItemId: string) => void
-  handleDragEnd: () => void
-  handleDragOver: (e: React.DragEvent, timelineItemId: string) => void
-  handleDragLeave: () => void
-  handleDrop: (e: React.DragEvent, targetTimelineItemId: string) => void
-  moveTimelineItem: (timelineItemId: string, direction: 'up' | 'down') => void
-  toggleTimelineItemEdit: (timelineItemId: string) => void
-  editorialPublishAnalysis: EditorialPublishAnalysis
-  fixEditorialBlock: (blockId: string) => void
-  updateEditorialBlockMarkdown: (blockId: string, nextMarkdown: string) => void
-  removeEditorialBlock: (blockId: string) => void
-  updateBlockContent: (blockId: string, newContent: string) => void
-  rewriteTextBlockWithAi: (
-    blockId: string,
-    currentContent: string,
-    prompt: string,
-    includeWholeArticleContext: boolean
-  ) => Promise<string>
-  addImageAfterBlock: (
-    blockId: string,
-    imageId: number,
-    imageAfterAltText?: string,
-    replaceExisting?: boolean
-  ) => string | null
-  addImgPairAfterBlock: (
-    blockId: string,
-    imageOne: MediaAsset,
-    imageTwo: MediaAsset,
-    caption?: string,
-    replaceExisting?: boolean
-  ) => void
-  addImgTrioAfterBlock: (
-    blockId: string,
-    format: ImgTrioFormat,
-    imageOne: MediaAsset,
-    imageTwo: MediaAsset,
-    imageThree: MediaAsset,
-    caption?: string,
-    replaceExisting?: boolean
-  ) => void
-  updateMediaGroupCaption: (blockId: string, caption: string) => void
-  removeImageAfterBlock: (blockId: string) => void
-  removeImgPairAfterBlock: (blockId: string) => void
-  removeImgTrioAfterBlock: (blockId: string) => void
-  mergeWithNextBlock: (blockId: string) => void
-  resetToOriginalBlocks: () => void
-  findHeaderSplitPoints: (content: string) => { lineIndex: number; headerText: string }[]
-  splitBlockAtHeader: (blockId: string, lineIndex: number) => void
-  addNewBlock: (afterBlockId?: string) => void
-  addNewEditorialBlock: (component: SupportedEditorialComponent, afterBlockId?: string) => void
-  deleteBlock: (blockId: string) => void
-  updateStagedArticle: (updates: Partial<StagedArticle>) => void
-  handleDelete: () => void
-  isConverting: boolean
-  isPublishing: boolean
-  publishResult: PublishResult
-  setPublishResult: Dispatch<SetStateAction<PublishResult>>
-  openImagePickerTarget: string | null
-  openEditorialPickerTarget: string | null
-  toggleImagePicker: (target: string) => void
-  toggleEditorialPicker: (target: string) => void
-  showImageModal: boolean
-  setShowImageModalTracked: Dispatch<SetStateAction<boolean>>
-  featuredImageUploadExternalRef: string
-  featuredImageFileNamePrefix: string
-  featuredImageSource: ImageSourceOption
-  setFeaturedImageSource: Dispatch<SetStateAction<ImageSourceOption>>
-  imageSearch: string
-  setImageSearch: Dispatch<SetStateAction<string>>
-  unsplashFeaturedQuery: string
-  setUnsplashFeaturedQuery: Dispatch<SetStateAction<string>>
-  unsplashFeaturedResults: UnsplashPhoto[]
-  isSearchingUnsplashFeatured: boolean
-  unsplashFeaturedError: string | null
-  unsplashFeaturedOrientation: PexelsOrientationOption
-  setUnsplashFeaturedOrientation: Dispatch<SetStateAction<PexelsOrientationOption>>
-  unsplashFeaturedPerPage: number
-  setUnsplashFeaturedPerPage: Dispatch<SetStateAction<number>>
-  pexelsFeaturedQuery: string
-  setPexelsFeaturedQuery: Dispatch<SetStateAction<string>>
-  pexelsFeaturedResults: PexelsPhoto[]
-  isSearchingPexelsFeatured: boolean
-  pexelsFeaturedError: string | null
-  pexelsFeaturedOrientation: PexelsOrientationOption
-  setPexelsFeaturedOrientation: Dispatch<SetStateAction<PexelsOrientationOption>>
-  pexelsFeaturedPerPage: number
-  setPexelsFeaturedPerPage: Dispatch<SetStateAction<number>>
-  isImportingFeaturedExternalImage: boolean
-  runFeaturedUnsplashSearch: () => Promise<void>
-  runFeaturedPexelsSearch: () => Promise<void>
-  blockImageModal: BlockImageModalState | null
-  blockImageSource: ImageSourceOption
-  setBlockImageSource: Dispatch<SetStateAction<ImageSourceOption>>
-  blockImageSearch: string
-  setBlockImageSearch: Dispatch<SetStateAction<string>>
-  imgBlockAssets: MediaAsset[]
-  isLoadingImgBlockAssets: boolean
-  imgBlockAssetsError: string | null
-  hasMoreImgBlockAssets: boolean
-  loadMoreImgBlockAssets: () => Promise<void>
-  selectedImgBlockAssetIds: number[]
-  toggleImgBlockAssetSelection: (assetId: number, requiredCount: number) => void
-  imgBlockCaption: string
-  setImgBlockCaption: Dispatch<SetStateAction<string>>
-  imgTrioFormat: ImgTrioFormat
-  setImgTrioFormat: Dispatch<SetStateAction<ImgTrioFormat>>
-  unsplashBlockQuery: string
-  setUnsplashBlockQuery: Dispatch<SetStateAction<string>>
-  unsplashBlockResults: UnsplashPhoto[]
-  isSearchingUnsplashBlock: boolean
-  unsplashBlockError: string | null
-  unsplashBlockOrientation: PexelsOrientationOption
-  setUnsplashBlockOrientation: Dispatch<SetStateAction<PexelsOrientationOption>>
-  unsplashBlockPerPage: number
-  setUnsplashBlockPerPage: Dispatch<SetStateAction<number>>
-  pexelsBlockQuery: string
-  setPexelsBlockQuery: Dispatch<SetStateAction<string>>
-  pexelsBlockResults: PexelsPhoto[]
-  isSearchingPexelsBlock: boolean
-  pexelsBlockError: string | null
-  pexelsBlockOrientation: PexelsOrientationOption
-  setPexelsBlockOrientation: Dispatch<SetStateAction<PexelsOrientationOption>>
-  pexelsBlockPerPage: number
-  setPexelsBlockPerPage: Dispatch<SetStateAction<number>>
-  openBlockImageModalTracked: (
-    blockId: string,
-    mode: BlockImageModalState['mode'],
-    options?: OpenBlockImageModalOptions
-  ) => void
-  closeBlockImageModalTracked: () => void
-  isImportingBlockExternalImage: boolean
-  runBlockUnsplashSearch: () => Promise<void>
-  runBlockPexelsSearch: () => Promise<void>
-  mergeMediaAssetsIntoState: (newAssets: MediaAsset[]) => void
-  findPreferredVariantAsset: (assetId: number, preferredVariant: MediaVariant) => MediaAsset | null
-  handlePublish: (targetStatus: 'draft' | 'published') => void
+  workspace: EditorialStageArticleWorkspace
+  media: EditorialStageArticleMediaController
+  publishing: EditorialStageArticlePublishing
 }
 
 type UseEditorialStageLoadedArticleViewsResult = {
@@ -190,8 +38,38 @@ type UseEditorialStageLoadedArticleViewsResult = {
 }
 
 export function useEditorialStageLoadedArticleViews(
-  params: UseEditorialStageLoadedArticleViewsParams
+  controllerParams: UseEditorialStageLoadedArticleViewsParams,
 ): UseEditorialStageLoadedArticleViewsResult {
+  const {
+    stagedArticle,
+    stagePath,
+    token,
+    workspace,
+    media,
+    publishing,
+  } = controllerParams
+  const params = {
+    ...workspace.page,
+    ...workspace.timeline,
+    ...workspace.blocks,
+    ...media.featured,
+    ...media.block,
+    ...media.shared,
+    ...publishing,
+    stagedArticle,
+    stagePath,
+    token,
+    editorialPublishAnalysis: workspace.editorialPublishAnalysis,
+    setPublishResult: workspace.setPublishResult,
+    openImagePickerTarget: workspace.uiState.pickers.openImageTarget,
+    openEditorialPickerTarget: workspace.uiState.pickers.openEditorialTarget,
+    toggleImagePicker: workspace.toggleImagePicker,
+    toggleEditorialPicker: workspace.toggleEditorialPicker,
+    addNewEditorialBlock: workspace.addEditorialFromPicker,
+    setShowImageModalTracked: media.setShowImageModalTracked,
+    openBlockImageModalTracked: media.openBlockImageModalTracked,
+    closeBlockImageModalTracked: media.closeBlockImageModalTracked,
+  }
   const {
     selectedLocation,
     selectedFeaturedImage,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/view-model/empty-staged-article.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/view-model/empty-staged-article.ts
@@ -1,0 +1,27 @@
+import type { StagedArticle } from '../../../types'
+import { createEmptySeoSection } from '../../../../../shared/seo/services/seo-section.service'
+
+export const EMPTY_STAGED_ARTICLE: StagedArticle = {
+  id: '',
+  runId: '',
+  originalTitle: '',
+  originalContent: '',
+  originalType: '',
+  title: '',
+  content: '',
+  blocks: [],
+  editorialBlocks: [],
+  sharedNeighborhoods: [],
+  seoSection: createEmptySeoSection(),
+  syncBehavior: 'finalize',
+  lexicalConverted: false,
+  publishedToPayload: false,
+  hasUnsyncedPayloadChanges: false,
+  payloadStatus: undefined,
+  payloadSlug: undefined,
+  payloadPublishedAt: undefined,
+  payloadUpdatedAt: undefined,
+  payloadAuthorName: undefined,
+  createdAt: '',
+  updatedAt: '',
+}


### PR DESCRIPTION
## Summary
- reduce the editorial stage screen view-model hook from 498 lines / 15 imports to 78 lines / 8 imports
- introduce focused workspace, media/modal, and publishing controllers
- replace the loaded-view adapter’s 90-plus-property flat contract with grouped controller contracts
- isolate the empty staged-article fallback in the view-model layer
- preserve the public screen view-model shape and existing UI behavior

## Verification
- frontend boundary check
- full frontend ESLint
- Vitest: 91 files, 352 tests passed
- Vite production build