### PR TITLE
NOJIRA: Decompose the photo import service

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import.service.ts
@@ -1,360 +1,88 @@
-import { join } from "node:path";
-import { BadRequestError, NotFoundError } from "@shared/errors/http-error";
+import { BadRequestError } from "@shared/errors/http-error";
 import { GOOGLE_PHOTO_IMPORT_TOGGLE_KEY } from "@questurian/lm-shared";
 import { isIntegrationEnabled } from "@server/shared/settings/integration-toggles";
 import type {
-  PhotoImportPhoto,
   PhotoImportPreview,
   PhotoImportStartPhoto,
   PhotoImportStartResponse,
-  ImageSet,
 } from "@questurian/lm-shared";
-import { GooglePlacesPhotosClient } from "./clients/google-places-photos.client";
+import type { Upload } from "../../models/location";
 import { ImageStorageService } from "../storage/image-storage.service";
-import { getLocationById, updateLocationById } from "../../repositories/core";
+import { GooglePlacesPhotosClient } from "./clients/google-places-photos.client";
+import { GooglePhotoDownloadProcessor } from "./photo-import/google-photo-download.processor";
+import { GooglePhotoPreviewService } from "./photo-import/google-photo-preview.service";
+import { GooglePhotoStagingService } from "./photo-import/google-photo-staging.service";
 import {
-  saveUpload,
-  getUploadById,
-  getUploadsByLocationId,
-  deleteUploadById,
-  getRejectedGooglePhotoNames,
-  addRejectedGooglePhoto,
-  removeRejectedGooglePhoto,
-  rejectInstagramMedia,
-  getInstagramEmbedById,
-} from "../../repositories/content";
-import { sanitizeUploadedImageBuffer } from "../../utils/image-upload-sanitizer";
-import { extractImageMetadata } from "../../utils/image-metadata-extractor";
-import type { Upload, ImageSetUpload } from "../../models/location";
-
-const PHOTO_MAX_WIDTH = 1600;
+  DEFAULT_GOOGLE_PHOTO_MAX_WIDTH,
+} from "./photo-import/photo-import.constants";
+import { StagedSourceRejectionService } from "./photo-import/staged-source-rejection.service";
 
 export class PhotoImportService {
+  private readonly previewService: GooglePhotoPreviewService;
+  private readonly stagingService: GooglePhotoStagingService;
+  private readonly rejectionService: StagedSourceRejectionService;
+
   constructor(
     private readonly googlePhotos: GooglePlacesPhotosClient,
-    private readonly imageStorage: ImageStorageService,
-  ) {}
+    imageStorage: ImageStorageService,
+  ) {
+    const isConfigured = () => this.isConfigured();
+    const downloadProcessor = new GooglePhotoDownloadProcessor(
+      googlePhotos,
+      imageStorage,
+    );
 
-  isConfigured(): boolean {
-    return isIntegrationEnabled(GOOGLE_PHOTO_IMPORT_TOGGLE_KEY) && this.googlePhotos.isConfigured();
+    this.previewService = new GooglePhotoPreviewService(googlePhotos, isConfigured);
+    this.stagingService = new GooglePhotoStagingService(
+      isConfigured,
+      downloadProcessor,
+    );
+    this.rejectionService = new StagedSourceRejectionService(imageStorage);
   }
 
-  /**
-   * Resolve the signed media URL for a Google place photo and return the bytes.
-   * Used by the Add-flow pre-Create cropping pipeline (ADR-0007). Different from
-   * the StagedSource processDownload path: no DB row, no disk write, no alt-text —
-   * just the raw bytes for the browser-side cropper.
-   */
+  isConfigured(): boolean {
+    return isIntegrationEnabled(GOOGLE_PHOTO_IMPORT_TOGGLE_KEY)
+      && this.googlePhotos.isConfigured();
+  }
+
   async proxyPhotoBytes(photoName: string, maxWidth?: number): Promise<Buffer> {
     if (!this.isConfigured()) {
       throw new BadRequestError("Google Photo Import is disabled");
     }
-    return this.googlePhotos.fetchPhotoBytes(photoName, maxWidth ?? PHOTO_MAX_WIDTH);
-  }
-
-  /**
-   * Pre-Create preview: no Location yet, so no rejection memory or existing-upload status.
-   * Every photo comes back as status='new'. Used by the pre-Create "Pick photos" phase.
-   */
-  async previewByPlaceId(placeId: string): Promise<PhotoImportPreview> {
-    if (!placeId) throw new BadRequestError("placeId required");
-    if (!this.isConfigured()) {
-      return { locationId: -1, placeId, photos: [], configured: false };
-    }
-
-    const photos = await this.googlePhotos.getPhotosForPlace(placeId);
-    const previewUrls = await Promise.all(
-      photos.map(async (photo) => {
-        try {
-          return await this.googlePhotos.getPhotoUri(photo.name, 600);
-        } catch {
-          return null;
-        }
-      })
+    return this.googlePhotos.fetchPhotoBytes(
+      photoName,
+      maxWidth ?? DEFAULT_GOOGLE_PHOTO_MAX_WIDTH,
     );
-
-    const annotated: PhotoImportPhoto[] = photos.map((photo, idx) => ({
-      name: photo.name,
-      widthPx: photo.widthPx,
-      heightPx: photo.heightPx,
-      authorAttributions: photo.authorAttributions.map((a) => ({
-        displayName: a.displayName,
-        ...(a.uri ? { uri: a.uri } : {}),
-      })),
-      status: "new" as const,
-      previewUrl: previewUrls[idx],
-    }));
-
-    return { locationId: -1, placeId, photos: annotated, configured: true };
   }
 
-  /**
-   * Fetch Google photos for the Location's placeId and annotate each with status:
-   * new | staged | imported | rejected. See LM CONTEXT.md "Photo Import flow".
-   */
-  async preview(locationId: number): Promise<PhotoImportPreview> {
-    const location = getLocationById(locationId);
-    if (!location) throw new NotFoundError("Location", locationId);
-
-    const placeId = (location as { placeId?: string | null }).placeId || "";
-    if (!placeId) {
-      throw new BadRequestError("Location has no placeId; cannot run Photo Import");
-    }
-
-    if (!this.isConfigured()) {
-      return { locationId, placeId, photos: [], configured: false };
-    }
-
-    const photos = await this.googlePhotos.getPhotosForPlace(placeId);
-    const uploads = getUploadsByLocationId(locationId);
-    const rejected = new Set(getRejectedGooglePhotoNames(locationId));
-
-    const byPhotoName = new Map<string, Upload>();
-    for (const upload of uploads) {
-      const name = (upload as ImageSetUpload).googlePhotoName;
-      if (name) byPhotoName.set(name, upload);
-    }
-
-    // Fan out and grab thumbnail URLs for any photo we don't already have a local source for.
-    // School-project use; latency is acceptable. Failures fall through to null so the grid can render a placeholder.
-    const previewUrls = await Promise.all(
-      photos.map(async (photo) => {
-        const existing = byPhotoName.get(photo.name);
-        const isImported = !!existing?.imageSet && (existing.imageSet.variants?.length ?? 0) > 0;
-        if (isImported) return null;
-        try {
-          return await this.googlePhotos.getPhotoUri(photo.name, 600);
-        } catch {
-          return null;
-        }
-      })
-    );
-
-    const annotated: PhotoImportPhoto[] = photos.map((photo, idx) => {
-      const existing = byPhotoName.get(photo.name);
-      const isImported = !!existing?.imageSet && (existing.imageSet.variants?.length ?? 0) > 0;
-      const isStaged = !!existing && !isImported;
-
-      let status: PhotoImportPhoto["status"];
-      if (isImported) status = "imported";
-      else if (isStaged) status = "staged";
-      else if (rejected.has(photo.name)) status = "rejected";
-      else status = "new";
-
-      return {
-        name: photo.name,
-        widthPx: photo.widthPx,
-        heightPx: photo.heightPx,
-        authorAttributions: photo.authorAttributions.map((a) => ({
-          displayName: a.displayName,
-          ...(a.uri ? { uri: a.uri } : {}),
-        })),
-        status,
-        ...(existing?.id ? { uploadId: existing.id } : {}),
-        ...(existing?.errorMessage ? { errorMessage: existing.errorMessage } : {}),
-        previewUrl: previewUrls[idx],
-      };
-    });
-
-    return { locationId, placeId, photos: annotated, configured: true };
+  previewByPlaceId(placeId: string): Promise<PhotoImportPreview> {
+    return this.previewService.previewByPlaceId(placeId);
   }
 
-  /**
-   * Insert StagedSource rows for each selected photoName and kick off async downloads.
-   * Returns immediately so the client can poll.
-   */
-  async start(
+  preview(locationId: number): Promise<PhotoImportPreview> {
+    return this.previewService.preview(locationId);
+  }
+
+  start(
     locationId: number,
-    photos: PhotoImportStartPhoto[]
+    photos: PhotoImportStartPhoto[],
   ): Promise<PhotoImportStartResponse> {
-    const location = getLocationById(locationId);
-    if (!location) throw new NotFoundError("Location", locationId);
-    if (!this.isConfigured()) {
-      throw new BadRequestError("Google Photo Import is disabled");
-    }
-    if (!photos || photos.length === 0) {
-      return { startedUploadIds: [], skipped: [] };
-    }
-
-    const placeId = (location as { placeId?: string | null }).placeId || "";
-    if (!placeId) throw new BadRequestError("Location has no placeId");
-
-    // NOTE: Google's Places API (New) returns a *different* opaque photo `name`
-    // on every call to the place details endpoint. The names are session/request
-    // tokens, not stable photo identifiers. We therefore do NOT re-fetch the
-    // place here to validate names — we trust the names the client just got
-    // from its preview call (which used the same key, moments ago). If a name
-    // has rotated by the time getPhotoUri is called, the per-photo download
-    // will surface as 'failed' on the StagedSource and the operator can retry.
-    const startedUploadIds: number[] = [];
-    const skipped: PhotoImportStartResponse["skipped"] = [];
-
-    for (const { photoName, photographerCredit } of photos) {
-      const credit = photographerCredit?.trim() || "Google";
-      const entry: ImageSetUpload = {
-        location_id: locationId,
-        format: "imageset",
-        stagedSourceStatus: "downloading",
-        sourceKind: "google",
-        googlePhotoName: photoName,
-        imageSet: undefined,
-      };
-
-      const savedId = saveUpload(entry);
-      if (typeof savedId !== "number") {
-        skipped.push({ photoName, reason: "not-in-place" });
-        continue;
-      }
-      entry.id = savedId;
-      startedUploadIds.push(savedId);
-
-      // Fire-and-forget: download bytes + pre-warm alt text in parallel per photo.
-      void this.processDownload(entry, photoName, credit, location.name);
-    }
-
-    this.touchLocationUpdatedAt(locationId);
-
-    return { startedUploadIds, skipped };
+    return this.stagingService.start(locationId, photos);
   }
 
-  /** Retry a failed StagedSource. Spends against Google, so the toggle gates it. */
-  async retry(uploadId: number): Promise<Upload> {
-    if (!this.isConfigured()) {
-      throw new BadRequestError("Google Photo Import is disabled");
-    }
-    const upload = getUploadById(uploadId);
-    if (!upload) throw new NotFoundError("Upload", uploadId);
-    const u = upload as ImageSetUpload;
-    if (u.stagedSourceStatus !== "failed") {
-      throw new BadRequestError("Upload is not a failed StagedSource");
-    }
-    if (!u.googlePhotoName) {
-      throw new BadRequestError("Upload has no googlePhotoName");
-    }
-
-    const location = getLocationById(u.location_id);
-    if (!location) throw new NotFoundError("Location", u.location_id);
-
-    u.stagedSourceStatus = "downloading";
-    u.errorMessage = null;
-    saveUpload(u);
-
-    // Photo names rotate between Google API calls — re-fetching would just yield
-    // names we can't match against the stored one. The retry uses the same
-    // (possibly stale) name; if it's expired, processDownload marks as 'failed'.
-    void this.processDownload(u, u.googlePhotoName, "Google", location.name);
-    return u;
+  retry(uploadId: number): Promise<Upload> {
+    return this.stagingService.retry(uploadId);
   }
 
-  /** Add a photoName to the Location's Rejected Source list. */
   rejectPhoto(locationId: number, photoName: string): void {
-    addRejectedGooglePhoto(locationId, photoName);
-    this.touchLocationUpdatedAt(locationId);
+    this.rejectionService.rejectPhoto(locationId, photoName);
   }
 
-  /** Remove a photoName from the Location's Rejected Source list. */
   unrejectPhoto(locationId: number, photoName: string): void {
-    removeRejectedGooglePhoto(locationId, photoName);
-    this.touchLocationUpdatedAt(locationId);
+    this.rejectionService.unrejectPhoto(locationId, photoName);
   }
 
-  /**
-   * Delete-as-reject: deleting a StagedSource that never finished cropping
-   * adds its googlePhotoName to the Rejected Source list.
-   */
-  async deleteStagedSource(uploadId: number): Promise<void> {
-    const upload = getUploadById(uploadId);
-    if (!upload) throw new NotFoundError("Upload", uploadId);
-    const u = upload as ImageSetUpload;
-
-    if (u.googlePhotoName) {
-      this.rejectPhoto(u.location_id, u.googlePhotoName);
-    } else if (u.instagramEmbedId && u.instagramMediaKey && getInstagramEmbedById(u.instagramEmbedId)) {
-      rejectInstagramMedia(u.instagramEmbedId, u.instagramMediaKey, u.sourcePosition ?? 0);
-    }
-
-    // Best-effort source file cleanup if present.
-    const sourcePath = u.imageSet?.sourceImage?.path;
-    if (sourcePath) {
-      const meta = this.imageStorage.extractPathMetadata(sourcePath);
-      if (meta) {
-        try {
-          await this.imageStorage.deleteTimestampFolder(meta.timestampDir);
-        } catch (error) {
-          console.error("Failed to clean StagedSource files", { uploadId, error });
-        }
-      }
-    }
-    deleteUploadById(uploadId);
-    this.touchLocationUpdatedAt(u.location_id);
-  }
-
-  // ---- internals ----
-
-  private async processDownload(
-    entry: ImageSetUpload,
-    photoName: string,
-    credit: string,
-    locationName: string
-  ): Promise<void> {
-    const uploadId = entry.id!;
-    const timestamp = Date.now();
-    const storagePath = this.imageStorage.generateStoragePath({
-      baseDir: (this.imageStorage as unknown as { baseImagesDir: string }).baseImagesDir,
-      locationName,
-      storageType: "uploads",
-      timestamp,
-    });
-
-    try {
-      await this.imageStorage.ensureDirectoryExists(storagePath);
-      const rawBytes = await this.googlePhotos.fetchPhotoBytes(photoName, PHOTO_MAX_WIDTH);
-      const webpBytes = await sanitizeUploadedImageBuffer(rawBytes);
-
-      const sourceFileName = `source_0.webp`;
-      const sourceFilePath = join(storagePath, sourceFileName);
-      await Bun.write(sourceFilePath, webpBytes);
-
-      const relativeSourcePath = sourceFilePath.replace(process.cwd() + "/", "");
-      const meta = await extractImageMetadata(sourceFilePath);
-
-      const imageSet: ImageSet = {
-        id: `${timestamp}`,
-        sourceImage: {
-          path: relativeSourcePath,
-          dimensions: { width: meta.width, height: meta.height },
-          size: meta.size,
-          format: meta.format,
-        },
-        variants: [],
-        photographerCredit: credit,
-        created_at: new Date().toISOString(),
-      };
-
-      const fresh = getUploadById(uploadId);
-      if (!fresh) return; // Deleted while downloading; abandon.
-      const f = fresh as ImageSetUpload;
-      f.imageSet = imageSet;
-      f.stagedSourceStatus = "ready";
-      f.errorMessage = null;
-      saveUpload(f);
-      this.touchLocationUpdatedAt(entry.location_id);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const fresh = getUploadById(uploadId);
-      if (!fresh) return;
-      const f = fresh as ImageSetUpload;
-      f.stagedSourceStatus = "failed";
-      f.errorMessage = message;
-      saveUpload(f);
-      console.warn(`[PhotoImport] Download failed for ${photoName}: ${message}`);
-      this.touchLocationUpdatedAt(entry.location_id);
-    }
-  }
-
-  private touchLocationUpdatedAt(locationId: number): void {
-    updateLocationById(locationId, {
-      updated_at: new Date().toISOString().replace("T", " ").replace(/\.\d{3}Z$/, ""),
-    });
+  deleteStagedSource(uploadId: number): Promise<void> {
+    return this.rejectionService.deleteStagedSource(uploadId);
   }
 }

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-download.processor.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-download.processor.ts
@@ -1,0 +1,97 @@
+import { join } from "node:path";
+import type { ImageSet } from "@questurian/lm-shared";
+import type { ImageSetUpload } from "../../../models/location";
+import { getUploadById, saveUpload } from "../../../repositories/content";
+import { extractImageMetadata } from "../../../utils/image-metadata-extractor";
+import { sanitizeUploadedImageBuffer } from "../../../utils/image-upload-sanitizer";
+import { ImageStorageService } from "../../storage/image-storage.service";
+import { GooglePlacesPhotosClient } from "../clients/google-places-photos.client";
+import { DEFAULT_GOOGLE_PHOTO_MAX_WIDTH } from "./photo-import.constants";
+import { touchLocationUpdatedAt } from "./photo-import-location";
+
+export class GooglePhotoDownloadProcessor {
+  constructor(
+    private readonly googlePhotos: GooglePlacesPhotosClient,
+    private readonly imageStorage: ImageStorageService,
+  ) {}
+
+  async process(
+    entry: ImageSetUpload,
+    photoName: string,
+    credit: string,
+    locationName: string,
+  ): Promise<void> {
+    const uploadId = entry.id!;
+    const timestamp = Date.now();
+    const storagePath = this.imageStorage.generateStoragePath({
+      baseDir: (this.imageStorage as unknown as { baseImagesDir: string }).baseImagesDir,
+      locationName,
+      storageType: "uploads",
+      timestamp,
+    });
+
+    try {
+      await this.imageStorage.ensureDirectoryExists(storagePath);
+      const rawBytes = await this.googlePhotos.fetchPhotoBytes(
+        photoName,
+        DEFAULT_GOOGLE_PHOTO_MAX_WIDTH,
+      );
+      const webpBytes = await sanitizeUploadedImageBuffer(rawBytes);
+      const sourceFilePath = join(storagePath, "source_0.webp");
+
+      await Bun.write(sourceFilePath, webpBytes);
+
+      const metadata = await extractImageMetadata(sourceFilePath);
+      const imageSet: ImageSet = {
+        id: `${timestamp}`,
+        sourceImage: {
+          path: sourceFilePath.replace(process.cwd() + "/", ""),
+          dimensions: { width: metadata.width, height: metadata.height },
+          size: metadata.size,
+          format: metadata.format,
+        },
+        variants: [],
+        photographerCredit: credit,
+        created_at: new Date().toISOString(),
+      };
+
+      this.persistReadyUpload(uploadId, imageSet, entry.location_id);
+    } catch (error) {
+      this.persistFailedUpload(uploadId, photoName, error, entry.location_id);
+    }
+  }
+
+  private persistReadyUpload(
+    uploadId: number,
+    imageSet: ImageSet,
+    locationId: number,
+  ): void {
+    const fresh = getUploadById(uploadId);
+    if (!fresh) return;
+
+    const upload = fresh as ImageSetUpload;
+    upload.imageSet = imageSet;
+    upload.stagedSourceStatus = "ready";
+    upload.errorMessage = null;
+    saveUpload(upload);
+    touchLocationUpdatedAt(locationId);
+  }
+
+  private persistFailedUpload(
+    uploadId: number,
+    photoName: string,
+    error: unknown,
+    locationId: number,
+  ): void {
+    const fresh = getUploadById(uploadId);
+    if (!fresh) return;
+
+    const message = error instanceof Error ? error.message : String(error);
+    const upload = fresh as ImageSetUpload;
+    upload.stagedSourceStatus = "failed";
+    upload.errorMessage = message;
+    saveUpload(upload);
+    console.warn(`[PhotoImport] Download failed for ${photoName}: ${message}`);
+    touchLocationUpdatedAt(locationId);
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-preview.service.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-preview.service.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { ImageSetUpload, Upload } from "../../../models/location";
+import type { GooglePlacePhoto } from "../clients/google-places-photos.client";
+import { annotateGooglePhotos } from "./google-photo-preview.service";
+
+const photos: GooglePlacePhoto[] = [
+  buildPhoto("imported"),
+  buildPhoto("staged"),
+  buildPhoto("rejected"),
+  buildPhoto("new"),
+];
+
+describe("annotateGooglePhotos", () => {
+  test("assigns imported, staged, rejected, and new statuses by precedence", () => {
+    const uploads = new Map<string, Upload>([
+      ["imported", buildUpload(1, "imported", true)],
+      ["staged", buildUpload(2, "staged", false)],
+    ]);
+
+    const result = annotateGooglePhotos(
+      photos,
+      uploads,
+      new Set(["imported", "staged", "rejected"]),
+      [null, "staged-preview", "rejected-preview", "new-preview"],
+    );
+
+    expect(result.map(({ status }) => status)).toEqual([
+      "imported",
+      "staged",
+      "rejected",
+      "new",
+    ]);
+    expect(result[0]?.uploadId).toBe(1);
+    expect(result[1]?.previewUrl).toBe("staged-preview");
+  });
+
+  test("preserves attribution links and staged-source errors", () => {
+    const failed = buildUpload(3, "new", false);
+    failed.errorMessage = "download failed";
+
+    const [result] = annotateGooglePhotos(
+      [buildPhoto("new")],
+      new Map([["new", failed]]),
+      new Set(),
+      ["preview"],
+    );
+
+    expect(result?.authorAttributions).toEqual([
+      { displayName: "Photographer", uri: "https://example.test/author" },
+    ]);
+    expect(result?.errorMessage).toBe("download failed");
+  });
+});
+
+function buildPhoto(name: string): GooglePlacePhoto {
+  return {
+    name,
+    widthPx: 1200,
+    heightPx: 800,
+    authorAttributions: [{
+      displayName: "Photographer",
+      uri: "https://example.test/author",
+    }],
+  };
+}
+
+function buildUpload(
+  id: number,
+  photoName: string,
+  imported: boolean,
+): ImageSetUpload {
+  return {
+    id,
+    location_id: 10,
+    format: "imageset",
+    googlePhotoName: photoName,
+    imageSet: imported
+      ? {
+          id: `${id}`,
+          sourceImage: {
+            path: "images/source.webp",
+            dimensions: { width: 1200, height: 800 },
+            size: 100,
+            format: "webp",
+          },
+          variants: [{
+            type: "square",
+            aspectRatio: "1:1",
+            path: "images/square.webp",
+            dimensions: { width: 600, height: 600 },
+            size: 50,
+            format: "webp",
+          }],
+          created_at: "2026-07-25T00:00:00.000Z",
+        }
+      : undefined,
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-preview.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-preview.service.ts
@@ -1,0 +1,145 @@
+import { BadRequestError, NotFoundError } from "@shared/errors/http-error";
+import type { PhotoImportPhoto, PhotoImportPreview } from "@questurian/lm-shared";
+import type { ImageSetUpload, Upload } from "../../../models/location";
+import { getLocationById } from "../../../repositories/core";
+import {
+  getRejectedGooglePhotoNames,
+  getUploadsByLocationId,
+} from "../../../repositories/content";
+import {
+  GooglePlacesPhotosClient,
+  type GooglePlacePhoto,
+} from "../clients/google-places-photos.client";
+
+type IsConfigured = () => boolean;
+
+export class GooglePhotoPreviewService {
+  constructor(
+    private readonly googlePhotos: GooglePlacesPhotosClient,
+    private readonly isConfigured: IsConfigured,
+  ) {}
+
+  async previewByPlaceId(placeId: string): Promise<PhotoImportPreview> {
+    if (!placeId) throw new BadRequestError("placeId required");
+    if (!this.isConfigured()) {
+      return { locationId: -1, placeId, photos: [], configured: false };
+    }
+
+    const photos = await this.googlePhotos.getPhotosForPlace(placeId);
+    const previewUrls = await this.fetchPreviewUrls(photos);
+
+    return {
+      locationId: -1,
+      placeId,
+      photos: photos.map((photo, index) => toPreviewPhoto(
+        photo,
+        "new",
+        previewUrls[index],
+      )),
+      configured: true,
+    };
+  }
+
+  async preview(locationId: number): Promise<PhotoImportPreview> {
+    const location = getLocationById(locationId);
+    if (!location) throw new NotFoundError("Location", locationId);
+
+    const placeId = (location as { placeId?: string | null }).placeId || "";
+    if (!placeId) {
+      throw new BadRequestError("Location has no placeId; cannot run Photo Import");
+    }
+    if (!this.isConfigured()) {
+      return { locationId, placeId, photos: [], configured: false };
+    }
+
+    const photos = await this.googlePhotos.getPhotosForPlace(placeId);
+    const uploads = getUploadsByLocationId(locationId);
+    const uploadsByPhotoName = indexUploadsByPhotoName(uploads);
+    const previewUrls = await this.fetchPreviewUrls(
+      photos,
+      (photo) => !isImported(uploadsByPhotoName.get(photo.name)),
+    );
+
+    return {
+      locationId,
+      placeId,
+      photos: annotateGooglePhotos(
+        photos,
+        uploadsByPhotoName,
+        new Set(getRejectedGooglePhotoNames(locationId)),
+        previewUrls,
+      ),
+      configured: true,
+    };
+  }
+
+  private async fetchPreviewUrls(
+    photos: GooglePlacePhoto[],
+    shouldFetch: (photo: GooglePlacePhoto) => boolean = () => true,
+  ): Promise<(string | null)[]> {
+    return Promise.all(photos.map(async (photo) => {
+      if (!shouldFetch(photo)) return null;
+      try {
+        return await this.googlePhotos.getPhotoUri(photo.name, 600);
+      } catch {
+        return null;
+      }
+    }));
+  }
+}
+
+export function annotateGooglePhotos(
+  photos: GooglePlacePhoto[],
+  uploadsByPhotoName: Map<string, Upload>,
+  rejectedPhotoNames: Set<string>,
+  previewUrls: (string | null)[],
+): PhotoImportPhoto[] {
+  return photos.map((photo, index) => {
+    const existing = uploadsByPhotoName.get(photo.name);
+    const imported = isImported(existing);
+    const status = imported
+      ? "imported"
+      : existing
+        ? "staged"
+        : rejectedPhotoNames.has(photo.name)
+          ? "rejected"
+          : "new";
+
+    return {
+      ...toPreviewPhoto(photo, status, previewUrls[index]),
+      ...(existing?.id ? { uploadId: existing.id } : {}),
+      ...(existing?.errorMessage ? { errorMessage: existing.errorMessage } : {}),
+    };
+  });
+}
+
+function indexUploadsByPhotoName(uploads: Upload[]): Map<string, Upload> {
+  const indexed = new Map<string, Upload>();
+  for (const upload of uploads) {
+    const photoName = (upload as ImageSetUpload).googlePhotoName;
+    if (photoName) indexed.set(photoName, upload);
+  }
+  return indexed;
+}
+
+function isImported(upload: Upload | undefined): boolean {
+  return !!upload?.imageSet && (upload.imageSet.variants?.length ?? 0) > 0;
+}
+
+function toPreviewPhoto(
+  photo: GooglePlacePhoto,
+  status: PhotoImportPhoto["status"],
+  previewUrl: string | null | undefined,
+): PhotoImportPhoto {
+  return {
+    name: photo.name,
+    widthPx: photo.widthPx,
+    heightPx: photo.heightPx,
+    authorAttributions: photo.authorAttributions.map((attribution) => ({
+      displayName: attribution.displayName,
+      ...(attribution.uri ? { uri: attribution.uri } : {}),
+    })),
+    status,
+    previewUrl: previewUrl ?? null,
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-staging.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/google-photo-staging.service.ts
@@ -1,0 +1,102 @@
+import { BadRequestError, NotFoundError } from "@shared/errors/http-error";
+import type {
+  PhotoImportStartPhoto,
+  PhotoImportStartResponse,
+} from "@questurian/lm-shared";
+import type { ImageSetUpload, Upload } from "../../../models/location";
+import { getLocationById } from "../../../repositories/core";
+import { getUploadById, saveUpload } from "../../../repositories/content";
+import { GooglePhotoDownloadProcessor } from "./google-photo-download.processor";
+import { touchLocationUpdatedAt } from "./photo-import-location";
+
+type IsConfigured = () => boolean;
+
+export class GooglePhotoStagingService {
+  constructor(
+    private readonly isConfigured: IsConfigured,
+    private readonly downloadProcessor: GooglePhotoDownloadProcessor,
+  ) {}
+
+  async start(
+    locationId: number,
+    photos: PhotoImportStartPhoto[],
+  ): Promise<PhotoImportStartResponse> {
+    const location = getLocationById(locationId);
+    if (!location) throw new NotFoundError("Location", locationId);
+    if (!this.isConfigured()) {
+      throw new BadRequestError("Google Photo Import is disabled");
+    }
+    if (!photos || photos.length === 0) {
+      return { startedUploadIds: [], skipped: [] };
+    }
+
+    const placeId = (location as { placeId?: string | null }).placeId || "";
+    if (!placeId) throw new BadRequestError("Location has no placeId");
+
+    // Google returns opaque photo names that can rotate between Place Details calls.
+    // Trust the names from the immediately preceding preview instead of re-fetching.
+    const startedUploadIds: number[] = [];
+    const skipped: PhotoImportStartResponse["skipped"] = [];
+
+    for (const { photoName, photographerCredit } of photos) {
+      const entry: ImageSetUpload = {
+        location_id: locationId,
+        format: "imageset",
+        stagedSourceStatus: "downloading",
+        sourceKind: "google",
+        googlePhotoName: photoName,
+        imageSet: undefined,
+      };
+      const savedId = saveUpload(entry);
+
+      if (typeof savedId !== "number") {
+        skipped.push({ photoName, reason: "not-in-place" });
+        continue;
+      }
+
+      entry.id = savedId;
+      startedUploadIds.push(savedId);
+      void this.downloadProcessor.process(
+        entry,
+        photoName,
+        photographerCredit?.trim() || "Google",
+        location.name,
+      );
+    }
+
+    touchLocationUpdatedAt(locationId);
+    return { startedUploadIds, skipped };
+  }
+
+  async retry(uploadId: number): Promise<Upload> {
+    if (!this.isConfigured()) {
+      throw new BadRequestError("Google Photo Import is disabled");
+    }
+    const upload = getUploadById(uploadId);
+    if (!upload) throw new NotFoundError("Upload", uploadId);
+
+    const stagedUpload = upload as ImageSetUpload;
+    if (stagedUpload.stagedSourceStatus !== "failed") {
+      throw new BadRequestError("Upload is not a failed StagedSource");
+    }
+    if (!stagedUpload.googlePhotoName) {
+      throw new BadRequestError("Upload has no googlePhotoName");
+    }
+
+    const location = getLocationById(stagedUpload.location_id);
+    if (!location) throw new NotFoundError("Location", stagedUpload.location_id);
+
+    stagedUpload.stagedSourceStatus = "downloading";
+    stagedUpload.errorMessage = null;
+    saveUpload(stagedUpload);
+    // Retry the stored token. Re-fetching the place would return names that cannot
+    // be matched reliably to this staged source.
+    void this.downloadProcessor.process(
+      stagedUpload,
+      stagedUpload.googlePhotoName,
+      "Google",
+      location.name,
+    );
+    return stagedUpload;
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/photo-import-location.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/photo-import-location.ts
@@ -1,0 +1,7 @@
+import { updateLocationById } from "../../../repositories/core";
+
+export function touchLocationUpdatedAt(locationId: number): void {
+  updateLocationById(locationId, {
+    updated_at: new Date().toISOString().replace("T", " ").replace(/\.\d{3}Z$/, ""),
+  });
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/photo-import.constants.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/photo-import.constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_GOOGLE_PHOTO_MAX_WIDTH = 1600;

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/staged-source-rejection.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/photo-import/staged-source-rejection.service.ts
@@ -1,0 +1,72 @@
+import { NotFoundError } from "@shared/errors/http-error";
+import type { ImageSetUpload } from "../../../models/location";
+import {
+  addRejectedGooglePhoto,
+  deleteUploadById,
+  getInstagramEmbedById,
+  getUploadById,
+  rejectInstagramMedia,
+  removeRejectedGooglePhoto,
+} from "../../../repositories/content";
+import { ImageStorageService } from "../../storage/image-storage.service";
+import { touchLocationUpdatedAt } from "./photo-import-location";
+
+export class StagedSourceRejectionService {
+  constructor(private readonly imageStorage: ImageStorageService) {}
+
+  rejectPhoto(locationId: number, photoName: string): void {
+    addRejectedGooglePhoto(locationId, photoName);
+    touchLocationUpdatedAt(locationId);
+  }
+
+  unrejectPhoto(locationId: number, photoName: string): void {
+    removeRejectedGooglePhoto(locationId, photoName);
+    touchLocationUpdatedAt(locationId);
+  }
+
+  async deleteStagedSource(uploadId: number): Promise<void> {
+    const upload = getUploadById(uploadId);
+    if (!upload) throw new NotFoundError("Upload", uploadId);
+
+    const stagedUpload = upload as ImageSetUpload;
+    this.rememberRejection(stagedUpload);
+    await this.cleanSourceFiles(stagedUpload, uploadId);
+    deleteUploadById(uploadId);
+    touchLocationUpdatedAt(stagedUpload.location_id);
+  }
+
+  private rememberRejection(upload: ImageSetUpload): void {
+    if (upload.googlePhotoName) {
+      this.rejectPhoto(upload.location_id, upload.googlePhotoName);
+      return;
+    }
+    if (
+      upload.instagramEmbedId
+      && upload.instagramMediaKey
+      && getInstagramEmbedById(upload.instagramEmbedId)
+    ) {
+      rejectInstagramMedia(
+        upload.instagramEmbedId,
+        upload.instagramMediaKey,
+        upload.sourcePosition ?? 0,
+      );
+    }
+  }
+
+  private async cleanSourceFiles(
+    upload: ImageSetUpload,
+    uploadId: number,
+  ): Promise<void> {
+    const sourcePath = upload.imageSet?.sourceImage?.path;
+    if (!sourcePath) return;
+
+    const metadata = this.imageStorage.extractPathMetadata(sourcePath);
+    if (!metadata) return;
+
+    try {
+      await this.imageStorage.deleteTimestampFolder(metadata.timestampDir);
+    } catch (error) {
+      console.error("Failed to clean StagedSource files", { uploadId, error });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- reduce `PhotoImportService` from 360 lines to an 88-line compatibility facade
- isolate Google preview annotation, staged-source commands, byte processing, and rejection cleanup
- preserve controller and service-container APIs while moving repository and filesystem details behind focused collaborators
- retain the opaque Google photo-token rule in the staging boundary
- add focused tests for imported/staged/rejected/new status precedence and preview metadata

The extracted production modules are each 145 lines or fewer and have one lifecycle responsibility.

## Verification
- focused preview-state suite — 2 tests passed
- full Location Manager suite — 227 tests passed across 49 files
- direct Bun bundle of `photo-import.service.ts` succeeded
- `pnpm run lint` — repository-standard intentional skip
- `pnpm run build` — repository-standard no-op for Bun