### PR TITLE
refactor(abw): split Stage 3 quality responsibilities

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/CONTEXT.md
@@ -26,6 +26,8 @@ operations.
 | `orchestrator.py` | Run initialization and the graph entrypoint |
 | `content/` | Pure Markdown transformations and measurements |
 | `quality/` | Pure Quality Gate, retry, near-pass, and rollback policy |
+| `quality/article_assessment.py` | Pure Stage 3 assessment normalization and heuristic fallback |
+| `quality/article_revision.py` | Pure Stage 3 rewrite-mode selection and targeted feedback |
 | `dependencies.py` | Explicit external collaborators |
 | `run_recorder.py` | The only adapter that writes lifecycle, StageResult, trace, or Pipeline Artifact data |
 | `graph/state.py` | Typed graph state |
@@ -49,6 +51,9 @@ operations.
 | `stages/stage_3_composition.py` | Final article prompt, composition, and prose repair |
 | `stages/stage_3_pipeline.py` | Legacy sequential Stage 3 orchestration |
 | `stages/stage_3.py` | Stable thin Stage 3 facade and compatibility seams |
+| `stages/stage_3_quality_assessment.py` | Stage 3 quality prompt, LLM invocation, and fallback selection |
+| `stages/stage_3_quality_rewrite.py` | Stage 3 rewrite prompt, LLM invocation, anti-AI repair, and length safeguard |
+| `stages/stage_3_quality.py` | Stable thin Stage 3 quality facade |
 
 ## Dependency direction
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/article_assessment.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/article_assessment.py
@@ -1,0 +1,170 @@
+"""Pure Stage 3 article assessment policy."""
+
+from __future__ import annotations
+
+import re
+from statistics import mean
+from typing import Any
+
+QUALITY_DIMENSIONS = (
+    "clarity",
+    "structure_coherence",
+    "specificity",
+    "usefulness_actionability",
+    "repetition_control",
+    "audience_fit",
+)
+
+_DEFAULT_REWRITE_BRIEF = [
+    "Reduce filler and repetition while preserving meaning.",
+    "Increase specificity with concrete wording.",
+    "Improve structure and transitions for smoother reading.",
+]
+
+
+def clamp_score(value: Any, *, default: float = 5.0) -> float:
+    """Coerce an assessment score into the supported zero-to-ten range."""
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return default
+    return round(max(0.0, min(10.0, score)), 2)
+
+
+def _safe_list_of_strings(value: Any, *, max_items: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    items: list[str] = []
+    for raw in value:
+        text = str(raw).strip()
+        if not text:
+            continue
+        items.append(text)
+        if len(items) >= max_items:
+            break
+    return items
+
+
+def tokenize_words(value: str) -> list[str]:
+    """Return normalized words for quality metrics and rewrite safeguards."""
+    return re.findall(r"[A-Za-z0-9']+", value.lower())
+
+
+def normalize_llm_assessment(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Normalize an untrusted assessment payload into the Quality Gate contract."""
+    raw_dimensions = parsed.get("dimension_scores", {})
+    dimension_scores = {
+        key: clamp_score(raw_dimensions.get(key), default=5.0)
+        for key in QUALITY_DIMENSIONS
+    }
+    overall_quality_score = clamp_score(
+        parsed.get("overall_quality_score"),
+        default=mean(dimension_scores.values()),
+    )
+    top_issues = _safe_list_of_strings(parsed.get("top_issues"), max_items=3)
+    rewrite_brief = _safe_list_of_strings(parsed.get("rewrite_brief"), max_items=5)
+
+    if not top_issues:
+        sorted_dimensions = sorted(
+            dimension_scores.items(),
+            key=lambda item: item[1],
+        )
+        top_issues = [
+            f"Improve {name.replace('_', ' ')}." for name, _ in sorted_dimensions[:3]
+        ]
+    if not rewrite_brief:
+        rewrite_brief = list(_DEFAULT_REWRITE_BRIEF)
+
+    return {
+        "dimension_scores": dimension_scores,
+        "overall_quality_score": overall_quality_score,
+        "top_issues": top_issues,
+        "rewrite_brief": rewrite_brief,
+        "evaluation_source": "llm",
+    }
+
+
+def assess_article_heuristically(article: str) -> dict[str, Any]:
+    """Provide a deterministic assessment when the provider cannot evaluate."""
+    words = tokenize_words(article)
+    word_count = len(words)
+    unique_ratio = (len(set(words)) / max(1, word_count)) if word_count else 0.0
+    paragraphs = [part for part in re.split(r"\n\s*\n", article) if part.strip()]
+    paragraph_count = len(paragraphs)
+    headings_count = len(re.findall(r"(?m)^\s{0,3}#{1,6}\s+\S", article))
+    sentence_like = re.split(r"(?<=[.!?])\s+", article.strip())
+    sentence_lengths = [
+        len(tokenize_words(sentence)) for sentence in sentence_like if sentence
+    ]
+    avg_sentence_len = mean(sentence_lengths) if sentence_lengths else 0.0
+    actionable_markers = len(
+        re.findall(
+            r"\b(step|steps|how to|should|can|need to|tip|tips|checklist|action)\b",
+            article.lower(),
+        )
+    )
+    numeric_markers = len(re.findall(r"\b\d+(?:\.\d+)?\b", article))
+
+    clarity = 7.0
+    if avg_sentence_len > 28:
+        clarity -= 1.2
+    elif avg_sentence_len < 8:
+        clarity -= 0.8
+    if paragraph_count < 3:
+        clarity -= 1.0
+
+    structure = 6.8
+    if headings_count >= 2:
+        structure += 0.8
+    if paragraph_count < 4:
+        structure -= 0.9
+
+    specificity = 6.5
+    if numeric_markers >= 3:
+        specificity += 0.7
+    if unique_ratio < 0.42:
+        specificity -= 1.0
+
+    usefulness = 6.3
+    if actionable_markers >= 3:
+        usefulness += 0.9
+    if word_count < 220:
+        usefulness -= 0.8
+
+    repetition = 7.0
+    if unique_ratio < 0.36:
+        repetition -= 1.6
+    elif unique_ratio < 0.42:
+        repetition -= 0.9
+
+    audience_fit = 6.9
+    if headings_count >= 2 and actionable_markers >= 2:
+        audience_fit += 0.6
+
+    dimension_scores = {
+        "clarity": clamp_score(clarity),
+        "structure_coherence": clamp_score(structure),
+        "specificity": clamp_score(specificity),
+        "usefulness_actionability": clamp_score(usefulness),
+        "repetition_control": clamp_score(repetition),
+        "audience_fit": clamp_score(audience_fit),
+    }
+    sorted_dimensions = sorted(
+        dimension_scores.items(),
+        key=lambda item: item[1],
+    )
+    return {
+        "dimension_scores": dimension_scores,
+        "overall_quality_score": round(mean(dimension_scores.values()), 2),
+        "top_issues": [
+            f"Improve {name.replace('_', ' ')} (current {score:.1f}/10)."
+            for name, score in sorted_dimensions[:3]
+        ],
+        "rewrite_brief": [
+            "Tighten verbose sentences and remove redundant phrasing.",
+            "Increase concrete detail and examples where sections are generic.",
+            "Strengthen transitions between sections for clearer flow.",
+            "Preserve factual content while improving reader usefulness.",
+        ],
+        "evaluation_source": "heuristic_fallback",
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/article_revision.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/article_revision.py
@@ -1,0 +1,77 @@
+"""Pure Stage 3 article rewrite policy."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_DIMENSION_HINTS = {
+    "clarity": "Shorten dense sentences and resolve ambiguous phrasing.",
+    "structure_coherence": (
+        "Reorder sections for clearer progression and add stronger transitions."
+    ),
+    "specificity": (
+        "Replace generic wording with concrete examples/details already present "
+        "in source."
+    ),
+    "usefulness_actionability": (
+        "Make guidance more actionable with explicit reader takeaways."
+    ),
+    "repetition_control": "Remove repetitive statements and redundant filler phrases.",
+    "audience_fit": (
+        "Align framing and depth with the intended reader and article type."
+    ),
+}
+
+
+def articles_are_equivalent(left: str, right: str) -> bool:
+    """Compare article text while ignoring case and whitespace differences."""
+
+    def normalize(value: str) -> str:
+        return re.sub(r"\s+", " ", value).strip().lower()
+
+    return normalize(left) == normalize(right)
+
+
+def pick_improvement_mode(
+    *,
+    overall_quality_score: float,
+    retry_count: int,
+) -> str:
+    """Select rewrite intensity based on score and retry count."""
+    if retry_count >= 2:
+        return "strong"
+    if overall_quality_score >= 7.3:
+        return "light"
+    if overall_quality_score >= 6.2:
+        return "medium"
+    return "strong"
+
+
+def build_targeted_feedback(
+    *,
+    dimension_scores: dict[str, float],
+    top_issues: list[str],
+    rewrite_brief: list[str],
+) -> dict[str, Any]:
+    """Derive focused rewrite instructions from weak quality dimensions."""
+    ranked = sorted(dimension_scores.items(), key=lambda item: item[1])
+    focus_dimensions = [name for name, _ in ranked[:3]]
+
+    enhanced_brief = list(rewrite_brief)
+    for key in focus_dimensions:
+        hint = _DIMENSION_HINTS.get(key)
+        if hint and hint not in enhanced_brief:
+            enhanced_brief.append(hint)
+
+    enhanced_issues = list(top_issues)
+    for key in focus_dimensions:
+        issue = f"Raise {key.replace('_', ' ')} with targeted rewrite."
+        if issue not in enhanced_issues:
+            enhanced_issues.append(issue)
+
+    return {
+        "focus_dimensions": focus_dimensions,
+        "top_issues": enhanced_issues[:5],
+        "rewrite_brief": enhanced_brief[:7],
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_quality.py
@@ -1,228 +1,32 @@
-"""Stage 3 quality assessment and improvement helpers."""
+"""Stable Stage 3 quality facade.
+
+Provider-backed assessment and rewriting live in focused modules. Deterministic
+revision decisions live under ``quality`` so callers can test them without an
+LLM dependency.
+"""
 
 from __future__ import annotations
 
-import logging
-import re
-from statistics import mean
 from typing import Any
 
-from langchain_core.prompts import PromptTemplate
-
-from app.features.youtube2blog.config import (
-    Y2B_PRIMARY_MODEL,
-    Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS,
+from app.features.youtube2blog.config import Y2B_PRIMARY_MODEL
+from app.features.youtube2blog.quality.article_assessment import QUALITY_DIMENSIONS
+from app.features.youtube2blog.quality.article_revision import (
+    build_targeted_feedback,
+    pick_improvement_mode,
 )
-from app.shared.prompts import ANTI_AI_TELLS_FULL
 from app.shared.text import enforce_anti_ai_tells_markdown
 from shared import Stage3Output
 from utils import get_vertex_llm, parse_json_response
 
-logger = logging.getLogger(__name__)
-
-QUALITY_DIMENSIONS = (
-    "clarity",
-    "structure_coherence",
-    "specificity",
-    "usefulness_actionability",
-    "repetition_control",
-    "audience_fit",
+from .stage_3_quality_assessment import (
+    ARTICLE_QUALITY_ASSESSMENT_PROMPT,
+    assess_article_quality,
 )
-
-ARTICLE_QUALITY_ASSESSMENT_PROMPT = """You are evaluating article readiness for publication.
-
-Task:
-- Evaluate whether the draft is high quality for its article type and guideline.
-- Do NOT classify tone or label it as "AI sounding."
-- Focus on practical quality signals that impact reader value.
-
-ARTICLE TYPE:
-{article_type}
-
-GUIDELINE:
-{guideline}
-
-DRAFT ARTICLE (MARKDOWN):
-{article}
-
-Return strict JSON only:
-{{
-  "dimension_scores": {{
-    "clarity": <0-10>,
-    "structure_coherence": <0-10>,
-    "specificity": <0-10>,
-    "usefulness_actionability": <0-10>,
-    "repetition_control": <0-10>,
-    "audience_fit": <0-10>
-  }},
-  "overall_quality_score": <0-10>,
-  "top_issues": ["<max 3 concrete issues>"],
-  "rewrite_brief": ["<3-5 specific rewrite instructions>"]
-}}
-
-Scoring intent:
-- clarity: easy to understand without ambiguity
-- structure_coherence: logical flow and section sequencing
-- specificity: concrete details/examples vs generic filler
-- usefulness_actionability: reader can do something with it
-- repetition_control: low redundancy and low fluff
-- audience_fit: aligns with intent of article type + guideline
-"""
-
-ARTICLE_QUALITY_IMPROVEMENT_PROMPT = """You are improving an article draft for publication quality.
-
-Rewrite mode: {mode}
-Article type: {article_type}
-Guideline: {guideline}
-Priority quality dimensions:
-{focus_dimensions}
-
-Quality issues to fix:
-{top_issues}
-
-Rewrite brief:
-{rewrite_brief}
-
-Rules:
-1. Preserve factual meaning from the source draft.
-2. Do NOT add new factual claims, numbers, dates, or entities not supported by source draft.
-3. Improve clarity, specificity, flow, and usefulness.
-4. Reduce generic filler and repetition.
-5. Preserve markdown format and section structure.
-6. Keep roughly similar coverage depth (do not collapse into a short summary).
-7. Respect rewrite mode:
-   - light: tighten wording and improve transitions with minimal structural changes
-   - medium: rephrase and reorganize sections for clarity and usefulness
-   - strong: substantial rewrite for clarity/specificity while keeping factual meaning
-
-SOURCE DRAFT:
-{article}
-
-Output only the improved markdown article. No JSON, no explanations.
-"""
-
-
-def _clamp_score(value: Any, *, default: float = 5.0) -> float:
-    try:
-        score = float(value)
-    except (TypeError, ValueError):
-        return default
-    return round(max(0.0, min(10.0, score)), 2)
-
-
-def _safe_list_of_strings(value: Any, *, max_items: int) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    items: list[str] = []
-    for raw in value:
-        text = str(raw).strip()
-        if not text:
-            continue
-        items.append(text)
-        if len(items) >= max_items:
-            break
-    return items
-
-
-def _tokenize_words(value: str) -> list[str]:
-    return re.findall(r"[A-Za-z0-9']+", value.lower())
-
-
-def _normalize_for_similarity(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip().lower()
-
-
-def _derive_focus_dimensions(dimension_scores: dict[str, float]) -> list[str]:
-    ranked = sorted(dimension_scores.items(), key=lambda item: item[1])
-    focused = [name for name, _ in ranked[:3]]
-    return focused
-
-
-def _heuristic_quality_assessment(article: str) -> dict[str, Any]:
-    words = _tokenize_words(article)
-    word_count = len(words)
-    unique_ratio = (len(set(words)) / max(1, word_count)) if word_count else 0.0
-    paragraphs = [part for part in re.split(r"\n\s*\n", article) if part.strip()]
-    paragraph_count = len(paragraphs)
-    headings_count = len(re.findall(r"(?m)^\s{0,3}#{1,6}\s+\S", article))
-    sentence_like = re.split(r"(?<=[.!?])\s+", article.strip())
-    sentence_lengths = [len(_tokenize_words(sentence)) for sentence in sentence_like if sentence]
-    avg_sentence_len = mean(sentence_lengths) if sentence_lengths else 0.0
-    actionable_markers = len(
-        re.findall(
-            r"\b(step|steps|how to|should|can|need to|tip|tips|checklist|action)\b",
-            article.lower(),
-        )
-    )
-    numeric_markers = len(re.findall(r"\b\d+(?:\.\d+)?\b", article))
-
-    clarity = 7.0
-    if avg_sentence_len > 28:
-        clarity -= 1.2
-    elif avg_sentence_len < 8:
-        clarity -= 0.8
-    if paragraph_count < 3:
-        clarity -= 1.0
-
-    structure = 6.8
-    if headings_count >= 2:
-        structure += 0.8
-    if paragraph_count < 4:
-        structure -= 0.9
-
-    specificity = 6.5
-    if numeric_markers >= 3:
-        specificity += 0.7
-    if unique_ratio < 0.42:
-        specificity -= 1.0
-
-    usefulness = 6.3
-    if actionable_markers >= 3:
-        usefulness += 0.9
-    if word_count < 220:
-        usefulness -= 0.8
-
-    repetition = 7.0
-    if unique_ratio < 0.36:
-        repetition -= 1.6
-    elif unique_ratio < 0.42:
-        repetition -= 0.9
-
-    audience_fit = 6.9
-    if headings_count >= 2 and actionable_markers >= 2:
-        audience_fit += 0.6
-
-    dimension_scores = {
-        "clarity": _clamp_score(clarity),
-        "structure_coherence": _clamp_score(structure),
-        "specificity": _clamp_score(specificity),
-        "usefulness_actionability": _clamp_score(usefulness),
-        "repetition_control": _clamp_score(repetition),
-        "audience_fit": _clamp_score(audience_fit),
-    }
-    overall_quality_score = round(mean(dimension_scores.values()), 2)
-
-    sorted_dimensions = sorted(
-        dimension_scores.items(),
-        key=lambda item: item[1],
-    )
-    top_issues = [
-        f"Improve {name.replace('_', ' ')} (current {score:.1f}/10)."
-        for name, score in sorted_dimensions[:3]
-    ]
-    rewrite_brief = [
-        "Tighten verbose sentences and remove redundant phrasing.",
-        "Increase concrete detail and examples where sections are generic.",
-        "Strengthen transitions between sections for clearer flow.",
-        "Preserve factual content while improving reader usefulness.",
-    ]
-    return {
-        "dimension_scores": dimension_scores,
-        "overall_quality_score": overall_quality_score,
-        "top_issues": top_issues,
-        "rewrite_brief": rewrite_brief,
-        "evaluation_source": "heuristic_fallback",
-    }
+from .stage_3_quality_rewrite import (
+    ARTICLE_QUALITY_IMPROVEMENT_PROMPT,
+    improve_article,
+)
 
 
 def stage_3_assess_article_quality(
@@ -230,71 +34,12 @@ def stage_3_assess_article_quality(
     stage3: Stage3Output,
     model_name: str = Y2B_PRIMARY_MODEL,
 ) -> dict[str, Any]:
-    """Assess Stage 3 article quality against publication-readiness dimensions."""
-    llm = get_vertex_llm(
-        temperature=0.05,
-        max_tokens=2048,
+    return assess_article_quality(
+        stage3=stage3,
         model_name=model_name,
+        llm_factory=get_vertex_llm,
+        json_parser=parse_json_response,
     )
-    prompt = PromptTemplate(
-        input_variables=["article_type", "guideline", "article"],
-        template=ARTICLE_QUALITY_ASSESSMENT_PROMPT,
-    )
-    full_prompt = prompt.format(
-        article_type=stage3.article_type,
-        guideline=stage3.guideline_used[:8000],
-        article=stage3.final_article[:20000],
-    )
-
-    try:
-        raw_response = llm.invoke(full_prompt)
-        if not raw_response or not str(raw_response).strip():
-            raise RuntimeError("Quality assessment returned empty response")
-        parsed = parse_json_response(str(raw_response))
-        raw_dimensions = parsed.get("dimension_scores", {})
-        dimension_scores = {
-            key: _clamp_score(raw_dimensions.get(key), default=5.0)
-            for key in QUALITY_DIMENSIONS
-        }
-        overall_quality_score = _clamp_score(
-            parsed.get("overall_quality_score"),
-            default=mean(dimension_scores.values()),
-        )
-        top_issues = _safe_list_of_strings(parsed.get("top_issues"), max_items=3)
-        rewrite_brief = _safe_list_of_strings(parsed.get("rewrite_brief"), max_items=5)
-
-        if not top_issues:
-            sorted_dimensions = sorted(
-                dimension_scores.items(),
-                key=lambda item: item[1],
-            )
-            top_issues = [
-                f"Improve {name.replace('_', ' ')}."
-                for name, _ in sorted_dimensions[:3]
-            ]
-        if not rewrite_brief:
-            rewrite_brief = [
-                "Reduce filler and repetition while preserving meaning.",
-                "Increase specificity with concrete wording.",
-                "Improve structure and transitions for smoother reading.",
-            ]
-
-        return {
-            "dimension_scores": dimension_scores,
-            "overall_quality_score": overall_quality_score,
-            "top_issues": top_issues,
-            "rewrite_brief": rewrite_brief,
-            "evaluation_source": "llm",
-            "debug_quality_prompt": full_prompt,
-            "debug_quality_response": str(raw_response),
-        }
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Stage 3 quality assessment fallback triggered: %s", exc)
-        heuristic = _heuristic_quality_assessment(stage3.final_article)
-        heuristic["debug_quality_prompt"] = full_prompt
-        heuristic["debug_quality_response"] = ""
-        heuristic["error"] = str(exc)
-        return heuristic
 
 
 def stage_3_pick_improvement_mode(
@@ -302,14 +47,10 @@ def stage_3_pick_improvement_mode(
     overall_quality_score: float,
     retry_count: int,
 ) -> str:
-    """Select rewrite intensity based on score and retry count."""
-    if retry_count >= 2:
-        return "strong"
-    if overall_quality_score >= 7.3:
-        return "light"
-    if overall_quality_score >= 6.2:
-        return "medium"
-    return "strong"
+    return pick_improvement_mode(
+        overall_quality_score=overall_quality_score,
+        retry_count=retry_count,
+    )
 
 
 def stage_3_improve_article(
@@ -322,94 +63,17 @@ def stage_3_improve_article(
     model_name: str = Y2B_PRIMARY_MODEL,
     tone_guidance: str | None = None,
 ) -> dict[str, Any]:
-    """Rewrite article draft to improve quality while preserving facts."""
-    if mode not in {"light", "medium", "strong"}:
-        raise ValueError(f"Unsupported rewrite mode: {mode}")
-
-    llm = get_vertex_llm(
-        temperature=0.2,
-        max_tokens=Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS,
-        model_name=model_name,
-    )
-    prompt = PromptTemplate(
-        input_variables=[
-            "mode",
-            "article_type",
-            "guideline",
-            "focus_dimensions",
-            "top_issues",
-            "rewrite_brief",
-            "article",
-        ],
-        template=ARTICLE_QUALITY_IMPROVEMENT_PROMPT,
-    )
-    full_prompt = prompt.format(
+    return improve_article(
+        stage3=stage3,
+        top_issues=top_issues,
+        rewrite_brief=rewrite_brief,
         mode=mode,
-        article_type=stage3.article_type,
-        guideline=stage3.guideline_used[:8000],
-        focus_dimensions=", ".join(focus_dimensions or []) or "clarity, specificity, structure",
-        top_issues="\n".join(f"- {item}" for item in top_issues[:3]) or "- Improve overall quality.",
-        rewrite_brief="\n".join(f"- {item}" for item in rewrite_brief[:5])
-        or "- Improve clarity and usefulness while preserving facts.",
-        article=stage3.final_article[:24000],
+        focus_dimensions=focus_dimensions,
+        model_name=model_name,
+        tone_guidance=tone_guidance,
+        llm_factory=get_vertex_llm,
+        anti_ai_enforcer=enforce_anti_ai_tells_markdown,
     )
-    if tone_guidance:
-        full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"
-    full_prompt = f"{full_prompt}\n\n{ANTI_AI_TELLS_FULL}"
-
-    raw_response = llm.invoke(full_prompt)
-    if not raw_response or not str(raw_response).strip():
-        raise RuntimeError("Stage 3 quality improvement returned empty response")
-
-    improved_article = enforce_anti_ai_tells_markdown(
-        str(raw_response),
-        repair=lambda repair_prompt: llm.invoke(repair_prompt),
-        context="youtube2blog quality improvement",
-    )
-    first_response_text = str(raw_response)
-
-    # If the rewrite is effectively unchanged, force a stronger second attempt.
-    if _normalize_for_similarity(improved_article) == _normalize_for_similarity(
-        stage3.final_article
-    ):
-        stronger_mode = "strong" if mode != "strong" else mode
-        fallback_prompt = (
-            full_prompt
-            + "\n\nThe prior rewrite was too similar. Rewrite more decisively while preserving facts."
-        )
-        second_raw = llm.invoke(fallback_prompt)
-        if second_raw and str(second_raw).strip():
-            improved_article = enforce_anti_ai_tells_markdown(
-                str(second_raw),
-                repair=lambda repair_prompt: llm.invoke(repair_prompt),
-                context="youtube2blog quality fallback",
-            )
-            raw_response = second_raw
-            mode = stronger_mode
-            full_prompt = fallback_prompt
-
-    original_word_count = len(_tokenize_words(stage3.final_article))
-    improved_word_count = len(_tokenize_words(improved_article))
-    min_allowed_words = max(120, int(original_word_count * 0.55))
-    if improved_word_count < min_allowed_words:
-        logger.warning(
-            "Stage 3 quality improvement too short (%d < %d); keeping original draft",
-            improved_word_count,
-            min_allowed_words,
-        )
-        improved_article = stage3.final_article
-        improved_word_count = original_word_count
-
-    return {
-        "mode": mode,
-        "focus_dimensions": list(focus_dimensions or []),
-        "improved_article": improved_article,
-        "word_count_before": original_word_count,
-        "word_count_after": improved_word_count,
-        "debug_improve_prompt": full_prompt,
-        "debug_improve_response": str(raw_response),
-        "debug_improve_first_response": first_response_text,
-    }
 
 
 def stage_3_build_targeted_feedback(
@@ -418,32 +82,19 @@ def stage_3_build_targeted_feedback(
     top_issues: list[str],
     rewrite_brief: list[str],
 ) -> dict[str, Any]:
-    """Derive focused rewrite instructions from weak quality dimensions."""
-    focus_dimensions = _derive_focus_dimensions(dimension_scores)
+    return build_targeted_feedback(
+        dimension_scores=dimension_scores,
+        top_issues=top_issues,
+        rewrite_brief=rewrite_brief,
+    )
 
-    dimension_hints = {
-        "clarity": "Shorten dense sentences and resolve ambiguous phrasing.",
-        "structure_coherence": "Reorder sections for clearer progression and add stronger transitions.",
-        "specificity": "Replace generic wording with concrete examples/details already present in source.",
-        "usefulness_actionability": "Make guidance more actionable with explicit reader takeaways.",
-        "repetition_control": "Remove repetitive statements and redundant filler phrases.",
-        "audience_fit": "Align framing and depth with the intended reader and article type.",
-    }
 
-    enhanced_brief = list(rewrite_brief)
-    for key in focus_dimensions:
-        hint = dimension_hints.get(key)
-        if hint and hint not in enhanced_brief:
-            enhanced_brief.append(hint)
-
-    enhanced_issues = list(top_issues)
-    for key in focus_dimensions:
-        issue = f"Raise {key.replace('_', ' ')} with targeted rewrite."
-        if issue not in enhanced_issues:
-            enhanced_issues.append(issue)
-
-    return {
-        "focus_dimensions": focus_dimensions,
-        "top_issues": enhanced_issues[:5],
-        "rewrite_brief": enhanced_brief[:7],
-    }
+__all__ = [
+    "ARTICLE_QUALITY_ASSESSMENT_PROMPT",
+    "ARTICLE_QUALITY_IMPROVEMENT_PROMPT",
+    "QUALITY_DIMENSIONS",
+    "stage_3_assess_article_quality",
+    "stage_3_build_targeted_feedback",
+    "stage_3_improve_article",
+    "stage_3_pick_improvement_mode",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_quality_assessment.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_quality_assessment.py
@@ -1,0 +1,102 @@
+"""LLM-backed Stage 3 article quality assessment."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.prompts import PromptTemplate
+
+from app.features.youtube2blog.config import Y2B_PRIMARY_MODEL
+from app.features.youtube2blog.quality.article_assessment import (
+    assess_article_heuristically,
+    normalize_llm_assessment,
+)
+from shared import Stage3Output
+from utils import get_vertex_llm, parse_json_response
+
+logger = logging.getLogger(__name__)
+
+ARTICLE_QUALITY_ASSESSMENT_PROMPT = """You are evaluating article readiness for publication.
+
+Task:
+- Evaluate whether the draft is high quality for its article type and guideline.
+- Do NOT classify tone or label it as "AI sounding."
+- Focus on practical quality signals that impact reader value.
+
+ARTICLE TYPE:
+{article_type}
+
+GUIDELINE:
+{guideline}
+
+DRAFT ARTICLE (MARKDOWN):
+{article}
+
+Return strict JSON only:
+{{
+  "dimension_scores": {{
+    "clarity": <0-10>,
+    "structure_coherence": <0-10>,
+    "specificity": <0-10>,
+    "usefulness_actionability": <0-10>,
+    "repetition_control": <0-10>,
+    "audience_fit": <0-10>
+  }},
+  "overall_quality_score": <0-10>,
+  "top_issues": ["<max 3 concrete issues>"],
+  "rewrite_brief": ["<3-5 specific rewrite instructions>"]
+}}
+
+Scoring intent:
+- clarity: easy to understand without ambiguity
+- structure_coherence: logical flow and section sequencing
+- specificity: concrete details/examples vs generic filler
+- usefulness_actionability: reader can do something with it
+- repetition_control: low redundancy and low fluff
+- audience_fit: aligns with intent of article type + guideline
+"""
+
+
+def assess_article_quality(
+    *,
+    stage3: Stage3Output,
+    model_name: str = Y2B_PRIMARY_MODEL,
+    llm_factory: Callable[..., Any] | None = None,
+    json_parser: Callable[[str], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Assess Stage 3 article quality against publication-readiness dimensions."""
+    llm = (llm_factory or get_vertex_llm)(
+        temperature=0.05,
+        max_tokens=2048,
+        model_name=model_name,
+    )
+    prompt = PromptTemplate(
+        input_variables=["article_type", "guideline", "article"],
+        template=ARTICLE_QUALITY_ASSESSMENT_PROMPT,
+    )
+    full_prompt = prompt.format(
+        article_type=stage3.article_type,
+        guideline=stage3.guideline_used[:8000],
+        article=stage3.final_article[:20000],
+    )
+
+    try:
+        raw_response = llm.invoke(full_prompt)
+        if not raw_response or not str(raw_response).strip():
+            raise RuntimeError("Quality assessment returned empty response")
+        parsed = (json_parser or parse_json_response)(str(raw_response))
+        assessment = normalize_llm_assessment(parsed)
+        return {
+            **assessment,
+            "debug_quality_prompt": full_prompt,
+            "debug_quality_response": str(raw_response),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Stage 3 quality assessment fallback triggered: %s", exc)
+        heuristic = assess_article_heuristically(stage3.final_article)
+        heuristic["debug_quality_prompt"] = full_prompt
+        heuristic["debug_quality_response"] = ""
+        heuristic["error"] = str(exc)
+        return heuristic

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_quality_rewrite.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_3_quality_rewrite.py
@@ -1,0 +1,157 @@
+"""LLM-backed Stage 3 quality rewrite with deterministic safeguards."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.prompts import PromptTemplate
+
+from app.features.youtube2blog.config import (
+    Y2B_PRIMARY_MODEL,
+    Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS,
+)
+from app.features.youtube2blog.quality.article_assessment import tokenize_words
+from app.features.youtube2blog.quality.article_revision import articles_are_equivalent
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+from app.shared.text import enforce_anti_ai_tells_markdown
+from shared import Stage3Output
+from utils import get_vertex_llm
+
+logger = logging.getLogger(__name__)
+
+ARTICLE_QUALITY_IMPROVEMENT_PROMPT = """You are improving an article draft for publication quality.
+
+Rewrite mode: {mode}
+Article type: {article_type}
+Guideline: {guideline}
+Priority quality dimensions:
+{focus_dimensions}
+
+Quality issues to fix:
+{top_issues}
+
+Rewrite brief:
+{rewrite_brief}
+
+Rules:
+1. Preserve factual meaning from the source draft.
+2. Do NOT add new factual claims, numbers, dates, or entities not supported by source draft.
+3. Improve clarity, specificity, flow, and usefulness.
+4. Reduce generic filler and repetition.
+5. Preserve markdown format and section structure.
+6. Keep roughly similar coverage depth (do not collapse into a short summary).
+7. Respect rewrite mode:
+   - light: tighten wording and improve transitions with minimal structural changes
+   - medium: rephrase and reorganize sections for clarity and usefulness
+   - strong: substantial rewrite for clarity/specificity while keeping factual meaning
+
+SOURCE DRAFT:
+{article}
+
+Output only the improved markdown article. No JSON, no explanations.
+"""
+
+
+def improve_article(
+    *,
+    stage3: Stage3Output,
+    top_issues: list[str],
+    rewrite_brief: list[str],
+    mode: str,
+    focus_dimensions: list[str] | None = None,
+    model_name: str = Y2B_PRIMARY_MODEL,
+    tone_guidance: str | None = None,
+    llm_factory: Callable[..., Any] | None = None,
+    anti_ai_enforcer: Callable[..., str] | None = None,
+) -> dict[str, Any]:
+    """Rewrite article draft to improve quality while preserving facts."""
+    if mode not in {"light", "medium", "strong"}:
+        raise ValueError(f"Unsupported rewrite mode: {mode}")
+
+    llm = (llm_factory or get_vertex_llm)(
+        temperature=0.2,
+        max_tokens=Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS,
+        model_name=model_name,
+    )
+    prompt = PromptTemplate(
+        input_variables=[
+            "mode",
+            "article_type",
+            "guideline",
+            "focus_dimensions",
+            "top_issues",
+            "rewrite_brief",
+            "article",
+        ],
+        template=ARTICLE_QUALITY_IMPROVEMENT_PROMPT,
+    )
+    full_prompt = prompt.format(
+        mode=mode,
+        article_type=stage3.article_type,
+        guideline=stage3.guideline_used[:8000],
+        focus_dimensions=", ".join(focus_dimensions or [])
+        or "clarity, specificity, structure",
+        top_issues="\n".join(f"- {item}" for item in top_issues[:3])
+        or "- Improve overall quality.",
+        rewrite_brief="\n".join(f"- {item}" for item in rewrite_brief[:5])
+        or "- Improve clarity and usefulness while preserving facts.",
+        article=stage3.final_article[:24000],
+    )
+    if tone_guidance:
+        full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"
+    full_prompt = f"{full_prompt}\n\n{ANTI_AI_TELLS_FULL}"
+
+    raw_response = llm.invoke(full_prompt)
+    if not raw_response or not str(raw_response).strip():
+        raise RuntimeError("Stage 3 quality improvement returned empty response")
+
+    enforce = anti_ai_enforcer or enforce_anti_ai_tells_markdown
+    improved_article = enforce(
+        str(raw_response),
+        repair=lambda repair_prompt: llm.invoke(repair_prompt),
+        context="youtube2blog quality improvement",
+    )
+    first_response_text = str(raw_response)
+
+    if articles_are_equivalent(improved_article, stage3.final_article):
+        stronger_mode = "strong" if mode != "strong" else mode
+        fallback_prompt = (
+            full_prompt
+            + "\n\nThe prior rewrite was too similar. Rewrite more decisively while "
+            "preserving facts."
+        )
+        second_raw = llm.invoke(fallback_prompt)
+        if second_raw and str(second_raw).strip():
+            improved_article = enforce(
+                str(second_raw),
+                repair=lambda repair_prompt: llm.invoke(repair_prompt),
+                context="youtube2blog quality fallback",
+            )
+            raw_response = second_raw
+            mode = stronger_mode
+            full_prompt = fallback_prompt
+
+    original_word_count = len(tokenize_words(stage3.final_article))
+    improved_word_count = len(tokenize_words(improved_article))
+    min_allowed_words = max(120, int(original_word_count * 0.55))
+    if improved_word_count < min_allowed_words:
+        logger.warning(
+            "Stage 3 quality improvement too short (%d < %d); keeping original draft",
+            improved_word_count,
+            min_allowed_words,
+        )
+        improved_article = stage3.final_article
+        improved_word_count = original_word_count
+
+    return {
+        "mode": mode,
+        "focus_dimensions": list(focus_dimensions or []),
+        "improved_article": improved_article,
+        "word_count_before": original_word_count,
+        "word_count_after": improved_word_count,
+        "debug_improve_prompt": full_prompt,
+        "debug_improve_response": str(raw_response),
+        "debug_improve_first_response": first_response_text,
+    }

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage3_quality.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage3_quality.py
@@ -1,0 +1,267 @@
+import pytest
+
+from app.features.youtube2blog.config import (
+    Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS,
+)
+from app.features.youtube2blog.quality.article_assessment import QUALITY_DIMENSIONS
+from app.features.youtube2blog.quality.article_revision import (
+    build_targeted_feedback,
+    pick_improvement_mode,
+)
+from app.features.youtube2blog.stages import stage_3_quality
+from app.features.youtube2blog.stages import stage_3_quality_assessment as assessment
+from app.features.youtube2blog.stages import stage_3_quality_rewrite as rewrite
+from shared import Stage3Output
+
+
+class _FakeLlm:
+    def __init__(self, responses: list[str]):
+        self.responses = responses
+        self.prompts: list[str] = []
+
+    def invoke(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self.responses.pop(0)
+
+
+def _stage3(article: str = "## Guide\n\nA useful article.") -> Stage3Output:
+    return Stage3Output(
+        video_id="vid-123",
+        title="Sample Video",
+        article_type="How-to Guides",
+        coverage_sufficient=True,
+        coverage_analysis="Coverage looks good.",
+        missing_sections=[],
+        supplemental_content=None,
+        final_article=article,
+        guideline_used="Use clear sections.",
+    )
+
+
+def test_quality_facade_preserves_public_stage_functions(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_assess(**kwargs):
+        captured.update(kwargs)
+        return {"overall_quality_score": 8.0}
+
+    monkeypatch.setattr(
+        stage_3_quality,
+        "assess_article_quality",
+        fake_assess,
+    )
+    fake_llm_factory = object()
+    fake_json_parser = object()
+    monkeypatch.setattr(stage_3_quality, "get_vertex_llm", fake_llm_factory)
+    monkeypatch.setattr(stage_3_quality, "parse_json_response", fake_json_parser)
+
+    stage3 = _stage3()
+    assert stage_3_quality.stage_3_assess_article_quality(stage3=stage3) == {
+        "overall_quality_score": 8.0
+    }
+    assert captured == {
+        "stage3": stage3,
+        "model_name": stage_3_quality.Y2B_PRIMARY_MODEL,
+        "llm_factory": fake_llm_factory,
+        "json_parser": fake_json_parser,
+    }
+    assert (
+        stage_3_quality.stage_3_pick_improvement_mode(
+            overall_quality_score=7.3,
+            retry_count=0,
+        )
+        == "light"
+    )
+
+
+def test_assessment_normalizes_provider_payload(monkeypatch):
+    raw_response = """{
+      "dimension_scores": {
+        "clarity": 12,
+        "structure_coherence": "invalid",
+        "specificity": -3,
+        "usefulness_actionability": 8.25,
+        "repetition_control": 7,
+        "audience_fit": 6
+      },
+      "top_issues": ["", "Be concrete", 2, "Improve flow", "Ignored"]
+    }"""
+    llm = _FakeLlm([raw_response])
+    llm_options: dict[str, object] = {}
+
+    def fake_get_vertex_llm(**kwargs):
+        llm_options.update(kwargs)
+        return llm
+
+    monkeypatch.setattr(assessment, "get_vertex_llm", fake_get_vertex_llm)
+
+    result = assessment.assess_article_quality(
+        stage3=_stage3(),
+        model_name="assessment-model",
+    )
+
+    assert result["dimension_scores"] == {
+        "clarity": 10.0,
+        "structure_coherence": 5.0,
+        "specificity": 0.0,
+        "usefulness_actionability": 8.25,
+        "repetition_control": 7.0,
+        "audience_fit": 6.0,
+    }
+    assert result["overall_quality_score"] == pytest.approx(6.0416666667)
+    assert result["top_issues"] == ["Be concrete", "2", "Improve flow"]
+    assert len(result["rewrite_brief"]) == 3
+    assert result["evaluation_source"] == "llm"
+    assert result["debug_quality_response"] == raw_response
+    assert "How-to Guides" in llm.prompts[0]
+    assert llm_options == {
+        "temperature": 0.05,
+        "max_tokens": 2048,
+        "model_name": "assessment-model",
+    }
+
+
+def test_assessment_falls_back_to_heuristics_on_provider_failure(monkeypatch):
+    monkeypatch.setattr(
+        assessment,
+        "get_vertex_llm",
+        lambda **_kwargs: _FakeLlm([""]),
+    )
+
+    result = assessment.assess_article_quality(
+        stage3=_stage3(
+            "## Start\n\nTake these 3 steps. You should check item 2.\n\n"
+            "## Finish\n\nUse tip 1 to complete the action."
+        )
+    )
+
+    assert result["evaluation_source"] == "heuristic_fallback"
+    assert tuple(result["dimension_scores"]) == QUALITY_DIMENSIONS
+    assert result["debug_quality_response"] == ""
+    assert result["error"] == "Quality assessment returned empty response"
+
+
+@pytest.mark.parametrize(
+    ("score", "retry_count", "expected"),
+    [
+        (7.3, 0, "light"),
+        (6.2, 0, "medium"),
+        (6.19, 0, "strong"),
+        (9.5, 2, "strong"),
+    ],
+)
+def test_revision_mode_policy_keeps_score_and_retry_boundaries(
+    score,
+    retry_count,
+    expected,
+):
+    assert (
+        pick_improvement_mode(
+            overall_quality_score=score,
+            retry_count=retry_count,
+        )
+        == expected
+    )
+
+
+def test_targeted_feedback_prioritizes_three_weakest_dimensions():
+    result = build_targeted_feedback(
+        dimension_scores={
+            "clarity": 7.0,
+            "specificity": 4.0,
+            "audience_fit": 6.0,
+            "repetition_control": 5.0,
+        },
+        top_issues=["Existing issue."],
+        rewrite_brief=["Existing instruction."],
+    )
+
+    assert result["focus_dimensions"] == [
+        "specificity",
+        "repetition_control",
+        "audience_fit",
+    ]
+    assert result["top_issues"][0] == "Existing issue."
+    assert "concrete examples/details already present" in result["rewrite_brief"][1]
+
+
+def test_rewrite_retries_an_unchanged_article_with_strong_mode(monkeypatch):
+    original = " ".join(f"original{index}" for index in range(130))
+    second_article = " ".join(f"improved{index}" for index in range(130))
+    llm = _FakeLlm([f"  {original.upper()}  ", second_article])
+    llm_options: dict[str, object] = {}
+    enforcement_contexts: list[str] = []
+
+    def fake_get_vertex_llm(**kwargs):
+        llm_options.update(kwargs)
+        return llm
+
+    def fake_enforce(content, *, repair, context):
+        del repair
+        enforcement_contexts.append(context)
+        return content.strip()
+
+    monkeypatch.setattr(rewrite, "get_vertex_llm", fake_get_vertex_llm)
+    monkeypatch.setattr(rewrite, "enforce_anti_ai_tells_markdown", fake_enforce)
+
+    result = rewrite.improve_article(
+        stage3=_stage3(original),
+        top_issues=["Improve specificity."],
+        rewrite_brief=["Use concrete wording."],
+        mode="light",
+        focus_dimensions=["specificity"],
+        model_name="rewrite-model",
+        tone_guidance="Keep it direct.",
+    )
+
+    assert result["mode"] == "strong"
+    assert result["improved_article"] == second_article
+    assert result["debug_improve_first_response"] == f"  {original.upper()}  "
+    assert "prior rewrite was too similar" in result["debug_improve_prompt"]
+    assert "Keep it direct." in llm.prompts[0]
+    assert enforcement_contexts == [
+        "youtube2blog quality improvement",
+        "youtube2blog quality fallback",
+    ]
+    assert llm_options == {
+        "temperature": 0.2,
+        "max_tokens": Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS,
+        "model_name": "rewrite-model",
+    }
+
+
+def test_rewrite_rolls_back_an_output_that_loses_too_much_content(monkeypatch):
+    original = " ".join(f"source{index}" for index in range(220))
+    llm = _FakeLlm(["Far too short."])
+    monkeypatch.setattr(rewrite, "get_vertex_llm", lambda **_kwargs: llm)
+    monkeypatch.setattr(
+        rewrite,
+        "enforce_anti_ai_tells_markdown",
+        lambda content, **_kwargs: content,
+    )
+
+    result = rewrite.improve_article(
+        stage3=_stage3(original),
+        top_issues=[],
+        rewrite_brief=[],
+        mode="medium",
+    )
+
+    assert result["improved_article"] == original
+    assert result["word_count_before"] == 220
+    assert result["word_count_after"] == 220
+
+
+def test_rewrite_rejects_an_unknown_mode_before_requesting_an_llm(monkeypatch):
+    def fail_if_called(**_kwargs):
+        raise AssertionError("LLM should not be requested")
+
+    monkeypatch.setattr(rewrite, "get_vertex_llm", fail_if_called)
+
+    with pytest.raises(ValueError, match="Unsupported rewrite mode: invalid"):
+        rewrite.improve_article(
+            stage3=_stage3(),
+            top_issues=[],
+            rewrite_brief=[],
+            mode="invalid",
+        )


### PR DESCRIPTION
## Original issue

`stage_3_quality.py` was a 449-line module with 10 definitions and seven interleaved responsibilities: heuristic scoring, assessment normalization, provider-backed assessment, improvement-mode selection, targeted feedback, provider-backed rewriting, and rewrite safeguards.

## Root cause

The Stage 3 quality loop grew in one helper module as fallback scoring, retry policy, prompt handling, and post-generation safeguards were added over time. Production callers only needed four stable stage functions, but the implementation did not use that natural facade boundary.

## Refactor performed

- Kept `stage_3_quality.py` as a 95-line compatibility facade with the same four public `stage_3_*` functions and legacy collaborator patch seams.
- Extracted deterministic assessment normalization and heuristic fallback to `quality/article_assessment.py`.
- Extracted deterministic rewrite-mode and targeted-feedback policy to `quality/article_revision.py`.
- Extracted provider-backed assessment to `stages/stage_3_quality_assessment.py`.
- Extracted provider-backed rewriting, anti-AI repair, unchanged-response retry, and length rollback to `stages/stage_3_quality_rewrite.py`.
- Updated the YouTube2Blog module map and added focused contract tests.

## Why better

The stable caller surface is now visibly separate from provider I/O and pure policy. Deterministic scoring and revision decisions can be tested without loading an LLM, while assessment and rewrite failures remain localized to their respective adapters. No extracted production module exceeds 170 lines, so the original bloat is not relocated.

## Validation

- Black check: passed.
- AI Blog Writer flake8: passed.
- Focused Stage 3/graph/facade/anti-AI tests: 29 passed.
- Full backend suite: 367 passed.
- Root `pnpm test`: passed (7/7 Turbo tasks; ABW backend 367 and frontend 362 tests).
- AI Blog Writer `pnpm build`: passed.
- Python compileall: passed.
- Root `pnpm lint`: ABW lint passed; root command stops on an unrelated Questura server baseline (`@next/next/no-img-element` rule unavailable).
- Root `pnpm build`: ABW build passed independently; root command stops on Questura server under Node 18.19 (`undici` requires global `File`, while the package declares Node >=20.9).

## Risks/tradeoffs/follow-ups

This is intentionally a structural refactor: prompts, score thresholds, response fields, retry behavior, model settings, anti-AI enforcement, and short-rewrite rollback are preserved. Internal implementation helpers now live in focused modules; callers should continue using the stable facade exports. The unrelated Questura lint/toolchain baselines remain follow-up work outside this PR.