### PR TITLE
refactor(abw): split research profile modules

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/CONTEXT.md
@@ -50,6 +50,10 @@ _Avoid_: article prose, full SEO document
   editorial policy, builders, and output validation live in the adjacent
   `listicle_writer_contracts.py`, `listicle_prompt_policy.py`,
   `listicle_prompt_builders.py`, and `listicle_writer_validation.py` modules.
+- `research_profile.py` is a compatibility facade. Research Profile contracts,
+  prompt construction, response parsing, grounded execution, fallback policy,
+  and batch concurrency live in cohesive adjacent `research_profile_*` modules.
+  The facade preserves the grounded-invocation patch seam used by route tests.
 - The `blurb_composition_*` family owns Listicle Content Generation path
   selection, retry policy, validation traces, and writer execution. New prompt
   modules must reuse that execution boundary rather than introduce another

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile.py
@@ -1,407 +1,47 @@
-"""Writer-ready grounded research profile for one listicle blurb."""
+"""Compatibility facade for grounded Research Profile generation.
+
+Contracts, prompt construction, parsing, grounded execution, fallbacks, and
+batch concurrency live in cohesive adjacent modules. The facade preserves the
+existing import surface and ``_invoke_grounded`` patch seam.
+"""
 
 from __future__ import annotations
 
 import logging
-import re
-from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
-from typing import Any, Literal
-
-from utils import parse_json_response
+from typing import Any
 
 from .angle_assignment import ListicleAngle
+from .research_profile_batch import execute_research_profiles_concurrently
+from .research_profile_contracts import (  # noqa: F401
+    CATEGORY_BUCKET_PRIORITIES,
+    STANDARD_RESEARCH_BUCKETS,
+    ResearchBucketName,
+    ResearchFinding,
+    ResearchProfile,
+    ResearchProfileRequest,
+    ResearchProfileTrace,
+    SelectedAngleEvidence,
+    SelectedAngleStatus,
+    empty_buckets as _empty_buckets,
+    fallback_profile as _fallback_profile,
+    has_usable_bucket_evidence as _has_usable_bucket_evidence,
+)
+from .research_profile_execution import execute_research_profile
+from .research_profile_parsing import (  # noqa: F401
+    clean_citations as _clean_citations,
+    clean_summary as _clean_summary,
+    extract_json as _extract_json,
+    parse_research_profile_response as _parse_research_profile_response,
+)
+from .research_profile_prompt import build_research_profile_prompt
 
 logger = logging.getLogger(__name__)
