### PR TITLE
NOJIRA: Decompose the editorial sidebar

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialSidebar.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialSidebar.tsx
@@ -1,20 +1,12 @@
 import type { Location, MediaAsset } from '../../api'
 import type { StagedArticle } from '../../types'
-import payloadLogoUrl from '../../../../assets/payload-logo.svg?url'
 import { usePermissions } from '../../../auth'
-import { EDITOR_MODEL_OPTIONS, resolveEditorModelName } from '../../features/editorial-stage-article/constants'
-import { getMediaAssetAltText } from '../../features/editorial-stage-article/media-utils'
-import {
-  isSeoCoreComplete,
-  validateStandardArticleSeoSection,
-} from '../../features/editorial-stage-article/services/standard-article-seo.service'
-import { getLocationDisplayName } from '../../features/editorial-stage-article/utils/editorial-stage-view.utils'
-import {
-  buildPrimaryLocationUpdate,
-  getSharedNeighborhoodOptions,
-  sanitizeSharedNeighborhoods,
-} from '../../features/editorial-stage-article/utils/sharedNeighborhoods'
 import { isStagedArticleEditingLocked } from '../../utils/staged-article-sync'
+import { EditorialArticleSettings } from './editorial-sidebar/EditorialArticleSettings'
+import { EditorialFeaturedImageSection } from './editorial-sidebar/EditorialFeaturedImageSection'
+import { EditorialLocationSection } from './editorial-sidebar/EditorialLocationSection'
+import { EditorialPublishingSection } from './editorial-sidebar/EditorialPublishingSection'
+import { getEditorialSidebarPublishingState } from './editorial-sidebar/editorial-sidebar-publishing-state'
 
 type PublishResult = { success: boolean; message: string } | null
 
