### PR TITLE
NOJIRA: Split accommodations suggestion orchestration

### DIFF
--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-eligibility.test.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-eligibility.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { ACCOMMODATIONS_FORM_DEFAULT_VALUES } from "../accommodations-create.types";
+import {
+  canSuggestAccommodationsField,
+  getEligibleAutoSuggestionFields,
+} from "./accommodations-suggestion-eligibility";
+
+describe("canSuggestAccommodationsField", () => {
+  const baseInput = {
+    fieldKey: "bookingUrl" as const,
+    value: "",
+    locationTypes: [],
+    isPrefillReady: true,
+    isDirty: false,
+    isApiFilled: false,
+    isAiSuggested: false,
+    isPending: false,
+    isQueued: false,
+  };
+
+  test("allows an untouched URL field after prefill", () => {
+    expect(canSuggestAccommodationsField(baseInput)).toBe(true);
+  });
+
+  test("blocks fields that already have an in-flight or queued result", () => {
+    expect(
+      canSuggestAccommodationsField({ ...baseInput, isPending: true })
+    ).toBe(false);
+    expect(
+      canSuggestAccommodationsField({ ...baseInput, isQueued: true })
+    ).toBe(false);
+  });
+});
+
+describe("getEligibleAutoSuggestionFields", () => {
+  test("keeps empty fields while excluding API-owned and operator-filled fields", () => {
+    const eligible = getEligibleAutoSuggestionFields({
+      formValues: {
+        ...ACCOMMODATIONS_FORM_DEFAULT_VALUES,
+        type: "hotel",
+      },
+      apiFilledFields: new Set(["wifi"]),
+      locationTypes: [{ value: "hotel", label: "Hotel" }],
+    });
+
+    expect(eligible.includes("bookingUrl")).toBe(true);
+    expect(eligible.includes("type")).toBe(false);
+    expect(eligible.includes("wifi")).toBe(false);
+    expect(eligible.includes("kidFriendly")).toBe(true);
+  });
+});

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-eligibility.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-eligibility.ts
@@ -1,0 +1,78 @@
+import { isOptionSuggestionEligible } from "../../autofill/option-suggestion-eligibility";
+import type { AddAccommodationsFormData } from "../../validation/add-accommodations.schema";
+import {
+  ACCOMMODATIONS_FORM_DEFAULT_VALUES,
+  type AiSuggestedField,
+  type ApiFilledField,
+} from "../accommodations-create.types";
+import {
+  AUTO_AI_SUGGESTION_FIELDS,
+  getSuggestionField,
+  getSuggestionFieldOptions,
+} from "./accommodations-suggestion-utils";
+import type { LocationTypeOption } from "./accommodations-suggestion-request";
+
+interface SuggestionEligibilityInput {
+  fieldKey: AiSuggestedField;
+  value: AddAccommodationsFormData[AiSuggestedField];
+  locationTypes: LocationTypeOption[];
+  isPrefillReady: boolean;
+  isDirty: boolean;
+  isApiFilled: boolean;
+  isAiSuggested: boolean;
+  isPending: boolean;
+  isQueued: boolean;
+}
+
+export function canSuggestAccommodationsField({
+  fieldKey,
+  value,
+  locationTypes,
+  isPrefillReady,
+  isDirty,
+  isApiFilled,
+  isAiSuggested,
+  isPending,
+  isQueued,
+}: SuggestionEligibilityInput) {
+  if (isPending || isQueued) return false;
+  const definition = getSuggestionField(fieldKey);
+  return isOptionSuggestionEligible({
+    value,
+    defaultValue: ACCOMMODATIONS_FORM_DEFAULT_VALUES[fieldKey],
+    isPrefillReady,
+    optionsCount: getSuggestionFieldOptions(fieldKey, locationTypes).length,
+    isDirty,
+    isApiFilled,
+    isAiSuggested,
+    isUrlKind: definition?.kind === "url",
+  });
+}
+
+export function getEligibleAutoSuggestionFields({
+  formValues,
+  apiFilledFields,
+  locationTypes,
+}: {
+  formValues: AddAccommodationsFormData;
+  apiFilledFields: Set<ApiFilledField>;
+  locationTypes: LocationTypeOption[];
+}) {
+  return AUTO_AI_SUGGESTION_FIELDS.filter((fieldKey) => {
+    const definition = getSuggestionField(fieldKey);
+    return (
+      Boolean(definition) &&
+      !apiFilledFields.has(fieldKey as ApiFilledField) &&
+      isOptionSuggestionEligible({
+        value: formValues[fieldKey],
+        defaultValue: ACCOMMODATIONS_FORM_DEFAULT_VALUES[fieldKey],
+        isPrefillReady: true,
+        optionsCount: getSuggestionFieldOptions(fieldKey, locationTypes).length,
+        isDirty: false,
+        isApiFilled: false,
+        isAiSuggested: false,
+        isUrlKind: definition?.kind === "url",
+      })
+    );
+  });
+}

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-request.test.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-request.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { GooglePrefillResponse } from "@client/shared/services/api/types";
+import { ACCOMMODATIONS_FORM_DEFAULT_VALUES } from "../accommodations-create.types";
+import {
+  buildAccommodationsSuggestionError,
+  buildAccommodationsSuggestionRequest,
+  canRequestAccommodationsSuggestion,
+} from "./accommodations-suggestion-request";
+
+const googleContext: GooglePrefillResponse = {
+  googleUrl: "https://google.example/context",
+  placeId: "context-place",
+  lat: 40,
+  lng: -73,
+  locationKey: "us|new-york|soho",
+  district: "SoHo",
+  ianaTimeId: "America/New_York",
+  phoneNumber: "+1 212 555 0100",
+  website: "https://hotel.example",
+  priceLevel: "$$$",
+  operationHours: null,
+  accommodationsHints: {
+    source: "foursquare",
+    price: "$$$",
+  },
+  type: null,
+  tripadvisorUrl: null,
+  tripadvisorPlaceData: null,
+  menuUrl: null,
+  bookingUrl: null,
+  provenance: {},
+};
+
+describe("buildAccommodationsSuggestionRequest", () => {
+  test("uses API context ahead of stale form context", () => {
+    const request = buildAccommodationsSuggestionRequest({
+      fieldKey: "bookingUrl",
+      formValues: {
+        ...ACCOMMODATIONS_FORM_DEFAULT_VALUES,
+        googleUrl: "https://google.example/form",
+        placeId: "form-place",
+        phone: "+1 212 555 0199",
+      },
+      context: googleContext,
+      locationTypes: [],
+    });
+
+    expect(request.category).toBe("accommodations");
+    expect(request.apiContext?.googleUrl).toBe(
+      "https://google.example/context"
+    );
+    expect(request.apiContext?.placeId).toBe("context-place");
+    expect(request.apiContext?.phoneNumber).toBe("+1 212 555 0100");
+    expect(request.apiContext?.priceLevel).toBe("$$$");
+    expect(request.apiContext?.accommodationsHints).toEqual(
+      googleContext.accommodationsHints
+    );
+    expect(request.allowedOptions).toEqual([]);
+  });
+
+  test("falls back to current form context when API context is absent", () => {
+    const request = buildAccommodationsSuggestionRequest({
+      fieldKey: "type",
+      formValues: {
+        ...ACCOMMODATIONS_FORM_DEFAULT_VALUES,
+        googleUrl: "https://google.example/form",
+        placeId: "form-place",
+        locationKey: "us|chicago|loop",
+        phone: "+1 312 555 0100",
+      },
+      context: null,
+      locationTypes: [{ value: "hotel", label: "Hotel" }],
+    });
+
+    expect(request.apiContext?.googleUrl).toBe("https://google.example/form");
+    expect(request.apiContext?.placeId).toBe("form-place");
+    expect(request.apiContext?.locationKey).toBe("us|chicago|loop");
+    expect(request.apiContext?.phoneNumber).toBe("+1 312 555 0100");
+    expect(request.allowedOptions).toEqual([
+      {
+        value: "hotel",
+        label: "Hotel",
+        description: "Accommodation type from the configured taxonomy.",
+      },
+    ]);
+  });
+});
+
+describe("accommodations suggestion request eligibility", () => {
+  test("allows URL suggestions without a fixed option list", () => {
+    expect(canRequestAccommodationsSuggestion("bookingUrl", [])).toBe(true);
+  });
+
+  test("requires configured options for taxonomy-backed type suggestions", () => {
+    expect(canRequestAccommodationsSuggestion("type", [])).toBe(false);
+    expect(
+      canRequestAccommodationsSuggestion("type", [
+        { value: "hotel", label: "Hotel" },
+      ])
+    ).toBe(true);
+  });
+});
+
+describe("buildAccommodationsSuggestionError", () => {
+  test("normalizes thrown and non-Error failures for operator review", () => {
+    const thrownError = buildAccommodationsSuggestionError(
+      "bookingUrl",
+      new Error("request failed")
+    );
+    expect(thrownError.fieldKey).toBe("bookingUrl");
+    expect(thrownError.kind).toBe("url");
+    expect(thrownError.error).toBe("request failed");
+    expect(
+      buildAccommodationsSuggestionError("type", "request failed").error
+    ).toBe("Unknown error");
+  });
+});

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-request.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/accommodations-suggestion-request.ts
@@ -1,0 +1,73 @@
+import type {
+  AccommodationsFieldSuggestionRequest,
+  AccommodationsFieldSuggestionResponse,
+  GooglePrefillResponse,
+} from "@client/shared/services/api/types";
+import type { AddAccommodationsFormData } from "../../validation/add-accommodations.schema";
+import type { AiSuggestedField } from "../accommodations-create.types";
+import {
+  getSuggestionField,
+  getSuggestionFieldOptions,
+} from "./accommodations-suggestion-utils";
+
+export type LocationTypeOption = { value: string; label: string };
+
+export function buildAccommodationsSuggestionRequest({
+  fieldKey,
+  formValues,
+  context,
+  locationTypes,
+}: {
+  fieldKey: AiSuggestedField;
+  formValues: AddAccommodationsFormData;
+  context: GooglePrefillResponse | null;
+  locationTypes: LocationTypeOption[];
+}): AccommodationsFieldSuggestionRequest {
+  return {
+    category: "accommodations",
+    fieldKey,
+    formValues: formValues as unknown as Record<string, unknown>,
+    apiContext: {
+      googleUrl: context?.googleUrl || formValues.googleUrl || null,
+      placeId: context?.placeId || formValues.placeId || null,
+      locationKey: context?.locationKey || formValues.locationKey || null,
+      district: context?.district || formValues.district || null,
+      ianaTimeId: context?.ianaTimeId || formValues.ianaTimeId || null,
+      phoneNumber: context?.phoneNumber || formValues.phone || null,
+      website: context?.website || formValues.websiteUrl || null,
+      priceLevel: context?.priceLevel || null,
+      accommodationsHints: context?.accommodationsHints || null,
+    },
+    allowedOptions: getSuggestionFieldOptions(fieldKey, locationTypes),
+  };
+}
+
+export function buildAccommodationsSuggestionError(
+  fieldKey: AiSuggestedField,
+  error: unknown
+): AccommodationsFieldSuggestionResponse {
+  const field = getSuggestionField(fieldKey);
+  return {
+    fieldKey,
+    fieldLabel: field?.label || fieldKey,
+    suggestion: null,
+    kind: field?.kind || "single",
+    confidence: 0,
+    source: "ai",
+    reason: "",
+    sources: [],
+    error: error instanceof Error ? error.message : "Unknown error",
+  };
+}
+
+export function canRequestAccommodationsSuggestion(
+  fieldKey: AiSuggestedField,
+  locationTypes: LocationTypeOption[]
+) {
+  const field = getSuggestionField(fieldKey);
+  return Boolean(
+    field &&
+      (field.kind === "url" ||
+        getSuggestionFieldOptions(fieldKey, locationTypes).length > 0)
+  );
+}

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsAutoFill.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsAutoFill.ts
@@ -1,0 +1,117 @@
+import { useState, type Dispatch, type SetStateAction } from "react";
+import { locationsApi } from "@client/shared/services/api";
+import type {
+  AccommodationsFieldSuggestionResponse,
+  GooglePrefillResponse,
+} from "@client/shared/services/api/types";
+import { runSuggestionBatch } from "../../autofill/run-suggestion-batch";
+import type {
+  AiSuggestedField,
+  AiSuggestionEvidence,
+  ApiFilledField,
+  AutoFillProgress,
+} from "../accommodations-create.types";
+import { getSuggestionField } from "./accommodations-suggestion-utils";
+import { buildAccommodationsSuggestionError } from "./accommodations-suggestion-request";
+
+const AUTO_FILL_CONCURRENCY = 3;
+
+interface UseAccommodationsAutoFillOptions {
+  getEligibleFields: (fields: Set<ApiFilledField>) => AiSuggestedField[];
+  buildRequest: (
+    fieldKey: AiSuggestedField,
+    context: GooglePrefillResponse
+  ) => Parameters<typeof locationsApi.suggestField>[0];
+  applySuggestion: (
+    item: AccommodationsFieldSuggestionResponse,
+    source: "auto" | "manual"
+  ) => boolean;
+  setAiSuggestionEvidence: Dispatch<SetStateAction<AiSuggestionEvidence>>;
+  beginPending: (fieldKey: AiSuggestedField) => void;
+  endPending: (fieldKey: AiSuggestedField) => void;
+}
+
+export function useAccommodationsAutoFill({
+  getEligibleFields,
+  buildRequest,
+  applySuggestion,
+  setAiSuggestionEvidence,
+  beginPending,
+  endPending,
+}: UseAccommodationsAutoFillOptions) {
+  const [autoFillProgress, setAutoFillProgress] =
+    useState<AutoFillProgress | null>(null);
+
+  const runAutoAiFill = async (
+    context: GooglePrefillResponse,
+    fields: Set<ApiFilledField>
+  ) => {
+    const eligibleFields = getEligibleFields(fields);
+    if (eligibleFields.length === 0) {
+      return { applied: 0, failed: 0, total: 0 };
+    }
+
+    setAutoFillProgress({
+      total: eligibleFields.length,
+      completed: 0,
+      applied: 0,
+      failed: 0,
+      currentFieldLabel: "Starting AI fill",
+    });
+    const result = await runSuggestionBatch({
+      fields: eligibleFields,
+      concurrency: AUTO_FILL_CONCURRENCY,
+      run: async (fieldKey) => {
+        const response = await locationsApi.suggestField(
+          buildRequest(fieldKey, context)
+        );
+        if (!response.error && applySuggestion(response, "auto")) return true;
+        setAiSuggestionEvidence((evidence) => ({
+          ...evidence,
+          [fieldKey]: response,
+        }));
+        return false;
+      },
+      onFieldStart: (fieldKey) => {
+        beginPending(fieldKey);
+        setAutoFillProgress((progress) =>
+          progress
+            ? {
+                ...progress,
+                currentFieldLabel:
+                  getSuggestionField(fieldKey)?.label || fieldKey,
+              }
+            : progress
+        );
+      },
+      onFieldSettled: (fieldKey, outcome, error, progress) => {
+        if (outcome === "error") {
+          setAiSuggestionEvidence((evidence) => ({
+            ...evidence,
+            [fieldKey]: buildAccommodationsSuggestionError(fieldKey, error),
+          }));
+        }
+        endPending(fieldKey);
+        setAutoFillProgress((current) =>
+          current
+            ? {
+                ...current,
+                completed: progress.completed,
+                applied: progress.applied,
+                failed: progress.failed,
+              }
+            : current
+        );
+      },
+    });
+    setAutoFillProgress(null);
+    return result;
+  };
+
+  return {
+    autoFillProgress,
+    resetAutoFill: () => setAutoFillProgress(null),
+    runAutoAiFill,
+    setAutoFillProgress,
+  };
+}

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsSuggestionForm.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsSuggestionForm.ts
@@ -1,0 +1,132 @@
+import { useState, type Dispatch, type SetStateAction } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import type { AccommodationsFieldSuggestionResponse } from "@client/shared/services/api/types";
+import { markAiUrlSuggested } from "../../autofill/ai-url-ack";
+import type { AddAccommodationsFormData } from "../../validation/add-accommodations.schema";
+import type {
+  AiSuggestedField,
+  AiSuggestionEvidence,
+  MultiField,
+} from "../accommodations-create.types";
+import {
+  getSuggestionFieldOptions,
+  validateClientSuggestion,
+} from "./accommodations-suggestion-utils";
+import type { LocationTypeOption } from "./accommodations-suggestion-request";
+
+interface UseAccommodationsSuggestionFormOptions {
+  form: UseFormReturn<AddAccommodationsFormData>;
+  locationTypes: LocationTypeOption[];
+  setVerifiedAiUrls: Dispatch<SetStateAction<{ bookingUrl: boolean }>>;
+}
+
+export function useAccommodationsSuggestionForm({
+  form,
+  locationTypes,
+  setVerifiedAiUrls,
+}: UseAccommodationsSuggestionFormOptions) {
+  const [aiSuggestedFields, setAiSuggestedFields] = useState<
+    Set<AiSuggestedField>
+  >(() => new Set());
+  const [manuallySelectedFields, setManuallySelectedFields] = useState<
+    Set<AiSuggestedField>
+  >(() => new Set());
+  const [aiSuggestionEvidence, setAiSuggestionEvidence] =
+    useState<AiSuggestionEvidence>({});
+
+  const clearAiSuggestion = (field: AiSuggestedField) => {
+    setAiSuggestedFields(
+      (current) => new Set([...current].filter((item) => item !== field))
+    );
+    setAiSuggestionEvidence((current) => {
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  };
+
+  const markManuallySelected = (field: AiSuggestedField) => {
+    clearAiSuggestion(field);
+    setManuallySelectedFields((current) => new Set(current).add(field));
+  };
+
+  const setSingleOptionField = <
+    TField extends Exclude<AiSuggestedField, MultiField>,
+  >(
+    field: TField,
+    value: AddAccommodationsFormData[TField]
+  ) => {
+    form.setValue(field, value as never, {
+      shouldDirty: true,
+      shouldValidate: true,
+      shouldTouch: true,
+    });
+    markManuallySelected(field);
+  };
+
+  const toggleMultiOption = (field: MultiField, value: string) => {
+    const current = (form.getValues(field) || []) as string[];
+    const next = current.includes(value)
+      ? current.filter((item) => item !== value)
+      : [...current, value];
+    form.setValue(field, next as AddAccommodationsFormData[MultiField], {
+      shouldDirty: true,
+      shouldValidate: true,
+      shouldTouch: true,
+    });
+    markManuallySelected(field);
+  };
+
+  const applySuggestionToField = (
+    item: AccommodationsFieldSuggestionResponse,
+    source: "auto" | "manual"
+  ) => {
+    const fieldKey = item.fieldKey as AiSuggestedField;
+    const suggestion = validateClientSuggestion(
+      item.suggestion,
+      getSuggestionFieldOptions(fieldKey, locationTypes),
+      item.kind
+    );
+    if (!suggestion) return false;
+
+    form.setValue(fieldKey, suggestion as never, {
+      shouldDirty: source === "manual",
+      shouldValidate: true,
+      shouldTouch: true,
+    });
+    setAiSuggestedFields((fields) => new Set(fields).add(fieldKey));
+    setManuallySelectedFields(
+      (fields) => new Set([...fields].filter((field) => field !== fieldKey))
+    );
+    if (item.kind === "url" && fieldKey === "bookingUrl") {
+      setVerifiedAiUrls((urls) => markAiUrlSuggested(urls, "bookingUrl"));
+    }
+    if (source === "auto") {
+      setAiSuggestionEvidence((evidence) => ({
+        ...evidence,
+        [fieldKey]: item,
+      }));
+    }
+    return true;
+  };
+
+  const resetSuggestionForm = () => {
+    setAiSuggestedFields(new Set());
+    setManuallySelectedFields(new Set());
+    setAiSuggestionEvidence({});
+  };
+
+  return {
+    aiSuggestedFields,
+    aiSuggestionEvidence,
+    applySuggestionToField,
+    isAiSuggested: (field: AiSuggestedField) => aiSuggestedFields.has(field),
+    isManuallySelected: (field: AiSuggestedField) =>
+      manuallySelectedFields.has(field),
+    resetSuggestionForm,
+    setAiSuggestedFields,
+    setAiSuggestionEvidence,
+    setSingleOptionField,
+    toggleMultiOption,
+  };
+}

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsSuggestionQueue.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsSuggestionQueue.ts
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { locationsApi } from "@client/shared/services/api";
+import type { AccommodationsFieldSuggestionResponse } from "@client/shared/services/api/types";
+import type { AiSuggestedField } from "../accommodations-create.types";
+import {
+  buildAccommodationsSuggestionError,
+  canRequestAccommodationsSuggestion,
+  type LocationTypeOption,
+} from "./accommodations-suggestion-request";
+
+interface UseAccommodationsSuggestionQueueOptions {
+  locationTypes: LocationTypeOption[];
+  buildRequest: (fieldKey: AiSuggestedField) => Parameters<
+    typeof locationsApi.suggestField
+  >[0];
+  applySuggestion: (
+    item: AccommodationsFieldSuggestionResponse,
+    source: "auto" | "manual"
+  ) => boolean;
+}
+
+export function useAccommodationsSuggestionQueue({
+  locationTypes,
+  buildRequest,
+  applySuggestion,
+}: UseAccommodationsSuggestionQueueOptions) {
+  const [pendingFields, setPendingFields] = useState<Set<AiSuggestedField>>(
+    () => new Set()
+  );
+  const [suggestionStack, setSuggestionStack] = useState<
+    AccommodationsFieldSuggestionResponse[]
+  >([]);
+
+  const beginPending = (fieldKey: AiSuggestedField) => {
+    setPendingFields((pending) => new Set(pending).add(fieldKey));
+  };
+
+  const endPending = (fieldKey: AiSuggestedField) => {
+    setPendingFields(
+      (pending) => new Set([...pending].filter((item) => item !== fieldKey))
+    );
+  };
+
+  const queueSuggestion = async (fieldKey: AiSuggestedField) => {
+    if (!canRequestAccommodationsSuggestion(fieldKey, locationTypes)) return;
+
+    beginPending(fieldKey);
+    try {
+      const response = await locationsApi.suggestField(buildRequest(fieldKey));
+      setSuggestionStack((stack) => [...stack, response]);
+    } catch (error) {
+      setSuggestionStack((stack) => [
+        ...stack,
+        buildAccommodationsSuggestionError(fieldKey, error),
+      ]);
+    } finally {
+      endPending(fieldKey);
+    }
+  };
+
+  const removeFromStack = (item: AccommodationsFieldSuggestionResponse) => {
+    setSuggestionStack((stack) =>
+      stack.filter((suggestion) => suggestion !== item)
+    );
+  };
+
+  const resetSuggestionQueue = () => {
+    setPendingFields(new Set());
+    setSuggestionStack([]);
+  };
+
+  return {
+    applyStackedSuggestion: (
+      item: AccommodationsFieldSuggestionResponse
+    ) => {
+      applySuggestion(item, "manual");
+      removeFromStack(item);
+    },
+    beginPending,
+    dismissStackedSuggestion: removeFromStack,
+    endPending,
+    hasQueuedSuggestion: (field: AiSuggestedField) =>
+      suggestionStack.some((item) => item.fieldKey === field),
+    isSectionPending: (fields: AiSuggestedField[]) =>
+      fields.some((field) => pendingFields.has(field)),
+    pendingFields,
+    queueSuggestion,
+    resetSuggestionQueue,
+    suggestionStack,
+  };
+}

--- a/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsSuggestions.ts
+++ b/apps/location-manager/packages/client/src/features/location-create/accommodations-create/suggestions/useAccommodationsSuggestions.ts
@@ -1,47 +1,33 @@
-import { useState, type Dispatch, type SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import type { UseFormReturn } from "react-hook-form";
-import { locationsApi } from "@client/shared/services/api";
-import type {
-  AccommodationsFieldSuggestionResponse,
-  GooglePrefillResponse,
-} from "@client/shared/services/api/types";
-import { markAiUrlSuggested } from "../../autofill/ai-url-ack";
-import {
-  isOptionSuggestionEligible,
-  optionValueIsEmpty,
-  optionValueMatchesDefault,
-} from "../../autofill/option-suggestion-eligibility";
-import { runSuggestionBatch } from "../../autofill/run-suggestion-batch";
+import type { GooglePrefillResponse } from "@client/shared/services/api/types";
 import type { AddAccommodationsFormData } from "../../validation/add-accommodations.schema";
-import {
-  ACCOMMODATIONS_FORM_DEFAULT_VALUES,
-  type AiSuggestedField,
-  type ApiFilledField,
-  type AutoFillProgress,
-  type MultiField,
+import type {
+  AiSuggestedField,
+  ApiFilledField,
 } from "../accommodations-create.types";
 import {
-  AUTO_AI_SUGGESTION_FIELDS,
-  getSuggestionField,
-  getSuggestionFieldOptions,
-  validateClientSuggestion,
-} from "./accommodations-suggestion-utils";
-
-const AUTO_FILL_CONCURRENCY = 3;
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : "Unknown error";
-}
+  canSuggestAccommodationsField,
+  getEligibleAutoSuggestionFields,
+} from "./accommodations-suggestion-eligibility";
+import {
+  buildAccommodationsSuggestionRequest,
+  type LocationTypeOption,
+} from "./accommodations-suggestion-request";
+import { useAccommodationsAutoFill } from "./useAccommodationsAutoFill";
+import { useAccommodationsSuggestionForm } from "./useAccommodationsSuggestionForm";
+import { useAccommodationsSuggestionQueue } from "./useAccommodationsSuggestionQueue";
 
 interface UseAccommodationsSuggestionsOptions {
   form: UseFormReturn<AddAccommodationsFormData>;
   isPrefillReady: boolean;
-  locationTypes: Array<{ value: string; label: string }>;
+  locationTypes: LocationTypeOption[];
   apiFilledFields: Set<ApiFilledField>;
   googlePrefillContext: GooglePrefillResponse | null;
   setVerifiedAiUrls: Dispatch<SetStateAction<{ bookingUrl: boolean }>>;
 }
 
+/** Composes the add-flow suggestion form, review queue, and automatic batch. */
 export function useAccommodationsSuggestions({
   form,
   isPrefillReady,
@@ -50,176 +36,85 @@ export function useAccommodationsSuggestions({
   googlePrefillContext,
   setVerifiedAiUrls,
 }: UseAccommodationsSuggestionsOptions) {
-  const [aiSuggestedFields, setAiSuggestedFields] = useState<Set<AiSuggestedField>>(() => new Set());
-  const [manuallySelectedFields, setManuallySelectedFields] = useState<Set<AiSuggestedField>>(() => new Set());
-  const [pendingFields, setPendingFields] = useState<Set<AiSuggestedField>>(() => new Set());
-  const [suggestionStack, setSuggestionStack] = useState<AccommodationsFieldSuggestionResponse[]>([]);
-  const [autoFillProgress, setAutoFillProgress] = useState<AutoFillProgress | null>(null);
-  const [aiSuggestionEvidence, setAiSuggestionEvidence] = useState<
-    Partial<Record<AiSuggestedField, AccommodationsFieldSuggestionResponse>>
-  >({});
+  const suggestionForm = useAccommodationsSuggestionForm({
+    form,
+    locationTypes,
+    setVerifiedAiUrls,
+  });
+  const isApiFilled = (field: string) =>
+    apiFilledFields.has(field as ApiFilledField);
+  const buildRequest = (
+    fieldKey: AiSuggestedField,
+    context = googlePrefillContext
+  ) =>
+    buildAccommodationsSuggestionRequest({
+      fieldKey,
+      formValues: form.getValues(),
+      context,
+      locationTypes,
+    });
+
+  const queue = useAccommodationsSuggestionQueue({
+    locationTypes,
+    buildRequest,
+    applySuggestion: suggestionForm.applySuggestionToField,
+  });
+  const autoFill = useAccommodationsAutoFill({
+    getEligibleFields: (fields) =>
+      getEligibleAutoSuggestionFields({
+        formValues: form.getValues(),
+        apiFilledFields: fields,
+        locationTypes,
+      }),
+    buildRequest,
+    applySuggestion: suggestionForm.applySuggestionToField,
+    setAiSuggestionEvidence: suggestionForm.setAiSuggestionEvidence,
+    beginPending: queue.beginPending,
+    endPending: queue.endPending,
+  });
+
+  const getCanSuggestField = (fieldKey: AiSuggestedField) =>
+    canSuggestAccommodationsField({
+      fieldKey,
+      value: form.watch(fieldKey) as AddAccommodationsFormData[AiSuggestedField],
+      locationTypes,
+      isPrefillReady,
+      isDirty: Boolean(form.formState.dirtyFields[fieldKey]),
+      isApiFilled: isApiFilled(fieldKey),
+      isAiSuggested: suggestionForm.isAiSuggested(fieldKey),
+      isPending: queue.pendingFields.has(fieldKey),
+      isQueued: queue.hasQueuedSuggestion(fieldKey),
+    });
 
   const resetSuggestions = () => {
-    setAiSuggestedFields(new Set());
-    setManuallySelectedFields(new Set());
-    setPendingFields(new Set());
-    setSuggestionStack([]);
-    setAutoFillProgress(null);
-    setAiSuggestionEvidence({});
-  };
-  const isApiFilled = (field: string) => apiFilledFields.has(field as ApiFilledField);
-  const isAiSuggested = (field: AiSuggestedField) => aiSuggestedFields.has(field);
-  const isManuallySelected = (field: AiSuggestedField) => manuallySelectedFields.has(field);
-  const isEmptyOrDefaultSuggestionField = (field: AiSuggestedField) => {
-    const value = form.getValues(field) as AddAccommodationsFormData[AiSuggestedField];
-    return optionValueIsEmpty(value) || optionValueMatchesDefault(value, ACCOMMODATIONS_FORM_DEFAULT_VALUES[field]);
-  };
-  const getCanSuggestField = (field: AiSuggestedField) => {
-    if (pendingFields.has(field) || suggestionStack.some((item) => item.fieldKey === field)) return false;
-    const definition = getSuggestionField(field);
-    return isOptionSuggestionEligible({
-      value: form.watch(field) as AddAccommodationsFormData[AiSuggestedField],
-      defaultValue: ACCOMMODATIONS_FORM_DEFAULT_VALUES[field],
-      isPrefillReady,
-      optionsCount: getSuggestionFieldOptions(field, locationTypes).length,
-      isDirty: Boolean(form.formState.dirtyFields[field]),
-      isApiFilled: isApiFilled(field),
-      isAiSuggested: isAiSuggested(field),
-      isUrlKind: definition?.kind === "url",
-    });
-  };
-  const setSingleOptionField = <TField extends Exclude<AiSuggestedField, MultiField>>(
-    field: TField,
-    value: AddAccommodationsFormData[TField]
-  ) => {
-    form.setValue(field, value as never, { shouldDirty: true, shouldValidate: true, shouldTouch: true });
-    setAiSuggestedFields((current) => new Set([...current].filter((item) => item !== field)));
-    setAiSuggestionEvidence((current) => {
-      const next = { ...current };
-      delete next[field];
-      return next;
-    });
-    setManuallySelectedFields((current) => new Set(current).add(field));
-  };
-  const toggleMultiOption = (field: MultiField, value: string) => {
-    const current = (form.getValues(field) || []) as string[];
-    const next = current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
-    form.setValue(field, next as AddAccommodationsFormData[MultiField], {
-      shouldDirty: true,
-      shouldValidate: true,
-      shouldTouch: true,
-    });
-    setAiSuggestedFields((fields) => new Set([...fields].filter((item) => item !== field)));
-    setAiSuggestionEvidence((evidence) => {
-      const nextEvidence = { ...evidence };
-      delete nextEvidence[field];
-      return nextEvidence;
-    });
-    setManuallySelectedFields((fields) => new Set(fields).add(field));
-  };
-  const buildSuggestionRequest = (fieldKey: AiSuggestedField, context: GooglePrefillResponse | null) => ({
-    category: "accommodations" as const,
-    fieldKey,
-    formValues: form.getValues() as unknown as Record<string, unknown>,
-    apiContext: {
-      googleUrl: context?.googleUrl || form.getValues("googleUrl") || null,
-      placeId: context?.placeId || form.getValues("placeId") || null,
-      locationKey: context?.locationKey || form.getValues("locationKey") || null,
-      district: context?.district || form.getValues("district") || null,
-      ianaTimeId: context?.ianaTimeId || form.getValues("ianaTimeId") || null,
-      phoneNumber: context?.phoneNumber || form.getValues("phone") || null,
-      website: context?.website || form.getValues("websiteUrl") || null,
-      priceLevel: context?.priceLevel || null,
-      accommodationsHints: context?.accommodationsHints || null,
-    },
-    allowedOptions: getSuggestionFieldOptions(fieldKey, locationTypes),
-  });
-  const applySuggestionToField = (item: AccommodationsFieldSuggestionResponse, source: "auto" | "manual") => {
-    const fieldKey = item.fieldKey as AiSuggestedField;
-    const suggestion = validateClientSuggestion(
-      item.suggestion,
-      getSuggestionFieldOptions(fieldKey, locationTypes),
-      item.kind
-    );
-    if (!suggestion) return false;
-    form.setValue(fieldKey, suggestion as never, {
-      shouldDirty: source === "manual",
-      shouldValidate: true,
-      shouldTouch: true,
-    });
-    setAiSuggestedFields((fields) => new Set(fields).add(fieldKey));
-    setManuallySelectedFields((fields) => new Set([...fields].filter((field) => field !== fieldKey)));
-    if (item.kind === "url" && fieldKey === "bookingUrl") {
-      setVerifiedAiUrls((urls) => markAiUrlSuggested(urls, "bookingUrl"));
-    }
-    if (source === "auto") setAiSuggestionEvidence((evidence) => ({ ...evidence, [fieldKey]: item }));
-    return true;
-  };
-  const runAutoAiFill = async (context: GooglePrefillResponse, fields: Set<ApiFilledField>) => {
-    const eligibleFields = AUTO_AI_SUGGESTION_FIELDS.filter((fieldKey) => {
-      const field = getSuggestionField(fieldKey);
-      return Boolean(field) &&
-        (field?.kind === "url" || getSuggestionFieldOptions(fieldKey, locationTypes).length > 0) &&
-        !fields.has(fieldKey as ApiFilledField) &&
-        isEmptyOrDefaultSuggestionField(fieldKey);
-    });
-    if (eligibleFields.length === 0) return { applied: 0, failed: 0, total: 0 };
-    setAutoFillProgress({ total: eligibleFields.length, completed: 0, applied: 0, failed: 0, currentFieldLabel: "Starting AI fill" });
-    const result = await runSuggestionBatch({
-      fields: eligibleFields,
-      concurrency: AUTO_FILL_CONCURRENCY,
-      run: async (fieldKey) => {
-        const response = await locationsApi.suggestField(buildSuggestionRequest(fieldKey, context));
-        if (!response.error && applySuggestionToField(response, "auto")) return true;
-        setAiSuggestionEvidence((evidence) => ({ ...evidence, [fieldKey]: response }));
-        return false;
-      },
-      onFieldStart: (fieldKey) => {
-        setPendingFields((pending) => new Set(pending).add(fieldKey));
-        setAutoFillProgress((progress) => progress ? { ...progress, currentFieldLabel: getSuggestionField(fieldKey)?.label || fieldKey } : progress);
-      },
-      onFieldSettled: (fieldKey, outcome, error, progress) => {
-        if (outcome === "error") {
-          const field = getSuggestionField(fieldKey);
-          setAiSuggestionEvidence((evidence) => ({
-            ...evidence,
-            [fieldKey]: { fieldKey, fieldLabel: field?.label || fieldKey, suggestion: null, kind: field?.kind || "single", confidence: 0, source: "ai", reason: "", sources: [], error: getErrorMessage(error) },
-          }));
-        }
-        setPendingFields((pending) => new Set([...pending].filter((item) => item !== fieldKey)));
-        setAutoFillProgress((current) => current ? { ...current, completed: progress.completed, applied: progress.applied, failed: progress.failed } : current);
-      },
-    });
-    setAutoFillProgress(null);
-    return { applied: result.applied, failed: result.failed, total: result.total };
-  };
-  const queueSuggestion = async (fieldKey: AiSuggestedField) => {
-    const field = getSuggestionField(fieldKey);
-    if (!field || getSuggestionFieldOptions(fieldKey, locationTypes).length === 0) return;
-    setPendingFields((pending) => new Set(pending).add(fieldKey));
-    try {
-      const response = await locationsApi.suggestField(buildSuggestionRequest(fieldKey, googlePrefillContext));
-      setSuggestionStack((stack) => [...stack, response]);
-    } catch (error) {
-      setSuggestionStack((stack) => [...stack, { fieldKey, fieldLabel: field.label, suggestion: null, kind: field.kind, confidence: 0, source: "ai", reason: "", sources: [], error: getErrorMessage(error) }]);
-    } finally {
-      setPendingFields((pending) => new Set([...pending].filter((item) => item !== fieldKey)));
-    }
+    suggestionForm.resetSuggestionForm();
+    queue.resetSuggestionQueue();
+    autoFill.resetAutoFill();
   };
 
   return {
-    aiSuggestedFields, aiSuggestionEvidence, autoFillProgress, getCanSuggestField, isAiSuggested,
-    isApiFilled, isManuallySelected, isSectionPending: (fields: AiSuggestedField[]) => fields.some((field) => pendingFields.has(field)),
-    pendingFields, queueSuggestion, resetSuggestions, runAutoAiFill, setAiSuggestedFields,
-    setAutoFillProgress, setSingleOptionField, suggestionStack,
-    applyStackedSuggestion: (item: AccommodationsFieldSuggestionResponse) => {
-      applySuggestionToField(item, "manual");
-      setSuggestionStack((stack) => stack.filter((suggestion) => suggestion !== item));
-    },
-    dismissStackedSuggestion: (item: AccommodationsFieldSuggestionResponse) =>
-      setSuggestionStack((stack) => stack.filter((suggestion) => suggestion !== item)),
+    aiSuggestedFields: suggestionForm.aiSuggestedFields,
+    aiSuggestionEvidence: suggestionForm.aiSuggestionEvidence,
+    autoFillProgress: autoFill.autoFillProgress,
+    isAiSuggested: suggestionForm.isAiSuggested,
+    isManuallySelected: suggestionForm.isManuallySelected,
+    isSectionPending: queue.isSectionPending,
+    pendingFields: queue.pendingFields,
+    queueSuggestion: queue.queueSuggestion,
+    runAutoAiFill: autoFill.runAutoAiFill,
+    setAiSuggestedFields: suggestionForm.setAiSuggestedFields,
+    setAutoFillProgress: autoFill.setAutoFillProgress,
+    setSingleOptionField: suggestionForm.setSingleOptionField,
+    suggestionStack: queue.suggestionStack,
+    applyStackedSuggestion: queue.applyStackedSuggestion,
+    dismissStackedSuggestion: queue.dismissStackedSuggestion,
+    toggleMultiOption: suggestionForm.toggleMultiOption,
+    getCanSuggestField,
+    isApiFilled,
+    resetSuggestions,
     suggestAllFields: (fields: AiSuggestedField[]) =>
-      fields.filter((field) => getCanSuggestField(field)).forEach((field) => void queueSuggestion(field)),
-    toggleMultiOption,
+      fields
+        .filter((field) => getCanSuggestField(field))
+        .forEach((field) => void queue.queueSuggestion(field)),
   };
 }


### PR DESCRIPTION
## Original issue

Finding 26 identified `useAccommodationsSuggestions.ts` as a 225-line hook combining eligibility, API request construction, bounded batch execution, validation, form writes, provenance, queue state, evidence, and progress.

## Root cause

The add-accommodations suggestion workflow grew inside one hook as automatic gap-fill and manual retry behavior were added. Although the behaviors shared state, their policies and side effects had no dedicated module boundaries.

## Refactor performed

- Kept `useAccommodationsSuggestions` as the caller-compatible composition facade.
- Extracted pure eligibility and request/error construction helpers.
- Extracted form/provenance transitions, the operator-reviewed suggestion queue, and automatic batch/progress execution into focused hooks.
- Preserved concurrency 3, API-over-AI ownership, empty/default-only automatic fill, validation, evidence, URL acknowledgment, failure reporting, and the existing return contract.
- Corrected the manual booking URL Suggest path so URL-kind fields do not require enum options, matching the existing URL-aware eligibility UI.
- Added focused tests for ownership eligibility, queued/pending gating, request context precedence and fallback, allowed options, URL requests, and normalized errors.

## Why better

The original hook is now 120 lines and coordinates explicit collaborators instead of owning each workflow concern. Pure policy and request construction are directly testable, while automatic and operator-reviewed suggestion paths can evolve independently without expanding the facade.

## Validation

- `pnpm --filter @questurian/lm-client exec eslint src/features/location-create/accommodations-create/suggestions` — passed
- `pnpm --filter @questurian/lm-client exec bun test src` — 107 passed
- `pnpm --filter @questurian/lm-client exec tsc -b --pretty false` — passed
- `pnpm --filter @questurian/lm-client build` — passed
- `pnpm test` — passed, 8/8 root Turbo tasks
- `pnpm lint` — unrelated baseline failure in Questura Server: missing `@next/next/no-img-element` rule in `FocalPointPickerField.tsx:184`; changed folder focused ESLint passes
- `pnpm build` — unrelated environment baseline failure in Questura Server under Node 18.19.1: Undici requires global `File`; that package declares Node `^18.20.2 || >=20.9.0`; LM client build passes independently
- `git diff --check` — passed

## Risks/tradeoffs/follow-ups

The workflow still shares pending-field state between the automatic batch and manual queue by design so the UI reports one coherent in-flight set. The extraction adds small internal modules, but each has one reason to change and no server/API contract changes. Root lint/build baselines are outside this finding and should be fixed separately.