### PR TITLE
NOJIRA: Decompose location upload controller

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads.controller.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads.controller.ts
@@ -1,370 +1,43 @@
 import type { Context } from "hono";
-import type { ImageVariantType, VariantCropRegion } from "@questurian/lm-shared";
-import { successResponse } from "@shared/types/api-response";
-import { BadRequestError } from "@shared/errors/http-error";
-import {
-  MAX_FILE_SIZE,
-  MAX_TOTAL_SIZE,
-  type AddUploadParamsDto,
-  type DeleteUploadParamsDto,
-  type UploadIdParamsDto,
-  type UpdateUploadPhotographerCreditBodyDto,
-} from "../../validation/schemas/uploads.schemas";
 import { getUploadsControllerDeps } from "../dependencies";
+import {
+  handleAddImageSetUpload,
+  handleLegacyUpload,
+  handleReplaceUploadVariants,
+} from "./uploads/image-set-upload.handlers";
+import { handleGenerateAltText } from "./uploads/upload-alt-text.handler";
+import {
+  handleDeleteUpload,
+  handleReprocessUploadVariants,
+  handleUpdateUploadPhotographerCredit,
+} from "./uploads/upload-lifecycle.handlers";
 
 const { uploads } = getUploadsControllerDeps();
 
-const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
-const REQUIRED_VARIANT_TYPES: ImageVariantType[] = [
-  "thumbnail",
-  "square",
-  "wide",
-  "open_graph",
-  "editorial",
-  "portrait",
-  "hero",
-];
-
-function parseRequiredPhotographerCredit(formData: FormData): string {
-  const photographerCredit = formData.get("photographerCredit");
-  if (typeof photographerCredit !== "string") {
-    throw new BadRequestError("Photographer credit is required");
-  }
-
-  const normalizedCredit = photographerCredit.trim();
-  if (!normalizedCredit) {
-    throw new BadRequestError("Photographer credit is required");
-  }
-
-  return normalizedCredit;
-}
-
-function isVariantCropRegion(value: unknown): value is VariantCropRegion {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Record<string, unknown>;
-  return (
-    typeof candidate.left === "number" &&
-    typeof candidate.top === "number" &&
-    typeof candidate.width === "number" &&
-    typeof candidate.height === "number"
-  );
-}
-
-/**
- * Parse the optional `cropRegions_0` sidecar JSON sent by the LM upload form.
- * Format: `{ "<variantType>": { left, top, width, height }, ... }` (pixels in
- * the source image). Persisted on each ImageVariant so the Questura
- * `from-source` pipeline can reproduce the crops server-side per ADR 0002.
- */
-function parseCropRegionsForUpload(
-  formData: FormData,
-): Partial<Record<ImageVariantType, VariantCropRegion>> {
-  const raw = formData.get("cropRegions_0");
-  if (typeof raw !== "string" || !raw.trim()) return {};
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new BadRequestError("cropRegions_0 must be valid JSON");
-  }
-  if (typeof parsed !== "object" || parsed === null) {
-    throw new BadRequestError("cropRegions_0 must be an object keyed by variant type");
-  }
-  const result: Partial<Record<ImageVariantType, VariantCropRegion>> = {};
-  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
-    if (!REQUIRED_VARIANT_TYPES.includes(key as ImageVariantType)) {
-      throw new BadRequestError(`cropRegions_0 has unknown variant key: ${key}`);
-    }
-    if (!isVariantCropRegion(value)) {
-      throw new BadRequestError(
-        `cropRegions_0[${key}] must be { left, top, width, height } numbers`,
-      );
-    }
-    result[key as ImageVariantType] = value;
-  }
-  return result;
-}
-
 export async function postAddUpload(c: Context) {
-  throw new BadRequestError(
-    "Legacy upload endpoint is disabled. Use /api/:category/:id/uploads/imageset with photographerCredit."
-  );
+  return handleLegacyUpload(c);
+}
+
+export async function postAddUploadImageSet(c: Context) {
+  return handleAddImageSetUpload(c, uploads);
+}
+
+export async function postReplaceUploadVariants(c: Context) {
+  return handleReplaceUploadVariants(c, uploads);
 }
 
 export async function deleteUpload(c: Context) {
-  // Extract validated URL parameter
-  const params = c.get("validatedParams") as DeleteUploadParamsDto;
-  const uploadId = parseInt(params.id, 10);
-
-  if (isNaN(uploadId)) {
-    throw new BadRequestError("Invalid upload ID");
-  }
-
-  // Call service to delete upload (includes file cleanup)
-  await uploads.deleteUpload(uploadId);
-
-  return c.json(successResponse({ message: "Upload deleted successfully" }));
+  return handleDeleteUpload(c, uploads);
 }
 
