### PR TITLE
NOJIRA: Decompose editor-assist blurb composer

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composer.py
@@ -1,420 +1,76 @@
-"""Composition orchestration for one editor-assist listicle target.
+"""Thin composition API for one Editor Assist listicle target.
 
-This module owns sequencing policy for Critical Fields, Research Profile,
-Writer Brief, prompt selection, retry, validation, warnings, and
-low-confidence signaling. Routes adapt HTTP/Pydantic inputs into this smaller
-interface.
+The public contracts stay available from this module for compatibility. Cohesive
+evidence, prompt-policy, and writer-execution concerns live in adjacent modules.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-import logging
 import time
-from typing import Any, Literal, Protocol
 
-from .angle_assignment import (
-    ANTI_AI_PROMPT_CATEGORIES,
-    LEAN_PROMPT_CATEGORIES,
-    ListicleAngle,
+from .blurb_composition_contracts import (
+    CompositionStatus,
+    ListicleCompositionDeps,
+    ListicleCompositionResult,
+    ListicleCompositionSettings,
+    ListicleCompositionStep,
+    ListicleCompositionTarget,
+    ListicleCompositionWriterError,
+    StepStatus,
+    WriterBriefRunner,
+    WriterInvoker,
+    WriterModelResult,
+)
+from .blurb_composition_confidence import initial_low_confidence
+from .blurb_composition_evidence import (
+    format_research_profile_block,
+    prepare_research,
+    prepare_writer_brief,
+)
+from .blurb_composition_execution import execute_writer_plan
+from .blurb_composition_policy import (
+    select_writer_prompt,
+    to_listicle_writer_target,
+    uses_lean_prompt,
 )
 from .critical_fields import CriticalFieldsResult
-from .listicle_writer import (
-    ListTone,
-    ListicleArticleType,
-    ListicleCategory,
-    ListicleFieldType,
-    ListicleWriterTarget,
-    build_identity_only_writer_prompt,
-    build_lean_writer_prompt,
-    build_retry_prompt,
-    build_writer_prompt,
-    strip_generation_fence,
-    validate_generated_text,
-)
-from .research_profile import (
-    ResearchFinding,
-    ResearchProfile,
-    ResearchProfileTrace,
-)
-from .writer_brief import (
-    MIN_SOURCE_FACTS,
-    WriterBrief,
-    WriterBriefTrace,
-    run_writer_brief,
-)
-from app.shared.writer_invocation import WriterModelError, invoke_writer_model
+from .research_profile import ResearchProfile, ResearchProfileTrace
 
-logger = logging.getLogger(__name__)
-
-_LEAN_INLINE_RETRY_CATEGORIES = {"nightlife"}
-_LEAN_RETRY_BUILDER_CATEGORIES = {"dining", "accommodations", "attractions"}
-
-CompositionStatus = Literal["generated", "error"]
-StepStatus = Literal["ok", "skipped", "failed"]
-
-
-class WriterModelResult(Protocol):
-    text: str
-    model_name: str
-
-
-class WriterInvoker(Protocol):
-    def __call__(
-        self,
-        *,
-        prompt: str,
-        model_name: str,
-        max_tokens: int,
-        temperature: float,
-    ) -> WriterModelResult: ...
-
-
-class WriterBriefRunner(Protocol):
-    def __call__(
-        self,
-        *,
-        venue_name: str,
-        location_label: str,
-        category: str,
-        angle: ListicleAngle | None,
-        research_profile: ResearchProfile,
-    ) -> tuple[WriterBrief, WriterBriefTrace]: ...
-
-
-@dataclass(frozen=True)
-class ListicleCompositionTarget:
-    target_id: str
-    field_type: ListicleFieldType
-    category: ListicleCategory | None = None
-    display_name: str | None = None
-    research_subject: str | None = None
-    location_label: str | None = None
-    current_content: str = ""
-    supporting_context: str | None = None
-
-
-@dataclass(frozen=True)
-class ListicleCompositionSettings:
-    article_title: str
-    article_type: ListicleArticleType
-    article_location: str
-    article_context: str
-    custom_instruction: str
-    model_name: str
-    list_tone: ListTone | None = None
-    requested_angle: ListicleAngle | None = None
-    effective_angle: ListicleAngle | None = None
-
-
-@dataclass(frozen=True)
-class ListicleCompositionStep:
-    name: str
-    status: StepStatus
-    prompt: str | None = None
-    output: str | None = None
-    model: str | None = None
-    details: dict[str, Any] = field(default_factory=dict)
-    duration_ms: int = 0
-
-
-@dataclass(frozen=True)
-class ListicleCompositionResult:
-    target_id: str
-    status: CompositionStatus
-    model_used: str
-    markdown: str | None = None
-    source_urls: list[str] = field(default_factory=list)
-    validation_errors: list[str] = field(default_factory=list)
-    error_message: str | None = None
-    low_confidence: bool = False
-    warnings: list[str] = field(default_factory=list)
-    requested_angle: ListicleAngle | None = None
-    effective_angle: ListicleAngle | None = None
-    steps: list[ListicleCompositionStep] = field(default_factory=list)
-
-
-@dataclass(frozen=True)
-class ListicleCompositionDeps:
-    invoke_writer: WriterInvoker = invoke_writer_model
-    run_writer_brief: WriterBriefRunner = run_writer_brief
-
-
-class ListicleCompositionWriterError(Exception):
-    """Raised when writer model calls fail and HTTP adapter should return 502."""
-
-
-@dataclass
-class _LowConfidence:
-    reasons: list[str] = field(default_factory=list)
-
-    def add(self, reason: str) -> None:
-        if reason not in self.reasons:
-            self.reasons.append(reason)
-
-    @property
-    def value(self) -> bool:
-        return bool(self.reasons)
-
-
-@dataclass(frozen=True)
-class _WriterPromptPlan:
-    prompt: str
-    writer_target: ListicleWriterTarget
-    path: Literal["lean", "identity", "legacy"]
-    writer_brief: WriterBrief | None = None
+__all__ = [
+    "CompositionStatus",
+    "ListicleCompositionDeps",
+    "ListicleCompositionResult",
+    "ListicleCompositionSettings",
+    "ListicleCompositionStep",
+    "ListicleCompositionTarget",
+    "ListicleCompositionWriterError",
+    "StepStatus",
+    "WriterBriefRunner",
+    "WriterInvoker",
+    "WriterModelResult",
+    "compose_listicle_target",
+]
 
 
 def _elapsed_ms(start: float) -> int:
     return int((time.perf_counter() - start) * 1000)
 
 
-def _merge_urls(*groups: list[str]) -> list[str]:
-    seen: set[str] = set()
-    merged: list[str] = []
-    for group in groups:
-        for url in group:
-            if url in seen:
-                continue
-            seen.add(url)
-            merged.append(url)
-    return merged
-
-
-def _format_research_profile_block(
-    research_profile: ResearchProfile | None,
-) -> str:
-    """Render supported angle evidence and bucket evidence for the writer."""
-    if research_profile is None:
-        return ""
-    lines: list[str] = ["RESEARCH PROFILE"]
-    selected = research_profile.selected_angle
-    if selected.status == "supported" and selected.angle and selected.summary:
-        lines.append("SELECTED ANGLE EVIDENCE")
-        lines.append(f"- {selected.angle} (effective angle): {selected.summary}")
-    bucket_lines: list[str] = []
-    for bucket, findings in research_profile.standard_buckets.items():
-        for finding in findings:
-            bucket_lines.append(f"- {bucket}: {finding.summary}")
-    if bucket_lines:
-        lines.append("STANDARD EVIDENCE BUCKETS")
-        lines.extend(bucket_lines)
-    return "\n".join(lines)
-
-
-def _research_buckets_details(
-    buckets: dict[str, list[ResearchFinding]],
-) -> dict[str, list[dict[str, Any]]]:
-    return {
-        bucket: [
-            {
-                "summary": finding.summary,
-                "citations": list(finding.citations),
-            }
-            for finding in findings
-        ]
-        for bucket, findings in buckets.items()
-    }
-
-
-def _to_listicle_writer_target(
+def _critical_fields_step(
     target: ListicleCompositionTarget,
-    *,
-    extra_supporting_context: str = "",
-) -> ListicleWriterTarget:
-    base_context = target.supporting_context or ""
-    if extra_supporting_context:
-        supporting_context = (
-            f"{base_context}\n\n{extra_supporting_context}".strip()
-            if base_context.strip()
-            else extra_supporting_context
-        )
-    else:
-        supporting_context = base_context
-
-    return ListicleWriterTarget(
-        target_id=target.target_id,
-        field_type=target.field_type,
-        category=target.category,
-        display_name=target.display_name,
-        research_subject=target.research_subject,
-        location_label=target.location_label,
-        current_content=target.current_content or "",
-        supporting_context=supporting_context,
-    )
-
-
-def _initial_low_confidence(
-    *,
-    is_blurb: bool,
-    target: ListicleCompositionTarget,
-    research_profile: ResearchProfile | None,
-    requested_angle: ListicleAngle | None,
-    effective_angle: ListicleAngle | None,
-) -> _LowConfidence:
-    low_confidence = _LowConfidence()
-    angle_failed = (
-        is_blurb
-        and target.category in ANTI_AI_PROMPT_CATEGORIES
-        and requested_angle is not None
-        and effective_angle is None
-    )
-    if angle_failed:
-        low_confidence.add("requested angle unsupported")
-    if (
-        is_blurb
-        and research_profile is not None
-        and not research_profile.usable_for_blurb
-    ):
-        low_confidence.add("research profile unusable")
-    return low_confidence
-
-
-def _uses_lean_prompt(
-    *,
-    is_blurb: bool,
-    target: ListicleCompositionTarget,
-    research_profile: ResearchProfile | None,
-) -> bool:
-    return (
-        is_blurb
-        and target.category in LEAN_PROMPT_CATEGORIES
-        and research_profile is not None
-        and research_profile.usable_for_blurb
-    )
-
-
-def _select_writer_prompt(
-    *,
-    settings: ListicleCompositionSettings,
-    target: ListicleCompositionTarget,
-    writer_target: ListicleWriterTarget,
-    is_blurb: bool,
-    use_lean_prompt: bool,
-    research_profile: ResearchProfile | None,
-    writer_brief: WriterBrief | None,
-) -> _WriterPromptPlan:
-    if use_lean_prompt and writer_brief is not None and writer_brief.is_usable:
-        lean_target = _to_listicle_writer_target(target)
-        prompt = build_lean_writer_prompt(
-            category=target.category or "nightlife",
-            article_title=settings.article_title,
-            article_type=settings.article_type,
-            article_location=settings.article_location,
-            target=lean_target,
-            brief=writer_brief,
-            custom_instruction=settings.custom_instruction,
-            list_tone=settings.list_tone,
-        )
-        return _WriterPromptPlan(
-            prompt=prompt,
-            writer_target=writer_target,
-            path="lean",
-            writer_brief=writer_brief,
-        )
-
-    if (
-        is_blurb
-        and research_profile is not None
-        and not research_profile.usable_for_blurb
-    ):
-        prompt = build_identity_only_writer_prompt(
-            article_title=settings.article_title,
-            article_type=settings.article_type,
-            article_location=settings.article_location,
-            target=writer_target,
-            article_context=settings.article_context,
-            custom_instruction=settings.custom_instruction,
-            list_tone=settings.list_tone,
-        )
-        return _WriterPromptPlan(
-            prompt=prompt, writer_target=writer_target, path="identity"
-        )
-
-    if use_lean_prompt:
-        prompt = build_identity_only_writer_prompt(
-            article_title=settings.article_title,
-            article_type=settings.article_type,
-            article_location=settings.article_location,
-            target=writer_target,
-            article_context=settings.article_context,
-            custom_instruction=settings.custom_instruction,
-            list_tone=settings.list_tone,
-        )
-        return _WriterPromptPlan(
-            prompt=prompt, writer_target=writer_target, path="identity"
-        )
-
-    prompt = build_writer_prompt(
-        article_title=settings.article_title,
-        article_type=settings.article_type,
-        article_location=settings.article_location,
-        target=writer_target,
-        article_context=settings.article_context,
-        custom_instruction=settings.custom_instruction,
-        list_tone=settings.list_tone,
-        listicle_angle=settings.effective_angle,
-    )
-    return _WriterPromptPlan(prompt=prompt, writer_target=writer_target, path="legacy")
-
-
-def _build_retry_prompt_for_plan(
-    *,
-    settings: ListicleCompositionSettings,
-    target: ListicleCompositionTarget,
-    plan: _WriterPromptPlan,
-    candidate: str,
-    validation_errors: list[str],
-) -> str:
-    if (
-        plan.path == "lean"
-        and plan.writer_brief is not None
-        and plan.writer_brief.is_usable
-        and target.category in _LEAN_INLINE_RETRY_CATEGORIES
-    ):
-        lean_target = _to_listicle_writer_target(target)
-        base_lean_prompt = build_lean_writer_prompt(
-            category="nightlife",
-            article_title=settings.article_title,
-            article_type=settings.article_type,
-            article_location=settings.article_location,
-            target=lean_target,
-            brief=plan.writer_brief,
-            custom_instruction=settings.custom_instruction,
-            list_tone=settings.list_tone,
-        )
-        failures = "\n".join(f"- {item}" for item in validation_errors)
-        return (
-            f"{base_lean_prompt}\n\n"
-            "REVISION TASK\n"
-            "The previous draft did not pass validation. Rewrite it so it fully complies.\n\n"
-            f"VALIDATION FAILURES\n{failures}\n\n"
-            f"CURRENT DRAFT\n{candidate.strip()}\n\n"
-            "Return only the corrected final paragraph."
-        )
-
-    retry_brief = (
-        plan.writer_brief
-        if (
-            plan.path == "lean"
-            and plan.writer_brief is not None
-            and plan.writer_brief.is_usable
-            and target.category in _LEAN_RETRY_BUILDER_CATEGORIES
-        )
-        else None
-    )
-    return build_retry_prompt(
-        article_title=settings.article_title,
-        article_type=settings.article_type,
-        article_location=settings.article_location,
-        target=plan.writer_target,
-        article_context=settings.article_context,
-        custom_instruction=settings.custom_instruction,
-        current_output=candidate,
-        validation_errors=validation_errors,
-        list_tone=settings.list_tone,
-        listicle_angle=settings.effective_angle,
-        brief=retry_brief,
+    cf_result: CriticalFieldsResult,
+) -> ListicleCompositionStep:
+    start = time.perf_counter()
+    return ListicleCompositionStep(
+        name="critical_fields_evaluated",
+        status="ok" if cf_result.passed else "failed",
+        details={
+            "passed": cf_result.passed,
+            "missing": list(cf_result.missing),
+            "category": target.category,
+            "field_type": target.field_type,
+        },
+        duration_ms=_elapsed_ms(start),
     )
 
 
@@ -427,321 +83,74 @@ def compose_listicle_target(
     research_profile_trace: ResearchProfileTrace | None,
     deps: ListicleCompositionDeps | None = None,
 ) -> ListicleCompositionResult:
-    deps = deps or ListicleCompositionDeps()
-    steps: list[ListicleCompositionStep] = []
-    source_urls: list[str] = []
-    warnings: list[str] = []
-
-    cf_start = time.perf_counter()
-    steps.append(
-        ListicleCompositionStep(
-            name="critical_fields_evaluated",
-            status="ok" if cf_result.passed else "failed",
-            details={
-                "passed": cf_result.passed,
-                "missing": list(cf_result.missing),
-                "category": target.category,
-                "field_type": target.field_type,
-            },
-            duration_ms=_elapsed_ms(cf_start),
-        )
-    )
+    """Compose and validate one target while preserving the stable route seam."""
+    dependencies = deps or ListicleCompositionDeps()
+    steps = [_critical_fields_step(target, cf_result)]
     if not cf_result.passed:
         return ListicleCompositionResult(
             target_id=target.target_id,
             status="error",
             model_used=settings.model_name,
-            error_message=f"Critical Fields gate failed: missing {', '.join(cf_result.missing)}",
+            error_message=(
+                f"Critical Fields gate failed: missing {', '.join(cf_result.missing)}"
+            ),
             requested_angle=settings.requested_angle,
             effective_angle=settings.effective_angle,
             steps=steps,
         )
 
     is_blurb = target.field_type == "blurb"
-    if is_blurb and research_profile is not None:
-        rp_start = time.perf_counter()
-        source_urls = _merge_urls(source_urls, research_profile.source_urls)
-        warnings = list(research_profile.warnings)
-        trace = research_profile_trace or ResearchProfileTrace(prompt="")
-        steps.append(
-            ListicleCompositionStep(
-                name="research_profile_completed",
-                status="ok" if research_profile.usable_for_blurb else "failed",
-                prompt=trace.prompt or None,
-                output=trace.raw_response or None,
-                model=trace.model or None,
-                details={
-                    "requested_angle": settings.requested_angle,
-                    "effective_angle": research_profile.effective_angle,
-                    "selected_angle": {
-                        "angle": research_profile.selected_angle.angle,
-                        "status": research_profile.selected_angle.status,
-                        "summary": research_profile.selected_angle.summary,
-                        "citations": list(research_profile.selected_angle.citations),
-                        "reason": research_profile.selected_angle.reason,
-                    },
-                    "standard_buckets": _research_buckets_details(
-                        research_profile.standard_buckets
-                    ),
-                    "usable_for_blurb": research_profile.usable_for_blurb,
-                    "source_urls": list(source_urls),
-                    "warnings": list(warnings),
-                    "parser_dropped_reason": trace.parser_dropped_reason,
-                    "error": trace.error,
-                },
-                duration_ms=_elapsed_ms(rp_start),
-            )
-        )
+    research = prepare_research(
+        is_blurb=is_blurb,
+        settings=settings,
+        research_profile=research_profile,
+        research_profile_trace=research_profile_trace,
+    )
+    steps.extend(research.steps)
 
-    low_confidence = _initial_low_confidence(
+    low_confidence = initial_low_confidence(
         is_blurb=is_blurb,
         target=target,
         research_profile=research_profile,
-        requested_angle=settings.requested_angle,
-        effective_angle=settings.effective_angle,
+        settings=settings,
     )
-
-    use_lean_prompt = _uses_lean_prompt(
+    use_lean_prompt = uses_lean_prompt(
         is_blurb=is_blurb,
         target=target,
         research_profile=research_profile,
     )
-    writer_brief: WriterBrief | None = None
-    if use_lean_prompt:
-        wb_start = time.perf_counter()
-        venue_name = (target.research_subject or target.display_name or "").strip()
-        location_label = (target.location_label or settings.article_location).strip()
-        writer_brief, wb_trace = deps.run_writer_brief(
-            venue_name=venue_name,
-            location_label=location_label,
-            category=target.category or "nightlife",
-            angle=settings.effective_angle,
-            research_profile=research_profile,
-        )
-        if not writer_brief.is_usable:
-            low_confidence.add("writer brief unusable")
-        steps.append(
-            ListicleCompositionStep(
-                name="writer_brief_completed",
-                status="ok" if writer_brief.is_usable else "failed",
-                prompt=wb_trace.prompt or None,
-                output=wb_trace.raw_response or None,
-                model=wb_trace.model or None,
-                details={
-                    "angle": writer_brief.angle,
-                    "angle_directive": writer_brief.angle_directive,
-                    "source_facts": [
-                        {"fact": entry.fact, "citations": list(entry.citations)}
-                        for entry in writer_brief.source_facts
-                    ],
-                    "source_facts_count": len(writer_brief.source_facts),
-                    "min_source_facts": MIN_SOURCE_FACTS,
-                    "is_usable": writer_brief.is_usable,
-                    "parser_dropped_reason": wb_trace.parser_dropped_reason,
-                    "error": wb_trace.error,
-                },
-                duration_ms=_elapsed_ms(wb_start),
-            )
-        )
-
-    findings_block = _format_research_profile_block(research_profile)
-    writer_target = _to_listicle_writer_target(
-        target, extra_supporting_context=findings_block
+    brief = prepare_writer_brief(
+        use_lean_prompt=use_lean_prompt,
+        target=target,
+        settings=settings,
+        research_profile=research_profile,
+        deps=dependencies,
     )
-    plan = _select_writer_prompt(
+    if brief.low_confidence_reason:
+        low_confidence.add(brief.low_confidence_reason)
+    if brief.step is not None:
+        steps.append(brief.step)
+
+    writer_target = to_listicle_writer_target(
+        target,
+        extra_supporting_context=format_research_profile_block(research_profile),
+    )
+    plan = select_writer_prompt(
         settings=settings,
         target=target,
         writer_target=writer_target,
         is_blurb=is_blurb,
         use_lean_prompt=use_lean_prompt,
         research_profile=research_profile,
-        writer_brief=writer_brief,
+        writer_brief=brief.writer_brief,
     )
-
-    wr_start = time.perf_counter()
-    try:
-        writer_result = deps.invoke_writer(
-            prompt=plan.prompt,
-            model_name=settings.model_name,
-            max_tokens=8192,
-            temperature=0.15,
-        )
-    except WriterModelError as exc:
-        steps.append(
-            ListicleCompositionStep(
-                name="writer_called",
-                status="failed",
-                prompt=plan.prompt,
-                model=settings.model_name,
-                details={
-                    "error": str(exc),
-                    "custom_instruction": settings.custom_instruction or None,
-                    "list_tone": settings.list_tone,
-                    "requested_angle": settings.requested_angle,
-                    "effective_angle": settings.effective_angle,
-                    "low_confidence": low_confidence.value,
-                    "low_confidence_reasons": list(low_confidence.reasons),
-                    "warnings": list(warnings),
-                },
-                duration_ms=_elapsed_ms(wr_start),
-            )
-        )
-        logger.exception("Writer model call failed for target %s", target.target_id)
-        raise ListicleCompositionWriterError(str(exc)) from exc
-
-    candidate = strip_generation_fence(writer_result.text)
-    model_used = writer_result.model_name
-    steps.append(
-        ListicleCompositionStep(
-            name="writer_called",
-            status="ok",
-            prompt=plan.prompt,
-            output=candidate,
-            model=model_used,
-            details={
-                "raw_output": writer_result.text,
-                "custom_instruction": settings.custom_instruction or None,
-                "list_tone": settings.list_tone,
-                "requested_angle": settings.requested_angle,
-                "effective_angle": settings.effective_angle,
-                "low_confidence": low_confidence.value,
-                "low_confidence_reasons": list(low_confidence.reasons),
-                "warnings": list(warnings),
-            },
-            duration_ms=_elapsed_ms(wr_start),
-        )
-    )
-
-    val_start = time.perf_counter()
-    validation_errors = validate_generated_text(
-        field_type=writer_target.field_type,
-        text=candidate,
-    )
-    steps.append(
-        ListicleCompositionStep(
-            name="validated",
-            status="ok" if not validation_errors else "failed",
-            details={
-                "validation_errors": list(validation_errors),
-                "passed": not validation_errors,
-                "field_type": writer_target.field_type,
-            },
-            duration_ms=_elapsed_ms(val_start),
-        )
-    )
-
-    if validation_errors:
-        rt_start = time.perf_counter()
-        retry_prompt = _build_retry_prompt_for_plan(
-            settings=settings,
-            target=target,
-            plan=plan,
-            candidate=candidate,
-            validation_errors=validation_errors,
-        )
-        try:
-            retry_result = deps.invoke_writer(
-                prompt=retry_prompt,
-                model_name=settings.model_name,
-                max_tokens=8192,
-                temperature=0.1,
-            )
-        except WriterModelError as exc:
-            steps.append(
-                ListicleCompositionStep(
-                    name="retry_called",
-                    status="failed",
-                    prompt=retry_prompt,
-                    model=settings.model_name,
-                    details={"error": str(exc)},
-                    duration_ms=_elapsed_ms(rt_start),
-                )
-            )
-            logger.exception(
-                "Writer model retry failed for target %s", target.target_id
-            )
-            raise ListicleCompositionWriterError(str(exc)) from exc
-
-        candidate = strip_generation_fence(retry_result.text)
-        validation_errors = validate_generated_text(
-            field_type=writer_target.field_type,
-            text=candidate,
-        )
-        model_used = retry_result.model_name
-        steps.append(
-            ListicleCompositionStep(
-                name="retry_called",
-                status="ok" if not validation_errors else "failed",
-                prompt=retry_prompt,
-                output=candidate,
-                model=model_used,
-                details={
-                    "raw_output": retry_result.text,
-                    "post_retry_validation_errors": list(validation_errors),
-                    "passed": not validation_errors,
-                },
-                duration_ms=_elapsed_ms(rt_start),
-            )
-        )
-
-    fn_start = time.perf_counter()
-    if validation_errors:
-        steps.append(
-            ListicleCompositionStep(
-                name="finalized",
-                status="failed",
-                output=candidate,
-                model=model_used,
-                details={
-                    "final_status": "error",
-                    "validation_errors": list(validation_errors),
-                    "source_urls": list(source_urls),
-                    "low_confidence": low_confidence.value,
-                    "low_confidence_reasons": list(low_confidence.reasons),
-                    "warnings": list(warnings),
-                },
-                duration_ms=_elapsed_ms(fn_start),
-            )
-        )
-        return ListicleCompositionResult(
-            target_id=target.target_id,
-            status="error",
-            model_used=model_used,
-            source_urls=source_urls,
-            validation_errors=validation_errors,
-            error_message="Generated content failed validation after retry.",
-            low_confidence=low_confidence.value,
-            warnings=warnings,
-            requested_angle=settings.requested_angle,
-            effective_angle=settings.effective_angle,
-            steps=steps,
-        )
-
-    steps.append(
-        ListicleCompositionStep(
-            name="finalized",
-            status="ok",
-            output=candidate,
-            model=model_used,
-            details={
-                "final_status": "generated",
-                "source_urls": list(source_urls),
-                "low_confidence": low_confidence.value,
-                "low_confidence_reasons": list(low_confidence.reasons),
-                "warnings": list(warnings),
-            },
-            duration_ms=_elapsed_ms(fn_start),
-        )
-    )
-    return ListicleCompositionResult(
-        target_id=target.target_id,
-        status="generated",
-        markdown=candidate,
-        model_used=model_used,
-        source_urls=source_urls,
-        low_confidence=low_confidence.value,
-        warnings=warnings,
-        requested_angle=settings.requested_angle,
-        effective_angle=settings.effective_angle,
-        steps=steps,
+    return execute_writer_plan(
+        target=target,
+        settings=settings,
+        plan=plan,
+        deps=dependencies,
+        source_urls=research.source_urls,
+        warnings=research.warnings,
+        low_confidence=low_confidence,
+        prior_steps=steps,
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_confidence.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_confidence.py
@@ -1,0 +1,50 @@
+"""Low-confidence policy for generated listicle blurbs."""
+
+from dataclasses import dataclass, field
+
+from .angle_assignment import ANTI_AI_PROMPT_CATEGORIES
+from .blurb_composition_contracts import (
+    ListicleCompositionSettings,
+    ListicleCompositionTarget,
+)
+from .research_profile import ResearchProfile
+
+
+@dataclass
+class LowConfidence:
+    """Accumulate unique reasons that a generated blurb needs editorial review."""
+
+    reasons: list[str] = field(default_factory=list)
+
+    def add(self, reason: str) -> None:
+        if reason not in self.reasons:
+            self.reasons.append(reason)
+
+    @property
+    def value(self) -> bool:
+        return bool(self.reasons)
+
+
+def initial_low_confidence(
+    *,
+    is_blurb: bool,
+    target: ListicleCompositionTarget,
+    research_profile: ResearchProfile | None,
+    settings: ListicleCompositionSettings,
+) -> LowConfidence:
+    low_confidence = LowConfidence()
+    angle_failed = (
+        is_blurb
+        and target.category in ANTI_AI_PROMPT_CATEGORIES
+        and settings.requested_angle is not None
+        and settings.effective_angle is None
+    )
+    if angle_failed:
+        low_confidence.add("requested angle unsupported")
+    if (
+        is_blurb
+        and research_profile is not None
+        and not research_profile.usable_for_blurb
+    ):
+        low_confidence.add("research profile unusable")
+    return low_confidence

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_contracts.py
@@ -1,0 +1,111 @@
+"""Stable contracts for composing one listicle target."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+from app.shared.writer_invocation import invoke_writer_model
+
+from .angle_assignment import ListicleAngle
+from .listicle_writer import (
+    ListTone,
+    ListicleArticleType,
+    ListicleCategory,
+    ListicleFieldType,
+)
+from .research_profile import ResearchProfile
+from .writer_brief import WriterBrief, WriterBriefTrace, run_writer_brief
+
+CompositionStatus = Literal["generated", "error"]
+StepStatus = Literal["ok", "skipped", "failed"]
+
+
+class WriterModelResult(Protocol):
+    text: str
+    model_name: str
+
+
+class WriterInvoker(Protocol):
+    def __call__(
+        self,
+        *,
+        prompt: str,
+        model_name: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> WriterModelResult: ...
+
+
+class WriterBriefRunner(Protocol):
+    def __call__(
+        self,
+        *,
+        venue_name: str,
+        location_label: str,
+        category: str,
+        angle: ListicleAngle | None,
+        research_profile: ResearchProfile,
+    ) -> tuple[WriterBrief, WriterBriefTrace]: ...
+
+
+@dataclass(frozen=True)
+class ListicleCompositionTarget:
+    target_id: str
+    field_type: ListicleFieldType
+    category: ListicleCategory | None = None
+    display_name: str | None = None
+    research_subject: str | None = None
+    location_label: str | None = None
+    current_content: str = ""
+    supporting_context: str | None = None
+
+
+@dataclass(frozen=True)
+class ListicleCompositionSettings:
+    article_title: str
+    article_type: ListicleArticleType
+    article_location: str
+    article_context: str
+    custom_instruction: str
+    model_name: str
+    list_tone: ListTone | None = None
+    requested_angle: ListicleAngle | None = None
+    effective_angle: ListicleAngle | None = None
+
+
+@dataclass(frozen=True)
+class ListicleCompositionStep:
+    name: str
+    status: StepStatus
+    prompt: str | None = None
+    output: str | None = None
+    model: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    duration_ms: int = 0
+
+
+@dataclass(frozen=True)
+class ListicleCompositionResult:
+    target_id: str
+    status: CompositionStatus
+    model_used: str
+    markdown: str | None = None
+    source_urls: list[str] = field(default_factory=list)
+    validation_errors: list[str] = field(default_factory=list)
+    error_message: str | None = None
+    low_confidence: bool = False
+    warnings: list[str] = field(default_factory=list)
+    requested_angle: ListicleAngle | None = None
+    effective_angle: ListicleAngle | None = None
+    steps: list[ListicleCompositionStep] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ListicleCompositionDeps:
+    invoke_writer: WriterInvoker = invoke_writer_model
+    run_writer_brief: WriterBriefRunner = run_writer_brief
+
+
+class ListicleCompositionWriterError(Exception):
+    """Raised when writer model calls fail and HTTP adapter should return 502."""

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_evidence.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_evidence.py
@@ -1,0 +1,173 @@
+"""Research Profile and Writer Brief preparation for listicle composition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+from typing import Any
+
+from .blurb_composition_contracts import (
+    ListicleCompositionDeps,
+    ListicleCompositionSettings,
+    ListicleCompositionStep,
+    ListicleCompositionTarget,
+)
+from .research_profile import (
+    ResearchFinding,
+    ResearchProfile,
+    ResearchProfileTrace,
+)
+from .writer_brief import MIN_SOURCE_FACTS, WriterBrief
+
+
+@dataclass(frozen=True)
+class ResearchPreparation:
+    source_urls: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    steps: list[ListicleCompositionStep] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WriterBriefPreparation:
+    writer_brief: WriterBrief | None = None
+    step: ListicleCompositionStep | None = None
+    low_confidence_reason: str | None = None
+
+
+def _elapsed_ms(start: float) -> int:
+    return int((time.perf_counter() - start) * 1000)
+
+
+def format_research_profile_block(
+    research_profile: ResearchProfile | None,
+) -> str:
+    """Render supported angle evidence and bucket evidence for the legacy writer."""
+    if research_profile is None:
+        return ""
+    lines: list[str] = ["RESEARCH PROFILE"]
+    selected = research_profile.selected_angle
+    if selected.status == "supported" and selected.angle and selected.summary:
+        lines.append("SELECTED ANGLE EVIDENCE")
+        lines.append(f"- {selected.angle} (effective angle): {selected.summary}")
+    bucket_lines: list[str] = []
+    for bucket, findings in research_profile.standard_buckets.items():
+        for finding in findings:
+            bucket_lines.append(f"- {bucket}: {finding.summary}")
+    if bucket_lines:
+        lines.append("STANDARD EVIDENCE BUCKETS")
+        lines.extend(bucket_lines)
+    return "\n".join(lines)
+
+
+def _research_buckets_details(
+    buckets: dict[str, list[ResearchFinding]],
+) -> dict[str, list[dict[str, Any]]]:
+    return {
+        bucket: [
+            {
+                "summary": finding.summary,
+                "citations": list(finding.citations),
+            }
+            for finding in findings
+        ]
+        for bucket, findings in buckets.items()
+    }
+
+
+def prepare_research(
+    *,
+    is_blurb: bool,
+    settings: ListicleCompositionSettings,
+    research_profile: ResearchProfile | None,
+    research_profile_trace: ResearchProfileTrace | None,
+) -> ResearchPreparation:
+    if not is_blurb or research_profile is None:
+        return ResearchPreparation()
+
+    start = time.perf_counter()
+    source_urls = list(research_profile.source_urls)
+    warnings = list(research_profile.warnings)
+    trace = research_profile_trace or ResearchProfileTrace(prompt="")
+    step = ListicleCompositionStep(
+        name="research_profile_completed",
+        status="ok" if research_profile.usable_for_blurb else "failed",
+        prompt=trace.prompt or None,
+        output=trace.raw_response or None,
+        model=trace.model or None,
+        details={
+            "requested_angle": settings.requested_angle,
+            "effective_angle": research_profile.effective_angle,
+            "selected_angle": {
+                "angle": research_profile.selected_angle.angle,
+                "status": research_profile.selected_angle.status,
+                "summary": research_profile.selected_angle.summary,
+                "citations": list(research_profile.selected_angle.citations),
+                "reason": research_profile.selected_angle.reason,
+            },
+            "standard_buckets": _research_buckets_details(
+                research_profile.standard_buckets
+            ),
+            "usable_for_blurb": research_profile.usable_for_blurb,
+            "source_urls": list(source_urls),
+            "warnings": list(warnings),
+            "parser_dropped_reason": trace.parser_dropped_reason,
+            "error": trace.error,
+        },
+        duration_ms=_elapsed_ms(start),
+    )
+    return ResearchPreparation(
+        source_urls=source_urls,
+        warnings=warnings,
+        steps=[step],
+    )
+
+
+def prepare_writer_brief(
+    *,
+    use_lean_prompt: bool,
+    target: ListicleCompositionTarget,
+    settings: ListicleCompositionSettings,
+    research_profile: ResearchProfile | None,
+    deps: ListicleCompositionDeps,
+) -> WriterBriefPreparation:
+    if not use_lean_prompt or research_profile is None:
+        return WriterBriefPreparation()
+
+    start = time.perf_counter()
+    venue_name = (target.research_subject or target.display_name or "").strip()
+    location_label = (target.location_label or settings.article_location).strip()
+    writer_brief, trace = deps.run_writer_brief(
+        venue_name=venue_name,
+        location_label=location_label,
+        category=target.category or "nightlife",
+        angle=settings.effective_angle,
+        research_profile=research_profile,
+    )
+    step = ListicleCompositionStep(
+        name="writer_brief_completed",
+        status="ok" if writer_brief.is_usable else "failed",
+        prompt=trace.prompt or None,
+        output=trace.raw_response or None,
+        model=trace.model or None,
+        details={
+            "angle": writer_brief.angle,
+            "angle_directive": writer_brief.angle_directive,
+            "source_facts": [
+                {"fact": entry.fact, "citations": list(entry.citations)}
+                for entry in writer_brief.source_facts
+            ],
+            "source_facts_count": len(writer_brief.source_facts),
+            "min_source_facts": MIN_SOURCE_FACTS,
+            "is_usable": writer_brief.is_usable,
+            "parser_dropped_reason": trace.parser_dropped_reason,
+            "error": trace.error,
+        },
+        duration_ms=_elapsed_ms(start),
+    )
+    return WriterBriefPreparation(
+        writer_brief=writer_brief,
+        step=step,
+        low_confidence_reason=(
+            None if writer_brief.is_usable else "writer brief unusable"
+        ),
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_execution.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_execution.py
@@ -1,0 +1,192 @@
+"""Writer execution, validation, retry, and finalization for one target."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from app.shared.writer_invocation import WriterModelError
+
+from .blurb_composition_confidence import LowConfidence
+from .blurb_composition_contracts import (
+    ListicleCompositionDeps,
+    ListicleCompositionResult,
+    ListicleCompositionSettings,
+    ListicleCompositionStep,
+    ListicleCompositionTarget,
+    ListicleCompositionWriterError,
+)
+from .blurb_composition_policy import WriterPromptPlan
+from .blurb_composition_retry import build_retry_prompt_for_plan
+from .blurb_composition_validation import (
+    build_validation_step,
+    finalize_validated_result,
+    validate_candidate,
+)
+from .listicle_writer import strip_generation_fence
+
+logger = logging.getLogger(__name__)
+
+
+def _elapsed_ms(start: float) -> int:
+    return int((time.perf_counter() - start) * 1000)
+
+
+def _writer_step_details(
+    *,
+    settings: ListicleCompositionSettings,
+    low_confidence: LowConfidence,
+    warnings: list[str],
+) -> dict[str, object]:
+    return {
+        "custom_instruction": settings.custom_instruction or None,
+        "list_tone": settings.list_tone,
+        "requested_angle": settings.requested_angle,
+        "effective_angle": settings.effective_angle,
+        "low_confidence": low_confidence.value,
+        "low_confidence_reasons": list(low_confidence.reasons),
+        "warnings": list(warnings),
+    }
+
+
+def execute_writer_plan(
+    *,
+    target: ListicleCompositionTarget,
+    settings: ListicleCompositionSettings,
+    plan: WriterPromptPlan,
+    deps: ListicleCompositionDeps,
+    source_urls: list[str],
+    warnings: list[str],
+    low_confidence: LowConfidence,
+    prior_steps: list[ListicleCompositionStep],
+) -> ListicleCompositionResult:
+    """Run the selected writer path and return its final validated result."""
+    steps = list(prior_steps)
+    writer_start = time.perf_counter()
+    try:
+        writer_result = deps.invoke_writer(
+            prompt=plan.prompt,
+            model_name=settings.model_name,
+            max_tokens=8192,
+            temperature=0.15,
+        )
+    except WriterModelError as exc:
+        steps.append(
+            ListicleCompositionStep(
+                name="writer_called",
+                status="failed",
+                prompt=plan.prompt,
+                model=settings.model_name,
+                details={
+                    "error": str(exc),
+                    **_writer_step_details(
+                        settings=settings,
+                        low_confidence=low_confidence,
+                        warnings=warnings,
+                    ),
+                },
+                duration_ms=_elapsed_ms(writer_start),
+            )
+        )
+        logger.exception("Writer model call failed for target %s", target.target_id)
+        raise ListicleCompositionWriterError(str(exc)) from exc
+
+    candidate = strip_generation_fence(writer_result.text)
+    model_used = writer_result.model_name
+    steps.append(
+        ListicleCompositionStep(
+            name="writer_called",
+            status="ok",
+            prompt=plan.prompt,
+            output=candidate,
+            model=model_used,
+            details={
+                "raw_output": writer_result.text,
+                **_writer_step_details(
+                    settings=settings,
+                    low_confidence=low_confidence,
+                    warnings=warnings,
+                ),
+            },
+            duration_ms=_elapsed_ms(writer_start),
+        )
+    )
+
+    validation_start = time.perf_counter()
+    validation_errors = validate_candidate(
+        field_type=plan.writer_target.field_type,
+        text=candidate,
+    )
+    steps.append(
+        build_validation_step(
+            field_type=plan.writer_target.field_type,
+            validation_errors=validation_errors,
+            started_at=validation_start,
+        )
+    )
+
+    if validation_errors:
+        retry_start = time.perf_counter()
+        retry_prompt = build_retry_prompt_for_plan(
+            settings=settings,
+            target=target,
+            plan=plan,
+            candidate=candidate,
+            validation_errors=validation_errors,
+        )
+        try:
+            retry_result = deps.invoke_writer(
+                prompt=retry_prompt,
+                model_name=settings.model_name,
+                max_tokens=8192,
+                temperature=0.1,
+            )
+        except WriterModelError as exc:
+            steps.append(
+                ListicleCompositionStep(
+                    name="retry_called",
+                    status="failed",
+                    prompt=retry_prompt,
+                    model=settings.model_name,
+                    details={"error": str(exc)},
+                    duration_ms=_elapsed_ms(retry_start),
+                )
+            )
+            logger.exception(
+                "Writer model retry failed for target %s", target.target_id
+            )
+            raise ListicleCompositionWriterError(str(exc)) from exc
+
+        candidate = strip_generation_fence(retry_result.text)
+        validation_errors = validate_candidate(
+            field_type=plan.writer_target.field_type,
+            text=candidate,
+        )
+        model_used = retry_result.model_name
+        steps.append(
+            ListicleCompositionStep(
+                name="retry_called",
+                status="ok" if not validation_errors else "failed",
+                prompt=retry_prompt,
+                output=candidate,
+                model=model_used,
+                details={
+                    "raw_output": retry_result.text,
+                    "post_retry_validation_errors": list(validation_errors),
+                    "passed": not validation_errors,
+                },
+                duration_ms=_elapsed_ms(retry_start),
+            )
+        )
+
+    return finalize_validated_result(
+        target=target,
+        settings=settings,
+        candidate=candidate,
+        model_used=model_used,
+        source_urls=source_urls,
+        warnings=warnings,
+        low_confidence=low_confidence,
+        validation_errors=validation_errors,
+        steps=steps,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_policy.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_policy.py
@@ -1,0 +1,143 @@
+"""Writer prompt-path policy for listicle composition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .angle_assignment import LEAN_PROMPT_CATEGORIES
+from .blurb_composition_contracts import (
+    ListicleCompositionSettings,
+    ListicleCompositionTarget,
+)
+from .listicle_writer import (
+    ListicleWriterTarget,
+    build_identity_only_writer_prompt,
+    build_lean_writer_prompt,
+    build_writer_prompt,
+)
+from .research_profile import ResearchProfile
+from .writer_brief import WriterBrief
+
+
+@dataclass(frozen=True)
+class WriterPromptPlan:
+    prompt: str
+    writer_target: ListicleWriterTarget
+    path: Literal["lean", "identity", "legacy"]
+    writer_brief: WriterBrief | None = None
+
+
+def uses_lean_prompt(
+    *,
+    is_blurb: bool,
+    target: ListicleCompositionTarget,
+    research_profile: ResearchProfile | None,
+) -> bool:
+    return (
+        is_blurb
+        and target.category in LEAN_PROMPT_CATEGORIES
+        and research_profile is not None
+        and research_profile.usable_for_blurb
+    )
+
+
+def to_listicle_writer_target(
+    target: ListicleCompositionTarget,
+    *,
+    extra_supporting_context: str = "",
+) -> ListicleWriterTarget:
+    base_context = target.supporting_context or ""
+    if extra_supporting_context:
+        supporting_context = (
+            f"{base_context}\n\n{extra_supporting_context}".strip()
+            if base_context.strip()
+            else extra_supporting_context
+        )
+    else:
+        supporting_context = base_context
+
+    return ListicleWriterTarget(
+        target_id=target.target_id,
+        field_type=target.field_type,
+        category=target.category,
+        display_name=target.display_name,
+        research_subject=target.research_subject,
+        location_label=target.location_label,
+        current_content=target.current_content or "",
+        supporting_context=supporting_context,
+    )
+
+
+def select_writer_prompt(
+    *,
+    settings: ListicleCompositionSettings,
+    target: ListicleCompositionTarget,
+    writer_target: ListicleWriterTarget,
+    is_blurb: bool,
+    use_lean_prompt: bool,
+    research_profile: ResearchProfile | None,
+    writer_brief: WriterBrief | None,
+) -> WriterPromptPlan:
+    if use_lean_prompt and writer_brief is not None and writer_brief.is_usable:
+        lean_target = to_listicle_writer_target(target)
+        prompt = build_lean_writer_prompt(
+            category=target.category or "nightlife",
+            article_title=settings.article_title,
+            article_type=settings.article_type,
+            article_location=settings.article_location,
+            target=lean_target,
+            brief=writer_brief,
+            custom_instruction=settings.custom_instruction,
+            list_tone=settings.list_tone,
+        )
+        return WriterPromptPlan(
+            prompt=prompt,
+            writer_target=writer_target,
+            path="lean",
+            writer_brief=writer_brief,
+        )
+
+    if (
+        is_blurb
+        and research_profile is not None
+        and not research_profile.usable_for_blurb
+    ):
+        prompt = build_identity_only_writer_prompt(
+            article_title=settings.article_title,
+            article_type=settings.article_type,
+            article_location=settings.article_location,
+            target=writer_target,
+            article_context=settings.article_context,
+            custom_instruction=settings.custom_instruction,
+            list_tone=settings.list_tone,
+        )
+        return WriterPromptPlan(
+            prompt=prompt, writer_target=writer_target, path="identity"
+        )
+
+    if use_lean_prompt:
+        prompt = build_identity_only_writer_prompt(
+            article_title=settings.article_title,
+            article_type=settings.article_type,
+            article_location=settings.article_location,
+            target=writer_target,
+            article_context=settings.article_context,
+            custom_instruction=settings.custom_instruction,
+            list_tone=settings.list_tone,
+        )
+        return WriterPromptPlan(
+            prompt=prompt, writer_target=writer_target, path="identity"
+        )
+
+    prompt = build_writer_prompt(
+        article_title=settings.article_title,
+        article_type=settings.article_type,
+        article_location=settings.article_location,
+        target=writer_target,
+        article_context=settings.article_context,
+        custom_instruction=settings.custom_instruction,
+        list_tone=settings.list_tone,
+        listicle_angle=settings.effective_angle,
+    )
+    return WriterPromptPlan(prompt=prompt, writer_target=writer_target, path="legacy")

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_retry.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_retry.py
@@ -1,0 +1,71 @@
+"""Retry-prompt policy for failed listicle composition validation."""
+
+from .blurb_composition_contracts import (
+    ListicleCompositionSettings,
+    ListicleCompositionTarget,
+)
+from .blurb_composition_policy import WriterPromptPlan, to_listicle_writer_target
+from .listicle_writer import build_lean_writer_prompt, build_retry_prompt
+
+_LEAN_INLINE_RETRY_CATEGORIES = {"nightlife"}
+_LEAN_RETRY_BUILDER_CATEGORIES = {"dining", "accommodations", "attractions"}
+
+
+def build_retry_prompt_for_plan(
+    *,
+    settings: ListicleCompositionSettings,
+    target: ListicleCompositionTarget,
+    plan: WriterPromptPlan,
+    candidate: str,
+    validation_errors: list[str],
+) -> str:
+    if (
+        plan.path == "lean"
+        and plan.writer_brief is not None
+        and plan.writer_brief.is_usable
+        and target.category in _LEAN_INLINE_RETRY_CATEGORIES
+    ):
+        lean_target = to_listicle_writer_target(target)
+        base_lean_prompt = build_lean_writer_prompt(
+            category="nightlife",
+            article_title=settings.article_title,
+            article_type=settings.article_type,
+            article_location=settings.article_location,
+            target=lean_target,
+            brief=plan.writer_brief,
+            custom_instruction=settings.custom_instruction,
+            list_tone=settings.list_tone,
+        )
+        failures = "\n".join(f"- {item}" for item in validation_errors)
+        return (
+            f"{base_lean_prompt}\n\n"
+            "REVISION TASK\n"
+            "The previous draft did not pass validation. Rewrite it so it fully complies.\n\n"
+            f"VALIDATION FAILURES\n{failures}\n\n"
+            f"CURRENT DRAFT\n{candidate.strip()}\n\n"
+            "Return only the corrected final paragraph."
+        )
+
+    retry_brief = (
+        plan.writer_brief
+        if (
+            plan.path == "lean"
+            and plan.writer_brief is not None
+            and plan.writer_brief.is_usable
+            and target.category in _LEAN_RETRY_BUILDER_CATEGORIES
+        )
+        else None
+    )
+    return build_retry_prompt(
+        article_title=settings.article_title,
+        article_type=settings.article_type,
+        article_location=settings.article_location,
+        target=plan.writer_target,
+        article_context=settings.article_context,
+        custom_instruction=settings.custom_instruction,
+        current_output=candidate,
+        validation_errors=validation_errors,
+        list_tone=settings.list_tone,
+        listicle_angle=settings.effective_angle,
+        brief=retry_brief,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_validation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_validation.py
@@ -1,0 +1,116 @@
+"""Validation trace and final result policy for listicle composition."""
+
+from __future__ import annotations
+
+import time
+
+from .blurb_composition_confidence import LowConfidence
+from .blurb_composition_contracts import (
+    ListicleCompositionResult,
+    ListicleCompositionSettings,
+    ListicleCompositionStep,
+    ListicleCompositionTarget,
+)
+from .listicle_writer import ListicleFieldType, validate_generated_text
+
+
+def _elapsed_ms(start: float) -> int:
+    return int((time.perf_counter() - start) * 1000)
+
+
+def validate_candidate(*, field_type: ListicleFieldType, text: str) -> list[str]:
+    """Apply the canonical listicle text validator."""
+    return validate_generated_text(field_type=field_type, text=text)
+
+
+def build_validation_step(
+    *,
+    field_type: ListicleFieldType,
+    validation_errors: list[str],
+    started_at: float,
+) -> ListicleCompositionStep:
+    return ListicleCompositionStep(
+        name="validated",
+        status="ok" if not validation_errors else "failed",
+        details={
+            "validation_errors": list(validation_errors),
+            "passed": not validation_errors,
+            "field_type": field_type,
+        },
+        duration_ms=_elapsed_ms(started_at),
+    )
+
+
+def finalize_validated_result(
+    *,
+    target: ListicleCompositionTarget,
+    settings: ListicleCompositionSettings,
+    candidate: str,
+    model_used: str,
+    source_urls: list[str],
+    warnings: list[str],
+    low_confidence: LowConfidence,
+    validation_errors: list[str],
+    steps: list[ListicleCompositionStep],
+) -> ListicleCompositionResult:
+    start = time.perf_counter()
+    if validation_errors:
+        steps.append(
+            ListicleCompositionStep(
+                name="finalized",
+                status="failed",
+                output=candidate,
+                model=model_used,
+                details={
+                    "final_status": "error",
+                    "validation_errors": list(validation_errors),
+                    "source_urls": list(source_urls),
+                    "low_confidence": low_confidence.value,
+                    "low_confidence_reasons": list(low_confidence.reasons),
+                    "warnings": list(warnings),
+                },
+                duration_ms=_elapsed_ms(start),
+            )
+        )
+        return ListicleCompositionResult(
+            target_id=target.target_id,
+            status="error",
+            model_used=model_used,
+            source_urls=source_urls,
+            validation_errors=validation_errors,
+            error_message="Generated content failed validation after retry.",
+            low_confidence=low_confidence.value,
+            warnings=warnings,
+            requested_angle=settings.requested_angle,
+            effective_angle=settings.effective_angle,
+            steps=steps,
+        )
+
+    steps.append(
+        ListicleCompositionStep(
+            name="finalized",
+            status="ok",
+            output=candidate,
+            model=model_used,
+            details={
+                "final_status": "generated",
+                "source_urls": list(source_urls),
+                "low_confidence": low_confidence.value,
+                "low_confidence_reasons": list(low_confidence.reasons),
+                "warnings": list(warnings),
+            },
+            duration_ms=_elapsed_ms(start),
+        )
+    )
+    return ListicleCompositionResult(
+        target_id=target.target_id,
+        status="generated",
+        markdown=candidate,
+        model_used=model_used,
+        source_urls=source_urls,
+        low_confidence=low_confidence.value,
+        warnings=warnings,
+        requested_angle=settings.requested_angle,
+        effective_angle=settings.effective_angle,
+        steps=steps,
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
@@ -53,3 +53,35 @@ def test_root_routes_module_only_aggregates_family_routers():
         and node.value.func.attr == "include_router"
     ]
     assert len(included_routers) == 4
+
+
+def test_blurb_composer_remains_a_thin_compatible_orchestrator():
+    composer_path = (
+        Path(__file__).parents[1]
+        / "app"
+        / "features"
+        / "editor_assist"
+        / "blurb_composer.py"
+    )
+    source = composer_path.read_text()
+    module = ast.parse(source)
+
+    top_level_defs = [
+        node
+        for node in module.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    assert len(source.splitlines()) <= 200
+    assert [node.name for node in top_level_defs] == [
+        "_elapsed_ms",
+        "_critical_fields_step",
+        "compose_listicle_target",
+    ]
+
+    imported_modules = {
+        node.module
+        for node in module.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "listicle_writer" not in imported_modules
+    assert "writer_brief" not in imported_modules

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_blurb_composer.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_blurb_composer.py
@@ -1,7 +1,10 @@
+import pytest
+
 from app.features.editor_assist.blurb_composer import (
     ListicleCompositionDeps,
     ListicleCompositionSettings,
     ListicleCompositionTarget,
+    ListicleCompositionWriterError,
     compose_listicle_target,
 )
 from app.features.editor_assist.critical_fields import CriticalFieldsResult
@@ -16,6 +19,7 @@ from app.features.editor_assist.writer_brief import (
     WriterBrief,
     WriterBriefTrace,
 )
+from app.shared.writer_invocation import WriterModelError
 
 
 class _WriterResult:
@@ -61,6 +65,7 @@ def _profile(
     *,
     angle="signature-dish",
     usable_for_blurb=True,
+    warnings=None,
 ) -> ResearchProfile:
     return ResearchProfile(
         selected_angle=SelectedAngleEvidence(
@@ -84,6 +89,7 @@ def _profile(
             "experience-texture": [],
         },
         usable_for_blurb=usable_for_blurb,
+        warnings=warnings or [],
     )
 
 
@@ -192,3 +198,115 @@ def test_lean_retry_stays_inside_composer_without_http_route():
     assert "Source facts (use only what you need):" in prompts[1]
     assert "BUILDER CONTEXT" not in prompts[1]
     assert "RESEARCH PROFILE" not in prompts[1]
+
+
+def test_critical_fields_failure_short_circuits_all_model_dependencies():
+    def _should_not_run(**_kwargs):
+        raise AssertionError(
+            "model dependency must not run after Critical Fields failure"
+        )
+
+    result = compose_listicle_target(
+        target=_target(),
+        settings=_settings(),
+        cf_result=CriticalFieldsResult(passed=False, missing=["payload_doc_id"]),
+        research_profile=None,
+        research_profile_trace=None,
+        deps=ListicleCompositionDeps(
+            invoke_writer=_should_not_run,
+            run_writer_brief=_should_not_run,
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "Critical Fields gate failed: missing payload_doc_id"
+    )
+    assert [step.name for step in result.steps] == ["critical_fields_evaluated"]
+    assert result.steps[0].status == "failed"
+
+
+def test_unusable_research_preserves_warnings_sources_and_confidence_reasons():
+    profile = ResearchProfile(
+        selected_angle=SelectedAngleEvidence(
+            angle="signature-dish",
+            status="unsupported",
+            reason="No cited dish evidence.",
+        ),
+        standard_buckets={
+            "standout-hook": [
+                ResearchFinding(
+                    summary="The dining room overlooks the coast.",
+                    citations=["https://example.com/hook"],
+                )
+            ],
+            "experience-texture": [],
+        },
+        usable_for_blurb=False,
+        warnings=["Selected angle could not be supported."],
+    )
+
+    result = compose_listicle_target(
+        target=_target(),
+        settings=_settings(effective_angle=None),
+        cf_result=CriticalFieldsResult(passed=True, missing=[]),
+        research_profile=profile,
+        research_profile_trace=None,
+        deps=ListicleCompositionDeps(
+            invoke_writer=lambda **_kwargs: _WriterResult(_paragraph(100))
+        ),
+    )
+
+    assert result.status == "generated"
+    assert result.source_urls == ["https://example.com/hook"]
+    assert result.warnings == ["Selected angle could not be supported."]
+    assert result.low_confidence is True
+    writer_step = next(step for step in result.steps if step.name == "writer_called")
+    assert writer_step.details["low_confidence_reasons"] == [
+        "requested angle unsupported",
+        "research profile unusable",
+    ]
+
+
+def test_second_validation_failure_returns_error_with_retry_trace():
+    calls = 0
+
+    def _writer(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return _WriterResult("still too short")
+
+    result = compose_listicle_target(
+        target=_target(category="key_location"),
+        settings=_settings(requested_angle=None, effective_angle=None),
+        cf_result=CriticalFieldsResult(passed=True, missing=[]),
+        research_profile=None,
+        research_profile_trace=None,
+        deps=ListicleCompositionDeps(invoke_writer=_writer),
+    )
+
+    assert calls == 2
+    assert result.status == "error"
+    assert result.markdown is None
+    assert result.error_message == "Generated content failed validation after retry."
+    assert result.validation_errors
+    assert [(step.name, step.status) for step in result.steps[-3:]] == [
+        ("validated", "failed"),
+        ("retry_called", "failed"),
+        ("finalized", "failed"),
+    ]
+
+
+def test_writer_error_is_translated_through_compatible_composer_exception():
+    def _writer(**_kwargs):
+        raise WriterModelError("writer unavailable")
+
+    with pytest.raises(ListicleCompositionWriterError, match="writer unavailable"):
+        compose_listicle_target(
+            target=_target(category="key_location"),
+            settings=_settings(requested_angle=None, effective_angle=None),
+            cf_result=CriticalFieldsResult(passed=True, missing=[]),
+            research_profile=None,
+            research_profile_trace=None,
+            deps=ListicleCompositionDeps(invoke_writer=_writer),
+        )


### PR DESCRIPTION
## Original issue

`apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composer.py` had grown to 747 lines and 25 definitions. One module owned stable composition contracts, Research Profile and Writer Brief preparation, evidence traces, confidence decisions, prompt selection, retry construction, model execution, output validation, warning propagation, and result finalization.

## Root cause

The composer began as a single target orchestration entry point. Research grounding, confidence policy, retry behavior, and validation were added around that stable API over time, while tests and route callers continued importing the same module. Cohesive policies therefore became private helpers in one central file instead of explicit feature-local boundaries.

## Refactor

- Reduced `blurb_composer.py` to a 156-line compatible facade and orchestrator.
- Extracted stable DTOs, dependency injection, and error contracts to `blurb_composition_contracts.py`.
- Extracted Research Profile/Writer Brief preparation, source traces, and warnings to `blurb_composition_evidence.py`.
- Extracted confidence, prompt selection, retry policy, validation, and writer execution/finalization into focused modules, each under 200 lines.
- Preserved all public re-exports, route imports, result shapes, step ordering, prompt behavior, and the `ListicleCompositionDeps` fake-adapter seam.
- Added five behavior regressions plus an AST architecture guard that keeps the facade thin and free of writer/prompt implementation imports.

## Why this design is better

Each policy now has one reason to change and can be tested without understanding the entire composer. The public API stays stable, dependency injection remains explicit, and evidence, confidence, retries, validation, and execution can evolve independently without introducing cross-feature dependencies.

## Validation

- Focused composer/listicle route/architecture tests: 19 passed.
- Full backend: 342 passed.
- Full AI Blog Writer test command: backend 342 and frontend 359 across 94 files passed.
- Full workspace lint: all four projects passed.
- Black on all changed Python files: passed.
- Converter configured TypeScript typecheck: passed.
- Frontend and converter builds: passed.
- Backend compile build: passed with the repository virtualenv on PATH.
- Repository-wide Black still identifies 49 unrelated pre-existing files; none are introduced here.

## Risks, tradeoffs, and follow-ups

- The feature has more internal modules, but callers continue using the same facade and injected dependency seam.
- Import/step-order drift is the primary risk; direct regressions and the full backend suite cover both.
- No runtime behavior, prompts, model policy, result schema, or route contract intentionally changed.
- Future evidence, confidence, retry, and validation changes should stay in their owning modules rather than expanding the facade.