@@ -52,337 +44,50 @@ export function EditorialSidebar({
   onDeepExpand,
 }: EditorialSidebarProps) {
   const { canManagePublished, role } = usePermissions()
-  const hasBlockingEditorial = editorialBlockingMessages.length > 0
   const isEditingLocked = isStagedArticleEditingLocked(stagedArticle)
-  const isPublished = stagedArticle.payloadStatus === 'published'
-  const isLinkedDraft = Boolean(stagedArticle.payloadArticleId) && !isPublished
-  const selectedLocation = locations.find((location) => location.id === stagedArticle.locationId)
-  const sharedNeighborhoodOptions = getSharedNeighborhoodOptions(locations, stagedArticle.locationId)
-  const selectedSharedNeighborhoods = sanitizeSharedNeighborhoods(
-    stagedArticle.sharedNeighborhoods,
+  const publishingState = getEditorialSidebarPublishingState({
+    stagedArticle,
+    allFieldsFilled,
+    missingPublishFields,
+    editorialBlockingMessages,
     locations,
-    stagedArticle.locationId
-  )
-  const seoSection = stagedArticle.seoSection ?? {
-    seoTitle: '',
-    metaDescription: '',
-    openGraph: {
-      title: '',
-      description: '',
-      imageUrl: '',
-      url: '',
-    },
-    twitterCard: {
-      card: 'summary',
-      title: '',
-      description: '',
-      imageUrl: '',
-    },
-    structuredData: '',
-    robots: {
-      index: 'index',
-      follow: 'follow',
-    },
-  }
-  const publishBlockedReasons = [
-    ...(!allFieldsFilled ? missingPublishFields : []),
-    ...(!isSeoCoreComplete(seoSection) ? ['SEO title and meta description'] : []),
-    ...(!seoSection.structuredData.trim() ? ['Structured Data'] : []),
-    ...(!seoSection.openGraph.imageUrl.trim() ? ['Open Graph image URL'] : []),
-    ...validateStandardArticleSeoSection({
-      seoSection,
-      locationLabel: locations.find((location) => location.id === stagedArticle.locationId)?.locationKey,
-    }),
-  ]
-  const canSaveDraft = allFieldsFilled && !hasBlockingEditorial && !isEditingLocked
-  const canPublish = canSaveDraft && publishBlockedReasons.length === 0
-  const payloadStatusLabel = isPublished
-    ? `Published in Payload${stagedArticle.payloadArticleId ? ` · ID ${stagedArticle.payloadArticleId}` : ''}`
-    : isLinkedDraft
-      ? `Draft synced to Payload${stagedArticle.payloadArticleId ? ` · ID ${stagedArticle.payloadArticleId}` : ''}`
-      : null
+    isEditingLocked,
+  })
 
   return (
     <aside className="stage-article-sidebar">
       <div className="stage-article-sidebar-inner">
-        <div className="stage-article-sidebar-section stage-article-sidebar-publish">
-          {payloadStatusLabel ? (
-            <div className="stage-article-published-notice">{payloadStatusLabel}</div>
-          ) : null}
-
-          {!isPublished && (
-            <button
-              onClick={() => onPublish('draft')}
-              disabled={isPublishing || !canSaveDraft}
-              className="stage-article-publish-btn payload-action-btn"
-            >
-              <img
-                src={payloadLogoUrl}
-                alt=""
-                aria-hidden="true"
-                className="payload-action-btn-icon"
-              />
-              {isPublishing ? 'Saving...' :
-               !allFieldsFilled ? 'Complete fields below' :
-               hasBlockingEditorial ? 'Fix editorial blocks' :
-               isLinkedDraft ? 'Update Draft in Payload' :
-               'Save Draft to Payload'}
-            </button>
-          )}
-
-          <button
-            onClick={() => onPublish('published')}
-            disabled={isPublishing || !canPublish || !canManagePublished}
-            className="stage-article-publish-btn payload-action-btn"
-          >
-            <img
-              src={payloadLogoUrl}
-              alt=""
-              aria-hidden="true"
-              className="payload-action-btn-icon"
-            />
-            {isPublishing ? 'Publishing...' :
-             !canManagePublished ? (isPublished ? 'Update Published' : 'Publish') :
-             !canSaveDraft ? 'Complete draft first' :
-             isPublished ? 'Update Published' :
-             'Publish'}
-          </button>
-          {!canManagePublished ? (
-            <p className="stage-article-publish-checklist-more">
-              {isPublished
-                ? `Updating a published article requires an editor or admin role (you are signed in as ${role ?? 'unknown'}).`
-                : `Publishing requires an editor or admin role (you are signed in as ${role ?? 'unknown'}).`}
-            </p>
-          ) : null}
-
-          {!seoSection.openGraph.url.trim() ? (
-            <p className="stage-article-publish-checklist-more">Set-up urls later</p>
-          ) : null}
-
-          {(!canSaveDraft || (canManagePublished && !canPublish)) && (
-            <div className="stage-article-publish-checklist">
-              {!canSaveDraft && missingPublishFields.length > 0 && (
-                <>
-                  <p className="stage-article-publish-checklist-title">Missing required fields:</p>
-                  <ul className="stage-article-publish-checklist-list">
-                    {missingPublishFields.map((field) => (
-                      <li key={field}>{field}</li>
-                    ))}
-                  </ul>
-                </>
-              )}
-              {hasBlockingEditorial && (
-                <>
-                  <p className="stage-article-publish-checklist-title">Fix editorial blocks before publish:</p>
-                  <ul className="stage-article-publish-checklist-list">
-                    {editorialBlockingMessages.slice(0, 3).map((message, index) => (
-                      <li key={`${message}-${index}`}>{message}</li>
-                    ))}
-                  </ul>
-                  {editorialBlockingMessages.length > 3 && (
-                    <p className="stage-article-publish-checklist-more">
-                      +{editorialBlockingMessages.length - 3} more block issues
-                    </p>
-                  )}
-                </>
-              )}
-              {canManagePublished && !canPublish && publishBlockedReasons.length > 0 && (
-                <>
-                  <p className="stage-article-publish-checklist-title">Publish requirements:</p>
-                  <ul className="stage-article-publish-checklist-list">
-                    {publishBlockedReasons.map((reason, index) => (
-                      <li key={`${reason}-${index}`}>{reason}</li>
-                    ))}
-                  </ul>
-                </>
-              )}
-            </div>
-          )}
-
-          {publishResult && (
-            <div className={`stage-article-result ${publishResult.success ? 'success' : 'error'}`}>
-              {publishResult.message}
-            </div>
-          )}
-        </div>
-
-        <div className="stage-article-sidebar-section">
-          <label className="stage-article-label">
-            Featured Image <span className="required">*</span>
-          </label>
-          <span className="stage-article-label-hint">
-            Required: {featuredImageRequirementLabel}
-          </span>
-
-          {selectedFeaturedImage ? (
-            <div className="stage-article-featured-image">
-              <img
-                src={getImageUrl(selectedFeaturedImage)}
-                alt={getMediaAssetAltText(selectedFeaturedImage) || selectedFeaturedImage.filename}
-              />
-              {!isEditingLocked && (
-                <button
-                  type="button"
-                  onClick={onOpenFeaturedImageModal}
-                  className="stage-article-change-btn"
-                >
-                  Change
-                </button>
-              )}
-            </div>
-          ) : stagedArticle.featuredImageId ? (
-            <div className="stage-article-featured-image-pending">
-              <p>Featured image selected (ID {stagedArticle.featuredImageId}). Preview will load shortly.</p>
-              {!isEditingLocked && (
-                <button
-                  type="button"
-                  onClick={onOpenFeaturedImageModal}
-                  className="stage-article-change-btn-inline"
-                >
-                  Change
-                </button>
-              )}
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={onOpenFeaturedImageModal}
-              className="stage-article-image-placeholder"
-              disabled={isEditingLocked}
-            >
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
-                <circle cx="8.5" cy="8.5" r="1.5"/>
-                <polyline points="21 15 16 10 5 21"/>
-              </svg>
-              <span>Select image</span>
-            </button>
-          )}
-        </div>
-
-        <div className="stage-article-sidebar-section">
-          <label className="stage-article-label">
-            Location <span className="required">*</span>
-          </label>
-          <select
-            value={stagedArticle.locationId || ''}
-            onChange={(event) => {
-              const nextLocationId = Number(event.target.value) || undefined
-              onUpdateStagedArticle(buildPrimaryLocationUpdate({
-                locations,
-                nextLocationId,
-                sharedNeighborhoods: stagedArticle.sharedNeighborhoods,
-              }))
-            }}
-            className="stage-article-select"
-            disabled={isEditingLocked}
-          >
-            <option value="">-- Select --</option>
-            {locations.map((location) => (
-              <option key={location.id} value={location.id}>
-                {getLocationDisplayName(location)} ({location.level})
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {selectedLocation?.level === 'city' ? (
-          <div className="stage-article-sidebar-section">
-            <label className="stage-article-label">Shared Neighborhoods</label>
-            <span className="stage-article-label-hint">
-              Optional. Exact neighborhood scoping only.
-            </span>
-            <select
-              multiple
-              value={selectedSharedNeighborhoods.map(String)}
-              onChange={(event) => {
-                const nextSharedNeighborhoods = Array.from(
-                  event.currentTarget.selectedOptions,
-                  (option) => Number(option.value)
-                ).filter((value) => Number.isFinite(value) && value > 0)
-
-                onUpdateStagedArticle({
-                  sharedNeighborhoods: sanitizeSharedNeighborhoods(
-                    nextSharedNeighborhoods,
-                    locations,
-                    stagedArticle.locationId
-                  ),
-                })
-              }}
-              className="stage-article-select"
-              disabled={isEditingLocked || sharedNeighborhoodOptions.length === 0}
-              style={{ minHeight: '8rem' }}
-            >
-              {sharedNeighborhoodOptions.map((location) => (
-                <option key={location.id} value={location.id}>
-                  {getLocationDisplayName(location)}
-                </option>
-              ))}
-            </select>
-            {sharedNeighborhoodOptions.length === 0 ? (
-              <p className="stage-article-publish-checklist-more">
-                No neighborhoods are available for this city yet.
-              </p>
-            ) : null}
-          </div>
-        ) : null}
-
-        <div className="stage-article-sidebar-section">
-          <label className="stage-article-label">Slug</label>
-          <span className="stage-article-label-hint">
-            URL-friendly identifier (e.g. medellin-digital-nomad-guide-2026)
-          </span>
-          <input
-            type="text"
-            value={stagedArticle.payloadSlug || ''}
-            onChange={(event) => onUpdateStagedArticle({ payloadSlug: event.target.value })}
-            className="stage-article-select"
-            placeholder="auto-generated if blank"
-            disabled={isEditingLocked}
-          />
-        </div>
-
-        <div className="stage-article-sidebar-section">
-          <label className="stage-article-label">
-            AI Model
-          </label>
-          <select
-            value={resolveEditorModelName(stagedArticle.editorModelName)}
-            onChange={(event) => onUpdateStagedArticle({
-              editorModelName: resolveEditorModelName(event.target.value),
-            })}
-            className="stage-article-select"
-            disabled={isEditingLocked}
-          >
-            {EDITOR_MODEL_OPTIONS.map((modelOption) => (
-              <option key={modelOption.value} value={modelOption.value}>
-                {modelOption.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {onDeepExpand && !isEditingLocked && (
-          <div className="stage-article-sidebar-section">
-            <label className="stage-article-label">AI Tools</label>
-            <button
-              type="button"
-              onClick={onDeepExpand}
-              className="stage-article-deep-expand-btn"
-            >
-              Deep Expand Article
-            </button>
-            <p className="stage-article-publish-checklist-more">
-              Adds new sections and deeper content while keeping everything existing intact.
-            </p>
-          </div>
-        )}
-
-        <div className="stage-article-sidebar-section stage-article-info-box">
-          <p><strong>Run ID:</strong> {stagedArticle.runId}</p>
-          <p><strong>Created:</strong> {new Date(stagedArticle.createdAt).toLocaleDateString()}</p>
-          <p><strong>Updated:</strong> {new Date(stagedArticle.updatedAt).toLocaleDateString()}</p>
-        </div>
+        <EditorialPublishingSection
+          state={publishingState}
+          isPublishing={isPublishing}
+          allFieldsFilled={allFieldsFilled}
+          missingPublishFields={missingPublishFields}
+          editorialBlockingMessages={editorialBlockingMessages}
+          publishResult={publishResult}
+          canManagePublished={canManagePublished}
+          role={role}
+          onPublish={onPublish}
+        />
+        <EditorialFeaturedImageSection
+          stagedArticle={stagedArticle}
+          requirementLabel={featuredImageRequirementLabel}
+          selectedImage={selectedFeaturedImage}
+          isEditingLocked={isEditingLocked}
+          getImageUrl={getImageUrl}
+          onOpenModal={onOpenFeaturedImageModal}
+        />
+        <EditorialLocationSection
+          stagedArticle={stagedArticle}
+          locations={locations}
+          isEditingLocked={isEditingLocked}
+          onUpdate={onUpdateStagedArticle}
+        />
+        <EditorialArticleSettings
+          stagedArticle={stagedArticle}
+          isEditingLocked={isEditingLocked}
+          onUpdate={onUpdateStagedArticle}
+          onDeepExpand={onDeepExpand}
+        />
       </div>
     </aside>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialArticleSettings.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialArticleSettings.tsx
@@ -1,0 +1,78 @@
+import type { StagedArticle } from '../../../types'
+import {
+  EDITOR_MODEL_OPTIONS,
+  resolveEditorModelName,
+} from '../../../features/editorial-stage-article/constants'
+
+type EditorialArticleSettingsProps = {
+  stagedArticle: StagedArticle
+  isEditingLocked: boolean
+  onUpdate: (updates: Partial<StagedArticle>) => void
+  onDeepExpand?: () => void
+}
+
+export function EditorialArticleSettings({
+  stagedArticle,
+  isEditingLocked,
+  onUpdate,
+  onDeepExpand,
+}: EditorialArticleSettingsProps) {
+  return (
+    <>
+      <div className="stage-article-sidebar-section">
+        <label className="stage-article-label">Slug</label>
+        <span className="stage-article-label-hint">
+          URL-friendly identifier (e.g. medellin-digital-nomad-guide-2026)
+        </span>
+        <input
+          type="text"
+          value={stagedArticle.payloadSlug || ''}
+          onChange={(event) => onUpdate({ payloadSlug: event.target.value })}
+          className="stage-article-select"
+          placeholder="auto-generated if blank"
+          disabled={isEditingLocked}
+        />
+      </div>
+
+      <div className="stage-article-sidebar-section">
+        <label className="stage-article-label">AI Model</label>
+        <select
+          value={resolveEditorModelName(stagedArticle.editorModelName)}
+          onChange={(event) => onUpdate({
+            editorModelName: resolveEditorModelName(event.target.value),
+          })}
+          className="stage-article-select"
+          disabled={isEditingLocked}
+        >
+          {EDITOR_MODEL_OPTIONS.map((modelOption) => (
+            <option key={modelOption.value} value={modelOption.value}>
+              {modelOption.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {onDeepExpand && !isEditingLocked && (
+        <div className="stage-article-sidebar-section">
+          <label className="stage-article-label">AI Tools</label>
+          <button
+            type="button"
+            onClick={onDeepExpand}
+            className="stage-article-deep-expand-btn"
+          >
+            Deep Expand Article
+          </button>
+          <p className="stage-article-publish-checklist-more">
+            Adds new sections and deeper content while keeping everything existing intact.
+          </p>
+        </div>
+      )}
+
+      <div className="stage-article-sidebar-section stage-article-info-box">
+        <p><strong>Run ID:</strong> {stagedArticle.runId}</p>
+        <p><strong>Created:</strong> {new Date(stagedArticle.createdAt).toLocaleDateString()}</p>
+        <p><strong>Updated:</strong> {new Date(stagedArticle.updatedAt).toLocaleDateString()}</p>
+      </div>
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialFeaturedImageSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialFeaturedImageSection.tsx
@@ -1,0 +1,80 @@
+import type { MediaAsset } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import { getMediaAssetAltText } from '../../../features/editorial-stage-article/media-utils'
+
+type EditorialFeaturedImageSectionProps = {
+  stagedArticle: StagedArticle
+  requirementLabel: string
+  selectedImage: MediaAsset | null
+  isEditingLocked: boolean
+  getImageUrl: (asset: MediaAsset) => string
+  onOpenModal: () => void
+}
+
+export function EditorialFeaturedImageSection({
+  stagedArticle,
+  requirementLabel,
+  selectedImage,
+  isEditingLocked,
+  getImageUrl,
+  onOpenModal,
+}: EditorialFeaturedImageSectionProps) {
+  return (
+    <div className="stage-article-sidebar-section">
+      <label className="stage-article-label">
+        Featured Image <span className="required">*</span>
+      </label>
+      <span className="stage-article-label-hint">Required: {requirementLabel}</span>
+
+      {selectedImage ? (
+        <div className="stage-article-featured-image">
+          <img
+            src={getImageUrl(selectedImage)}
+            alt={getMediaAssetAltText(selectedImage) || selectedImage.filename}
+          />
+          {!isEditingLocked && (
+            <button type="button" onClick={onOpenModal} className="stage-article-change-btn">
+              Change
+            </button>
+          )}
+        </div>
+      ) : stagedArticle.featuredImageId ? (
+        <div className="stage-article-featured-image-pending">
+          <p>
+            Featured image selected (ID {stagedArticle.featuredImageId}). Preview will load shortly.
+          </p>
+          {!isEditingLocked && (
+            <button
+              type="button"
+              onClick={onOpenModal}
+              className="stage-article-change-btn-inline"
+            >
+              Change
+            </button>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onOpenModal}
+          className="stage-article-image-placeholder"
+          disabled={isEditingLocked}
+        >
+          <svg
+            width="32"
+            height="32"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <polyline points="21 15 16 10 5 21" />
+          </svg>
+          <span>Select image</span>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialLocationSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialLocationSection.tsx
@@ -1,0 +1,101 @@
+import type { Location } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import { getLocationDisplayName } from '../../../features/editorial-stage-article/utils/editorial-stage-view.utils'
+import {
+  buildPrimaryLocationUpdate,
+  getSharedNeighborhoodOptions,
+  sanitizeSharedNeighborhoods,
+} from '../../../features/editorial-stage-article/utils/sharedNeighborhoods'
+
+type EditorialLocationSectionProps = {
+  stagedArticle: StagedArticle
+  locations: Location[]
+  isEditingLocked: boolean
+  onUpdate: (updates: Partial<StagedArticle>) => void
+}
+
+export function EditorialLocationSection({
+  stagedArticle,
+  locations,
+  isEditingLocked,
+  onUpdate,
+}: EditorialLocationSectionProps) {
+  const selectedLocation = locations.find((location) => location.id === stagedArticle.locationId)
+  const sharedNeighborhoodOptions = getSharedNeighborhoodOptions(locations, stagedArticle.locationId)
+  const selectedSharedNeighborhoods = sanitizeSharedNeighborhoods(
+    stagedArticle.sharedNeighborhoods,
+    locations,
+    stagedArticle.locationId,
+  )
+
+  return (
+    <>
+      <div className="stage-article-sidebar-section">
+        <label className="stage-article-label">
+          Location <span className="required">*</span>
+        </label>
+        <select
+          value={stagedArticle.locationId || ''}
+          onChange={(event) => {
+            const nextLocationId = Number(event.target.value) || undefined
+            onUpdate(buildPrimaryLocationUpdate({
+              locations,
+              nextLocationId,
+              sharedNeighborhoods: stagedArticle.sharedNeighborhoods,
+            }))
+          }}
+          className="stage-article-select"
+          disabled={isEditingLocked}
+        >
+          <option value="">-- Select --</option>
+          {locations.map((location) => (
+            <option key={location.id} value={location.id}>
+              {getLocationDisplayName(location)} ({location.level})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {selectedLocation?.level === 'city' ? (
+        <div className="stage-article-sidebar-section">
+          <label className="stage-article-label">Shared Neighborhoods</label>
+          <span className="stage-article-label-hint">
+            Optional. Exact neighborhood scoping only.
+          </span>
+          <select
+            multiple
+            value={selectedSharedNeighborhoods.map(String)}
+            onChange={(event) => {
+              const nextSharedNeighborhoods = Array.from(
+                event.currentTarget.selectedOptions,
+                (option) => Number(option.value),
+              ).filter((value) => Number.isFinite(value) && value > 0)
+
+              onUpdate({
+                sharedNeighborhoods: sanitizeSharedNeighborhoods(
+                  nextSharedNeighborhoods,
+                  locations,
+                  stagedArticle.locationId,
+                ),
+              })
+            }}
+            className="stage-article-select"
+            disabled={isEditingLocked || sharedNeighborhoodOptions.length === 0}
+            style={{ minHeight: '8rem' }}
+          >
+            {sharedNeighborhoodOptions.map((location) => (
+              <option key={location.id} value={location.id}>
+                {getLocationDisplayName(location)}
+              </option>
+            ))}
+          </select>
+          {sharedNeighborhoodOptions.length === 0 ? (
+            <p className="stage-article-publish-checklist-more">
+              No neighborhoods are available for this city yet.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialPublishingSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/EditorialPublishingSection.tsx
@@ -1,0 +1,156 @@
+import payloadLogoUrl from '../../../../../assets/payload-logo.svg?url'
+import type { EditorialSidebarPublishingState } from './editorial-sidebar-publishing-state'
+
+type PublishResult = { success: boolean; message: string } | null
+
+type EditorialPublishingSectionProps = {
+  state: EditorialSidebarPublishingState
+  isPublishing: boolean
+  allFieldsFilled: boolean
+  missingPublishFields: string[]
+  editorialBlockingMessages: string[]
+  publishResult: PublishResult
+  canManagePublished: boolean
+  role: string | null
+  onPublish: (targetStatus: 'draft' | 'published') => void
+}
+
+export function EditorialPublishingSection({
+  state,
+  isPublishing,
+  allFieldsFilled,
+  missingPublishFields,
+  editorialBlockingMessages,
+  publishResult,
+  canManagePublished,
+  role,
+  onPublish,
+}: EditorialPublishingSectionProps) {
+  return (
+    <div className="stage-article-sidebar-section stage-article-sidebar-publish">
+      {state.payloadStatusLabel ? (
+        <div className="stage-article-published-notice">{state.payloadStatusLabel}</div>
+      ) : null}
+
+      {!state.isPublished && (
+        <button
+          onClick={() => onPublish('draft')}
+          disabled={isPublishing || !state.canSaveDraft}
+          className="stage-article-publish-btn payload-action-btn"
+        >
+          <PayloadIcon />
+          {isPublishing ? 'Saving...' :
+           !allFieldsFilled ? 'Complete fields below' :
+           state.hasBlockingEditorial ? 'Fix editorial blocks' :
+           state.isLinkedDraft ? 'Update Draft in Payload' :
+           'Save Draft to Payload'}
+        </button>
+      )}
+
+      <button
+        onClick={() => onPublish('published')}
+        disabled={isPublishing || !state.canPublish || !canManagePublished}
+        className="stage-article-publish-btn payload-action-btn"
+      >
+        <PayloadIcon />
+        {isPublishing ? 'Publishing...' :
+         !canManagePublished ? (state.isPublished ? 'Update Published' : 'Publish') :
+         !state.canSaveDraft ? 'Complete draft first' :
+         state.isPublished ? 'Update Published' :
+         'Publish'}
+      </button>
+
+      {!canManagePublished ? (
+        <p className="stage-article-publish-checklist-more">
+          {state.isPublished
+            ? `Updating a published article requires an editor or admin role (you are signed in as ${role ?? 'unknown'}).`
+            : `Publishing requires an editor or admin role (you are signed in as ${role ?? 'unknown'}).`}
+        </p>
+      ) : null}
+
+      {state.shouldSetUpUrlsLater ? (
+        <p className="stage-article-publish-checklist-more">Set-up urls later</p>
+      ) : null}
+
+      {(!state.canSaveDraft || (canManagePublished && !state.canPublish)) && (
+        <PublishChecklist
+          state={state}
+          missingPublishFields={missingPublishFields}
+          editorialBlockingMessages={editorialBlockingMessages}
+          canManagePublished={canManagePublished}
+        />
+      )}
+
+      {publishResult && (
+        <div className={`stage-article-result ${publishResult.success ? 'success' : 'error'}`}>
+          {publishResult.message}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PayloadIcon() {
+  return (
+    <img
+      src={payloadLogoUrl}
+      alt=""
+      aria-hidden="true"
+      className="payload-action-btn-icon"
+    />
+  )
+}
+
+type PublishChecklistProps = Pick<
+  EditorialPublishingSectionProps,
+  'missingPublishFields' | 'editorialBlockingMessages' | 'canManagePublished'
+> & {
+  state: EditorialSidebarPublishingState
+}
+
+function PublishChecklist({
+  state,
+  missingPublishFields,
+  editorialBlockingMessages,
+  canManagePublished,
+}: PublishChecklistProps) {
+  return (
+    <div className="stage-article-publish-checklist">
+      {!state.canSaveDraft && missingPublishFields.length > 0 && (
+        <>
+          <p className="stage-article-publish-checklist-title">Missing required fields:</p>
+          <ul className="stage-article-publish-checklist-list">
+            {missingPublishFields.map((field) => <li key={field}>{field}</li>)}
+          </ul>
+        </>
+      )}
+      {state.hasBlockingEditorial && (
+        <>
+          <p className="stage-article-publish-checklist-title">
+            Fix editorial blocks before publish:
+          </p>
+          <ul className="stage-article-publish-checklist-list">
+            {editorialBlockingMessages.slice(0, 3).map((message, index) => (
+              <li key={`${message}-${index}`}>{message}</li>
+            ))}
+          </ul>
+          {editorialBlockingMessages.length > 3 && (
+            <p className="stage-article-publish-checklist-more">
+              +{editorialBlockingMessages.length - 3} more block issues
+            </p>
+          )}
+        </>
+      )}
+      {canManagePublished && !state.canPublish && state.publishBlockedReasons.length > 0 && (
+        <>
+          <p className="stage-article-publish-checklist-title">Publish requirements:</p>
+          <ul className="stage-article-publish-checklist-list">
+            {state.publishBlockedReasons.map((reason, index) => (
+              <li key={`${reason}-${index}`}>{reason}</li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/editorial-sidebar-publishing-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/editorial-sidebar/editorial-sidebar-publishing-state.ts
@@ -1,0 +1,81 @@
+import type { Location } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import {
+  isSeoCoreComplete,
+  validateStandardArticleSeoSection,
+} from '../../../features/editorial-stage-article/services/standard-article-seo.service'
+
+type PublishingStateInput = {
+  stagedArticle: StagedArticle
+  allFieldsFilled: boolean
+  missingPublishFields: string[]
+  editorialBlockingMessages: string[]
+  locations: Location[]
+  isEditingLocked: boolean
+}
+
+export function getEditorialSidebarPublishingState({
+  stagedArticle,
+  allFieldsFilled,
+  missingPublishFields,
+  editorialBlockingMessages,
+  locations,
+  isEditingLocked,
+}: PublishingStateInput) {
+  const seoSection = stagedArticle.seoSection ?? {
+    seoTitle: '',
+    metaDescription: '',
+    openGraph: {
+      title: '',
+      description: '',
+      imageUrl: '',
+      url: '',
+    },
+    twitterCard: {
+      card: 'summary',
+      title: '',
+      description: '',
+      imageUrl: '',
+    },
+    structuredData: '',
+    robots: {
+      index: 'index',
+      follow: 'follow',
+    },
+  }
+  const isPublished = stagedArticle.payloadStatus === 'published'
+  const isLinkedDraft = Boolean(stagedArticle.payloadArticleId) && !isPublished
+  const hasBlockingEditorial = editorialBlockingMessages.length > 0
+  const canSaveDraft = allFieldsFilled
+    && !hasBlockingEditorial
+    && !isEditingLocked
+  const publishBlockedReasons = [
+    ...(!allFieldsFilled ? missingPublishFields : []),
+    ...(!isSeoCoreComplete(seoSection) ? ['SEO title and meta description'] : []),
+    ...(!seoSection.structuredData.trim() ? ['Structured Data'] : []),
+    ...(!seoSection.openGraph.imageUrl.trim() ? ['Open Graph image URL'] : []),
+    ...validateStandardArticleSeoSection({
+      seoSection,
+      locationLabel: locations.find((location) => location.id === stagedArticle.locationId)?.locationKey,
+    }),
+  ]
+
+  return {
+    canPublish: canSaveDraft && publishBlockedReasons.length === 0,
+    canSaveDraft,
+    hasBlockingEditorial,
+    isLinkedDraft,
+    isPublished,
+    publishBlockedReasons,
+    payloadStatusLabel: isPublished
+      ? `Published in Payload${stagedArticle.payloadArticleId ? ` · ID ${stagedArticle.payloadArticleId}` : ''}`
+      : isLinkedDraft
+        ? `Draft synced to Payload${stagedArticle.payloadArticleId ? ` · ID ${stagedArticle.payloadArticleId}` : ''}`
+        : null,
+    shouldSetUpUrlsLater: !seoSection.openGraph.url.trim(),
+  }
+}
+
+export type EditorialSidebarPublishingState = ReturnType<
+  typeof getEditorialSidebarPublishingState
+>


### PR DESCRIPTION
## Summary
- reduce `EditorialSidebar.tsx` from 389 lines to a 94-line composition root
- isolate publishing eligibility and status derivation in a pure state module
- extract focused publishing, featured-image, location-scoping, and article-settings sections
- preserve the existing sidebar prop contract, permission behavior, lock behavior, and CSS hooks

Every extracted module is under 160 lines and owns one cohesive UI responsibility.

## Verification
- frontend boundary check passed
- full frontend ESLint passed
- full frontend Vitest suite — 91 files, 352 tests passed
- focused `EditorialSidebar` suite — 3 tests passed
- production Vite build passed