-/**
- * PATCH /api/uploads/:id/photographer-credit
- * Update photographer credit for an existing image-set upload
- */
 export async function patchUploadPhotographerCredit(c: Context) {
-  const params = c.get("validatedParams") as UploadIdParamsDto;
-  const body = c.get("validatedBody") as UpdateUploadPhotographerCreditBodyDto;
-  const uploadId = parseInt(params.id, 10);
-
-  if (isNaN(uploadId)) {
-    throw new BadRequestError("Upload ID must be a number");
-  }
-
-  const entry = await uploads.updateUploadPhotographerCredit(
-    uploadId,
-    body.photographerCredit
-  );
-
-  return c.json(successResponse({ entry }));
+  return handleUpdateUploadPhotographerCredit(c, uploads);
 }
 
-/**
- * POST /api/add-upload-imageset/:id
- * Upload a multi-variant image set (source + all configured variants)
- */
-export async function postAddUploadImageSet(c: Context) {
-  const formData = await c.req.formData();
-
-  // Extract validated URL parameter
-  const params = c.get("validatedParams") as AddUploadParamsDto;
-  const locationId = params.id;
-
-  // Parse photographer credit
-  const photographerCreditValue = parseRequiredPhotographerCredit(formData);
-
-  // Parse alt text (optional - will generate if not provided)
-  const altText = formData.get("altText");
-  const altTextValue = typeof altText === "string"
-    ? (altText.trim() || null)
-    : null;
-
-  // Parse source file (only expecting 1 source file for now)
-  const sourceFile = formData.get("source_0");
-  if (!sourceFile || !(sourceFile instanceof File)) {
-    throw new BadRequestError("Source file required (source_0)");
-  }
-
-  // Validate source file
-  if (!ALLOWED_MIME_TYPES.includes(sourceFile.type)) {
-    throw new BadRequestError(
-      `Invalid source file type. Only JPEG, PNG, and WebP images are allowed.`
-    );
-  }
-
-  if (sourceFile.size > MAX_FILE_SIZE) {
-    throw new BadRequestError(`Source file exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
-  }
-
-  const cropRegions = parseCropRegionsForUpload(formData);
-
-  // Parse variant files (expecting all configured variants)
-  const variantFiles: {
-    type: ImageVariantType;
-    file: File;
-    cropRegion?: VariantCropRegion;
-  }[] = [];
-
-  let totalSize = sourceFile.size;
-
-  for (const type of REQUIRED_VARIANT_TYPES) {
-    const fileKey = `variant_0_${type}`;
-    const file = formData.get(fileKey);
-
-    if (!file || !(file instanceof File)) {
-      throw new BadRequestError(`Missing variant file: ${type} (expected key: ${fileKey})`);
-    }
-
-    // Validate variant file
-    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
-      throw new BadRequestError(
-        `Invalid file type for variant "${type}". Only JPEG, PNG, and WebP images are allowed.`
-      );
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      throw new BadRequestError(`Variant "${type}" exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
-    }
-
-    totalSize += file.size;
-    variantFiles.push({
-      type,
-      file,
-      ...(cropRegions[type] ? { cropRegion: cropRegions[type] } : {}),
-    });
-  }
-
-  // Validate total size (source + all variants)
-  if (totalSize > MAX_TOTAL_SIZE) {
-    throw new BadRequestError(`Total upload size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit`);
-  }
-
-  // Call service to process the upload
-  const entry = await uploads.addImageSetUpload(
-    locationId,
-    sourceFile,
-    variantFiles,
-    photographerCreditValue,
-    altTextValue
-  );
-
-  return c.json(successResponse({ entry }));
-}
-
-/**
- * POST /api/uploads/:id/reprocess-variants
- * Regenerate all configured variants from the stored source image.
- * Only allowed when the upload has fewer than 7 variants.
- */
 export async function postReprocessUploadVariants(c: Context) {
-  const params = c.get("validatedParams") as UploadIdParamsDto;
-  const uploadId = parseInt(params.id, 10);
-
-  if (isNaN(uploadId)) {
-    throw new BadRequestError("Upload ID must be a number");
-  }
-
-  const entry = await uploads.reprocessUploadVariants(uploadId);
-
-  return c.json(successResponse({ entry }));
+  return handleReprocessUploadVariants(c, uploads);
 }
 
