### PR TITLE
NOJIRA: Refactor day-blurb composition service

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/constants/builder-options.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/constants/builder-options.constants.ts
@@ -21,6 +21,17 @@ export const BLOCK_TYPE_OPTIONS_STOPS = BLOCK_TYPE_OPTIONS.filter(
   (option) => option.value !== 'itinerary-where-staying',
 )
 
+/** Reader-facing category labels shared by itinerary composition requests. */
+export const ITINERARY_BLOCK_CATEGORY_LABELS: Record<ItineraryBlockType, string> = {
+  'itinerary-dining': 'Dining',
+  'itinerary-accommodations': 'Accommodations',
+  'itinerary-where-staying': "Where You're Staying",
+  'itinerary-attractions': 'Attractions',
+  'itinerary-nightlife': 'Nightlife',
+  'itinerary-key-location': 'Key Location',
+  'itinerary-tour-agency': 'Tour Agency',
+}
+
 export const EMPTY_RELATED_BY_BLOCK_TYPE: Record<ItineraryBlockType, RelatedItemOption[]> = {
   'itinerary-dining': [],
   'itinerary-accommodations': [],

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryContentAiActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryContentAiActions.ts
@@ -11,17 +11,19 @@ import {
   buildItineraryGenerateListicleContentRequest,
   getItineraryAutoWriteTargetIds
 } from '../services/ai-autowrite.service'
+import { buildItineraryComposeDayBlurbsRequest } from '../services/compose-day-blurbs.service'
 import {
-  applyItineraryComposedDayBlurbs,
-  buildFailedDayBlurbComposeReport,
-  buildItineraryComposeDayBlurbsRequest,
   dayHasExistingBlurbs,
   getComposableDayIndexes,
   getItineraryDayBlurbComposeDisabledReason,
   getItineraryStopBlurbComposeDisabledReason,
-  itineraryStopBlurbWriteStrandsNeighbor,
-  resolveStopTitle
-} from '../services/compose-day-blurbs.service'
+  itineraryStopBlurbWriteStrandsNeighbor
+} from '../services/day-blurb-readiness.service'
+import {
+  applyItineraryComposedDayBlurbs,
+  buildFailedDayBlurbComposeReport
+} from '../services/day-blurb-results.service'
+import { resolveStopTitle } from '../utils/itineraryStopBlock.utils'
 import type { ComposeStopReasonResult } from '../services/compose-stop-reason.service'
 import { composeItineraryStopReason } from '../services/compose-stop-reason.service'
 import {
@@ -269,7 +271,6 @@ export function useItineraryContentAiActions({
       const { dayIndex, item } = found
 
       const disabledReason = getItineraryStopBlurbComposeDisabledReason(
-        draft,
         item,
         relatedByBlockType
       )

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from 'vitest'
+import { buildItineraryComposeDayBlurbsRequest } from './compose-day-blurbs.service'
 import {
-  applyItineraryComposedDayBlurbs,
-  buildFailedDayBlurbComposeReport,
-  buildItineraryComposeDayBlurbsRequest,
   dayHasExistingBlurbs,
   getComposableDayIndexes,
   getItineraryDayBlurbComposeDisabledReason,
   getItineraryStopBlurbComposeDisabledReason,
   isDayBlurbsFullyComposed,
   itineraryStopBlurbWriteStrandsNeighbor,
-} from './compose-day-blurbs.service'
+} from './day-blurb-readiness.service'
+import {
+  applyItineraryComposedDayBlurbs,
+  buildFailedDayBlurbComposeReport,
+} from './day-blurb-results.service'
 import type {
   ItineraryBlockType,
   ItineraryItemBlock,
@@ -236,6 +238,44 @@ describe('day-blurb composer service', () => {
     expect(request.nextDayFirstStop).toBeUndefined()
   })
 
+  it('resolves a manual tour stop from its title before falling back to its operator', () => {
+    const draft = buildDraft({
+      dayCount: 1,
+      days: [{
+        id: 'day_1',
+        whereStaying: [],
+        items: [
+          buildItem({
+            id: 'tour-1',
+            blockType: 'itinerary-tour-agency',
+            title: '  Sunset Coast Tour  ',
+            operator: 'Fallback Operator',
+            selectionReason: 'coastal sunset route',
+          }),
+          buildItem({
+            id: 'tour-2',
+            blockType: 'itinerary-tour-agency',
+            operator: '  Lima Night Walks  ',
+            selectionReason: 'after-dark city route',
+          }),
+        ],
+      }],
+    })
+
+    const request = buildItineraryComposeDayBlurbsRequest({
+      draft,
+      dayIndex: 0,
+      relatedByBlockType: buildRelatedByBlockType(),
+      locations: buildLocations(),
+      modelName: 'claude-opus-4-8',
+    })
+
+    expect(request.stops.map(({ title, category }) => ({ title, category }))).toEqual([
+      { title: 'Sunset Coast Tour', category: 'Tour Agency' },
+      { title: 'Lima Night Walks', category: 'Tour Agency' },
+    ])
+  })
+
   it('applies only generated blurbs, only to the target day', () => {
     const response: ComposeDayBlurbsResponse = {
       model_used: 'claude-opus-4-8',
@@ -278,43 +318,37 @@ describe('day-blurb composer service', () => {
     it('is ready for a resolved stop with an angle and a reason under a locked intro', () => {
       const draft = buildDraft()
       expect(
-        getItineraryStopBlurbComposeDisabledReason(draft, draft.days[0].items[0], buildRelatedByBlockType()),
+        getItineraryStopBlurbComposeDisabledReason(draft.days[0].items[0], buildRelatedByBlockType()),
       ).toBeUndefined()
     })
 
-    it('gates on this stop\'s angle and reason, not intro lock or siblings', () => {
+    it('gates on this stop\'s angle and reason, not siblings', () => {
       const related = buildRelatedByBlockType()
-
-      const noIntro = buildDraft({ step2_in_update_mode: true })
-      expect(
-        getItineraryStopBlurbComposeDisabledReason(noIntro, noIntro.days[0].items[0], related),
-      ).toBeUndefined()
 
       const noAngle = buildDraft()
       noAngle.days[0].items[0].angle = null
       expect(
-        getItineraryStopBlurbComposeDisabledReason(noAngle, noAngle.days[0].items[0], related),
+        getItineraryStopBlurbComposeDisabledReason(noAngle.days[0].items[0], related),
       ).toBe('Select a blurb angle for "Mérito"')
 
       const noReason = buildDraft()
       noReason.days[0].items[0].selectionReason = ''
       expect(
-        getItineraryStopBlurbComposeDisabledReason(noReason, noReason.days[0].items[0], related),
+        getItineraryStopBlurbComposeDisabledReason(noReason.days[0].items[0], related),
       ).toBe('Add a "Why this pick" for "Mérito"')
 
       // A sibling missing its angle/reason does NOT block this stop (it rides as context).
       const siblingBroken = buildDraft()
       siblingBroken.days[0].whereStaying[0].selectionReason = ''
       expect(
-        getItineraryStopBlurbComposeDisabledReason(siblingBroken, siblingBroken.days[0].items[0], related),
+        getItineraryStopBlurbComposeDisabledReason(siblingBroken.days[0].items[0], related),
       ).toBeUndefined()
     })
 
     it('gates on resolving this stop', () => {
-      const draft = buildDraft()
       const unresolved = buildItem({ id: 'fresh', blockType: 'itinerary-attractions', item: null })
       expect(
-        getItineraryStopBlurbComposeDisabledReason(draft, unresolved, buildRelatedByBlockType()),
+        getItineraryStopBlurbComposeDisabledReason(unresolved, buildRelatedByBlockType()),
       ).toBe('Resolve this stop (pick or name it) before composing its blurb')
     })
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.ts
@@ -1,91 +1,29 @@
 import type {
   ComposeDayBlurbsNeighborStop,
   ComposeDayBlurbsRequest,
-  ComposeDayBlurbsResponse,
-  ComposeDayBlurbStop,
+  ComposeDayBlurbStop
 } from '../../../staging/api'
 import type {
   ItineraryBlockType,
-  ItineraryDaySlice,
   ItineraryItemBlock,
   ListicleItineraryDraft,
   LocationOption,
-  RelatedItemOption,
+  RelatedItemOption
 } from '../../types'
+import { resolveItineraryAngleForBlockType } from '../../types'
+import { ITINERARY_BLOCK_CATEGORY_LABELS } from '../constants/builder-options.constants'
 import {
-  isManualItineraryBlockType,
-  resolveItineraryAngleForBlockType,
-} from '../../types'
-import { getItineraryStopAngleDisabledReason } from './ai-autowrite.service'
+  getResolvedDayStops,
+  resolveStopTitle
+} from '../utils/itineraryStopBlock.utils'
 import { buildArticleLocationLabel } from './ai-autowrite.service'
 import { getItineraryAiArticleTitle } from './ai-rewrite.service'
 
-export const ITINERARY_BLOCK_CATEGORY_LABELS: Record<ItineraryBlockType, string> = {
-  'itinerary-dining': 'Dining',
-  'itinerary-accommodations': 'Accommodations',
-  'itinerary-where-staying': "Where You're Staying",
-  'itinerary-attractions': 'Attractions',
-  'itinerary-nightlife': 'Nightlife',
-  'itinerary-key-location': 'Key Location',
-  'itinerary-tour-agency': 'Tour Agency',
-}
-
-export function buildFailedDayBlurbComposeReport(params: {
-  modelName: string
-  errorMessage: string
-  durationMs: number
-  label?: string
-}): ComposeDayBlurbsResponse {
-  return {
-    model_used: params.modelName,
-    results: {},
-    steps: [
-      {
-        name: 'request',
-        label: params.label ?? 'Day composer request',
-        status: 'failed',
-        duration_ms: params.durationMs,
-        model: params.modelName,
-        details: { error: params.errorMessage },
-      },
-    ],
-  }
-}
-
-export function resolveStopTitle(
-  item: ItineraryItemBlock,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): string {
-  if (isManualItineraryBlockType(item.blockType)) {
-    return item.title.trim() || item.operator.trim()
-  }
-  if (!item.item) return ''
-  const relatedOptions = relatedByBlockType[item.blockType] || []
-  return relatedOptions.find((entry) => entry.id === item.item)?.title?.trim() || ''
-}
-
-/** Lodging rows first, then stops — matches the per-day article order. */
-function getDayBlocksInArticleOrder(day: ItineraryDaySlice): ItineraryItemBlock[] {
-  return [...day.whereStaying, ...day.items]
-}
-
-/**
- * Day stops that have a resolved identity, in article order. These are the
- * stops the day composer writes against; unresolved slots are skipped, the same
- * way the intro composer skips them.
- */
-function getResolvedDayStops(
-  day: ItineraryDaySlice,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): ItineraryItemBlock[] {
-  return getDayBlocksInArticleOrder(day).filter(
-    (item) => Boolean(resolveStopTitle(item, relatedByBlockType)),
-  )
-}
+type RelatedStopsByBlockType = Record<ItineraryBlockType, RelatedItemOption[]>
 
 function toComposeStop(
   item: ItineraryItemBlock,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
+  relatedByBlockType: RelatedStopsByBlockType
 ): ComposeDayBlurbStop {
   return {
     targetId: `${item.id}_blurb`,
@@ -94,15 +32,15 @@ function toComposeStop(
     daypart: item.shellSlotDaypart,
     angle: resolveItineraryAngleForBlockType(item.blockType, item.angle),
     selectionReason: item.selectionReason?.trim() || undefined,
-    // Carried so a context-only stop (one not in writeTargetIds) can be threaded
-    // off its existing copy without being rewritten (ADR 0022).
-    existingBlurb: item.blurbMarkdown.trim() || undefined,
+    // Context-only stops carry existing copy so the composer can preserve the
+    // day's handoffs without rewriting those stops (ADR 0022).
+    existingBlurb: item.blurbMarkdown.trim() || undefined
   }
 }
 
 function toNeighborStop(
   item: ItineraryItemBlock | undefined,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
+  relatedByBlockType: RelatedStopsByBlockType
 ): ComposeDayBlurbsNeighborStop | undefined {
   if (!item) return undefined
   const title = resolveStopTitle(item, relatedByBlockType)
@@ -110,85 +48,10 @@ function toNeighborStop(
   return { title, category: ITINERARY_BLOCK_CATEGORY_LABELS[item.blockType] }
 }
 
-/**
- * Why day `dayIndex`'s blurbs cannot be composed, or undefined if it is ready.
- * Gated on: ≥1 resolved stop, every pooled-category stop having an Angle
- * (ADR 0010), and every resolved stop having a Selection reason (ADR 0020).
- * Intro is optional framing input; Step 2 lock state never blocks composition.
- */
-export function getItineraryDayBlurbComposeDisabledReason(
-  draft: ListicleItineraryDraft,
-  dayIndex: number,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): string | undefined {
-  const day = draft.days[dayIndex]
-  if (!day) return 'Day not found'
-
-  const resolved = getResolvedDayStops(day, relatedByBlockType)
-  if (resolved.length < 1) {
-    return `Day ${dayIndex + 1}: add at least one resolved stop before composing blurbs`
-  }
-  for (const item of resolved) {
-    if (getItineraryStopAngleDisabledReason(item)) {
-      return `Day ${dayIndex + 1}: select a blurb angle for "${resolveStopTitle(item, relatedByBlockType)}"`
-    }
-    // Hard gate (ADR 0020): every resolved stop needs a Selection reason to seed
-    // its blurb. Autobuild fills this for stops it picks; an empty reason means
-    // an operator-added or swapped stop still needs a "Why this pick".
-    if (!item.selectionReason?.trim()) {
-      return `Day ${dayIndex + 1}: add a "Why this pick" for "${resolveStopTitle(item, relatedByBlockType)}"`
-    }
-  }
-  return undefined
-}
-
-/** True when every resolved stop in the day already has a blurb (write-all skips these). */
-export function isDayBlurbsFullyComposed(
-  draft: ListicleItineraryDraft,
-  dayIndex: number,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): boolean {
-  const day = draft.days[dayIndex]
-  if (!day) return false
-  const resolved = getResolvedDayStops(day, relatedByBlockType)
-  if (resolved.length < 1) return false
-  return resolved.every((item) => item.blurbMarkdown.trim().length > 0)
-}
-
-/** True when any resolved stop in the day already has a blurb (whole-day regen overwrites these → confirm). */
-export function dayHasExistingBlurbs(
-  draft: ListicleItineraryDraft,
-  dayIndex: number,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): boolean {
-  const day = draft.days[dayIndex]
-  if (!day) return false
-  return getResolvedDayStops(day, relatedByBlockType).some(
-    (item) => item.blurbMarkdown.trim().length > 0,
-  )
-}
-
-/**
- * Day indexes the "write all" pass should compose: composable and not already
- * fully composed (auto-skip composed-clean days, ADR 0019).
- */
-export function getComposableDayIndexes(
-  draft: ListicleItineraryDraft,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): number[] {
-  const indexes: number[] = []
-  for (let dayIndex = 0; dayIndex < draft.days.length; dayIndex += 1) {
-    if (getItineraryDayBlurbComposeDisabledReason(draft, dayIndex, relatedByBlockType)) continue
-    if (isDayBlurbsFullyComposed(draft, dayIndex, relatedByBlockType)) continue
-    indexes.push(dayIndex)
-  }
-  return indexes
-}
-
 export function buildItineraryComposeDayBlurbsRequest(params: {
   draft: ListicleItineraryDraft
   dayIndex: number
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>
+  relatedByBlockType: RelatedStopsByBlockType
   locations: LocationOption[]
   modelName: ComposeDayBlurbsRequest['modelName']
   /**
@@ -197,13 +60,23 @@ export function buildItineraryComposeDayBlurbsRequest(params: {
    */
   writeTargetIds?: string[]
 }): ComposeDayBlurbsRequest {
-  const { draft, dayIndex, relatedByBlockType, locations, modelName, writeTargetIds } = params
+  const {
+    draft,
+    dayIndex,
+    relatedByBlockType,
+    locations,
+    modelName,
+    writeTargetIds
+  } = params
   const day = draft.days[dayIndex]
-
   const prevDay = draft.days[dayIndex - 1]
   const nextDay = draft.days[dayIndex + 1]
-  const prevResolved = prevDay ? getResolvedDayStops(prevDay, relatedByBlockType) : []
-  const nextResolved = nextDay ? getResolvedDayStops(nextDay, relatedByBlockType) : []
+  const prevResolved = prevDay
+    ? getResolvedDayStops(prevDay, relatedByBlockType)
+    : []
+  const nextResolved = nextDay
+    ? getResolvedDayStops(nextDay, relatedByBlockType)
+    : []
 
   return {
     articleTitle: getItineraryAiArticleTitle(draft),
@@ -213,88 +86,15 @@ export function buildItineraryComposeDayBlurbsRequest(params: {
     intro: draft.header.introMarkdown.trim() || undefined,
     dayLabel: `Day ${dayIndex + 1}`,
     dayCount: draft.days.length || undefined,
-    prevDayLastStop: toNeighborStop(prevResolved[prevResolved.length - 1], relatedByBlockType),
+    prevDayLastStop: toNeighborStop(
+      prevResolved[prevResolved.length - 1],
+      relatedByBlockType
+    ),
     nextDayFirstStop: toNeighborStop(nextResolved[0], relatedByBlockType),
     writeTargetIds,
     modelName,
     stops: getResolvedDayStops(day, relatedByBlockType).map((item) =>
-      toComposeStop(item, relatedByBlockType),
-    ),
-  }
-}
-
-/**
- * Why a single stop's blurb cannot be composed on its own (ADR 0022), or
- * undefined when it is ready. Stop-scoped sibling of
- * `getItineraryDayBlurbComposeDisabledReason`: the day-wide gate fails if any
- * sibling lacks an angle/reason, but a single-stop aware compose only needs THIS
- * stop ready — siblings ride along as read-only context. Still gated on the
- * this stop's own angle + "Why this pick" (ADR 0020). Intro and Step 2 lock
- * state are optional context, not gates.
- */
-export function getItineraryStopBlurbComposeDisabledReason(
-  draft: ListicleItineraryDraft,
-  item: ItineraryItemBlock,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): string | undefined {
-  const title = resolveStopTitle(item, relatedByBlockType)
-  if (!title) {
-    return 'Resolve this stop (pick or name it) before composing its blurb'
-  }
-  if (getItineraryStopAngleDisabledReason(item)) {
-    return `Select a blurb angle for "${title}"`
-  }
-  if (!item.selectionReason?.trim()) {
-    return `Add a "Why this pick" for "${title}"`
-  }
-  return undefined
-}
-
-/**
- * True when authoring only `itemId` would leave a sibling's already-written
- * handoff stale (ADR 0022). A stop appended at the day's end strands nothing —
- * no existing copy pointed past the old last stop. A stop anywhere earlier, in a
- * day that already has other blurbs, can leave the prose around it referencing
- * the wrong next move. Drives the warning in the "just this stop" choice.
- */
-export function itineraryStopBlurbWriteStrandsNeighbor(
-  draft: ListicleItineraryDraft,
-  dayIndex: number,
-  itemId: string,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): boolean {
-  const day = draft.days[dayIndex]
-  if (!day) return false
-  const resolved = getResolvedDayStops(day, relatedByBlockType)
-  const position = resolved.findIndex((stop) => stop.id === itemId)
-  if (position < 0) return false
-  if (position === resolved.length - 1) return false // append-at-end: nothing stranded
-  return resolved.some(
-    (stop) => stop.id !== itemId && stop.blurbMarkdown.trim().length > 0,
-  )
-}
-
-/** Apply composed blurbs for one day; only `generated` results land. */
-export function applyItineraryComposedDayBlurbs(
-  draft: ListicleItineraryDraft,
-  dayIndex: number,
-  response: ComposeDayBlurbsResponse,
-): ListicleItineraryDraft {
-  const applyToRow = (item: ItineraryItemBlock): ItineraryItemBlock => {
-    const result = response.results[`${item.id}_blurb`]
-    if (result?.status !== 'generated' || !result.markdown) return item
-    return { ...item, blurbMarkdown: result.markdown, blurbJsonText: '' }
-  }
-
-  return {
-    ...draft,
-    days: draft.days.map((day, index) => {
-      if (index !== dayIndex) return day
-      return {
-        ...day,
-        whereStaying: day.whereStaying.map(applyToRow),
-        items: day.items.map(applyToRow),
-      }
-    }),
+      toComposeStop(item, relatedByBlockType)
+    )
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-stop-reason.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/compose-stop-reason.service.ts
@@ -12,7 +12,8 @@ import type {
 import { resolveItineraryAngleForBlockType } from '../../types'
 import { buildArticleLocationLabel } from './ai-autowrite.service'
 import { getItineraryAiArticleTitle } from './ai-rewrite.service'
-import { ITINERARY_BLOCK_CATEGORY_LABELS, resolveStopTitle } from './compose-day-blurbs.service'
+import { ITINERARY_BLOCK_CATEGORY_LABELS } from '../constants/builder-options.constants'
+import { resolveStopTitle } from '../utils/itineraryStopBlock.utils'
 
 export type ComposeStopReasonParams = {
   draft: ListicleItineraryDraft

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/day-blurb-readiness.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/day-blurb-readiness.service.ts
@@ -1,0 +1,138 @@
+import type {
+  ItineraryBlockType,
+  ItineraryItemBlock,
+  ListicleItineraryDraft,
+  RelatedItemOption
+} from '../../types'
+import { getItineraryStopAngleDisabledReason } from './ai-autowrite.service'
+import {
+  getResolvedDayStops,
+  resolveStopTitle
+} from '../utils/itineraryStopBlock.utils'
+
+type RelatedStopsByBlockType = Record<ItineraryBlockType, RelatedItemOption[]>
+
+/**
+ * Why day `dayIndex`'s blurbs cannot be composed, or undefined if it is ready.
+ * Gated on: ≥1 resolved stop, every pooled-category stop having an Angle
+ * (ADR 0010), and every resolved stop having a Selection reason (ADR 0020).
+ * Intro is optional framing input; Step 2 lock state never blocks composition.
+ */
+export function getItineraryDayBlurbComposeDisabledReason(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  relatedByBlockType: RelatedStopsByBlockType
+): string | undefined {
+  const day = draft.days[dayIndex]
+  if (!day) return 'Day not found'
+
+  const resolved = getResolvedDayStops(day, relatedByBlockType)
+  if (resolved.length < 1) {
+    return `Day ${dayIndex + 1}: add at least one resolved stop before composing blurbs`
+  }
+  for (const item of resolved) {
+    const title = resolveStopTitle(item, relatedByBlockType)
+    if (getItineraryStopAngleDisabledReason(item)) {
+      return `Day ${dayIndex + 1}: select a blurb angle for "${title}"`
+    }
+    // Hard gate (ADR 0020): every resolved stop needs a Selection reason to seed
+    // its blurb. Autobuild fills this for stops it picks; an empty reason means
+    // an operator-added or swapped stop still needs a "Why this pick".
+    if (!item.selectionReason?.trim()) {
+      return `Day ${dayIndex + 1}: add a "Why this pick" for "${title}"`
+    }
+  }
+  return undefined
+}
+
+/** True when every resolved stop in the day already has a blurb (write-all skips these). */
+export function isDayBlurbsFullyComposed(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  relatedByBlockType: RelatedStopsByBlockType
+): boolean {
+  const day = draft.days[dayIndex]
+  if (!day) return false
+  const resolved = getResolvedDayStops(day, relatedByBlockType)
+  if (resolved.length < 1) return false
+  return resolved.every((item) => item.blurbMarkdown.trim().length > 0)
+}
+
+/** True when any resolved stop in the day already has a blurb (whole-day regen overwrites these → confirm). */
+export function dayHasExistingBlurbs(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  relatedByBlockType: RelatedStopsByBlockType
+): boolean {
+  const day = draft.days[dayIndex]
+  if (!day) return false
+  return getResolvedDayStops(day, relatedByBlockType).some(
+    (item) => item.blurbMarkdown.trim().length > 0
+  )
+}
+
+/**
+ * Day indexes the "write all" pass should compose: composable and not already
+ * fully composed (auto-skip composed-clean days, ADR 0019).
+ */
+export function getComposableDayIndexes(
+  draft: ListicleItineraryDraft,
+  relatedByBlockType: RelatedStopsByBlockType
+): number[] {
+  const indexes: number[] = []
+  for (let dayIndex = 0; dayIndex < draft.days.length; dayIndex += 1) {
+    if (
+      getItineraryDayBlurbComposeDisabledReason(
+        draft,
+        dayIndex,
+        relatedByBlockType
+      )
+    )
+      continue
+    if (isDayBlurbsFullyComposed(draft, dayIndex, relatedByBlockType)) continue
+    indexes.push(dayIndex)
+  }
+  return indexes
+}
+
+/**
+ * Why a single stop's blurb cannot be composed on its own (ADR 0022), or
+ * undefined when it is ready. Unlike the day-wide gate, siblings ride along as
+ * read-only context and do not need to be ready themselves.
+ */
+export function getItineraryStopBlurbComposeDisabledReason(
+  item: ItineraryItemBlock,
+  relatedByBlockType: RelatedStopsByBlockType
+): string | undefined {
+  const title = resolveStopTitle(item, relatedByBlockType)
+  if (!title) {
+    return 'Resolve this stop (pick or name it) before composing its blurb'
+  }
+  if (getItineraryStopAngleDisabledReason(item)) {
+    return `Select a blurb angle for "${title}"`
+  }
+  if (!item.selectionReason?.trim()) {
+    return `Add a "Why this pick" for "${title}"`
+  }
+  return undefined
+}
+
+/**
+ * True when authoring only `itemId` would leave a sibling's already-written
+ * handoff stale (ADR 0022). Appending at the end strands nothing.
+ */
+export function itineraryStopBlurbWriteStrandsNeighbor(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  itemId: string,
+  relatedByBlockType: RelatedStopsByBlockType
+): boolean {
+  const day = draft.days[dayIndex]
+  if (!day) return false
+  const resolved = getResolvedDayStops(day, relatedByBlockType)
+  const position = resolved.findIndex((stop) => stop.id === itemId)
+  if (position < 0 || position === resolved.length - 1) return false
+  return resolved.some(
+    (stop) => stop.id !== itemId && stop.blurbMarkdown.trim().length > 0
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/day-blurb-results.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/day-blurb-results.service.ts
@@ -1,0 +1,49 @@
+import type { ComposeDayBlurbsResponse } from '../../../staging/api'
+import type { ItineraryItemBlock, ListicleItineraryDraft } from '../../types'
+
+export function buildFailedDayBlurbComposeReport(params: {
+  modelName: string
+  errorMessage: string
+  durationMs: number
+  label?: string
+}): ComposeDayBlurbsResponse {
+  return {
+    model_used: params.modelName,
+    results: {},
+    steps: [
+      {
+        name: 'request',
+        label: params.label ?? 'Day composer request',
+        status: 'failed',
+        duration_ms: params.durationMs,
+        model: params.modelName,
+        details: { error: params.errorMessage }
+      }
+    ]
+  }
+}
+
+/** Apply composed blurbs for one day; only `generated` results land. */
+export function applyItineraryComposedDayBlurbs(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  response: ComposeDayBlurbsResponse
+): ListicleItineraryDraft {
+  const applyToRow = (item: ItineraryItemBlock): ItineraryItemBlock => {
+    const result = response.results[`${item.id}_blurb`]
+    if (result?.status !== 'generated' || !result.markdown) return item
+    return { ...item, blurbMarkdown: result.markdown, blurbJsonText: '' }
+  }
+
+  return {
+    ...draft,
+    days: draft.days.map((day, index) => {
+      if (index !== dayIndex) return day
+      return {
+        ...day,
+        whereStaying: day.whereStaying.map(applyToRow),
+        items: day.items.map(applyToRow)
+      }
+    })
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/intro-composer.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/intro-composer.service.ts
@@ -1,26 +1,16 @@
 import type { ComposeItineraryIntroRequest, ComposeItineraryIntroStop } from '../../../staging/api'
 import type {
   ItineraryBlockType,
-  ItineraryItemBlock,
   ListicleItineraryDraft,
   LocationOption,
   RelatedItemOption,
 } from '../../types'
-import { isManualItineraryBlockType } from '../../types'
+import { ITINERARY_BLOCK_CATEGORY_LABELS } from '../constants/builder-options.constants'
+import { getResolvedDayStops, resolveStopTitle } from '../utils/itineraryStopBlock.utils'
 import { getItineraryAiArticleTitle } from './ai-rewrite.service'
 import { buildArticleLocationLabel } from './ai-autowrite.service'
 
 const INTRO_TARGET_ID_SUFFIX = '_header_intro'
-
-const ITINERARY_BLOCK_CATEGORY_LABELS: Record<ItineraryBlockType, string> = {
-  'itinerary-dining': 'Dining',
-  'itinerary-accommodations': 'Accommodations',
-  'itinerary-where-staying': "Where You're Staying",
-  'itinerary-attractions': 'Attractions',
-  'itinerary-nightlife': 'Nightlife',
-  'itinerary-key-location': 'Key Location',
-  'itinerary-tour-agency': 'Tour Agency',
-}
 
 /**
  * Stable marker id for the intro auto-write in the builder's single
@@ -29,18 +19,6 @@ const ITINERARY_BLOCK_CATEGORY_LABELS: Record<ItineraryBlockType, string> = {
  */
 export function getItineraryIntroTargetId(draft: ListicleItineraryDraft): string {
   return `${draft.draftId}${INTRO_TARGET_ID_SUFFIX}`
-}
-
-function resolveStopTitle(
-  item: ItineraryItemBlock,
-  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
-): string {
-  if (isManualItineraryBlockType(item.blockType)) {
-    return item.title.trim() || item.operator.trim()
-  }
-  if (!item.item) return ''
-  const relatedOptions = relatedByBlockType[item.blockType] || []
-  return relatedOptions.find((entry) => entry.id === item.item)?.title?.trim() || ''
 }
 
 /**
@@ -58,9 +36,8 @@ export function getItineraryIntroComposableStops(
 
   draft.days.forEach((day, dayIndex) => {
     const dayLabel = `Day ${dayIndex + 1}`
-    ;[...day.whereStaying, ...day.items].forEach((item) => {
+    getResolvedDayStops(day, relatedByBlockType).forEach((item) => {
       const title = resolveStopTitle(item, relatedByBlockType)
-      if (!title) return
       stops.push({
         title,
         category: ITINERARY_BLOCK_CATEGORY_LABELS[item.blockType],

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/utils/itineraryStopBlock.utils.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/utils/itineraryStopBlock.utils.ts
@@ -1,8 +1,33 @@
 import type {
   ItineraryBlockType,
+  ItineraryDaySlice,
   ItineraryItemBlock,
+  RelatedItemOption,
   TourAgencyKeyLocationRow,
 } from '../../types'
+import { isManualItineraryBlockType } from '../../types'
+
+export function resolveStopTitle(
+  item: ItineraryItemBlock,
+  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
+): string {
+  if (isManualItineraryBlockType(item.blockType)) {
+    return item.title.trim() || item.operator.trim()
+  }
+  if (!item.item) return ''
+  const relatedOptions = relatedByBlockType[item.blockType] || []
+  return relatedOptions.find((entry) => entry.id === item.item)?.title?.trim() || ''
+}
+
+/** Resolved stops in the same lodging-first order used by the article. */
+export function getResolvedDayStops(
+  day: ItineraryDaySlice,
+  relatedByBlockType: Record<ItineraryBlockType, RelatedItemOption[]>,
+): ItineraryItemBlock[] {
+  return [...day.whereStaying, ...day.items].filter((item) =>
+    Boolean(resolveStopTitle(item, relatedByBlockType)),
+  )
+}
 
 export function createKeyLocationRow(
   itemId: string,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/pages/ListicleItineraryBuilderPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/pages/ListicleItineraryBuilderPage.tsx
@@ -26,7 +26,7 @@ import {
 import {
   getComposableDayIndexes,
   getItineraryDayBlurbComposeDisabledReason,
-} from '../builder/services/compose-day-blurbs.service'
+} from '../builder/services/day-blurb-readiness.service'
 import {
   buildListicleItineraryStructuredDataTemplate,
   serializeStructuredDataTemplate,


### PR DESCRIPTION
## Original issue

`compose-day-blurbs.service.ts` had grown to 300 lines with 14 definitions, 11 exports, and seven concerns. It mixed stop identity resolution, category configuration, article ordering, readiness policy, request DTO assembly, response application, and failure-report construction. Its stop title/category rules were also duplicated by the intro composer.

## Root cause

Day-wide composition, single-stop composition, write-all readiness, inspector reporting, and intro/Selection reason support were added incrementally to one service. The original module became both an orchestration entry point and a general utility surface, so unrelated consumers imported it for shared stop metadata.

## Refactor

- Reduced `compose-day-blurbs.service.ts` to a request assembler: 100 lines and one export.
- Moved day/stop eligibility, composed-state checks, write-all selection, and stale-neighbor detection into `day-blurb-readiness.service.ts`.
- Moved failed-request report construction and generated-result application into `day-blurb-results.service.ts`.
- Centralized shared category labels, resolved stop titles, and lodging-first resolved ordering in existing builder constants/utilities.
- Updated the builder page, AI action hook, intro composer, and Selection reason composer to import only the concern they consume.
- Removed the unused Draft argument from the stop-scoped readiness function.
- Added regression coverage for manual tour stop title/operator resolution while retaining all existing day composition coverage.

## Why this design is better

The composition entry point now owns only transport request assembly. Readiness policy and response mutation can evolve independently, callers reveal their actual dependency, and intro/day/Selection reason composition share one stop-identity vocabulary. The split follows existing feature folders and avoids barrel re-exports, so the old broad module does not remain as a compatibility facade.

## Validation

- `pnpm exec prettier --check apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.ts apps/frontend/src/features/listicleItineraries/builder/services/day-blurb-readiness.service.ts apps/frontend/src/features/listicleItineraries/builder/services/day-blurb-results.service.ts` — passed.
- `node apps/frontend/scripts/check-boundaries.cjs && pnpm exec eslint "apps/frontend/src/**/*.{ts,tsx}"` — passed.
- `pnpm exec vitest run --config apps/frontend/vite.config.ts apps/frontend/src/features/listicleItineraries/builder/services/compose-day-blurbs.service.test.ts apps/frontend/src/features/listicleItineraries/builder/services/intro-composer.service.test.ts apps/frontend/src/features/listicleItineraries/builder/services/compose-stop-reason.service.test.ts` — 3 files, 28 tests passed.
- `pnpm exec vitest run --config apps/frontend/vite.config.ts` — 94 files, 359 tests passed.
- `pnpm exec vite build --config apps/frontend/vite.config.ts` — passed (existing >500 kB chunk-size warning only).
- `pnpm exec tsc --noEmit -p apps/frontend/tsconfig.json` — reports five existing errors outside this change in `MainHomepagePage.tsx`, `homepageHotelGridSlots.utils.ts` (two diagnostics), `BuilderSetupPanel.tsx`, and `SingleTypeListicleBuilderPage.tsx`; no changed file was reported.
- `git diff origin/main...HEAD --check` — passed.

## Risks, tradeoffs, and follow-ups

- Internal import paths changed, but every repository consumer was updated and no feature barrel exported the old service members.
- This is a structural refactor; request fields, readiness messages, overwrite behavior, and response application semantics are preserved.
- The frontend-wide TypeScript baseline remains red on the unrelated diagnostics listed above and should be repaired separately.
