### PR TITLE
NOJIRA: Decompose editorial augmentation stage

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
@@ -30,6 +30,11 @@ operations.
 | `stages/listicle_rewrite.py` | Listicle detection and complete curated-item rewrites |
 | `stages/deep_expand_llm.py` | JSON/text LLM invocation policy shared by the two expansion paths |
 | `stages/stage_deep_expand.py` | Stable public facade, branch selection, and terminal job status |
+| `content/editorial_blocks.py` | Pure Editorial Augmentation Markdown marker repair |
+| `stages/editorial_augmentation_prompts.py` | Editorial Augmentation prompt policy |
+| `stages/editorial_augmentation_validation.py` | Model-output normalization and preservation checks |
+| `stages/editorial_augmentation_llm.py` | Editorial model invocation, JSON retry, and prose repair |
+| `stages/stage_editorial_augmentation.py` | Stable thin Editorial Augmentation Stage facade |
 
 ## Dependency direction
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/content/editorial_blocks.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/content/editorial_blocks.py
@@ -1,0 +1,216 @@
+"""Pure Markdown marker handling for editorial augmentation blocks."""
+
+from __future__ import annotations
+
+import re
+
+EDITORIAL_COMPONENT_LABELS = {
+    "pull_quote": "Pull Quote",
+    "in_the_know_box": "In The Know",
+    "key_takeaways_box": "Key Takeaways",
+    "highlight_callout": "Highlight Callout",
+    "faq_block": "FAQ Block",
+}
+
+
+def _safe_str(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def _editorial_box_marker(component: str) -> str:
+    return f"[!EDITORIAL-BOX|{component}]"
+
+
+def _editorial_block_start_marker(component: str) -> str:
+    return f"[!EDITORIAL-BLOCK-START|{component}]"
+
+
+def _editorial_block_end_marker(component: str) -> str:
+    return f"[!EDITORIAL-BLOCK-END|{component}]"
+
+
+def _editorial_block_label_marker(component: str) -> str:
+    label = EDITORIAL_COMPONENT_LABELS.get(component, component)
+    return f"[!EDITORIAL-BLOCK-LABEL|{label}]"
+
+
+def _line_matches_editorial_marker(line: str, marker: str) -> bool:
+    return bool(
+        re.match(
+            rf"^\s*>\s*{re.escape(marker)}\s*$",
+            line,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _find_editorial_block_range(
+    lines: list[str], component: str
+) -> tuple[int, int] | None:
+    start_marker = _editorial_block_start_marker(component)
+    end_marker = _editorial_block_end_marker(component)
+    start_idx = -1
+
+    for idx, line in enumerate(lines):
+        if start_idx == -1:
+            if _line_matches_editorial_marker(line, start_marker):
+                start_idx = idx
+            continue
+
+        if _line_matches_editorial_marker(line, end_marker):
+            return start_idx, idx
+
+    return None
+
+
+def _content_has_editorial_block(content: str, component: str) -> bool:
+    start_marker = re.escape(_editorial_block_start_marker(component))
+    end_marker = re.escape(_editorial_block_end_marker(component))
+    pattern = rf"(?mis)^\s*>\s*{start_marker}\s*$.*?^\s*>\s*{end_marker}\s*$"
+    return bool(re.search(pattern, content))
+
+
+def _build_editorial_metadata_box(component_entry: dict[str, str]) -> str:
+    component = component_entry["component"]
+    label = EDITORIAL_COMPONENT_LABELS.get(component, component)
+    lines = [
+        f"> {_editorial_block_start_marker(component)}",
+        f"> {_editorial_block_label_marker(component)}",
+        f"> {_editorial_box_marker(component)}",
+        f"> **Component:** {label}",
+    ]
+    placement = _safe_str(component_entry.get("placement"))
+    if placement:
+        lines.append(f"> **Placement:** {placement}")
+    justification = _safe_str(component_entry.get("justification"))
+    if justification:
+        lines.append(f"> **Why:** {justification}")
+    lines.append(f"> {_editorial_block_end_marker(component)}")
+    return "\n".join(lines)
+
+
+def _wrap_existing_editorial_box_with_markers(content: str, component: str) -> str:
+    if not content:
+        return content
+    if _content_has_editorial_block(content, component):
+        return content
+
+    marker_line_re = re.compile(
+        rf"^\s*>\s*{re.escape(_editorial_box_marker(component))}\s*$",
+        flags=re.IGNORECASE,
+    )
+    start_line = f"> {_editorial_block_start_marker(component)}"
+    end_line = f"> {_editorial_block_end_marker(component)}"
+
+    lines = content.splitlines()
+    for idx, line in enumerate(lines):
+        if not marker_line_re.match(line):
+            continue
+
+        if idx > 0 and lines[idx - 1].strip().lower() == start_line.lower():
+            return content
+
+        block_end = idx
+        while block_end + 1 < len(lines) and lines[block_end + 1].lstrip().startswith(
+            ">"
+        ):
+            block_end += 1
+
+        lines.insert(idx, start_line)
+        lines.insert(block_end + 2, end_line)
+        return "\n".join(lines)
+
+    return content
+
+
+def _ensure_editorial_block_labels(content: str, component: str) -> str:
+    if not content:
+        return content
+
+    lines = content.splitlines()
+    block_range = _find_editorial_block_range(lines, component)
+    if not block_range:
+        return content
+
+    start_idx, end_idx = block_range
+    box_marker = _editorial_box_marker(component)
+    label_marker = _editorial_block_label_marker(component)
+    label_text = EDITORIAL_COMPONENT_LABELS.get(component, component)
+    display_label_line = f"**Component:** {label_text}"
+
+    box_idx = next(
+        (
+            idx
+            for idx in range(start_idx, end_idx + 1)
+            if _line_matches_editorial_marker(lines[idx], box_marker)
+        ),
+        -1,
+    )
+    label_marker_idx = next(
+        (
+            idx
+            for idx in range(start_idx, end_idx + 1)
+            if _line_matches_editorial_marker(lines[idx], label_marker)
+        ),
+        -1,
+    )
+    display_label_idx = next(
+        (
+            idx
+            for idx in range(start_idx, end_idx + 1)
+            if _line_matches_editorial_marker(lines[idx], display_label_line)
+        ),
+        -1,
+    )
+
+    if label_marker_idx == -1:
+        insert_after = box_idx if box_idx != -1 else start_idx
+        lines.insert(insert_after + 1, f"> {label_marker}")
+        label_marker_idx = insert_after + 1
+        if display_label_idx > insert_after:
+            display_label_idx += 1
+
+    if display_label_idx == -1:
+        lines.insert(label_marker_idx + 1, f"> {display_label_line}")
+
+    return "\n".join(lines)
+
+
+def ensure_editorial_component_boxes(
+    content: str, components_added: list[dict[str, str]]
+) -> str:
+    """Repair marker envelopes and append metadata-only fallbacks when absent."""
+    if not content or not components_added:
+        return content
+
+    updated_content = content
+    for component_entry in components_added:
+        component = component_entry["component"]
+        updated_content = _wrap_existing_editorial_box_with_markers(
+            updated_content,
+            component,
+        )
+        updated_content = _ensure_editorial_block_labels(updated_content, component)
+
+    missing_components = [
+        component_entry
+        for component_entry in components_added
+        if not _content_has_editorial_block(
+            updated_content, component_entry["component"]
+        )
+    ]
+    if not missing_components:
+        return updated_content
+
+    fallback_boxes = "\n\n".join(
+        _build_editorial_metadata_box(component_entry)
+        for component_entry in missing_components
+    ).strip()
+    if not fallback_boxes:
+        return updated_content
+
+    return f"{updated_content.strip()}\n\n{fallback_boxes}".strip()

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/editorial_augmentation_llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/editorial_augmentation_llm.py
@@ -1,0 +1,88 @@
+"""LLM execution policy for YouTube2Blog editorial augmentation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.features.youtube2blog.config import (
+    Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
+    Y2B_EDITORIAL_AUGMENTATION_MODEL,
+)
+from app.shared.text import enforce_anti_ai_tells_markdown
+from utils import get_vertex_llm, parse_json_response
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = Y2B_EDITORIAL_AUGMENTATION_MODEL
+
+
+def _safe_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def invoke_json_llm(
+    *, prompt: str, model_name: str = DEFAULT_MODEL
+) -> tuple[dict[str, Any], str]:
+    """Invoke the editorial model and retry malformed JSON responses."""
+    strict_prompt = (
+        f"{prompt}\n\n"
+        "CRITICAL OUTPUT RULE:\n"
+        "Return ONLY one valid JSON object.\n"
+        "No prose, no markdown, no code fences."
+    )
+
+    llm = get_vertex_llm(
+        temperature=0.05,
+        max_tokens=Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
+        model_name=model_name,
+    )
+
+    current_prompt = strict_prompt
+    last_error = "Unknown JSON parse failure"
+    last_response = ""
+
+    for attempt in range(1, 4):
+        raw_response = _safe_str(llm.invoke(current_prompt))
+        last_response = raw_response
+
+        try:
+            parsed = parse_json_response(raw_response)
+            return parsed, raw_response
+        except Exception as exc:  # noqa: BLE001
+            last_error = str(exc)
+            logger.warning(
+                "YouTube2Blog editorial JSON parse failed (attempt %d): %s",
+                attempt,
+                last_error,
+            )
+            current_prompt = (
+                "Your previous output was invalid JSON.\n"
+                "Return ONLY one strict JSON object.\n"
+                "No markdown fences, no commentary.\n\n"
+                f"Previous invalid output:\n{raw_response[:4000]}"
+            )
+
+    raise RuntimeError(
+        "Failed to parse JSON LLM response: "
+        f"{last_error}. Preview: {last_response[:240]}"
+    )
+
+
+def enforce_editorial_anti_ai_tells(content: str, *, model_name: str) -> str:
+    """Apply the shared prose policy using the editorial model for repairs."""
+    return enforce_anti_ai_tells_markdown(
+        content,
+        repair=lambda repair_prompt: _safe_str(
+            get_vertex_llm(
+                temperature=0.1,
+                max_tokens=Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
+                model_name=model_name,
+            ).invoke(repair_prompt)
+        ),
+        context="youtube2blog editorial augmentation",
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/editorial_augmentation_prompts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/editorial_augmentation_prompts.py
@@ -1,0 +1,130 @@
+"""Prompt policy for YouTube2Blog editorial augmentation."""
+
+from __future__ import annotations
+
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+
+Y2B_EDITORIAL_AUGMENTATION_PROMPT = """You are running YouTube2Blog EDITORIAL AUGMENTATION on a finished draft.
+
+Goal:
+- Optionally add high-signal editorial components that improve comprehension, pacing, or emphasis.
+- Default to zero add-ons when the article already reads clearly.
+- Keep output in Markdown and preserve the author's voice.
+
+Return strict JSON only:
+{
+  "augmented_content": "string",
+  "components_added": [
+    {
+      "component": "pull_quote|in_the_know_box|key_takeaways_box|highlight_callout|faq_block",
+      "justification": "string",
+      "placement": "string"
+    }
+  ],
+  "diagnostic": {
+    "cognitive_load": "strong|weak",
+    "narrative_density": "strong|weak",
+    "emphasis_clarity": "strong|weak",
+    "reading_behavior_risk": "strong|weak"
+  },
+  "augmentation_summary": "string"
+}
+
+Core principle:
+- Do not add a component unless it measurably improves comprehension, pacing, or emphasis.
+- If uncertain, do nothing.
+
+Decision process:
+1) Diagnose these axes before adding anything:
+   - cognitive_load
+   - narrative_density
+   - emphasis_clarity
+   - reading_behavior_risk
+2) Add components only if at least one axis is weak.
+3) Use restraint: one component is common, two is acceptable, more is rare.
+4) Never add more than one component in the same immediate section.
+5) Every component must be defensible in one clear sentence.
+
+Component rules:
+- pull_quote:
+  - 1 per article (2 max for long pieces).
+  - Quote must already exist in article text.
+  - Amplify emphasis only; do not explain or add facts.
+  - Skip for list-heavy or purely informational drafts when redundant.
+- in_the_know_box:
+  - Use only to prevent likely reader confusion.
+  - Neutral factual tone, clearly labeled.
+  - No repetition of nearby prose.
+- key_takeaways_box:
+  - Use for long or argument-driven drafts where skimmers may miss the point.
+  - 3-5 bullets only.
+  - No new information.
+- highlight_callout:
+  - 1-2 sentences only.
+  - Use to relieve dense pacing, not to restate nearby callouts.
+  - No decorative styling instructions.
+- faq_block:
+  - 2-5 questions maximum.
+  - Each answer must be 1-3 sentences.
+  - No new information; restate only what article already says.
+  - Questions should mirror natural search phrasing.
+  - Place near the end (typically after key takeaways), unless an explainer
+    needs earlier clarification.
+  - Skip for short or purely narrative pieces, or when likely questions
+    require new information.
+
+Markdown constraints:
+- Keep Markdown headings and existing structure intact.
+- Do not add HTML/CSS.
+- Do not add code fences.
+- Do not add new factual claims.
+- When a component is applied, wrap it in an isolated parse-friendly Markdown block.
+- Required delimiter lines:
+  > [!EDITORIAL-BLOCK-START|<component_key>]
+  > [!EDITORIAL-BLOCK-LABEL|<official_label>]
+  > [!EDITORIAL-BLOCK-END|<component_key>]
+- Inside that block include this exact marker line:
+  > [!EDITORIAL-BOX|<component_key>]
+- Allowed component_key values:
+  pull_quote, in_the_know_box, key_takeaways_box, highlight_callout, faq_block
+- Immediately after the marker line include:
+  > **Component:** <human label>
+- <official_label> and <human label> must match the canonical label.
+- Then include the component content inside the same blockquote.
+- Example:
+  > [!EDITORIAL-BLOCK-START|in_the_know_box]
+  > [!EDITORIAL-BLOCK-LABEL|In The Know]
+  > [!EDITORIAL-BOX|in_the_know_box]
+  > **Component:** In The Know
+  > Short neutral context note.
+  > [!EDITORIAL-BLOCK-END|in_the_know_box]
+
+ARTICLE TITLE:
+{article_title}
+
+ARTICLE CONTENT (MARKDOWN):
+{article_content}
+
+ARTICLE TYPE:
+{article_type}
+"""
+
+
+def build_editorial_augmentation_prompt(
+    *,
+    article_title: str,
+    article_content: str,
+    article_type: str,
+    tone_guidance: str | None = None,
+) -> str:
+    """Build the complete editorial prompt with bounded source fields."""
+    prompt = (
+        Y2B_EDITORIAL_AUGMENTATION_PROMPT.replace(
+            "{article_title}", article_title[:500]
+        )
+        .replace("{article_content}", article_content[:20_000])
+        .replace("{article_type}", article_type)
+    )
+    if tone_guidance:
+        prompt = f"{prompt}\n\n{tone_guidance.strip()}"
+    return f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/editorial_augmentation_validation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/editorial_augmentation_validation.py
@@ -1,0 +1,201 @@
+"""Normalization and validation for editorial augmentation model output."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, TypedDict
+
+from app.features.youtube2blog.content.editorial_blocks import (
+    ensure_editorial_component_boxes,
+)
+
+
+class EditorialAugmentation(TypedDict):
+    """Validated editorial augmentation data used by the stage facade."""
+
+    augmented_content: str
+    components_added: list[dict[str, str]]
+    diagnostic: dict[str, Literal["strong", "weak"]]
+    augmentation_summary: str
+    augmentation_applied: bool
+
+
+def _safe_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _tokenize_words(value: str) -> list[str]:
+    return re.findall(r"[A-Za-z0-9']+", _safe_str(value))
+
+
+def _ensure_markdown_section_headers(content: str) -> str:
+    cleaned = _safe_str(content)
+    if not cleaned:
+        return ""
+
+    cleaned = re.sub(r"(?m)^\s*#\s+", "## ", cleaned).strip()
+
+    if re.search(r"(?m)^\s{0,3}#{2,6}\s+\S", cleaned):
+        return cleaned
+
+    paragraphs = [
+        item.strip() for item in re.split(r"\n\s*\n", cleaned) if item.strip()
+    ]
+    if not paragraphs:
+        return cleaned
+
+    if len(paragraphs) == 1:
+        return f"## Overview\n\n{paragraphs[0]}"
+
+    headings = ["Overview", "Key Insights", "Practical Guidance", "Takeaways"]
+    sections = []
+    for index, paragraph in enumerate(paragraphs):
+        heading = (
+            headings[index]
+            if index < len(headings)
+            else f"Additional Insight {index - 3}"
+        )
+        sections.append(f"## {heading}\n\n{paragraph}")
+
+    return "\n\n".join(sections)
+
+
+def _normalize_editorial_component_name(value: str) -> str:
+    normalized = re.sub(r"[\s\-]+", "_", value.strip().lower())
+    aliases = {
+        "pull_quote": "pull_quote",
+        "quote": "pull_quote",
+        "in_the_know_box": "in_the_know_box",
+        "in_the_know": "in_the_know_box",
+        "in_theknow_box": "in_the_know_box",
+        "in_the_know_callout": "in_the_know_box",
+        "key_takeaways_box": "key_takeaways_box",
+        "key_takeaways": "key_takeaways_box",
+        "takeaways": "key_takeaways_box",
+        "highlight_callout": "highlight_callout",
+        "highlight": "highlight_callout",
+        "callout": "highlight_callout",
+        "faq_block": "faq_block",
+        "faq": "faq_block",
+        "faqs": "faq_block",
+        "qa_block": "faq_block",
+        "q_and_a_block": "faq_block",
+    }
+    return aliases.get(normalized, "")
+
+
+def _sanitize_editorial_diagnostic_axis(value: Any) -> Literal["strong", "weak"]:
+    normalized = _safe_str(value).lower()
+    weak_values = {
+        "weak",
+        "needs_support",
+        "needs support",
+        "high",
+        "high_risk",
+        "at_risk",
+        "risky",
+        "yes",
+    }
+    if normalized in weak_values:
+        return "weak"
+    return "strong"
+
+
+def _normalize_markdown_for_comparison(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def sanitize_editorial_augmentation(
+    parsed: dict[str, Any], *, fallback_content: str
+) -> EditorialAugmentation:
+    """Normalize untrusted model output and preserve the source article."""
+    fallback_markdown = _ensure_markdown_section_headers(fallback_content)
+    augmented_content = _safe_str(parsed.get("augmented_content"))
+    if not augmented_content:
+        augmented_content = fallback_markdown
+
+    augmented_content = _ensure_markdown_section_headers(augmented_content)
+
+    components_added: list[dict[str, str]] = []
+    raw_components = parsed.get("components_added")
+    if isinstance(raw_components, list):
+        for item in raw_components:
+            if not isinstance(item, dict):
+                continue
+            component = _normalize_editorial_component_name(
+                _safe_str(item.get("component"))
+            )
+            if not component:
+                continue
+            components_added.append(
+                {
+                    "component": component,
+                    "justification": _safe_str(item.get("justification")),
+                    "placement": _safe_str(item.get("placement")),
+                }
+            )
+            if len(components_added) >= 5:
+                break
+
+    if components_added:
+        augmented_content = ensure_editorial_component_boxes(
+            augmented_content,
+            components_added,
+        )
+
+    if len(_tokenize_words(augmented_content)) < len(
+        _tokenize_words(fallback_markdown)
+    ):
+        augmented_content = ensure_editorial_component_boxes(
+            fallback_markdown,
+            components_added,
+        )
+
+    diagnostic_raw = _safe_dict(parsed.get("diagnostic"))
+    diagnostic = {
+        axis: _sanitize_editorial_diagnostic_axis(diagnostic_raw.get(axis))
+        for axis in (
+            "cognitive_load",
+            "narrative_density",
+            "emphasis_clarity",
+            "reading_behavior_risk",
+        )
+    }
+
+    augmentation_summary = _safe_str(parsed.get("augmentation_summary"))
+    if not augmentation_summary:
+        if components_added:
+            component_names = ", ".join(item["component"] for item in components_added)
+            augmentation_summary = (
+                "Applied restrained editorial augmentation: " f"{component_names}."
+            )
+        else:
+            augmentation_summary = (
+                "No editorial augmentation added; the draft already read clearly."
+            )
+
+    augmentation_applied = bool(
+        components_added
+    ) and _normalize_markdown_for_comparison(
+        augmented_content
+    ) != _normalize_markdown_for_comparison(
+        fallback_markdown
+    )
+
+    return {
+        "augmented_content": augmented_content,
+        "components_added": components_added,
+        "diagnostic": diagnostic,
+        "augmentation_summary": augmentation_summary,
+        "augmentation_applied": augmentation_applied,
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_editorial_augmentation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_editorial_augmentation.py
@@ -1,563 +1,39 @@
-"""
-Stage: Editorial augmentation.
-
-Adds optional editorial blocks to improve comprehension and pacing while
-preserving factual integrity.
-"""
+"""Thin orchestration facade for the Editorial Augmentation Stage."""
 
 from __future__ import annotations
 
 import logging
-import re
-from typing import Any
 
-from app.features.youtube2blog.config import (
-    Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
-    Y2B_EDITORIAL_AUGMENTATION_MODEL,
+from app.features.youtube2blog.config import Y2B_EDITORIAL_AUGMENTATION_MODEL
+from app.features.youtube2blog.content.editorial_blocks import (
+    EDITORIAL_COMPONENT_LABELS,
 )
-from app.shared.prompts import ANTI_AI_TELLS_FULL
-from app.shared.text import enforce_anti_ai_tells_markdown
-from utils import get_vertex_llm, parse_json_response
 from shared import Stage3Output, StageEditorialAugmentationOutput
+
+from .editorial_augmentation_llm import (
+    enforce_editorial_anti_ai_tells,
+    invoke_json_llm,
+)
+from .editorial_augmentation_prompts import (
+    Y2B_EDITORIAL_AUGMENTATION_PROMPT,
+    build_editorial_augmentation_prompt,
+)
+from .editorial_augmentation_validation import sanitize_editorial_augmentation
 
 logger = logging.getLogger(__name__)
 
-# Pinned to the Claude editorial model (routed via get_vertex_llm's
-# claude-* dispatch); callers may still pass an explicit model_name.
 DEFAULT_MODEL = Y2B_EDITORIAL_AUGMENTATION_MODEL
 
-EDITORIAL_COMPONENT_LABELS = {
-    "pull_quote": "Pull Quote",
-    "in_the_know_box": "In The Know",
-    "key_takeaways_box": "Key Takeaways",
-    "highlight_callout": "Highlight Callout",
-    "faq_block": "FAQ Block",
-}
-
-Y2B_EDITORIAL_AUGMENTATION_PROMPT = """You are running YouTube2Blog EDITORIAL AUGMENTATION on a finished draft.
-
-Goal:
-- Optionally add high-signal editorial components that improve comprehension, pacing, or emphasis.
-- Default to zero add-ons when the article already reads clearly.
-- Keep output in Markdown and preserve the author's voice.
-
-Return strict JSON only:
-{
-  "augmented_content": "string",
-  "components_added": [
-    {
-      "component": "pull_quote|in_the_know_box|key_takeaways_box|highlight_callout|faq_block",
-      "justification": "string",
-      "placement": "string"
-    }
-  ],
-  "diagnostic": {
-    "cognitive_load": "strong|weak",
-    "narrative_density": "strong|weak",
-    "emphasis_clarity": "strong|weak",
-    "reading_behavior_risk": "strong|weak"
-  },
-  "augmentation_summary": "string"
-}
-
-Core principle:
-- Do not add a component unless it measurably improves comprehension, pacing, or emphasis.
-- If uncertain, do nothing.
-
-Decision process:
-1) Diagnose these axes before adding anything:
-   - cognitive_load
-   - narrative_density
-   - emphasis_clarity
-   - reading_behavior_risk
-2) Add components only if at least one axis is weak.
-3) Use restraint: one component is common, two is acceptable, more is rare.
-4) Never add more than one component in the same immediate section.
-5) Every component must be defensible in one clear sentence.
-
-Component rules:
-- pull_quote:
-  - 1 per article (2 max for long pieces).
-  - Quote must already exist in article text.
-  - Amplify emphasis only; do not explain or add facts.
-  - Skip for list-heavy or purely informational drafts when redundant.
-- in_the_know_box:
-  - Use only to prevent likely reader confusion.
-  - Neutral factual tone, clearly labeled.
-  - No repetition of nearby prose.
-- key_takeaways_box:
-  - Use for long or argument-driven drafts where skimmers may miss the point.
-  - 3-5 bullets only.
-  - No new information.
-- highlight_callout:
-  - 1-2 sentences only.
-  - Use to relieve dense pacing, not to restate nearby callouts.
-  - No decorative styling instructions.
-- faq_block:
-  - 2-5 questions maximum.
-  - Each answer must be 1-3 sentences.
-  - No new information; restate only what article already says.
-  - Questions should mirror natural search phrasing.
-  - Place near the end (typically after key takeaways), unless an explainer
-    needs earlier clarification.
-  - Skip for short or purely narrative pieces, or when likely questions
-    require new information.
-
-Markdown constraints:
-- Keep Markdown headings and existing structure intact.
-- Do not add HTML/CSS.
-- Do not add code fences.
-- Do not add new factual claims.
-- When a component is applied, wrap it in an isolated parse-friendly Markdown block.
-- Required delimiter lines:
-  > [!EDITORIAL-BLOCK-START|<component_key>]
-  > [!EDITORIAL-BLOCK-LABEL|<official_label>]
-  > [!EDITORIAL-BLOCK-END|<component_key>]
-- Inside that block include this exact marker line:
-  > [!EDITORIAL-BOX|<component_key>]
-- Allowed component_key values:
-  pull_quote, in_the_know_box, key_takeaways_box, highlight_callout, faq_block
-- Immediately after the marker line include:
-  > **Component:** <human label>
-- <official_label> and <human label> must match the canonical label.
-- Then include the component content inside the same blockquote.
-- Example:
-  > [!EDITORIAL-BLOCK-START|in_the_know_box]
-  > [!EDITORIAL-BLOCK-LABEL|In The Know]
-  > [!EDITORIAL-BOX|in_the_know_box]
-  > **Component:** In The Know
-  > Short neutral context note.
-  > [!EDITORIAL-BLOCK-END|in_the_know_box]
-
-ARTICLE TITLE:
-{article_title}
-
-ARTICLE CONTENT (MARKDOWN):
-{article_content}
-
-ARTICLE TYPE:
-{article_type}
-"""
-
-
-def _safe_str(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value.strip()
-    return str(value).strip()
-
-
-def _safe_dict(value: Any) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    return {}
-
-
-def _tokenize_words(value: str) -> list[str]:
-    return re.findall(r"[A-Za-z0-9']+", _safe_str(value))
-
-
-def _ensure_markdown_section_headers(content: str) -> str:
-    cleaned = _safe_str(content)
-    if not cleaned:
-        return ""
-
-    cleaned = re.sub(r"(?m)^\s*#\s+", "## ", cleaned).strip()
-
-    if re.search(r"(?m)^\s{0,3}#{2,6}\s+\S", cleaned):
-        return cleaned
-
-    paragraphs = [item.strip() for item in re.split(r"\n\s*\n", cleaned) if item.strip()]
-    if not paragraphs:
-        return cleaned
-
-    if len(paragraphs) == 1:
-        return f"## Overview\n\n{paragraphs[0]}"
-
-    headings = ["Overview", "Key Insights", "Practical Guidance", "Takeaways"]
-    sections = []
-    for index, paragraph in enumerate(paragraphs):
-        heading = headings[index] if index < len(headings) else f"Additional Insight {index - 3}"
-        sections.append(f"## {heading}\n\n{paragraph}")
-
-    return "\n\n".join(sections)
-
-
-def _normalize_editorial_component_name(value: str) -> str:
-    normalized = re.sub(r"[\s\-]+", "_", value.strip().lower())
-    aliases = {
-        "pull_quote": "pull_quote",
-        "quote": "pull_quote",
-        "in_the_know_box": "in_the_know_box",
-        "in_the_know": "in_the_know_box",
-        "in_theknow_box": "in_the_know_box",
-        "in_the_know_callout": "in_the_know_box",
-        "key_takeaways_box": "key_takeaways_box",
-        "key_takeaways": "key_takeaways_box",
-        "takeaways": "key_takeaways_box",
-        "highlight_callout": "highlight_callout",
-        "highlight": "highlight_callout",
-        "callout": "highlight_callout",
-        "faq_block": "faq_block",
-        "faq": "faq_block",
-        "faqs": "faq_block",
-        "qa_block": "faq_block",
-        "q_and_a_block": "faq_block",
-    }
-    return aliases.get(normalized, "")
-
-
-def _sanitize_editorial_diagnostic_axis(value: Any) -> str:
-    normalized = _safe_str(value).lower()
-    weak_values = {
-        "weak",
-        "needs_support",
-        "needs support",
-        "high",
-        "high_risk",
-        "at_risk",
-        "risky",
-        "yes",
-    }
-    if normalized in weak_values:
-        return "weak"
-    return "strong"
-
-
-def _normalize_markdown_for_comparison(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip().lower()
-
-
-def _editorial_box_marker(component: str) -> str:
-    return f"[!EDITORIAL-BOX|{component}]"
-
-
-def _editorial_block_start_marker(component: str) -> str:
-    return f"[!EDITORIAL-BLOCK-START|{component}]"
-
-
-def _editorial_block_end_marker(component: str) -> str:
-    return f"[!EDITORIAL-BLOCK-END|{component}]"
-
-
-def _editorial_block_label_marker(component: str) -> str:
-    label = EDITORIAL_COMPONENT_LABELS.get(component, component)
-    return f"[!EDITORIAL-BLOCK-LABEL|{label}]"
-
-
-def _line_matches_editorial_marker(line: str, marker: str) -> bool:
-    return bool(
-        re.match(
-            rf"^\s*>\s*{re.escape(marker)}\s*$",
-            line,
-            flags=re.IGNORECASE,
-        )
-    )
-
-
-def _find_editorial_block_range(
-    lines: list[str], component: str
-) -> tuple[int, int] | None:
-    start_marker = _editorial_block_start_marker(component)
-    end_marker = _editorial_block_end_marker(component)
-    start_idx = -1
-
-    for idx, line in enumerate(lines):
-        if start_idx == -1:
-            if _line_matches_editorial_marker(line, start_marker):
-                start_idx = idx
-            continue
-
-        if _line_matches_editorial_marker(line, end_marker):
-            return start_idx, idx
-
-    return None
-
-
-def _content_has_editorial_block(content: str, component: str) -> bool:
-    start_marker = re.escape(_editorial_block_start_marker(component))
-    end_marker = re.escape(_editorial_block_end_marker(component))
-    pattern = rf"(?mis)^\s*>\s*{start_marker}\s*$.*?^\s*>\s*{end_marker}\s*$"
-    return bool(re.search(pattern, content))
-
-
-def _build_editorial_metadata_box(component_entry: dict[str, str]) -> str:
-    component = component_entry["component"]
-    label = EDITORIAL_COMPONENT_LABELS.get(component, component)
-    lines = [
-        f"> {_editorial_block_start_marker(component)}",
-        f"> {_editorial_block_label_marker(component)}",
-        f"> {_editorial_box_marker(component)}",
-        f"> **Component:** {label}",
-    ]
-    placement = _safe_str(component_entry.get("placement"))
-    if placement:
-        lines.append(f"> **Placement:** {placement}")
-    justification = _safe_str(component_entry.get("justification"))
-    if justification:
-        lines.append(f"> **Why:** {justification}")
-    lines.append(f"> {_editorial_block_end_marker(component)}")
-    return "\n".join(lines)
-
-
-def _wrap_existing_editorial_box_with_markers(content: str, component: str) -> str:
-    if not content:
-        return content
-    if _content_has_editorial_block(content, component):
-        return content
-
-    marker_line_re = re.compile(
-        rf"^\s*>\s*{re.escape(_editorial_box_marker(component))}\s*$",
-        flags=re.IGNORECASE,
-    )
-    start_line = f"> {_editorial_block_start_marker(component)}"
-    end_line = f"> {_editorial_block_end_marker(component)}"
-
-    lines = content.splitlines()
-    for idx, line in enumerate(lines):
-        if not marker_line_re.match(line):
-            continue
-
-        if idx > 0 and lines[idx - 1].strip().lower() == start_line.lower():
-            return content
-
-        block_end = idx
-        while (
-            block_end + 1 < len(lines)
-            and lines[block_end + 1].lstrip().startswith(">")
-        ):
-            block_end += 1
-
-        lines.insert(idx, start_line)
-        lines.insert(block_end + 2, end_line)
-        return "\n".join(lines)
-
-    return content
-
-
-def _ensure_editorial_block_labels(content: str, component: str) -> str:
-    if not content:
-        return content
-
-    lines = content.splitlines()
-    block_range = _find_editorial_block_range(lines, component)
-    if not block_range:
-        return content
-
-    start_idx, end_idx = block_range
-    box_marker = _editorial_box_marker(component)
-    label_marker = _editorial_block_label_marker(component)
-    label_text = EDITORIAL_COMPONENT_LABELS.get(component, component)
-    display_label_line = f"**Component:** {label_text}"
-
-    box_idx = next(
-        (
-            idx
-            for idx in range(start_idx, end_idx + 1)
-            if _line_matches_editorial_marker(lines[idx], box_marker)
-        ),
-        -1,
-    )
-    label_marker_idx = next(
-        (
-            idx
-            for idx in range(start_idx, end_idx + 1)
-            if _line_matches_editorial_marker(lines[idx], label_marker)
-        ),
-        -1,
-    )
-    display_label_idx = next(
-        (
-            idx
-            for idx in range(start_idx, end_idx + 1)
-            if _line_matches_editorial_marker(lines[idx], display_label_line)
-        ),
-        -1,
-    )
-
-    if label_marker_idx == -1:
-        insert_after = box_idx if box_idx != -1 else start_idx
-        lines.insert(insert_after + 1, f"> {label_marker}")
-        end_idx += 1
-        label_marker_idx = insert_after + 1
-        if box_idx > insert_after:
-            box_idx += 1
-        if display_label_idx > insert_after:
-            display_label_idx += 1
-
-    if display_label_idx == -1:
-        lines.insert(label_marker_idx + 1, f"> {display_label_line}")
-
-    return "\n".join(lines)
-
-
-def _ensure_editorial_component_boxes(
-    content: str, components_added: list[dict[str, str]]
-) -> str:
-    if not content or not components_added:
-        return content
-
-    updated_content = content
-    for component_entry in components_added:
-        updated_content = _wrap_existing_editorial_box_with_markers(
-            updated_content,
-            component_entry["component"],
-        )
-        updated_content = _ensure_editorial_block_labels(
-            updated_content,
-            component_entry["component"],
-        )
-
-    missing_components = [
-        component_entry
-        for component_entry in components_added
-        if not _content_has_editorial_block(updated_content, component_entry["component"])
-    ]
-    if not missing_components:
-        return updated_content
-
-    fallback_boxes = "\n\n".join(
-        _build_editorial_metadata_box(component_entry)
-        for component_entry in missing_components
-    ).strip()
-    if not fallback_boxes:
-        return updated_content
-
-    return f"{updated_content.strip()}\n\n{fallback_boxes}".strip()
-
-
-def _sanitize_editorial_augmentation(
-    parsed: dict[str, Any], *, fallback_content: str
-) -> dict[str, Any]:
-    fallback_markdown = _ensure_markdown_section_headers(fallback_content)
-    augmented_content = _safe_str(parsed.get("augmented_content"))
-    if not augmented_content:
-        augmented_content = fallback_markdown
-
-    augmented_content = _ensure_markdown_section_headers(augmented_content)
-
-    components_added: list[dict[str, str]] = []
-    raw_components = parsed.get("components_added")
-    if isinstance(raw_components, list):
-        for item in raw_components:
-            if not isinstance(item, dict):
-                continue
-            component = _normalize_editorial_component_name(
-                _safe_str(item.get("component"))
-            )
-            if not component:
-                continue
-            components_added.append(
-                {
-                    "component": component,
-                    "justification": _safe_str(item.get("justification")),
-                    "placement": _safe_str(item.get("placement")),
-                }
-            )
-            if len(components_added) >= 5:
-                break
-
-    if components_added:
-        augmented_content = _ensure_editorial_component_boxes(
-            augmented_content,
-            components_added,
-        )
-
-    fallback_word_count = len(_tokenize_words(fallback_markdown))
-    augmented_word_count = len(_tokenize_words(augmented_content))
-    if augmented_word_count < fallback_word_count:
-        augmented_content = _ensure_editorial_component_boxes(
-            fallback_markdown,
-            components_added,
-        )
-
-    diagnostic_raw = _safe_dict(parsed.get("diagnostic"))
-    diagnostic = {
-        "cognitive_load": _sanitize_editorial_diagnostic_axis(
-            diagnostic_raw.get("cognitive_load")
-        ),
-        "narrative_density": _sanitize_editorial_diagnostic_axis(
-            diagnostic_raw.get("narrative_density")
-        ),
-        "emphasis_clarity": _sanitize_editorial_diagnostic_axis(
-            diagnostic_raw.get("emphasis_clarity")
-        ),
-        "reading_behavior_risk": _sanitize_editorial_diagnostic_axis(
-            diagnostic_raw.get("reading_behavior_risk")
-        ),
-    }
-
-    augmentation_summary = _safe_str(parsed.get("augmentation_summary"))
-    if not augmentation_summary:
-        if components_added:
-            component_names = ", ".join(item["component"] for item in components_added)
-            augmentation_summary = (
-                "Applied restrained editorial augmentation: " f"{component_names}."
-            )
-        else:
-            augmentation_summary = (
-                "No editorial augmentation added; the draft already read clearly."
-            )
-
-    augmentation_applied = (
-        bool(components_added)
-        and _normalize_markdown_for_comparison(augmented_content)
-        != _normalize_markdown_for_comparison(fallback_markdown)
-    )
-
-    return {
-        "augmented_content": augmented_content,
-        "components_added": components_added,
-        "diagnostic": diagnostic,
-        "augmentation_summary": augmentation_summary,
-        "augmentation_applied": augmentation_applied,
-    }
-
-
-def _invoke_json_llm(*, prompt: str, model_name: str = DEFAULT_MODEL) -> tuple[dict[str, Any], str]:
-    strict_prompt = (
-        f"{prompt}\n\n"
-        "CRITICAL OUTPUT RULE:\n"
-        "Return ONLY one valid JSON object.\n"
-        "No prose, no markdown, no code fences."
-    )
-
-    llm = get_vertex_llm(
-        temperature=0.05,
-        max_tokens=Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
-        model_name=model_name,
-    )
-
-    current_prompt = strict_prompt
-    last_error = "Unknown JSON parse failure"
-    last_response = ""
-
-    for attempt in range(1, 4):
-        raw_response = _safe_str(llm.invoke(current_prompt))
-        last_response = raw_response
-
-        try:
-            parsed = parse_json_response(raw_response)
-            return parsed, raw_response
-        except Exception as exc:  # noqa: BLE001
-            last_error = str(exc)
-            logger.warning(
-                "YouTube2Blog editorial JSON parse failed (attempt %d): %s",
-                attempt,
-                last_error,
-            )
-            current_prompt = (
-                "Your previous output was invalid JSON.\n"
-                "Return ONLY one strict JSON object.\n"
-                "No markdown fences, no commentary.\n\n"
-                f"Previous invalid output:\n{raw_response[:4000]}"
-            )
-
-    raise RuntimeError(
-        "Failed to parse JSON LLM response: "
-        f"{last_error}. Preview: {last_response[:240]}"
-    )
+# Keep the private seam available for existing tests and callers that patch the
+# stage transport without invoking a provider.
+_invoke_json_llm = invoke_json_llm
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "EDITORIAL_COMPONENT_LABELS",
+    "Y2B_EDITORIAL_AUGMENTATION_PROMPT",
+    "stage_editorial_augmentation",
+]
 
 
 def stage_editorial_augmentation(
@@ -569,17 +45,16 @@ def stage_editorial_augmentation(
     tone_guidance: str | None = None,
 ) -> StageEditorialAugmentationOutput:
     """Apply optional editorial augmentation to stage 3 content."""
-    prompt = (
-        Y2B_EDITORIAL_AUGMENTATION_PROMPT
-        .replace("{article_title}", stage3.title[:500])
-        .replace("{article_content}", stage3.final_article[:20_000])
-        .replace("{article_type}", stage3.article_type)
+    prompt = build_editorial_augmentation_prompt(
+        article_title=stage3.title,
+        article_content=stage3.final_article,
+        article_type=stage3.article_type,
+        tone_guidance=tone_guidance,
     )
-    if tone_guidance:
-        prompt = f"{prompt}\n\n{tone_guidance.strip()}"
-    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
-
-    fallback = _sanitize_editorial_augmentation({}, fallback_content=stage3.final_article)
+    fallback = sanitize_editorial_augmentation(
+        {},
+        fallback_content=stage3.final_article,
+    )
 
     # Pinned to the Claude editorial model regardless of the caller-supplied
     # base model (the graph runner passes the run's Gemini model here).
@@ -587,21 +62,15 @@ def stage_editorial_augmentation(
     editorial_model = writing_model or Y2B_EDITORIAL_AUGMENTATION_MODEL
     try:
         parsed, raw_response = _invoke_json_llm(
-            prompt=prompt, model_name=editorial_model
+            prompt=prompt,
+            model_name=editorial_model,
         )
         if isinstance(parsed.get("augmented_content"), str):
-            parsed["augmented_content"] = enforce_anti_ai_tells_markdown(
+            parsed["augmented_content"] = enforce_editorial_anti_ai_tells(
                 parsed["augmented_content"],
-                repair=lambda repair_prompt: _safe_str(
-                    get_vertex_llm(
-                        temperature=0.1,
-                        max_tokens=Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
-                        model_name=editorial_model,
-                    ).invoke(repair_prompt)
-                ),
-                context="youtube2blog editorial augmentation",
+                model_name=editorial_model,
             )
-        editorial = _sanitize_editorial_augmentation(
+        editorial = sanitize_editorial_augmentation(
             parsed,
             fallback_content=stage3.final_article,
         )
@@ -620,7 +89,9 @@ def stage_editorial_augmentation(
         )
     except Exception as exc:  # noqa: BLE001
         if fail_fast:
-            raise RuntimeError(f"YouTube2Blog editorial augmentation failed: {exc}") from exc
+            raise RuntimeError(
+                f"YouTube2Blog editorial augmentation failed: {exc}"
+            ) from exc
         logger.warning("YouTube2Blog editorial augmentation failed: %s", exc)
         return StageEditorialAugmentationOutput(
             video_id=stage3.video_id,

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_editorial_stage.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_editorial_stage.py
@@ -1,10 +1,25 @@
 import importlib
 
-from app.features.youtube2blog.config import Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS
+from app.features.youtube2blog.config import (
+    Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS,
+)
+from app.features.youtube2blog.content.editorial_blocks import (
+    ensure_editorial_component_boxes,
+)
+from app.features.youtube2blog.stages.editorial_augmentation_prompts import (
+    build_editorial_augmentation_prompt,
+)
+from app.features.youtube2blog.stages.editorial_augmentation_validation import (
+    sanitize_editorial_augmentation,
+)
+from app.shared.prompts import ANTI_AI_TELLS_FULL
 from shared import Stage3Output
 
 editorial_stage = importlib.import_module(
     "app.features.youtube2blog.stages.stage_editorial_augmentation"
+)
+editorial_llm = importlib.import_module(
+    "app.features.youtube2blog.stages.editorial_augmentation_llm"
 )
 
 
@@ -25,6 +40,11 @@ def _sample_stage3_output() -> Stage3Output:
 def test_editorial_augmentation_applies_components_and_markers(monkeypatch):
     stage3 = _sample_stage3_output()
 
+    monkeypatch.setattr(
+        editorial_stage,
+        "enforce_editorial_anti_ai_tells",
+        lambda content, **_kwargs: content,
+    )
     monkeypatch.setattr(
         editorial_stage,
         "_invoke_json_llm",
@@ -63,6 +83,87 @@ def test_editorial_augmentation_applies_components_and_markers(monkeypatch):
     assert output.error is None
 
 
+def test_editorial_prompt_bounds_source_fields_and_appends_guidance():
+    prompt = build_editorial_augmentation_prompt(
+        article_title=f"{'T' * 500}EXCLUDED",
+        article_content=f"{'C' * 20_000}EXCLUDED",
+        article_type="How-to Guides",
+        tone_guidance="  Keep the tone direct.  ",
+    )
+
+    assert "T" * 500 in prompt
+    assert "C" * 20_000 in prompt
+    assert "EXCLUDED" not in prompt
+    assert "Keep the tone direct." in prompt
+    assert prompt.endswith(ANTI_AI_TELLS_FULL)
+
+
+def test_editorial_markers_wrap_existing_box_without_appending_metadata_only_box():
+    content = (
+        "## Overview\n\n"
+        "> [!EDITORIAL-BOX|highlight_callout]\n"
+        "> Dense ideas become easier to scan."
+    )
+
+    updated = ensure_editorial_component_boxes(
+        content,
+        [
+            {
+                "component": "highlight_callout",
+                "justification": "Improves pacing.",
+                "placement": "After overview.",
+            }
+        ],
+    )
+
+    assert updated.count("[!EDITORIAL-BLOCK-START|highlight_callout]") == 1
+    assert updated.count("[!EDITORIAL-BLOCK-END|highlight_callout]") == 1
+    assert "[!EDITORIAL-BLOCK-LABEL|Highlight Callout]" in updated
+    assert "**Component:** Highlight Callout" in updated
+    assert "**Placement:**" not in updated
+
+
+def test_editorial_validation_normalizes_and_preserves_longer_fallback():
+    fallback = (
+        "## Overview\n\n" + " ".join(f"original-{index}" for index in range(80)) + "."
+    )
+
+    editorial = sanitize_editorial_augmentation(
+        {
+            "augmented_content": "Short.",
+            "components_added": [
+                {
+                    "component": "faq",
+                    "justification": 42,
+                    "placement": None,
+                },
+                {"component": "unsupported"},
+            ],
+            "diagnostic": {
+                "cognitive_load": "high_risk",
+                "narrative_density": "unknown",
+            },
+        },
+        fallback_content=fallback,
+    )
+
+    assert fallback in editorial["augmented_content"]
+    assert editorial["components_added"] == [
+        {
+            "component": "faq_block",
+            "justification": "42",
+            "placement": "",
+        }
+    ]
+    assert editorial["diagnostic"] == {
+        "cognitive_load": "weak",
+        "narrative_density": "strong",
+        "emphasis_clarity": "strong",
+        "reading_behavior_risk": "strong",
+    }
+    assert "[!EDITORIAL-BLOCK-START|faq_block]" in editorial["augmented_content"]
+
+
 def test_editorial_augmentation_falls_back_on_error(monkeypatch):
     stage3 = _sample_stage3_output()
 
@@ -91,9 +192,9 @@ def test_editorial_augmentation_json_llm_uses_longform_output_cap(monkeypatch):
         captured.update(kwargs)
         return StubLLM()
 
-    monkeypatch.setattr(editorial_stage, "get_vertex_llm", fake_get_vertex_llm)
+    monkeypatch.setattr(editorial_llm, "get_vertex_llm", fake_get_vertex_llm)
 
-    parsed, _raw = editorial_stage._invoke_json_llm(
+    parsed, _raw = editorial_llm.invoke_json_llm(
         prompt="Return augmented article JSON.",
         model_name="editorial-model",
     )
@@ -101,3 +202,62 @@ def test_editorial_augmentation_json_llm_uses_longform_output_cap(monkeypatch):
     assert parsed["augmented_content"] == "Body"
     assert captured["model_name"] == "editorial-model"
     assert captured["max_tokens"] == Y2B_EDITORIAL_AUGMENTATION_MAX_OUTPUT_TOKENS
+
+
+def test_editorial_augmentation_json_llm_retries_invalid_json(monkeypatch):
+    prompts: list[str] = []
+    responses = iter(
+        [
+            "not json",
+            '{"augmented_content":"Body","components_added":[]}',
+        ]
+    )
+
+    class StubLLM:
+        def invoke(self, prompt: str) -> str:
+            prompts.append(prompt)
+            return next(responses)
+
+    monkeypatch.setattr(editorial_llm, "get_vertex_llm", lambda **_kwargs: StubLLM())
+
+    parsed, raw = editorial_llm.invoke_json_llm(prompt="Original prompt")
+
+    assert parsed["augmented_content"] == "Body"
+    assert raw.startswith('{"augmented_content"')
+    assert len(prompts) == 2
+    assert "Previous invalid output:\nnot json" in prompts[1]
+
+
+def test_editorial_augmentation_uses_writing_model_for_stage_execution(monkeypatch):
+    captured: dict[str, str] = {}
+
+    def fake_invoke_json_llm(*, prompt: str, model_name: str):
+        captured["prompt"] = prompt
+        captured["model_name"] = model_name
+        return (
+            {
+                "augmented_content": "## Overview\n\nOriginal article body.",
+                "components_added": [],
+                "diagnostic": {},
+                "augmentation_summary": "",
+            },
+            "{}",
+        )
+
+    monkeypatch.setattr(editorial_stage, "_invoke_json_llm", fake_invoke_json_llm)
+    monkeypatch.setattr(
+        editorial_stage,
+        "enforce_editorial_anti_ai_tells",
+        lambda content, **_kwargs: content,
+    )
+
+    output = editorial_stage.stage_editorial_augmentation(
+        _sample_stage3_output(),
+        model_name="base-model",
+        writing_model="editorial-writing-model",
+        tone_guidance="Keep it concise.",
+    )
+
+    assert captured["model_name"] == "editorial-writing-model"
+    assert "Keep it concise." in captured["prompt"]
+    assert output.error is None


### PR DESCRIPTION
## Original issue

`apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_editorial_augmentation.py` was a 637-line, 21-definition stage with a bloat score of 15. Prompt policy, response parsing, Markdown marker manipulation, output validation, anti-AI repair, provider invocation, retry handling, and Stage orchestration all shared one module.

## Root cause

Editorial Augmentation grew around a single Stage entrypoint without internal responsibility boundaries. Deterministic content operations and validation accumulated beside provider transport and orchestration, so changing one concern required understanding and testing the entire stage.

## Refactor

- Keep `stage_editorial_augmentation(...)` as a thin, compatible 108-line facade and preserve its package export, signature, model-selection behavior, failure behavior, exported constants, and transport patch seam.
- Extract prompt assembly and source-field bounds to `editorial_augmentation_prompts.py`.
- Extract pure Markdown marker envelope/label repair to `content/editorial_blocks.py`.
- Extract untrusted response normalization, component aliasing, diagnostics, article-preservation checks, and summary defaults to `editorial_augmentation_validation.py`.
- Extract JSON-only provider invocation, parse retries, output-budget configuration, and shared anti-AI prose repair to `editorial_augmentation_llm.py`.
- Update the YouTube2Blog module map and expand tests across each extracted boundary plus facade orchestration.

## Why this is better

Each module now has one coherent reason to change. Pure marker and validation behavior can be tested without provider setup, provider retry policy is isolated, prompt changes no longer touch Stage control flow, and the public Stage remains the stable graph-facing API. This reduces the blast radius of future editorial component work without changing the canonical Stage contract or adding cross-feature dependencies.

## Validation

- `PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src /home/webdev/Desktop/questurian/apps/ai-blog-writer/.venv/bin/python -m pytest apps/backend/tests/test_youtube2blog_editorial_stage.py` — 8 passed.
- `PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src /home/webdev/Desktop/questurian/apps/ai-blog-writer/.venv/bin/python -m pytest $(rg --files apps/backend/tests | rg '/test_youtube2blog.*\\.py$' | sort)` — 48 passed, 2 warnings.
- `PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src /home/webdev/Desktop/questurian/apps/ai-blog-writer/.venv/bin/python -m pytest apps/backend/tests` — 325 passed, 2 warnings.
- `/home/webdev/Desktop/questurian/apps/ai-blog-writer/.venv/bin/python -m flake8 apps/backend/app packages/shared/src packages/utils/src` — passed.
- `PYTHONPYCACHEPREFIX=<temporary-directory> /home/webdev/Desktop/questurian/apps/ai-blog-writer/.venv/bin/python -m compileall -q apps/backend/app` — passed.
- `/home/webdev/Desktop/questurian/apps/ai-blog-writer/.venv/bin/python -m black --check <six changed Python files>` — passed.
- `git diff --check` — passed.

A repository-wide Black check was also attempted and reports 69 pre-existing files that would be reformatted. Those unrelated files were deliberately left untouched; every Python file changed by this PR passes Black.

## Risks, tradeoffs, and follow-ups

- Risk is primarily import/patch-seam drift from moving private helpers. The graph-facing function and package export are unchanged, original public constants are re-exported, and full backend tests pass.
- The marker module remains deliberately feature-local even though sibling pipelines have similar logic; consolidating cross-feature editorial block behavior would be a separate change with broader contract risk.
- No LLM prompt text, model choice, retry count, output-token policy, marker schema, or fallback behavior was intentionally changed.
