### PR TITLE
NOJIRA: Decompose curated homepage block editor

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockEditor.tsx
@@ -1,60 +1,28 @@
-import { useEffect, useMemo, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
-import HomepageBlockConvertSection from './HomepageBlockConvertSection'
-import HomepageBlockSectionTextFields from './HomepageBlockSectionTextFields'
+import { useMemo, useState } from 'react'
+import CuratedHomepageBlockSettings from './CuratedHomepageBlockSettings'
 import HomepageFeaturedSlotEditor from './HomepageFeaturedSlotEditor'
-import HomepageBlockDeleteTrigger from './HomepageBlockDeleteTrigger'
-import HomepageBlockSettingsModal from './HomepageBlockSettingsModal'
-import HomepageBlockSlotCountSection from './HomepageBlockSlotCountSection'
 import {
   ARTICLE_CURATED_HOMEPAGE_BLOCK_TYPES,
   CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES,
   HOMEPAGE_PAGE_BLOCK_CONFIG,
   type ArticleCuratedHomepageBlockResponse,
-  type ArticleGridBlockResponse,
   type ArticleGridFourLayout,
   type CuratedHomepageBlockType,
-  type FeaturedArticlesBlockResponse,
   type FeaturedArticlesSlot3Layout,
   type FeaturedArticlesSlot4Layout,
   type FeaturedArticlesSlot5Layout,
 } from './pageBlocks'
-import { useHomepageFeaturedSlots, type CandidateParams, type UseHomepageFeaturedSlotsResult } from './useHomepageFeaturedSlots'
+import { useCuratedHomepageLayouts } from './useCuratedHomepageLayouts'
+import {
+  useHomepageFeaturedSlots,
+  type CandidateParams,
+} from './useHomepageFeaturedSlots'
+import { usePageBlockDuplicateExclusion } from './usePageBlockDuplicateExclusion'
 import type {
   HomepageFeaturedCandidatesResponse,
   HomepageFeaturedItemRef,
   HomepageFeaturedSelection,
 } from './types'
-
-function slot3LayoutForBlock(block: ArticleCuratedHomepageBlockResponse): FeaturedArticlesSlot3Layout {
-  if (block.blockType !== 'featured-articles' || block.selection.totalSlots !== 3) {
-    return 'hero-left'
-  }
-  return (block as FeaturedArticlesBlockResponse).slot3Layout ?? 'hero-left'
-}
-
-function slot4LayoutForBlock(block: ArticleCuratedHomepageBlockResponse): FeaturedArticlesSlot4Layout {
-  if (block.blockType !== 'featured-articles' || block.selection.totalSlots !== 4) {
-    return 'sidebar-stack'
-  }
-  return (block as FeaturedArticlesBlockResponse).slot4Layout ?? 'sidebar-stack'
-}
-
-function slot5LayoutForBlock(block: ArticleCuratedHomepageBlockResponse): FeaturedArticlesSlot5Layout {
-  if (block.blockType !== 'featured-articles' || block.selection.totalSlots !== 5) {
-    return 'card-grid'
-  }
-  return (block as FeaturedArticlesBlockResponse).slot5Layout ?? 'card-grid'
-}
-
-function articleGridFourLayoutForBlock(
-  block: ArticleCuratedHomepageBlockResponse,
-): ArticleGridFourLayout {
-  if (block.blockType !== 'article-grid' || block.selection.totalSlots !== 4) {
-    return 'four-across'
-  }
-  return (block as ArticleGridBlockResponse).articleGridFourLayout ?? 'four-across'
-}
 
 type Props = {
   block: ArticleCuratedHomepageBlockResponse
@@ -67,20 +35,12 @@ type Props = {
     items: HomepageFeaturedItemRef[],
     slotCount?: number,
   ) => Promise<HomepageFeaturedSelection>
-  /** Persist optional section title (PUT without items). */
   saveSectionHeading?: (token: string, value: string | null) => Promise<void>
   saveSectionSubheading?: (token: string, value: string | null) => Promise<void>
-  /** Persist 3-slot layout for Featured Articles (PUT without items). */
   saveSlot3Layout?: (token: string, value: FeaturedArticlesSlot3Layout) => Promise<void>
-  /** Persist 4-slot layout for Featured Articles (PUT without items). */
   saveSlot4Layout?: (token: string, value: FeaturedArticlesSlot4Layout) => Promise<void>
   saveSlot5Layout?: (token: string, value: FeaturedArticlesSlot5Layout) => Promise<void>
-  /** Article Grid with 4 slots: one row × four (wide) vs 2×2 (square). */
   saveArticleGridFourLayout?: (token: string, value: ArticleGridFourLayout) => Promise<void>
-  /**
-   * When this article-curated block has no saved items, user can switch type (section title kept).
-   * Defaults to {@link CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES} when unset.
-   */
   convertEmptyFeaturedArticlesTargets?: CuratedHomepageBlockType[]
   onConvertEmptyFeaturedArticlesBlock?: (
     token: string,
@@ -94,9 +54,7 @@ type Props = {
   onDeleteBlock: (blockId: string) => void
   isDeletingBlock: boolean
   deleteError: string | null
-  /** Keys used in other blocks on the same page (all collections). Used to enforce page-level article exclusion. */
   externalUsedKeys?: Set<string>
-  /** Called when this block's draft slot keys change so the parent can track page-level usage. */
   onSlotsChange?: (blockId: string, keys: Set<string>) => void
 }
 
@@ -122,87 +80,16 @@ export default function CuratedHomepageBlockEditor({
   externalUsedKeys,
   onSlotsChange,
 }: Props) {
-  const savedSectionHeading = block.sectionHeading ?? ''
-  const savedSectionSubheading = block.sectionSubheading ?? ''
-
-  const [slot3LayoutDraft, setSlot3LayoutDraft] = useState<FeaturedArticlesSlot3Layout>(() =>
-    slot3LayoutForBlock(block),
-  )
-  const [slot4LayoutDraft, setSlot4LayoutDraft] = useState<FeaturedArticlesSlot4Layout>(() =>
-    slot4LayoutForBlock(block),
-  )
-  const [slot5LayoutDraft, setSlot5LayoutDraft] = useState<FeaturedArticlesSlot5Layout>(() =>
-    slot5LayoutForBlock(block),
-  )
-  const [articleGridFourLayoutDraft, setArticleGridFourLayoutDraft] = useState<ArticleGridFourLayout>(
-    () => articleGridFourLayoutForBlock(block),
-  )
   const [settingsOpen, setSettingsOpen] = useState(false)
-
-  const convertTargets = useMemo(() => {
-    const list =
-      convertEmptyFeaturedArticlesTargets.length > 0 ? convertEmptyFeaturedArticlesTargets : []
-    const others = list.filter((t) => t !== block.blockType)
-    return [block.blockType, ...others]
-  }, [convertEmptyFeaturedArticlesTargets, block.blockType])
-
-  const savedSlot3Layout = slot3LayoutForBlock(block)
-
-  useEffect(() => {
-    setSlot3LayoutDraft(savedSlot3Layout)
-  }, [savedSlot3Layout])
-
-  const savedSlot4Layout = slot4LayoutForBlock(block)
-
-  useEffect(() => {
-    setSlot4LayoutDraft(savedSlot4Layout)
-  }, [savedSlot4Layout])
-
-  const savedSlot5Layout = slot5LayoutForBlock(block)
-
-  useEffect(() => {
-    setSlot5LayoutDraft(savedSlot5Layout)
-  }, [savedSlot5Layout])
-
-  const savedArticleGridFourLayout = articleGridFourLayoutForBlock(block)
-
-  useEffect(() => {
-    setArticleGridFourLayoutDraft(savedArticleGridFourLayout)
-  }, [savedArticleGridFourLayout])
-
-  const slot3LayoutDirty = slot3LayoutDraft !== savedSlot3Layout
-  const slot4LayoutDirty = slot4LayoutDraft !== savedSlot4Layout
-  const slot5LayoutDirty = slot5LayoutDraft !== savedSlot5Layout
-  const articleGridFourLayoutDirty = articleGridFourLayoutDraft !== savedArticleGridFourLayout
-
-  const slot3LayoutMutation = useMutation({
-    mutationFn: async (value: FeaturedArticlesSlot3Layout) => {
-      if (!token || !saveSlot3Layout) return
-      await saveSlot3Layout(token, value)
-    },
+  const blockConfig = HOMEPAGE_PAGE_BLOCK_CONFIG[block.blockType]
+  const layouts = useCuratedHomepageLayouts({
+    block,
+    token,
+    saveSlot3Layout,
+    saveSlot4Layout,
+    saveSlot5Layout,
+    saveArticleGridFourLayout,
   })
-
-  const slot4LayoutMutation = useMutation({
-    mutationFn: async (value: FeaturedArticlesSlot4Layout) => {
-      if (!token || !saveSlot4Layout) return
-      await saveSlot4Layout(token, value)
-    },
-  })
-
-  const slot5LayoutMutation = useMutation({
-    mutationFn: async (value: FeaturedArticlesSlot5Layout) => {
-      if (!token || !saveSlot5Layout) return
-      await saveSlot5Layout(token, value)
-    },
-  })
-
-  const articleGridFourLayoutMutation = useMutation({
-    mutationFn: async (value: ArticleGridFourLayout) => {
-      if (!token || !saveArticleGridFourLayout) return
-      await saveArticleGridFourLayout(token, value)
-    },
-  })
-
   const slotEditorState = useHomepageFeaturedSlots({
     token,
     canManage,
@@ -213,70 +100,47 @@ export default function CuratedHomepageBlockEditor({
     lockedCollectionFilter:
       block.blockType === 'questurian-maps' ? 'single-type-listicles' : undefined,
   })
+  const effectiveSlotEditorState = usePageBlockDuplicateExclusion({
+    blockId: block.id,
+    slotEditorState,
+    externalUsedKeys,
+    onSlotsChange,
+  })
 
-  const {
-    saveMutation,
-    slots,
-    saveDisabled,
-    handleSave,
-    handleResizeSlotCount,
-    savedSlots,
-    savedInvalidItems,
-    hasUnsavedChanges,
-  } = slotEditorState
+  const convertTargets = useMemo(() => {
+    const others = convertEmptyFeaturedArticlesTargets.filter(
+      (target) => target !== block.blockType,
+    )
+    return [block.blockType, ...others]
+  }, [convertEmptyFeaturedArticlesTargets, block.blockType])
 
-  // Report this block's internal slot keys to the parent for page-level exclusion tracking.
-  useEffect(() => {
-    onSlotsChange?.(block.id, slotEditorState.usedKeys)
-    return () => { onSlotsChange?.(block.id, new Set()) }
-  }, [block.id, slotEditorState.usedKeys, onSlotsChange])
-
-  // Merge external keys so the picker greys out articles used elsewhere on the page.
-  const mergedUsedKeys = useMemo<UseHomepageFeaturedSlotsResult['usedKeys']>(() =>
-    externalUsedKeys && externalUsedKeys.size > 0
-      ? new Set([...slotEditorState.usedKeys, ...externalUsedKeys])
-      : slotEditorState.usedKeys,
-  [slotEditorState.usedKeys, externalUsedKeys])
-
-  // Block save when this block contains an article already placed in another block.
-  const hasCrossBlockDuplicate =
-    externalUsedKeys != null &&
-    externalUsedKeys.size > 0 &&
-    slots.some((s) => s != null && externalUsedKeys.has(`${s.relationTo}:${s.id}`))
-
-  const effectiveSlotEditorState: UseHomepageFeaturedSlotsResult =
-    hasCrossBlockDuplicate || mergedUsedKeys !== slotEditorState.usedKeys
-      ? { ...slotEditorState, usedKeys: mergedUsedKeys, saveDisabled: saveDisabled || hasCrossBlockDuplicate }
-      : slotEditorState
-
-  const totalSlots = slots.length
+  const { slots, savedSlots, savedInvalidItems, hasUnsavedChanges } = slotEditorState
   const savedTotalSlots = block.selection.totalSlots
   const slotsFilled = slots.filter(Boolean).length
-  const slotsTotal = slots.length
-  const blockConfig = HOMEPAGE_PAGE_BLOCK_CONFIG[block.blockType]
   const staleSlotNotice =
     savedInvalidItems.length === 0
       ? null
       : `${savedInvalidItems.length} slot${savedInvalidItems.length === 1 ? '' : 's'} ${savedInvalidItems.length === 1 ? 'has a broken item' : 'have broken items'}. This block stays at ${savedTotalSlots} slot${savedTotalSlots === 1 ? '' : 's'} and is blocked — hidden from the published homepage — until you replace ${savedInvalidItems.length === 1 ? 'it' : 'them'}.`
-
-  const canConvertEmptyFeaturedArticles =
-    ARTICLE_CURATED_HOMEPAGE_BLOCK_TYPES.includes(block.blockType)
-    && Boolean(onConvertEmptyFeaturedArticlesBlock)
-    && convertTargets.length > 0
-    && !hasUnsavedChanges
-    && savedSlots.every((s) => !s)
-    && savedInvalidItems.length === 0
+  const canConvert =
+    ARTICLE_CURATED_HOMEPAGE_BLOCK_TYPES.includes(block.blockType) &&
+    Boolean(onConvertEmptyFeaturedArticlesBlock) &&
+    convertTargets.length > 0 &&
+    !hasUnsavedChanges &&
+    savedSlots.every((slot) => !slot) &&
+    savedInvalidItems.length === 0
 
   return (
     <div className="hf-block-section">
       <div className="hf-block-header">
         <div className="hf-block-label">
           <span>Block {blockIndex + 1}</span>
-          <span className="hf-block-type-tag">{blockConfig.label} · {totalSlots} slots</span>
+          <span className="hf-block-type-tag">
+            {blockConfig.label} · {slots.length} slots
+          </span>
         </div>
         <div className="hf-block-header-actions">
           <span className="hf-block-slot-meta" aria-live="polite">
-            {slotsFilled} / {slotsTotal} filled
+            {slotsFilled} / {slots.length} filled
           </span>
           <button
             type="button"
@@ -291,351 +155,54 @@ export default function CuratedHomepageBlockEditor({
         </div>
       </div>
 
-      {staleSlotNotice ? (
-        <div className="hf-banner error">
-          {staleSlotNotice}
-        </div>
-      ) : null}
+      {staleSlotNotice ? <div className="hf-banner error">{staleSlotNotice}</div> : null}
 
-      <HomepageBlockSettingsModal
+      <CuratedHomepageBlockSettings
+        block={block}
+        blockIndex={blockIndex}
+        token={token}
         isOpen={settingsOpen}
         onClose={() => setSettingsOpen(false)}
-        footer={
-          <>
-            <button
-              type="button"
-              className="hf-btn-primary hf-block-header-save"
-              onClick={handleSave}
-              disabled={saveDisabled}
-            >
-              {saveMutation.isPending ? 'Saving…' : 'Save'}
-            </button>
-            <HomepageBlockDeleteTrigger
-              blockId={block.id}
-              blockIndex={blockIndex}
-              blockLabel={blockConfig.label}
-              onDeleteBlock={onDeleteBlock}
-              isDeletingBlock={isDeletingBlock}
-              deleteError={deleteError}
-            />
-          </>
+        layoutState={layouts}
+        saveSectionHeading={saveSectionHeading}
+        saveSectionSubheading={saveSectionSubheading}
+        enableSlot3Layout={
+          Boolean(saveSlot3Layout) &&
+          block.blockType === 'featured-articles' &&
+          savedTotalSlots === 3
         }
-      >
-        <p
-          className="hf-block-slot-meta hf-block-settings-slot-summary"
-          aria-live="polite"
-        >
-          {slotsFilled} / {slotsTotal} filled
-        </p>
-          <HomepageBlockSectionTextFields
-            blockId={block.id}
-            token={token}
-            sectionHeading={block.sectionHeading}
-            sectionSubheading={block.sectionSubheading}
-            settingsOpen={settingsOpen}
-            saveSectionHeading={saveSectionHeading}
-            saveSectionSubheading={saveSectionSubheading}
-          />
-
-          <HomepageBlockSlotCountSection
-            blockId={block.id}
-            blockType={block.blockType}
-            currentSlotCount={slots.length}
-            savedSlotCount={savedTotalSlots}
-            slots={slots}
-            invalidSlots={savedInvalidItems.map((item) => item.slot)}
-            disabled={!token || saveMutation.isPending}
-            isPending={saveMutation.isPending}
-            onResize={handleResizeSlotCount}
-          />
-
-          {saveSlot3Layout &&
+        enableSlot4Layout={
+          Boolean(saveSlot4Layout) &&
           block.blockType === 'featured-articles' &&
-          block.selection.totalSlots === 3 ? (
-            <section className="hf-block-settings-section">
-              <h3 className="hf-block-settings-kicker">Three-slot layout</h3>
-              <p className="hf-block-settings-hint">
-                How the three articles are arranged in this block (public homepage follows this).
-              </p>
-              <div
-                className="hf-slot3-layout-options"
-                role="radiogroup"
-                aria-label="Three-slot layout"
-              >
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-slot3-${block.id}`}
-                    checked={slot3LayoutDraft === 'hero-left'}
-                    onChange={() => setSlot3LayoutDraft('hero-left')}
-                    disabled={!token || slot3LayoutMutation.isPending}
-                  />
-                  <span>
-                    Hero left — two stacked on the right
-                  </span>
-                </label>
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-slot3-${block.id}`}
-                    checked={slot3LayoutDraft === 'featured-center'}
-                    onChange={() => setSlot3LayoutDraft('featured-center')}
-                    disabled={!token || slot3LayoutMutation.isPending}
-                  />
-                  <span>
-                    Three columns — large feature in the center
-                  </span>
-                </label>
-              </div>
-              <div className="hf-block-section-heading-row">
-                <button
-                  type="button"
-                  className="hf-btn-ghost"
-                  disabled={!token || !slot3LayoutDirty || slot3LayoutMutation.isPending}
-                  onClick={() => setSlot3LayoutDraft(savedSlot3Layout)}
-                >
-                  Reset
-                </button>
-                <button
-                  type="button"
-                  className="hf-btn-primary"
-                  disabled={!token || !slot3LayoutDirty || slot3LayoutMutation.isPending}
-                  onClick={() => slot3LayoutMutation.mutate(slot3LayoutDraft)}
-                >
-                  {slot3LayoutMutation.isPending ? 'Saving…' : 'Save layout'}
-                </button>
-              </div>
-              {slot3LayoutMutation.isError ? (
-                <p className="hf-block-section-heading-error">
-                  {slot3LayoutMutation.error instanceof Error
-                    ? slot3LayoutMutation.error.message
-                    : 'Failed to save layout.'}
-                </p>
-              ) : null}
-            </section>
-          ) : null}
-
-          {saveSlot4Layout &&
+          savedTotalSlots === 4
+        }
+        enableSlot5Layout={
+          Boolean(saveSlot5Layout) &&
           block.blockType === 'featured-articles' &&
-          block.selection.totalSlots === 4 ? (
-            <section className="hf-block-settings-section">
-              <h3 className="hf-block-settings-kicker">Four-slot layout</h3>
-              <p className="hf-block-settings-hint">
-                How the four articles are arranged (public homepage follows this).
-              </p>
-              <div
-                className="hf-slot3-layout-options"
-                role="radiogroup"
-                aria-label="Four-slot layout"
-              >
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-slot4-${block.id}`}
-                    checked={slot4LayoutDraft === 'sidebar-stack'}
-                    onChange={() => setSlot4LayoutDraft('sidebar-stack')}
-                    disabled={!token || slot4LayoutMutation.isPending}
-                  />
-                  <span>Hero column + stacked sidebar (default)</span>
-                </label>
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-slot4-${block.id}`}
-                    checked={slot4LayoutDraft === 'one-over-three'}
-                    onChange={() => setSlot4LayoutDraft('one-over-three')}
-                    disabled={!token || slot4LayoutMutation.isPending}
-                  />
-                  <span>Lead row: text + image, then three columns</span>
-                </label>
-              </div>
-              <div className="hf-block-section-heading-row">
-                <button
-                  type="button"
-                  className="hf-btn-ghost"
-                  disabled={!token || !slot4LayoutDirty || slot4LayoutMutation.isPending}
-                  onClick={() => setSlot4LayoutDraft(savedSlot4Layout)}
-                >
-                  Reset
-                </button>
-                <button
-                  type="button"
-                  className="hf-btn-primary"
-                  disabled={!token || !slot4LayoutDirty || slot4LayoutMutation.isPending}
-                  onClick={() => slot4LayoutMutation.mutate(slot4LayoutDraft)}
-                >
-                  {slot4LayoutMutation.isPending ? 'Saving…' : 'Save layout'}
-                </button>
-              </div>
-              {slot4LayoutMutation.isError ? (
-                <p className="hf-block-section-heading-error">
-                  {slot4LayoutMutation.error instanceof Error
-                    ? slot4LayoutMutation.error.message
-                    : 'Failed to save layout.'}
-                </p>
-              ) : null}
-            </section>
-          ) : null}
-
-          {saveSlot5Layout &&
-          block.blockType === 'featured-articles' &&
-          block.selection.totalSlots === 5 ? (
-            <section className="hf-block-settings-section">
-              <h3 className="hf-block-settings-kicker">Five-slot layout</h3>
-              <p className="hf-block-settings-hint">
-                Card grid matches the old default; magazine uses a wide hero and a narrow sidebar
-                (section title above the block still comes from Section title).
-              </p>
-              <div
-                className="hf-slot3-layout-options"
-                role="radiogroup"
-                aria-label="Five-slot layout"
-              >
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-slot5-${block.id}`}
-                    checked={slot5LayoutDraft === 'card-grid'}
-                    onChange={() => setSlot5LayoutDraft('card-grid')}
-                    disabled={!token || slot5LayoutMutation.isPending}
-                  />
-                  <span>Card grid (default)</span>
-                </label>
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-slot5-${block.id}`}
-                    checked={slot5LayoutDraft === 'hero-sidebar'}
-                    onChange={() => setSlot5LayoutDraft('hero-sidebar')}
-                    disabled={!token || slot5LayoutMutation.isPending}
-                  />
-                  <span>Magazine — hero + sidebar stack</span>
-                </label>
-              </div>
-              <div className="hf-block-section-heading-row">
-                <button
-                  type="button"
-                  className="hf-btn-ghost"
-                  disabled={!token || !slot5LayoutDirty || slot5LayoutMutation.isPending}
-                  onClick={() => setSlot5LayoutDraft(savedSlot5Layout)}
-                >
-                  Reset
-                </button>
-                <button
-                  type="button"
-                  className="hf-btn-primary"
-                  disabled={!token || !slot5LayoutDirty || slot5LayoutMutation.isPending}
-                  onClick={() => slot5LayoutMutation.mutate(slot5LayoutDraft)}
-                >
-                  {slot5LayoutMutation.isPending ? 'Saving…' : 'Save layout'}
-                </button>
-              </div>
-              {slot5LayoutMutation.isError ? (
-                <p className="hf-block-section-heading-error">
-                  {slot5LayoutMutation.error instanceof Error
-                    ? slot5LayoutMutation.error.message
-                    : 'Failed to save layout.'}
-                </p>
-              ) : null}
-            </section>
-          ) : null}
-
-          {saveArticleGridFourLayout &&
+          savedTotalSlots === 5
+        }
+        enableArticleGridFourLayout={
+          Boolean(saveArticleGridFourLayout) &&
           block.blockType === 'article-grid' &&
-          block.selection.totalSlots === 4 ? (
-            <section className="hf-block-settings-section">
-              <h3 className="hf-block-settings-kicker">Four-card layout</h3>
-              <p className="hf-block-settings-hint">
-                One row × four uses wide (16:10) thumbnails. 2×2 uses square (1:1) thumbnails.
-              </p>
-              <div
-                className="hf-slot3-layout-options"
-                role="radiogroup"
-                aria-label="Article grid four-slot layout"
-              >
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-ag4-${block.id}`}
-                    checked={articleGridFourLayoutDraft === 'four-across'}
-                    onChange={() => setArticleGridFourLayoutDraft('four-across')}
-                    disabled={!token || articleGridFourLayoutMutation.isPending}
-                  />
-                  <span>One row × four — wide images</span>
-                </label>
-                <label className="hf-slot3-layout-label">
-                  <input
-                    type="radio"
-                    name={`hf-ag4-${block.id}`}
-                    checked={articleGridFourLayoutDraft === 'two-by-two'}
-                    onChange={() => setArticleGridFourLayoutDraft('two-by-two')}
-                    disabled={!token || articleGridFourLayoutMutation.isPending}
-                  />
-                  <span>2×2 grid — square images</span>
-                </label>
-              </div>
-              <div className="hf-block-section-heading-row">
-                <button
-                  type="button"
-                  className="hf-btn-ghost"
-                  disabled={
-                    !token || !articleGridFourLayoutDirty || articleGridFourLayoutMutation.isPending
-                  }
-                  onClick={() => setArticleGridFourLayoutDraft(savedArticleGridFourLayout)}
-                >
-                  Reset
-                </button>
-                <button
-                  type="button"
-                  className="hf-btn-primary"
-                  disabled={
-                    !token || !articleGridFourLayoutDirty || articleGridFourLayoutMutation.isPending
-                  }
-                  onClick={() => articleGridFourLayoutMutation.mutate(articleGridFourLayoutDraft)}
-                >
-                  {articleGridFourLayoutMutation.isPending ? 'Saving…' : 'Save layout'}
-                </button>
-              </div>
-              {articleGridFourLayoutMutation.isError ? (
-                <p className="hf-block-section-heading-error">
-                  {articleGridFourLayoutMutation.error instanceof Error
-                    ? articleGridFourLayoutMutation.error.message
-                    : 'Failed to save layout.'}
-                </p>
-              ) : null}
-            </section>
-          ) : null}
-
-          {!saveSectionHeading && !canConvertEmptyFeaturedArticles ? (
-            <p className="hf-block-settings-hint">
-              Choose articles in the grid below, then use <strong>Save</strong> in the footer to
-              persist slot picks.
-            </p>
-          ) : null}
-
-          <HomepageBlockConvertSection
-            blockId={block.id}
-            currentBlockType={block.blockType}
-            currentSlotCount={block.selection.totalSlots}
-            token={token}
-            convertTargetOptions={convertTargets}
-            canConvert={canConvertEmptyFeaturedArticles}
-            onConvert={async (tok, blockType, slotCount) => {
-              if (!onConvertEmptyFeaturedArticlesBlock) return
-              await onConvertEmptyFeaturedArticlesBlock(tok, blockType, slotCount)
-            }}
-            onConverted={() => setSettingsOpen(false)}
-          />
-      </HomepageBlockSettingsModal>
+          savedTotalSlots === 4
+        }
+        slotEditorState={slotEditorState}
+        convertTargets={convertTargets}
+        canConvert={canConvert}
+        onConvert={onConvertEmptyFeaturedArticlesBlock}
+        onDeleteBlock={onDeleteBlock}
+        isDeletingBlock={isDeletingBlock}
+        deleteError={deleteError}
+      />
 
       <div className="hf-block-content">
-        {savedSectionHeading.trim() ? (
+        {block.sectionHeading?.trim() ? (
           <h2 className="hf-block-section-heading-h2 hf-block-public-section-title">
-            {savedSectionHeading.trim()}
+            {block.sectionHeading.trim()}
           </h2>
         ) : null}
-        {savedSectionSubheading.trim() ? (
-          <p className="hf-block-public-section-subtitle">{savedSectionSubheading.trim()}</p>
+        {block.sectionSubheading?.trim() ? (
+          <p className="hf-block-public-section-subtitle">{block.sectionSubheading.trim()}</p>
         ) : null}
         <HomepageFeaturedSlotEditor
           pageTitle=""
@@ -645,23 +212,23 @@ export default function CuratedHomepageBlockEditor({
           suppressToolbar
           variant={block.blockType}
           featuredArticlesSlot3Layout={
-            block.blockType === 'featured-articles' && block.selection.totalSlots === 3
-              ? slot3LayoutDraft
+            block.blockType === 'featured-articles' && savedTotalSlots === 3
+              ? layouts.slot3.draft
               : undefined
           }
           featuredArticlesSlot4Layout={
-            block.blockType === 'featured-articles' && block.selection.totalSlots === 4
-              ? slot4LayoutDraft
+            block.blockType === 'featured-articles' && savedTotalSlots === 4
+              ? layouts.slot4.draft
               : undefined
           }
           featuredArticlesSlot5Layout={
-            block.blockType === 'featured-articles' && block.selection.totalSlots === 5
-              ? slot5LayoutDraft
+            block.blockType === 'featured-articles' && savedTotalSlots === 5
+              ? layouts.slot5.draft
               : undefined
           }
           articleGridFourLayout={
-            block.blockType === 'article-grid' && block.selection.totalSlots === 4
-              ? articleGridFourLayoutDraft
+            block.blockType === 'article-grid' && savedTotalSlots === 4
+              ? layouts.articleGridFour.draft
               : undefined
           }
         />

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockSettings.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockSettings.tsx
@@ -1,0 +1,232 @@
+import HomepageBlockConvertSection from './HomepageBlockConvertSection'
+import HomepageBlockDeleteTrigger from './HomepageBlockDeleteTrigger'
+import HomepageBlockLayoutSection from './HomepageBlockLayoutSection'
+import HomepageBlockSectionTextFields from './HomepageBlockSectionTextFields'
+import HomepageBlockSettingsModal from './HomepageBlockSettingsModal'
+import HomepageBlockSlotCountSection from './HomepageBlockSlotCountSection'
+import {
+  HOMEPAGE_PAGE_BLOCK_CONFIG,
+  type ArticleCuratedHomepageBlockResponse,
+  type CuratedHomepageBlockType,
+} from './pageBlocks'
+import type { CuratedHomepageLayoutsState } from './useCuratedHomepageLayouts'
+import type { UseHomepageFeaturedSlotsResult } from './useHomepageFeaturedSlots'
+
+type Props = {
+  block: ArticleCuratedHomepageBlockResponse
+  blockIndex: number
+  token: string | null
+  isOpen: boolean
+  onClose: () => void
+  layoutState: CuratedHomepageLayoutsState
+  saveSectionHeading?: (token: string, value: string | null) => Promise<void>
+  saveSectionSubheading?: (token: string, value: string | null) => Promise<void>
+  enableSlot3Layout: boolean
+  enableSlot4Layout: boolean
+  enableSlot5Layout: boolean
+  enableArticleGridFourLayout: boolean
+  slotEditorState: UseHomepageFeaturedSlotsResult
+  convertTargets: CuratedHomepageBlockType[]
+  canConvert: boolean
+  onConvert?: (
+    token: string,
+    blockType: CuratedHomepageBlockType,
+    slotCount: number,
+  ) => Promise<void>
+  onDeleteBlock: (blockId: string) => void
+  isDeletingBlock: boolean
+  deleteError: string | null
+}
+
+export default function CuratedHomepageBlockSettings({
+  block,
+  blockIndex,
+  token,
+  isOpen,
+  onClose,
+  layoutState,
+  saveSectionHeading,
+  saveSectionSubheading,
+  enableSlot3Layout,
+  enableSlot4Layout,
+  enableSlot5Layout,
+  enableArticleGridFourLayout,
+  slotEditorState,
+  convertTargets,
+  canConvert,
+  onConvert,
+  onDeleteBlock,
+  isDeletingBlock,
+  deleteError,
+}: Props) {
+  const {
+    saveMutation,
+    slots,
+    saveDisabled,
+    handleSave,
+    handleResizeSlotCount,
+    savedInvalidItems,
+  } = slotEditorState
+  const blockConfig = HOMEPAGE_PAGE_BLOCK_CONFIG[block.blockType]
+  const slotsFilled = slots.filter(Boolean).length
+
+  return (
+    <HomepageBlockSettingsModal
+      isOpen={isOpen}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            className="hf-btn-primary hf-block-header-save"
+            onClick={handleSave}
+            disabled={saveDisabled}
+          >
+            {saveMutation.isPending ? 'Saving…' : 'Save'}
+          </button>
+          <HomepageBlockDeleteTrigger
+            blockId={block.id}
+            blockIndex={blockIndex}
+            blockLabel={blockConfig.label}
+            onDeleteBlock={onDeleteBlock}
+            isDeletingBlock={isDeletingBlock}
+            deleteError={deleteError}
+          />
+        </>
+      }
+    >
+      <p className="hf-block-slot-meta hf-block-settings-slot-summary" aria-live="polite">
+        {slotsFilled} / {slots.length} filled
+      </p>
+      <HomepageBlockSectionTextFields
+        blockId={block.id}
+        token={token}
+        sectionHeading={block.sectionHeading}
+        sectionSubheading={block.sectionSubheading}
+        settingsOpen={isOpen}
+        saveSectionHeading={saveSectionHeading}
+        saveSectionSubheading={saveSectionSubheading}
+      />
+      <HomepageBlockSlotCountSection
+        blockId={block.id}
+        blockType={block.blockType}
+        currentSlotCount={slots.length}
+        savedSlotCount={block.selection.totalSlots}
+        slots={slots}
+        invalidSlots={savedInvalidItems.map((item) => item.slot)}
+        disabled={!token || saveMutation.isPending}
+        isPending={saveMutation.isPending}
+        onResize={handleResizeSlotCount}
+      />
+
+      {enableSlot3Layout ? (
+        <HomepageBlockLayoutSection
+          title="Three-slot layout"
+          hint="How the three articles are arranged in this block (public homepage follows this)."
+          name={`hf-slot3-${block.id}`}
+          ariaLabel="Three-slot layout"
+          value={layoutState.slot3.draft}
+          options={[
+            { value: 'hero-left', label: 'Hero left — two stacked on the right' },
+            { value: 'featured-center', label: 'Three columns — large feature in the center' },
+          ]}
+          disabled={!token}
+          dirty={layoutState.slot3.dirty}
+          isPending={layoutState.slot3.mutation.isPending}
+          error={layoutState.slot3.mutation.error}
+          onChange={layoutState.slot3.setDraft}
+          onReset={() => layoutState.slot3.setDraft(layoutState.slot3.savedValue)}
+          onSave={() => layoutState.slot3.mutation.mutate(layoutState.slot3.draft)}
+        />
+      ) : null}
+
+      {enableSlot4Layout ? (
+        <HomepageBlockLayoutSection
+          title="Four-slot layout"
+          hint="How the four articles are arranged (public homepage follows this)."
+          name={`hf-slot4-${block.id}`}
+          ariaLabel="Four-slot layout"
+          value={layoutState.slot4.draft}
+          options={[
+            { value: 'sidebar-stack', label: 'Hero column + stacked sidebar (default)' },
+            { value: 'one-over-three', label: 'Lead row: text + image, then three columns' },
+          ]}
+          disabled={!token}
+          dirty={layoutState.slot4.dirty}
+          isPending={layoutState.slot4.mutation.isPending}
+          error={layoutState.slot4.mutation.error}
+          onChange={layoutState.slot4.setDraft}
+          onReset={() => layoutState.slot4.setDraft(layoutState.slot4.savedValue)}
+          onSave={() => layoutState.slot4.mutation.mutate(layoutState.slot4.draft)}
+        />
+      ) : null}
+
+      {enableSlot5Layout ? (
+        <HomepageBlockLayoutSection
+          title="Five-slot layout"
+          hint="Card grid matches the old default; magazine uses a wide hero and a narrow sidebar."
+          name={`hf-slot5-${block.id}`}
+          ariaLabel="Five-slot layout"
+          value={layoutState.slot5.draft}
+          options={[
+            { value: 'card-grid', label: 'Card grid (default)' },
+            { value: 'hero-sidebar', label: 'Magazine — hero + sidebar stack' },
+          ]}
+          disabled={!token}
+          dirty={layoutState.slot5.dirty}
+          isPending={layoutState.slot5.mutation.isPending}
+          error={layoutState.slot5.mutation.error}
+          onChange={layoutState.slot5.setDraft}
+          onReset={() => layoutState.slot5.setDraft(layoutState.slot5.savedValue)}
+          onSave={() => layoutState.slot5.mutation.mutate(layoutState.slot5.draft)}
+        />
+      ) : null}
+
+      {enableArticleGridFourLayout ? (
+        <HomepageBlockLayoutSection
+          title="Four-card layout"
+          hint="One row × four uses wide (16:10) thumbnails. 2×2 uses square (1:1) thumbnails."
+          name={`hf-ag4-${block.id}`}
+          ariaLabel="Article grid four-slot layout"
+          value={layoutState.articleGridFour.draft}
+          options={[
+            { value: 'four-across', label: 'One row × four — wide images' },
+            { value: 'two-by-two', label: '2×2 grid — square images' },
+          ]}
+          disabled={!token}
+          dirty={layoutState.articleGridFour.dirty}
+          isPending={layoutState.articleGridFour.mutation.isPending}
+          error={layoutState.articleGridFour.mutation.error}
+          onChange={layoutState.articleGridFour.setDraft}
+          onReset={() =>
+            layoutState.articleGridFour.setDraft(layoutState.articleGridFour.savedValue)
+          }
+          onSave={() =>
+            layoutState.articleGridFour.mutation.mutate(layoutState.articleGridFour.draft)
+          }
+        />
+      ) : null}
+
+      {!saveSectionHeading && !canConvert ? (
+        <p className="hf-block-settings-hint">
+          Choose articles in the grid below, then use <strong>Save</strong> in the footer to
+          persist slot picks.
+        </p>
+      ) : null}
+
+      <HomepageBlockConvertSection
+        blockId={block.id}
+        currentBlockType={block.blockType}
+        currentSlotCount={block.selection.totalSlots}
+        token={token}
+        convertTargetOptions={convertTargets}
+        canConvert={canConvert}
+        onConvert={async (currentToken, blockType, slotCount) => {
+          if (!onConvert) return
+          await onConvert(currentToken, blockType, slotCount)
+        }}
+        onConverted={onClose}
+      />
+    </HomepageBlockSettingsModal>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockLayoutSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockLayoutSection.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from 'react'
+
+type Option<T extends string> = {
+  value: T
+  label: ReactNode
+}
+
+type Props<T extends string> = {
+  title: string
+  hint: ReactNode
+  name: string
+  ariaLabel: string
+  value: T
+  options: Option<T>[]
+  disabled: boolean
+  dirty: boolean
+  isPending: boolean
+  error: unknown
+  onChange: (value: T) => void
+  onReset: () => void
+  onSave: () => void
+}
+
+export default function HomepageBlockLayoutSection<T extends string>({
+  title,
+  hint,
+  name,
+  ariaLabel,
+  value,
+  options,
+  disabled,
+  dirty,
+  isPending,
+  error,
+  onChange,
+  onReset,
+  onSave,
+}: Props<T>) {
+  return (
+    <section className="hf-block-settings-section">
+      <h3 className="hf-block-settings-kicker">{title}</h3>
+      <p className="hf-block-settings-hint">{hint}</p>
+      <div className="hf-slot3-layout-options" role="radiogroup" aria-label={ariaLabel}>
+        {options.map((option) => (
+          <label className="hf-slot3-layout-label" key={option.value}>
+            <input
+              type="radio"
+              name={name}
+              checked={value === option.value}
+              onChange={() => onChange(option.value)}
+              disabled={disabled || isPending}
+            />
+            <span>{option.label}</span>
+          </label>
+        ))}
+      </div>
+      <div className="hf-block-section-heading-row">
+        <button
+          type="button"
+          className="hf-btn-ghost"
+          disabled={disabled || !dirty || isPending}
+          onClick={onReset}
+        >
+          Reset
+        </button>
+        <button
+          type="button"
+          className="hf-btn-primary"
+          disabled={disabled || !dirty || isPending}
+          onClick={onSave}
+        >
+          {isPending ? 'Saving…' : 'Save layout'}
+        </button>
+      </div>
+      {error ? (
+        <p className="hf-block-section-heading-error">
+          {error instanceof Error ? error.message : 'Failed to save layout.'}
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/curatedHomepageLayouts.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/curatedHomepageLayouts.ts
@@ -1,0 +1,45 @@
+import type {
+  ArticleCuratedHomepageBlockResponse,
+  ArticleGridBlockResponse,
+  ArticleGridFourLayout,
+  FeaturedArticlesBlockResponse,
+  FeaturedArticlesSlot3Layout,
+  FeaturedArticlesSlot4Layout,
+  FeaturedArticlesSlot5Layout,
+} from './pageBlocks'
+
+export function slot3LayoutForBlock(
+  block: ArticleCuratedHomepageBlockResponse,
+): FeaturedArticlesSlot3Layout {
+  if (block.blockType !== 'featured-articles' || block.selection.totalSlots !== 3) {
+    return 'hero-left'
+  }
+  return (block as FeaturedArticlesBlockResponse).slot3Layout ?? 'hero-left'
+}
+
+export function slot4LayoutForBlock(
+  block: ArticleCuratedHomepageBlockResponse,
+): FeaturedArticlesSlot4Layout {
+  if (block.blockType !== 'featured-articles' || block.selection.totalSlots !== 4) {
+    return 'sidebar-stack'
+  }
+  return (block as FeaturedArticlesBlockResponse).slot4Layout ?? 'sidebar-stack'
+}
+
+export function slot5LayoutForBlock(
+  block: ArticleCuratedHomepageBlockResponse,
+): FeaturedArticlesSlot5Layout {
+  if (block.blockType !== 'featured-articles' || block.selection.totalSlots !== 5) {
+    return 'card-grid'
+  }
+  return (block as FeaturedArticlesBlockResponse).slot5Layout ?? 'card-grid'
+}
+
+export function articleGridFourLayoutForBlock(
+  block: ArticleCuratedHomepageBlockResponse,
+): ArticleGridFourLayout {
+  if (block.blockType !== 'article-grid' || block.selection.totalSlots !== 4) {
+    return 'four-across'
+  }
+  return (block as ArticleGridBlockResponse).articleGridFourLayout ?? 'four-across'
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useCuratedHomepageLayouts.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useCuratedHomepageLayouts.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import {
+  articleGridFourLayoutForBlock,
+  slot3LayoutForBlock,
+  slot4LayoutForBlock,
+  slot5LayoutForBlock,
+} from './curatedHomepageLayouts'
+import type {
+  ArticleCuratedHomepageBlockResponse,
+  ArticleGridFourLayout,
+  FeaturedArticlesSlot3Layout,
+  FeaturedArticlesSlot4Layout,
+  FeaturedArticlesSlot5Layout,
+} from './pageBlocks'
+
+function usePersistedLayoutDraft<T extends string>(
+  savedValue: T,
+  token: string | null,
+  save: ((token: string, value: T) => Promise<void>) | undefined,
+) {
+  const [draft, setDraft] = useState(savedValue)
+
+  useEffect(() => {
+    setDraft(savedValue)
+  }, [savedValue])
+
+  const mutation = useMutation({
+    mutationFn: async (value: T) => {
+      if (!token || !save) return
+      await save(token, value)
+    },
+  })
+
+  return {
+    draft,
+    setDraft,
+    savedValue,
+    dirty: draft !== savedValue,
+    mutation,
+  }
+}
+
+type Params = {
+  block: ArticleCuratedHomepageBlockResponse
+  token: string | null
+  saveSlot3Layout?: (token: string, value: FeaturedArticlesSlot3Layout) => Promise<void>
+  saveSlot4Layout?: (token: string, value: FeaturedArticlesSlot4Layout) => Promise<void>
+  saveSlot5Layout?: (token: string, value: FeaturedArticlesSlot5Layout) => Promise<void>
+  saveArticleGridFourLayout?: (token: string, value: ArticleGridFourLayout) => Promise<void>
+}
+
+export function useCuratedHomepageLayouts({
+  block,
+  token,
+  saveSlot3Layout,
+  saveSlot4Layout,
+  saveSlot5Layout,
+  saveArticleGridFourLayout,
+}: Params) {
+  const slot3 = usePersistedLayoutDraft(slot3LayoutForBlock(block), token, saveSlot3Layout)
+  const slot4 = usePersistedLayoutDraft(slot4LayoutForBlock(block), token, saveSlot4Layout)
+  const slot5 = usePersistedLayoutDraft(slot5LayoutForBlock(block), token, saveSlot5Layout)
+  const articleGridFour = usePersistedLayoutDraft(
+    articleGridFourLayoutForBlock(block),
+    token,
+    saveArticleGridFourLayout,
+  )
+
+  return { slot3, slot4, slot5, articleGridFour }
+}
+
+export type CuratedHomepageLayoutsState = ReturnType<typeof useCuratedHomepageLayouts>

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/usePageBlockDuplicateExclusion.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/usePageBlockDuplicateExclusion.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo } from 'react'
+import type { UseHomepageFeaturedSlotsResult } from './useHomepageFeaturedSlots'
+
+type Params = {
+  blockId: string
+  slotEditorState: UseHomepageFeaturedSlotsResult
+  externalUsedKeys?: Set<string>
+  onSlotsChange?: (blockId: string, keys: Set<string>) => void
+}
+
+export function usePageBlockDuplicateExclusion({
+  blockId,
+  slotEditorState,
+  externalUsedKeys,
+  onSlotsChange,
+}: Params): UseHomepageFeaturedSlotsResult {
+  useEffect(() => {
+    onSlotsChange?.(blockId, slotEditorState.usedKeys)
+    return () => {
+      onSlotsChange?.(blockId, new Set())
+    }
+  }, [blockId, slotEditorState.usedKeys, onSlotsChange])
+
+  const mergedUsedKeys = useMemo<UseHomepageFeaturedSlotsResult['usedKeys']>(
+    () =>
+      externalUsedKeys && externalUsedKeys.size > 0
+        ? new Set([...slotEditorState.usedKeys, ...externalUsedKeys])
+        : slotEditorState.usedKeys,
+    [slotEditorState.usedKeys, externalUsedKeys],
+  )
+
+  const hasCrossBlockDuplicate =
+    externalUsedKeys != null &&
+    externalUsedKeys.size > 0 &&
+    slotEditorState.slots.some(
+      (slot) => slot != null && externalUsedKeys.has(`${slot.relationTo}:${slot.id}`),
+    )
+
+  return hasCrossBlockDuplicate || mergedUsedKeys !== slotEditorState.usedKeys
+    ? {
+        ...slotEditorState,
+        usedKeys: mergedUsedKeys,
+        saveDisabled: slotEditorState.saveDisabled || hasCrossBlockDuplicate,
+      }
+    : slotEditorState
+}


### PR DESCRIPTION
## Summary
- reduce `CuratedHomepageBlockEditor` from 671 to 238 lines by making it an orchestration component
- move settings, layout persistence, layout value derivation, and cross-block duplicate exclusion into focused modules
- keep all block variants, conversion rules, draft synchronization, mutation behavior, and page-level duplicate protection intact

## Validation
- `NX_DAEMON=false pnpm exec nx run @questurian/abw-client:lint`
- `NX_DAEMON=false pnpm exec nx run @questurian/abw-client:test` (94 files, 358 tests)
- `pnpm exec vitest run --config apps/frontend/vite.config.ts apps/frontend/src/features/homepageFeaturedContent` (16 files, 45 tests)
- `pnpm exec vite build --config apps/frontend/vite.config.ts`
- targeted ESLint for all extracted modules
- `git diff --check`