-/**
- * POST /api/uploads/:id/replace-variants
- * Replace source + all variants for an existing image-set upload.
- */
-export async function postReplaceUploadVariants(c: Context) {
-  const formData = await c.req.formData();
-  const params = c.get("validatedParams") as UploadIdParamsDto;
-  const uploadId = parseInt(params.id, 10);
-
-  if (isNaN(uploadId)) {
-    throw new BadRequestError("Upload ID must be a number");
-  }
-
-  const altText = formData.get("altText");
-  const altTextValue = typeof altText === "string" ? altText : undefined;
-
-  const sourceFile = formData.get("source_0");
-  if (!sourceFile || !(sourceFile instanceof File)) {
-    throw new BadRequestError("Source file required (source_0)");
-  }
-
-  if (!ALLOWED_MIME_TYPES.includes(sourceFile.type)) {
-    throw new BadRequestError(
-      `Invalid source file type. Only JPEG, PNG, and WebP images are allowed.`
-    );
-  }
-
-  if (sourceFile.size > MAX_FILE_SIZE) {
-    throw new BadRequestError(`Source file exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
-  }
-
-  const cropRegions = parseCropRegionsForUpload(formData);
-
-  const variantFiles: {
-    type: ImageVariantType;
-    file: File;
-    cropRegion?: VariantCropRegion;
-  }[] = [];
-  let totalSize = sourceFile.size;
-
-  for (const type of REQUIRED_VARIANT_TYPES) {
-    const fileKey = `variant_0_${type}`;
-    const file = formData.get(fileKey);
-
-    if (!file || !(file instanceof File)) {
-      throw new BadRequestError(`Missing variant file: ${type} (expected key: ${fileKey})`);
-    }
-
-    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
-      throw new BadRequestError(
-        `Invalid file type for variant "${type}". Only JPEG, PNG, and WebP images are allowed.`
-      );
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      throw new BadRequestError(`Variant "${type}" exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
-    }
-
-    totalSize += file.size;
-    variantFiles.push({
-      type,
-      file,
-      ...(cropRegions[type] ? { cropRegion: cropRegions[type] } : {}),
-    });
-  }
-
-  if (totalSize > MAX_TOTAL_SIZE) {
-    throw new BadRequestError(`Total upload size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit`);
-  }
-
-  const entry = await uploads.replaceUploadVariants(
-    uploadId,
-    sourceFile,
-    variantFiles,
-    altTextValue
-  );
-
-  return c.json(successResponse({ entry }));
-}
-
-/**
- * Generate alt text for an image preview (before upload)
- * POST /api/generate-alt-text
- */
 export async function postGenerateAltText(c: Context) {
-  const formData = await c.req.formData();
-
-  // Parse image file
-  const imageFile = formData.get("image");
-  if (!imageFile || !(imageFile instanceof File)) {
-    throw new BadRequestError("Image file required");
-  }
-
-  // Validate image file
-  if (!ALLOWED_MIME_TYPES.includes(imageFile.type)) {
-    throw new BadRequestError(
-      `Invalid file type. Only JPEG, PNG, WebP, and GIF images are allowed.`
-    );
-  }
-
-  if (imageFile.size > MAX_FILE_SIZE) {
-    throw new BadRequestError(`File exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
-  }
-
-  // Generate alt text using the service
-  try {
-    const imageBuffer = await imageFile.arrayBuffer();
-    const fileExtension = imageFile.name.split('.').pop()?.toLowerCase() || 'jpg';
-
-    const altText = await uploads.generateAltText(
-      Buffer.from(imageBuffer),
-      imageFile.name,
-      fileExtension
-    );
-    const uploadIdRaw = formData.get("uploadId");
-    if (typeof uploadIdRaw === "string" && uploadIdRaw.trim()) {
-      const uploadId = Number(uploadIdRaw);
-      if (!Number.isInteger(uploadId) || uploadId <= 0) throw new BadRequestError("Valid uploadId required");
-      uploads.cacheStagedAltText(uploadId, altText);
-    }
-
-    return c.json(successResponse({ altText }));
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error("[AltText][Vertex] Failed to generate preview alt text", {
-      filename: imageFile.name,
-      error: errorMessage,
-    });
-    throw new BadRequestError("Failed to generate alt text");
-  }
+  return handleGenerateAltText(c, uploads);
 }

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.handlers.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.handlers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { ImageSetUpload } from "../../../models/location";
+import type { UploadsService } from "../../../services/integrations/uploads.service";
+import {
+  handleAddImageSetUpload,
+  handleReplaceUploadVariants,
+} from "./image-set-upload.handlers";
+import { REQUIRED_VARIANT_TYPES } from "./image-set-upload.request";
+
+type TestEnv = {
+  Variables: {
+    validatedParams: unknown;
+    validatedBody: unknown;
+  };
+};
+
+function completeImageSetFormData(): FormData {
+  const formData = new FormData();
+  formData.set(
+    "source_0",
+    new File(["source"], "source.jpg", { type: "image/jpeg" }),
+  );
+  for (const type of REQUIRED_VARIANT_TYPES) {
+    formData.set(
+      `variant_0_${type}`,
+      new File([type], `${type}.webp`, { type: "image/webp" }),
+    );
+  }
+  return formData;
+}
+
+describe("image-set upload handlers", () => {
+  test("passes a parsed create request to the upload service", async () => {
+    const calls: unknown[][] = [];
+    const entry = {
+      id: 91,
+      location_id: 42,
+      format: "imageset",
+    } as ImageSetUpload;
+    const app = new Hono<TestEnv>();
+    app.post("/", async (c) => {
+      c.set("validatedParams", { id: 42 });
+      const uploads: Pick<UploadsService, "addImageSetUpload"> = {
+        addImageSetUpload: async (
+          ...args: Parameters<UploadsService["addImageSetUpload"]>
+        ) => {
+          calls.push(args);
+          return entry;
+        },
+      };
+      return handleAddImageSetUpload(c, uploads);
+    });
+
+    const formData = completeImageSetFormData();
+    formData.set("photographerCredit", "  Jane Doe  ");
+    const response = await app.request("/", { method: "POST", body: formData });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      data: { entry },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe(42);
+    expect(calls[0]?.[2]).toHaveLength(REQUIRED_VARIANT_TYPES.length);
+    expect(calls[0]?.[3]).toBe("Jane Doe");
+    expect(calls[0]?.[4]).toBeNull();
+  });
+
+  test("passes replacement data without requiring photographer credit", async () => {
+    const calls: unknown[][] = [];
+    const entry = {
+      id: 91,
+      location_id: 42,
+      format: "imageset",
+    } as ImageSetUpload;
+    const app = new Hono<TestEnv>();
+    app.post("/", async (c) => {
+      c.set("validatedParams", { id: "91" });
+      const uploads: Pick<UploadsService, "replaceUploadVariants"> = {
+        replaceUploadVariants: async (
+          ...args: Parameters<UploadsService["replaceUploadVariants"]>
+        ) => {
+          calls.push(args);
+          return entry;
+        },
+      };
+      return handleReplaceUploadVariants(c, uploads);
+    });
+
+    const formData = completeImageSetFormData();
+    formData.set("altText", "New description");
+    const response = await app.request("/", { method: "POST", body: formData });
+
+    expect(response.status).toBe(200);
+    expect(calls[0]?.[0]).toBe(91);
+    expect(calls[0]?.[3]).toBe("New description");
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.handlers.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.handlers.ts
@@ -1,0 +1,66 @@
+import type { Context } from "hono";
+import { BadRequestError } from "@shared/errors/http-error";
+import { successResponse } from "@shared/types/api-response";
+import type { UploadsService } from "../../../services/integrations/uploads.service";
+import type {
+  AddUploadParamsDto,
+  UploadIdParamsDto,
+} from "../../../validation/schemas/uploads.schemas";
+import {
+  parseNewImageSetUploadRequest,
+  parseReplacementImageSetUploadRequest,
+} from "./image-set-upload.request";
+
+export function handleLegacyUpload(_c: Context) {
+  throw new BadRequestError(
+    "Legacy upload endpoint is disabled. Use /api/:category/:id/uploads/imageset with photographerCredit.",
+  );
+}
+
+/**
+ * POST /api/:category/:id/uploads/imageset
+ * Upload a source image and all configured variants as one image set.
+ */
+export async function handleAddImageSetUpload(
+  c: Context,
+  uploads: Pick<UploadsService, "addImageSetUpload">,
+) {
+  const formData = await c.req.formData();
+  const params = c.get("validatedParams") as AddUploadParamsDto;
+  const request = parseNewImageSetUploadRequest(formData);
+  const entry = await uploads.addImageSetUpload(
+    params.id,
+    request.sourceFile,
+    request.variantFiles,
+    request.photographerCredit,
+    request.altText,
+  );
+
+  return c.json(successResponse({ entry }));
+}
+
+/**
+ * POST /api/uploads/:id/replace-variants
+ * Replace the source image and all variants for an existing image set.
+ */
+export async function handleReplaceUploadVariants(
+  c: Context,
+  uploads: Pick<UploadsService, "replaceUploadVariants">,
+) {
+  const formData = await c.req.formData();
+  const params = c.get("validatedParams") as UploadIdParamsDto;
+  const uploadId = Number.parseInt(params.id, 10);
+  if (Number.isNaN(uploadId)) {
+    throw new BadRequestError("Upload ID must be a number");
+  }
+
+  const request = parseReplacementImageSetUploadRequest(formData);
+  const entry = await uploads.replaceUploadVariants(
+    uploadId,
+    request.sourceFile,
+    request.variantFiles,
+    request.altText,
+  );
+
+  return c.json(successResponse({ entry }));
+}

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.request.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.request.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { BadRequestError } from "@shared/errors/http-error";
+import {
+  parseNewImageSetUploadRequest,
+  parseReplacementImageSetUploadRequest,
+  REQUIRED_VARIANT_TYPES,
+} from "./image-set-upload.request";
+
+function imageFile(name: string, type = "image/jpeg"): File {
+  return new File(["image-bytes"], name, { type });
+}
+
+function completeImageSetFormData(): FormData {
+  const formData = new FormData();
+  formData.set("source_0", imageFile("source.jpg"));
+  for (const type of REQUIRED_VARIANT_TYPES) {
+    formData.set(`variant_0_${type}`, imageFile(`${type}.webp`, "image/webp"));
+  }
+  return formData;
+}
+
+describe("image-set upload request parsing", () => {
+  test("normalizes new upload metadata and attaches crop regions", () => {
+    const formData = completeImageSetFormData();
+    formData.set("photographerCredit", "  Jane Doe  ");
+    formData.set("altText", "  A market at dusk  ");
+    formData.set(
+      "cropRegions_0",
+      JSON.stringify({
+        square: { left: 10, top: 20, width: 300, height: 300 },
+      }),
+    );
+
+    const request = parseNewImageSetUploadRequest(formData);
+
+    expect(request.photographerCredit).toBe("Jane Doe");
+    expect(request.altText).toBe("A market at dusk");
+    expect(request.variantFiles.map(({ type }) => type)).toEqual([
+      ...REQUIRED_VARIANT_TYPES,
+    ]);
+    expect(
+      request.variantFiles.find(({ type }) => type === "square")?.cropRegion,
+    ).toEqual({ left: 10, top: 20, width: 300, height: 300 });
+  });
+
+  test("preserves replacement alt text for service-level normalization", () => {
+    const formData = completeImageSetFormData();
+    formData.set("altText", "  replacement text  ");
+
+    const request = parseReplacementImageSetUploadRequest(formData);
+
+    expect(request.altText).toBe("  replacement text  ");
+  });
+
+  test("rejects a missing configured variant with the existing message", () => {
+    const formData = completeImageSetFormData();
+    formData.set("photographerCredit", "Jane Doe");
+    formData.delete("variant_0_hero");
+
+    expect(() => parseNewImageSetUploadRequest(formData)).toThrow(
+      "Missing variant file: hero (expected key: variant_0_hero)",
+    );
+  });
+
+  test("rejects unknown crop-region keys", () => {
+    const formData = completeImageSetFormData();
+    formData.set("photographerCredit", "Jane Doe");
+    formData.set(
+      "cropRegions_0",
+      JSON.stringify({
+        social: { left: 0, top: 0, width: 100, height: 100 },
+      }),
+    );
+
+    expect(() => parseNewImageSetUploadRequest(formData)).toThrow(
+      new BadRequestError("cropRegions_0 has unknown variant key: social"),
+    );
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.request.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/image-set-upload.request.ts
@@ -1,0 +1,199 @@
+import type {
+  ImageVariantType,
+  VariantCropRegion,
+} from "@questurian/lm-shared";
+import { BadRequestError } from "@shared/errors/http-error";
+import {
+  MAX_FILE_SIZE,
+  MAX_TOTAL_SIZE,
+} from "../../../validation/schemas/uploads.schemas";
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export const REQUIRED_VARIANT_TYPES = [
+  "thumbnail",
+  "square",
+  "wide",
+  "open_graph",
+  "editorial",
+  "portrait",
+  "hero",
+] as const satisfies readonly ImageVariantType[];
+
+export type ImageSetVariantUpload = {
+  type: ImageVariantType;
+  file: File;
+  cropRegion?: VariantCropRegion;
+};
+
+export interface NewImageSetUploadRequest {
+  sourceFile: File;
+  variantFiles: ImageSetVariantUpload[];
+  photographerCredit: string;
+  altText: string | null;
+}
+
+export interface ReplacementImageSetUploadRequest {
+  sourceFile: File;
+  variantFiles: ImageSetVariantUpload[];
+  altText: string | undefined;
+}
+
+function parseRequiredPhotographerCredit(formData: FormData): string {
+  const photographerCredit = formData.get("photographerCredit");
+  if (typeof photographerCredit !== "string") {
+    throw new BadRequestError("Photographer credit is required");
+  }
+
+  const normalizedCredit = photographerCredit.trim();
+  if (!normalizedCredit) {
+    throw new BadRequestError("Photographer credit is required");
+  }
+
+  return normalizedCredit;
+}
+
+function isVariantCropRegion(value: unknown): value is VariantCropRegion {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.left === "number" &&
+    typeof candidate.top === "number" &&
+    typeof candidate.width === "number" &&
+    typeof candidate.height === "number"
+  );
+}
+
+/**
+ * Parse the optional `cropRegions_0` sidecar JSON sent by the LM upload form.
+ * Values are pixel coordinates in the source image and let Questura reproduce
+ * each crop server-side per ADR 0002.
+ */
+function parseCropRegions(
+  formData: FormData,
+): Partial<Record<ImageVariantType, VariantCropRegion>> {
+  const raw = formData.get("cropRegions_0");
+  if (typeof raw !== "string" || !raw.trim()) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new BadRequestError("cropRegions_0 must be valid JSON");
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new BadRequestError(
+      "cropRegions_0 must be an object keyed by variant type",
+    );
+  }
+
+  const result: Partial<Record<ImageVariantType, VariantCropRegion>> = {};
+  for (const [key, value] of Object.entries(
+    parsed as Record<string, unknown>,
+  )) {
+    if (!REQUIRED_VARIANT_TYPES.includes(key as ImageVariantType)) {
+      throw new BadRequestError(
+        `cropRegions_0 has unknown variant key: ${key}`,
+      );
+    }
+    if (!isVariantCropRegion(value)) {
+      throw new BadRequestError(
+        `cropRegions_0[${key}] must be { left, top, width, height } numbers`,
+      );
+    }
+    result[key as ImageVariantType] = value;
+  }
+
+  return result;
+}
+
+function parseImageSetFiles(formData: FormData): {
+  sourceFile: File;
+  variantFiles: ImageSetVariantUpload[];
+} {
+  const sourceFile = formData.get("source_0");
+  if (!(sourceFile instanceof File)) {
+    throw new BadRequestError("Source file required (source_0)");
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(sourceFile.type)) {
+    throw new BadRequestError(
+      "Invalid source file type. Only JPEG, PNG, and WebP images are allowed.",
+    );
+  }
+
+  if (sourceFile.size > MAX_FILE_SIZE) {
+    throw new BadRequestError(
+      `Source file exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`,
+    );
+  }
+
+  const cropRegions = parseCropRegions(formData);
+  const variantFiles: ImageSetVariantUpload[] = [];
+  let totalSize = sourceFile.size;
+
+  for (const type of REQUIRED_VARIANT_TYPES) {
+    const fileKey = `variant_0_${type}`;
+    const file = formData.get(fileKey);
+
+    if (!(file instanceof File)) {
+      throw new BadRequestError(
+        `Missing variant file: ${type} (expected key: ${fileKey})`,
+      );
+    }
+
+    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+      throw new BadRequestError(
+        `Invalid file type for variant "${type}". Only JPEG, PNG, and WebP images are allowed.`,
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw new BadRequestError(
+        `Variant "${type}" exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`,
+      );
+    }
+
+    totalSize += file.size;
+    variantFiles.push({
+      type,
+      file,
+      ...(cropRegions[type] ? { cropRegion: cropRegions[type] } : {}),
+    });
+  }
+
+  if (totalSize > MAX_TOTAL_SIZE) {
+    throw new BadRequestError(
+      `Total upload size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit`,
+    );
+  }
+
+  return { sourceFile, variantFiles };
+}
+
+export function parseNewImageSetUploadRequest(
+  formData: FormData,
+): NewImageSetUploadRequest {
+  const photographerCredit = parseRequiredPhotographerCredit(formData);
+  const altText = formData.get("altText");
+  const altTextValue =
+    typeof altText === "string" ? altText.trim() || null : null;
+
+  return {
+    ...parseImageSetFiles(formData),
+    photographerCredit,
+    altText: altTextValue,
+  };
+}
+
+export function parseReplacementImageSetUploadRequest(
+  formData: FormData,
+): ReplacementImageSetUploadRequest {
+  const altText = formData.get("altText");
+
+  return {
+    ...parseImageSetFiles(formData),
+    altText: typeof altText === "string" ? altText : undefined,
+  };
+}

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-alt-text.handler.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-alt-text.handler.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { UploadsService } from "../../../services/integrations/uploads.service";
+import { handleGenerateAltText } from "./upload-alt-text.handler";
+
+function appWithErrorBody() {
+  const app = new Hono();
+  app.onError((error, c) =>
+    c.json(
+      {
+        message: error.message,
+        statusCode: (error as { statusCode?: number }).statusCode,
+      },
+      400,
+    ),
+  );
+  return app;
+}
+
+describe("upload alt-text handler", () => {
+  test("generates preview alt text and caches it for a staged upload", async () => {
+    const generated: unknown[][] = [];
+    const cached: unknown[][] = [];
+    const app = appWithErrorBody();
+    app.post("/", (c) => {
+      const uploads: Pick<
+        UploadsService,
+        "generateAltText" | "cacheStagedAltText"
+      > = {
+        generateAltText: async (
+          ...args: Parameters<UploadsService["generateAltText"]>
+        ) => {
+          generated.push(args);
+          return "A busy night market";
+        },
+        cacheStagedAltText: (
+          ...args: Parameters<UploadsService["cacheStagedAltText"]>
+        ) => {
+          cached.push(args);
+        },
+      };
+      return handleGenerateAltText(c, uploads);
+    });
+
+    const formData = new FormData();
+    formData.set(
+      "image",
+      new File(["image"], "market.jpeg", { type: "image/jpeg" }),
+    );
+    formData.set("uploadId", "17");
+
+    const response = await app.request("/", { method: "POST", body: formData });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      data: { altText: "A busy night market" },
+    });
+    expect(generated[0]?.[1]).toBe("market.jpeg");
+    expect(generated[0]?.[2]).toBe("jpeg");
+    expect(cached).toEqual([[17, "A busy night market"]]);
+  });
+
+  test("preserves preview-generation failure translation", async () => {
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    try {
+      const app = appWithErrorBody();
+      app.post("/", (c) => {
+        const uploads: Pick<
+          UploadsService,
+          "generateAltText" | "cacheStagedAltText"
+        > = {
+          generateAltText: async () => {
+            throw new Error("Vertex unavailable");
+          },
+          cacheStagedAltText: () => {},
+        };
+        return handleGenerateAltText(c, uploads);
+      });
+
+      const formData = new FormData();
+      formData.set(
+        "image",
+        new File(["image"], "market.webp", { type: "image/webp" }),
+      );
+      const response = await app.request("/", {
+        method: "POST",
+        body: formData,
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "Failed to generate alt text",
+        statusCode: 400,
+      });
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-alt-text.handler.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-alt-text.handler.ts
@@ -1,0 +1,69 @@
+import type { Context } from "hono";
+import { BadRequestError } from "@shared/errors/http-error";
+import { successResponse } from "@shared/types/api-response";
+import type { UploadsService } from "../../../services/integrations/uploads.service";
+import { MAX_FILE_SIZE } from "../../../validation/schemas/uploads.schemas";
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+type AltTextService = Pick<
+  UploadsService,
+  "generateAltText" | "cacheStagedAltText"
+>;
+
+/**
+ * POST /api/generate-alt-text
+ * Generate alt text for an image preview and optionally cache it on a staged
+ * image source.
+ */
+export async function handleGenerateAltText(
+  c: Context,
+  uploads: AltTextService,
+) {
+  const formData = await c.req.formData();
+  const imageFile = formData.get("image");
+  if (!(imageFile instanceof File)) {
+    throw new BadRequestError("Image file required");
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(imageFile.type)) {
+    throw new BadRequestError(
+      "Invalid file type. Only JPEG, PNG, WebP, and GIF images are allowed.",
+    );
+  }
+
+  if (imageFile.size > MAX_FILE_SIZE) {
+    throw new BadRequestError(
+      `File exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`,
+    );
+  }
+
+  try {
+    const imageBuffer = await imageFile.arrayBuffer();
+    const fileExtension =
+      imageFile.name.split(".").pop()?.toLowerCase() || "jpg";
+    const altText = await uploads.generateAltText(
+      Buffer.from(imageBuffer),
+      imageFile.name,
+      fileExtension,
+    );
+
+    const uploadIdRaw = formData.get("uploadId");
+    if (typeof uploadIdRaw === "string" && uploadIdRaw.trim()) {
+      const uploadId = Number(uploadIdRaw);
+      if (!Number.isInteger(uploadId) || uploadId <= 0) {
+        throw new BadRequestError("Valid uploadId required");
+      }
+      uploads.cacheStagedAltText(uploadId, altText);
+    }
+
+    return c.json(successResponse({ altText }));
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error("[AltText][Vertex] Failed to generate preview alt text", {
+      filename: imageFile.name,
+      error: errorMessage,
+    });
+    throw new BadRequestError("Failed to generate alt text");
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-lifecycle.handlers.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-lifecycle.handlers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { ImageSetUpload } from "../../../models/location";
+import type { UploadsService } from "../../../services/integrations/uploads.service";
+import {
+  handleDeleteUpload,
+  handleReprocessUploadVariants,
+  handleUpdateUploadPhotographerCredit,
+} from "./upload-lifecycle.handlers";
+
+type TestEnv = {
+  Variables: {
+    validatedParams: unknown;
+    validatedBody: unknown;
+  };
+};
+
+describe("upload lifecycle handlers", () => {
+  test("deletes the validated upload ID", async () => {
+    const deleted: number[] = [];
+    const app = new Hono<TestEnv>();
+    app.delete("/", (c) => {
+      c.set("validatedParams", { id: "23" });
+      const uploads: Pick<UploadsService, "deleteUpload"> = {
+        deleteUpload: async (id: number) => {
+          deleted.push(id);
+        },
+      };
+      return handleDeleteUpload(c, uploads);
+    });
+
+    const response = await app.request("/", { method: "DELETE" });
+
+    expect(response.status).toBe(200);
+    expect(deleted).toEqual([23]);
+    expect(await response.json()).toEqual({
+      success: true,
+      data: { message: "Upload deleted successfully" },
+    });
+  });
+
+  test("passes credit updates and reprocess requests to their service methods", async () => {
+    const entry = {
+      id: 23,
+      location_id: 7,
+      format: "imageset",
+    } as ImageSetUpload;
+    const creditCalls: unknown[][] = [];
+    const reprocessCalls: number[] = [];
+    const app = new Hono<TestEnv>();
+    app.patch("/credit", (c) => {
+      c.set("validatedParams", { id: "23" });
+      c.set("validatedBody", { photographerCredit: "Jane Doe" });
+      const uploads: Pick<UploadsService, "updateUploadPhotographerCredit"> = {
+        updateUploadPhotographerCredit: async (
+          ...args: Parameters<UploadsService["updateUploadPhotographerCredit"]>
+        ) => {
+          creditCalls.push(args);
+          return entry;
+        },
+      };
+      return handleUpdateUploadPhotographerCredit(c, uploads);
+    });
+    app.post("/reprocess", (c) => {
+      c.set("validatedParams", { id: "23" });
+      const uploads: Pick<UploadsService, "reprocessUploadVariants"> = {
+        reprocessUploadVariants: async (id: number) => {
+          reprocessCalls.push(id);
+          return entry;
+        },
+      };
+      return handleReprocessUploadVariants(c, uploads);
+    });
+
+    const creditResponse = await app.request("/credit", { method: "PATCH" });
+    const reprocessResponse = await app.request("/reprocess", {
+      method: "POST",
+    });
+
+    expect(creditResponse.status).toBe(200);
+    expect(reprocessResponse.status).toBe(200);
+    expect(creditCalls).toEqual([[23, "Jane Doe"]]);
+    expect(reprocessCalls).toEqual([23]);
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-lifecycle.handlers.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/content/uploads/upload-lifecycle.handlers.ts
@@ -1,0 +1,56 @@
+import type { Context } from "hono";
+import { BadRequestError } from "@shared/errors/http-error";
+import { successResponse } from "@shared/types/api-response";
+import type { UploadsService } from "../../../services/integrations/uploads.service";
+import type {
+  DeleteUploadParamsDto,
+  UploadIdParamsDto,
+  UpdateUploadPhotographerCreditBodyDto,
+} from "../../../validation/schemas/uploads.schemas";
+
+export async function handleDeleteUpload(
+  c: Context,
+  uploads: Pick<UploadsService, "deleteUpload">,
+) {
+  const params = c.get("validatedParams") as DeleteUploadParamsDto;
+  const uploadId = Number.parseInt(params.id, 10);
+  if (Number.isNaN(uploadId)) {
+    throw new BadRequestError("Invalid upload ID");
+  }
+
+  await uploads.deleteUpload(uploadId);
+  return c.json(successResponse({ message: "Upload deleted successfully" }));
+}
+
+export async function handleUpdateUploadPhotographerCredit(
+  c: Context,
+  uploads: Pick<UploadsService, "updateUploadPhotographerCredit">,
+) {
+  const params = c.get("validatedParams") as UploadIdParamsDto;
+  const body = c.get("validatedBody") as UpdateUploadPhotographerCreditBodyDto;
+  const uploadId = Number.parseInt(params.id, 10);
+  if (Number.isNaN(uploadId)) {
+    throw new BadRequestError("Upload ID must be a number");
+  }
+
+  const entry = await uploads.updateUploadPhotographerCredit(
+    uploadId,
+    body.photographerCredit,
+  );
+
+  return c.json(successResponse({ entry }));
+}
+
+export async function handleReprocessUploadVariants(
+  c: Context,
+  uploads: Pick<UploadsService, "reprocessUploadVariants">,
+) {
+  const params = c.get("validatedParams") as UploadIdParamsDto;
+  const uploadId = Number.parseInt(params.id, 10);
+  if (Number.isNaN(uploadId)) {
+    throw new BadRequestError("Upload ID must be a number");
+  }
+
+  const entry = await uploads.reprocessUploadVariants(uploadId);
+  return c.json(successResponse({ entry }));
+}


### PR DESCRIPTION
## Original issue

`uploads.controller.ts` had grown to 370 lines and mixed legacy upload compatibility, multipart parsing, image-set creation/replacement, crop validation, MIME/size limits, reprocessing, photographer credit changes, deletion, and preview alt-text generation.

## Root cause

As the media workflow expanded, each route handler and its request-validation details were added directly to the original controller. Duplicated source/variant validation and broad `UploadsService` access made HTTP orchestration, business validation, and service mutation change together.

## Refactor

- Reduced the route-facing controller to a 43-line compatibility facade with all seven established exports.
- Extracted image-set create/replace, upload lifecycle mutations, and preview alt-text into cohesive handlers with narrow `Pick<UploadsService>` dependencies.
- Centralized multipart image-set parsing, crop-region validation, MIME limits, per-file limits, aggregate-size validation, and source/variant ordering.
- Added focused parser and Hono handler tests for create, replace, delete, credit, reprocessing, alt-text caching, and error translation.
- Preserved request/response envelopes, validation messages, service calls, and route registrations.

## Why this design is better

The controller now only binds stable route exports to focused handlers. Multipart validation has one reusable owner, handler dependencies state exactly which service operations they require, and each lifecycle can be tested without constructing the full controller dependency surface.

## Validation

- Prettier on all changed TypeScript files: passed.
- Focused upload controller suite: 10 passed.
- Full Location Manager server suite: 237 passed, 536 expectations.
- `tsc --noEmit --rootDir ../..`: passed.
- Controller export smoke check: all seven route exports present.
- `git diff --check`: passed.
- Package lint and build commands exited successfully with their documented intentional no-op behavior.

Tooling baseline: the default server `tsc --noEmit` retains the pre-existing TS6059 issue because its `rootDir` excludes imported sibling shared sources; the wider-root check passes. Aggregate Location Manager Turbo scripts retain a pre-existing recursive root-task configuration error.

## Risks, tradeoffs, and follow-ups

- More handler files add navigation overhead, offset by explicit ownership and narrow service dependencies.
- Multipart parsing and error-message drift are the main risks; parser and HTTP contract tests cover them.
- No repository, persistence, media-processing, or external alt-text behavior changed.
- The server tsconfig rootDir and aggregate Turbo task configuration should be repaired separately so the standard aggregate commands become meaningful gates.
