### PR TITLE
NOJIRA: Split dining enrichment concerns

### DIFF
--- a/apps/location-manager/packages/client/src/features/location-create/dining-create/enrichment/diningAiSuggestions.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/dining-create/enrichment/diningAiSuggestions.ts
@@ -1,0 +1,144 @@
+import type { UseFormReturn } from "react-hook-form";
+import { locationsApi } from "@client/shared/services/api";
+import type {
+  DiningFieldSuggestionResponse,
+  TripadvisorPrefillFields,
+} from "@client/shared/services/api/types";
+import type { FieldProvenance } from "@questurian/lm-shared";
+import type { AddDiningFormData } from "../../validation/add-dining.schema";
+import {
+  AI_CONFIDENCE_THRESHOLD,
+  AI_FIELD_KEYS,
+  type AiFieldStatus,
+  type AiSuggestionFieldKey,
+  type ProvenanceTrackedField,
+} from "../dining-create.types";
+
+export type AiCallContext = {
+  name: string;
+  address: string;
+  prefillType: string;
+  currentIdealFor: string[];
+};
+
+export function initialAiFieldStatusMap(): Record<
+  AiSuggestionFieldKey,
+  AiFieldStatus
+> {
+  return AI_FIELD_KEYS.reduce(
+    (statuses, key) => {
+      statuses[key] = {
+        state: "idle",
+        confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
+      };
+      return statuses;
+    },
+    {} as Record<AiSuggestionFieldKey, AiFieldStatus>
+  );
+}
+
+export function statusFromAiResult(
+  result: DiningFieldSuggestionResponse
+): AiFieldStatus {
+  const details = {
+    confidence: result.confidence,
+    reason: result.reason,
+    sources: result.sources,
+    confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
+  };
+  if (result.error) {
+    return { state: "error", errorMessage: result.error, ...details };
+  }
+  return {
+    state: result.suggestion == null ? "no-result" : "suggested",
+    ...details,
+  };
+}
+
+export function statusFromThrown(error: unknown): AiFieldStatus {
+  return {
+    state: "error",
+    errorMessage: error instanceof Error ? error.message : String(error),
+    confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
+  };
+}
+
+export function callDiningAiSuggestion(
+  form: UseFormReturn<AddDiningFormData>,
+  prefillWebsite: string | null,
+  tripadvisorData: TripadvisorPrefillFields | null,
+  fieldKey: AiSuggestionFieldKey,
+  context: AiCallContext
+): Promise<DiningFieldSuggestionResponse> {
+  return locationsApi.suggestDiningField({
+    category: "dining",
+    fieldKey,
+    formValues: {
+      name: context.name,
+      address: context.address,
+      type: context.prefillType,
+      idealFor: context.currentIdealFor,
+    },
+    apiContext: {
+      placeId: form.getValues("placeId") || null,
+      locationKey: form.getValues("locationKey") || null,
+      district: form.getValues("district") || null,
+      priceLevel: tripadvisorData?.priceLevel ?? null,
+      website: form.getValues("website") || prefillWebsite || null,
+      tripadvisorUrl: form.getValues("tripadvisorUrl") || null,
+      tripadvisorMealTypes: tripadvisorData?.mealTypes ?? null,
+      tripadvisorCuisines: tripadvisorData?.cuisines ?? null,
+      tripadvisorFeatures: tripadvisorData?.features ?? null,
+    },
+  });
+}
+
+export function applyDiningAiResultToForm(
+  form: UseFormReturn<AddDiningFormData>,
+  result: DiningFieldSuggestionResponse,
+  options: {
+    wantsTypeFromAi: boolean;
+    nextProvenance: Partial<
+      Record<ProvenanceTrackedField, FieldProvenance>
+    >;
+    nextPrefilled: Partial<Record<ProvenanceTrackedField, string>>;
+    onUrlSuggested?: (field: "menuUrl" | "bookingUrl") => void;
+  }
+) {
+  const { wantsTypeFromAi, nextProvenance, nextPrefilled, onUrlSuggested } =
+    options;
+  if (result.fieldKey === "idealFor" && Array.isArray(result.suggestion)) {
+    form.setValue(
+      "idealFor",
+      result.suggestion as AddDiningFormData["idealFor"],
+      { shouldDirty: true, shouldValidate: true, shouldTouch: true }
+    );
+  }
+  if (
+    result.fieldKey === "type" &&
+    typeof result.suggestion === "string" &&
+    wantsTypeFromAi
+  ) {
+    form.setValue("type", result.suggestion, {
+      shouldDirty: true,
+      shouldValidate: true,
+      shouldTouch: true,
+    });
+    nextProvenance.type = "ai";
+    nextPrefilled.type = result.suggestion;
+  }
+  if (
+    (result.fieldKey === "menuUrl" || result.fieldKey === "bookingUrl") &&
+    typeof result.suggestion === "string"
+  ) {
+    const field = result.fieldKey;
+    form.setValue(field, result.suggestion, {
+      shouldDirty: true,
+      shouldValidate: true,
+      shouldTouch: true,
+    });
+    nextProvenance[field] = "ai";
+    nextPrefilled[field] = result.suggestion;
+    onUrlSuggested?.(field);
+  }
+}

