### PR TITLE
NOJIRA: Refactor shared images API facade

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/imagesApi.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/imagesApi.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fluxEditApi } from './flux-edit.api'
+import { generateSocialImageApi } from './generate-social-image.api'
+import {
+  generateFluxEditedImage,
+  generateSocialImageFromFeatured,
+  uploadImageVariants
+} from './imagesApi'
+import { uploadVariantsApi } from './uploads/upload-variants.api'
+
+vi.mock('./flux-edit.api', () => ({
+  fluxEditApi: vi.fn()
+}))
+
+vi.mock('./generate-social-image.api', () => ({
+  generateSocialImageApi: vi.fn()
+}))
+
+vi.mock('./uploads/upload-variants.api', () => ({
+  uploadVariantsApi: vi.fn()
+}))
+
+describe('imagesApi compatibility facade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps the positional variant upload contract to the focused upload API', async () => {
+    const variantFiles = [
+      {
+        type: 'wide' as const,
+        file: new File(['wide'], 'wide.webp', { type: 'image/webp' })
+      }
+    ]
+    const onProgress = vi.fn()
+    const response = {
+      success: true,
+      mediaSetId: '42',
+      externalRef: 'featured-upload',
+      variants: {}
+    }
+    vi.mocked(uploadVariantsApi).mockResolvedValue(response)
+
+    await expect(
+      uploadImageVariants(
+        variantFiles,
+        'featured-upload',
+        'A waterfront skyline',
+        undefined,
+        'token',
+        'Photographer',
+        onProgress,
+        [3, 5]
+      )
+    ).resolves.toBe(response)
+
+    expect(uploadVariantsApi).toHaveBeenCalledWith({
+      variantFiles,
+      externalRef: 'featured-upload',
+      altText: 'A waterfront skyline',
+      locationRef: undefined,
+      token: 'token',
+      photographerCredit: 'Photographer',
+      onProgress,
+      tags: [3, 5]
+    })
+  })
+
+  it('preserves the featured MediaSet discriminator for social generation', async () => {
+    const response = {
+      success: true,
+      featuredAssetId: null,
+      mediaSetId: '17',
+      sourceAssetId: '21',
+      generatedAssetId: '22',
+      generatedImageUrl: 'https://images.example/social.webp',
+      width: 1200,
+      height: 630
+    }
+    vi.mocked(generateSocialImageApi).mockResolvedValue(response)
+
+    await expect(
+      generateSocialImageFromFeatured({ featuredMediaSetId: 17 }, 'token')
+    ).resolves.toBe(response)
+
+    expect(generateSocialImageApi).toHaveBeenCalledWith({
+      featuredMediaSetId: 17,
+      token: 'token'
+    })
+  })
+
+  it('forwards optional FLUX settings without changing the public signature', async () => {
+    const referenceImage = new File(['reference'], 'reference.png', {
+      type: 'image/png'
+    })
+    const additionalReferenceImage = new File(
+      ['additional'],
+      'additional.png',
+      {
+        type: 'image/png'
+      }
+    )
+    const response = {
+      blob: new Blob(['generated'], { type: 'image/png' }),
+      fileName: 'generated.png',
+      contentType: 'image/png',
+      requestId: 'request-1',
+      model: 'flux-2-pro',
+      cost: 0.1,
+      inputMegapixels: 1,
+      outputMegapixels: 1
+    }
+    vi.mocked(fluxEditApi).mockResolvedValue(response)
+
+    await expect(
+      generateFluxEditedImage('Recreate this scene', referenceImage, 'token', {
+        additionalReferenceImages: [additionalReferenceImage],
+        modelId: 'flux-2-pro',
+        width: 1200,
+        height: 630,
+        safetyTolerance: 2,
+        promptUpsampling: true,
+        seed: '1234'
+      })
+    ).resolves.toBe(response)
+
+    expect(fluxEditApi).toHaveBeenCalledWith({
+      prompt: 'Recreate this scene',
+      referenceImage,
+      token: 'token',
+      additionalReferenceImages: [additionalReferenceImage],
+      modelId: 'flux-2-pro',
+      width: 1200,
+      height: 630,
+      safetyTolerance: 2,
+      promptUpsampling: true,
+      seed: '1234'
+    })
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/imagesApi.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/imagesApi.ts
@@ -1,5 +1,8 @@
 /**
- * API client for image upload and processing
+ * Compatibility facade for shared image APIs.
+ *
+ * Keep the positional call signatures stable; focused API modules own transport,
+ * response parsing, and error handling.
  */
 
 import type { ImageVariantType } from '../utils/imageProcessing';
@@ -9,8 +12,6 @@ import { describeSceneApi } from './describe-scene.api';
 import { describeSubjectApi } from './describe-subject.api';
 import { buildEditPromptApi } from './build-edit-prompt.api';
 import { buildInsertPromptApi, type InsertImage } from './build-insert-prompt.api';
-import { postJson } from './client/imageApiClient';
-import { parseErrorMessage } from './errors/image-api-error.utils';
 import type {
   FluxEditImageResponse,
   GenerateSocialImageResponse,
@@ -167,22 +168,6 @@ export async function uploadSocialImage(
     token,
     photographerCredit,
   });
-}
-
-/**
- * Resolve tag names to IDs, creating any that don't exist in Payload.
- */
-export async function resolveTagsByName(
-  names: string[],
-  token: string,
-): Promise<{ id: number; name: string }[]> {
-  const response = await postJson('/images/tags/resolve', { names }, token)
-  if (!response.ok) {
-    const message = await parseErrorMessage(response, 'Failed to resolve tags')
-    throw new Error(message)
-  }
-  const data = await response.json() as { tags: { id: number; name: string }[] }
-  return data.tags
 }
 
 export async function generateFluxEditedImage(


### PR DESCRIPTION
## Original issue

`imagesApi.ts` scored as a 208-line module with 15 dependencies and 18 exports. Most of that surface is intentional compatibility delegation and type re-exports, but the file also retained one inline transport/error-handling function.

## Root cause

The facade preserves legacy positional signatures over focused object-parameter API modules. `resolveTagsByName` was added for the former Batch Upload page; that page was later removed while the unused export and its unique HTTP/error dependencies remained.

## Refactor

- Documented `imagesApi.ts` as the intentional compatibility facade.
- Removed the zero-consumer `resolveTagsByName` export and its direct `postJson`/`parseErrorMessage` dependencies.
- Preserved every current consumer import path and positional wrapper signature.
- Added focused compatibility tests for variant-upload mapping, MediaSet social-image discriminators, and FLUX option forwarding.

## Why this design is better

The facade remains a useful stable boundary rather than being fragmented into redundant adapters. Removing its only inline HTTP concern leaves delegation and type contracts as its sole responsibilities, reduces it from 208 to 193 lines and 15 to 13 dependencies, and locks intentional compatibility behavior with tests.

## Validation

- Prettier and diff checks: passed.
- Frontend lint and boundary checks: passed.
- Full frontend suite: 95 files, 362 tests passed.
- Frontend production build: passed.
- Full TypeScript check reports only five pre-existing unrelated homepage/listicle errors; no image API diagnostics.

## Risks, tradeoffs, and follow-ups

- The removed export has no repository consumer; backend tag resolution is unchanged.
- Retaining a compatibility facade keeps a broad export count, but avoids churn across current callers.
- Future wrappers should remain pure delegates. New transport or response parsing belongs in the focused `*.api.ts` modules, and obsolete positional wrappers can be removed only after their consumers disappear.
