### PR TITLE
refactor(abw): split writer brief modules

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/CONTEXT.md
@@ -54,6 +54,11 @@ _Avoid_: article prose, full SEO document
   prompt construction, response parsing, grounded execution, fallback policy,
   and batch concurrency live in cohesive adjacent `research_profile_*` modules.
   The facade preserves the grounded-invocation patch seam used by route tests.
+- `writer_brief.py` is a compatibility facade. Writer Brief contracts, angle
+  directive policy, curator prompt construction, response parsing, execution
+  fallbacks, and writer-facing rendering live in cohesive adjacent
+  `writer_brief_*` modules. The facade preserves the curator-invocation patch
+  seam used by route tests.
 - The `blurb_composition_*` family owns Listicle Content Generation path
   selection, retry policy, validation traces, and writer execution. New prompt
   modules must reuse that execution boundary rather than introduce another

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_contracts.py
@@ -15,7 +15,8 @@ from .listicle_writer_contracts import (
     ListicleFieldType,
 )
 from .research_profile import ResearchProfile
-from .writer_brief import WriterBrief, WriterBriefTrace, run_writer_brief
+from .writer_brief import run_writer_brief
+from .writer_brief_contracts import WriterBrief, WriterBriefTrace
 
 CompositionStatus = Literal["generated", "error"]
 StepStatus = Literal["ok", "skipped", "failed"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_evidence.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_evidence.py
@@ -17,7 +17,7 @@ from .research_profile import (
     ResearchProfile,
     ResearchProfileTrace,
 )
-from .writer_brief import MIN_SOURCE_FACTS, WriterBrief
+from .writer_brief_contracts import MIN_SOURCE_FACTS, WriterBrief
 
 
 @dataclass(frozen=True)

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_policy.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_policy.py
@@ -17,7 +17,7 @@ from .listicle_prompt_builders import (
 )
 from .listicle_writer_contracts import ListicleWriterTarget
 from .research_profile import ResearchProfile
-from .writer_brief import WriterBrief
+from .writer_brief_contracts import WriterBrief
 
 
 @dataclass(frozen=True)

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_retry.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/blurb_composition_retry.py
@@ -12,7 +12,7 @@ from .listicle_writer_contracts import (
     ListicleArticleType,
     ListicleWriterTarget,
 )
-from .writer_brief import WriterBrief
+from .writer_brief_contracts import WriterBrief
 
 _LEAN_INLINE_RETRY_CATEGORIES = {"nightlife"}
 _LEAN_RETRY_BUILDER_CATEGORIES = {"dining", "accommodations", "attractions"}

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_prompt_builders.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_prompt_builders.py
@@ -25,7 +25,8 @@ from .listicle_writer_contracts import (
     ListicleCategory,
     ListicleWriterTarget,
 )
-from .writer_brief import WriterBrief, render_source_facts_block
+from .writer_brief_contracts import WriterBrief
+from .writer_brief_rendering import render_source_facts_block
 
 
 def build_generation_prompt(

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_writer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_writer.py
@@ -58,7 +58,8 @@ from .listicle_writer_validation import (  # noqa: F401
     validate_generated_text,
     word_count as _word_count,
 )
-from .writer_brief import WriterBrief, render_source_facts_block
+from .writer_brief_contracts import WriterBrief
+from .writer_brief_rendering import render_source_facts_block
 
 __all__ = [
     "ANTI_AI_PROMPT_CATEGORIES",

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief.py
@@ -1,340 +1,40 @@
-"""Writer Brief curator.
+"""Compatibility facade for Writer Brief curation.
 
-Per ADR 0007, the nightlife writer no longer reads the Research Profile
-directly. The Research Profile (cited evidence bundle, 11 potentially
-overlapping buckets) is passed through a per-blurb curation step that emits a
-Writer Brief: a venue-tailored angle directive plus a flat, deduped Source
-Facts list (2-8 bullets) with bucket labels stripped.
-
-This module owns the curation step: prompt building, LLM invocation,
-JSON parsing, cap enforcement, and structured fallback signaling. The
-non-grounded synthesis call is routed through Vertex (gemini-2.5-flash by
-default) at low temperature.
+Contracts, editorial directive policy, prompt construction, parsing, execution,
+fallbacks, and writer-facing rendering live in cohesive adjacent modules. The
+facade preserves the existing import surface and ``_invoke_curator_model``
+patch seam.
 """
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from typing import Any
-
-from utils import parse_json_response
 
 from .angle_assignment import ListicleAngle
-from .listicle_prompt_policy import format_location_for_prompt
 from .research_profile import ResearchProfile
+from .writer_brief_contracts import (  # noqa: F401
+    MAX_SOURCE_FACTS,
+    MIN_SOURCE_FACTS,
+    SourceFact,
+    WriterBrief,
+    WriterBriefTrace,
+)
+from .writer_brief_execution import execute_writer_brief
+from .writer_brief_parsing import (  # noqa: F401
+    extract_json as _extract_json,
+    parse_writer_brief_response,
+)
+from .writer_brief_policy import (  # noqa: F401
+    ANGLE_DIRECTIVES_BY_CATEGORY,
+    render_angle_directive_template as _render_template_fallback,
+)
+from .writer_brief_prompt import (  # noqa: F401
+    build_curator_prompt,
+    format_research_profile_for_curator as _format_research_profile_for_curator,
+)
+from .writer_brief_rendering import render_source_facts_block
 
 logger = logging.getLogger(__name__)
-
-
-# Per-angle directive templates, keyed by category. The {venue} placeholder is
-# filled by the curator (or by deterministic fallback rendering) before the
-# directive reaches the writer prompt. These are the venue-facing directives
-# referenced in ADR 0007 (nightlife), ADR 0009 (dining), ADR 0011
-# (accommodations), and ADR 0012 (attractions) — distinct from
-# LISTICLE_ANGLE_GUIDANCE, which is the legacy model-facing instruction text
-# still used by fat-prompt categories.
-ANGLE_DIRECTIVES_BY_CATEGORY: dict[str, dict[ListicleAngle, str]] = {
-    "nightlife": {
-        "best-for-night": (
-            "Open by naming the kind of night {venue} is best for, and give one "
-            "concrete reason rooted in the room, the drinks, the crowd, or the "
-            "pacing."
-        ),
-    },
-    "dining": {
-        "signature-dish": (
-            "Open by naming one specific dish at {venue} and one concrete "
-            "reason it's worth ordering."
-        ),
-        "atmosphere": (
-            "Open by placing the reader in the room at {venue} with one "
-            "concrete physical detail — the light, the seating, the music, "
-            "the crowd at a specific hour."
-        ),
-        "founders-backstory": (
-            "Open by naming the person behind {venue} and one specific fact "
-            "about them — where they trained, what they ran before, when "
-            "they opened."
-        ),
-        "insider-tip": (
-            "Open with one specific, actionable tip at {venue} a first-time "
-            "visitor wouldn't guess — a time, a seat, an order, a side door."
-        ),
-        "best-for": (
-            "Open by naming the occasion {venue} serves best, then one "
-            "concrete reason rooted in the room, the menu, the pacing, or "
-            "the price."
-        ),
-        "whats-different": (
-            "Open by naming the specific thing that sets {venue} apart from "
-            "neighboring options of the same kind — a technique, a sourcing "
-            "choice, a format."
-        ),
-    },
-    "accommodations": {
-        "location-and-setting": (
-            "Open by placing {venue} in its physical setting with one "
-            "concrete geographic anchor — the bay, the ridge, the named "
-            "neighborhood, what's on either side. No 'centrally located'."
-        ),
-        "view-and-vista": (
-            "Open by naming what guests actually see from {venue} — the "
-            "specific sightline, which rooms or spaces it's from, one "
-            "concrete fact about it."
-        ),
-        "design-and-aesthetic": (
-            "Open by describing one concrete material, named space, or "
-            "design choice at {venue} — the lobby, the restaurant, the pool "
-            "deck, or the rooms, whichever carries the strongest identity."
-        ),
-        "signature-amenity": (
-            "Open by naming the one standalone feature that defines a stay "
-            "at {venue} — the rooftop hammam, the private beach club, the "
-            "library — and one concrete fact about it."
-        ),
-        "food-and-beverage": (
-            "Open by naming a specific on-site restaurant, bar, breakfast, "
-            "or rooftop at {venue} and one concrete fact — the chef, the "
-            "cuisine, the cocktail program, the hours."
-        ),
-        "trip-fit": (
-            "Open by naming the kind of trip {venue} serves best — a "
-            "honeymoon, a long remote-work stay, a family with toddlers, a "
-            "solo business swing — and one concrete reason rooted in the "
-            "rooms, the service, or the property's rhythm."
-        ),
-        "property-backstory": (
-            "Open by naming the owner, designer, or origin year of {venue} "
-            "and one specific fact — a former use of the building, the "
-            "architect, the family that runs it."
-        ),
-        "booking-tip": (
-            "Open with one specific, actionable booking or stay tip for "
-            "{venue} a first-time guest wouldn't guess — a room to request, "
-            "a night of the week, an arrival window."
-        ),
-        "whats-different": (
-            "Open by naming the specific thing that sets {venue} apart from "
-            "neighboring properties of the same kind — a design choice, a "
-            "service rhythm, a location format, a hybrid concept."
-        ),
-    },
-    "attractions": {
-        "signature-feature": (
-            "Open by naming the specific feature {venue} is built around — "
-            "the viewpoint, route, room, artwork, ruin, exhibit, or natural "
-            "formation — and one concrete fact that makes it worth the stop."
-        ),
-        "setting": (
-            "Open by placing the reader at {venue} with one concrete physical "
-            "detail — the approach, surrounding terrain, material, light at a "
-            "specific hour, or what frames the site."
-        ),
-        "history-built": (
-            "Open by naming when {venue} was built, founded, used, or changed "
-            "and one specific fact tied to that history — who built it, what it "
-            "replaced, what it survived, or why it matters."
-        ),
-        "visit-time-tip": (
-            "Open with one specific, actionable visit tip for {venue} a "
-            "first-time visitor would not guess — a time of day, entrance, "
-            "walking order, ticket choice, or pacing move."
-        ),
-        "best-for-visit-type": (
-            "Open by naming the kind of visit {venue} serves best — a quick "
-            "photo stop, rainy afternoon, kid-friendly half day, full deep dive, "
-            "or quiet early-morning visit — and one concrete reason."
-        ),
-        "whats-different": (
-            "Open by naming the specific thing that sets {venue} apart from "
-            "nearby attractions of the same kind — a format, scale, access, "
-            "setting, collection, route, or viewpoint."
-        ),
-    },
-}
-
-MIN_SOURCE_FACTS = 2
-MAX_SOURCE_FACTS = 8
-
-
-@dataclass(frozen=True)
-class SourceFact:
-    fact: str
-    citations: list[str] = field(default_factory=list)
-
-
-@dataclass(frozen=True)
-class WriterBrief:
-    angle_directive: str
-    source_facts: list[SourceFact]
-    angle: ListicleAngle | None
-    venue: str
-
-    @property
-    def is_usable(self) -> bool:
-        return bool(self.angle_directive) and len(self.source_facts) >= MIN_SOURCE_FACTS
-
-
-@dataclass(frozen=True)
-class WriterBriefTrace:
-    prompt: str
-    raw_response: str = ""
-    model: str = ""
-    error: str | None = None
-    parser_dropped_reason: str | None = None
-
-
-def _format_research_profile_for_curator(profile: ResearchProfile) -> str:
-    lines: list[str] = []
-    selected = profile.selected_angle
-    if selected.status == "supported" and selected.angle and selected.summary:
-        lines.append(f"selected-angle ({selected.angle}): {selected.summary}")
-    for bucket, findings in profile.standard_buckets.items():
-        for finding in findings:
-            lines.append(f"{bucket}: {finding.summary}")
-    return "\n".join(f"- {line}" for line in lines) if lines else "(no findings)"
-
-
-def build_curator_prompt(
-    *,
-    venue_name: str,
-    location_label: str,
-    category: str,
-    angle: ListicleAngle | None,
-    angle_directive_template: str | None,
-    research_profile: ResearchProfile,
-) -> str:
-    findings_block = _format_research_profile_for_curator(research_profile)
-    location = format_location_for_prompt(location_label)
-    if angle_directive_template:
-        starting_point = angle_directive_template.replace("{venue}", venue_name)
-        directive_block = (
-            "Angle directive starting point (rewrite when the findings warrant a sharper opening):\n"
-            f"{starting_point}"
-        )
-    else:
-        directive_block = (
-            "Angle directive starting point: write a one-line directive that names "
-            f"{venue_name} and opens the blurb with one concrete reason this venue "
-            "belongs in the list."
-        )
-    return (
-        "You are curating a Writer Brief for one travel listicle blurb. Compress "
-        "the research findings into a deduped Source Facts list and write a "
-        f"venue-tailored angle directive.\n\n"
-        f"Venue: {venue_name}, {location}\n"
-        f"Category: {category}\n"
-        f"Angle: {angle or 'none'}\n\n"
-        f"{directive_block}\n\n"
-        "Research findings:\n"
-        f"{findings_block}\n\n"
-        "Return one JSON object only. No code fences, no commentary.\n\n"
-        "Shape:\n"
-        "{\n"
-        '  "angle_directive": "...",\n'
-        '  "source_facts": [\n'
-        '    { "fact": "...", "citations": ["https://..."] }\n'
-        "  ]\n"
-        "}\n\n"
-        "Rules:\n"
-        f"- {MIN_SOURCE_FACTS} to {MAX_SOURCE_FACTS} source_facts. Use what you have; don't pad, don't invent.\n"
-        "- Findings may overlap across buckets. Collapse to one fact.\n"
-        "- Strip bucket labels from fact text.\n"
-        "- Drop database-field noise (exact hours, square meters, age ranges) unless central to the angle.\n"
-        "- Preserve citations per fact, merged from the source findings.\n"
-        "- Prefer facts that serve the angle's lead shape; supporting texture is fine but should not dominate.\n"
-        "- The angle_directive must read as a finished sentence about the venue, not a template."
-    )
-
-
-def _extract_json(text: str) -> Any:
-    try:
-        return parse_json_response(text)
-    except (RuntimeError, TypeError):
-        return None
-
-
-def _render_template_fallback(template: str | None, venue_name: str) -> str:
-    if not template:
-        return ""
-    return template.replace("{venue}", venue_name)
-
-
-def parse_writer_brief_response(
-    *,
-    raw_text: str,
-    venue_name: str,
-    angle: ListicleAngle | None,
-    angle_directive_template: str | None,
-) -> tuple[WriterBrief, str | None]:
-    """Parse a curator JSON response into a WriterBrief.
-
-    Returns (brief, drop_reason). If the response cannot yield a usable brief
-    the caller should fall back to the identity-only writer path.
-    """
-    parsed = _extract_json(raw_text)
-    drop_reasons: list[str] = []
-
-    fallback_directive = _render_template_fallback(angle_directive_template, venue_name)
-
-    if not isinstance(parsed, dict):
-        return (
-            WriterBrief(
-                angle_directive=fallback_directive,
-                source_facts=[],
-                angle=angle,
-                venue=venue_name,
-            ),
-            "response was not a JSON object",
-        )
-
-    directive_raw = parsed.get("angle_directive")
-    if isinstance(directive_raw, str) and directive_raw.strip():
-        directive = directive_raw.strip().replace("{venue}", venue_name)
-    else:
-        drop_reasons.append("angle_directive missing; fell back to template")
-        directive = fallback_directive
-
-    facts_raw = parsed.get("source_facts")
-    cleaned: list[SourceFact] = []
-    if isinstance(facts_raw, list):
-        for entry in facts_raw:
-            if len(cleaned) >= MAX_SOURCE_FACTS:
-                drop_reasons.append(
-                    f"source_facts capped at {MAX_SOURCE_FACTS}; extras dropped"
-                )
-                break
-            if not isinstance(entry, dict):
-                drop_reasons.append("source_facts entry not an object")
-                continue
-            fact_raw = entry.get("fact")
-            if not isinstance(fact_raw, str) or not fact_raw.strip():
-                drop_reasons.append("source_facts entry missing fact text")
-                continue
-            citations_raw = entry.get("citations")
-            citations = (
-                [
-                    citation.strip()
-                    for citation in citations_raw
-                    if isinstance(citation, str) and citation.strip()
-                ]
-                if isinstance(citations_raw, list)
-                else []
-            )
-            cleaned.append(SourceFact(fact=fact_raw.strip(), citations=citations))
-    else:
-        drop_reasons.append("source_facts missing or not a list")
-
-    return (
-        WriterBrief(
-            angle_directive=directive,
-            source_facts=cleaned,
-            angle=angle,
-            venue=venue_name,
-        ),
-        "; ".join(drop_reasons) if drop_reasons else None,
-    )
 
 
 def _invoke_curator_model(
@@ -344,7 +44,6 @@ def _invoke_curator_model(
     max_tokens: int,
     temperature: float,
 ) -> tuple[str, str]:
-    """Call the Vertex synthesis model. Returns (raw_text, resolved_model_name)."""
     from utils import get_vertex_llm  # type: ignore
 
     llm = get_vertex_llm(
@@ -368,91 +67,30 @@ def run_writer_brief(
     max_tokens: int = 10240,
     temperature: float = 0.1,
 ) -> tuple[WriterBrief, WriterBriefTrace]:
-    """Run the curator for a single blurb. Returns (brief, trace).
-
-    The caller is responsible for checking `brief.is_usable` and falling back
-    to the identity-only writer path when the curator could not produce a
-    Writer Brief with at least MIN_SOURCE_FACTS facts.
-    """
-    category_directives = ANGLE_DIRECTIVES_BY_CATEGORY.get(category, {})
-    angle_directive_template = (
-        category_directives.get(angle) if angle is not None else None
-    )
-    prompt = build_curator_prompt(
+    """Run the curator while preserving the facade's injectable model seam."""
+    return execute_writer_brief(
         venue_name=venue_name,
         location_label=location_label,
         category=category,
         angle=angle,
-        angle_directive_template=angle_directive_template,
         research_profile=research_profile,
-    )
-
-    try:
-        raw_text, resolved_model = _invoke_curator_model(
-            prompt=prompt,
-            model_name=model_name,
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.exception("Writer Brief curator call failed for venue %r", venue_name)
-        fallback_directive = _render_template_fallback(
-            angle_directive_template, venue_name
-        )
-        return (
-            WriterBrief(
-                angle_directive=fallback_directive,
-                source_facts=[],
-                angle=angle,
-                venue=venue_name,
-            ),
-            WriterBriefTrace(
-                prompt=prompt,
-                model=model_name,
-                error=f"curator call raised: {exc!r}",
-            ),
-        )
-
-    if not raw_text.strip():
-        fallback_directive = _render_template_fallback(
-            angle_directive_template, venue_name
-        )
-        return (
-            WriterBrief(
-                angle_directive=fallback_directive,
-                source_facts=[],
-                angle=angle,
-                venue=venue_name,
-            ),
-            WriterBriefTrace(
-                prompt=prompt,
-                raw_response=raw_text,
-                model=resolved_model,
-                error="curator returned empty text",
-            ),
-        )
-
-    brief, drop_reason = parse_writer_brief_response(
-        raw_text=raw_text,
-        venue_name=venue_name,
-        angle=angle,
-        angle_directive_template=angle_directive_template,
-    )
-    return brief, WriterBriefTrace(
-        prompt=prompt,
-        raw_response=raw_text,
-        model=resolved_model,
-        parser_dropped_reason=drop_reason,
+        model_name=model_name,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        invoke_curator=_invoke_curator_model,
+        exception_logger=logger,
     )
 
 
-def render_source_facts_block(brief: WriterBrief) -> str:
-    """Render the Source Facts bullet list for the writer prompt.
-
-    Citations are intentionally omitted from the writer-facing text; they live
-    only in the inspector trace.
-    """
-    if not brief.source_facts:
-        return ""
-    bullets = "\n".join(f"- {entry.fact}" for entry in brief.source_facts)
-    return f"Source facts (use only what you need):\n{bullets}"
+__all__ = [
+    "ANGLE_DIRECTIVES_BY_CATEGORY",
+    "MAX_SOURCE_FACTS",
+    "MIN_SOURCE_FACTS",
+    "SourceFact",
+    "WriterBrief",
+    "WriterBriefTrace",
+    "build_curator_prompt",
+    "parse_writer_brief_response",
+    "render_source_facts_block",
+    "run_writer_brief",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_contracts.py
@@ -1,0 +1,62 @@
+"""Writer Brief data contracts and source-fact limits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .angle_assignment import ListicleAngle
+
+MIN_SOURCE_FACTS = 2
+MAX_SOURCE_FACTS = 8
+
+
+@dataclass(frozen=True)
+class SourceFact:
+    fact: str
+    citations: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WriterBrief:
+    angle_directive: str
+    source_facts: list[SourceFact]
+    angle: ListicleAngle | None
+    venue: str
+
+    @property
+    def is_usable(self) -> bool:
+        return bool(self.angle_directive) and len(self.source_facts) >= MIN_SOURCE_FACTS
+
+
+@dataclass(frozen=True)
+class WriterBriefTrace:
+    prompt: str
+    raw_response: str = ""
+    model: str = ""
+    error: str | None = None
+    parser_dropped_reason: str | None = None
+
+
+def empty_writer_brief(
+    *,
+    venue_name: str,
+    angle: ListicleAngle | None,
+    angle_directive: str,
+) -> WriterBrief:
+    """Build the unusable brief returned by parser and runtime fallbacks."""
+    return WriterBrief(
+        angle_directive=angle_directive,
+        source_facts=[],
+        angle=angle,
+        venue=venue_name,
+    )
+
+
+__all__ = [
+    "MAX_SOURCE_FACTS",
+    "MIN_SOURCE_FACTS",
+    "SourceFact",
+    "WriterBrief",
+    "WriterBriefTrace",
+    "empty_writer_brief",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_execution.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_execution.py
@@ -1,0 +1,107 @@
+"""Curator execution and runtime fallbacks for one Writer Brief."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from .angle_assignment import ListicleAngle
+from .research_profile import ResearchProfile
+from .writer_brief_contracts import (
+    WriterBrief,
+    WriterBriefTrace,
+    empty_writer_brief,
+)
+from .writer_brief_parsing import parse_writer_brief_response
+from .writer_brief_policy import (
+    get_angle_directive_template,
+    render_angle_directive_template,
+)
+from .writer_brief_prompt import build_curator_prompt
+
+CuratorInvoker = Callable[..., tuple[str, str]]
+
+
+def execute_writer_brief(
+    *,
+    venue_name: str,
+    location_label: str,
+    category: str,
+    angle: ListicleAngle | None,
+    research_profile: ResearchProfile,
+    model_name: str,
+    max_tokens: int,
+    temperature: float,
+    invoke_curator: CuratorInvoker,
+    exception_logger: logging.Logger,
+) -> tuple[WriterBrief, WriterBriefTrace]:
+    angle_directive_template = get_angle_directive_template(category, angle)
+    prompt = build_curator_prompt(
+        venue_name=venue_name,
+        location_label=location_label,
+        category=category,
+        angle=angle,
+        angle_directive_template=angle_directive_template,
+        research_profile=research_profile,
+    )
+
+    try:
+        raw_text, resolved_model = invoke_curator(
+            prompt=prompt,
+            model_name=model_name,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+    except Exception as exc:  # noqa: BLE001
+        exception_logger.exception(
+            "Writer Brief curator call failed for venue %r", venue_name
+        )
+        return (
+            _fallback_brief(venue_name, angle, angle_directive_template),
+            WriterBriefTrace(
+                prompt=prompt,
+                model=model_name,
+                error=f"curator call raised: {exc!r}",
+            ),
+        )
+
+    if not raw_text.strip():
+        return (
+            _fallback_brief(venue_name, angle, angle_directive_template),
+            WriterBriefTrace(
+                prompt=prompt,
+                raw_response=raw_text,
+                model=resolved_model,
+                error="curator returned empty text",
+            ),
+        )
+
+    brief, drop_reason = parse_writer_brief_response(
+        raw_text=raw_text,
+        venue_name=venue_name,
+        angle=angle,
+        angle_directive_template=angle_directive_template,
+    )
+    return brief, WriterBriefTrace(
+        prompt=prompt,
+        raw_response=raw_text,
+        model=resolved_model,
+        parser_dropped_reason=drop_reason,
+    )
+
+
+def _fallback_brief(
+    venue_name: str,
+    angle: ListicleAngle | None,
+    angle_directive_template: str | None,
+) -> WriterBrief:
+    return empty_writer_brief(
+        venue_name=venue_name,
+        angle=angle,
+        angle_directive=render_angle_directive_template(
+            angle_directive_template, venue_name
+        ),
+    )
+
+
+__all__ = ["CuratorInvoker", "execute_writer_brief"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_parsing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_parsing.py
@@ -1,0 +1,98 @@
+"""Sanitize and parse Writer Brief curator responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils import parse_json_response
+
+from .angle_assignment import ListicleAngle
+from .writer_brief_contracts import (
+    MAX_SOURCE_FACTS,
+    SourceFact,
+    WriterBrief,
+    empty_writer_brief,
+)
+from .writer_brief_policy import render_angle_directive_template
+
+
+def extract_json(text: str) -> Any:
+    try:
+        return parse_json_response(text)
+    except (RuntimeError, TypeError):
+        return None
+
+
+def parse_writer_brief_response(
+    *,
+    raw_text: str,
+    venue_name: str,
+    angle: ListicleAngle | None,
+    angle_directive_template: str | None,
+) -> tuple[WriterBrief, str | None]:
+    """Return a parsed brief and any response fields that were dropped."""
+    parsed = extract_json(raw_text)
+    drop_reasons: list[str] = []
+    fallback_directive = render_angle_directive_template(
+        angle_directive_template, venue_name
+    )
+
+    if not isinstance(parsed, dict):
+        return (
+            empty_writer_brief(
+                venue_name=venue_name,
+                angle=angle,
+                angle_directive=fallback_directive,
+            ),
+            "response was not a JSON object",
+        )
+
+    directive_raw = parsed.get("angle_directive")
+    if isinstance(directive_raw, str) and directive_raw.strip():
+        directive = directive_raw.strip().replace("{venue}", venue_name)
+    else:
+        drop_reasons.append("angle_directive missing; fell back to template")
+        directive = fallback_directive
+
+    facts_raw = parsed.get("source_facts")
+    cleaned: list[SourceFact] = []
+    if isinstance(facts_raw, list):
+        for entry in facts_raw:
+            if len(cleaned) >= MAX_SOURCE_FACTS:
+                drop_reasons.append(
+                    f"source_facts capped at {MAX_SOURCE_FACTS}; extras dropped"
+                )
+                break
+            if not isinstance(entry, dict):
+                drop_reasons.append("source_facts entry not an object")
+                continue
+            fact_raw = entry.get("fact")
+            if not isinstance(fact_raw, str) or not fact_raw.strip():
+                drop_reasons.append("source_facts entry missing fact text")
+                continue
+            citations_raw = entry.get("citations")
+            citations = (
+                [
+                    citation.strip()
+                    for citation in citations_raw
+                    if isinstance(citation, str) and citation.strip()
+                ]
+                if isinstance(citations_raw, list)
+                else []
+            )
+            cleaned.append(SourceFact(fact=fact_raw.strip(), citations=citations))
+    else:
+        drop_reasons.append("source_facts missing or not a list")
+
+    return (
+        WriterBrief(
+            angle_directive=directive,
+            source_facts=cleaned,
+            angle=angle,
+            venue=venue_name,
+        ),
+        "; ".join(drop_reasons) if drop_reasons else None,
+    )
+
+
+__all__ = ["extract_json", "parse_writer_brief_response"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_policy.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_policy.py
@@ -1,0 +1,154 @@
+"""Static editorial policy for Writer Brief angle directives."""
+
+from __future__ import annotations
+
+from .angle_assignment import ListicleAngle
+
+# Per-angle directive templates, keyed by category. The {venue} placeholder is
+# filled by the curator (or by deterministic fallback rendering) before the
+# directive reaches the writer prompt. These are the venue-facing directives
+# referenced in ADR 0007 (nightlife), ADR 0009 (dining), ADR 0011
+# (accommodations), and ADR 0012 (attractions) — distinct from
+# LISTICLE_ANGLE_GUIDANCE, which is the legacy model-facing instruction text
+# still used by fat-prompt categories.
+ANGLE_DIRECTIVES_BY_CATEGORY: dict[str, dict[ListicleAngle, str]] = {
+    "nightlife": {
+        "best-for-night": (
+            "Open by naming the kind of night {venue} is best for, and give one "
+            "concrete reason rooted in the room, the drinks, the crowd, or the "
+            "pacing."
+        ),
+    },
+    "dining": {
+        "signature-dish": (
+            "Open by naming one specific dish at {venue} and one concrete "
+            "reason it's worth ordering."
+        ),
+        "atmosphere": (
+            "Open by placing the reader in the room at {venue} with one "
+            "concrete physical detail — the light, the seating, the music, "
+            "the crowd at a specific hour."
+        ),
+        "founders-backstory": (
+            "Open by naming the person behind {venue} and one specific fact "
+            "about them — where they trained, what they ran before, when "
+            "they opened."
+        ),
+        "insider-tip": (
+            "Open with one specific, actionable tip at {venue} a first-time "
+            "visitor wouldn't guess — a time, a seat, an order, a side door."
+        ),
+        "best-for": (
+            "Open by naming the occasion {venue} serves best, then one "
+            "concrete reason rooted in the room, the menu, the pacing, or "
+            "the price."
+        ),
+        "whats-different": (
+            "Open by naming the specific thing that sets {venue} apart from "
+            "neighboring options of the same kind — a technique, a sourcing "
+            "choice, a format."
+        ),
+    },
+    "accommodations": {
+        "location-and-setting": (
+            "Open by placing {venue} in its physical setting with one "
+            "concrete geographic anchor — the bay, the ridge, the named "
+            "neighborhood, what's on either side. No 'centrally located'."
+        ),
+        "view-and-vista": (
+            "Open by naming what guests actually see from {venue} — the "
+            "specific sightline, which rooms or spaces it's from, one "
+            "concrete fact about it."
+        ),
+        "design-and-aesthetic": (
+            "Open by describing one concrete material, named space, or "
+            "design choice at {venue} — the lobby, the restaurant, the pool "
+            "deck, or the rooms, whichever carries the strongest identity."
+        ),
+        "signature-amenity": (
+            "Open by naming the one standalone feature that defines a stay "
+            "at {venue} — the rooftop hammam, the private beach club, the "
+            "library — and one concrete fact about it."
+        ),
+        "food-and-beverage": (
+            "Open by naming a specific on-site restaurant, bar, breakfast, "
+            "or rooftop at {venue} and one concrete fact — the chef, the "
+            "cuisine, the cocktail program, the hours."
+        ),
+        "trip-fit": (
+            "Open by naming the kind of trip {venue} serves best — a "
+            "honeymoon, a long remote-work stay, a family with toddlers, a "
+            "solo business swing — and one concrete reason rooted in the "
+            "rooms, the service, or the property's rhythm."
+        ),
+        "property-backstory": (
+            "Open by naming the owner, designer, or origin year of {venue} "
+            "and one specific fact — a former use of the building, the "
+            "architect, the family that runs it."
+        ),
+        "booking-tip": (
+            "Open with one specific, actionable booking or stay tip for "
+            "{venue} a first-time guest wouldn't guess — a room to request, "
+            "a night of the week, an arrival window."
+        ),
+        "whats-different": (
+            "Open by naming the specific thing that sets {venue} apart from "
+            "neighboring properties of the same kind — a design choice, a "
+            "service rhythm, a location format, a hybrid concept."
+        ),
+    },
+    "attractions": {
+        "signature-feature": (
+            "Open by naming the specific feature {venue} is built around — "
+            "the viewpoint, route, room, artwork, ruin, exhibit, or natural "
+            "formation — and one concrete fact that makes it worth the stop."
+        ),
+        "setting": (
+            "Open by placing the reader at {venue} with one concrete physical "
+            "detail — the approach, surrounding terrain, material, light at a "
+            "specific hour, or what frames the site."
+        ),
+        "history-built": (
+            "Open by naming when {venue} was built, founded, used, or changed "
+            "and one specific fact tied to that history — who built it, what it "
+            "replaced, what it survived, or why it matters."
+        ),
+        "visit-time-tip": (
+            "Open with one specific, actionable visit tip for {venue} a "
+            "first-time visitor would not guess — a time of day, entrance, "
+            "walking order, ticket choice, or pacing move."
+        ),
+        "best-for-visit-type": (
+            "Open by naming the kind of visit {venue} serves best — a quick "
+            "photo stop, rainy afternoon, kid-friendly half day, full deep dive, "
+            "or quiet early-morning visit — and one concrete reason."
+        ),
+        "whats-different": (
+            "Open by naming the specific thing that sets {venue} apart from "
+            "nearby attractions of the same kind — a format, scale, access, "
+            "setting, collection, route, or viewpoint."
+        ),
+    },
+}
+
+
+def get_angle_directive_template(
+    category: str,
+    angle: ListicleAngle | None,
+) -> str | None:
+    if angle is None:
+        return None
+    return ANGLE_DIRECTIVES_BY_CATEGORY.get(category, {}).get(angle)
+
+
+def render_angle_directive_template(template: str | None, venue_name: str) -> str:
+    if not template:
+        return ""
+    return template.replace("{venue}", venue_name)
+
+
+__all__ = [
+    "ANGLE_DIRECTIVES_BY_CATEGORY",
+    "get_angle_directive_template",
+    "render_angle_directive_template",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_prompt.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_prompt.py
@@ -1,0 +1,77 @@
+"""Prompt construction for Writer Brief curation."""
+
+from __future__ import annotations
+
+from .angle_assignment import ListicleAngle
+from .listicle_prompt_policy import format_location_for_prompt
+from .research_profile import ResearchProfile
+from .writer_brief_contracts import MAX_SOURCE_FACTS, MIN_SOURCE_FACTS
+from .writer_brief_policy import render_angle_directive_template
+
+
+def format_research_profile_for_curator(profile: ResearchProfile) -> str:
+    lines: list[str] = []
+    selected = profile.selected_angle
+    if selected.status == "supported" and selected.angle and selected.summary:
+        lines.append(f"selected-angle ({selected.angle}): {selected.summary}")
+    for bucket, findings in profile.standard_buckets.items():
+        for finding in findings:
+            lines.append(f"{bucket}: {finding.summary}")
+    return "\n".join(f"- {line}" for line in lines) if lines else "(no findings)"
+
+
+def build_curator_prompt(
+    *,
+    venue_name: str,
+    location_label: str,
+    category: str,
+    angle: ListicleAngle | None,
+    angle_directive_template: str | None,
+    research_profile: ResearchProfile,
+) -> str:
+    findings_block = format_research_profile_for_curator(research_profile)
+    location = format_location_for_prompt(location_label)
+    if angle_directive_template:
+        starting_point = render_angle_directive_template(
+            angle_directive_template, venue_name
+        )
+        directive_block = (
+            "Angle directive starting point (rewrite when the findings warrant a sharper opening):\n"
+            f"{starting_point}"
+        )
+    else:
+        directive_block = (
+            "Angle directive starting point: write a one-line directive that names "
+            f"{venue_name} and opens the blurb with one concrete reason this venue "
+            "belongs in the list."
+        )
+    return (
+        "You are curating a Writer Brief for one travel listicle blurb. Compress "
+        "the research findings into a deduped Source Facts list and write a "
+        f"venue-tailored angle directive.\n\n"
+        f"Venue: {venue_name}, {location}\n"
+        f"Category: {category}\n"
+        f"Angle: {angle or 'none'}\n\n"
+        f"{directive_block}\n\n"
+        "Research findings:\n"
+        f"{findings_block}\n\n"
+        "Return one JSON object only. No code fences, no commentary.\n\n"
+        "Shape:\n"
+        "{\n"
+        '  "angle_directive": "...",\n'
+        '  "source_facts": [\n'
+        '    { "fact": "...", "citations": ["https://..."] }\n'
+        "  ]\n"
+        "}\n\n"
+        "Rules:\n"
+        f"- {MIN_SOURCE_FACTS} to {MAX_SOURCE_FACTS} source_facts. Use what you have; don't pad, don't invent.\n"
+        "- Findings may overlap across buckets. Collapse to one fact.\n"
+        "- Strip bucket labels from fact text.\n"
+        "- Drop database-field noise (exact hours, square meters, age ranges) unless central to the angle.\n"
+        "- Preserve citations per fact, merged from the source findings.\n"
+        "- Prefer facts that serve the angle's lead shape; supporting texture is fine but should not dominate.\n"
+        "- The angle_directive must read as a finished sentence about the venue, not a template."
+    )
+
+
+__all__ = ["build_curator_prompt", "format_research_profile_for_curator"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_rendering.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/writer_brief_rendering.py
@@ -1,0 +1,16 @@
+"""Writer-facing rendering for a curated Writer Brief."""
+
+from __future__ import annotations
+
+from .writer_brief_contracts import WriterBrief
+
+
+def render_source_facts_block(brief: WriterBrief) -> str:
+    """Render Source Facts without inspector-only citations."""
+    if not brief.source_facts:
+        return ""
+    bullets = "\n".join(f"- {entry.fact}" for entry in brief.source_facts)
+    return f"Source facts (use only what you need):\n{bullets}"
+
+
+__all__ = ["render_source_facts_block"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
@@ -147,6 +147,38 @@ def test_research_profile_remains_a_thin_compatible_facade():
     }.issubset(imported_modules)
 
 
+def test_writer_brief_remains_a_thin_compatible_facade():
+    feature_path = Path(__file__).parents[1] / "app" / "features" / "editor_assist"
+    facade_path = feature_path / "writer_brief.py"
+    source = facade_path.read_text()
+    module = ast.parse(source)
+
+    top_level_defs = [
+        node
+        for node in module.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    imported_modules = {
+        node.module
+        for node in module.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert len(source.splitlines()) <= 120
+    assert [node.name for node in top_level_defs] == [
+        "_invoke_curator_model",
+        "run_writer_brief",
+    ]
+    assert {
+        "writer_brief_contracts",
+        "writer_brief_execution",
+        "writer_brief_parsing",
+        "writer_brief_policy",
+        "writer_brief_prompt",
+        "writer_brief_rendering",
+    }.issubset(imported_modules)
+
+
 def test_editor_assist_internals_do_not_depend_on_listicle_writer_facade():
     feature_path = Path(__file__).parents[1] / "app" / "features" / "editor_assist"
     facade_importers: list[str] = []

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_writer_brief_execution.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_writer_brief_execution.py
@@ -1,0 +1,99 @@
+"""Execution and compatibility seams for Writer Brief generation."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from app.features.editor_assist.research_profile_contracts import (
+    ResearchFinding,
+    ResearchProfile,
+    SelectedAngleEvidence,
+    empty_buckets,
+)
+from app.features.editor_assist.writer_brief_execution import execute_writer_brief
+
+
+def _profile() -> ResearchProfile:
+    buckets = empty_buckets()
+    buckets["experience-texture"] = [
+        ResearchFinding(
+            summary="Folkloric art and winding wood staircases.",
+            citations=["https://example.com/rooms"],
+        )
+    ]
+    return ResearchProfile(
+        selected_angle=SelectedAngleEvidence(
+            angle="best-for-night",
+            status="supported",
+            summary="Top 35 bars in the world, late close, mansion setting.",
+            citations=["https://example.com/angle"],
+        ),
+        standard_buckets=buckets,
+        usable_for_blurb=True,
+    )
+
+
+def test_execution_injects_curator_and_preserves_resolved_model():
+    seen: dict[str, object] = {}
+
+    def _invoke(**kwargs):
+        seen.update(kwargs)
+        return (
+            json.dumps(
+                {
+                    "angle_directive": "Lead with Ayahuasca's late-night pacing.",
+                    "source_facts": [
+                        {"fact": "Mansion setting.", "citations": []},
+                        {"fact": "Pisco-forward drinks.", "citations": []},
+                    ],
+                }
+            ),
+            "resolved-curator",
+        )
+
+    brief, trace = execute_writer_brief(
+        venue_name="Ayahuasca",
+        location_label="Barranco, Lima",
+        category="nightlife",
+        angle="best-for-night",
+        research_profile=_profile(),
+        model_name="requested-curator",
+        max_tokens=10240,
+        temperature=0.1,
+        invoke_curator=_invoke,
+        exception_logger=logging.getLogger(__name__),
+    )
+
+    assert brief.is_usable
+    assert trace.model == "resolved-curator"
+    assert seen["model_name"] == "requested-curator"
+    assert seen["max_tokens"] == 10240
+    assert seen["temperature"] == 0.1
+    assert "Writer Brief" in str(seen["prompt"])
+
+
+def test_execution_failure_returns_template_fallback_without_facts():
+    def _raise(**_kwargs):
+        raise RuntimeError("curator unavailable")
+
+    brief, trace = execute_writer_brief(
+        venue_name="Ayahuasca",
+        location_label="Barranco, Lima",
+        category="nightlife",
+        angle="best-for-night",
+        research_profile=_profile(),
+        model_name="requested-curator",
+        max_tokens=10240,
+        temperature=0.1,
+        invoke_curator=_raise,
+        exception_logger=logging.getLogger(__name__),
+    )
+
+    assert brief.angle_directive.startswith(
+        "Open by naming the kind of night Ayahuasca"
+    )
+    assert brief.source_facts == []
+    assert not brief.is_usable
+    assert trace.model == "requested-curator"
+    assert trace.error == "curator call raised: RuntimeError('curator unavailable')"


### PR DESCRIPTION
## Original issue

`writer_brief.py` scored 12 at 458 LOC with contracts, static directive policy, curator prompt construction, response parsing, runtime fallback handling, Vertex invocation, and writer-facing rendering in one module.

## Root cause

The Writer Brief curator grew category-by-category as dining, accommodations, and attractions joined nightlife on the lean listicle path. Each addition was cohesive with the feature but accumulated behind a single import and monkeypatch seam.

## Refactor performed

- Extracted stable contracts and source-fact limits into `writer_brief_contracts.py`.
- Extracted category angle directives and template resolution into `writer_brief_policy.py`.
- Extracted curator prompt construction, response parsing, runtime execution/fallbacks, and writer-facing rendering into focused adjacent modules.
- Reduced `writer_brief.py` to a 97-line compatibility facade that preserves every existing public import and the `_invoke_curator_model` patch seam used by route tests.
- Updated internal callers to depend directly on contracts/rendering where they do not need the facade.
- Documented the module boundary and added an architecture guard plus injected execution/fallback tests.

## Why better

Each module now has one change axis: editorial policy, prompt text, parser rules, runtime behavior, rendering, or contracts. Category directive edits no longer share a file with Vertex execution; parser and fallback changes can be tested through explicit dependency injection; and the facade prevents churn for existing callers. This removes the residual bloat without changing the HTTP, prompt, trace, fallback, or monkeypatch contracts.

## Validation

- Root `pnpm run test`: passed (7/7 Turbo tasks).
- Focused Writer Brief/composition/routes: 56 passed.
- Full backend suite: 356 passed.
- `pnpm --filter @questurian/ai-blog-writer lint`: passed all four Nx lint targets, including backend Flake8.
- `pnpm --filter @questurian/ai-blog-writer build`: passed Vite production build and backend compileall.
- Black check for all changed Python files: passed.
- `git diff --check`: passed.
- Backend has no configured Python typecheck target.
- Root `pnpm run lint`: blocked outside this change in `@questura/server` because ESLint cannot find the configured `@next/next/no-img-element` rule in `FocalPointPickerField.tsx`; the AI Blog Writer lint target passes.
- Root `pnpm run build`: blocked outside this change in `@questura/server` under Node 18.19.1 (the package requires `^18.20.2 || >=20.9.0`); Payload type generation loads Undici and fails with `ReferenceError: File is not defined`. The AI Blog Writer build target passes.

## Risks/tradeoffs/follow-ups

The change adds six small adjacent modules, trading a single-file reading path for explicit responsibility boundaries. Import compatibility is intentionally retained through the facade. There are no known behavior changes. Repository-wide lint/build require repairing the Questura ESLint dependency and running the documented supported Node version; both are unrelated follow-ups.