### PR TITLE
NOJIRA: Separate main homepage orchestration

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepageBlockRenderer.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepageBlockRenderer.tsx
@@ -1,0 +1,336 @@
+import {
+  fetchHomepageFeaturedCandidates,
+  fetchHomepageHotelGridCandidates,
+  fetchHomepageLocationGridCandidates,
+  fetchThingsToDoAttractionCandidates,
+  fetchThingsToDoListicleCandidates,
+  fetchTourGridCandidates,
+  fetchWhereToEatDrinkCandidates,
+  updateMainHomepageArticleGridFourLayout,
+  updateMainHomepageBlock,
+  updateMainHomepageFeaturedSectionHeading,
+  updateMainHomepageFeaturedSectionSubheading,
+  updateMainHomepageFeaturedSlot3Layout,
+  updateMainHomepageFeaturedSlot4Layout,
+  updateMainHomepageFeaturedSlot5Layout,
+  updateMainHomepageLocationGridMediaAspect,
+} from './api'
+import CuratedHomepageBlockEditor from './CuratedHomepageBlockEditor'
+import HomepageBlockDeleteTrigger from './HomepageBlockDeleteTrigger'
+import HotelGridBlockEditor from './HotelGridBlockEditor'
+import LocationGridBlockEditor from './LocationGridBlockEditor'
+import NewsletterSignupBlockEditor from './NewsletterSignupBlockEditor'
+import {
+  CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES,
+  homepageBlockEditorIdentity,
+  isArticleCuratedHomepageBlock,
+  isHotelGridBlock,
+  isLocationGridBlock,
+  isNewsletterSignupBlock,
+  isThingsToDoAttractionsBlock,
+  isTourGridBlock,
+  type ArticleCuratedHomepageBlockResponse,
+  type CuratedHomepageBlockType,
+  type HotelOrAttractionGridBlockResponse,
+  type LocationGridBlockResponse,
+  type PageBlockResponse,
+} from './pageBlocks'
+
+type Props = {
+  block: PageBlockResponse
+  blockIndex: number
+  token: string | null
+  canManage: boolean
+  externalUsedKeys: Set<string>
+  onSlotsChange: (blockId: string, keys: Set<string>) => void
+  onDeleteBlock: (blockId: string) => void
+  isDeletePending: boolean
+  deletingBlockId: string | null
+  deleteError: string | null
+  onConvertBlock: (
+    block: PageBlockResponse,
+    currentToken: string,
+    blockType: CuratedHomepageBlockType,
+    slotCount: number,
+  ) => Promise<void>
+  invalidateHomepage: () => void
+}
+
+export default function MainHomepageBlockRenderer({
+  block,
+  blockIndex,
+  token,
+  canManage,
+  externalUsedKeys,
+  onSlotsChange,
+  onDeleteBlock,
+  isDeletePending,
+  deletingBlockId,
+  deleteError,
+  onConvertBlock,
+  invalidateHomepage,
+}: Props) {
+  const isDeletingBlockFor = (blockId: string) =>
+    isDeletePending && deletingBlockId === blockId
+  const deleteErrorFor = (blockId: string) =>
+    isDeletePending || deletingBlockId !== blockId ? null : deleteError
+
+  if (isArticleCuratedHomepageBlock(block)) {
+    return (
+      <CuratedHomepageBlockEditor
+        block={block}
+        blockIndex={blockIndex}
+        token={token}
+        canManage={canManage}
+        onDeleteBlock={onDeleteBlock}
+        isDeletingBlock={isDeletingBlockFor(block.id)}
+        deleteError={deleteErrorFor(block.id)}
+        selectionQueryKey={[
+          'main-homepage-block',
+          ...homepageBlockEditorIdentity(block),
+          token,
+        ]}
+        saveSelection={async (currentToken, items, slotCount) => {
+          const updated = await updateMainHomepageBlock(
+            currentToken,
+            block.id,
+            items,
+            slotCount,
+          )
+          const updatedBlock = updated.pageBlocks.find(
+            (candidate): candidate is ArticleCuratedHomepageBlockResponse =>
+              candidate.id === block.id && candidate.blockType === block.blockType,
+          )
+          if (!updatedBlock) throw new Error('Block not found after save.')
+          invalidateHomepage()
+          return updatedBlock.selection
+        }}
+        fetchCandidates={(currentToken, params) =>
+          block.blockType === 'questurian-maps'
+            ? fetchHomepageFeaturedCandidates(currentToken, {
+                ...params,
+                type: 'single-type-listicles',
+              })
+            : block.blockType === 'where-to-eat-drink'
+              ? fetchWhereToEatDrinkCandidates(currentToken, params)
+              : block.blockType === 'things-to-do-listicles'
+                ? fetchThingsToDoListicleCandidates(currentToken, params)
+                : fetchHomepageFeaturedCandidates(currentToken, params)}
+        saveSectionHeading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+        saveSectionSubheading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+        saveSlot3Layout={
+          block.blockType === 'featured-articles' && block.selection.totalSlots === 3
+            ? async (currentToken, value) => {
+                await updateMainHomepageFeaturedSlot3Layout(currentToken, block.id, value)
+                invalidateHomepage()
+              }
+            : undefined
+        }
+        saveSlot4Layout={
+          block.blockType === 'featured-articles' && block.selection.totalSlots === 4
+            ? async (currentToken, value) => {
+                await updateMainHomepageFeaturedSlot4Layout(currentToken, block.id, value)
+                invalidateHomepage()
+              }
+            : undefined
+        }
+        saveSlot5Layout={
+          block.blockType === 'featured-articles' && block.selection.totalSlots === 5
+            ? async (currentToken, value) => {
+                await updateMainHomepageFeaturedSlot5Layout(currentToken, block.id, value)
+                invalidateHomepage()
+              }
+            : undefined
+        }
+        saveArticleGridFourLayout={
+          block.blockType === 'article-grid' && block.selection.totalSlots === 4
+            ? async (currentToken, value) => {
+                await updateMainHomepageArticleGridFourLayout(currentToken, block.id, value)
+                invalidateHomepage()
+              }
+            : undefined
+        }
+        convertEmptyFeaturedArticlesTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
+        onConvertEmptyFeaturedArticlesBlock={async (
+          currentToken,
+          blockType,
+          slotCount,
+        ) => {
+          await onConvertBlock(block, currentToken, blockType, slotCount)
+        }}
+        externalUsedKeys={externalUsedKeys}
+        onSlotsChange={onSlotsChange}
+      />
+    )
+  }
+
+  if (isLocationGridBlock(block)) {
+    return (
+      <LocationGridBlockEditor
+        block={block}
+        blockIndex={blockIndex}
+        token={token}
+        canManage={canManage}
+        onDeleteBlock={onDeleteBlock}
+        isDeletingBlock={isDeletingBlockFor(block.id)}
+        deleteError={deleteErrorFor(block.id)}
+        childLevel="city"
+        selectionQueryKey={[
+          'main-homepage-location-grid',
+          ...homepageBlockEditorIdentity(block),
+          token,
+        ]}
+        saveSelection={async (currentToken, items, slotCount) => {
+          const updated = await updateMainHomepageBlock(
+            currentToken,
+            block.id,
+            items,
+            slotCount,
+          )
+          const updatedBlock = updated.pageBlocks.find(
+            (candidate): candidate is LocationGridBlockResponse =>
+              candidate.id === block.id && candidate.blockType === block.blockType,
+          )
+          if (!updatedBlock) throw new Error('Block not found after save.')
+          invalidateHomepage()
+          return updatedBlock.selection
+        }}
+        fetchCandidates={fetchHomepageLocationGridCandidates}
+        saveLocationGridSectionHeading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+        saveLocationGridSectionSubheading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+        saveLocationGridMediaAspect={async (currentToken, value) => {
+          await updateMainHomepageLocationGridMediaAspect(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+        convertBlockTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
+        onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
+          await onConvertBlock(block, currentToken, blockType, slotCount)
+        }}
+      />
+    )
+  }
+
+  if (isNewsletterSignupBlock(block)) {
+    return (
+      <NewsletterSignupBlockEditor
+        block={block}
+        blockIndex={blockIndex}
+        token={token}
+        onDeleteBlock={onDeleteBlock}
+        isDeletingBlock={isDeletingBlockFor(block.id)}
+        deleteError={deleteErrorFor(block.id)}
+        saveSectionHeading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+        saveSectionSubheading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
+          invalidateHomepage()
+        }}
+      />
+    )
+  }
+
+  if (
+    isHotelGridBlock(block)
+    || isTourGridBlock(block)
+    || isThingsToDoAttractionsBlock(block)
+  ) {
+    const gridBlock = block
+    return (
+      <HotelGridBlockEditor
+        block={gridBlock}
+        blockIndex={blockIndex}
+        token={token}
+        canManage={canManage}
+        onDeleteBlock={onDeleteBlock}
+        isDeletingBlock={isDeletingBlockFor(gridBlock.id)}
+        deleteError={deleteErrorFor(gridBlock.id)}
+        selectionQueryKey={[
+          'main-homepage-hotel-grid',
+          ...homepageBlockEditorIdentity(gridBlock),
+          token,
+        ]}
+        saveSelection={async (currentToken, items, slotCount) => {
+          const updated = await updateMainHomepageBlock(
+            currentToken,
+            gridBlock.id,
+            items,
+            slotCount,
+          )
+          const updatedBlock = updated.pageBlocks.find(
+            (candidate): candidate is HotelOrAttractionGridBlockResponse =>
+              candidate.id === gridBlock.id
+              && candidate.blockType === gridBlock.blockType,
+          )
+          if (!updatedBlock) throw new Error('Block not found after save.')
+          invalidateHomepage()
+          return updatedBlock.selection
+        }}
+        fetchCandidates={(currentToken, params) =>
+          gridBlock.blockType === 'things-to-do-attractions'
+            ? fetchThingsToDoAttractionCandidates(currentToken, params)
+            : gridBlock.blockType === 'tour-grid'
+              ? fetchTourGridCandidates(currentToken, params)
+              : fetchHomepageHotelGridCandidates(currentToken, params)}
+        convertBlockTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
+        onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
+          await onConvertBlock(gridBlock, currentToken, blockType, slotCount)
+        }}
+        saveHotelGridSectionHeading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionHeading(
+            currentToken,
+            gridBlock.id,
+            value,
+          )
+          invalidateHomepage()
+        }}
+        saveHotelGridSectionSubheading={async (currentToken, value) => {
+          await updateMainHomepageFeaturedSectionSubheading(
+            currentToken,
+            gridBlock.id,
+            value,
+          )
+          invalidateHomepage()
+        }}
+      />
+    )
+  }
+
+  return (
+    <div className="hf-block-section">
+      <div className="hf-block-header">
+        <div className="hf-block-label">
+          <span>Block {blockIndex + 1}</span>
+          <span className="hf-block-type-tag">{block.blockType}</span>
+        </div>
+        <HomepageBlockDeleteTrigger
+          blockId={block.id}
+          blockIndex={blockIndex}
+          blockLabel={block.blockType}
+          onDeleteBlock={onDeleteBlock}
+          isDeletingBlock={isDeletingBlockFor(block.id)}
+          deleteError={deleteErrorFor(block.id)}
+        />
+      </div>
+      <div className="hf-block-content hf-empty">
+        <p>
+          Editor for &ldquo;{block.blockType}&rdquo; blocks is not yet available in
+          this tool.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.tsx
@@ -1,219 +1,49 @@
-import { useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { useAuth, usePermissions } from '../auth'
-import './homepageFeaturedContent.css'
-import {
-  addMainHomepageBlock,
-  deleteMainHomepageBlock,
-  fetchHomepageFeaturedCandidates,
-  fetchHomepageHotelGridCandidates,
-  fetchHomepageLocationGridCandidates,
-  fetchTourGridCandidates,
-  fetchThingsToDoAttractionCandidates,
-  fetchThingsToDoListicleCandidates,
-  fetchWhereToEatDrinkCandidates,
-  convertMainHomepageFeaturedArticlesBlock,
-  fetchMainHomepage,
-  publishMainHomepage,
-  reorderMainHomepageBlocks,
-  updateMainHomepageBlock,
-  updateMainHomepageFeaturedSectionHeading,
-  updateMainHomepageFeaturedSectionSubheading,
-  updateMainHomepageLocationGridMediaAspect,
-  updateMainHomepageFeaturedSlot3Layout,
-  updateMainHomepageFeaturedSlot4Layout,
-  updateMainHomepageFeaturedSlot5Layout,
-  updateMainHomepageArticleGridFourLayout,
-  type MainHomepageResponse,
-} from './api'
-import HomepageBlocksSortableList from './HomepageBlocksSortableList'
 import AddHomepageBlockPicker from './AddHomepageBlockPicker'
-import HomepageBlockDeleteTrigger from './HomepageBlockDeleteTrigger'
-import CuratedHomepageBlockEditor from './CuratedHomepageBlockEditor'
-import HotelGridBlockEditor from './HotelGridBlockEditor'
-import LocationGridBlockEditor from './LocationGridBlockEditor'
-import NewsletterSignupBlockEditor from './NewsletterSignupBlockEditor'
-import PublishedHomepagePreview from './PublishedHomepagePreview'
+import HomepageBlocksSortableList from './HomepageBlocksSortableList'
 import HomepageDraftPublishSummary from './HomepageDraftPublishSummary'
-import {
-  buildOptimisticConvertedHomepageBlock,
-  deleteHomepageBlockFromCache,
-  reorderHomepageBlocksInCache,
-  replaceHomepageBlockInCache,
-} from './homepageBlockOptimisticUpdates'
-import {
-  isHotelGridBlock,
-  isTourGridBlock,
-  isThingsToDoAttractionsBlock,
-  isArticleCuratedHomepageBlock,
-  CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES,
-  homepageBlockEditorIdentity,
-  isLocationGridBlock,
-  isNewsletterSignupBlock,
-  type ArticleCuratedHomepageBlockResponse,
-  type CuratedHomepageBlockType,
-  type HotelOrAttractionGridBlockResponse,
-  type LocationGridBlockResponse,
-  type PageBlockResponse,
-} from './pageBlocks'
+import MainHomepageBlockRenderer from './MainHomepageBlockRenderer'
+import PublishedHomepagePreview from './PublishedHomepagePreview'
+import './homepageFeaturedContent.css'
+import { homepageBlockEditorIdentity, type PageBlockResponse } from './pageBlocks'
+import { useMainHomepageEditor } from './useMainHomepageEditor'
+
+function usedKeysOutsideBlock(
+  slotKeysByBlock: Map<string, Set<string>>,
+  blockId: string,
+) {
+  const usedKeys = new Set<string>()
+  for (const [candidateBlockId, keys] of slotKeysByBlock) {
+    if (candidateBlockId !== blockId) {
+      for (const key of keys) usedKeys.add(key)
+    }
+  }
+  return usedKeys
+}
+
 export default function MainHomepagePage() {
   const { token } = useAuth()
   const { canManagePublished: canManage } = usePermissions()
-  const queryClient = useQueryClient()
-  const mainHomepageQueryKey = ['main-homepage', token]
-
-  const homepageQuery = useQuery({
-    queryKey: mainHomepageQueryKey,
-    queryFn: ({ signal }) => fetchMainHomepage(token!, signal),
-    enabled: Boolean(token && canManage),
-  })
-
-  const [showAddBlock, setShowAddBlock] = useState(false)
-  const [viewMode, setViewMode] = useState<'draft' | 'published'>('draft')
-  const [deletingBlockId, setDeletingBlockId] = useState<string | null>(null)
-  const [pageBlockSlotKeys, setPageBlockSlotKeys] = useState<Map<string, Set<string>>>(() => new Map())
-
-  const handleSlotsChange = useCallback((blockId: string, keys: Set<string>) => {
-    setPageBlockSlotKeys((prev) => {
-      // Bail out without a state change when the keys are unchanged; block
-      // editors report on every keys-identity change, and an unconditional new
-      // Map here would re-render them and loop.
-      const existing = prev.get(blockId)
-      if (keys.size === 0 && !existing) return prev
-      if (existing && existing.size === keys.size && [...keys].every((key) => existing.has(key))) {
-        return prev
-      }
-      const next = new Map(prev)
-      if (keys.size === 0) {
-        next.delete(blockId)
-      } else {
-        next.set(blockId, keys)
-      }
-      return next
-    })
-  }, [])
-
-  const addBlockMutation = useMutation({
-    mutationFn: ({
-      blockType,
-      slotCount,
-      sectionHeading,
-      sectionSubheading,
-    }: {
-      blockType: CuratedHomepageBlockType
-      slotCount: number
-      sectionHeading?: string | null
-      sectionSubheading?: string | null
-    }) =>
-      addMainHomepageBlock(token!, blockType, slotCount, sectionHeading, sectionSubheading),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-      setShowAddBlock(false)
-    },
-  })
-
-  const deleteBlockMutation = useMutation({
-    mutationFn: ({ blockId }: { blockId: string }) =>
-      deleteMainHomepageBlock(token!, blockId),
-    onMutate: async ({ blockId }) => {
-      setDeletingBlockId(blockId)
-      await queryClient.cancelQueries({ queryKey: mainHomepageQueryKey })
-      const previousHomepage =
-        queryClient.getQueryData<MainHomepageResponse>(mainHomepageQueryKey)
-      queryClient.setQueryData<MainHomepageResponse>(mainHomepageQueryKey, (current) =>
-        deleteHomepageBlockFromCache(current, blockId),
-      )
-      return { previousHomepage }
-    },
-    onError: (_error, _variables, context) => {
-      if (context?.previousHomepage) {
-        queryClient.setQueryData(mainHomepageQueryKey, context.previousHomepage)
-      }
-    },
-    onSettled: () => {
-      setDeletingBlockId(null)
-    },
-  })
-
-  const reorderBlocksMutation = useMutation({
-    mutationFn: (orderedBlockIds: string[]) =>
-      reorderMainHomepageBlocks(token!, orderedBlockIds),
-    onMutate: async (orderedBlockIds) => {
-      await queryClient.cancelQueries({ queryKey: mainHomepageQueryKey })
-      const previousHomepage =
-        queryClient.getQueryData<MainHomepageResponse>(mainHomepageQueryKey)
-      queryClient.setQueryData<MainHomepageResponse>(mainHomepageQueryKey, (current) =>
-        reorderHomepageBlocksInCache(current, orderedBlockIds),
-      )
-      return { previousHomepage }
-    },
-    onSuccess: (result) => {
-      queryClient.setQueryData<MainHomepageResponse>(mainHomepageQueryKey, (current) =>
-        reorderHomepageBlocksInCache(current, result.orderedBlockIds),
-      )
-    },
-    onError: (_error, _variables, context) => {
-      if (context?.previousHomepage) {
-        queryClient.setQueryData(mainHomepageQueryKey, context.previousHomepage)
-      }
-    },
-  })
-
-  const publishMutation = useMutation({
-    mutationFn: () => publishMainHomepage(token!),
-    onSuccess: (result) => {
-      queryClient.setQueryData<MainHomepageResponse>(mainHomepageQueryKey, result)
-      queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-    },
-  })
-
-  async function handleConvertBlock(
-    block: PageBlockResponse,
-    currentToken: string,
-    blockType: CuratedHomepageBlockType,
-    slotCount: number,
-  ) {
-    await queryClient.cancelQueries({ queryKey: mainHomepageQueryKey })
-    const previousHomepage =
-      queryClient.getQueryData<MainHomepageResponse>(mainHomepageQueryKey)
-    const optimisticBlock = buildOptimisticConvertedHomepageBlock(block, blockType, slotCount)
-
-    queryClient.setQueryData<MainHomepageResponse>(mainHomepageQueryKey, (current) =>
-      replaceHomepageBlockInCache(current, optimisticBlock),
-    )
-
-    try {
-      const result = await convertMainHomepageFeaturedArticlesBlock(
-        currentToken,
-        block.id,
-        blockType,
-        slotCount,
-      )
-      queryClient.setQueryData<MainHomepageResponse>(mainHomepageQueryKey, (current) =>
-        replaceHomepageBlockInCache(current, result.block),
-      )
-    } catch (error) {
-      if (previousHomepage) {
-        queryClient.setQueryData(mainHomepageQueryKey, previousHomepage)
-      }
-      throw error
-    }
-  }
-
-  function handleConfirmAddBlock(
-    blockType: CuratedHomepageBlockType,
-    slotCount: number,
-    sectionHeading?: string | null,
-    sectionSubheading?: string | null,
-  ) {
-    addBlockMutation.mutate({ blockType, slotCount, sectionHeading, sectionSubheading })
-  }
-
-  const deleteError = deleteBlockMutation.isError
-    ? (deleteBlockMutation.error instanceof Error ? deleteBlockMutation.error.message : 'Failed to delete block.')
-    : null
+  const {
+    homepageQuery,
+    publishMutation,
+    showAddBlock,
+    setShowAddBlock,
+    viewMode,
+    setViewMode,
+    deletingBlockId,
+    pageBlockSlotKeys,
+    handleSlotsChange,
+    addBlockMutation,
+    deleteBlockMutation,
+    reorderBlocksMutation,
+    handleConvertBlock,
+    handleConfirmAddBlock,
+    deleteError,
+    invalidateHomepage,
+  } = useMainHomepageEditor(token, canManage)
 
   if (!canManage) {
     return (
@@ -247,7 +77,11 @@ export default function MainHomepagePage() {
               ? homepageQuery.error.message
               : 'Failed to load main homepage.'}
           </p>
-          <Link to="/homepage-featured-content" className="hf-btn-ghost" style={{ marginTop: '1rem' }}>
+          <Link
+            to="/homepage-featured-content"
+            className="hf-btn-ghost"
+            style={{ marginTop: '1rem' }}
+          >
             Back to hub
           </Link>
         </div>
@@ -259,7 +93,6 @@ export default function MainHomepagePage() {
 
   return (
     <div className="hf-page">
-      {/* ── Header ─────────────────────────────────────────── */}
       <div className="hf-detail-header">
         <div className="hf-detail-header-left">
           <Link to="/homepage-featured-content" className="hf-btn-ghost">
@@ -267,7 +100,13 @@ export default function MainHomepagePage() {
           </Link>
           <div className="hf-detail-title-block">
             <h1>Main Homepage</h1>
-            <span style={{ fontSize: '0.78rem', color: 'var(--muted)', fontFamily: 'monospace' }}>
+            <span
+              style={{
+                fontSize: '0.78rem',
+                color: 'var(--muted)',
+                fontFamily: 'monospace',
+              }}
+            >
               domain.com
             </span>
           </div>
@@ -288,9 +127,9 @@ export default function MainHomepagePage() {
             <button
               type="button"
               onClick={() => setViewMode('published')}
-              disabled={!homepage.publishedPageBlocks || homepage.publishedPageBlocks.length === 0}
+              disabled={!homepage.publishedPageBlocks?.length}
               title={
-                homepage.publishedPageBlocks && homepage.publishedPageBlocks.length > 0
+                homepage.publishedPageBlocks?.length
                   ? 'View the published page (read-only)'
                   : 'Nothing published yet'
               }
@@ -310,9 +149,11 @@ export default function MainHomepagePage() {
           </button>
         </div>
       </div>
+
       {homepage.lastPublishedAt && (
         <div className="hf-detail-meta">
-          Published revision {homepage.publishedRevision ?? 0} · {new Date(homepage.lastPublishedAt).toLocaleString()}
+          Published revision {homepage.publishedRevision ?? 0} ·{' '}
+          {new Date(homepage.lastPublishedAt).toLocaleString()}
         </div>
       )}
       {publishMutation.isError && (
@@ -323,297 +164,69 @@ export default function MainHomepagePage() {
         </div>
       )}
 
-      {/* ── Blocks ─────────────────────────────────────────── */}
       {viewMode === 'published' ? (
         <PublishedHomepagePreview blocks={homepage.publishedPageBlocks} />
       ) : (
-      <>
-      <HomepageDraftPublishSummary blocks={homepage.pageBlocks} />
-      {homepage.pageBlocks.length === 0 ? (
-        <div className="hf-state-screen">
-          <h2>No blocks yet</h2>
-          <p>
-            The main homepage has no content blocks. Add a content block to start curating.
-          </p>
-        </div>
-      ) : (
-        <HomepageBlocksSortableList
-          blocks={homepage.pageBlocks}
-          disabled={
-            reorderBlocksMutation.isPending
-            || deleteBlockMutation.isPending
-            || addBlockMutation.isPending
-          }
-          onReorder={(orderedIds) => reorderBlocksMutation.mutate(orderedIds)}
-        >
-          {(block: PageBlockResponse, idx: number) => {
-            const externalUsedKeys = (() => {
-              const combined = new Set<string>()
-              for (const [id, keys] of pageBlockSlotKeys) {
-                if (id !== block.id) for (const k of keys) combined.add(k)
+        <>
+          <HomepageDraftPublishSummary blocks={homepage.pageBlocks} />
+          {homepage.pageBlocks.length === 0 ? (
+            <div className="hf-state-screen">
+              <h2>No blocks yet</h2>
+              <p>
+                The main homepage has no content blocks. Add a content block to
+                start curating.
+              </p>
+            </div>
+          ) : (
+            <HomepageBlocksSortableList
+              blocks={homepage.pageBlocks}
+              disabled={
+                reorderBlocksMutation.isPending
+                || deleteBlockMutation.isPending
+                || addBlockMutation.isPending
               }
-              return combined
-            })()
-
-            if (isArticleCuratedHomepageBlock(block)) {
-              return (
-                <CuratedHomepageBlockEditor
+              onReorder={(orderedIds) => reorderBlocksMutation.mutate(orderedIds)}
+            >
+              {(block: PageBlockResponse, blockIndex: number) => (
+                <MainHomepageBlockRenderer
                   key={homepageBlockEditorIdentity(block).join(':')}
                   block={block}
-                  blockIndex={idx}
+                  blockIndex={blockIndex}
                   token={token}
                   canManage={canManage}
-                  onDeleteBlock={(blockId) => deleteBlockMutation.mutate({ blockId })}
-                  isDeletingBlock={deleteBlockMutation.isPending && deletingBlockId === block.id}
-                  deleteError={deleteBlockMutation.isPending || deletingBlockId !== block.id ? null : deleteError}
-                  selectionQueryKey={[
-                    'main-homepage-block',
-                    ...homepageBlockEditorIdentity(block),
-                    token,
-                  ]}
-                  saveSelection={async (currentToken, items, slotCount) => {
-                    const updated = await updateMainHomepageBlock(
-                      currentToken,
-                      block.id,
-                      items,
-                      slotCount,
-                    )
-                    const updatedBlock = updated.pageBlocks.find(
-                      (candidate): candidate is ArticleCuratedHomepageBlockResponse =>
-                        candidate.id === block.id && candidate.blockType === block.blockType,
-                    )
-                    if (!updatedBlock) throw new Error('Block not found after save.')
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                    return updatedBlock.selection
-                  }}
-                  fetchCandidates={(currentToken, params) =>
-                    block.blockType === 'questurian-maps'
-                      ? fetchHomepageFeaturedCandidates(currentToken, {
-                          ...params,
-                          type: 'single-type-listicles',
-                        })
-                      : block.blockType === 'where-to-eat-drink'
-                        ? fetchWhereToEatDrinkCandidates(currentToken, params)
-                        : block.blockType === 'things-to-do-listicles'
-                          ? fetchThingsToDoListicleCandidates(currentToken, params)
-                          : fetchHomepageFeaturedCandidates(currentToken, params)}
-                  saveSectionHeading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  saveSectionSubheading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  saveSlot3Layout={
-                    block.blockType === 'featured-articles' && block.selection.totalSlots === 3
-                      ? async (currentToken, value) => {
-                          await updateMainHomepageFeaturedSlot3Layout(currentToken, block.id, value)
-                          queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                        }
-                      : undefined
-                  }
-                  saveSlot4Layout={
-                    block.blockType === 'featured-articles' && block.selection.totalSlots === 4
-                      ? async (currentToken, value) => {
-                          await updateMainHomepageFeaturedSlot4Layout(currentToken, block.id, value)
-                          queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                        }
-                      : undefined
-                  }
-                  saveSlot5Layout={
-                    block.blockType === 'featured-articles' && block.selection.totalSlots === 5
-                      ? async (currentToken, value) => {
-                          await updateMainHomepageFeaturedSlot5Layout(currentToken, block.id, value)
-                          queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                        }
-                      : undefined
-                  }
-                  saveArticleGridFourLayout={
-                    block.blockType === 'article-grid' && block.selection.totalSlots === 4
-                      ? async (currentToken, value) => {
-                          await updateMainHomepageArticleGridFourLayout(currentToken, block.id, value)
-                          queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                        }
-                      : undefined
-                  }
-                  convertEmptyFeaturedArticlesTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
-                  onConvertEmptyFeaturedArticlesBlock={async (currentToken, blockType, slotCount) => {
-                    await handleConvertBlock(block, currentToken, blockType, slotCount)
-                  }}
-                  externalUsedKeys={externalUsedKeys}
+                  externalUsedKeys={usedKeysOutsideBlock(pageBlockSlotKeys, block.id)}
                   onSlotsChange={handleSlotsChange}
-                />
-              )
-            }
-            if (isLocationGridBlock(block)) {
-              return (
-                <LocationGridBlockEditor
-                  key={homepageBlockEditorIdentity(block).join(':')}
-                  block={block}
-                  blockIndex={idx}
-                  token={token}
-                  canManage={canManage}
                   onDeleteBlock={(blockId) => deleteBlockMutation.mutate({ blockId })}
-                  isDeletingBlock={deleteBlockMutation.isPending && deletingBlockId === block.id}
-                  deleteError={deleteBlockMutation.isPending || deletingBlockId !== block.id ? null : deleteError}
-                  childLevel="city"
-                  selectionQueryKey={[
-                    'main-homepage-location-grid',
-                    ...homepageBlockEditorIdentity(block),
-                    token,
-                  ]}
-                  saveSelection={async (currentToken, items, slotCount) => {
-                    const updated = await updateMainHomepageBlock(currentToken, block.id, items, slotCount)
-                    const updatedBlock = updated.pageBlocks.find(
-                      (candidate): candidate is LocationGridBlockResponse =>
-                        candidate.id === block.id && candidate.blockType === block.blockType,
-                    )
-                    if (!updatedBlock) throw new Error('Block not found after save.')
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                    return updatedBlock.selection
-                  }}
-                  fetchCandidates={(currentToken, params) =>
-                    fetchHomepageLocationGridCandidates(currentToken, params)}
-                  saveLocationGridSectionHeading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  saveLocationGridSectionSubheading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  saveLocationGridMediaAspect={async (currentToken, value) => {
-                    await updateMainHomepageLocationGridMediaAspect(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  convertBlockTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
-                  onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
-                    await handleConvertBlock(block, currentToken, blockType, slotCount)
-                  }}
+                  isDeletePending={deleteBlockMutation.isPending}
+                  deletingBlockId={deletingBlockId}
+                  deleteError={deleteError}
+                  onConvertBlock={handleConvertBlock}
+                  invalidateHomepage={invalidateHomepage}
                 />
-              )
-            }
-            if (isNewsletterSignupBlock(block)) {
-              return (
-                <NewsletterSignupBlockEditor
-                  key={homepageBlockEditorIdentity(block).join(':')}
-                  block={block}
-                  blockIndex={idx}
-                  token={token}
-                  onDeleteBlock={(blockId) => deleteBlockMutation.mutate({ blockId })}
-                  isDeletingBlock={deleteBlockMutation.isPending && deletingBlockId === block.id}
-                  deleteError={deleteBlockMutation.isPending || deletingBlockId !== block.id ? null : deleteError}
-                  saveSectionHeading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  saveSectionSubheading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                />
-              )
-            }
-            if (isHotelGridBlock(block) || isTourGridBlock(block) || isThingsToDoAttractionsBlock(block)) {
-              const gridBlock = block
-              return (
-                <HotelGridBlockEditor
-                  key={homepageBlockEditorIdentity(gridBlock).join(':')}
-                  block={gridBlock}
-                  blockIndex={idx}
-                  token={token}
-                  canManage={canManage}
-                  onDeleteBlock={(blockId) => deleteBlockMutation.mutate({ blockId })}
-                  isDeletingBlock={deleteBlockMutation.isPending && deletingBlockId === gridBlock.id}
-                  deleteError={
-                    deleteBlockMutation.isPending || deletingBlockId !== gridBlock.id ? null : deleteError
-                  }
-                  selectionQueryKey={[
-                    'main-homepage-hotel-grid',
-                    ...homepageBlockEditorIdentity(gridBlock),
-                    token,
-                  ]}
-                  saveSelection={async (currentToken, items, slotCount) => {
-                    const updated = await updateMainHomepageBlock(currentToken, gridBlock.id, items, slotCount)
-                    const updatedBlock = updated.pageBlocks.find(
-                      (candidate): candidate is HotelOrAttractionGridBlockResponse =>
-                        candidate.id === gridBlock.id && candidate.blockType === gridBlock.blockType,
-                    )
-                    if (!updatedBlock) throw new Error('Block not found after save.')
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                    return updatedBlock.selection
-                  }}
-                  fetchCandidates={(currentToken, params) =>
-                    gridBlock.blockType === 'things-to-do-attractions'
-                      ? fetchThingsToDoAttractionCandidates(currentToken, params)
-                      : gridBlock.blockType === 'tour-grid'
-                        ? fetchTourGridCandidates(currentToken, params)
-                        : fetchHomepageHotelGridCandidates(currentToken, params)}
-                  convertBlockTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
-                  onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
-                    await handleConvertBlock(gridBlock, currentToken, blockType, slotCount)
-                  }}
-                  saveHotelGridSectionHeading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionHeading(currentToken, gridBlock.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                  saveHotelGridSectionSubheading={async (currentToken, value) => {
-                    await updateMainHomepageFeaturedSectionSubheading(currentToken, gridBlock.id, value)
-                    queryClient.invalidateQueries({ queryKey: mainHomepageQueryKey })
-                  }}
-                />
-              )
-            }
-            return (
-              <div key={block.id} className="hf-block-section">
-                <div className="hf-block-header">
-                  <div className="hf-block-label">
-                    <span>Block {idx + 1}</span>
-                    <span className="hf-block-type-tag">{block.blockType}</span>
-                  </div>
-                  <HomepageBlockDeleteTrigger
-                    blockId={block.id}
-                    blockIndex={idx}
-                    blockLabel={block.blockType}
-                    onDeleteBlock={(blockId) => deleteBlockMutation.mutate({ blockId })}
-                    isDeletingBlock={deleteBlockMutation.isPending && deletingBlockId === block.id}
-                    deleteError={deleteBlockMutation.isPending || deletingBlockId !== block.id ? null : deleteError}
-                  />
-                </div>
-                <div className="hf-block-content hf-empty">
-                  <p>
-                    Editor for &ldquo;{block.blockType}&rdquo; blocks is not yet available in this
-                    tool.
-                  </p>
-                </div>
-              </div>
-            )
-          }}
-        </HomepageBlocksSortableList>
-      )}
-      </>
+              )}
+            </HomepageBlocksSortableList>
+          )}
+        </>
       )}
 
-      {/* ── Add block ──────────────────────────────────────── */}
       {viewMode === 'draft' && (
-      <div className="hf-add-block-row">
-        {!showAddBlock ? (
-          <button
-            type="button"
-            className="hf-btn-ghost"
-            onClick={() => setShowAddBlock(true)}
-          >
-            + Add Block
-          </button>
-        ) : (
-          <AddHomepageBlockPicker
-            isPending={addBlockMutation.isPending}
-            onConfirm={handleConfirmAddBlock}
-            onCancel={() => setShowAddBlock(false)}
-          />
-        )}
-      </div>
+        <div className="hf-add-block-row">
+          {!showAddBlock ? (
+            <button
+              type="button"
+              className="hf-btn-ghost"
+              onClick={() => setShowAddBlock(true)}
+            >
+              + Add Block
+            </button>
+          ) : (
+            <AddHomepageBlockPicker
+              isPending={addBlockMutation.isPending}
+              onConfirm={handleConfirmAddBlock}
+              onCancel={() => setShowAddBlock(false)}
+            />
+          )}
+        </div>
       )}
     </div>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useMainHomepageEditor.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useMainHomepageEditor.ts
@@ -1,0 +1,218 @@
+import { useCallback, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import {
+  addMainHomepageBlock,
+  convertMainHomepageFeaturedArticlesBlock,
+  deleteMainHomepageBlock,
+  fetchMainHomepage,
+  publishMainHomepage,
+  reorderMainHomepageBlocks,
+  type MainHomepageResponse,
+} from './api'
+import {
+  buildOptimisticConvertedHomepageBlock,
+  deleteHomepageBlockFromCache,
+  reorderHomepageBlocksInCache,
+  replaceHomepageBlockInCache,
+} from './homepageBlockOptimisticUpdates'
+import type { CuratedHomepageBlockType, PageBlockResponse } from './pageBlocks'
+
+export function useMainHomepageEditor(
+  token: string | null | undefined,
+  canManage: boolean,
+) {
+  const queryClient = useQueryClient()
+  const homepageQueryKey = ['main-homepage', token]
+
+  const homepageQuery = useQuery({
+    queryKey: homepageQueryKey,
+    queryFn: ({ signal }) => fetchMainHomepage(token!, signal),
+    enabled: Boolean(token && canManage),
+  })
+
+  const [showAddBlock, setShowAddBlock] = useState(false)
+  const [viewMode, setViewMode] = useState<'draft' | 'published'>('draft')
+  const [deletingBlockId, setDeletingBlockId] = useState<string | null>(null)
+  const [pageBlockSlotKeys, setPageBlockSlotKeys] = useState<Map<string, Set<string>>>(
+    () => new Map(),
+  )
+
+  const handleSlotsChange = useCallback((blockId: string, keys: Set<string>) => {
+    setPageBlockSlotKeys((previous) => {
+      const existing = previous.get(blockId)
+      if (keys.size === 0 && !existing) return previous
+      if (
+        existing
+        && existing.size === keys.size
+        && [...keys].every((key) => existing.has(key))
+      ) {
+        return previous
+      }
+
+      const next = new Map(previous)
+      if (keys.size === 0) next.delete(blockId)
+      else next.set(blockId, keys)
+      return next
+    })
+  }, [])
+
+  const addBlockMutation = useMutation({
+    mutationFn: ({
+      blockType,
+      slotCount,
+      sectionHeading,
+      sectionSubheading,
+    }: {
+      blockType: CuratedHomepageBlockType
+      slotCount: number
+      sectionHeading?: string | null
+      sectionSubheading?: string | null
+    }) => addMainHomepageBlock(
+      token!,
+      blockType,
+      slotCount,
+      sectionHeading,
+      sectionSubheading,
+    ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: homepageQueryKey })
+      setShowAddBlock(false)
+    },
+  })
+
+  const deleteBlockMutation = useMutation({
+    mutationFn: ({ blockId }: { blockId: string }) =>
+      deleteMainHomepageBlock(token!, blockId),
+    onMutate: async ({ blockId }) => {
+      setDeletingBlockId(blockId)
+      await queryClient.cancelQueries({ queryKey: homepageQueryKey })
+      const previousHomepage =
+        queryClient.getQueryData<MainHomepageResponse>(homepageQueryKey)
+      queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, (current) =>
+        deleteHomepageBlockFromCache(current, blockId),
+      )
+      return { previousHomepage }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousHomepage) {
+        queryClient.setQueryData(homepageQueryKey, context.previousHomepage)
+      }
+    },
+    onSettled: () => {
+      setDeletingBlockId(null)
+    },
+  })
+
+  const reorderBlocksMutation = useMutation({
+    mutationFn: (orderedBlockIds: string[]) =>
+      reorderMainHomepageBlocks(token!, orderedBlockIds),
+    onMutate: async (orderedBlockIds) => {
+      await queryClient.cancelQueries({ queryKey: homepageQueryKey })
+      const previousHomepage =
+        queryClient.getQueryData<MainHomepageResponse>(homepageQueryKey)
+      queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, (current) =>
+        reorderHomepageBlocksInCache(current, orderedBlockIds),
+      )
+      return { previousHomepage }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, (current) =>
+        reorderHomepageBlocksInCache(current, result.orderedBlockIds),
+      )
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousHomepage) {
+        queryClient.setQueryData(homepageQueryKey, context.previousHomepage)
+      }
+    },
+  })
+
+  const publishMutation = useMutation({
+    mutationFn: () => publishMainHomepage(token!),
+    onSuccess: (result) => {
+      queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, result)
+      queryClient.invalidateQueries({ queryKey: homepageQueryKey })
+    },
+  })
+
+  async function handleConvertBlock(
+    block: PageBlockResponse,
+    currentToken: string,
+    blockType: CuratedHomepageBlockType,
+    slotCount: number,
+  ) {
+    await queryClient.cancelQueries({ queryKey: homepageQueryKey })
+    const previousHomepage =
+      queryClient.getQueryData<MainHomepageResponse>(homepageQueryKey)
+    const optimisticBlock = buildOptimisticConvertedHomepageBlock(
+      block,
+      blockType,
+      slotCount,
+    )
+
+    queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, (current) =>
+      replaceHomepageBlockInCache(current, optimisticBlock),
+    )
+
+    try {
+      const result = await convertMainHomepageFeaturedArticlesBlock(
+        currentToken,
+        block.id,
+        blockType,
+        slotCount,
+      )
+      queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, (current) =>
+        replaceHomepageBlockInCache(current, result.block),
+      )
+    } catch (error) {
+      if (previousHomepage) {
+        queryClient.setQueryData(homepageQueryKey, previousHomepage)
+      }
+      throw error
+    }
+  }
+
+  function handleConfirmAddBlock(
+    blockType: CuratedHomepageBlockType,
+    slotCount: number,
+    sectionHeading?: string | null,
+    sectionSubheading?: string | null,
+  ) {
+    addBlockMutation.mutate({
+      blockType,
+      slotCount,
+      sectionHeading,
+      sectionSubheading,
+    })
+  }
+
+  const deleteError = deleteBlockMutation.isError
+    ? deleteBlockMutation.error instanceof Error
+      ? deleteBlockMutation.error.message
+      : 'Failed to delete block.'
+    : null
+
+  const invalidateHomepage = () => {
+    queryClient.invalidateQueries({ queryKey: homepageQueryKey })
+  }
+
+  return {
+    homepageQuery,
+    publishMutation,
+    showAddBlock,
+    setShowAddBlock,
+    viewMode,
+    setViewMode,
+    deletingBlockId,
+    pageBlockSlotKeys,
+    handleSlotsChange,
+    addBlockMutation,
+    deleteBlockMutation,
+    reorderBlocksMutation,
+    handleConvertBlock,
+    handleConfirmAddBlock,
+    deleteError,
+    invalidateHomepage,
+  }
+}


### PR DESCRIPTION
## Summary
- reduce `MainHomepagePage` from 620 to 233 lines and leave it responsible for page states and composition
- move fetching, publication, optimistic block mutations, conversion rollback, and draft slot tracking into `useMainHomepageEditor`
- move per-block editor selection and API callback wiring into `MainHomepageBlockRenderer`
- preserve block keys, lazy candidate loading, duplicate exclusion, optimistic cache behavior, and all supported block variants

## Validation
- `NX_DAEMON=false pnpm exec nx run @questurian/abw-client:lint`
- `NX_DAEMON=false pnpm exec nx run @questurian/abw-client:test` (94 files, 358 tests)
- focused main-homepage and optimistic-update tests (2 files, 5 tests)
- `pnpm exec vite build --config apps/frontend/vite.config.ts`
- targeted ESLint for the three changed modules
- `git diff --check`