-
-SelectedAngleStatus = Literal["supported", "weak", "unsupported", "not-requested"]
-ResearchBucketName = Literal[
-    "reputation-summary",
-    "specific-offerings",
-    "experience-texture",
-    "history-or-ownership",
-    "practical-usefulness",
-    "best-for",
-    "standout-hook",
-    "social-proof",
-    "visual-assets",
-    "caveats-or-fit-warnings",
-    "timing-tips",
-    "neighborhood-context",
-    "crowd-and-vibe",
-]
-
-STANDARD_RESEARCH_BUCKETS: tuple[ResearchBucketName, ...] = (
-    "reputation-summary",
-    "specific-offerings",
-    "experience-texture",
-    "history-or-ownership",
-    "practical-usefulness",
-    "best-for",
-    "standout-hook",
-    "social-proof",
-    "visual-assets",
-    "caveats-or-fit-warnings",
-    "timing-tips",
-    "neighborhood-context",
-    "crowd-and-vibe",
-)
-
-CATEGORY_BUCKET_PRIORITIES: dict[str, tuple[ResearchBucketName, ...]] = {
-    "dining": (
-        "specific-offerings",  # signature-dish
-        "experience-texture",  # atmosphere
-        "history-or-ownership",  # founders-backstory
-        "standout-hook",  # insider-tip + whats-different
-        "best-for",  # best-for
-        "social-proof",  # cross-angle reputation evidence
-        "caveats-or-fit-warnings",  # cross-angle restraint
-    ),
-    "nightlife": (
-        "experience-texture",
-        "timing-tips",
-        "best-for",
-        "social-proof",
-    ),
-    "attractions": (
-        "timing-tips",
-        "standout-hook",
-        "visual-assets",
-        "caveats-or-fit-warnings",
-    ),
-    "accommodations": (
-        "neighborhood-context",
-        "specific-offerings",
-        "experience-texture",
-        "crowd-and-vibe",
-        "best-for",
-        "visual-assets",
-        "caveats-or-fit-warnings",
-    ),
-}
-
-_VALID_SELECTED_STATUSES = {"supported", "weak", "unsupported", "not-requested"}
-_BUCKET_SET = set(STANDARD_RESEARCH_BUCKETS)
-
-
-@dataclass(frozen=True)
-class ResearchFinding:
-    summary: str
-    citations: list[str]
-
-
-@dataclass(frozen=True)
-class SelectedAngleEvidence:
-    angle: ListicleAngle | None
-    status: SelectedAngleStatus
-    summary: str = ""
-    citations: list[str] = field(default_factory=list)
-    reason: str = ""
-
-
-@dataclass(frozen=True)
-class ResearchProfile:
-    selected_angle: SelectedAngleEvidence
-    standard_buckets: dict[ResearchBucketName, list[ResearchFinding]]
-    usable_for_blurb: bool
-    warnings: list[str] = field(default_factory=list)
-
-    @property
-    def effective_angle(self) -> ListicleAngle | None:
-        if self.selected_angle.status == "supported":
-            return self.selected_angle.angle
-        return None
-
-    @property
-    def bucket_findings_count(self) -> int:
-        return sum(len(findings) for findings in self.standard_buckets.values())
-
-    @property
-    def source_urls(self) -> list[str]:
-        merged: list[str] = []
-        seen: set[str] = set()
-        groups = [self.selected_angle.citations]
-        groups.extend(
-            finding.citations
-            for findings in self.standard_buckets.values()
-            for finding in findings
-        )
-        for group in groups:
-            for url in group:
-                if url in seen:
-                    continue
-                seen.add(url)
-                merged.append(url)
-        return merged
-
-
-@dataclass(frozen=True)
-class ResearchProfileTrace:
-    prompt: str
-    raw_response: str = ""
-    model: str = ""
-    error: str | None = None
-    parser_dropped_reason: str | None = None
-
-
-@dataclass(frozen=True)
-class ResearchProfileRequest:
-    target_id: str
-    venue_name: str
-    location_label: str
-    category: str
-    requested_angle: ListicleAngle | None
-
-
-def build_research_profile_prompt(
-    *,
-    venue_name: str,
-    location_label: str,
-    category: str,
-    requested_angle: ListicleAngle | None,
-) -> str:
-    bucket_list = "\n".join(f'  - "{bucket}"' for bucket in STANDARD_RESEARCH_BUCKETS)
-    priority = CATEGORY_BUCKET_PRIORITIES.get(category, ())
-    priority_line = ", ".join(priority) if priority else "none"
-    angle_line = (
-        f'Research selected angle "{requested_angle}" and decide whether it is supported.'
-        if requested_angle
-        else "No angle is selected. Do not evaluate angle framing; gather standard buckets only."
-    )
-    selected_angle_shape = (
-        '{ "angle": "selected-angle", "status": "supported|weak|unsupported", '
-        '"summary": "one short writer-ready finding when supported", '
-        '"citations": ["https://..."], "reason": "short explanation" }'
-        if requested_angle
-        else '{ "angle": null, "status": "not-requested", "summary": "", "citations": [], "reason": "" }'
-    )
-    return (
-        "You are building a cited Research Profile for one travel listicle blurb.\n\n"
-        f"Venue: {venue_name}\n"
-        f"Location: {location_label}\n"
-        f"Category: {category}\n\n"
-        f"{angle_line}\n"
-        "Use web search. Return facts only when backed by URLs you actually consulted. "
-        "Do not write blurb prose.\n\n"
-        "Standard Research Buckets:\n"
-        f"{bucket_list}\n\n"
-        f"Category priorities: {priority_line}. Keep low-signal buckets empty rather than padded.\n\n"
-        "Bucket boundaries:\n"
-        "- best-for means audience/use-case evidence, not angle framing.\n"
-        "- timing-tips means practical timing facts, not an insider-tip lead.\n"
-        "- visual-assets means visual details for prose only, not media selection.\n"
-        "- caveats-or-fit-warnings must be factual and restrained.\n"
-        "- standout-hook is strongest concise fact found, but must not override the selected angle.\n\n"
-        "Output one JSON object only, no code fences, with this shape:\n"
-        "{\n"
-        f'  "selected_angle": {selected_angle_shape},\n'
-        '  "standard_buckets": {\n'
-        '    "bucket-name": [{ "summary": "one short finding", "citations": ["https://..."] }]\n'
-        "  },\n"
-        '  "warnings": ["optional warning"]\n'
-        "}\n\n"
-        "Rules:\n"
-        "- Every selected-angle supported finding requires citations.\n"
-        "- Every bucket finding requires citations; uncited findings are invalid.\n"
-        "- Each bucket may return zero, one, or two findings.\n"
-        "- If selected angle is weak or unsupported, explain why in reason and do not provide a leading summary.\n"
-        "- If no angle is selected, selected_angle.status must be not-requested."
-    )
 
 
 def _invoke_grounded(*args: Any, **kwargs: Any) -> Any:
     from utils import invoke_google_grounded_text as _invoke
 
     return _invoke(*args, **kwargs)
