### PR TITLE
refactor(abw): separate draft sync signatures

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/utils/itinerary-draft-sync-signature.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/utils/itinerary-draft-sync-signature.ts
@@ -10,7 +10,7 @@ import {
   normalizeNumberSet,
   normalizeText,
   sortKeysDeep
-} from '../../../../shared/payloadSync/draftPayloadSync'
+} from '../../../../shared/payloadSync/payloadSyncSignature'
 
 function normalizeRichTextMarkdown(
   markdown: string | undefined,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/utils/itinerary-media-fingerprint.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/utils/itinerary-media-fingerprint.ts
@@ -1,5 +1,5 @@
 import { getRelatedPhotoIds } from '../../../../shared/builder/utils/item-media.utils'
-import { stableSerialize } from '../../../../shared/payloadSync/draftPayloadSync'
+import { stableSerialize } from '../../../../shared/payloadSync/payloadSyncSignature'
 import {
   getItineraryBlocksInArticleOrder,
   isManualItineraryBlockType,

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/utils/single-type-listicle-draft-sync-signature.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/utils/single-type-listicle-draft-sync-signature.ts
@@ -4,7 +4,7 @@ import {
   normalizeNumberSet,
   normalizeText,
   sortKeysDeep,
-} from '../../../../shared/payloadSync/draftPayloadSync'
+} from '../../../../shared/payloadSync/payloadSyncSignature'
 import { normalizeSeoSection } from '../services/seo-section.service'
 import type { ListicleItemBlock, PayloadRichText, SingleTypeListicleDraft } from '../../types'
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/staged-article-payload-sync.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/staged-article-payload-sync.service.ts
@@ -4,7 +4,7 @@ import {
   normalizeNumberSet,
   normalizeText,
   sortKeysDeep,
-} from '../../../../../shared/payloadSync/draftPayloadSync'
+} from '../../../../../shared/payloadSync/payloadSyncSignature'
 import type { ContentBlock, EditorialBlock, StagedArticle } from '../../../types'
 
 export function hasPayloadArticleIdentity(article: StagedArticle): boolean {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/draftPayloadSync.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/draftPayloadSync.test.ts
@@ -1,0 +1,281 @@
+import {
+  hasUnsyncedPayloadChanges,
+  markDraftAsPayloadSynced,
+  markDraftAsPayloadUnsynced,
+  payloadSyncFieldsEqual,
+  readStoredPayloadSyncFields,
+  refreshDraftPayloadSyncState,
+  stripLegacyPayloadSyncFields,
+  type PayloadSyncStateFields,
+} from './draftPayloadSync'
+
+type TestDraft = PayloadSyncStateFields & {
+  payloadId?: number
+  externalId?: string
+  title: string
+}
+
+const buildComparableShape = (draft: TestDraft) => ({
+  title: draft.title.trim(),
+})
+
+describe('stored Payload Sync state', () => {
+  it('reads current fields and trims persisted strings', () => {
+    expect(
+      readStoredPayloadSyncFields({
+        currentPayloadSignature: ' current ',
+        lastPayloadSyncSignature: ' baseline ',
+        lastPayloadSyncAt: ' 2026-07-25T12:00:00.000Z ',
+        lastPayloadSyncMediaFingerprint: ' media ',
+        hasUnsyncedPayloadChanges: true,
+      }),
+    ).toEqual({
+      currentPayloadSignature: 'current',
+      lastPayloadSyncSignature: 'baseline',
+      lastPayloadSyncAt: '2026-07-25T12:00:00.000Z',
+      lastPayloadSyncMediaFingerprint: 'media',
+      hasUnsyncedPayloadChanges: true,
+    })
+  })
+
+  it('falls back to legacy baseline and dirty fields', () => {
+    expect(
+      readStoredPayloadSyncFields({
+        payloadSyncBaseline: ' legacy-baseline ',
+        hasLocalChanges: true,
+      }),
+    ).toEqual({
+      lastPayloadSyncSignature: 'legacy-baseline',
+      hasUnsyncedPayloadChanges: true,
+    })
+  })
+
+  it('ignores malformed persisted state', () => {
+    expect(readStoredPayloadSyncFields(null)).toEqual({})
+    expect(
+      readStoredPayloadSyncFields({
+        currentPayloadSignature: 1,
+        lastPayloadSyncSignature: ' ',
+        hasUnsyncedPayloadChanges: 'yes',
+      }),
+    ).toEqual({})
+  })
+})
+
+describe('Payload Sync dirty-state resolution', () => {
+  it('requires Payload identity before a draft can be dirty', () => {
+    expect(
+      hasUnsyncedPayloadChanges({
+        hasPayloadIdentity: false,
+        currentPayloadSignature: 'current',
+        lastPayloadSyncSignature: 'baseline',
+        hasUnsyncedPayloadChanges: true,
+        missingBaselineIsUnsynced: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('prefers signature comparison, then stored dirty state, then missing-baseline policy', () => {
+    expect(
+      hasUnsyncedPayloadChanges({
+        hasPayloadIdentity: true,
+        currentPayloadSignature: 'current',
+        lastPayloadSyncSignature: 'current',
+        hasUnsyncedPayloadChanges: true,
+      }),
+    ).toBe(false)
+    expect(
+      hasUnsyncedPayloadChanges({
+        hasPayloadIdentity: true,
+        currentPayloadSignature: 'current',
+        lastPayloadSyncSignature: 'baseline',
+        hasUnsyncedPayloadChanges: false,
+      }),
+    ).toBe(true)
+    expect(
+      hasUnsyncedPayloadChanges({
+        hasPayloadIdentity: true,
+        hasUnsyncedPayloadChanges: true,
+      }),
+    ).toBe(true)
+    expect(
+      hasUnsyncedPayloadChanges({
+        hasPayloadIdentity: true,
+        missingBaselineIsUnsynced: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('compares every persisted sync field', () => {
+    const fields: PayloadSyncStateFields = {
+      currentPayloadSignature: 'current',
+      lastPayloadSyncSignature: 'baseline',
+      lastPayloadSyncAt: '2026-07-25T12:00:00.000Z',
+      lastPayloadSyncMediaFingerprint: 'media',
+      hasUnsyncedPayloadChanges: false,
+    }
+
+    expect(payloadSyncFieldsEqual(fields, { ...fields })).toBe(true)
+    expect(
+      payloadSyncFieldsEqual(fields, {
+        ...fields,
+        lastPayloadSyncMediaFingerprint: 'changed-media',
+      }),
+    ).toBe(false)
+    expect(payloadSyncFieldsEqual({}, { hasUnsyncedPayloadChanges: false })).toBe(true)
+  })
+})
+
+describe('Draft Payload Sync transitions', () => {
+  it('clears sync metadata from drafts without default Payload identity', () => {
+    const refreshed = refreshDraftPayloadSyncState<TestDraft>(
+      {
+        title: 'Draft',
+        currentPayloadSignature: 'current',
+        lastPayloadSyncSignature: 'baseline',
+        lastPayloadSyncAt: '2026-07-25T12:00:00.000Z',
+        lastPayloadSyncMediaFingerprint: 'media',
+        hasUnsyncedPayloadChanges: true,
+      },
+      buildComparableShape,
+    )
+
+    expect(refreshed).toEqual({
+      title: 'Draft',
+      currentPayloadSignature: undefined,
+      lastPayloadSyncSignature: undefined,
+      lastPayloadSyncAt: undefined,
+      lastPayloadSyncMediaFingerprint: undefined,
+      hasUnsyncedPayloadChanges: false,
+    })
+  })
+
+  it('refreshes signatures and preserves external media fingerprints', () => {
+    const refreshed = refreshDraftPayloadSyncState<TestDraft>(
+      {
+        payloadId: 10,
+        title: 'Changed title',
+        lastPayloadSyncSignature: '{"title":"Original title"}',
+        lastPayloadSyncAt: '2026-07-25T12:00:00.000Z',
+        lastPayloadSyncMediaFingerprint: 'media',
+      },
+      buildComparableShape,
+    )
+
+    expect(refreshed).toMatchObject({
+      currentPayloadSignature: '{"title":"Changed title"}',
+      lastPayloadSyncSignature: '{"title":"Original title"}',
+      lastPayloadSyncAt: '2026-07-25T12:00:00.000Z',
+      lastPayloadSyncMediaFingerprint: 'media',
+      hasUnsyncedPayloadChanges: true,
+    })
+  })
+
+  it('can initialize a clean legacy draft baseline as synced', () => {
+    const refreshed = refreshDraftPayloadSyncState<TestDraft>(
+      {
+        payloadId: 10,
+        title: 'Current title',
+        hasUnsyncedPayloadChanges: false,
+      },
+      buildComparableShape,
+      {
+        initializeMissingBaselineAsSynced: true,
+      },
+    )
+
+    expect(refreshed.currentPayloadSignature).toBe('{"title":"Current title"}')
+    expect(refreshed.lastPayloadSyncSignature).toBe(refreshed.currentPayloadSignature)
+    expect(refreshed.hasUnsyncedPayloadChanges).toBe(false)
+  })
+
+  it('does not initialize a baseline over a stored dirty flag', () => {
+    const refreshed = refreshDraftPayloadSyncState<TestDraft>(
+      {
+        payloadId: 10,
+        title: 'Current title',
+        hasUnsyncedPayloadChanges: true,
+      },
+      buildComparableShape,
+      {
+        initializeMissingBaselineAsSynced: true,
+      },
+    )
+
+    expect(refreshed.lastPayloadSyncSignature).toBeUndefined()
+    expect(refreshed.hasUnsyncedPayloadChanges).toBe(true)
+  })
+
+  it('supports feature-specific Payload identity', () => {
+    const refreshed = refreshDraftPayloadSyncState<TestDraft>(
+      {
+        externalId: 'payload-10',
+        title: 'Current title',
+      },
+      buildComparableShape,
+      {
+        hasPayloadIdentity: (draft) => Boolean(draft.externalId),
+        missingBaselineIsUnsynced: true,
+      },
+    )
+
+    expect(refreshed.currentPayloadSignature).toBe('{"title":"Current title"}')
+    expect(refreshed.hasUnsyncedPayloadChanges).toBe(true)
+  })
+
+  it('marks an identified draft synced at one signature', () => {
+    const synced = markDraftAsPayloadSynced<TestDraft>(
+      {
+        payloadId: 10,
+        title: ' Current title ',
+        lastPayloadSyncMediaFingerprint: 'media',
+      },
+      buildComparableShape,
+      '2026-07-25T12:00:00.000Z',
+    )
+
+    expect(synced).toMatchObject({
+      currentPayloadSignature: '{"title":"Current title"}',
+      lastPayloadSyncSignature: '{"title":"Current title"}',
+      lastPayloadSyncAt: '2026-07-25T12:00:00.000Z',
+      lastPayloadSyncMediaFingerprint: 'media',
+      hasUnsyncedPayloadChanges: false,
+    })
+  })
+
+  it('marks an identified draft unsynced without replacing its baseline', () => {
+    const unsynced = markDraftAsPayloadUnsynced<TestDraft>(
+      {
+        payloadId: 10,
+        title: 'Changed title',
+        lastPayloadSyncSignature: '{"title":"Original title"}',
+        lastPayloadSyncMediaFingerprint: 'media',
+      },
+      buildComparableShape,
+    )
+
+    expect(unsynced).toMatchObject({
+      currentPayloadSignature: '{"title":"Changed title"}',
+      lastPayloadSyncSignature: '{"title":"Original title"}',
+      lastPayloadSyncMediaFingerprint: 'media',
+      hasUnsyncedPayloadChanges: true,
+    })
+  })
+
+  it('strips legacy fields from a copy without mutating the draft', () => {
+    const legacyDraft = {
+      title: 'Draft',
+      payloadSyncBaseline: 'baseline',
+      hasLocalChanges: true,
+    }
+
+    expect(stripLegacyPayloadSyncFields(legacyDraft)).toEqual({
+      title: 'Draft',
+    })
+    expect(legacyDraft).toEqual({
+      title: 'Draft',
+      payloadSyncBaseline: 'baseline',
+      hasLocalChanges: true,
+    })
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/draftPayloadSync.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/draftPayloadSync.ts
@@ -1,3 +1,5 @@
+import { buildDraftPayloadSyncSignature } from './payloadSyncSignature'
+
 export type PayloadSyncStateFields = {
   currentPayloadSignature?: string
   lastPayloadSyncSignature?: string
@@ -30,66 +32,18 @@ function cleanString(value: unknown): string | undefined {
 }
 
 function hasDefaultPayloadIdentity(value: unknown): boolean {
-  return isRecord(value)
-    && typeof value.payloadId === 'number'
-    && Number.isFinite(value.payloadId)
+  return isRecord(value) && typeof value.payloadId === 'number' && Number.isFinite(value.payloadId)
 }
 
-function resolveHasPayloadIdentity<TDraft>(
-  draft: TDraft,
-  options: PayloadIdentityOptions<TDraft> = {},
-): boolean {
-  return options.hasPayloadIdentity
-    ? options.hasPayloadIdentity(draft)
-    : hasDefaultPayloadIdentity(draft)
-}
-
-export function normalizeText(value: unknown): string {
-  return typeof value === 'string' ? value.trim() : ''
-}
-
-export function normalizeNumberSet(values: unknown): number[] {
-  return Array.isArray(values)
-    ? [...new Set(values.filter((value): value is number => Number.isFinite(value)))]
-        .sort((a, b) => a - b)
-    : []
-}
-
-export function normalizeRelationshipId(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (isRecord(value) && typeof value.id === 'number' && Number.isFinite(value.id)) return value.id
-  return null
-}
-
-export function sortKeysDeep(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortKeysDeep)
-  if (!value || typeof value !== 'object') return value
-
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, sortKeysDeep(entry)]),
-  )
-}
-
-export function stableSerialize(value: unknown): string {
-  return JSON.stringify(sortKeysDeep(value))
-}
-
-export function buildDraftPayloadSyncSignature<TDraft>(
-  draft: TDraft,
-  buildComparableShape: (draft: TDraft) => unknown,
-): string {
-  return stableSerialize(buildComparableShape(draft))
+function resolveHasPayloadIdentity<TDraft>(draft: TDraft, options: PayloadIdentityOptions<TDraft> = {}): boolean {
+  return options.hasPayloadIdentity ? options.hasPayloadIdentity(draft) : hasDefaultPayloadIdentity(draft)
 }
 
 export function readStoredPayloadSyncFields(value: unknown): PayloadSyncStateFields {
   if (!isRecord(value)) return {}
 
   const legacyBaseline = cleanString(value.payloadSyncBaseline)
-  const legacyDirty = typeof value.hasLocalChanges === 'boolean'
-    ? value.hasLocalChanges
-    : undefined
+  const legacyDirty = typeof value.hasLocalChanges === 'boolean' ? value.hasLocalChanges : undefined
   const fields: PayloadSyncStateFields = {}
   const currentPayloadSignature = cleanString(value.currentPayloadSignature)
   const lastPayloadSyncSignature = cleanString(value.lastPayloadSyncSignature) || legacyBaseline
@@ -109,15 +63,14 @@ export function readStoredPayloadSyncFields(value: unknown): PayloadSyncStateFie
   return fields
 }
 
-export function payloadSyncFieldsEqual(
-  left: PayloadSyncStateFields,
-  right: PayloadSyncStateFields,
-): boolean {
-  return left.currentPayloadSignature === right.currentPayloadSignature
-    && left.lastPayloadSyncSignature === right.lastPayloadSyncSignature
-    && left.lastPayloadSyncAt === right.lastPayloadSyncAt
-    && left.lastPayloadSyncMediaFingerprint === right.lastPayloadSyncMediaFingerprint
-    && Boolean(left.hasUnsyncedPayloadChanges) === Boolean(right.hasUnsyncedPayloadChanges)
+export function payloadSyncFieldsEqual(left: PayloadSyncStateFields, right: PayloadSyncStateFields): boolean {
+  return (
+    left.currentPayloadSignature === right.currentPayloadSignature &&
+    left.lastPayloadSyncSignature === right.lastPayloadSyncSignature &&
+    left.lastPayloadSyncAt === right.lastPayloadSyncAt &&
+    left.lastPayloadSyncMediaFingerprint === right.lastPayloadSyncMediaFingerprint &&
+    Boolean(left.hasUnsyncedPayloadChanges) === Boolean(right.hasUnsyncedPayloadChanges)
+  )
 }
 
 export function hasUnsyncedPayloadChanges(input: {
@@ -158,8 +111,9 @@ export function refreshDraftPayloadSyncState<TDraft extends PayloadSyncStateFiel
   const currentPayloadSignature = buildDraftPayloadSyncSignature(draft, buildComparableShape)
   const storedFields = readStoredPayloadSyncFields(draft)
   const storedDirty = Boolean(storedFields.hasUnsyncedPayloadChanges)
-  const lastPayloadSyncSignature = storedFields.lastPayloadSyncSignature
-    || (options.initializeMissingBaselineAsSynced && !storedDirty ? currentPayloadSignature : undefined)
+  const lastPayloadSyncSignature =
+    storedFields.lastPayloadSyncSignature ||
+    (options.initializeMissingBaselineAsSynced && !storedDirty ? currentPayloadSignature : undefined)
 
   return {
     ...draft,

--- a/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/payloadSyncSignature.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/payloadSyncSignature.test.ts
@@ -1,0 +1,57 @@
+import {
+  buildDraftPayloadSyncSignature,
+  normalizeNumberSet,
+  normalizeText,
+  sortKeysDeep,
+  stableSerialize,
+} from './payloadSyncSignature'
+
+describe('payload sync signature canonicalization', () => {
+  it('normalizes text and finite number sets', () => {
+    expect(normalizeText('  title  ')).toBe('title')
+    expect(normalizeText(null)).toBe('')
+    expect(normalizeNumberSet([3, 1, 3, Number.NaN, Number.POSITIVE_INFINITY, '2'])).toEqual([1, 3])
+    expect(normalizeNumberSet(null)).toEqual([])
+  })
+
+  it('sorts object keys recursively without changing array order', () => {
+    expect(
+      sortKeysDeep({
+        z: [
+          { b: 2, a: 1 },
+          { d: 4, c: 3 },
+        ],
+        a: { y: 2, x: 1 },
+      }),
+    ).toEqual({
+      a: { x: 1, y: 2 },
+      z: [
+        { a: 1, b: 2 },
+        { c: 3, d: 4 },
+      ],
+    })
+  })
+
+  it('serializes equivalent object shapes to the same signature', () => {
+    expect(stableSerialize({ z: 2, nested: { b: 2, a: 1 } })).toBe(stableSerialize({ nested: { a: 1, b: 2 }, z: 2 }))
+  })
+
+  it('builds a signature from only the comparable draft shape', () => {
+    const first = {
+      payloadId: 10,
+      title: ' Draft title ',
+      localOnlyUpdatedAt: '2026-07-25T00:00:00.000Z',
+    }
+    const second = {
+      ...first,
+      localOnlyUpdatedAt: '2026-07-26T00:00:00.000Z',
+    }
+    const buildComparableShape = (draft: typeof first) => ({
+      title: normalizeText(draft.title),
+    })
+
+    expect(buildDraftPayloadSyncSignature(first, buildComparableShape)).toBe(
+      buildDraftPayloadSyncSignature(second, buildComparableShape),
+    )
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/payloadSyncSignature.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/payloadSyncSignature.ts
@@ -1,0 +1,31 @@
+export function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function normalizeNumberSet(values: unknown): number[] {
+  return Array.isArray(values)
+    ? [...new Set(values.filter((value): value is number => Number.isFinite(value)))].sort((a, b) => a - b)
+    : []
+}
+
+export function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep)
+  if (!value || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortKeysDeep(entry)]),
+  )
+}
+
+export function stableSerialize(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value))
+}
+
+export function buildDraftPayloadSyncSignature<TDraft>(
+  draft: TDraft,
+  buildComparableShape: (draft: TDraft) => unknown,
+): string {
+  return stableSerialize(buildComparableShape(draft))
+}


### PR DESCRIPTION
## Original issue

Finding 27 flagged `apps/ai-blog-writer/apps/frontend/src/shared/payloadSync/draftPayloadSync.ts` at 223 LOC with a broad reusable API. The report counted 17 definitions, 14 public exports, and six concerns; current `main` actually exposed 11 functions plus one type.

## Root cause

The module was cohesive at the feature level, but it combined two independently reused responsibilities: canonical construction of Payload Sync signatures and the Draft Payload Sync lifecycle/legacy-state adapter. Canonicalization helpers were imported by three different draft-shape builders and the itinerary media fingerprint, while one exported relationship normalizer had no callers anywhere in the frontend.

## Refactor performed

- Moved text/number normalization, deep key sorting, stable serialization, and comparable-shape signature construction into `payloadSyncSignature.ts`.
- Kept `draftPayloadSync.ts` focused on stored-state recovery, dirty-state resolution, lifecycle transitions, and legacy-field cleanup.
- Updated the four direct canonicalization consumers to import from the new module.
- Removed the unreferenced `normalizeRelationshipId` export without a compatibility re-export.
- Added direct unit contracts for canonicalization, legacy migration, identity behavior, dirty-state precedence, sync/unsync transitions, media fingerprint preservation, and non-mutating legacy cleanup.

## Why better

The lifecycle module now has one reason to change and drops from 223 to 177 LOC and from 12 public declarations to eight. Signature canonicalization has an explicit home that is also appropriate for its non-Draft media-fingerprint consumer. Existing lifecycle APIs and behavior remain intact for the four workflows that use them: standard articles, itineraries, single-type listicles, and location documents.

## Validation

- Focused Payload Sync tests: 2 files, 18 tests passed.
- ABW frontend test suite: 97 files, 381 tests passed.
- ABW backend test suite: 367 tests passed.
- ABW converter: 15 tests passed.
- ABW nested lint: passed all five projects, including frontend boundary validation and ESLint.
- ABW nested production build: passed (Vite plus Python compileall).
- Root test suite: passed all eight configured Turbo tasks.
- Changed-file ESLint and `git diff --check`: passed.
- Frontend `tsc --noEmit` remains blocked by five existing errors outside Payload Sync in `MainHomepagePage.tsx`, `homepageHotelGridSlots.utils.ts`, `BuilderSetupPanel.tsx`, and `SingleTypeListicleBuilderPage.tsx`.
- Root lint remains blocked outside ABW by Questura server's unavailable `@next/next/no-img-element` rule in `FocalPointPickerField.tsx` (plus five warnings).
- Root build remains blocked outside ABW because Questura server's declared Node requirement is not met by local Node 18.19.1; Payload type generation fails in Undici with `ReferenceError: File is not defined`.

## Risks/tradeoffs/follow-ups

The canonicalization imports change path, but repository-wide caller inspection found and updated every direct consumer. There is no compatibility re-export, intentionally keeping the lifecycle surface narrow. No persisted fields, signatures, comparison shapes, identity policies, or transition semantics changed. Existing root lint/build/typecheck baselines are unrelated and remain follow-up work.
