### PR TITLE
NOJIRA: Split YouTube deep-expand pipelines

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
@@ -26,6 +26,10 @@ operations.
 | `graph/nodes/` | Cohesive node families for Transcript, Classification, composition, SEO, Editorial Augmentation, title, and finalization |
 | `graph/runner.py` | Model/tone resolution, graph execution, checkpointing, and tracing |
 | `stages/` | LLM-backed Stage implementations and prompt handling |
+| `stages/deep_expansion.py` | Gap analysis and additive article expansion |
+| `stages/listicle_rewrite.py` | Listicle detection and complete curated-item rewrites |
+| `stages/deep_expand_llm.py` | JSON/text LLM invocation policy shared by the two expansion paths |
+| `stages/stage_deep_expand.py` | Stable public facade, branch selection, and terminal job status |
 
 ## Dependency direction
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/deep_expand_llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/deep_expand_llm.py
@@ -1,0 +1,73 @@
+"""Shared LLM transport helpers for the deep-expand feature."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from app.features.youtube2blog.config import Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS
+
+
+class Invokable(Protocol):
+    def invoke(self, prompt: str) -> Any:
+        """Invoke the configured model."""
+
+
+GetLlm = Callable[..., Invokable]
+ParseJson = Callable[[str], dict[str, Any]]
+
+
+def invoke_json_llm(
+    prompt: str,
+    model_name: str,
+    *,
+    get_llm: GetLlm,
+    parse_json: ParseJson,
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    """Invoke an LLM and retry malformed JSON responses up to three times."""
+    strict_prompt = (
+        f"{prompt}\n\n"
+        "CRITICAL OUTPUT RULE:\n"
+        "Return ONLY one valid JSON object.\n"
+        "No prose, no markdown, no code fences."
+    )
+    llm = get_llm(temperature=0.1, max_tokens=4096, model_name=model_name)
+    current_prompt = strict_prompt
+    last_error = "Unknown parse failure"
+    last_response = ""
+
+    for attempt in range(1, 4):
+        raw = str(llm.invoke(current_prompt)).strip()
+        last_response = raw
+        try:
+            return parse_json(raw)
+        except Exception as exc:  # noqa: BLE001
+            last_error = str(exc)
+            logger.warning(
+                "Deep expand JSON parse failed (attempt %d): %s",
+                attempt,
+                last_error,
+            )
+            current_prompt = (
+                "Your previous output was invalid JSON.\n"
+                "Return ONLY one strict JSON object.\n"
+                "No markdown fences, no commentary.\n\n"
+                f"Previous invalid output:\n{raw[:4000]}"
+            )
+
+    raise RuntimeError(
+        "Failed to parse JSON after 3 attempts: "
+        f"{last_error}. Preview: {last_response[:240]}"
+    )
+
+
+def invoke_text_llm(prompt: str, model_name: str, *, get_llm: GetLlm) -> str:
+    """Invoke an LLM using the deep-expansion output budget."""
+    llm = get_llm(
+        temperature=0.2,
+        max_tokens=Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
+        model_name=model_name,
+    )
+    return str(llm.invoke(prompt)).strip()

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/deep_expand_prompts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/deep_expand_prompts.py
@@ -1,0 +1,98 @@
+"""Prompts used by the deep-expansion and listicle-rewrite pipelines."""
+
+GAP_ANALYSIS_PROMPT = """You are an expert content analyst reviewing a finished article.
+
+Your task: Identify what is MISSING to make this article more complete, useful, and authoritative for readers.
+
+Examine the article for:
+1. Background context or foundational knowledge readers likely need
+2. Topics mentioned but not explored deeply enough
+3. Practical "how to apply this" sections that are absent
+4. External data, statistics, research, or references that would strengthen claims
+5. Questions a reader would naturally have after finishing that go unanswered
+
+Article title: {title}
+Article type: {article_type}
+
+Article content:
+{article_content}
+
+Return strict JSON only — no prose, no markdown fences:
+{{
+  "gaps": [
+    {{
+      "type": "background_context" | "deeper_dive" | "practical_application" | "external_context" | "unanswered_question",
+      "topic": "the specific topic or question that is missing",
+      "reason": "why adding this would make the article more complete",
+      "suggested_section_title": "proposed heading for the new section"
+    }}
+  ],
+  "expansion_plan": "2-3 sentence summary describing what will be added and how it strengthens the article"
+}}"""
+
+EXPANSION_PROMPT = """You are expanding an existing article by adding new content.
+
+CRITICAL RULES — read carefully before writing:
+1. PRESERVE every word of the existing article content exactly as written — do not rephrase, reorder, or remove anything
+2. ADD new sections and subsections that integrate naturally with the existing structure
+3. Preserve the source meaning, details, and heading style; do not copy filler, hedges, or rambling cadence
+4. New content must be accurate, substantive, and genuinely useful — not filler
+5. Insert new sections where they make logical sense in the flow (not always at the end)
+6. Do not add a new top-level H1 title — keep the existing title if present
+
+What to add (gap analysis results):
+{gaps_json}
+
+Expansion plan:
+{expansion_plan}
+
+Original article to expand:
+{article_content}
+
+Return ONLY the complete expanded article in Markdown. Do not include any commentary or explanation — just the full article text."""
+
+LISTICLE_DETECT_PROMPT = """You are analyzing an article to determine if it is a listicle.
+
+A listicle is an article structured around a ranked or unranked list of items — such as dishes, restaurants, hotels, places, products, tips, books, movies, etc.
+
+Article title: {title}
+
+Article content (first 6000 chars):
+{article_content}
+
+Return strict JSON only — no prose, no markdown fences:
+{{
+  "is_listicle": true or false,
+  "list_type": "dishes" | "restaurants" | "hotels" | "places" | "products" | "tips" | "movies" | "books" | "other" | null,
+  "list_topic": "short description of what the list is about, e.g. best dishes in Peru" or null,
+  "detected_items": ["Item Name 1", "Item Name 2"]
+}}
+
+Rules:
+- detected_items should contain only the name/title of each item, not descriptions (max 20 items)
+- If not a listicle, return is_listicle: false and null for everything else
+- detected_items must be an array even if empty"""
+
+LISTICLE_REWRITE_PROMPT = """You are rewriting a listicle article with a new, curated set of items chosen by the editor.
+
+This is a COMPLETE REWRITE. The editor has decided exactly which items to include and in what order.
+Use the original article as a reference for factual scope, intro/outro purpose, and formatting. Do not copy filler, hedges, or rambling cadence.
+
+Article topic: {title}
+Article type: {article_type}
+
+Original article (reference only — do NOT copy item sections verbatim):
+{original_article}
+
+New item list — write about these items IN THIS EXACT ORDER, no more, no less:
+{items_list}
+
+Instructions:
+1. Write a complete, polished article with a section for each item in the list above
+2. Each section should be thorough, useful, and match the depth of the original
+3. Preserve the original article's factual scope, intro purpose, and conclusion purpose without copying filler, hedges, or rambling cadence
+4. Update the H1 title only if the item changes make it inaccurate — otherwise keep it
+5. Do NOT include any items that are not in the list above
+6. Do NOT change the order of items
+
+Return ONLY the complete rewritten article in Markdown. No commentary, no explanation."""

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/deep_expansion.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/deep_expansion.py
@@ -1,0 +1,141 @@
+"""Gap-analysis and additive expansion pipeline for non-listicle articles."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from app.features.youtube2blog.config import Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+from app.shared.text import enforce_anti_ai_tells_markdown
+
+from .deep_expand_llm import GetLlm
+from .deep_expand_prompts import EXPANSION_PROMPT, GAP_ANALYSIS_PROMPT
+
+InvokeJson = Callable[[str, str], dict[str, Any]]
+
+
+def analyze_article_gaps(
+    article: str,
+    article_type: str,
+    title: str,
+    model_name: str,
+    *,
+    invoke_json: InvokeJson,
+) -> dict[str, Any]:
+    """Identify useful material missing from an otherwise finished article."""
+    prompt = (
+        GAP_ANALYSIS_PROMPT
+        .replace("{title}", title[:300])
+        .replace("{article_type}", article_type[:100])
+        .replace("{article_content}", article[:20_000])
+    )
+    result = invoke_json(prompt, model_name)
+    gaps = result.get("gaps")
+    if not isinstance(gaps, list):
+        gaps = []
+
+    return {
+        "gaps": gaps[:10],
+        "expansion_plan": str(result.get("expansion_plan", "")).strip(),
+    }
+
+
+def expand_article_with_gaps(
+    article: str,
+    gaps: list[dict[str, Any]],
+    expansion_plan: str,
+    model_name: str,
+    *,
+    get_llm: GetLlm,
+) -> str:
+    """Add sections for the analyzed gaps while retaining existing material."""
+    gaps_json = json.dumps(gaps, indent=2, ensure_ascii=False)
+    prompt = (
+        EXPANSION_PROMPT
+        .replace("{gaps_json}", gaps_json[:3000])
+        .replace("{expansion_plan}", expansion_plan[:500])
+        .replace("{article_content}", article[:20_000])
+    )
+    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
+    llm = get_llm(
+        temperature=0.2,
+        max_tokens=Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
+        model_name=model_name,
+    )
+    raw = str(llm.invoke(prompt)).strip()
+    return enforce_anti_ai_tells_markdown(
+        raw,
+        repair=lambda repair_prompt: llm.invoke(repair_prompt),
+        context="youtube2blog deep expand",
+    )
+
+
+def run_deep_expansion(
+    job_id: str,
+    article: str,
+    article_type: str,
+    title: str,
+    model_name: str,
+    *,
+    feature_name: str,
+    now_iso: Callable[[], str],
+    write_status: Callable[..., Any],
+    write_stage_result: Callable[..., Any],
+    analyze: Callable[..., dict[str, Any]],
+    expand: Callable[..., str],
+) -> None:
+    """Persist and run the gap-analysis followed by additive expansion."""
+    write_status(
+        job_id,
+        {
+            "run_id": job_id,
+            "stage": "analyzing",
+            "state": "running",
+            "updated_at": now_iso(),
+            "error": None,
+        },
+        feature=feature_name,
+    )
+
+    analysis = analyze(article, article_type, title, model_name=model_name)
+    gaps = analysis["gaps"]
+    expansion_plan = analysis["expansion_plan"]
+    write_stage_result(
+        job_id,
+        "gap_analysis",
+        {
+            "gaps": gaps,
+            "expansion_plan": expansion_plan,
+            "created_at": now_iso(),
+        },
+    )
+
+    write_status(
+        job_id,
+        {
+            "run_id": job_id,
+            "stage": "expanding",
+            "state": "running",
+            "updated_at": now_iso(),
+            "error": None,
+        },
+        feature=feature_name,
+    )
+    expanded_article = expand(
+        article,
+        gaps,
+        expansion_plan,
+        model_name=model_name,
+    )
+    write_stage_result(
+        job_id,
+        "expand_result",
+        {
+            "expanded_article": expanded_article,
+            "gaps": gaps,
+            "expansion_plan": expansion_plan,
+            "created_at": now_iso(),
+        },
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/listicle_rewrite.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/listicle_rewrite.py
@@ -1,0 +1,136 @@
+"""Detection and complete rewrite pipeline for listicle articles."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from app.features.youtube2blog.config import Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+from app.shared.text import enforce_anti_ai_tells_markdown
+
+from .deep_expand_llm import GetLlm
+from .deep_expand_prompts import LISTICLE_DETECT_PROMPT, LISTICLE_REWRITE_PROMPT
+
+InvokeJson = Callable[[str, str], dict[str, Any]]
+
+
+def detect_listicle(
+    article: str,
+    title: str,
+    model_name: str,
+    *,
+    invoke_json: InvokeJson,
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    """Detect whether an article is list-driven and extract its item names."""
+    prompt = (
+        LISTICLE_DETECT_PROMPT
+        .replace("{title}", title[:300])
+        .replace("{article_content}", article[:6_000])
+    )
+    try:
+        result = invoke_json(prompt, model_name)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Listicle detection failed, defaulting to non-listicle: %s",
+            exc,
+        )
+        return {
+            "is_listicle": False,
+            "list_type": None,
+            "list_topic": None,
+            "detected_items": [],
+        }
+
+    detected_items = result.get("detected_items")
+    if not isinstance(detected_items, list):
+        detected_items = []
+    return {
+        "is_listicle": bool(result.get("is_listicle", False)),
+        "list_type": result.get("list_type"),
+        "list_topic": result.get("list_topic"),
+        "detected_items": [str(item) for item in detected_items[:20]],
+    }
+
+
+def rewrite_listicle_article(
+    original_article: str,
+    article_type: str,
+    title: str,
+    new_items: list[str],
+    model_name: str,
+    *,
+    get_llm: GetLlm,
+) -> str:
+    """Rewrite an article around the editor's exact ordered item list."""
+    numbered = "\n".join(
+        f"{index + 1}. {item}" for index, item in enumerate(new_items)
+    )
+    prompt = (
+        LISTICLE_REWRITE_PROMPT
+        .replace("{title}", title[:300])
+        .replace("{article_type}", article_type[:100])
+        .replace("{original_article}", original_article[:15_000])
+        .replace("{items_list}", numbered)
+    )
+    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
+    llm = get_llm(
+        temperature=0.2,
+        max_tokens=Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
+        model_name=model_name,
+    )
+    raw = str(llm.invoke(prompt)).strip()
+    return enforce_anti_ai_tells_markdown(
+        raw,
+        repair=lambda repair_prompt: llm.invoke(repair_prompt),
+        context="youtube2blog listicle rewrite",
+    )
+
+
+def run_listicle_rewrite(
+    job_id: str,
+    article: str,
+    article_type: str,
+    title: str,
+    rewrite_items: list[str],
+    model_name: str,
+    *,
+    feature_name: str,
+    now_iso: Callable[[], str],
+    write_status: Callable[..., Any],
+    write_stage_result: Callable[..., Any],
+    rewrite: Callable[..., str],
+) -> None:
+    """Persist and run the complete listicle rewrite branch."""
+    write_status(
+        job_id,
+        {
+            "run_id": job_id,
+            "stage": "rewriting",
+            "state": "running",
+            "updated_at": now_iso(),
+            "error": None,
+        },
+        feature=feature_name,
+    )
+    rewritten = rewrite(
+        article,
+        article_type,
+        title,
+        rewrite_items,
+        model_name=model_name,
+    )
+    write_stage_result(
+        job_id,
+        "expand_result",
+        {
+            "expanded_article": rewritten,
+            "gaps": [],
+            "expansion_plan": (
+                f"Rewritten around {len(rewrite_items)} curated items."
+            ),
+            "created_at": now_iso(),
+        },
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_deep_expand.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_deep_expand.py
@@ -1,14 +1,12 @@
-"""
-Stage: Deep Article Expansion & Listicle Rewrite.
+"""Compatibility facade and orchestrator for article expansion jobs.
 
-Two separate pipelines share this module:
+The two execution paths live in separate modules:
 
-1. Deep Expand (non-listicle)
-   Gap analysis → fills missing sections while preserving all existing content.
+- :mod:`deep_expansion` performs gap analysis and additive expansion.
+- :mod:`listicle_rewrite` detects and completely rewrites listicles.
 
-2. Listicle Rewrite
-   User curates the item list (remove / rename / add / reorder).
-   The article is completely rewritten around the new list.
+Public functions remain here because routes and integrations already import
+this stage module directly.
 """
 
 from __future__ import annotations
@@ -18,214 +16,64 @@ from datetime import datetime, timezone
 from typing import Any
 
 from app.core import write_stage_result, write_status
-from app.features.youtube2blog.config import (
-    Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
-    Y2B_PRIMARY_MODEL,
-)
-from app.shared.prompts import ANTI_AI_TELLS_FULL
-from app.shared.text import enforce_anti_ai_tells_markdown
+from app.features.youtube2blog.config import Y2B_PRIMARY_MODEL
 from utils import get_vertex_llm, parse_json_response
+
+from . import deep_expansion as expansion_pipeline
+from . import listicle_rewrite as listicle_pipeline
+from .deep_expand_llm import invoke_json_llm, invoke_text_llm
+from .deep_expand_prompts import (
+    EXPANSION_PROMPT,
+    GAP_ANALYSIS_PROMPT,
+    LISTICLE_DETECT_PROMPT,
+    LISTICLE_REWRITE_PROMPT,
+)
 
 logger = logging.getLogger(__name__)
 
 FEATURE_NAME = "youtube2blog_expand"
 
-# ---------------------------------------------------------------------------
-# Prompts
-# ---------------------------------------------------------------------------
-
-GAP_ANALYSIS_PROMPT = """You are an expert content analyst reviewing a finished article.
-
-Your task: Identify what is MISSING to make this article more complete, useful, and authoritative for readers.
-
-Examine the article for:
-1. Background context or foundational knowledge readers likely need
-2. Topics mentioned but not explored deeply enough
-3. Practical "how to apply this" sections that are absent
-4. External data, statistics, research, or references that would strengthen claims
-5. Questions a reader would naturally have after finishing that go unanswered
-
-Article title: {title}
-Article type: {article_type}
-
-Article content:
-{article_content}
-
-Return strict JSON only — no prose, no markdown fences:
-{{
-  "gaps": [
-    {{
-      "type": "background_context" | "deeper_dive" | "practical_application" | "external_context" | "unanswered_question",
-      "topic": "the specific topic or question that is missing",
-      "reason": "why adding this would make the article more complete",
-      "suggested_section_title": "proposed heading for the new section"
-    }}
-  ],
-  "expansion_plan": "2-3 sentence summary describing what will be added and how it strengthens the article"
-}}"""
-
-EXPANSION_PROMPT = """You are expanding an existing article by adding new content.
-
-CRITICAL RULES — read carefully before writing:
-1. PRESERVE every word of the existing article content exactly as written — do not rephrase, reorder, or remove anything
-2. ADD new sections and subsections that integrate naturally with the existing structure
-3. Preserve the source meaning, details, and heading style; do not copy filler, hedges, or rambling cadence
-4. New content must be accurate, substantive, and genuinely useful — not filler
-5. Insert new sections where they make logical sense in the flow (not always at the end)
-6. Do not add a new top-level H1 title — keep the existing title if present
-
-What to add (gap analysis results):
-{gaps_json}
-
-Expansion plan:
-{expansion_plan}
-
-Original article to expand:
-{article_content}
-
-Return ONLY the complete expanded article in Markdown. Do not include any commentary or explanation — just the full article text."""
-
-LISTICLE_DETECT_PROMPT = """You are analyzing an article to determine if it is a listicle.
-
-A listicle is an article structured around a ranked or unranked list of items — such as dishes, restaurants, hotels, places, products, tips, books, movies, etc.
-
-Article title: {title}
-
-Article content (first 6000 chars):
-{article_content}
-
-Return strict JSON only — no prose, no markdown fences:
-{{
-  "is_listicle": true or false,
-  "list_type": "dishes" | "restaurants" | "hotels" | "places" | "products" | "tips" | "movies" | "books" | "other" | null,
-  "list_topic": "short description of what the list is about, e.g. best dishes in Peru" or null,
-  "detected_items": ["Item Name 1", "Item Name 2"]
-}}
-
-Rules:
-- detected_items should contain only the name/title of each item, not descriptions (max 20 items)
-- If not a listicle, return is_listicle: false and null for everything else
-- detected_items must be an array even if empty"""
-
-LISTICLE_REWRITE_PROMPT = """You are rewriting a listicle article with a new, curated set of items chosen by the editor.
-
-This is a COMPLETE REWRITE. The editor has decided exactly which items to include and in what order.
-Use the original article as a reference for factual scope, intro/outro purpose, and formatting. Do not copy filler, hedges, or rambling cadence.
-
-Article topic: {title}
-Article type: {article_type}
-
-Original article (reference only — do NOT copy item sections verbatim):
-{original_article}
-
-New item list — write about these items IN THIS EXACT ORDER, no more, no less:
-{items_list}
-
-Instructions:
-1. Write a complete, polished article with a section for each item in the list above
-2. Each section should be thorough, useful, and match the depth of the original
-3. Preserve the original article's factual scope, intro purpose, and conclusion purpose without copying filler, hedges, or rambling cadence
-4. Update the H1 title only if the item changes make it inaccurate — otherwise keep it
-5. Do NOT include any items that are not in the list above
-6. Do NOT change the order of items
-
-Return ONLY the complete rewritten article in Markdown. No commentary, no explanation."""
-
-
-# ---------------------------------------------------------------------------
-# LLM helpers
-# ---------------------------------------------------------------------------
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _invoke_json_llm(prompt: str, model_name: str = Y2B_PRIMARY_MODEL) -> dict[str, Any]:
-    """Invoke LLM and parse JSON response with retries."""
-    strict_prompt = (
-        f"{prompt}\n\n"
-        "CRITICAL OUTPUT RULE:\n"
-        "Return ONLY one valid JSON object.\n"
-        "No prose, no markdown, no code fences."
-    )
-
-    llm = get_vertex_llm(
-        temperature=0.1,
-        max_tokens=4096,
-        model_name=model_name,
-    )
-
-    current_prompt = strict_prompt
-    last_error = "Unknown parse failure"
-    last_response = ""
-
-    for attempt in range(1, 4):
-        raw = str(llm.invoke(current_prompt)).strip()
-        last_response = raw
-        try:
-            return parse_json_response(raw)
-        except Exception as exc:  # noqa: BLE001
-            last_error = str(exc)
-            logger.warning("Deep expand JSON parse failed (attempt %d): %s", attempt, last_error)
-            current_prompt = (
-                "Your previous output was invalid JSON.\n"
-                "Return ONLY one strict JSON object.\n"
-                "No markdown fences, no commentary.\n\n"
-                f"Previous invalid output:\n{raw[:4000]}"
-            )
-
-    raise RuntimeError(
-        f"Failed to parse JSON after 3 attempts: {last_error}. Preview: {last_response[:240]}"
+def _invoke_json_llm(
+    prompt: str,
+    model_name: str = Y2B_PRIMARY_MODEL,
+) -> dict[str, Any]:
+    """Invoke the configured model and parse its strict JSON response."""
+    return invoke_json_llm(
+        prompt,
+        model_name,
+        get_llm=get_vertex_llm,
+        parse_json=parse_json_response,
+        logger=logger,
     )
 
 
-def _invoke_text_llm(prompt: str, model_name: str = Y2B_PRIMARY_MODEL) -> str:
-    """Invoke LLM and return plain text response."""
-    llm = get_vertex_llm(
-        temperature=0.2,
-        max_tokens=Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
-        model_name=model_name,
-    )
-    return str(llm.invoke(prompt)).strip()
+def _invoke_text_llm(
+    prompt: str,
+    model_name: str = Y2B_PRIMARY_MODEL,
+) -> str:
+    """Invoke the configured model using the expansion output budget."""
+    return invoke_text_llm(prompt, model_name, get_llm=get_vertex_llm)
 
-
-# ---------------------------------------------------------------------------
-# Listicle detection
-# ---------------------------------------------------------------------------
 
 def detect_listicle(
     article: str,
     title: str,
     model_name: str = Y2B_PRIMARY_MODEL,
 ) -> dict[str, Any]:
-    """Quickly detect whether the article is a listicle and extract its items."""
-    prompt = (
-        LISTICLE_DETECT_PROMPT
-        .replace("{title}", title[:300])
-        .replace("{article_content}", article[:6_000])
+    """Detect a listicle through the dedicated listicle pipeline."""
+    return listicle_pipeline.detect_listicle(
+        article,
+        title,
+        model_name,
+        invoke_json=_invoke_json_llm,
+        logger=logger,
     )
-    try:
-        result = _invoke_json_llm(prompt, model_name=model_name)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Listicle detection failed, defaulting to non-listicle: %s", exc)
-        return {"is_listicle": False, "list_type": None, "list_topic": None, "detected_items": []}
 
-    is_listicle = bool(result.get("is_listicle", False))
-    detected_items = result.get("detected_items")
-    if not isinstance(detected_items, list):
-        detected_items = []
-
-    return {
-        "is_listicle": is_listicle,
-        "list_type": result.get("list_type"),
-        "list_topic": result.get("list_topic"),
-        "detected_items": [str(i) for i in detected_items[:20]],
-    }
-
-
-# ---------------------------------------------------------------------------
-# Gap analysis + expansion (non-listicle path)
-# ---------------------------------------------------------------------------
 
 def analyze_article_gaps(
     article: str,
@@ -233,21 +81,14 @@ def analyze_article_gaps(
     title: str,
     model_name: str = Y2B_PRIMARY_MODEL,
 ) -> dict[str, Any]:
-    """Step 1: Identify what is missing from the article."""
-    prompt = (
-        GAP_ANALYSIS_PROMPT
-        .replace("{title}", title[:300])
-        .replace("{article_type}", article_type[:100])
-        .replace("{article_content}", article[:20_000])
+    """Analyze missing material through the additive-expansion pipeline."""
+    return expansion_pipeline.analyze_article_gaps(
+        article,
+        article_type,
+        title,
+        model_name,
+        invoke_json=_invoke_json_llm,
     )
-    result = _invoke_json_llm(prompt, model_name=model_name)
-
-    gaps = result.get("gaps")
-    if not isinstance(gaps, list):
-        gaps = []
-    expansion_plan = str(result.get("expansion_plan", "")).strip()
-
-    return {"gaps": gaps[:10], "expansion_plan": expansion_plan}
 
 
 def expand_article_with_gaps(
@@ -256,32 +97,15 @@ def expand_article_with_gaps(
     expansion_plan: str,
     model_name: str = Y2B_PRIMARY_MODEL,
 ) -> str:
-    """Step 2: Expand the article by filling identified gaps."""
-    import json
-    gaps_json = json.dumps(gaps, indent=2, ensure_ascii=False)
-    prompt = (
-        EXPANSION_PROMPT
-        .replace("{gaps_json}", gaps_json[:3000])
-        .replace("{expansion_plan}", expansion_plan[:500])
-        .replace("{article_content}", article[:20_000])
-    )
-    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
-    llm = get_vertex_llm(
-        temperature=0.2,
-        max_tokens=Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
-        model_name=model_name,
-    )
-    raw = str(llm.invoke(prompt)).strip()
-    return enforce_anti_ai_tells_markdown(
-        raw,
-        repair=lambda repair_prompt: llm.invoke(repair_prompt),
-        context="youtube2blog deep expand",
+    """Generate additive expansion through the dedicated pipeline."""
+    return expansion_pipeline.expand_article_with_gaps(
+        article,
+        gaps,
+        expansion_plan,
+        model_name,
+        get_llm=get_vertex_llm,
     )
 
-
-# ---------------------------------------------------------------------------
-# Listicle rewrite path
-# ---------------------------------------------------------------------------
 
 def rewrite_listicle_article(
     original_article: str,
@@ -290,32 +114,31 @@ def rewrite_listicle_article(
     new_items: list[str],
     model_name: str = Y2B_PRIMARY_MODEL,
 ) -> str:
-    """Rewrite the article from scratch around the editor-curated item list."""
-    numbered = "\n".join(f"{i + 1}. {item}" for i, item in enumerate(new_items))
-    prompt = (
-        LISTICLE_REWRITE_PROMPT
-        .replace("{title}", title[:300])
-        .replace("{article_type}", article_type[:100])
-        .replace("{original_article}", original_article[:15_000])
-        .replace("{items_list}", numbered)
-    )
-    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
-    llm = get_vertex_llm(
-        temperature=0.2,
-        max_tokens=Y2B_DEEP_EXPAND_MAX_OUTPUT_TOKENS,
-        model_name=model_name,
-    )
-    raw = str(llm.invoke(prompt)).strip()
-    return enforce_anti_ai_tells_markdown(
-        raw,
-        repair=lambda repair_prompt: llm.invoke(repair_prompt),
-        context="youtube2blog listicle rewrite",
+    """Rewrite a listicle through the dedicated listicle pipeline."""
+    return listicle_pipeline.rewrite_listicle_article(
+        original_article,
+        article_type,
+        title,
+        new_items,
+        model_name,
+        get_llm=get_vertex_llm,
     )
 
 
-# ---------------------------------------------------------------------------
-# Orchestrator
-# ---------------------------------------------------------------------------
+def _write_terminal_status(job_id: str, *, error: str | None = None) -> None:
+    failed = error is not None
+    write_status(
+        job_id,
+        {
+            "run_id": job_id,
+            "stage": "error" if failed else "completed",
+            "state": "failed" if failed else "completed",
+            "updated_at": _now_iso(),
+            "error": error,
+        },
+        feature=FEATURE_NAME,
+    )
+
 
 def run_deep_expand(
     expand_job_id: str,
@@ -325,127 +148,52 @@ def run_deep_expand(
     model_name: str = Y2B_PRIMARY_MODEL,
     rewrite_items: list[str] | None = None,
 ) -> None:
-    """
-    Orchestrate deep expansion or listicle rewrite.
-
-    Runs in a background task. Progress polled via status endpoint.
-    Results stored under expand_job_id in the stages table.
-
-    If rewrite_items is provided the article is fully rewritten around those items
-    (listicle path). Otherwise the standard gap-analysis + expansion path runs.
-    """
+    """Run and persist either additive expansion or a listicle rewrite."""
     try:
+        shared_dependencies = {
+            "feature_name": FEATURE_NAME,
+            "now_iso": _now_iso,
+            "write_status": write_status,
+            "write_stage_result": write_stage_result,
+        }
         if rewrite_items:
-            # ----------------------------------------------------------------
-            # Listicle rewrite path
-            # ----------------------------------------------------------------
-            write_status(
+            listicle_pipeline.run_listicle_rewrite(
                 expand_job_id,
-                {
-                    "run_id": expand_job_id,
-                    "stage": "rewriting",
-                    "state": "running",
-                    "updated_at": _now_iso(),
-                    "error": None,
-                },
-                feature=FEATURE_NAME,
+                article,
+                article_type,
+                title,
+                rewrite_items,
+                model_name,
+                rewrite=rewrite_listicle_article,
+                **shared_dependencies,
             )
-
-            rewritten = rewrite_listicle_article(
-                article, article_type, title, rewrite_items, model_name=model_name
-            )
-
-            write_stage_result(
-                expand_job_id,
-                "expand_result",
-                {
-                    "expanded_article": rewritten,
-                    "gaps": [],
-                    "expansion_plan": f"Rewritten around {len(rewrite_items)} curated items.",
-                    "created_at": _now_iso(),
-                },
-            )
-
         else:
-            # ----------------------------------------------------------------
-            # Standard gap analysis + expansion path
-            # ----------------------------------------------------------------
-            write_status(
+            expansion_pipeline.run_deep_expansion(
                 expand_job_id,
-                {
-                    "run_id": expand_job_id,
-                    "stage": "analyzing",
-                    "state": "running",
-                    "updated_at": _now_iso(),
-                    "error": None,
-                },
-                feature=FEATURE_NAME,
+                article,
+                article_type,
+                title,
+                model_name,
+                analyze=analyze_article_gaps,
+                expand=expand_article_with_gaps,
+                **shared_dependencies,
             )
-
-            analysis = analyze_article_gaps(article, article_type, title, model_name=model_name)
-            gaps = analysis["gaps"]
-            expansion_plan = analysis["expansion_plan"]
-
-            write_stage_result(
-                expand_job_id,
-                "gap_analysis",
-                {
-                    "gaps": gaps,
-                    "expansion_plan": expansion_plan,
-                    "created_at": _now_iso(),
-                },
-            )
-
-            write_status(
-                expand_job_id,
-                {
-                    "run_id": expand_job_id,
-                    "stage": "expanding",
-                    "state": "running",
-                    "updated_at": _now_iso(),
-                    "error": None,
-                },
-                feature=FEATURE_NAME,
-            )
-
-            expanded_article = expand_article_with_gaps(
-                article, gaps, expansion_plan, model_name=model_name
-            )
-
-            write_stage_result(
-                expand_job_id,
-                "expand_result",
-                {
-                    "expanded_article": expanded_article,
-                    "gaps": gaps,
-                    "expansion_plan": expansion_plan,
-                    "created_at": _now_iso(),
-                },
-            )
-
-        write_status(
-            expand_job_id,
-            {
-                "run_id": expand_job_id,
-                "stage": "completed",
-                "state": "completed",
-                "updated_at": _now_iso(),
-                "error": None,
-            },
-            feature=FEATURE_NAME,
-        )
-
+        _write_terminal_status(expand_job_id)
     except Exception as exc:  # noqa: BLE001
         logger.error("Deep expand failed for %s: %s", expand_job_id, exc)
-        write_status(
-            expand_job_id,
-            {
-                "run_id": expand_job_id,
-                "stage": "error",
-                "state": "failed",
-                "updated_at": _now_iso(),
-                "error": str(exc),
-            },
-            feature=FEATURE_NAME,
-        )
+        _write_terminal_status(expand_job_id, error=str(exc))
         raise
+
+
+__all__ = [
+    "EXPANSION_PROMPT",
+    "FEATURE_NAME",
+    "GAP_ANALYSIS_PROMPT",
+    "LISTICLE_DETECT_PROMPT",
+    "LISTICLE_REWRITE_PROMPT",
+    "analyze_article_gaps",
+    "detect_listicle",
+    "expand_article_with_gaps",
+    "rewrite_listicle_article",
+    "run_deep_expand",
+]

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_deep_expand.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_deep_expand.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+
+from app.features.youtube2blog.stages import stage_deep_expand
+
+
+def test_detect_listicle_keeps_stage_level_llm_seam(monkeypatch):
+    calls = []
+
+    def fake_invoke(prompt, model_name):
+        calls.append((prompt, model_name))
+        return {
+            "is_listicle": True,
+            "list_type": "places",
+            "list_topic": "islands",
+            "detected_items": list(range(25)),
+        }
+
+    monkeypatch.setattr(stage_deep_expand, "_invoke_json_llm", fake_invoke)
+
+    result = stage_deep_expand.detect_listicle(
+        "Article body",
+        "Island guide",
+        model_name="test-model",
+    )
+
+    assert calls[0][1] == "test-model"
+    assert result == {
+        "is_listicle": True,
+        "list_type": "places",
+        "list_topic": "islands",
+        "detected_items": [str(index) for index in range(20)],
+    }
+
+
+def test_run_deep_expand_persists_gap_analysis_and_expansion(monkeypatch):
+    statuses = []
+    results = []
+    monkeypatch.setattr(stage_deep_expand, "_now_iso", lambda: "now")
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "write_status",
+        lambda job_id, payload, **kwargs: statuses.append(
+            (job_id, payload, kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "write_stage_result",
+        lambda job_id, stage, payload: results.append((job_id, stage, payload)),
+    )
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "analyze_article_gaps",
+        lambda *args, **kwargs: {
+            "gaps": [{"topic": "history"}],
+            "expansion_plan": "Add context.",
+        },
+    )
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "expand_article_with_gaps",
+        lambda *args, **kwargs: "Expanded article",
+    )
+
+    stage_deep_expand.run_deep_expand(
+        "job-1",
+        "Article",
+        "guide",
+        "Title",
+        model_name="test-model",
+    )
+
+    assert [payload["stage"] for _, payload, _ in statuses] == [
+        "analyzing",
+        "expanding",
+        "completed",
+    ]
+    assert [stage for _, stage, _ in results] == [
+        "gap_analysis",
+        "expand_result",
+    ]
+    assert results[-1][2]["expanded_article"] == "Expanded article"
+
+
+def test_run_deep_expand_dispatches_listicle_rewrite(monkeypatch):
+    statuses = []
+    results = []
+    rewrite_calls = []
+    monkeypatch.setattr(stage_deep_expand, "_now_iso", lambda: "now")
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "write_status",
+        lambda job_id, payload, **kwargs: statuses.append(payload),
+    )
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "write_stage_result",
+        lambda job_id, stage, payload: results.append((stage, payload)),
+    )
+
+    def fake_rewrite(*args, **kwargs):
+        rewrite_calls.append((args, kwargs))
+        return "Rewritten article"
+
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "rewrite_listicle_article",
+        fake_rewrite,
+    )
+
+    stage_deep_expand.run_deep_expand(
+        "job-2",
+        "Article",
+        "listicle",
+        "Title",
+        model_name="test-model",
+        rewrite_items=["First", "Second"],
+    )
+
+    assert rewrite_calls[0][0][3] == ["First", "Second"]
+    assert [payload["stage"] for payload in statuses] == [
+        "rewriting",
+        "completed",
+    ]
+    assert results == [
+        (
+            "expand_result",
+            {
+                "expanded_article": "Rewritten article",
+                "gaps": [],
+                "expansion_plan": "Rewritten around 2 curated items.",
+                "created_at": "now",
+            },
+        )
+    ]
+
+
+def test_run_deep_expand_records_failure_and_reraises(monkeypatch):
+    statuses = []
+    monkeypatch.setattr(stage_deep_expand, "_now_iso", lambda: "now")
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "write_status",
+        lambda job_id, payload, **kwargs: statuses.append(payload),
+    )
+    monkeypatch.setattr(
+        stage_deep_expand,
+        "analyze_article_gaps",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("broken")),
+    )
+
+    with pytest.raises(RuntimeError, match="broken"):
+        stage_deep_expand.run_deep_expand(
+            "job-3",
+            "Article",
+            "guide",
+            "Title",
+        )
+
+    assert statuses[-1] == {
+        "run_id": "job-3",
+        "stage": "error",
+        "state": "failed",
+        "updated_at": "now",
+        "error": "broken",
+    }


### PR DESCRIPTION
## Summary
- separate additive gap analysis/expansion from listicle detection and complete curated-item rewrites
- isolate prompt ownership and shared JSON/text LLM transport policy
- reduce `stage_deep_expand.py` from 451 reported lines (483 in the current checkout) to a 199-line compatibility facade and job dispatcher
- preserve public imports, stage names, persistence payloads, status ordering, model configuration, anti-AI repair, and stage-level monkeypatch seams
- document the new YouTube2Blog stage boundaries and add direct branch/failure tests

## Validation
- `.venv/bin/flake8 apps/backend/app packages/shared/src packages/utils/src`
- `.venv/bin/pytest -q apps/backend/tests` (316 tests)
- focused deep-expand tests (4 tests)
- `git diff --check`