-
-
-# Grounded models sometimes drop prose, sentence fragments, or empty strings
-# into the citations array. We only trust entries that look like URLs.
-_URL_RE = re.compile(r"^https?://\S+$", re.I)
-
-
-def _clean_citations(raw: Any) -> list[str]:
-    """Keep only entries that look like URLs. Drop prose contamination."""
-    if not isinstance(raw, list):
-        return []
-    cleaned: list[str] = []
-    for entry in raw:
-        if not isinstance(entry, str):
-            continue
-        candidate = entry.strip()
-        if _URL_RE.match(candidate):
-            cleaned.append(candidate)
-    return cleaned
-
-
-# Inline Google-grounding markers like "[3]", "[3, 9, 10, 13]", or
-# "[3, 9-12]" sometimes leak into summary text. Strip them before
-# storing — the writer should never see grounded-response marker syntax.
-_INLINE_CITATION_MARKER_RE = re.compile(r"\s*\[\s*\d+(?:\s*[,\-]\s*\d+)*\s*\]")
-
-
-def _clean_summary(raw: Any) -> str:
-    if not isinstance(raw, str):
-        return ""
-    stripped = _INLINE_CITATION_MARKER_RE.sub("", raw)
-    # Collapse repeated whitespace introduced by marker removal.
-    return re.sub(r"\s{2,}", " ", stripped).strip()
-
-
-def _extract_json(text: str) -> Any:
-    try:
-        return parse_json_response(text)
-    except (RuntimeError, TypeError):
-        return None
-
-
-def _empty_buckets() -> dict[ResearchBucketName, list[ResearchFinding]]:
-    return {bucket: [] for bucket in STANDARD_RESEARCH_BUCKETS}
-
-
-def _fallback_profile(
-    requested_angle: ListicleAngle | None,
-    *,
-    warning: str | None = None,
-) -> ResearchProfile:
-    warnings = [warning] if warning else []
-    return ResearchProfile(
-        selected_angle=SelectedAngleEvidence(
-            angle=requested_angle,
-            status="unsupported" if requested_angle else "not-requested",
-        ),
-        standard_buckets=_empty_buckets(),
-        usable_for_blurb=False,
-        warnings=warnings,
-    )
-
-
-def _has_usable_bucket_evidence(
-    buckets: dict[ResearchBucketName, list[ResearchFinding]]
-) -> bool:
-    total = sum(len(findings) for findings in buckets.values())
-    if total >= 2:
-        return True
-    return len(buckets.get("standout-hook", [])) >= 1
-
-
-def _parse_research_profile_response(
-    *,
-    raw_text: str,
-    requested_angle: ListicleAngle | None,
-) -> tuple[ResearchProfile, str | None]:
-    parsed = _extract_json(raw_text)
-    if not isinstance(parsed, dict):
-        return (
-            _fallback_profile(
-                requested_angle, warning="Research Profile response was not JSON."
-            ),
-            "response was not a JSON object",
-        )
-
-    drop_reasons: list[str] = []
-    selected_raw = parsed.get("selected_angle")
-    selected = SelectedAngleEvidence(
-        angle=requested_angle,
-        status="not-requested" if requested_angle is None else "unsupported",
-    )
-    if isinstance(selected_raw, dict):
-        status = selected_raw.get("status")
-        if status not in _VALID_SELECTED_STATUSES:
-            drop_reasons.append(f"selected_angle invalid status {status!r}")
-            status = "not-requested" if requested_angle is None else "unsupported"
-        angle_value = selected_raw.get("angle")
-        angle = requested_angle if requested_angle is not None else None
-        if requested_angle is not None and angle_value not in {requested_angle, None}:
-            drop_reasons.append(f"selected_angle unexpected angle {angle_value!r}")
-        citations = _clean_citations(selected_raw.get("citations"))
-        summary = _clean_summary(selected_raw.get("summary"))
-        reason = _clean_summary(selected_raw.get("reason"))
-        if requested_angle is None:
-            status = "not-requested"
-            angle = None
-            summary = ""
-            citations = []
-        elif status == "supported" and (not summary or not citations):
-            drop_reasons.append(
-                "selected_angle supported without summary/citations; downgraded to unsupported"
-            )
-            status = "unsupported"
-            summary = ""
-            citations = []
-        elif status != "supported":
-            summary = ""
-            citations = []
-        selected = SelectedAngleEvidence(
-            angle=angle,
-            status=status,  # type: ignore[arg-type]
-            summary=summary,
-            citations=citations,
-            reason=reason,
-        )
-    elif selected_raw is not None:
-        drop_reasons.append("selected_angle was not an object")
-
-    buckets = _empty_buckets()
-    raw_buckets = parsed.get("standard_buckets")
-    if isinstance(raw_buckets, dict):
-        for bucket_name, raw_findings in raw_buckets.items():
-            if bucket_name not in _BUCKET_SET:
-                drop_reasons.append(f"unknown bucket {bucket_name!r}")
-                continue
-            if not isinstance(raw_findings, list):
-                drop_reasons.append(f"{bucket_name}: findings not an array")
-                continue
-            cleaned: list[ResearchFinding] = []
-            for entry in raw_findings[:2]:
-                if not isinstance(entry, dict):
-                    drop_reasons.append(f"{bucket_name}: finding not an object")
-                    continue
-                summary = _clean_summary(entry.get("summary"))
-                citations = _clean_citations(entry.get("citations"))
-                if not summary:
-                    drop_reasons.append(f"{bucket_name}: empty summary")
-                    continue
-                if not citations:
-                    drop_reasons.append(
-                        f"{bucket_name}: uncited finding dropped (no valid URL citations)"
-                    )
-                    continue
-                cleaned.append(
-                    ResearchFinding(
-                        summary=summary,
-                        citations=citations,
-                    )
-                )
-            buckets[bucket_name] = cleaned  # type: ignore[index]
-    elif raw_buckets is not None:
-        drop_reasons.append("standard_buckets was not an object")
-
-    warnings = (
-        [
-            warning.strip()
-            for warning in parsed.get("warnings", [])
-            if isinstance(warning, str) and warning.strip()
-        ]
-        if isinstance(parsed.get("warnings"), list)
-        else []
-    )
-
-    if requested_angle and selected.status != "supported":
-        warnings.append(f'Selected angle "{requested_angle}" lacked cited support.')
-
-    usable_for_blurb = selected.status == "supported" or _has_usable_bucket_evidence(
-        buckets
-    )
-    return (
-        ResearchProfile(
-            selected_angle=selected,
-            standard_buckets=buckets,
-            usable_for_blurb=usable_for_blurb,
-            warnings=warnings,
-        ),
-        "; ".join(drop_reasons) if drop_reasons else None,
-    )
 
 
 def run_research_profile(
@@ -412,63 +52,14 @@ def run_research_profile(
     requested_angle: ListicleAngle | None,
     grounded_model: str = "gemini-2.5-flash",
 ) -> tuple[ResearchProfile, ResearchProfileTrace]:
-    prompt = build_research_profile_prompt(
+    return execute_research_profile(
         venue_name=venue_name,
         location_label=location_label,
         category=category,
         requested_angle=requested_angle,
-    )
-    try:
-        result = _invoke_grounded(
-            prompt,
-            model_name=grounded_model,
-            fallback_model_name="gemini-2.5-flash",
-            max_tokens=16384,
-            temperature=0.1,
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "Research Profile grounded call failed for venue %r", venue_name
-        )
-        return (
-            _fallback_profile(
-                requested_angle, warning="Research Profile grounded call failed."
-            ),
-            ResearchProfileTrace(
-                prompt=prompt,
-                model=grounded_model,
-                error=f"grounded call raised: {exc!r}",
-            ),
-        )
-
-    raw_text = getattr(result, "text", "") if result is not None else ""
-    model_used = (
-        getattr(result, "model_name", grounded_model)
-        if result is not None
-        else grounded_model
-    )
-    if not raw_text.strip():
-        return (
-            _fallback_profile(
-                requested_angle, warning="Research Profile returned empty text."
-            ),
-            ResearchProfileTrace(
-                prompt=prompt,
-                raw_response=raw_text,
-                model=model_used,
-                error="grounded call returned empty text",
-            ),
-        )
-
-    profile, parser_reason = _parse_research_profile_response(
-        raw_text=raw_text,
-        requested_angle=requested_angle,
-    )
-    return profile, ResearchProfileTrace(
-        prompt=prompt,
-        raw_response=raw_text,
-        model=model_used,
-        parser_dropped_reason=parser_reason,
+        grounded_model=grounded_model,
+        invoke_grounded=_invoke_grounded,
+        exception_logger=logger,
     )
 
 
@@ -478,26 +69,25 @@ def run_research_profiles_concurrently(
     grounded_model: str = "gemini-2.5-flash",
     max_workers: int | None = None,
 ) -> dict[str, tuple[ResearchProfile, ResearchProfileTrace]]:
-    if not requests:
-        return {}
+    return execute_research_profiles_concurrently(
+        requests,
+        grounded_model=grounded_model,
+        max_workers=max_workers,
+        run_research_profile=run_research_profile,
+    )
 
-    workers = max_workers or min(8, len(requests))
-    results: dict[str, tuple[ResearchProfile, ResearchProfileTrace]] = {}
 
-    def _run_one(
-        req: ResearchProfileRequest,
-    ) -> tuple[str, ResearchProfile, ResearchProfileTrace]:
-        profile, trace = run_research_profile(
-            venue_name=req.venue_name,
-            location_label=req.location_label,
-            category=req.category,
-            requested_angle=req.requested_angle,
-            grounded_model=grounded_model,
-        )
-        return req.target_id, profile, trace
-
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        for target_id, profile, trace in pool.map(_run_one, requests):
-            results[target_id] = (profile, trace)
-
-    return results
+__all__ = [
+    "CATEGORY_BUCKET_PRIORITIES",
+    "STANDARD_RESEARCH_BUCKETS",
+    "ResearchBucketName",
+    "ResearchFinding",
+    "ResearchProfile",
+    "ResearchProfileRequest",
+    "ResearchProfileTrace",
+    "SelectedAngleEvidence",
+    "SelectedAngleStatus",
+    "build_research_profile_prompt",
+    "run_research_profile",
+    "run_research_profiles_concurrently",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_batch.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_batch.py
@@ -1,0 +1,52 @@
+"""Concurrent batch orchestration for Research Profiles."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+
+from .research_profile_contracts import (
+    ResearchProfile,
+    ResearchProfileRequest,
+    ResearchProfileTrace,
+)
+
+RunResearchProfile = Callable[
+    ...,
+    tuple[ResearchProfile, ResearchProfileTrace],
+]
+
+
+def execute_research_profiles_concurrently(
+    requests: list[ResearchProfileRequest],
+    *,
+    grounded_model: str,
+    max_workers: int | None,
+    run_research_profile: RunResearchProfile,
+) -> dict[str, tuple[ResearchProfile, ResearchProfileTrace]]:
+    if not requests:
+        return {}
+
+    workers = max_workers or min(8, len(requests))
+    results: dict[str, tuple[ResearchProfile, ResearchProfileTrace]] = {}
+
+    def _run_one(
+        req: ResearchProfileRequest,
+    ) -> tuple[str, ResearchProfile, ResearchProfileTrace]:
+        profile, trace = run_research_profile(
+            venue_name=req.venue_name,
+            location_label=req.location_label,
+            category=req.category,
+            requested_angle=req.requested_angle,
+            grounded_model=grounded_model,
+        )
+        return req.target_id, profile, trace
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for target_id, profile, trace in pool.map(_run_one, requests):
+            results[target_id] = (profile, trace)
+
+    return results
+
+
+__all__ = ["RunResearchProfile", "execute_research_profiles_concurrently"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_contracts.py
@@ -1,0 +1,189 @@
+"""Research Profile data contracts and evidence policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from .angle_assignment import ListicleAngle
+
+SelectedAngleStatus = Literal["supported", "weak", "unsupported", "not-requested"]
+ResearchBucketName = Literal[
+    "reputation-summary",
+    "specific-offerings",
+    "experience-texture",
+    "history-or-ownership",
+    "practical-usefulness",
+    "best-for",
+    "standout-hook",
+    "social-proof",
+    "visual-assets",
+    "caveats-or-fit-warnings",
+    "timing-tips",
+    "neighborhood-context",
+    "crowd-and-vibe",
+]
+
+STANDARD_RESEARCH_BUCKETS: tuple[ResearchBucketName, ...] = (
+    "reputation-summary",
+    "specific-offerings",
+    "experience-texture",
+    "history-or-ownership",
+    "practical-usefulness",
+    "best-for",
+    "standout-hook",
+    "social-proof",
+    "visual-assets",
+    "caveats-or-fit-warnings",
+    "timing-tips",
+    "neighborhood-context",
+    "crowd-and-vibe",
+)
+
+CATEGORY_BUCKET_PRIORITIES: dict[str, tuple[ResearchBucketName, ...]] = {
+    "dining": (
+        "specific-offerings",  # signature-dish
+        "experience-texture",  # atmosphere
+        "history-or-ownership",  # founders-backstory
+        "standout-hook",  # insider-tip + whats-different
+        "best-for",  # best-for
+        "social-proof",  # cross-angle reputation evidence
+        "caveats-or-fit-warnings",  # cross-angle restraint
+    ),
+    "nightlife": (
+        "experience-texture",
+        "timing-tips",
+        "best-for",
+        "social-proof",
+    ),
+    "attractions": (
+        "timing-tips",
+        "standout-hook",
+        "visual-assets",
+        "caveats-or-fit-warnings",
+    ),
+    "accommodations": (
+        "neighborhood-context",
+        "specific-offerings",
+        "experience-texture",
+        "crowd-and-vibe",
+        "best-for",
+        "visual-assets",
+        "caveats-or-fit-warnings",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ResearchFinding:
+    summary: str
+    citations: list[str]
+
+
+@dataclass(frozen=True)
+class SelectedAngleEvidence:
+    angle: ListicleAngle | None
+    status: SelectedAngleStatus
+    summary: str = ""
+    citations: list[str] = field(default_factory=list)
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ResearchProfile:
+    selected_angle: SelectedAngleEvidence
+    standard_buckets: dict[ResearchBucketName, list[ResearchFinding]]
+    usable_for_blurb: bool
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def effective_angle(self) -> ListicleAngle | None:
+        if self.selected_angle.status == "supported":
+            return self.selected_angle.angle
+        return None
+
+    @property
+    def bucket_findings_count(self) -> int:
+        return sum(len(findings) for findings in self.standard_buckets.values())
+
+    @property
+    def source_urls(self) -> list[str]:
+        merged: list[str] = []
+        seen: set[str] = set()
+        groups = [self.selected_angle.citations]
+        groups.extend(
+            finding.citations
+            for findings in self.standard_buckets.values()
+            for finding in findings
+        )
+        for group in groups:
+            for url in group:
+                if url in seen:
+                    continue
+                seen.add(url)
+                merged.append(url)
+        return merged
+
+
+@dataclass(frozen=True)
+class ResearchProfileTrace:
+    prompt: str
+    raw_response: str = ""
+    model: str = ""
+    error: str | None = None
+    parser_dropped_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ResearchProfileRequest:
+    target_id: str
+    venue_name: str
+    location_label: str
+    category: str
+    requested_angle: ListicleAngle | None
+
+
+def empty_buckets() -> dict[ResearchBucketName, list[ResearchFinding]]:
+    return {bucket: [] for bucket in STANDARD_RESEARCH_BUCKETS}
+
+
+def fallback_profile(
+    requested_angle: ListicleAngle | None,
+    *,
+    warning: str | None = None,
+) -> ResearchProfile:
+    warnings = [warning] if warning else []
+    return ResearchProfile(
+        selected_angle=SelectedAngleEvidence(
+            angle=requested_angle,
+            status="unsupported" if requested_angle else "not-requested",
+        ),
+        standard_buckets=empty_buckets(),
+        usable_for_blurb=False,
+        warnings=warnings,
+    )
+
+
+def has_usable_bucket_evidence(
+    buckets: dict[ResearchBucketName, list[ResearchFinding]]
+) -> bool:
+    total = sum(len(findings) for findings in buckets.values())
+    if total >= 2:
+        return True
+    return len(buckets.get("standout-hook", [])) >= 1
+
+
+__all__ = [
+    "CATEGORY_BUCKET_PRIORITIES",
+    "STANDARD_RESEARCH_BUCKETS",
+    "ResearchBucketName",
+    "ResearchFinding",
+    "ResearchProfile",
+    "ResearchProfileRequest",
+    "ResearchProfileTrace",
+    "SelectedAngleEvidence",
+    "SelectedAngleStatus",
+    "empty_buckets",
+    "fallback_profile",
+    "has_usable_bucket_evidence",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_execution.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_execution.py
@@ -1,0 +1,91 @@
+"""Grounded execution and runtime fallbacks for one Research Profile."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from .angle_assignment import ListicleAngle
+from .research_profile_contracts import (
+    ResearchProfile,
+    ResearchProfileTrace,
+    fallback_profile,
+)
+from .research_profile_parsing import parse_research_profile_response
+from .research_profile_prompt import build_research_profile_prompt
+
+GroundedInvoker = Callable[..., Any]
+
+
+def execute_research_profile(
+    *,
+    venue_name: str,
+    location_label: str,
+    category: str,
+    requested_angle: ListicleAngle | None,
+    grounded_model: str,
+    invoke_grounded: GroundedInvoker,
+    exception_logger: logging.Logger,
+) -> tuple[ResearchProfile, ResearchProfileTrace]:
+    prompt = build_research_profile_prompt(
+        venue_name=venue_name,
+        location_label=location_label,
+        category=category,
+        requested_angle=requested_angle,
+    )
+    try:
+        result = invoke_grounded(
+            prompt,
+            model_name=grounded_model,
+            fallback_model_name="gemini-2.5-flash",
+            max_tokens=16384,
+            temperature=0.1,
+        )
+    except Exception as exc:  # noqa: BLE001
+        exception_logger.exception(
+            "Research Profile grounded call failed for venue %r", venue_name
+        )
+        return (
+            fallback_profile(
+                requested_angle, warning="Research Profile grounded call failed."
+            ),
+            ResearchProfileTrace(
+                prompt=prompt,
+                model=grounded_model,
+                error=f"grounded call raised: {exc!r}",
+            ),
+        )
+
+    raw_text = getattr(result, "text", "") if result is not None else ""
+    model_used = (
+        getattr(result, "model_name", grounded_model)
+        if result is not None
+        else grounded_model
+    )
+    if not raw_text.strip():
+        return (
+            fallback_profile(
+                requested_angle, warning="Research Profile returned empty text."
+            ),
+            ResearchProfileTrace(
+                prompt=prompt,
+                raw_response=raw_text,
+                model=model_used,
+                error="grounded call returned empty text",
+            ),
+        )
+
+    profile, parser_reason = parse_research_profile_response(
+        raw_text=raw_text,
+        requested_angle=requested_angle,
+    )
+    return profile, ResearchProfileTrace(
+        prompt=prompt,
+        raw_response=raw_text,
+        model=model_used,
+        parser_dropped_reason=parser_reason,
+    )
+
+
+__all__ = ["GroundedInvoker", "execute_research_profile"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_parsing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_parsing.py
@@ -1,0 +1,187 @@
+"""Sanitize and parse grounded Research Profile responses."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from utils import parse_json_response
+
+from .angle_assignment import ListicleAngle
+from .research_profile_contracts import (
+    STANDARD_RESEARCH_BUCKETS,
+    ResearchFinding,
+    ResearchProfile,
+    SelectedAngleEvidence,
+    empty_buckets,
+    fallback_profile,
+    has_usable_bucket_evidence,
+)
+
+_VALID_SELECTED_STATUSES = {"supported", "weak", "unsupported", "not-requested"}
+_BUCKET_SET = set(STANDARD_RESEARCH_BUCKETS)
+
+# Grounded models sometimes drop prose, sentence fragments, or empty strings
+# into the citations array. We only trust entries that look like URLs.
+_URL_RE = re.compile(r"^https?://\S+$", re.I)
+
+# Inline Google-grounding markers like "[3]", "[3, 9, 10, 13]", or
+# "[3, 9-12]" sometimes leak into summary text. Strip them before
+# storing — the writer should never see grounded-response marker syntax.
+_INLINE_CITATION_MARKER_RE = re.compile(r"\s*\[\s*\d+(?:\s*[,\-]\s*\d+)*\s*\]")
+
+
+def clean_citations(raw: Any) -> list[str]:
+    """Keep only entries that look like URLs. Drop prose contamination."""
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        candidate = entry.strip()
+        if _URL_RE.match(candidate):
+            cleaned.append(candidate)
+    return cleaned
+
+
+def clean_summary(raw: Any) -> str:
+    if not isinstance(raw, str):
+        return ""
+    stripped = _INLINE_CITATION_MARKER_RE.sub("", raw)
+    # Collapse repeated whitespace introduced by marker removal.
+    return re.sub(r"\s{2,}", " ", stripped).strip()
+
+
+def extract_json(text: str) -> Any:
+    try:
+        return parse_json_response(text)
+    except (RuntimeError, TypeError):
+        return None
+
+
+def parse_research_profile_response(
+    *,
+    raw_text: str,
+    requested_angle: ListicleAngle | None,
+) -> tuple[ResearchProfile, str | None]:
+    parsed = extract_json(raw_text)
+    if not isinstance(parsed, dict):
+        return (
+            fallback_profile(
+                requested_angle, warning="Research Profile response was not JSON."
+            ),
+            "response was not a JSON object",
+        )
+
+    drop_reasons: list[str] = []
+    selected_raw = parsed.get("selected_angle")
+    selected = SelectedAngleEvidence(
+        angle=requested_angle,
+        status="not-requested" if requested_angle is None else "unsupported",
+    )
+    if isinstance(selected_raw, dict):
+        status = selected_raw.get("status")
+        if status not in _VALID_SELECTED_STATUSES:
+            drop_reasons.append(f"selected_angle invalid status {status!r}")
+            status = "not-requested" if requested_angle is None else "unsupported"
+        angle_value = selected_raw.get("angle")
+        angle = requested_angle if requested_angle is not None else None
+        if requested_angle is not None and angle_value not in {requested_angle, None}:
+            drop_reasons.append(f"selected_angle unexpected angle {angle_value!r}")
+        citations = clean_citations(selected_raw.get("citations"))
+        summary = clean_summary(selected_raw.get("summary"))
+        reason = clean_summary(selected_raw.get("reason"))
+        if requested_angle is None:
+            status = "not-requested"
+            angle = None
+            summary = ""
+            citations = []
+        elif status == "supported" and (not summary or not citations):
+            drop_reasons.append(
+                "selected_angle supported without summary/citations; downgraded to unsupported"
+            )
+            status = "unsupported"
+            summary = ""
+            citations = []
+        elif status != "supported":
+            summary = ""
+            citations = []
+        selected = SelectedAngleEvidence(
+            angle=angle,
+            status=status,  # type: ignore[arg-type]
+            summary=summary,
+            citations=citations,
+            reason=reason,
+        )
+    elif selected_raw is not None:
+        drop_reasons.append("selected_angle was not an object")
+
+    buckets = empty_buckets()
+    raw_buckets = parsed.get("standard_buckets")
+    if isinstance(raw_buckets, dict):
+        for bucket_name, raw_findings in raw_buckets.items():
+            if bucket_name not in _BUCKET_SET:
+                drop_reasons.append(f"unknown bucket {bucket_name!r}")
+                continue
+            if not isinstance(raw_findings, list):
+                drop_reasons.append(f"{bucket_name}: findings not an array")
+                continue
+            cleaned: list[ResearchFinding] = []
+            for entry in raw_findings[:2]:
+                if not isinstance(entry, dict):
+                    drop_reasons.append(f"{bucket_name}: finding not an object")
+                    continue
+                summary = clean_summary(entry.get("summary"))
+                citations = clean_citations(entry.get("citations"))
+                if not summary:
+                    drop_reasons.append(f"{bucket_name}: empty summary")
+                    continue
+                if not citations:
+                    drop_reasons.append(
+                        f"{bucket_name}: uncited finding dropped (no valid URL citations)"
+                    )
+                    continue
+                cleaned.append(
+                    ResearchFinding(
+                        summary=summary,
+                        citations=citations,
+                    )
+                )
+            buckets[bucket_name] = cleaned  # type: ignore[index]
+    elif raw_buckets is not None:
+        drop_reasons.append("standard_buckets was not an object")
+
+    warnings = (
+        [
+            warning.strip()
+            for warning in parsed.get("warnings", [])
+            if isinstance(warning, str) and warning.strip()
+        ]
+        if isinstance(parsed.get("warnings"), list)
+        else []
+    )
+
+    if requested_angle and selected.status != "supported":
+        warnings.append(f'Selected angle "{requested_angle}" lacked cited support.')
+
+    usable_for_blurb = selected.status == "supported" or has_usable_bucket_evidence(
+        buckets
+    )
+    return (
+        ResearchProfile(
+            selected_angle=selected,
+            standard_buckets=buckets,
+            usable_for_blurb=usable_for_blurb,
+            warnings=warnings,
+        ),
+        "; ".join(drop_reasons) if drop_reasons else None,
+    )
+
+
+__all__ = [
+    "clean_citations",
+    "clean_summary",
+    "extract_json",
+    "parse_research_profile_response",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_prompt.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/research_profile_prompt.py
@@ -1,0 +1,68 @@
+"""Prompt construction for grounded Research Profiles."""
+
+from __future__ import annotations
+
+from .angle_assignment import ListicleAngle
+from .research_profile_contracts import (
+    CATEGORY_BUCKET_PRIORITIES,
+    STANDARD_RESEARCH_BUCKETS,
+)
+
+
+def build_research_profile_prompt(
+    *,
+    venue_name: str,
+    location_label: str,
+    category: str,
+    requested_angle: ListicleAngle | None,
+) -> str:
+    bucket_list = "\n".join(f'  - "{bucket}"' for bucket in STANDARD_RESEARCH_BUCKETS)
+    priority = CATEGORY_BUCKET_PRIORITIES.get(category, ())
+    priority_line = ", ".join(priority) if priority else "none"
+    angle_line = (
+        f'Research selected angle "{requested_angle}" and decide whether it is supported.'
+        if requested_angle
+        else "No angle is selected. Do not evaluate angle framing; gather standard buckets only."
+    )
+    selected_angle_shape = (
+        '{ "angle": "selected-angle", "status": "supported|weak|unsupported", '
+        '"summary": "one short writer-ready finding when supported", '
+        '"citations": ["https://..."], "reason": "short explanation" }'
+        if requested_angle
+        else '{ "angle": null, "status": "not-requested", "summary": "", "citations": [], "reason": "" }'
+    )
+    return (
+        "You are building a cited Research Profile for one travel listicle blurb.\n\n"
+        f"Venue: {venue_name}\n"
+        f"Location: {location_label}\n"
+        f"Category: {category}\n\n"
+        f"{angle_line}\n"
+        "Use web search. Return facts only when backed by URLs you actually consulted. "
+        "Do not write blurb prose.\n\n"
+        "Standard Research Buckets:\n"
+        f"{bucket_list}\n\n"
+        f"Category priorities: {priority_line}. Keep low-signal buckets empty rather than padded.\n\n"
+        "Bucket boundaries:\n"
+        "- best-for means audience/use-case evidence, not angle framing.\n"
+        "- timing-tips means practical timing facts, not an insider-tip lead.\n"
+        "- visual-assets means visual details for prose only, not media selection.\n"
+        "- caveats-or-fit-warnings must be factual and restrained.\n"
+        "- standout-hook is strongest concise fact found, but must not override the selected angle.\n\n"
+        "Output one JSON object only, no code fences, with this shape:\n"
+        "{\n"
+        f'  "selected_angle": {selected_angle_shape},\n'
+        '  "standard_buckets": {\n'
+        '    "bucket-name": [{ "summary": "one short finding", "citations": ["https://..."] }]\n'
+        "  },\n"
+        '  "warnings": ["optional warning"]\n'
+        "}\n\n"
+        "Rules:\n"
+        "- Every selected-angle supported finding requires citations.\n"
+        "- Every bucket finding requires citations; uncited findings are invalid.\n"
+        "- Each bucket may return zero, one, or two findings.\n"
+        "- If selected angle is weak or unsupported, explain why in reason and do not provide a leading summary.\n"
+        "- If no angle is selected, selected_angle.status must be not-requested."
+    )
+
+
+__all__ = ["build_research_profile_prompt"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
@@ -115,6 +115,38 @@ def test_listicle_writer_remains_a_thin_compatible_facade():
     }.issubset(imported_modules)
 
 
+def test_research_profile_remains_a_thin_compatible_facade():
+    feature_path = Path(__file__).parents[1] / "app" / "features" / "editor_assist"
+    facade_path = feature_path / "research_profile.py"
+    source = facade_path.read_text()
+    module = ast.parse(source)
+
+    top_level_defs = [
+        node
+        for node in module.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    imported_modules = {
+        node.module
+        for node in module.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert len(source.splitlines()) <= 120
+    assert [node.name for node in top_level_defs] == [
+        "_invoke_grounded",
+        "run_research_profile",
+        "run_research_profiles_concurrently",
+    ]
+    assert {
+        "research_profile_batch",
+        "research_profile_contracts",
+        "research_profile_execution",
+        "research_profile_parsing",
+        "research_profile_prompt",
+    }.issubset(imported_modules)
+
+
 def test_editor_assist_internals_do_not_depend_on_listicle_writer_facade():
     feature_path = Path(__file__).parents[1] / "app" / "features" / "editor_assist"
     facade_importers: list[str] = []

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_research_profile_execution.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_research_profile_execution.py
@@ -1,0 +1,108 @@
+"""Execution and compatibility seams for Research Profile generation."""
+
+from types import SimpleNamespace
+
+import app.features.editor_assist.research_profile as research_profile
+from app.features.editor_assist.research_profile import (
+    ResearchProfileRequest,
+    ResearchProfileTrace,
+)
+
+
+def test_grounded_failure_returns_the_existing_fallback_shape(monkeypatch):
+    def _raise(*_args, **_kwargs):
+        raise TimeoutError("grounding timed out")
+
+    monkeypatch.setattr(research_profile, "_invoke_grounded", _raise)
+
+    profile, trace = research_profile.run_research_profile(
+        venue_name="La Mar",
+        location_label="Lima, Peru",
+        category="dining",
+        requested_angle="signature-dish",
+        grounded_model="gemini-test",
+    )
+
+    assert profile.selected_angle.angle == "signature-dish"
+    assert profile.selected_angle.status == "unsupported"
+    assert profile.usable_for_blurb is False
+    assert profile.warnings == ["Research Profile grounded call failed."]
+    assert trace.model == "gemini-test"
+    assert trace.error == "grounded call raised: TimeoutError('grounding timed out')"
+    assert "Venue: La Mar" in trace.prompt
+
+
+def test_empty_grounded_result_preserves_model_and_empty_response_trace(monkeypatch):
+    monkeypatch.setattr(
+        research_profile,
+        "_invoke_grounded",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            text="  ",
+            model_name="gemini-fallback",
+        ),
+    )
+
+    profile, trace = research_profile.run_research_profile(
+        venue_name="La Mar",
+        location_label="Lima, Peru",
+        category="dining",
+        requested_angle=None,
+    )
+
+    assert profile.selected_angle.status == "not-requested"
+    assert profile.warnings == ["Research Profile returned empty text."]
+    assert trace.raw_response == "  "
+    assert trace.model == "gemini-fallback"
+    assert trace.error == "grounded call returned empty text"
+
+
+def test_batch_execution_uses_the_facade_single_profile_seam(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def _fake_run_research_profile(
+        *,
+        venue_name,
+        location_label,
+        category,
+        requested_angle,
+        grounded_model,
+    ):
+        del location_label, category, requested_angle
+        calls.append((venue_name, grounded_model))
+        return (
+            research_profile._fallback_profile(None),
+            ResearchProfileTrace(prompt=venue_name, model=grounded_model),
+        )
+
+    monkeypatch.setattr(
+        research_profile,
+        "run_research_profile",
+        _fake_run_research_profile,
+    )
+    requests = [
+        ResearchProfileRequest(
+            target_id="first",
+            venue_name="Venue A",
+            location_label="Lima",
+            category="dining",
+            requested_angle=None,
+        ),
+        ResearchProfileRequest(
+            target_id="second",
+            venue_name="Venue B",
+            location_label="Lima",
+            category="dining",
+            requested_angle=None,
+        ),
+    ]
+
+    results = research_profile.run_research_profiles_concurrently(
+        requests,
+        grounded_model="gemini-test",
+        max_workers=1,
+    )
+
+    assert calls == [("Venue A", "gemini-test"), ("Venue B", "gemini-test")]
+    assert list(results) == ["first", "second"]
+    assert results["first"][1].prompt == "Venue A"
+    assert results["second"][1].prompt == "Venue B"


### PR DESCRIPTION
## Original issue

`editor_assist/research_profile.py` had grown to 503 lines and combined Research Profile contracts, prompt policy, response sanitization and parsing, runtime fallback handling, grounded invocation, and batch concurrency in one shallow module.

## Root cause

The original implementation accumulated each phase of ADR 0006 Research Profile generation in the first module that owned the feature. Callers and tests then depended on both its public contracts and its `_invoke_grounded` and parser helper patch seams, making a direct move risky.

## Refactor performed

- Kept `research_profile.py` as a 92-line compatibility facade.
- Extracted data contracts and evidence policy to `research_profile_contracts.py`.
- Extracted prompt construction to `research_profile_prompt.py`.
- Extracted sanitization and parsing to `research_profile_parsing.py`.
- Extracted grounded invocation and runtime fallbacks to `research_profile_execution.py`.
- Extracted ThreadPool batch orchestration to `research_profile_batch.py`.
- Preserved all existing caller imports, private parser helper imports, `_invoke_grounded` monkeypatch behavior, prompt text, parser behavior, fallback payloads, model parameters, ordering, and worker limits.
- Added architecture, runtime-fallback, empty-response, and batch-seam coverage and documented the module ownership decision in Editor Assist context.

## Why better

Each module now presents one cohesive interface with stronger locality: prompt changes no longer share a file with concurrency, parser hardening no longer shares a file with provider execution, and contracts can be understood without traversing operational code. The facade preserves leverage for existing callers while making the internal seams explicit and independently testable.

## Validation

- Focused Editor Assist suite: 50 passed.
- Full backend suite: 353 passed.
- `pnpm run test`: passed all four Nx projects; backend 353 passed, frontend 95 files / 362 tests passed, shared and utils explicit no-test skips.
- `pnpm run lint`: passed all four Nx projects, including Python flake8, frontend boundaries, and ESLint.
- `pnpm run build`: passed Vite production build and Python compileall.
- Black check passed for all changed Python files.
- `git diff --check` passed.
- No Python typecheck target is configured for the backend.

## Risks/tradeoffs/follow-ups

The split introduces five internal files and a small amount of delegation boilerplate. Runtime behavior remains behind the original facade, including the existing grounded-call patch seam. Existing repository warnings remain unchanged: pytest dependency deprecations, React Router/Vite warnings, and the frontend chunk-size advisory.