--- a/apps/location-manager/packages/client/src/features/location-create/dining-create/enrichment/useDiningEnrichment.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/dining-create/enrichment/useDiningEnrichment.ts
@@ -1,19 +1,8 @@
-import { useEffect, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { locationsApi } from "@client/shared/services/api";
-import type {
-  DiningFieldSuggestionResponse,
-  TripadvisorPrefillFields,
-} from "@client/shared/services/api/types";
-import { isFieldProvenance, type FieldProvenance } from "@questurian/lm-shared";
-import {
-  allAiUrlsAcknowledged,
-  initAiUrlAck,
-  liftAiUrlAckOnUserEdit,
-  markAiUrlSuggested,
-  setAiUrlAcknowledged,
-  type AiUrlAckState,
-} from "../../autofill/ai-url-ack";
+import type { DiningFieldSuggestionResponse } from "@client/shared/services/api/types";
+import { isFieldProvenance } from "@questurian/lm-shared";
+import { initAiUrlAck, markAiUrlSuggested } from "../../autofill/ai-url-ack";
 import {
   buildDiningPrefillSignature,
   normalizeDiningAddress,
@@ -22,216 +11,83 @@ import {
 } from "../../validation/add-dining.schema";
 import {
   AI_CONFIDENCE_THRESHOLD,
-  AI_FIELD_KEYS,
   PROVENANCE_TRACKED_FIELDS,
   type AiFieldStatus,
   type AiSuggestionFieldKey,
-  type ProvenanceTrackedField,
 } from "../dining-create.types";
-
-const AI_URL_ACK_FIELDS = ["menuUrl", "bookingUrl"] as const;
-type AiUrlAckField = (typeof AI_URL_ACK_FIELDS)[number];
-
-function initialAiFieldStatusMap(): Record<AiSuggestionFieldKey, AiFieldStatus> {
-  return AI_FIELD_KEYS.reduce(
-    (acc, key) => {
-      acc[key] = { state: "idle", confidenceThreshold: AI_CONFIDENCE_THRESHOLD };
-      return acc;
-    },
-    {} as Record<AiSuggestionFieldKey, AiFieldStatus>
-  );
-}
-
-function statusFromAiResult(result: DiningFieldSuggestionResponse): AiFieldStatus {
-  if (result.error) {
-    return {
-      state: "error",
-      errorMessage: result.error,
-      confidence: result.confidence,
-      reason: result.reason,
-      sources: result.sources,
-      confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
-    };
-  }
-  if (result.suggestion == null) {
-    return {
-      state: "no-result",
-      confidence: result.confidence,
-      reason: result.reason,
-      sources: result.sources,
-      confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
-    };
-  }
-  return {
-    state: "suggested",
-    confidence: result.confidence,
-    reason: result.reason,
-    sources: result.sources,
-    confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
-  };
-}
-
-function statusFromThrown(err: unknown): AiFieldStatus {
-  return {
-    state: "error",
-    errorMessage: err instanceof Error ? err.message : String(err),
-    confidenceThreshold: AI_CONFIDENCE_THRESHOLD,
-  };
-}
+import {
+  applyDiningAiResultToForm,
+  callDiningAiSuggestion,
+  initialAiFieldStatusMap,
+  statusFromAiResult,
+  statusFromThrown,
+  type AiCallContext,
+} from "./diningAiSuggestions";
+import {
+  AI_URL_ACK_FIELDS,
+  useDiningEnrichmentState,
+} from "./useDiningEnrichmentState";
 
 interface UseDiningEnrichmentOptions {
   form: UseFormReturn<AddDiningFormData>;
 }
 
 export function useDiningEnrichment({ form }: UseDiningEnrichmentOptions) {
-  const [isPrefillingGoogle, setIsPrefillingGoogle] = useState(false);
-  const [prefillMessage, setPrefillMessage] = useState<string | null>(null);
-  const [prefillError, setPrefillError] = useState<string | null>(null);
-  const [prefillSignature, setPrefillSignature] = useState<string | null>(null);
-  const [prefillOperationHours, setPrefillOperationHours] = useState<Record<string, unknown> | null>(null);
-  const [prefillPhoneNumber, setPrefillPhoneNumber] = useState<string | null>(null);
-  const [prefillWebsite, setPrefillWebsite] = useState<string | null>(null);
-  const [prefillTripadvisorPlaceData, setPrefillTripadvisorPlaceData] =
-    useState<TripadvisorPrefillFields | null>(null);
-  const [aiBatchStep, setAiBatchStep] = useState<"google" | "tripadvisor" | "ai" | null>(null);
-  const [verifiedAiUrls, setVerifiedAiUrls] = useState<AiUrlAckState<AiUrlAckField>>(() =>
-    initAiUrlAck(AI_URL_ACK_FIELDS)
-  );
-  const [provenance, setProvenance] = useState<
-    Partial<Record<ProvenanceTrackedField, FieldProvenance>>
-  >({});
-  const [prefilledValues, setPrefilledValues] = useState<Partial<Record<ProvenanceTrackedField, string>>>({});
-  const [aiFieldStatus, setAiFieldStatus] = useState<Record<AiSuggestionFieldKey, AiFieldStatus>>(
-    () => initialAiFieldStatusMap()
-  );
+  const state = useDiningEnrichmentState(form);
+  const {
+    isPrefillingGoogle,
+    setIsPrefillingGoogle,
+    prefillMessage,
+    setPrefillMessage,
+    prefillError,
+    setPrefillError,
+    prefillSignature,
+    setPrefillSignature,
+    prefillOperationHours,
+    setPrefillOperationHours,
+    prefillPhoneNumber,
+    setPrefillPhoneNumber,
+    prefillWebsite,
+    setPrefillWebsite,
+    prefillTripadvisorPlaceData,
+    setPrefillTripadvisorPlaceData,
+    aiBatchStep,
+    setAiBatchStep,
+    verifiedAiUrls,
+    setVerifiedAiUrls,
+    provenance,
+    setProvenance,
+    prefilledValues,
+    setPrefilledValues,
+    aiFieldStatus,
+    setAiFieldStatus,
+    isPrefillReady,
+    prefillIsStale,
+    resetEnrichmentState,
+    acknowledgeAiUrl,
+    allAiUrlsVerified,
+  } = state;
 
-  const currentPrefillSignature = buildDiningPrefillSignature(
-    form.watch("name"),
-    form.watch("address")
-  );
-  const isPrefillReady = prefillSignature !== null && prefillSignature === currentPrefillSignature;
-  const prefillIsStale = prefillSignature !== null && !isPrefillReady;
-
-  useEffect(() => {
-    const subscription = form.watch((value, { name }) => {
-      if (!name) return;
-      const trackedField = PROVENANCE_TRACKED_FIELDS.find((field) => field === name);
-      if (!trackedField) return;
-      const current = (value as Partial<AddDiningFormData>)[trackedField];
-      const prefilled = prefilledValues[trackedField];
-      if (prefilled === undefined) return;
-      if (typeof current !== "string" || current !== prefilled) {
-        setProvenance((prev) => {
-          if (!(trackedField in prev)) return prev;
-          const next = { ...prev };
-          delete next[trackedField];
-          return next;
-        });
-        if (trackedField === "menuUrl" || trackedField === "bookingUrl") {
-          setVerifiedAiUrls((prev) => liftAiUrlAckOnUserEdit(prev, trackedField));
-        }
-      }
-    });
-
-    return () => subscription.unsubscribe();
-  }, [form, prefilledValues]);
-
-  function resetEnrichmentState() {
-    setPrefillSignature(null);
-    setPrefillOperationHours(null);
-    setPrefillPhoneNumber(null);
-    setPrefillWebsite(null);
-    setPrefillTripadvisorPlaceData(null);
-    setProvenance({});
-    setPrefilledValues({});
-    setVerifiedAiUrls(initAiUrlAck(AI_URL_ACK_FIELDS));
-    setAiFieldStatus(initialAiFieldStatusMap());
-  }
-
-  interface AiCallContext {
-    name: string;
-    address: string;
-    prefillType: string;
-    currentIdealFor: string[];
-  }
-
-  function buildAiApiContextFromState(): Record<string, unknown> {
-    const ta = prefillTripadvisorPlaceData;
-    return {
-      placeId: form.getValues("placeId") || null,
-      locationKey: form.getValues("locationKey") || null,
-      district: form.getValues("district") || null,
-      priceLevel: ta?.priceLevel ?? null,
-      website: form.getValues("website") || prefillWebsite || null,
-      tripadvisorUrl: form.getValues("tripadvisorUrl") || null,
-      tripadvisorMealTypes: ta?.mealTypes ?? null,
-      tripadvisorCuisines: ta?.cuisines ?? null,
-      tripadvisorFeatures: ta?.features ?? null,
-    };
-  }
-
-  async function callAiSuggestion(
+  const callAiSuggestion = (
     fieldKey: AiSuggestionFieldKey,
-    ctx: AiCallContext
-  ): Promise<DiningFieldSuggestionResponse> {
-    return locationsApi.suggestDiningField({
-      category: "dining",
+    context: AiCallContext
+  ) =>
+    callDiningAiSuggestion(
+      form,
+      prefillWebsite,
+      prefillTripadvisorPlaceData,
       fieldKey,
-      formValues: {
-        name: ctx.name,
-        address: ctx.address,
-        type: ctx.prefillType,
-        idealFor: ctx.currentIdealFor,
-      },
-      apiContext: buildAiApiContextFromState(),
-    });
-  }
+      context
+    );
 
-  function applyAiResultToForm(
-    result: DiningFieldSuggestionResponse,
-    opts: {
-      wantsTypeFromAi: boolean;
-      nextProvenance: typeof provenance;
-      nextPrefilled: typeof prefilledValues;
-      onUrlSuggested?: (field: "menuUrl" | "bookingUrl") => void;
-    }
-  ) {
-    const { wantsTypeFromAi, nextProvenance, nextPrefilled, onUrlSuggested } = opts;
-    if (result.fieldKey === "idealFor" && Array.isArray(result.suggestion)) {
-      form.setValue("idealFor", result.suggestion as AddDiningFormData["idealFor"], {
-        shouldDirty: true,
-        shouldValidate: true,
-        shouldTouch: true,
-      });
-    }
-    if (
-      result.fieldKey === "type" &&
-      typeof result.suggestion === "string" &&
-      wantsTypeFromAi
-    ) {
-      form.setValue("type", result.suggestion, {
-        shouldDirty: true,
-        shouldValidate: true,
-        shouldTouch: true,
-      });
-      nextProvenance.type = "ai";
-      nextPrefilled.type = result.suggestion;
-    }
-    if (
-      (result.fieldKey === "menuUrl" || result.fieldKey === "bookingUrl") &&
-      typeof result.suggestion === "string"
-    ) {
-      const field = result.fieldKey;
-      form.setValue(field, result.suggestion, {
-        shouldDirty: true,
-        shouldValidate: true,
-        shouldTouch: true,
-      });
-      nextProvenance[field] = "ai";
-      nextPrefilled[field] = result.suggestion;
-      onUrlSuggested?.(field);
-    }
-  }
+  const applyAiResultToForm = (
+    ...args: Parameters<typeof applyDiningAiResultToForm> extends [
+      unknown,
+      ...infer Rest,
+    ]
+      ? Rest
+      : never
+  ) => applyDiningAiResultToForm(form, ...args);
 
   async function retryAiField(fieldKey: AiSuggestionFieldKey) {
     if (!isPrefillReady) return;
@@ -429,10 +285,6 @@ export function useDiningEnrichment({ form }: UseDiningEnrichmentOptions) {
     }
   }
 
-  function acknowledgeAiUrl(field: AiUrlAckField, verified: boolean) {
-    setVerifiedAiUrls((prev) => setAiUrlAcknowledged(prev, field, verified));
-  }
-
   return {
     isPrefillingGoogle,
     aiBatchStep,
@@ -462,6 +314,6 @@ export function useDiningEnrichment({ form }: UseDiningEnrichmentOptions) {
     retryAiField,
     resetEnrichmentState,
     acknowledgeAiUrl,
-    allAiUrlsVerified: allAiUrlsAcknowledged(verifiedAiUrls),
+    allAiUrlsVerified,
   };
 }

--- a/apps/location-manager/packages/client/src/features/location-create/dining-create/enrichment/useDiningEnrichmentState.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/dining-create/enrichment/useDiningEnrichmentState.ts
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import type { TripadvisorPrefillFields } from "@client/shared/services/api/types";
+import type { FieldProvenance } from "@questurian/lm-shared";
+import {
+  allAiUrlsAcknowledged,
+  initAiUrlAck,
+  liftAiUrlAckOnUserEdit,
+  setAiUrlAcknowledged,
+  type AiUrlAckState,
+} from "../../autofill/ai-url-ack";
+import {
+  buildDiningPrefillSignature,
+  type AddDiningFormData,
+} from "../../validation/add-dining.schema";
+import type {
+  AiFieldStatus,
+  AiSuggestionFieldKey,
+  ProvenanceTrackedField,
+} from "../dining-create.types";
+import { PROVENANCE_TRACKED_FIELDS } from "../dining-create.types";
+import { initialAiFieldStatusMap } from "./diningAiSuggestions";
+
+export const AI_URL_ACK_FIELDS = ["menuUrl", "bookingUrl"] as const;
+export type AiUrlAckField = (typeof AI_URL_ACK_FIELDS)[number];
+
+export function useDiningEnrichmentState(
+  form: UseFormReturn<AddDiningFormData>
+) {
+  const [isPrefillingGoogle, setIsPrefillingGoogle] = useState(false);
+  const [prefillMessage, setPrefillMessage] = useState<string | null>(null);
+  const [prefillError, setPrefillError] = useState<string | null>(null);
+  const [prefillSignature, setPrefillSignature] = useState<string | null>(null);
+  const [prefillOperationHours, setPrefillOperationHours] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const [prefillPhoneNumber, setPrefillPhoneNumber] = useState<string | null>(
+    null
+  );
+  const [prefillWebsite, setPrefillWebsite] = useState<string | null>(null);
+  const [prefillTripadvisorPlaceData, setPrefillTripadvisorPlaceData] =
+    useState<TripadvisorPrefillFields | null>(null);
+  const [aiBatchStep, setAiBatchStep] = useState<
+    "google" | "tripadvisor" | "ai" | null
+  >(null);
+  const [verifiedAiUrls, setVerifiedAiUrls] = useState<
+    AiUrlAckState<AiUrlAckField>
+  >(() => initAiUrlAck(AI_URL_ACK_FIELDS));
+  const [provenance, setProvenance] = useState<
+    Partial<Record<ProvenanceTrackedField, FieldProvenance>>
+  >({});
+  const [prefilledValues, setPrefilledValues] = useState<
+    Partial<Record<ProvenanceTrackedField, string>>
+  >({});
+  const [aiFieldStatus, setAiFieldStatus] = useState<
+    Record<AiSuggestionFieldKey, AiFieldStatus>
+  >(() => initialAiFieldStatusMap());
+
+  const currentSignature = buildDiningPrefillSignature(
+    form.watch("name"),
+    form.watch("address")
+  );
+  const isPrefillReady =
+    prefillSignature !== null && prefillSignature === currentSignature;
+
+  useEffect(() => {
+    const subscription = form.watch((value, { name }) => {
+      if (!name) return;
+      const trackedField = PROVENANCE_TRACKED_FIELDS.find(
+        (field) => field === name
+      );
+      if (!trackedField) return;
+      const current = (value as Partial<AddDiningFormData>)[trackedField];
+      const prefilled = prefilledValues[trackedField];
+      if (prefilled === undefined) return;
+      if (typeof current !== "string" || current !== prefilled) {
+        setProvenance((previous) => {
+          if (!(trackedField in previous)) return previous;
+          const next = { ...previous };
+          delete next[trackedField];
+          return next;
+        });
+        if (trackedField === "menuUrl" || trackedField === "bookingUrl") {
+          setVerifiedAiUrls((previous) =>
+            liftAiUrlAckOnUserEdit(previous, trackedField)
+          );
+        }
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [form, prefilledValues]);
+
+  const resetEnrichmentState = () => {
+    setPrefillSignature(null);
+    setPrefillOperationHours(null);
+    setPrefillPhoneNumber(null);
+    setPrefillWebsite(null);
+    setPrefillTripadvisorPlaceData(null);
+    setProvenance({});
+    setPrefilledValues({});
+    setVerifiedAiUrls(initAiUrlAck(AI_URL_ACK_FIELDS));
+    setAiFieldStatus(initialAiFieldStatusMap());
+  };
+
+  const acknowledgeAiUrl = (field: AiUrlAckField, verified: boolean) => {
+    setVerifiedAiUrls((previous) =>
+      setAiUrlAcknowledged(previous, field, verified)
+    );
+  };
+
+  return {
+    isPrefillingGoogle,
+    setIsPrefillingGoogle,
+    prefillMessage,
+    setPrefillMessage,
+    prefillError,
+    setPrefillError,
+    prefillSignature,
+    setPrefillSignature,
+    prefillOperationHours,
+    setPrefillOperationHours,
+    prefillPhoneNumber,
+    setPrefillPhoneNumber,
+    prefillWebsite,
+    setPrefillWebsite,
+    prefillTripadvisorPlaceData,
+    setPrefillTripadvisorPlaceData,
+    aiBatchStep,
+    setAiBatchStep,
+    verifiedAiUrls,
+    setVerifiedAiUrls,
+    provenance,
+    setProvenance,
+    prefilledValues,
+    setPrefilledValues,
+    aiFieldStatus,
+    setAiFieldStatus,
+    isPrefillReady,
+    prefillIsStale: prefillSignature !== null && !isPrefillReady,
+    resetEnrichmentState,
+    acknowledgeAiUrl,
+    allAiUrlsVerified: allAiUrlsAcknowledged(verifiedAiUrls),
+  };
+}


### PR DESCRIPTION
## Summary
- reduce `useDiningEnrichment` from 467 lines to a 318-line workflow coordinator
- isolate AI status mapping, API context construction, and form application in a focused service
- move enrichment state, provenance invalidation, and AI URL acknowledgement into a dedicated state hook

## Validation
- changed-file ESLint passed
- package lint ran (intentionally skipped by the repository script)
- package tests ran (no tests configured; intentionally skipped by the repository script)
- direct Vite production build passed (2,270 modules)
- full `tsc -b` reaches only the existing unrelated Zod v3/v4 resolver incompatibility baseline