### PR TITLE
NOJIRA: Decompose homepage hotel-grid hook

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.types.ts
@@ -1,0 +1,65 @@
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query'
+
+import type {
+  HomepageHotelGridCandidate,
+  HomepageHotelGridCandidatesResponse,
+  HomepageHotelGridInvalidItem,
+  HomepageHotelGridItemRef,
+  HomepageHotelGridSelection
+} from './hotelGridTypes'
+
+export type HotelGridSlotValue = HomepageHotelGridCandidate | null
+
+export type HotelGridCandidateParams = {
+  query?: string
+  page?: number
+  limit?: number
+}
+
+export type UseHomepageHotelGridSlotsOptions = {
+  token: string | null
+  canManage: boolean
+  selection: HomepageHotelGridSelection
+  saveSelection: (
+    token: string,
+    items: HomepageHotelGridItemRef[],
+    slotCount?: number
+  ) => Promise<HomepageHotelGridSelection>
+  fetchCandidates: (
+    token: string,
+    params: HotelGridCandidateParams
+  ) => Promise<HomepageHotelGridCandidatesResponse>
+  selectionQueryKey: unknown[]
+}
+
+export type UseHomepageHotelGridSlotsResult = {
+  selectionQuery: UseQueryResult<HomepageHotelGridSelection>
+  candidatesQuery: UseQueryResult<HomepageHotelGridCandidatesResponse>
+  saveMutation: UseMutationResult<
+    HomepageHotelGridSelection,
+    unknown,
+    HomepageHotelGridItemRef[]
+  >
+  slots: HotelGridSlotValue[]
+  savedSlots: HotelGridSlotValue[]
+  draftSlots: HotelGridSlotValue[] | null
+  savedInvalidItems: HomepageHotelGridInvalidItem[]
+  pickerSlotIndex: number | null
+  usedIds: Set<number>
+  hasUnsavedChanges: boolean
+  saveDisabled: boolean
+  invalidItemsBySlot: Map<number, HomepageHotelGridInvalidItem>
+  resultMessage: string | null
+  searchValue: string
+  candidatePage: number
+  handleCandidatePick: (candidate: HomepageHotelGridCandidate) => void
+  handleMove: (slotIndex: number, direction: -1 | 1) => void
+  handleReorderAll: (newSlots: HotelGridSlotValue[]) => void
+  handleResizeSlotCount: (slotCount: number) => void
+  handleRemove: (slotIndex: number) => void
+  handleReset: () => void
+  handleSave: () => void
+  setSearchValue: (value: string) => void
+  setCandidatePage: (value: number | ((previous: number) => number)) => void
+  setPickerSlotIndex: (value: number | null) => void
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.utils.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HomepageHotelGridSelection } from './hotelGridTypes'
+import {
+  areHotelSlotListsEqual,
+  buildHotelGridSaveItems,
+  mapHotelSelectionToSlots
+} from './homepageHotelGridSlots.utils'
+
+const selection: HomepageHotelGridSelection = {
+  items: [
+    {
+      id: 7,
+      slot: 2,
+      title: 'Hotel Seven',
+      slug: 'hotel-seven',
+      type: null,
+      priceLevel: null,
+      status: 'published',
+      updatedAt: null,
+      imageUrl: null,
+      location: null
+    }
+  ],
+  invalidItems: [],
+  isComplete: false,
+  allowDrafts: true,
+  totalSlots: 3
+}
+
+describe('homepage hotel grid slot utilities', () => {
+  it('maps one-based saved positions into the fixed-size editor slots', () => {
+    expect(
+      mapHotelSelectionToSlots(selection).map((item) => item?.id ?? null)
+    ).toEqual([null, 7, null])
+  })
+
+  it('compares slot identity and position', () => {
+    const slots = mapHotelSelectionToSlots(selection)
+
+    expect(areHotelSlotListsEqual([...slots], slots)).toBe(true)
+    expect(areHotelSlotListsEqual([slots[1], null, null], slots)).toBe(false)
+  })
+
+  it('builds the compact persistence payload in display order', () => {
+    const slots = mapHotelSelectionToSlots(selection)
+
+    expect(buildHotelGridSaveItems(slots)).toEqual([{ id: 7 }])
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.utils.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.utils.ts
@@ -1,0 +1,47 @@
+import type {
+  HomepageHotelGridInvalidItem,
+  HomepageHotelGridItemRef,
+  HomepageHotelGridSelection
+} from './hotelGridTypes'
+import type { HotelGridSlotValue } from './homepageHotelGridSlots.types'
+
+export function mapHotelSelectionToSlots(
+  selection: HomepageHotelGridSelection
+): HotelGridSlotValue[] {
+  const slots = Array.from<HotelGridSlotValue>(
+    { length: selection.totalSlots },
+    () => null
+  )
+
+  for (const item of selection.items) {
+    if (!item.slot) continue
+    const slotIndex = item.slot - 1
+    if (slotIndex < 0 || slotIndex >= slots.length) continue
+    slots[slotIndex] = item
+  }
+
+  return slots
+}
+
+export function areHotelSlotListsEqual(
+  left: HotelGridSlotValue[] | null,
+  right: HotelGridSlotValue[]
+): boolean {
+  if (!left) return false
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item?.id === right[index]?.id)
+  )
+}
+
+export function buildHotelGridSaveItems(
+  slots: HotelGridSlotValue[]
+): HomepageHotelGridItemRef[] {
+  return slots.flatMap((item) => (item ? [{ id: item.id }] : []))
+}
+
+export function mapHotelInvalidItemsBySlot(
+  invalidItems: HomepageHotelGridInvalidItem[]
+): Map<number, HomepageHotelGridInvalidItem> {
+  return new Map(invalidItems.map((item) => [item.slot, item]))
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridActions.ts
@@ -1,0 +1,80 @@
+import type { HomepageHotelGridCandidate } from './hotelGridTypes'
+import type { HotelGridSlotValue } from './homepageHotelGridSlots.types'
+
+type UseHomepageHotelGridActionsOptions = {
+  pickerSlotIndex: number | null
+  setPickerSlotIndex: (value: number | null) => void
+  updateSlots: (
+    transform: (current: HotelGridSlotValue[]) => HotelGridSlotValue[]
+  ) => void
+  resetToSavedSlots: () => void
+}
+
+export function useHomepageHotelGridActions({
+  pickerSlotIndex,
+  setPickerSlotIndex,
+  updateSlots,
+  resetToSavedSlots
+}: UseHomepageHotelGridActionsOptions) {
+  function handleCandidatePick(candidate: HomepageHotelGridCandidate) {
+    if (pickerSlotIndex === null) return
+    updateSlots((current) => {
+      const next = [...current]
+      next[pickerSlotIndex] = candidate
+      return next
+    })
+    setPickerSlotIndex(null)
+  }
+
+  function handleMove(slotIndex: number, direction: -1 | 1) {
+    updateSlots((current) => {
+      const nextIndex = slotIndex + direction
+      if (nextIndex < 0 || nextIndex >= current.length) return current
+      const next = [...current]
+      const currentValue = next[slotIndex]
+      next[slotIndex] = next[nextIndex]
+      next[nextIndex] = currentValue
+      return next
+    })
+  }
+
+  function handleReorderAll(newSlots: HotelGridSlotValue[]) {
+    updateSlots((current) => {
+      if (newSlots.length !== current.length) return current
+      return [...newSlots]
+    })
+  }
+
+  function handleResizeSlotCount(slotCount: number) {
+    if (slotCount < 0) return
+    if (pickerSlotIndex !== null && pickerSlotIndex >= slotCount) {
+      setPickerSlotIndex(null)
+    }
+    updateSlots((current) => {
+      if (slotCount === current.length) return current
+      if (slotCount < current.length) return current.slice(0, slotCount)
+
+      return [
+        ...current,
+        ...Array.from({ length: slotCount - current.length }, () => null)
+      ]
+    })
+  }
+
+  function handleRemove(slotIndex: number) {
+    updateSlots((current) => {
+      const next = [...current]
+      next[slotIndex] = null
+      return next
+    })
+  }
+
+  return {
+    handleCandidatePick,
+    handleMove,
+    handleReorderAll,
+    handleResizeSlotCount,
+    handleRemove,
+    handleReset: resetToSavedSlots
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridCandidates.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridCandidates.ts
@@ -1,0 +1,54 @@
+import { useDeferredValue, useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import type { UseHomepageHotelGridSlotsOptions } from './homepageHotelGridSlots.types'
+
+const CANDIDATE_PAGE_SIZE = 24
+
+type UseHomepageHotelGridCandidatesOptions = Pick<
+  UseHomepageHotelGridSlotsOptions,
+  'token' | 'canManage' | 'fetchCandidates' | 'selectionQueryKey'
+> & {
+  pickerSlotIndex: number | null
+}
+
+export function useHomepageHotelGridCandidates({
+  token,
+  canManage,
+  fetchCandidates,
+  selectionQueryKey,
+  pickerSlotIndex
+}: UseHomepageHotelGridCandidatesOptions) {
+  const [searchValue, setSearchValue] = useState('')
+  const deferredSearchValue = useDeferredValue(searchValue.trim())
+  const [candidatePage, setCandidatePage] = useState(1)
+
+  useEffect(() => {
+    setCandidatePage(1)
+  }, [deferredSearchValue])
+
+  const candidatesQuery = useQuery({
+    queryKey: [
+      ...selectionQueryKey,
+      'hotel-candidates',
+      deferredSearchValue,
+      candidatePage
+    ],
+    queryFn: () =>
+      fetchCandidates(token!, {
+        query: deferredSearchValue || undefined,
+        page: candidatePage,
+        limit: CANDIDATE_PAGE_SIZE
+      }),
+    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
+    placeholderData: (previousData) => previousData
+  })
+
+  return {
+    searchValue,
+    candidatePage,
+    candidatesQuery,
+    setSearchValue,
+    setCandidatePage
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridDraftSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridDraftSlots.ts
@@ -1,0 +1,80 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+
+import type {
+  HomepageHotelGridInvalidItem,
+  HomepageHotelGridSelection
+} from './hotelGridTypes'
+import type { HotelGridSlotValue } from './homepageHotelGridSlots.types'
+import { mapHotelSelectionToSlots } from './homepageHotelGridSlots.utils'
+
+export function useHomepageHotelGridDraftSlots(
+  selection: HomepageHotelGridSelection,
+  selectionQueryKey: unknown[]
+) {
+  const [draftSlots, setDraftSlots] = useState<HotelGridSlotValue[] | null>(
+    null
+  )
+  const [savedSlots, setSavedSlots] = useState<HotelGridSlotValue[]>([])
+  const [savedInvalidItems, setSavedInvalidItems] = useState<
+    HomepageHotelGridInvalidItem[]
+  >([])
+  const [pickerSlotIndex, setPickerSlotIndex] = useState<number | null>(null)
+  const [resultMessage, setResultMessage] = useState<string | null>(null)
+
+  const selectionKeyJson = JSON.stringify(selectionQueryKey)
+  const previousSelectionKeyRef = useRef<string | null>(null)
+  const previousSelectionRef = useRef<HomepageHotelGridSelection | null>(null)
+
+  const applySelection = useCallback(
+    (nextSelection: HomepageHotelGridSelection) => {
+      const nextSlots = mapHotelSelectionToSlots(nextSelection)
+      setSavedSlots(nextSlots)
+      setDraftSlots(nextSlots)
+      setSavedInvalidItems(nextSelection.invalidItems)
+      setPickerSlotIndex(null)
+    },
+    []
+  )
+
+  useLayoutEffect(() => {
+    if (
+      previousSelectionKeyRef.current === selectionKeyJson &&
+      previousSelectionRef.current === selection
+    ) {
+      return
+    }
+    previousSelectionKeyRef.current = selectionKeyJson
+    previousSelectionRef.current = selection
+    applySelection(selection)
+  }, [applySelection, selection, selectionKeyJson])
+
+  const updateSlots = useCallback(
+    (transform: (current: HotelGridSlotValue[]) => HotelGridSlotValue[]) => {
+      setDraftSlots((current) => {
+        const base = current ?? savedSlots
+        return transform([...base])
+      })
+      setResultMessage(null)
+    },
+    [savedSlots]
+  )
+
+  const resetToSavedSlots = useCallback(() => {
+    setDraftSlots([...savedSlots])
+    setPickerSlotIndex(null)
+    setResultMessage('Local changes discarded. Restored saved hotel selection.')
+  }, [savedSlots])
+
+  return {
+    draftSlots,
+    savedSlots,
+    savedInvalidItems,
+    pickerSlotIndex,
+    resultMessage,
+    setPickerSlotIndex,
+    setResultMessage,
+    applySelection,
+    updateSlots,
+    resetToSavedSlots
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSaveMutation.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSaveMutation.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query'
+import type { MutableRefObject } from 'react'
+
+import type {
+  HomepageHotelGridItemRef,
+  HomepageHotelGridSelection
+} from './hotelGridTypes'
+import type { UseHomepageHotelGridSlotsOptions } from './homepageHotelGridSlots.types'
+
+type UseHomepageHotelGridSaveMutationOptions = Pick<
+  UseHomepageHotelGridSlotsOptions,
+  'token' | 'saveSelection'
+> & {
+  slotCountRef: MutableRefObject<number>
+  onSuccess: (selection: HomepageHotelGridSelection) => void
+  onError: (error: unknown) => void
+}
+
+export function useHomepageHotelGridSaveMutation({
+  token,
+  saveSelection,
+  slotCountRef,
+  onSuccess,
+  onError
+}: UseHomepageHotelGridSaveMutationOptions) {
+  return useMutation({
+    mutationFn: (items: HomepageHotelGridItemRef[]) =>
+      saveSelection(token!, items, slotCountRef.current),
+    onSuccess,
+    onError
+  })
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSlots.ts
@@ -1,73 +1,31 @@
-import {
-  useDeferredValue,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState
-} from 'react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
 
+import type { HomepageHotelGridSelection } from './hotelGridTypes'
 import type {
-  HomepageHotelGridCandidate,
-  HomepageHotelGridCandidatesResponse,
-  HomepageHotelGridInvalidItem,
-  HomepageHotelGridItemRef,
-  HomepageHotelGridSelection
-} from './hotelGridTypes'
+  UseHomepageHotelGridSlotsOptions,
+  UseHomepageHotelGridSlotsResult
+} from './homepageHotelGridSlots.types'
+import {
+  areHotelSlotListsEqual,
+  buildHotelGridSaveItems,
+  mapHotelInvalidItemsBySlot
+} from './homepageHotelGridSlots.utils'
+import { useHomepageHotelGridActions } from './useHomepageHotelGridActions'
+import { useHomepageHotelGridCandidates } from './useHomepageHotelGridCandidates'
+import { useHomepageHotelGridDraftSlots } from './useHomepageHotelGridDraftSlots'
+import { useHomepageHotelGridSaveMutation } from './useHomepageHotelGridSaveMutation'
 
-const CANDIDATE_PAGE_SIZE = 24
+export type {
+  HotelGridCandidateParams,
+  HotelGridSlotValue,
+  UseHomepageHotelGridSlotsOptions,
+  UseHomepageHotelGridSlotsResult
+} from './homepageHotelGridSlots.types'
 
-export type HotelGridSlotValue = HomepageHotelGridCandidate | null
-
-function createEmptySlots(count: number): HotelGridSlotValue[] {
-  return Array.from({ length: count }, () => null)
-}
-
-function mapSelectionToSlots(
-  selection: HomepageHotelGridSelection
-): HotelGridSlotValue[] {
-  const slots = createEmptySlots(selection.totalSlots)
-  for (const item of selection.items) {
-    if (!item.slot) continue
-    const slotIndex = item.slot - 1
-    if (slotIndex < 0 || slotIndex >= slots.length) continue
-    slots[slotIndex] = item
-  }
-  return slots
-}
-
-function areSlotListsEqual(
-  left: HotelGridSlotValue[] | null,
-  right: HotelGridSlotValue[]
-): boolean {
-  if (!left) return false
-  return (
-    left.length === right.length &&
-    left.every((item, index) => item?.id === right[index]?.id)
-  )
-}
-
-export type HotelGridCandidateParams = {
-  query?: string
-  page?: number
-  limit?: number
-}
-
-export function useHomepageHotelGridSlots(options: {
-  token: string | null
-  canManage: boolean
-  selection: HomepageHotelGridSelection
-  saveSelection: (
-    token: string,
-    items: HomepageHotelGridItemRef[],
-    slotCount?: number
-  ) => Promise<HomepageHotelGridSelection>
-  fetchCandidates: (
-    token: string,
-    params: HotelGridCandidateParams
-  ) => Promise<HomepageHotelGridCandidatesResponse>
-  selectionQueryKey: unknown[]
-}) {
+export function useHomepageHotelGridSlots(
+  options: UseHomepageHotelGridSlotsOptions
+): UseHomepageHotelGridSlotsResult {
   const {
     token,
     canManage,
@@ -76,38 +34,22 @@ export function useHomepageHotelGridSlots(options: {
     fetchCandidates,
     selectionQueryKey
   } = options
-  const [searchValue, setSearchValue] = useState('')
-  const deferredSearchValue = useDeferredValue(searchValue.trim())
-  const [candidatePage, setCandidatePage] = useState(1)
-  const [draftSlots, setDraftSlots] = useState<HotelGridSlotValue[] | null>(
-    null
+  const draftState = useHomepageHotelGridDraftSlots(
+    selection,
+    selectionQueryKey
   )
-  const [savedSlots, setSavedSlots] = useState<HotelGridSlotValue[]>([])
-  const [savedInvalidItems, setSavedInvalidItems] = useState<
-    HomepageHotelGridInvalidItem[]
-  >([])
-  const [pickerSlotIndex, setPickerSlotIndex] = useState<number | null>(null)
-  const [resultMessage, setResultMessage] = useState<string | null>(null)
-
-  const selectionKeyJson = JSON.stringify(selectionQueryKey)
-  const prevSelectionKeyJsonRef = useRef<string | null>(null)
-  const prevSelectionRef = useRef<HomepageHotelGridSelection | null>(null)
-
-  useLayoutEffect(() => {
-    if (
-      prevSelectionKeyJsonRef.current === selectionKeyJson &&
-      prevSelectionRef.current === selection
-    ) {
-      return
-    }
-    prevSelectionKeyJsonRef.current = selectionKeyJson
-    prevSelectionRef.current = selection
-    const nextSlots = mapSelectionToSlots(selection)
-    setDraftSlots(nextSlots)
-    setSavedSlots(nextSlots)
-    setSavedInvalidItems(selection.invalidItems)
-    setPickerSlotIndex(null)
-  }, [selection, selectionKeyJson])
+  const {
+    draftSlots,
+    savedSlots,
+    savedInvalidItems,
+    pickerSlotIndex,
+    resultMessage,
+    setPickerSlotIndex,
+    setResultMessage,
+    applySelection,
+    updateSlots,
+    resetToSavedSlots
+  } = draftState
 
   const selectionQuery = {
     data: selection,
@@ -117,25 +59,12 @@ export function useHomepageHotelGridSlots(options: {
     isFetching: false
   } as ReturnType<typeof useQuery<HomepageHotelGridSelection>>
 
-  useEffect(() => {
-    setCandidatePage(1)
-  }, [deferredSearchValue])
-
-  const candidatesQuery = useQuery({
-    queryKey: [
-      ...selectionQueryKey,
-      'hotel-candidates',
-      deferredSearchValue,
-      candidatePage
-    ],
-    queryFn: () =>
-      fetchCandidates(token!, {
-        query: deferredSearchValue || undefined,
-        page: candidatePage,
-        limit: CANDIDATE_PAGE_SIZE
-      }),
-    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
-    placeholderData: (previousData) => previousData
+  const candidateState = useHomepageHotelGridCandidates({
+    token,
+    canManage,
+    fetchCandidates,
+    selectionQueryKey,
+    pickerSlotIndex
   })
 
   const slots = draftSlots ?? savedSlots
@@ -145,18 +74,15 @@ export function useHomepageHotelGridSlots(options: {
     currentSaveSlotCountRef.current = slots.length
   }, [slots.length])
 
-  const saveMutation = useMutation({
-    mutationFn: (items: HomepageHotelGridItemRef[]) =>
-      saveSelection(token!, items, currentSaveSlotCountRef.current),
-    onSuccess: (selection) => {
-      const nextSlots = mapSelectionToSlots(selection)
-      setSavedSlots(nextSlots)
-      setDraftSlots(nextSlots)
-      setSavedInvalidItems(selection.invalidItems)
-      setPickerSlotIndex(null)
+  const saveMutation = useHomepageHotelGridSaveMutation({
+    token,
+    saveSelection,
+    slotCountRef: currentSaveSlotCountRef,
+    onSuccess: (nextSelection) => {
+      applySelection(nextSelection)
       setResultMessage('Homepage hotel grid saved.')
     },
-    onError: (error: unknown) => {
+    onError: (error) => {
       setResultMessage(
         error instanceof Error
           ? error.message
@@ -165,114 +91,44 @@ export function useHomepageHotelGridSlots(options: {
     }
   })
 
-  const usedIds = new Set(slots.flatMap((item) => (item ? [item.id] : [])))
-  const hasAllSlotsFilled = slots.every((item) => item !== null)
-  const hasUnsavedChanges = areSlotListsEqual(draftSlots, savedSlots) === false
+  const hasUnsavedChanges = !areHotelSlotListsEqual(draftSlots, savedSlots)
   const saveDisabled =
-    !token || !hasAllSlotsFilled || saveMutation.isPending || !hasUnsavedChanges
-  const invalidItemsBySlot = new Map<number, HomepageHotelGridInvalidItem>()
-  for (const item of savedInvalidItems) invalidItemsBySlot.set(item.slot, item)
-
-  function updateSlots(
-    transform: (current: HotelGridSlotValue[]) => HotelGridSlotValue[]
-  ) {
-    setDraftSlots((current) => {
-      const base = current ?? savedSlots
-      return transform([...base])
-    })
-    setResultMessage(null)
-  }
-
-  function handleCandidatePick(candidate: HomepageHotelGridCandidate) {
-    if (pickerSlotIndex === null) return
-    updateSlots((current) => {
-      const next = [...current]
-      next[pickerSlotIndex] = candidate
-      return next
-    })
-    setPickerSlotIndex(null)
-  }
-
-  function handleMove(slotIndex: number, direction: -1 | 1) {
-    updateSlots((current) => {
-      const nextIndex = slotIndex + direction
-      if (nextIndex < 0 || nextIndex >= current.length) return current
-      const next = [...current]
-      const currentValue = next[slotIndex]
-      next[slotIndex] = next[nextIndex]
-      next[nextIndex] = currentValue
-      return next
-    })
-  }
-
-  function handleReorderAll(newSlots: HotelGridSlotValue[]) {
-    updateSlots((current) => {
-      if (newSlots.length !== current.length) return current
-      return [...newSlots]
-    })
-  }
-
-  function handleResizeSlotCount(slotCount: number) {
-    if (slotCount < 0) return
-    if (pickerSlotIndex !== null && pickerSlotIndex >= slotCount) {
-      setPickerSlotIndex(null)
-    }
-    updateSlots((current) => {
-      if (slotCount === current.length) return current
-      if (slotCount < current.length) return current.slice(0, slotCount)
-
-      return [
-        ...current,
-        ...Array.from({ length: slotCount - current.length }, () => null)
-      ]
-    })
-  }
-
-  function handleRemove(slotIndex: number) {
-    updateSlots((current) => {
-      const next = [...current]
-      next[slotIndex] = null
-      return next
-    })
-  }
-
-  function handleReset() {
-    setDraftSlots([...savedSlots])
-    setPickerSlotIndex(null)
-    setResultMessage('Local changes discarded. Restored saved hotel selection.')
-  }
+    !token ||
+    slots.some((item) => item === null) ||
+    saveMutation.isPending ||
+    !hasUnsavedChanges
+  const actions = useHomepageHotelGridActions({
+    pickerSlotIndex,
+    setPickerSlotIndex,
+    updateSlots,
+    resetToSavedSlots
+  })
 
   function handleSave() {
     if (saveDisabled) return
-    const items = slots.flatMap((item) => (item ? [{ id: item.id }] : []))
-    saveMutation.mutate(items)
+    saveMutation.mutate(buildHotelGridSaveItems(slots))
   }
 
   return {
     selectionQuery,
-    candidatesQuery,
+    candidatesQuery: candidateState.candidatesQuery,
     saveMutation,
     slots,
     savedSlots,
+    draftSlots,
     savedInvalidItems,
     pickerSlotIndex,
-    usedIds,
+    usedIds: new Set(slots.flatMap((item) => (item ? [item.id] : []))),
     hasUnsavedChanges,
     saveDisabled,
-    invalidItemsBySlot,
+    invalidItemsBySlot: mapHotelInvalidItemsBySlot(savedInvalidItems),
     resultMessage,
-    searchValue,
-    candidatePage,
-    handleCandidatePick,
-    handleMove,
-    handleReorderAll,
-    handleResizeSlotCount,
-    handleRemove,
-    handleReset,
+    searchValue: candidateState.searchValue,
+    candidatePage: candidateState.candidatePage,
+    ...actions,
     handleSave,
-    setSearchValue,
-    setCandidatePage,
-    setPickerSlotIndex,
-    draftSlots
+    setSearchValue: candidateState.setSearchValue,
+    setCandidatePage: candidateState.setCandidatePage,
+    setPickerSlotIndex
   }
 }


### PR DESCRIPTION
## Summary
- extract hotel-grid slot mapping, equality, payload, and invalid-item helpers
- isolate draft synchronization, candidate pagination, persistence, and editing actions
- keep the public hook contract stable while reducing the orchestrator to composition and derived state
- add regression tests for one-based slot mapping, ordered payloads, and equality

## Verification
- frontend boundary check and ESLint
- frontend Vitest suite (92 files, 355 tests)
- frontend production Vite build
- `git diff --check`

## Architectural impact
The hotel-grid editor now matches the repository’s decomposed location-grid pattern. Pure transformations are testable without React, and each stateful concern has a focused hook.