### PR TITLE
NOJIRA: Decompose homepage featured slots hook

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedActions.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react'
+
+import type { HomepageFeaturedCandidate } from './types'
+import type { SlotValue } from './homepageFeaturedSlots.types'
+
+type UseHomepageFeaturedActionsOptions = {
+  pickerSlotIndex: number | null
+  setPickerSlotIndex: (value: number | null) => void
+  setDraftSlots: (slots: SlotValue[]) => void
+  setResultMessage: (message: string | null) => void
+  updateSlots: (transform: (current: SlotValue[]) => SlotValue[]) => void
+  resetToSavedSlots: () => void
+}
+
+export function useHomepageFeaturedActions({
+  pickerSlotIndex,
+  setPickerSlotIndex,
+  setDraftSlots,
+  setResultMessage,
+  updateSlots,
+  resetToSavedSlots
+}: UseHomepageFeaturedActionsOptions) {
+  function handleCandidatePick(candidate: HomepageFeaturedCandidate) {
+    if (pickerSlotIndex === null) return
+
+    updateSlots((current) => {
+      const next = [...current]
+      next[pickerSlotIndex] = candidate
+      return next
+    })
+
+    setPickerSlotIndex(null)
+  }
+
+  function handleMove(slotIndex: number, direction: -1 | 1) {
+    updateSlots((current) => {
+      const nextIndex = slotIndex + direction
+      if (nextIndex < 0 || nextIndex >= current.length) return current
+
+      const next = [...current]
+      const currentValue = next[slotIndex]
+      next[slotIndex] = next[nextIndex]
+      next[nextIndex] = currentValue
+      return next
+    })
+  }
+
+  function handleRemove(slotIndex: number) {
+    updateSlots((current) => {
+      const next = [...current]
+      next[slotIndex] = null
+      return next
+    })
+  }
+
+  const handleReorderAll = useCallback(
+    (newSlots: SlotValue[]) => {
+      setDraftSlots(newSlots)
+      setResultMessage(null)
+    },
+    [setDraftSlots, setResultMessage]
+  )
+
+  return {
+    handleCandidatePick,
+    handleMove,
+    handleRemove,
+    handleReorderAll,
+    handleReset: resetToSavedSlots
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedCandidates.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedCandidates.ts
@@ -1,0 +1,69 @@
+import { useDeferredValue, useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import type { HomepageFeaturedCollection } from './types'
+import type { UseHomepageFeaturedSlotsOptions } from './homepageFeaturedSlots.types'
+
+const CANDIDATE_PAGE_SIZE = 24
+
+type UseHomepageFeaturedCandidatesOptions = Pick<
+  UseHomepageFeaturedSlotsOptions,
+  | 'token'
+  | 'canManage'
+  | 'fetchCandidates'
+  | 'selectionQueryKey'
+  | 'lockedCollectionFilter'
+> & {
+  pickerSlotIndex: number | null
+}
+
+export function useHomepageFeaturedCandidates({
+  token,
+  canManage,
+  fetchCandidates,
+  selectionQueryKey,
+  lockedCollectionFilter,
+  pickerSlotIndex
+}: UseHomepageFeaturedCandidatesOptions) {
+  const [searchValue, setSearchValue] = useState('')
+  const deferredSearchValue = useDeferredValue(searchValue.trim())
+  const [collectionFilter, setCollectionFilter] = useState<
+    HomepageFeaturedCollection | 'all'
+  >(lockedCollectionFilter ?? 'all')
+  const [candidatePage, setCandidatePage] = useState(1)
+
+  useEffect(() => {
+    setCandidatePage(1)
+  }, [collectionFilter, deferredSearchValue])
+
+  const effectiveCollectionFilter = lockedCollectionFilter ?? collectionFilter
+  const candidatesQuery = useQuery({
+    queryKey: [
+      ...selectionQueryKey,
+      'candidates',
+      effectiveCollectionFilter,
+      deferredSearchValue,
+      candidatePage
+    ],
+    queryFn: () =>
+      fetchCandidates(token!, {
+        type: effectiveCollectionFilter,
+        query: deferredSearchValue || undefined,
+        page: candidatePage,
+        limit: CANDIDATE_PAGE_SIZE
+      }),
+    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
+    placeholderData: (previousData) => previousData
+  })
+
+  return {
+    searchValue,
+    collectionFilter,
+    effectiveCollectionFilter,
+    candidatePage,
+    candidatesQuery,
+    setSearchValue,
+    setCollectionFilter,
+    setCandidatePage
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedDraftSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedDraftSlots.ts
@@ -1,0 +1,81 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+
+import type {
+  HomepageFeaturedInvalidItem,
+  HomepageFeaturedSelection
+} from './types'
+import type { SlotValue } from './homepageFeaturedSlots.types'
+import { mapSelectionToSlots } from './homepageFeaturedSlots.utils'
+
+export function useHomepageFeaturedDraftSlots(
+  selection: HomepageFeaturedSelection,
+  selectionQueryKey: unknown[]
+) {
+  const [draftSlots, setDraftSlots] = useState<SlotValue[] | null>(null)
+  const [savedSlots, setSavedSlots] = useState<SlotValue[]>([])
+  const [savedInvalidItems, setSavedInvalidItems] = useState<
+    HomepageFeaturedInvalidItem[]
+  >([])
+  const [pickerSlotIndex, setPickerSlotIndex] = useState<number | null>(null)
+  const [resultMessage, setResultMessage] = useState<string | null>(null)
+
+  const selectionKeyJson = JSON.stringify(selectionQueryKey)
+  const prevSelectionKeyJsonRef = useRef<string | null>(null)
+  const prevSelectionRef = useRef<HomepageFeaturedSelection | null>(null)
+
+  const applySelection = useCallback(
+    (nextSelection: HomepageFeaturedSelection) => {
+      const nextSlots = mapSelectionToSlots(nextSelection)
+      setSavedSlots(nextSlots)
+      setDraftSlots(nextSlots)
+      setSavedInvalidItems(nextSelection.invalidItems)
+      setPickerSlotIndex(null)
+    },
+    []
+  )
+
+  useLayoutEffect(() => {
+    if (
+      prevSelectionKeyJsonRef.current === selectionKeyJson &&
+      prevSelectionRef.current === selection
+    ) {
+      return
+    }
+    prevSelectionKeyJsonRef.current = selectionKeyJson
+    prevSelectionRef.current = selection
+    applySelection(selection)
+  }, [applySelection, selection, selectionKeyJson])
+
+  const updateSlots = useCallback(
+    (transform: (current: SlotValue[]) => SlotValue[]) => {
+      setDraftSlots((current) => {
+        const base = current ?? savedSlots
+        return transform([...base])
+      })
+      setResultMessage(null)
+    },
+    [savedSlots]
+  )
+
+  const resetToSavedSlots = useCallback(() => {
+    setDraftSlots([...savedSlots])
+    setPickerSlotIndex(null)
+    setResultMessage(
+      'Local changes discarded. Restored saved homepage selection.'
+    )
+  }, [savedSlots])
+
+  return {
+    draftSlots,
+    savedSlots,
+    savedInvalidItems,
+    pickerSlotIndex,
+    resultMessage,
+    setDraftSlots,
+    setPickerSlotIndex,
+    setResultMessage,
+    applySelection,
+    updateSlots,
+    resetToSavedSlots
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSaveMutation.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSaveMutation.ts
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import type { MutableRefObject } from 'react'
+
+import type {
+  HomepageFeaturedItemRef,
+  HomepageFeaturedSelection
+} from './types'
+import type {
+  SaveNotification,
+  UseHomepageFeaturedSlotsOptions
+} from './homepageFeaturedSlots.types'
+
+type UseHomepageFeaturedSaveMutationOptions = Pick<
+  UseHomepageFeaturedSlotsOptions,
+  'token' | 'saveSelection'
+> & {
+  slotCountRef: MutableRefObject<number>
+  onSuccess: (selection: HomepageFeaturedSelection) => void
+  onResultMessage: (message: string) => void
+}
+
+export function useHomepageFeaturedSaveMutation({
+  token,
+  saveSelection,
+  slotCountRef,
+  onSuccess,
+  onResultMessage
+}: UseHomepageFeaturedSaveMutationOptions) {
+  const [saveNotification, setSaveNotification] =
+    useState<SaveNotification | null>(null)
+
+  const saveMutation = useMutation({
+    mutationFn: (items: HomepageFeaturedItemRef[]) =>
+      saveSelection(token!, items, slotCountRef.current),
+    onSuccess: (selection) => {
+      onSuccess(selection)
+      onResultMessage('Homepage featured content saved.')
+      setSaveNotification({
+        message: 'Saved',
+        type: 'success',
+        seq: Date.now()
+      })
+    },
+    onError: (error: unknown) => {
+      onResultMessage(
+        error instanceof Error
+          ? error.message
+          : 'Failed to save homepage featured content.'
+      )
+      setSaveNotification({
+        message: 'Save failed',
+        type: 'error',
+        seq: Date.now()
+      })
+    }
+  })
+
+  return { saveMutation, saveNotification }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSlots.ts
@@ -1,39 +1,38 @@
-import { useDeferredValue, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
 
 import type {
-  HomepageFeaturedCandidate,
-  HomepageFeaturedCollection,
   HomepageFeaturedInvalidItem,
-  HomepageFeaturedItemRef,
-  HomepageFeaturedSelection,
+  HomepageFeaturedSelection
 } from './types'
 import type {
-  SaveNotification,
-  SlotValue,
   UseHomepageFeaturedSlotsOptions,
-  UseHomepageFeaturedSlotsResult,
+  UseHomepageFeaturedSlotsResult
 } from './homepageFeaturedSlots.types'
 import {
   areSlotListsEqual,
   buildSaveItems,
-  hasDuplicateSlots,
-  mapSelectionToSlots,
+  hasDuplicateSlots
 } from './homepageFeaturedSlots.utils'
+import { useHomepageFeaturedActions } from './useHomepageFeaturedActions'
+import { useHomepageFeaturedCandidates } from './useHomepageFeaturedCandidates'
+import { useHomepageFeaturedDraftSlots } from './useHomepageFeaturedDraftSlots'
+import { useHomepageFeaturedSaveMutation } from './useHomepageFeaturedSaveMutation'
 
 export type {
   CandidateParams,
   SaveNotification,
   SlotValue,
   UseHomepageFeaturedSlotsOptions,
-  UseHomepageFeaturedSlotsResult,
+  UseHomepageFeaturedSlotsResult
 } from './homepageFeaturedSlots.types'
-export { buildSaveItems, hasDuplicateSlots } from './homepageFeaturedSlots.utils'
-
-const CANDIDATE_PAGE_SIZE = 24
+export {
+  buildSaveItems,
+  hasDuplicateSlots
+} from './homepageFeaturedSlots.utils'
 
 export function useHomepageFeaturedSlots(
-  options: UseHomepageFeaturedSlotsOptions,
+  options: UseHomepageFeaturedSlotsOptions
 ): UseHomepageFeaturedSlotsResult {
   const {
     token,
@@ -43,73 +42,47 @@ export function useHomepageFeaturedSlots(
     fetchCandidates,
     selectionQueryKey,
     lockedCollectionFilter,
-    repairSlotCount,
+    repairSlotCount
   } = options
 
-  const [searchValue, setSearchValue] = useState('')
-  const deferredSearchValue = useDeferredValue(searchValue.trim())
-  const [collectionFilter, setCollectionFilter] = useState<HomepageFeaturedCollection | 'all'>(
-    lockedCollectionFilter ?? 'all',
-  )
-  const [candidatePage, setCandidatePage] = useState(1)
-  const [draftSlots, setDraftSlots] = useState<SlotValue[] | null>(null)
-  const [savedSlots, setSavedSlots] = useState<SlotValue[]>([])
-  const [savedInvalidItems, setSavedInvalidItems] = useState<HomepageFeaturedInvalidItem[]>([])
-  const [pickerSlotIndex, setPickerSlotIndex] = useState<number | null>(null)
-  const [resultMessage, setResultMessage] = useState<string | null>(null)
-  const [saveNotification, setSaveNotification] = useState<SaveNotification | null>(null)
-
-  const selectionKeyJson = JSON.stringify(selectionQueryKey)
-  const prevSelectionKeyJsonRef = useRef<string | null>(null)
-  const prevSelectionRef = useRef<HomepageFeaturedSelection | null>(null)
-
-  useLayoutEffect(() => {
-    if (
-      prevSelectionKeyJsonRef.current === selectionKeyJson
-      && prevSelectionRef.current === selection
-    ) {
-      return
-    }
-    prevSelectionKeyJsonRef.current = selectionKeyJson
-    prevSelectionRef.current = selection
-    const nextSlots = mapSelectionToSlots(selection)
-    setDraftSlots(nextSlots)
-    setSavedSlots(nextSlots)
-    setSavedInvalidItems(selection.invalidItems)
-    setPickerSlotIndex(null)
-  }, [selection, selectionKeyJson])
+  const {
+    draftSlots,
+    savedSlots,
+    savedInvalidItems,
+    pickerSlotIndex,
+    resultMessage,
+    setDraftSlots,
+    setPickerSlotIndex,
+    setResultMessage,
+    applySelection,
+    updateSlots,
+    resetToSavedSlots
+  } = useHomepageFeaturedDraftSlots(selection, selectionQueryKey)
 
   const selectionQuery = {
     data: selection,
     error: null,
     isLoading: false,
     isPending: false,
-    isFetching: false,
+    isFetching: false
   } as ReturnType<typeof useQuery<HomepageFeaturedSelection>>
 
-  useEffect(() => {
-    setCandidatePage(1)
-  }, [collectionFilter, deferredSearchValue])
-
-  const effectiveCollectionFilter = lockedCollectionFilter ?? collectionFilter
-
-  const candidatesQuery = useQuery({
-    queryKey: [
-      ...selectionQueryKey,
-      'candidates',
-      effectiveCollectionFilter,
-      deferredSearchValue,
-      candidatePage,
-    ],
-    queryFn: () =>
-      fetchCandidates(token!, {
-        type: effectiveCollectionFilter,
-        query: deferredSearchValue || undefined,
-        page: candidatePage,
-        limit: CANDIDATE_PAGE_SIZE,
-      }),
-    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
-    placeholderData: (previousData) => previousData,
+  const {
+    searchValue,
+    collectionFilter,
+    effectiveCollectionFilter,
+    candidatePage,
+    candidatesQuery,
+    setSearchValue,
+    setCollectionFilter,
+    setCandidatePage
+  } = useHomepageFeaturedCandidates({
+    token,
+    canManage,
+    fetchCandidates,
+    selectionQueryKey,
+    lockedCollectionFilter,
+    pickerSlotIndex
   })
 
   const slots = draftSlots ?? savedSlots
@@ -119,23 +92,12 @@ export function useHomepageFeaturedSlots(
     currentSaveSlotCountRef.current = repairSlotCount ?? slots.length
   }, [repairSlotCount, slots.length])
 
-  const saveMutation = useMutation({
-    mutationFn: (items: HomepageFeaturedItemRef[]) =>
-      saveSelection(token!, items, currentSaveSlotCountRef.current),
-    onSuccess: (selection) => {
-      const nextSlots = mapSelectionToSlots(selection)
-      setSavedSlots(nextSlots)
-      setDraftSlots(nextSlots)
-      setSavedInvalidItems(selection.invalidItems)
-      setPickerSlotIndex(null)
-      setResultMessage('Homepage featured content saved.')
-      setSaveNotification({ message: 'Saved', type: 'success', seq: Date.now() })
-    },
-    onError: (error: unknown) => {
-      const msg = error instanceof Error ? error.message : 'Failed to save homepage featured content.'
-      setResultMessage(msg)
-      setSaveNotification({ message: 'Save failed', type: 'error', seq: Date.now() })
-    },
+  const { saveMutation, saveNotification } = useHomepageFeaturedSaveMutation({
+    token,
+    saveSelection,
+    slotCountRef: currentSaveSlotCountRef,
+    onSuccess: applySelection,
+    onResultMessage: setResultMessage
   })
 
   const saveItems = buildSaveItems(slots)
@@ -143,8 +105,11 @@ export function useHomepageFeaturedSlots(
   // reports it to the page); an unstable identity there re-fires those effects
   // on every render and can feed back into an infinite render loop.
   const usedKeys = useMemo(
-    () => new Set(slots.flatMap((item) => (item ? [`${item.relationTo}:${item.id}`] : []))),
-    [slots],
+    () =>
+      new Set(
+        slots.flatMap((item) => (item ? [`${item.relationTo}:${item.id}`] : []))
+      ),
+    [slots]
   )
   const hasAllSlotsFilled = slots.every((item) => item !== null)
   const hasUnsavedChanges = areSlotListsEqual(draftSlots, savedSlots) === false
@@ -174,51 +139,14 @@ export function useHomepageFeaturedSlots(
     return () => clearTimeout(timer)
   }, [saveDisabled, draftSlots, mutate]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  function updateSlots(transform: (current: SlotValue[]) => SlotValue[]) {
-    setDraftSlots((current) => {
-      const base = current ?? savedSlots
-      return transform([...base])
-    })
-    setResultMessage(null)
-  }
-
-  function handleCandidatePick(candidate: HomepageFeaturedCandidate) {
-    if (pickerSlotIndex === null) return
-
-    updateSlots((current) => {
-      const next = [...current]
-      next[pickerSlotIndex] = candidate
-      return next
-    })
-
-    setPickerSlotIndex(null)
-  }
-
-  function handleMove(slotIndex: number, direction: -1 | 1) {
-    updateSlots((current) => {
-      const nextIndex = slotIndex + direction
-      if (nextIndex < 0 || nextIndex >= current.length) return current
-
-      const next = [...current]
-      const currentValue = next[slotIndex]
-      next[slotIndex] = next[nextIndex]
-      next[nextIndex] = currentValue
-      return next
-    })
-  }
-
-  function handleRemove(slotIndex: number) {
-    updateSlots((current) => {
-      const next = [...current]
-      next[slotIndex] = null
-      return next
-    })
-  }
-
-  const handleReorderAll = useCallback((newSlots: SlotValue[]) => {
-    setDraftSlots(newSlots)
-    setResultMessage(null)
-  }, [])
+  const actions = useHomepageFeaturedActions({
+    pickerSlotIndex,
+    setPickerSlotIndex,
+    setDraftSlots,
+    setResultMessage,
+    updateSlots,
+    resetToSavedSlots
+  })
 
   function handleResizeSlotCount(slotCount: number) {
     if (slotCount < 0) return
@@ -231,15 +159,9 @@ export function useHomepageFeaturedSlots(
 
       return [
         ...current,
-        ...Array.from({ length: slotCount - current.length }, () => null),
+        ...Array.from({ length: slotCount - current.length }, () => null)
       ]
     })
-  }
-
-  function handleReset() {
-    setDraftSlots([...savedSlots])
-    setPickerSlotIndex(null)
-    setResultMessage('Local changes discarded. Restored saved homepage selection.')
   }
 
   function handleSave() {
@@ -269,16 +191,12 @@ export function useHomepageFeaturedSlots(
     effectiveCollectionFilter,
     lockedCollectionFilter,
     candidatePage,
-    handleCandidatePick,
-    handleMove,
-    handleRemove,
-    handleReorderAll,
+    ...actions,
     handleResizeSlotCount,
-    handleReset,
     handleSave,
     setSearchValue,
     setCollectionFilter,
     setCandidatePage,
-    setPickerSlotIndex,
+    setPickerSlotIndex
   }
 }


### PR DESCRIPTION
## Summary
- extract saved/draft selection synchronization from the top-level hook
- isolate candidate search/filter pagination and its query
- isolate save mutation notifications and slot manipulation actions
- keep derived save eligibility, autosave, and the existing public hook contract in the orchestrator

## Verification
- frontend boundary check and ESLint
- frontend Vitest suite (91 files, 352 tests)
- frontend production Vite build
- `git diff --check`

## Architectural impact
State ownership now follows the existing location-grid hook pattern. Candidate loading, persistence, draft state, and editing actions can evolve independently without growing the public hook.