### PR TITLE
NOJIRA: Decompose YouTube2Blog stage 3

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
@@ -43,6 +43,12 @@ operations.
 | `stages/editorial_augmentation_validation.py` | Model-output normalization and preservation checks |
 | `stages/editorial_augmentation_llm.py` | Editorial model invocation, JSON retry, and prose repair |
 | `stages/stage_editorial_augmentation.py` | Stable thin Editorial Augmentation Stage facade |
+| `stages/stage_3_guidelines.py` | Stage 3 general and Article Type guideline retrieval |
+| `stages/stage_3_coverage.py` | Coverage Analysis prompt, invocation, and response parsing |
+| `stages/stage_3_supplement.py` | Missing-section supplementation and prose repair |
+| `stages/stage_3_composition.py` | Final article prompt, composition, and prose repair |
+| `stages/stage_3_pipeline.py` | Legacy sequential Stage 3 orchestration |
+| `stages/stage_3.py` | Stable thin Stage 3 facade and compatibility seams |
 
 ## Dependency direction
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3.py
@@ -1,40 +1,35 @@
-"""
-Stage 3: Article composition with coverage analysis.
-
-This stage:
-1. Retrieves guidelines for the classified article type
-2. Checks if the transcript covers the guideline requirements
-3. Generates supplemental content if coverage is insufficient
-4. Composes the final article in markdown format
-"""
+"""Stable facade for YouTube2Blog Stage 3 composition."""
 
 from __future__ import annotations
 
-import logging
-import re
 from pathlib import Path
 
-from langchain_core.prompts import PromptTemplate
-
-from app.core import get_article_type_by_name
 from app.config import ARTICLE_GUIDELINES_DIR
+from app.core import get_article_type_by_name
 from app.features.youtube2blog.config import (
     Y2B_COMPOSE_MODEL,
     Y2B_PRIMARY_MODEL,
     Y2B_STAGE3_MAX_OUTPUT_TOKENS,
 )
-from app.shared.prompts import ANTI_AI_TELLS_FULL
-from app.shared.text import enforce_anti_ai_tells_markdown
 from shared import Stage1Output, Stage2Output, Stage3Output
-from utils import get_vertex_llm, parse_json_response
+from utils import get_vertex_llm
 
-logger = logging.getLogger(__name__)
+from .stage_3_composition import compose_article
+from .stage_3_coverage import check_coverage
+from .stage_3_guidelines import (
+    load_general_guidelines,
+    load_guideline_from_file,
+    normalize_guideline_key,
+    retrieve_guideline,
+)
+from .stage_3_pipeline import compose_stage_3
+from .stage_3_supplement import gather_missing_info
 
-# Path to general guidelines file
 GENERAL_GUIDELINES_PATH = Path(__file__).resolve().parents[4] / "data" / "general.md"
 
 
 def _stage3_llm(model_name: str = Y2B_PRIMARY_MODEL):
+    """Create the Stage 3 LLM through the shared provider boundary."""
     return get_vertex_llm(
         temperature=0.3,
         max_tokens=Y2B_STAGE3_MAX_OUTPUT_TOKENS,
@@ -42,143 +37,44 @@ def _stage3_llm(model_name: str = Y2B_PRIMARY_MODEL):
     )
 
 
+# Keep these private wrappers in the facade: existing callers and tests patch
+# them directly, and the wrappers pass the facade's current dependencies into
+# the extracted implementations.
 def _load_general_guidelines() -> str:
-    """Load general guidelines from markdown file."""
-    try:
-        if GENERAL_GUIDELINES_PATH.exists():
-            content = GENERAL_GUIDELINES_PATH.read_text(encoding="utf-8").strip()
-            if content:
-                return f"\n\n---\n\nGENERAL GUIDELINES:\n\n{content}"
-        logger.warning(f"General guidelines file not found: {GENERAL_GUIDELINES_PATH}")
-        return ""
-    except Exception as e:
-        logger.warning(f"Failed to load general guidelines: {e}")
-        return ""
+    return load_general_guidelines(GENERAL_GUIDELINES_PATH)
 
 
 def _normalize_guideline_key(value: str) -> str:
-    normalized = value.replace("’", "'").replace("`", "'")
-    normalized = normalized.lower()
-    normalized = re.sub(r"\.md$", "", normalized)
-    normalized = normalized.replace("&", " and ")
-    normalized = re.sub(r"[^a-z0-9]+", "", normalized)
-    return normalized
+    return normalize_guideline_key(value)
 
 
 def _load_guideline_from_file(article_type: str) -> str:
-    """Load guideline markdown from filesystem when a matching file exists."""
-    if not ARTICLE_GUIDELINES_DIR.exists():
-        return ""
-
-    exact_path = ARTICLE_GUIDELINES_DIR / f"{article_type}.md"
-    if exact_path.exists():
-        try:
-            return exact_path.read_text(encoding="utf-8").strip()
-        except Exception as exc:
-            logger.warning("Failed reading guideline file %s: %s", exact_path, exc)
-            return ""
-
-    target_key = _normalize_guideline_key(article_type)
-    if not target_key:
-        return ""
-
-    for candidate in ARTICLE_GUIDELINES_DIR.glob("*.md"):
-        if _normalize_guideline_key(candidate.stem) == target_key:
-            try:
-                return candidate.read_text(encoding="utf-8").strip()
-            except Exception as exc:
-                logger.warning("Failed reading guideline file %s: %s", candidate, exc)
-                return ""
-    return ""
+    return load_guideline_from_file(
+        article_type,
+        guidelines_dir=ARTICLE_GUIDELINES_DIR,
+        normalize_key=_normalize_guideline_key,
+    )
 
 
 def _retrieve_guideline(article_type: str) -> str:
