### PR TITLE
NOJIRA: Trim location document schema surface

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/frontend/CONTEXT.md
@@ -99,9 +99,10 @@ Definition: payload sent to backend to start a run.
 
 Definition: backend → client poll response. Field `state` is `pending` / `running` / `completed` / `failed`; field `stage` names the current pipeline phase.
 
-### `LocationFieldDefinition`
+### `RelationshipFieldDefinition`
 
-Definition: schema row for the location-documents form. Includes `type`, `path`, `aiEnabled`, optional `relationshipFieldDefinition`.
+Definition: configuration for the Location Images editor's cover-image relationship. It identifies the `media-sets` relation, its option source, and the shared Image Picker used to select a MediaSet.
+Code references: `src/features/locationDocuments/types.ts`, `CoverImagePickerField.tsx`.
 
 ### `EditorAssistModelName`
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/schema.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/schema.test.ts
@@ -4,16 +4,13 @@ import {
   buildDraftFromPayloadDoc,
   buildLocationHierarchyTitle,
   buildPayloadLocationBody,
-  buildPayloadSyncSignature,
   createEmptyLocationDraft,
   markDraftAsPayloadSynced,
-  payloadLocationToDraft,
   refreshDraftPayloadSyncState,
-  resolveLocationDraftRef,
   sanitizeLocationDraftShape,
   validateDraft,
 } from './schema'