-    """Fetch guideline from markdown files first, DB second."""
-    file_guideline = _load_guideline_from_file(article_type)
-    if file_guideline:
-        return file_guideline
-
-    article_type_data = get_article_type_by_name(article_type)
-    if not article_type_data:
-        logger.warning(f"No article type found for: {article_type}")
-        return ""
-    return article_type_data.get("guideline", "") or ""
-
-
-def _check_coverage(transcript: str, guideline: str, llm) -> tuple[bool, str, list[str], str, str]:
-    """
-    LLM call to analyze if transcript covers guideline requirements.
-
-    Returns: (coverage_sufficient, analysis, missing_sections, prompt, response)
-    """
-    general_guidelines = _load_general_guidelines()
-
-    prompt = PromptTemplate(
-        input_variables=["transcript", "guideline", "general_guidelines"],
-        template="""You are an article content analyst.
-
-Your task is to analyze if a YouTube transcript provides sufficient content
-to write a complete article following the given guideline.
-
----
-
-GUIDELINE FOR THE ARTICLE:
-
-{guideline}
-
----
-
-TRANSCRIPT TO ANALYZE:
-
-{transcript}
-
----
-
-ANALYSIS INSTRUCTIONS:
-
-1. Identify the key sections/topics required by the guideline
-2. Check if the transcript provides content for each required section
-3. Determine if there are any major gaps that would require additional content
-
-A transcript has "sufficient coverage" if:
-- It covers at least 70% of the guideline's required sections
-- The main topic/theme is well addressed
-- Minor gaps can be filled with logical transitions
-
----
-
-OUTPUT FORMAT (STRICT JSON ONLY):
-
-{{
-  "coverage_sufficient": <true or false>,
-  "analysis": "<2-3 sentence explanation of the coverage assessment>",
-  "missing_sections": ["<list of major sections not covered by transcript>"]
-}}
-
-If coverage is sufficient, missing_sections should be an empty array [].
-{general_guidelines}
-"""
+    return retrieve_guideline(
+        article_type,
+        load_file_guideline=_load_guideline_from_file,
+        article_type_lookup=get_article_type_by_name,
     )
 
-    full_prompt = prompt.format(
-        transcript=transcript[:15000],  # Truncate for coverage check
-        guideline=guideline,
-        general_guidelines=general_guidelines,
+
+def _check_coverage(
+    transcript: str,
+    guideline: str,
+    llm,
+) -> tuple[bool, str, list[str], str, str]:
+    return check_coverage(
+        transcript,
+        guideline,
+        llm,
+        load_general_guidelines=_load_general_guidelines,
     )
-    logger.info(f"  Coverage check prompt length: {len(full_prompt)} chars")
-
-    result = llm.invoke(full_prompt)
-    logger.info(f"  Coverage check response length: {len(result) if result else 0} chars")
-
-    if not result or not result.strip():
-        raise RuntimeError("Coverage check failed: LLM returned empty response")
-
-    parsed = parse_json_response(result)
-    coverage_sufficient = parsed.get("coverage_sufficient", False)
-    analysis = parsed.get("analysis", "")
-    missing_sections = parsed.get("missing_sections", [])
-
-    return coverage_sufficient, analysis, missing_sections, full_prompt, result
 
 
 def _gather_missing_info(
@@ -188,88 +84,14 @@ def _gather_missing_info(
     llm,
     tone_guidance: str | None = None,
 ) -> tuple[str, str, str]:
-    """
-    LLM call to generate supplemental content for missing sections.
-
-    Returns: (supplemental_content, prompt, response)
-    """
-    sections_list = "\n".join(f"- {s}" for s in missing_sections)
-    general_guidelines = _load_general_guidelines()
-
-    prompt = PromptTemplate(
-        input_variables=["transcript", "missing_sections", "article_type", "general_guidelines"],
-        template="""You are a content enhancement specialist.
-
-The following transcript is being converted into a "{article_type}" article,
-but it's missing some required sections. Your task is to generate
-supplemental content that logically extends what's in the transcript.
-
----
-
-ORIGINAL TRANSCRIPT (for context):
-
-{transcript}
-
----
-
-MISSING SECTIONS TO GENERATE:
-
-{missing_sections}
-
----
-
-GENERATION RULES:
-
-1. Base supplemental content on themes and topics from the transcript
-2. Do NOT invent specific facts, statistics, or claims not in the transcript
-3. Use general knowledge to expand on concepts mentioned
-4. Preserve the source meaning and details; do not copy transcript filler, hedges, or rambling cadence
-5. Keep each section concise (2-4 paragraphs)
-6. Use clear logical transitions only where needed; avoid stock transition phrases
-7. Supplemental context may explain concepts already mentioned in the transcript, but the final article cannot invent unsupported specifics
-
----
-
-OUTPUT FORMAT:
-
-Write the supplemental content as markdown, with each section clearly labeled.
-Do NOT include any JSON formatting. Just write the content directly.
-
-Example:
-## [Section Name]
-
-[Content for this section...]
-
-## [Another Section]
-
-[Content for this section...]
-{general_guidelines}
-"""
+    return gather_missing_info(
+        transcript,
+        missing_sections,
+        article_type,
+        llm,
+        tone_guidance,
+        load_general_guidelines=_load_general_guidelines,
     )
-
-    full_prompt = prompt.format(
-        transcript=transcript[:10000],
-        missing_sections=sections_list,
-        article_type=article_type,
-        general_guidelines=general_guidelines,
-    )
-    if tone_guidance:
-        full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"
-    full_prompt = f"{full_prompt}\n\n{ANTI_AI_TELLS_FULL}"
-    logger.info(f"  Supplement generation prompt length: {len(full_prompt)} chars")
-
-    result = llm.invoke(full_prompt)
-    logger.info(f"  Supplement generation response length: {len(result) if result else 0} chars")
-
-    if not result or not result.strip():
-        return "", full_prompt, result
-
-    supplemental = enforce_anti_ai_tells_markdown(
-        str(result),
-        repair=lambda repair_prompt: llm.invoke(repair_prompt),
-        context="youtube2blog supplement",
-    )
-    return supplemental, full_prompt, result
 
 
 def _compose_article(
@@ -281,103 +103,20 @@ def _compose_article(
     llm,
     tone_guidance: str | None = None,
 ) -> tuple[str, str, str]:
-    """
-    LLM call to compose the final article.
-
-    Returns: (final_article, prompt, response)
-    """
-    content_section = f"""PRIMARY CONTENT (from transcript):
-
-{transcript}"""
-
-    if supplemental:
-        content_section += f"""
-
----
-
-SUPPLEMENTAL CONTENT (AI-generated to fill gaps):
-
-{supplemental}"""
-
-    general_guidelines = _load_general_guidelines()
-
-    prompt = PromptTemplate(
-        input_variables=["title", "article_type", "guideline", "content", "general_guidelines"],
-        template="""You are an expert article composer.
-
-Your task is to compose a complete, polished article from the provided content,
-following the structure and style defined in the guideline.
-
----
-
-ARTICLE DETAILS:
-
-Title: {title}
-Type: {article_type}
-
----
-
-GUIDELINE TO FOLLOW:
-
-{guideline}
-
----
-
-{content}
-
----
-
-COMPOSITION RULES:
-
-1. Follow the guideline's structure and formatting requirements
-2. Use ALL relevant content from the transcript
-3. Integrate supplemental content naturally (if provided)
-4. Write in clear, engaging prose appropriate for the article type
-5. Include proper headings, subheadings, and formatting
-6. Do NOT add new information not present in the source content
-7. Do NOT include meta-commentary about the article
-8. Start directly with the article content
-9. Write for readers first and SEO second. Use natural travel-news language, avoid keyword stuffing, avoid repetitive SEO headings, and make the article feel edited by a human. Include SEO elements only where they improve clarity: a strong headline, concise subhead, clean section structure, accurate metadata, and natural keywords. SEO structure and keywords never override the voice rules appended below.
-
----
-
-OUTPUT FORMAT:
-
-Write the complete article in markdown format.
-Start with a level-1 heading (# Title).
-Use proper markdown formatting throughout.
-{general_guidelines}
-"""
+    return compose_article(
+        transcript,
+        supplemental,
+        guideline,
+        article_type,
+        title,
+        llm,
+        tone_guidance,
+        load_general_guidelines=_load_general_guidelines,
     )
-
-    full_prompt = prompt.format(
-        title=title,
-        article_type=article_type,
-        guideline=guideline,
-        content=content_section,
-        general_guidelines=general_guidelines,
-    )
-    if tone_guidance:
-        full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"
-    full_prompt = f"{full_prompt}\n\n{ANTI_AI_TELLS_FULL}"
-    logger.info(f"  Composition prompt length: {len(full_prompt)} chars")
-
-    result = llm.invoke(full_prompt)
-    logger.info(f"  Composition response length: {len(result) if result else 0} chars")
-
-    if not result or not result.strip():
-        raise RuntimeError("Article composition failed: LLM returned empty response")
-
-    final_article = enforce_anti_ai_tells_markdown(
-        str(result),
-        repair=lambda repair_prompt: llm.invoke(repair_prompt),
-        context="youtube2blog compose",
-    )
-    return final_article, full_prompt, result
 
 
 def stage_3_retrieve_guideline(article_type: str) -> str:
-    """Public helper used by graph node to fetch article guideline."""
+    """Fetch an article guideline, falling back to a generic instruction."""
     guideline = _retrieve_guideline(article_type)
     if guideline:
         return guideline
@@ -390,15 +129,14 @@ def stage_3_coverage_check(
     guideline: str,
     model_name: str = Y2B_PRIMARY_MODEL,
 ) -> dict[str, object]:
-    """Run coverage analysis as an explicit graph branch node."""
-    llm = _stage3_llm(model_name)
+    """Run Coverage Analysis as an explicit graph branch node."""
     (
         coverage_sufficient,
         analysis,
         missing_sections,
         coverage_prompt,
         coverage_response,
-    ) = _check_coverage(transcript, guideline, llm)
+    ) = _check_coverage(transcript, guideline, _stage3_llm(model_name))
     return {
         "coverage_sufficient": bool(coverage_sufficient),
         "coverage_analysis": analysis,
@@ -416,19 +154,18 @@ def stage_3_generate_supplement(
     model_name: str = Y2B_PRIMARY_MODEL,
     tone_guidance: str | None = None,
 ) -> dict[str, str]:
-    """Generate supplemental markdown for missing sections."""
-    llm = _stage3_llm(model_name)
-    supplemental_content, supplement_prompt, supplement_response = _gather_missing_info(
+    """Generate supplemental Markdown for missing sections."""
+    content, prompt, response = _gather_missing_info(
         transcript,
         missing_sections,
         article_type,
-        llm,
+        _stage3_llm(model_name),
         tone_guidance,
     )
     return {
-        "supplemental_content": supplemental_content or "",
-        "debug_supplement_prompt": supplement_prompt or "",
-        "debug_supplement_response": supplement_response or "",
+        "supplemental_content": content or "",
+        "debug_supplement_prompt": prompt or "",
+        "debug_supplement_response": response or "",
     }
 
 
@@ -443,26 +180,21 @@ def stage_3_compose_from_parts(
     writing_model: str | None = None,
     tone_guidance: str | None = None,
 ) -> dict[str, str]:
-    """Compose article from explicit inputs used by branch nodes.
-
-    Composition runs on the caller-selected ``writing_model`` (defaulting to
-    Y2B_COMPOSE_MODEL) regardless of the run's base model; ``model_name`` still
-    selects the model for the other stage-3 nodes.
-    """
-    llm = _stage3_llm(writing_model or Y2B_COMPOSE_MODEL)
-    final_article, composition_prompt, composition_response = _compose_article(
+    """Compose an article from the explicit inputs used by graph nodes."""
+    _ = model_name
+    article, prompt, response = _compose_article(
         transcript,
         supplemental,
         guideline,
         article_type,
         title,
-        llm,
+        _stage3_llm(writing_model or Y2B_COMPOSE_MODEL),
         tone_guidance,
     )
     return {
-        "final_article": final_article,
-        "debug_composition_prompt": composition_prompt,
-        "debug_composition_response": composition_response,
+        "final_article": article,
+        "debug_composition_prompt": prompt,
+        "debug_composition_response": response,
     }
 
 
@@ -472,107 +204,15 @@ def stage_3_compose_article(
     *,
     tone_guidance: str | None = None,
 ) -> Stage3Output:
-    """
-    Stage 3: Compose the final article using guidelines and coverage analysis.
-
-    1. Retrieve guideline for the classified article type
-    2. Check if transcript covers guideline requirements
-    3. Generate supplemental content if needed
-    4. Compose the final article
-    """
-    logger.info("=" * 60)
-    logger.info("STAGE 3: Composing article")
-    logger.info("=" * 60)
-    logger.info(f"  Video: {stage1.title}")
-    logger.info(f"  Article Type: {stage2.classification}")
-    logger.info(f"  Transcript length: {len(stage1.cleaned_transcript)} chars")
-
-    llm = _stage3_llm()
-
-    # Step 1: Retrieve guideline
-    logger.info("  Step 1: Retrieving guideline...")
-    guideline = _retrieve_guideline(stage2.classification)
-    if not guideline:
-        logger.warning(f"  No guideline found for article type: {stage2.classification}")
-        guideline = f"Write a {stage2.classification} article based on the provided content."
-
-    logger.info(f"  Guideline length: {len(guideline)} chars")
-
-    # Step 2: Check coverage
-    logger.info("  Step 2: Checking transcript coverage...")
-    (
-        coverage_sufficient,
-        coverage_analysis,
-        missing_sections,
-        coverage_prompt,
-        coverage_response,
-    ) = _check_coverage(stage1.cleaned_transcript, guideline, llm)
-
-    logger.info(f"  Coverage sufficient: {coverage_sufficient}")
-    logger.info(f"  Analysis: {coverage_analysis}")
-    if missing_sections:
-        logger.info(f"  Missing sections: {missing_sections}")
-
-    # Step 3: Generate supplemental content if needed
-    supplemental_content = None
-    supplement_prompt = None
-    supplement_response = None
-
-    if not coverage_sufficient and missing_sections:
-        logger.info("  Step 3: Generating supplemental content...")
-        (
-            supplemental_content,
-            supplement_prompt,
-            supplement_response,
-        ) = _gather_missing_info(
-            stage1.cleaned_transcript,
-            missing_sections,
-            stage2.classification,
-            llm,
-            tone_guidance,
-        )
-        logger.info(f"  Supplemental content length: {len(supplemental_content) if supplemental_content else 0} chars")
-    else:
-        logger.info("  Step 3: Skipping supplemental content (coverage sufficient)")
-
-    # Step 4: Compose final article (pinned to the Claude compose model;
-    # coverage/supplement above stay on the primary model)
-    logger.info("  Step 4: Composing final article...")
-    (
-        final_article,
-        composition_prompt,
-        composition_response,
-    ) = _compose_article(
-        stage1.cleaned_transcript,
-        supplemental_content,
-        guideline,
-        stage2.classification,
-        stage1.title,
-        _stage3_llm(Y2B_COMPOSE_MODEL),
-        tone_guidance,
+    """Run the original sequential Stage 3 workflow."""
+    return compose_stage_3(
+        stage1,
+        stage2,
+        tone_guidance=tone_guidance,
+        compose_model=Y2B_COMPOSE_MODEL,
+        make_llm=_stage3_llm,
+        retrieve_guideline=_retrieve_guideline,
+        check_coverage=_check_coverage,
+        gather_missing_info=_gather_missing_info,
+        compose_article=_compose_article,
     )
-    logger.info(f"  Final article length: {len(final_article)} chars")
-
-    output = Stage3Output(
-        video_id=stage1.video_id,
-        title=stage1.title,
-        article_type=stage2.classification,
-        coverage_sufficient=coverage_sufficient,
-        coverage_analysis=coverage_analysis,
-        missing_sections=missing_sections,
-        supplemental_content=supplemental_content,
-        final_article=final_article,
-        guideline_used=guideline,
-        debug_coverage_prompt=coverage_prompt,
-        debug_coverage_response=coverage_response,
-        debug_supplement_prompt=supplement_prompt,
-        debug_supplement_response=supplement_response,
-        debug_composition_prompt=composition_prompt,
-        debug_composition_response=composition_response,
-    )
-
-    logger.info("=" * 60)
-    logger.info("  Stage 3 complete!")
-    logger.info("=" * 60)
-
-    return output

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_composition.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_composition.py
@@ -1,0 +1,122 @@
+"""Article composition for YouTube2Blog Stage 3."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.prompts import PromptTemplate
+
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+from app.shared.text import enforce_anti_ai_tells_markdown
+
+logger = logging.getLogger(__name__)
+
+COMPOSITION_PROMPT = """You are an expert article composer.
+
+Your task is to compose a complete, polished article from the provided content,
+following the structure and style defined in the guideline.
+
+---
+
+ARTICLE DETAILS:
+
+Title: {title}
+Type: {article_type}
+
+---
+
+GUIDELINE TO FOLLOW:
+
+{guideline}
+
+---
+
+{content}
+
+---
+
+COMPOSITION RULES:
+
+1. Follow the guideline's structure and formatting requirements
+2. Use ALL relevant content from the transcript
+3. Integrate supplemental content naturally (if provided)
+4. Write in clear, engaging prose appropriate for the article type
+5. Include proper headings, subheadings, and formatting
+6. Do NOT add new information not present in the source content
+7. Do NOT include meta-commentary about the article
+8. Start directly with the article content
+9. Write for readers first and SEO second. Use natural travel-news language, avoid keyword stuffing, avoid repetitive SEO headings, and make the article feel edited by a human. Include SEO elements only where they improve clarity: a strong headline, concise subhead, clean section structure, accurate metadata, and natural keywords. SEO structure and keywords never override the voice rules appended below.
+
+---
+
+OUTPUT FORMAT:
+
+Write the complete article in markdown format.
+Start with a level-1 heading (# Title).
+Use proper markdown formatting throughout.
+{general_guidelines}
+"""
+
+
+def compose_article(
+    transcript: str,
+    supplemental: str | None,
+    guideline: str,
+    article_type: str,
+    title: str,
+    llm: Any,
+    tone_guidance: str | None = None,
+    *,
+    load_general_guidelines: Callable[[], str],
+) -> tuple[str, str, str]:
+    """Compose the final Markdown article from explicit source parts."""
+    content_section = f"""PRIMARY CONTENT (from transcript):
+
+{transcript}"""
+    if supplemental:
+        content_section += f"""
+
+---
+
+SUPPLEMENTAL CONTENT (AI-generated to fill gaps):
+
+{supplemental}"""
+
+    prompt = PromptTemplate(
+        input_variables=[
+            "title",
+            "article_type",
+            "guideline",
+            "content",
+            "general_guidelines",
+        ],
+        template=COMPOSITION_PROMPT,
+    )
+    full_prompt = prompt.format(
+        title=title,
+        article_type=article_type,
+        guideline=guideline,
+        content=content_section,
+        general_guidelines=load_general_guidelines(),
+    )
+    if tone_guidance:
+        full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"
+    full_prompt = f"{full_prompt}\n\n{ANTI_AI_TELLS_FULL}"
+    logger.info("  Composition prompt length: %d chars", len(full_prompt))
+
+    result = llm.invoke(full_prompt)
+    logger.info(
+        "  Composition response length: %d chars",
+        len(result) if result else 0,
+    )
+    if not result or not result.strip():
+        raise RuntimeError("Article composition failed: LLM returned empty response")
+
+    final_article = enforce_anti_ai_tells_markdown(
+        str(result),
+        repair=lambda repair_prompt: llm.invoke(repair_prompt),
+        context="youtube2blog compose",
+    )
+    return final_article, full_prompt, result

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_coverage.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_coverage.py
@@ -1,0 +1,97 @@
+"""Coverage Analysis for YouTube2Blog Stage 3."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.prompts import PromptTemplate
+from utils import parse_json_response
+
+logger = logging.getLogger(__name__)
+
+COVERAGE_PROMPT = """You are an article content analyst.
+
+Your task is to analyze if a YouTube transcript provides sufficient content
+to write a complete article following the given guideline.
+
+---
+
+GUIDELINE FOR THE ARTICLE:
+
+{guideline}
+
+---
+
+TRANSCRIPT TO ANALYZE:
+
+{transcript}
+
+---
+
+ANALYSIS INSTRUCTIONS:
+
+1. Identify the key sections/topics required by the guideline
+2. Check if the transcript provides content for each required section
+3. Determine if there are any major gaps that would require additional content
+
+A transcript has "sufficient coverage" if:
+- It covers at least 70% of the guideline's required sections
+- The main topic/theme is well addressed
+- Minor gaps can be filled with logical transitions
+
+---
+
+OUTPUT FORMAT (STRICT JSON ONLY):
+
+{{
+  "coverage_sufficient": <true or false>,
+  "analysis": "<2-3 sentence explanation of the coverage assessment>",
+  "missing_sections": ["<list of major sections not covered by transcript>"]
+}}
+
+If coverage is sufficient, missing_sections should be an empty array [].
+{general_guidelines}
+"""
+
+
+def check_coverage(
+    transcript: str,
+    guideline: str,
+    llm: Any,
+    *,
+    load_general_guidelines: Callable[[], str],
+) -> tuple[bool, str, list[str], str, str]:
+    """Analyze whether the transcript covers the article guideline."""
+    prompt = PromptTemplate(
+        input_variables=["transcript", "guideline", "general_guidelines"],
+        template=COVERAGE_PROMPT,
+    )
+    full_prompt = prompt.format(
+        transcript=transcript[:15000],
+        guideline=guideline,
+        general_guidelines=load_general_guidelines(),
+    )
+    logger.info("  Coverage check prompt length: %d chars", len(full_prompt))
+
+    result = llm.invoke(full_prompt)
+    logger.info(
+        "  Coverage check response length: %d chars",
+        len(result) if result else 0,
+    )
+    if not result or not result.strip():
+        raise RuntimeError("Coverage check failed: LLM returned empty response")
+
+    parsed = parse_json_response(result)
+    coverage_sufficient = parsed.get("coverage_sufficient", False)
+    analysis = parsed.get("analysis", "")
+    missing_sections = parsed.get("missing_sections", [])
+
+    return (
+        coverage_sufficient,
+        analysis,
+        missing_sections,
+        full_prompt,
+        result,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_guidelines.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_guidelines.py
@@ -1,0 +1,84 @@
+"""Guideline retrieval policy for YouTube2Blog Stage 3."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def load_general_guidelines(path: Path) -> str:
+    """Load the cross-article composition guidelines."""
+    try:
+        if path.exists():
+            content = path.read_text(encoding="utf-8").strip()
+            if content:
+                return f"\n\n---\n\nGENERAL GUIDELINES:\n\n{content}"
+        logger.warning("General guidelines file not found: %s", path)
+        return ""
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load general guidelines: %s", exc)
+        return ""
+
+
+def normalize_guideline_key(value: str) -> str:
+    """Normalize article-type names for filename matching."""
+    normalized = value.replace("’", "'").replace("`", "'")
+    normalized = normalized.lower()
+    normalized = re.sub(r"\.md$", "", normalized)
+    normalized = normalized.replace("&", " and ")
+    return re.sub(r"[^a-z0-9]+", "", normalized)
+
+
+def load_guideline_from_file(
+    article_type: str,
+    *,
+    guidelines_dir: Path,
+    normalize_key: Callable[[str], str] = normalize_guideline_key,
+) -> str:
+    """Load guideline markdown when an exact or normalized file exists."""
+    if not guidelines_dir.exists():
+        return ""
+
+    exact_path = guidelines_dir / f"{article_type}.md"
+    if exact_path.exists():
+        try:
+            return exact_path.read_text(encoding="utf-8").strip()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed reading guideline file %s: %s", exact_path, exc)
+            return ""
+
+    target_key = normalize_key(article_type)
+    if not target_key:
+        return ""
+
+    for candidate in guidelines_dir.glob("*.md"):
+        if normalize_key(candidate.stem) == target_key:
+            try:
+                return candidate.read_text(encoding="utf-8").strip()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed reading guideline file %s: %s", candidate, exc)
+                return ""
+    return ""
+
+
+def retrieve_guideline(
+    article_type: str,
+    *,
+    load_file_guideline: Callable[[str], str],
+    article_type_lookup: Callable[[str], dict[str, Any] | None],
+) -> str:
+    """Fetch an article guideline from Markdown first and the database second."""
+    file_guideline = load_file_guideline(article_type)
+    if file_guideline:
+        return file_guideline
+
+    article_type_data = article_type_lookup(article_type)
+    if not article_type_data:
+        logger.warning("No article type found for: %s", article_type)
+        return ""
+    return article_type_data.get("guideline", "") or ""

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_pipeline.py
@@ -1,0 +1,117 @@
+"""Legacy all-in-one Stage 3 orchestration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from shared import Stage1Output, Stage2Output, Stage3Output
+
+logger = logging.getLogger(__name__)
+
+
+def compose_stage_3(
+    stage1: Stage1Output,
+    stage2: Stage2Output,
+    *,
+    tone_guidance: str | None,
+    compose_model: str,
+    make_llm: Callable[..., Any],
+    retrieve_guideline: Callable[[str], str],
+    check_coverage: Callable[..., tuple[bool, str, list[str], str, str]],
+    gather_missing_info: Callable[..., tuple[str, str, str]],
+    compose_article: Callable[..., tuple[str, str, str]],
+) -> Stage3Output:
+    """Run the original sequential Stage 3 workflow."""
+    logger.info("=" * 60)
+    logger.info("STAGE 3: Composing article")
+    logger.info("=" * 60)
+    logger.info("  Video: %s", stage1.title)
+    logger.info("  Article Type: %s", stage2.classification)
+    logger.info("  Transcript length: %d chars", len(stage1.cleaned_transcript))
+
+    llm = make_llm()
+
+    logger.info("  Step 1: Retrieving guideline...")
+    guideline = retrieve_guideline(stage2.classification)
+    if not guideline:
+        logger.warning(
+            "  No guideline found for article type: %s",
+            stage2.classification,
+        )
+        guideline = (
+            f"Write a {stage2.classification} article based on the provided content."
+        )
+    logger.info("  Guideline length: %d chars", len(guideline))
+
+    logger.info("  Step 2: Checking transcript coverage...")
+    (
+        coverage_sufficient,
+        coverage_analysis,
+        missing_sections,
+        coverage_prompt,
+        coverage_response,
+    ) = check_coverage(stage1.cleaned_transcript, guideline, llm)
+    logger.info("  Coverage sufficient: %s", coverage_sufficient)
+    logger.info("  Analysis: %s", coverage_analysis)
+    if missing_sections:
+        logger.info("  Missing sections: %s", missing_sections)
+
+    supplemental_content = None
+    supplement_prompt = None
+    supplement_response = None
+    if not coverage_sufficient and missing_sections:
+        logger.info("  Step 3: Generating supplemental content...")
+        (
+            supplemental_content,
+            supplement_prompt,
+            supplement_response,
+        ) = gather_missing_info(
+            stage1.cleaned_transcript,
+            missing_sections,
+            stage2.classification,
+            llm,
+            tone_guidance,
+        )
+        logger.info(
+            "  Supplemental content length: %d chars",
+            len(supplemental_content) if supplemental_content else 0,
+        )
+    else:
+        logger.info("  Step 3: Skipping supplemental content (coverage sufficient)")
+
+    logger.info("  Step 4: Composing final article...")
+    final_article, composition_prompt, composition_response = compose_article(
+        stage1.cleaned_transcript,
+        supplemental_content,
+        guideline,
+        stage2.classification,
+        stage1.title,
+        make_llm(compose_model),
+        tone_guidance,
+    )
+    logger.info("  Final article length: %d chars", len(final_article))
+
+    output = Stage3Output(
+        video_id=stage1.video_id,
+        title=stage1.title,
+        article_type=stage2.classification,
+        coverage_sufficient=coverage_sufficient,
+        coverage_analysis=coverage_analysis,
+        missing_sections=missing_sections,
+        supplemental_content=supplemental_content,
+        final_article=final_article,
+        guideline_used=guideline,
+        debug_coverage_prompt=coverage_prompt,
+        debug_coverage_response=coverage_response,
+        debug_supplement_prompt=supplement_prompt,
+        debug_supplement_response=supplement_response,
+        debug_composition_prompt=composition_prompt,
+        debug_composition_response=composition_response,
+    )
+
+    logger.info("=" * 60)
+    logger.info("  Stage 3 complete!")
+    logger.info("=" * 60)
+    return output

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_supplement.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_supplement.py
@@ -1,0 +1,108 @@
+"""Missing-section supplementation for YouTube2Blog Stage 3."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.prompts import PromptTemplate
+
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+from app.shared.text import enforce_anti_ai_tells_markdown
+
+logger = logging.getLogger(__name__)
+
+SUPPLEMENT_PROMPT = """You are a content enhancement specialist.
+
+The following transcript is being converted into a "{article_type}" article,
+but it's missing some required sections. Your task is to generate
+supplemental content that logically extends what's in the transcript.
+
+---
+
+ORIGINAL TRANSCRIPT (for context):
+
+{transcript}
+
+---
+
+MISSING SECTIONS TO GENERATE:
+
+{missing_sections}
+
+---
+
+GENERATION RULES:
+
+1. Base supplemental content on themes and topics from the transcript
+2. Do NOT invent specific facts, statistics, or claims not in the transcript
+3. Use general knowledge to expand on concepts mentioned
+4. Preserve the source meaning and details; do not copy transcript filler, hedges, or rambling cadence
+5. Keep each section concise (2-4 paragraphs)
+6. Use clear logical transitions only where needed; avoid stock transition phrases
+7. Supplemental context may explain concepts already mentioned in the transcript, but the final article cannot invent unsupported specifics
+
+---
+
+OUTPUT FORMAT:
+
+Write the supplemental content as markdown, with each section clearly labeled.
+Do NOT include any JSON formatting. Just write the content directly.
+
+Example:
+## [Section Name]
+
+[Content for this section...]
+
+## [Another Section]
+
+[Content for this section...]
+{general_guidelines}
+"""
+
+
+def gather_missing_info(
+    transcript: str,
+    missing_sections: list[str],
+    article_type: str,
+    llm: Any,
+    tone_guidance: str | None = None,
+    *,
+    load_general_guidelines: Callable[[], str],
+) -> tuple[str, str, str]:
+    """Generate supplemental Markdown for uncovered guideline sections."""
+    prompt = PromptTemplate(
+        input_variables=[
+            "transcript",
+            "missing_sections",
+            "article_type",
+            "general_guidelines",
+        ],
+        template=SUPPLEMENT_PROMPT,
+    )
+    full_prompt = prompt.format(
+        transcript=transcript[:10000],
+        missing_sections="\n".join(f"- {section}" for section in missing_sections),
+        article_type=article_type,
+        general_guidelines=load_general_guidelines(),
+    )
+    if tone_guidance:
+        full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"
+    full_prompt = f"{full_prompt}\n\n{ANTI_AI_TELLS_FULL}"
+    logger.info("  Supplement generation prompt length: %d chars", len(full_prompt))
+
+    result = llm.invoke(full_prompt)
+    logger.info(
+        "  Supplement generation response length: %d chars",
+        len(result) if result else 0,
+    )
+    if not result or not result.strip():
+        return "", full_prompt, result
+
+    supplemental = enforce_anti_ai_tells_markdown(
+        str(result),
+        repair=lambda repair_prompt: llm.invoke(repair_prompt),
+        context="youtube2blog supplement",
+    )
+    return supplemental, full_prompt, result

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage3_facade.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage3_facade.py
@@ -1,0 +1,169 @@
+from app.features.youtube2blog.stages import stage_3
+from app.features.youtube2blog.stages.stage_3_coverage import check_coverage
+from shared import Stage1Output, Stage2Output
+
+
+class _FakeLlm:
+    def __init__(self, response: str):
+        self.response = response
+        self.prompts: list[str] = []
+
+    def invoke(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.response
+
+
+def test_guideline_lookup_prefers_normalized_markdown_file(
+    monkeypatch,
+    tmp_path,
+):
+    guideline_path = tmp_path / "News & Trends.md"
+    guideline_path.write_text("Use the news structure.", encoding="utf-8")
+    database_calls: list[str] = []
+
+    def track_database_lookup(article_type: str):
+        database_calls.append(article_type)
+        return None
+
+    monkeypatch.setattr(stage_3, "ARTICLE_GUIDELINES_DIR", tmp_path)
+    monkeypatch.setattr(
+        stage_3,
+        "get_article_type_by_name",
+        track_database_lookup,
+    )
+
+    assert (
+        stage_3.stage_3_retrieve_guideline("News and Trends")
+        == "Use the news structure."
+    )
+    assert database_calls == []
+
+
+def test_guideline_lookup_preserves_database_patch_seam(monkeypatch):
+    monkeypatch.setattr(stage_3, "_load_guideline_from_file", lambda _name: "")
+    monkeypatch.setattr(
+        stage_3,
+        "get_article_type_by_name",
+        lambda name: {"guideline": f"Database guideline for {name}."},
+    )
+
+    assert (
+        stage_3.stage_3_retrieve_guideline("Review") == "Database guideline for Review."
+    )
+
+
+def test_coverage_analysis_parses_provider_response():
+    llm = _FakeLlm(
+        '{"coverage_sufficient": false, "analysis": "One gap.", '
+        '"missing_sections": ["Costs"]}'
+    )
+
+    result = check_coverage(
+        "Transcript",
+        "Guideline",
+        llm,
+        load_general_guidelines=lambda: "\n\nGeneral guidance.",
+    )
+
+    assert result[:3] == (False, "One gap.", ["Costs"])
+    assert "General guidance." in result[3]
+    assert result[4] == llm.response
+
+
+def test_legacy_stage_facade_orchestrates_extracted_concerns(monkeypatch):
+    analysis_llm = object()
+    composition_llm = object()
+    requested_models: list[str] = []
+
+    def fake_make_llm(model_name: str = "analysis-model"):
+        requested_models.append(model_name)
+        if model_name == stage_3.Y2B_COMPOSE_MODEL:
+            return composition_llm
+        return analysis_llm
+
+    def fake_check(transcript, guideline, llm):
+        assert llm is analysis_llm
+        return (
+            False,
+            f"{transcript} lacks {guideline}",
+            ["Context"],
+            "coverage prompt",
+            "coverage response",
+        )
+
+    def fake_gather(transcript, sections, article_type, llm, tone):
+        assert transcript == "Clean transcript"
+        assert sections == ["Context"]
+        assert article_type == "Review"
+        assert llm is analysis_llm
+        return (
+            "## Context\n\nSupplement.",
+            f"supplement prompt: {tone}",
+            "supplement response",
+        )
+
+    def fake_compose(
+        transcript,
+        supplement,
+        guideline,
+        article_type,
+        title,
+        llm,
+        tone,
+    ):
+        assert transcript == "Clean transcript"
+        assert supplement == "## Context\n\nSupplement."
+        assert guideline == "Review guideline."
+        assert article_type == "Review"
+        assert title == "Original title"
+        assert llm is composition_llm
+        return (
+            "# Final article",
+            f"composition prompt: {tone}",
+            "composition response",
+        )
+
+    monkeypatch.setattr(stage_3, "_stage3_llm", fake_make_llm)
+    monkeypatch.setattr(
+        stage_3,
+        "_retrieve_guideline",
+        lambda _article_type: "Review guideline.",
+    )
+    monkeypatch.setattr(
+        stage_3,
+        "_check_coverage",
+        fake_check,
+    )
+    monkeypatch.setattr(
+        stage_3,
+        "_gather_missing_info",
+        fake_gather,
+    )
+    monkeypatch.setattr(
+        stage_3,
+        "_compose_article",
+        fake_compose,
+    )
+
+    output = stage_3.stage_3_compose_article(
+        Stage1Output(
+            video_id="video-1",
+            title="Original title",
+            cleaned_transcript="Clean transcript",
+        ),
+        Stage2Output(
+            video_id="video-1",
+            title="Original title",
+            classification="Review",
+            confidence=0.9,
+            reasoning="Strong match.",
+        ),
+        tone_guidance="Keep it direct.",
+    )
+
+    assert requested_models == ["analysis-model", stage_3.Y2B_COMPOSE_MODEL]
+    assert output.coverage_sufficient is False
+    assert output.missing_sections == ["Context"]
+    assert output.supplemental_content == "## Context\n\nSupplement."
+    assert output.final_article == "# Final article"
+    assert output.debug_composition_response == "composition response"


### PR DESCRIPTION
## Original issue and root cause

`stage_3.py` had grown to 578 lines and mixed filesystem/database guideline retrieval, Coverage Analysis prompting and parsing, supplementation, composition, provider calls, anti-AI repair, and sequential orchestration. These policies accumulated around the original all-in-one Stage 3 entry point even after graph callers began using its individual functions.

## Refactor

- Split guideline retrieval, Coverage Analysis, supplementation, final composition, and legacy sequential orchestration into focused feature-local modules.
- Keep `stage_3.py` as the stable facade for graph callers, the legacy all-in-one entry point, and existing private monkeypatch seams.
- Preserve prompt text, model selection, output/debug payloads, fallback behavior, and anti-AI prose repair.
- Document the Stage 3 module boundaries in the YouTube2Blog context map.
- Add focused facade, guideline-source, parsing, and legacy-orchestration tests.

## Why this design is better

Each concern is independently testable and has one reason to change. Graph-facing and legacy APIs remain stable, while the split deliberately avoids crossing into the separate Stage 3 quality-gate or Editorial Augmentation modules.

Compatibility evidence:

- Public exports and graph-facing function signatures are unchanged.
- The legacy `stage_3_compose_article` workflow remains available.
- Existing private helper and provider patch seams remain available through the facade.
- All three extracted prompt templates are byte-for-byte identical to the originals.
- Coverage Analysis, supplement, composition, `Stage3Output`, and debug-field behavior are unchanged.

## Validation

- Black on all changed Python files: passed.
- `pnpm run lint`: all four configured AI Blog Writer targets passed.
- Converter configured typecheck: passed.
- Focused Stage 3 tests: 7 passed.
- All YouTube2Blog backend tests: 55 passed.
- Full `pnpm run test`: 359 frontend and 346 backend tests passed.
- `pnpm run build`: passed.
- Repository-wide Black reports 60 pre-existing files outside this change; standalone frontend TypeScript reports five existing homepage/listicle errors. Configured lint, test, and production build targets pass.

## Risks, tradeoffs, and follow-ups

- More internal modules increase import-boundary overhead; the facade intentionally absorbs compatibility concerns.
- Import/patch-seam or prompt drift is the primary risk; focused facade tests and byte-for-byte prompt assertions cover it.
- No quality-gate or Editorial Augmentation behavior changed.
- Future guideline, coverage, supplement, and composition changes should remain in their owning modules; retire legacy/private wrappers only in a separately reviewed compatibility change.