-import type { LocationOption, PayloadLocationDoc } from './types'
+import type { PayloadLocationDoc } from './types'
 
 describe('location image schema helpers', () => {
   it('migrates legacy guide media cover image into top-level coverImage', () => {
@@ -93,7 +90,7 @@ describe('location image schema helpers', () => {
   })
 
   it('falls back to legacy Payload guide media only when top-level coverImage is absent', () => {
-    const draft = payloadLocationToDraft({
+    const draft = buildDraftFromPayloadDoc({
       id: 12,
       level: 'city',
       country: 'peru',
@@ -116,7 +113,8 @@ describe('location image schema helpers', () => {
 
     const synced = markDraftAsPayloadSynced(draft, '2026-03-09T00:00:00.000Z')
     expect(synced.hasUnsyncedPayloadChanges).toBe(false)
-    expect(synced.lastPayloadSyncSignature).toBe(buildPayloadSyncSignature(synced))
+    expect(synced.currentPayloadSignature).toBe(synced.lastPayloadSyncSignature)
+    expect(synced.lastPayloadSyncSignature).toBeTruthy()
 
     const edited = refreshDraftPayloadSyncState({
       ...synced,
@@ -126,12 +124,10 @@ describe('location image schema helpers', () => {
   })
 
   it('requires an existing Payload location before syncing', () => {
-    expect(validateDraft(createEmptyLocationDraft())).toBe(
-      'Open an existing Payload location before syncing.',
-    )
+    expect(validateDraft(createEmptyLocationDraft())).toBe('Open an existing Payload location before syncing.')
   })
 
-  it('builds readable hierarchy titles and resolves existing location refs', () => {
+  it('builds readable hierarchy titles', () => {
     const draft = createEmptyLocationDraft()
     draft.level = 'neighborhood'
     draft.country = 'peru'
@@ -141,21 +137,16 @@ describe('location image schema helpers', () => {
     draft.cityName = 'Lima'
     draft.neighborhoodName = 'Barranco'
 
-    const options: LocationOption[] = [
-      {
-        id: 44,
-        level: 'neighborhood',
-        country: 'peru',
-        city: 'lima',
-        neighborhood: 'barranco',
-        countryName: 'Peru',
-        cityName: 'Lima',
-        neighborhoodName: 'Barranco',
-        locationKey: 'peru|lima|barranco',
-      },
-    ]
-
     expect(buildLocationHierarchyTitle(draft)).toBe('Barranco, Lima, Peru')
-    expect(resolveLocationDraftRef(draft, options)).toBe(44)
+  })
+
+  it('falls back to normalized hierarchy keys when display names are missing', () => {
+    const draft = createEmptyLocationDraft()
+    draft.level = 'neighborhood'
+    draft.country = '  Côte d Ivoire! '
+    draft.city = 'san--pedro'
+    draft.neighborhood = 'le   bardot'
+
+    expect(buildLocationHierarchyTitle(draft)).toBe('Le Bardot, San Pedro, Côte D Ivoire')
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/schema.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/schema.ts
@@ -1,13 +1,5 @@
-import type {
-  LocationDocumentDraft,
-  LocationIndexRow,
-  LocationOption,
-  PayloadLocationBody,
-  PayloadLocationDoc,
-  PayloadRelationship,
-} from './types'
+import type { LocationDocumentDraft, PayloadLocationBody, PayloadLocationDoc, PayloadRelationship } from './types'
 import {
-  buildDraftPayloadSyncSignature,
   markDraftAsPayloadSynced as markPayloadSyncStateSynced,
   readStoredPayloadSyncFields,
   refreshDraftPayloadSyncState as refreshPayloadSyncState,
@@ -17,7 +9,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
-export function normalizeKeyPart(value: string): string {
+function normalizeKeyPart(value: string): string {
   return value
     .trim()
     .toLowerCase()
@@ -28,7 +20,7 @@ export function normalizeKeyPart(value: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-export function formatFallbackName(value: string): string {
+function formatFallbackName(value: string): string {
   if (!value) return ''
 
   return value
@@ -84,24 +76,20 @@ export function createEmptyLocationDraft(): LocationDocumentDraft {
   }
 }
 
-export const createEmptyLocationDocumentDraft = createEmptyLocationDraft
-
 export function sanitizeLocationDraftShape(input: unknown): LocationDocumentDraft {
   const base = createEmptyLocationDraft()
   if (!isRecord(input)) return base
 
   const level = input.level === 'city' || input.level === 'neighborhood' ? input.level : 'country'
-  const hasTopLevelCoverImage = Object.prototype.hasOwnProperty.call(input, 'coverImage')
-    && input.coverImage !== undefined
+  const hasTopLevelCoverImage =
+    Object.prototype.hasOwnProperty.call(input, 'coverImage') && input.coverImage !== undefined
   const topLevelCoverImage = extractRelationshipId(input.coverImage as PayloadRelationship)
   const legacyCoverImage = extractLegacyCoverImage(input)
 
   return {
     ...base,
     draftId: trimText(input.draftId) || base.draftId,
-    payloadId: typeof input.payloadId === 'number' && Number.isFinite(input.payloadId)
-      ? input.payloadId
-      : undefined,
+    payloadId: typeof input.payloadId === 'number' && Number.isFinite(input.payloadId) ? input.payloadId : undefined,
     ...readStoredPayloadSyncFields(input),
     level,
     country: trimText(input.country),
@@ -125,62 +113,14 @@ export function buildLocationHierarchyTitle(
 ): string {
   const country = resolveHierarchyTitlePart(draft.countryName, draft.country)
   const city = resolveHierarchyTitlePart(draft.cityName, draft.city)
-  const neighborhood = resolveHierarchyTitlePart(
-    draft.neighborhoodName,
-    draft.neighborhood,
-  )
+  const neighborhood = resolveHierarchyTitlePart(draft.neighborhoodName, draft.neighborhood)
 
   if (draft.level === 'country') return country
   if (draft.level === 'city') return [city, country].filter(Boolean).join(', ')
   return [neighborhood, city, country].filter(Boolean).join(', ')
 }
 
-export function buildLocationKeyPreview(
-  draft: Pick<LocationDocumentDraft, 'level' | 'country' | 'city' | 'neighborhood'>,
-): string {
-  const country = normalizeKeyPart(draft.country)
-  const city = normalizeKeyPart(draft.city)
-  const neighborhood = normalizeKeyPart(draft.neighborhood)
-
-  if (!country) return ''
-  if (draft.level === 'country') return country
-  if (draft.level === 'city') return city ? `${country}|${city}` : country
-  if (!city) return country
-  return neighborhood ? `${country}|${city}|${neighborhood}` : `${country}|${city}`
-}
-
-export function buildParentKeyPreview(
-  draft: Pick<LocationDocumentDraft, 'level' | 'country' | 'city'>,
-): string {
-  const country = normalizeKeyPart(draft.country)
-  const city = normalizeKeyPart(draft.city)
-
-  if (!country || draft.level === 'country') return ''
-  if (draft.level === 'city') return country
-  return city ? `${country}|${city}` : country
-}
-
-export function resolveLocationDraftRef(
-  draft: Pick<LocationDocumentDraft, 'payloadId' | 'level' | 'country' | 'city' | 'neighborhood'>,
-  locationOptions: LocationOption[],
-): number | null {
-  if (typeof draft.payloadId === 'number' && Number.isFinite(draft.payloadId)) {
-    return draft.payloadId
-  }
-
-  const locationKey = buildLocationKeyPreview(draft)
-  if (!locationKey) return null
-
-  const normalizedLocationKey = locationKey.trim().toLowerCase()
-  const match = locationOptions.find((location) => (
-    location.level === draft.level
-      && location.locationKey.trim().toLowerCase() === normalizedLocationKey
-  ))
-
-  return match?.id ?? null
-}
-
-export function payloadLocationToDraft(doc: PayloadLocationDoc): LocationDocumentDraft {
+export function buildDraftFromPayloadDoc(doc: PayloadLocationDoc): LocationDocumentDraft {
   const draft = sanitizeLocationDraftShape({
     payloadId: doc.id,
     level: doc.level,
@@ -200,17 +140,11 @@ export function payloadLocationToDraft(doc: PayloadLocationDoc): LocationDocumen
   return markDraftAsPayloadSynced(draft, doc.updatedAt || new Date().toISOString())
 }
 
-export const buildDraftFromPayloadDoc = payloadLocationToDraft
-
 export function buildPayloadLocationBody(draft: LocationDocumentDraft): PayloadLocationBody {
   const sanitized = sanitizeLocationDraftShape(draft)
   return {
     coverImage: sanitized.coverImage,
   }
-}
-
-export function buildPayloadSyncSignature(draft: LocationDocumentDraft): string {
-  return buildDraftPayloadSyncSignature(draft, buildPayloadLocationBody)
 }
 
 export function refreshDraftPayloadSyncState(draft: LocationDocumentDraft): LocationDocumentDraft {
@@ -219,10 +153,7 @@ export function refreshDraftPayloadSyncState(draft: LocationDocumentDraft): Loca
   })
 }
 
-export function markDraftAsPayloadSynced(
-  draft: LocationDocumentDraft,
-  syncedAt: string,
-): LocationDocumentDraft {
+export function markDraftAsPayloadSynced(draft: LocationDocumentDraft, syncedAt: string): LocationDocumentDraft {
   return markPayloadSyncStateSynced(sanitizeLocationDraftShape(draft), buildPayloadLocationBody, syncedAt)
 }
 
@@ -232,18 +163,4 @@ export function validateDraft(draft: LocationDocumentDraft): string | null {
   }
 
   return null
-}
-
-export function formatLocationLabel(
-  location: Pick<LocationIndexRow, 'level' | 'countryName' | 'cityName' | 'neighborhoodName' | 'locationKey'>,
-): string {
-  if (location.level === 'country') {
-    return location.countryName || location.locationKey
-  }
-
-  if (location.level === 'city') {
-    return location.cityName || location.locationKey
-  }
-
-  return location.neighborhoodName || location.locationKey
 }


### PR DESCRIPTION
## Original issue

`locationDocuments/schema.ts` was reported at score 12 with 249 lines, 20 definitions, 17 public exports, and six apparent concerns. The transformation pipeline is cohesive, so splitting it into shallow files would not improve the architecture; the legitimate issue was the oversized interface and dead implementation left behind after the feature was narrowed.

## Root cause

The May 2026 change from a location-creation/guide editor to an existing-Payload Location Images editor removed the callers for key previews, parent-key previews, draft reference resolution, and old naming aliases, but left those functions exported. A second location-label formatter also remained despite the active formatter living in `utils.ts`. Tests continued importing two compatibility/test-only exports, making the stale interface look intentional.

## Refactor performed

- Kept normalization, Payload mapping, legacy storage migration, sync-state handling, and validation in one cohesive module.
- Deleted the retired location-creation key/parent/ref-resolution path and the duplicate unused label formatter.
- Replaced compatibility aliases with the canonical production name and removed the test-only sync-signature interface.
- Made hierarchy normalization helpers private implementation details.
- Updated tests to exercise behavior through the same interface as production callers, including hierarchy-key fallback.
- Corrected the frontend domain glossary to describe the current `RelationshipFieldDefinition`.

The module is now 166 lines with eight public exports (down from 249 lines and 17 exports).

## Why better

The interface now matches the behavior callers actually use, increasing module depth without scattering the implementation across shallow files. The deletion test supports this shape: deleting the active module would push migration, mapping, sync, and validation complexity into storage and the builder, while deleting the removed functions makes obsolete creation complexity disappear entirely. Tests now cross the production seam instead of depending on test-only helpers and aliases.

## Validation

- Modified-file ESLint: passed.
- Targeted TypeScript check for schema and tests: passed.
- Focused Location Documents tests: 12/12 passed.
- ABW frontend lint and boundary check: passed.
- ABW frontend tests: 95 files, 363 tests passed.
- ABW frontend production build: passed.
- Root `pnpm run test`: passed (8/8 Turbo tasks; ABW backend 367 tests passed).
- `git diff --check`: passed.
- Full frontend `tsc --noEmit` reaches five pre-existing errors in unrelated homepage/listicle files.
- Root `pnpm run lint` reaches an unrelated Questura Server ESLint configuration error: `@next/next/no-img-element` is unavailable.
- Root `pnpm run build` reaches an unrelated environment failure in Questura Server: Node 18.19.1 is below the declared engine and Undici cannot find the global `File` type.

## Risks/tradeoffs/follow-ups

Risk is low: repository-wide static and dynamic searches found no callers for the removed names; `schema.ts` is not re-exported from the feature barrel or a package export. Any unsupported external source import of those private frontend internals would need to use the canonical production interface. No runtime data shape, Payload body, storage migration, or sync behavior changed. The unrelated root lint/build/typecheck baselines remain follow-up work outside Finding 25.