### PR TITLE
refactor(abw): decompose listicle content generation

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/CONTEXT.md
@@ -63,3 +63,8 @@ _Avoid_: article prose, full SEO document
   selection, retry policy, validation traces, and writer execution. New prompt
   modules must reuse that execution boundary rather than introduce another
   listicle runner.
+- `listicle_content.py` is the compatible HTTP facade for Listicle Content
+  Generation. Its Pydantic contracts, Critical Fields and Research Profile batch
+  preparation, single-target composition adapter, batch orchestration, and
+  writer-vocabulary endpoint live in the adjacent `listicle_content_*` and
+  `listicle_guidelines.py` modules.

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content.py
@@ -1,409 +1,43 @@
-"""Listicle Content Generation HTTP contract and batch orchestration."""
+"""Compatible HTTP facade for Listicle Content Generation."""
 
 import logging
-from typing import Annotated, Any, Literal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
-from .angle_assignment import (
-    ANTI_AI_PROMPT_CATEGORIES,
-    ListicleAngle as AssignmentAngle,
-)
-from .blurb_composer import (
-    ListicleCompositionDeps,
-    ListicleCompositionResult,
-    ListicleCompositionSettings,
-    ListicleCompositionStep,
-    ListicleCompositionTarget,
-    ListicleCompositionWriterError,
-    compose_listicle_target,
-)
-from .contracts import (
-    DEFAULT_MODEL,
-    MAX_ARTICLE_CONTEXT_CHARS,
-    MAX_ARTICLE_TITLE_CHARS,
-    MAX_BLOCK_CHARS,
-    MAX_PROMPT_CHARS,
-    ListTone,
-)
-from .critical_fields import CriticalFieldsResult, evaluate_critical_fields
+from .angle_assignment import ListicleAngle as AssignmentAngle
+from .contracts import ListTone
+from .critical_fields import CriticalFieldsResult
 from .dependencies import EditorAssistDependencies, get_editor_assist_dependencies
-from .listicle_prompt_policy import (
-    LIST_TONE_GUIDANCE,
-    LISTICLE_ANGLE_GUIDANCE,
+from .listicle_content_contracts import (
+    GenerateListicleContentRequest,
+    GenerateListicleContentResponse,
+    GenerateListicleTargetRequest,
+    GenerateListicleTargetResponse,
+    ListicleAngleRequest,
+    ListicleGuidelinesResponse,
+    PayloadCollectionSlug,
+    StepEvent,
+    StepEventName,
+    StepEventStatus,
 )
-from .listicle_writer_contracts import (
-    ListicleArticleType,
-    ListicleCategory,
+from .listicle_content_generation import (
+    generate_listicle_content as _generate_listicle_content_impl,
 )
+from .listicle_guidelines import (
+    get_listicle_guidelines,
+    router as listicle_guidelines_router,
+)
+from .listicle_writer_contracts import ListicleArticleType, ListicleCategory
 from .research_profile import (
     ResearchProfile,
     ResearchProfileRequest,
     ResearchProfileTrace,
-    run_research_profiles_concurrently,
 )
-from .writer_brief import run_writer_brief
 
 router = APIRouter()
+router.include_router(listicle_guidelines_router)
 logger = logging.getLogger(__name__)
-
-PayloadCollectionSlug = Literal[
-    "dining", "accommodations", "attractions", "nightlife", "key-locations"
-]
-ListicleAngleRequest = Literal[
-    # Dining
-    "signature-dish",
-    "atmosphere",
-    "founders-backstory",
-    "insider-tip",
-    "best-for",
-    "whats-different",
-    # Accommodations (ADR 0011)
-    "location-and-setting",
-    "view-and-vista",
-    "design-and-aesthetic",
-    "signature-amenity",
-    "food-and-beverage",
-    "trip-fit",
-    "property-backstory",
-    "booking-tip",
-    # Attractions
-    "signature-feature",
-    "setting",
-    "history-built",
-    "visit-time-tip",
-    "best-for-visit-type",
-    # Nightlife (single-angle pool per ADR 0008)
-    "best-for-night",
-]
-
-
-class GenerateListicleTargetRequest(BaseModel):
-    target_id: str = Field(min_length=1, max_length=200)
-    field_type: Literal["intro", "blurb"]
-    category: ListicleCategory | None = None
-    display_name: str | None = Field(default=None, max_length=240)
-    research_subject: str | None = Field(default=None, max_length=240)
-    location_label: str | None = Field(default=None, max_length=300)
-    current_content: str = Field(default="", max_length=MAX_BLOCK_CHARS)
-    supporting_context: str | None = Field(default=None, max_length=12000)
-    payload_doc_id: str | None = Field(default=None, max_length=64)
-    payload_collection: PayloadCollectionSlug | None = None
-    angle: ListicleAngleRequest | None = None
-
-
-class GenerateListicleContentRequest(BaseModel):
-    article_title: str = Field(min_length=1, max_length=MAX_ARTICLE_TITLE_CHARS)
-    article_type: ListicleArticleType
-    location_label: str = Field(min_length=1, max_length=300)
-    article_context: str | None = Field(
-        default=None, max_length=MAX_ARTICLE_CONTEXT_CHARS
-    )
-    model_name: str | None = Field(default=None, max_length=120)
-    custom_instruction: str | None = Field(default=None, max_length=MAX_PROMPT_CHARS)
-    skip_existing: bool = False
-    list_tone: ListTone | None = None
-    targets: list[GenerateListicleTargetRequest] = Field(default_factory=list)
-
-
-StepEventName = Literal[
-    "critical_fields_evaluated",
-    "research_profile_completed",
-    "writer_brief_completed",
-    "writer_called",
-    "validated",
-    "retry_called",
-    "finalized",
-]
-StepEventStatus = Literal["ok", "skipped", "failed"]
-
-
-class StepEvent(BaseModel):
-    name: StepEventName
-    status: StepEventStatus
-    prompt: str | None = None
-    output: str | None = None
-    model: str | None = None
-    details: dict[str, Any] = Field(default_factory=dict)
-    duration_ms: int = 0
-
-
-class GenerateListicleTargetResponse(BaseModel):
-    target_id: str
-    status: Literal["generated", "skipped", "error"]
-    markdown: str | None = None
-    model_used: str
-    source_urls: list[str] = Field(default_factory=list)
-    validation_errors: list[str] = Field(default_factory=list)
-    error_message: str | None = None
-    low_confidence: bool = False
-    warnings: list[str] = Field(default_factory=list)
-    requested_angle: ListicleAngleRequest | None = None
-    effective_angle: ListicleAngleRequest | None = None
-    steps: list[StepEvent] = Field(default_factory=list)
-
-
-class GenerateListicleContentResponse(BaseModel):
-    results: dict[str, GenerateListicleTargetResponse]
-
-
-def _to_composition_target(
-    request_target: GenerateListicleTargetRequest,
-) -> ListicleCompositionTarget:
-    return ListicleCompositionTarget(
-        target_id=request_target.target_id,
-        field_type=request_target.field_type,
-        category=request_target.category,
-        display_name=request_target.display_name,
-        research_subject=request_target.research_subject,
-        location_label=request_target.location_label,
-        current_content=request_target.current_content or "",
-        supporting_context=request_target.supporting_context,
-    )
-
-
-def _to_step_event(step: ListicleCompositionStep) -> StepEvent:
-    return StepEvent(
-        name=step.name,
-        status=step.status,
-        prompt=step.prompt,
-        output=step.output,
-        model=step.model,
-        details=step.details,
-        duration_ms=step.duration_ms,
-    )
-
-
-def _to_target_response(
-    result: ListicleCompositionResult,
-) -> GenerateListicleTargetResponse:
-    return GenerateListicleTargetResponse(
-        target_id=result.target_id,
-        status=result.status,
-        markdown=result.markdown,
-        model_used=result.model_used,
-        source_urls=result.source_urls,
-        validation_errors=result.validation_errors,
-        error_message=result.error_message,
-        low_confidence=result.low_confidence,
-        warnings=result.warnings,
-        requested_angle=result.requested_angle,
-        effective_angle=result.effective_angle,
-        steps=[_to_step_event(step) for step in result.steps],
-    )
-
-
-def _generate_single_listicle_target(
-    *,
-    article_title: str,
-    article_type: ListicleArticleType,
-    article_location: str,
-    article_context: str,
-    request_target: GenerateListicleTargetRequest,
-    custom_instruction: str,
-    model_name: str,
-    cf_result: CriticalFieldsResult,
-    research_profile: ResearchProfile | None,
-    research_profile_trace: ResearchProfileTrace | None,
-    list_tone: ListTone | None = None,
-    requested_angle: AssignmentAngle | None = None,
-    effective_angle: AssignmentAngle | None = None,
-    dependencies: EditorAssistDependencies,
-) -> GenerateListicleTargetResponse:
-    settings = ListicleCompositionSettings(
-        article_title=article_title,
-        article_type=article_type,
-        article_location=article_location,
-        article_context=article_context,
-        custom_instruction=custom_instruction,
-        model_name=model_name,
-        list_tone=list_tone,
-        requested_angle=requested_angle,
-        effective_angle=effective_angle,
-    )
-    try:
-        result = compose_listicle_target(
-            target=_to_composition_target(request_target),
-            settings=settings,
-            cf_result=cf_result,
-            research_profile=research_profile,
-            research_profile_trace=research_profile_trace,
-            deps=ListicleCompositionDeps(
-                invoke_writer=dependencies.invoke_writer,
-                run_writer_brief=run_writer_brief,
-            ),
-        )
-    except ListicleCompositionWriterError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
-    return _to_target_response(result)
-
-
-def _evaluate_target_cf(
-    request_target: GenerateListicleTargetRequest,
-) -> CriticalFieldsResult:
-    if request_target.field_type == "intro":
-        return CriticalFieldsResult(passed=True, missing=[])
-    return evaluate_critical_fields(
-        name=request_target.display_name or request_target.research_subject,
-        category=request_target.category,
-        location_label=request_target.location_label,
-        payload_doc_id=request_target.payload_doc_id,
-    )
-
-
-def _is_skipped_existing_target(
-    target: GenerateListicleTargetRequest,
-    *,
-    skip_existing: bool,
-) -> bool:
-    return skip_existing and bool((target.current_content or "").strip())
-
-
-def _build_research_profile_requests(
-    targets: list[GenerateListicleTargetRequest],
-    cf_by_target_id: dict[str, CriticalFieldsResult],
-    *,
-    article_location: str,
-    skip_existing: bool,
-) -> list[ResearchProfileRequest]:
-    requests: list[ResearchProfileRequest] = []
-    for t in targets:
-        if t.field_type != "blurb":
-            continue
-        if _is_skipped_existing_target(t, skip_existing=skip_existing):
-            continue
-        if not cf_by_target_id.get(t.target_id, CriticalFieldsResult(False, [])).passed:
-            continue
-        if t.category not in ANTI_AI_PROMPT_CATEGORIES:
-            continue
-        venue_name = (t.display_name or t.research_subject or "").strip()
-        location_label = (t.location_label or article_location).strip()
-        requests.append(
-            ResearchProfileRequest(
-                target_id=t.target_id,
-                venue_name=venue_name,
-                location_label=location_label,
-                category=t.category,
-                requested_angle=t.angle,
-            )
-        )
-    return requests
-
-
-def _generate_listicle_content_impl(
-    request: GenerateListicleContentRequest,
-    dependencies: EditorAssistDependencies,
-) -> GenerateListicleContentResponse:
-    article_title = request.article_title.strip()
-    article_location = request.location_label.strip()
-    article_context = request.article_context.strip() if request.article_context else ""
-    custom_instruction = (
-        request.custom_instruction.strip() if request.custom_instruction else ""
-    )
-
-    if not article_title:
-        raise HTTPException(status_code=400, detail="article_title is required")
-    if not article_location:
-        raise HTTPException(status_code=400, detail="location_label is required")
-    if not request.targets:
-        raise HTTPException(status_code=400, detail="At least one target is required")
-
-    model_used = (request.model_name or DEFAULT_MODEL).strip() or DEFAULT_MODEL
-    results: dict[str, GenerateListicleTargetResponse] = {}
-
-    # 1) Critical Fields pass (per-target, in-memory, no I/O).
-    cf_by_target_id: dict[str, CriticalFieldsResult] = {
-        t.target_id: _evaluate_target_cf(t) for t in request.targets
-    }
-
-    # 2) Research Profile parallel pass for every generating blurb in enabled
-    #    categories. The operator-selected angle is authoritative (ADR 0010);
-    #    Research Profile validates it post-hoc.
-    rp_requests = _build_research_profile_requests(
-        request.targets,
-        cf_by_target_id,
-        article_location=article_location,
-        skip_existing=request.skip_existing,
-    )
-    research_results: dict[str, tuple[ResearchProfile, ResearchProfileTrace]] = (
-        run_research_profiles_concurrently(rp_requests) if rp_requests else {}
-    )
-    research_by_target_id: dict[str, ResearchProfile] = {
-        tid: pair[0] for tid, pair in research_results.items()
-    }
-    research_trace_by_target_id: dict[str, ResearchProfileTrace] = {
-        tid: pair[1] for tid, pair in research_results.items()
-    }
-    effective_angle_by_target_id: dict[str, AssignmentAngle | None] = {}
-    for t in request.targets:
-        profile = research_by_target_id.get(t.target_id)
-        if profile is not None:
-            effective_angle_by_target_id[t.target_id] = profile.effective_angle
-
-    # 5) Per-target composition.
-    for request_target in request.targets:
-        current_content = (request_target.current_content or "").strip()
-        if request.skip_existing and current_content:
-            results[request_target.target_id] = GenerateListicleTargetResponse(
-                target_id=request_target.target_id,
-                status="skipped",
-                model_used=model_used,
-                markdown=current_content,
-            )
-            continue
-
-        requested_angle = request_target.angle
-        effective_angle = effective_angle_by_target_id.get(request_target.target_id)
-        try:
-            results[request_target.target_id] = _generate_single_listicle_target(
-                article_title=article_title,
-                article_type=request.article_type,
-                article_location=article_location,
-                article_context=article_context,
-                request_target=request_target,
-                custom_instruction=custom_instruction,
-                model_name=model_used,
-                cf_result=cf_by_target_id[request_target.target_id],
-                research_profile=research_by_target_id.get(request_target.target_id),
-                research_profile_trace=research_trace_by_target_id.get(
-                    request_target.target_id
-                ),
-                list_tone=request.list_tone,
-                requested_angle=requested_angle,
-                effective_angle=effective_angle,
-                dependencies=dependencies,
-            )
-        except HTTPException:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            logger.exception(
-                "Listicle generation failed for target %s: %s",
-                request_target.target_id,
-                exc,
-            )
-            results[request_target.target_id] = GenerateListicleTargetResponse(
-                target_id=request_target.target_id,
-                status="error",
-                model_used=model_used,
-                error_message=str(exc),
-            )
-
-    return GenerateListicleContentResponse(results=results)
-
-
-class ListicleGuidelinesResponse(BaseModel):
-    angles: dict[str, str]
-    tones: dict[str, str]
-
-
-@router.get("/listicle-guidelines", response_model=ListicleGuidelinesResponse)
-async def get_listicle_guidelines() -> ListicleGuidelinesResponse:
-    """Return the exact angle and tone guidance strings injected into the writer prompt."""
-    return ListicleGuidelinesResponse(
-        angles=dict(LISTICLE_ANGLE_GUIDANCE),
-        tones=dict(LIST_TONE_GUIDANCE),
-    )
 
 
 @router.post(
@@ -430,3 +64,29 @@ async def generate_listicle_content(
             status_code=502,
             detail="AI listicle generation graph failed",
         ) from exc
+
+
+__all__ = [
+    "AssignmentAngle",
+    "CriticalFieldsResult",
+    "EditorAssistDependencies",
+    "GenerateListicleContentRequest",
+    "GenerateListicleContentResponse",
+    "GenerateListicleTargetRequest",
+    "GenerateListicleTargetResponse",
+    "ListicleAngleRequest",
+    "ListicleArticleType",
+    "ListicleCategory",
+    "ListicleGuidelinesResponse",
+    "ListTone",
+    "PayloadCollectionSlug",
+    "ResearchProfile",
+    "ResearchProfileRequest",
+    "ResearchProfileTrace",
+    "StepEvent",
+    "StepEventName",
+    "StepEventStatus",
+    "generate_listicle_content",
+    "get_listicle_guidelines",
+    "router",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_batch.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_batch.py
@@ -1,0 +1,123 @@
+"""Batch preparation for Listicle Content Generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .angle_assignment import (
+    ANTI_AI_PROMPT_CATEGORIES,
+    ListicleAngle as AssignmentAngle,
+)
+from .critical_fields import CriticalFieldsResult, evaluate_critical_fields
+from .listicle_content_contracts import GenerateListicleTargetRequest
+from .research_profile import (
+    ResearchProfile,
+    ResearchProfileRequest,
+    ResearchProfileTrace,
+    run_research_profiles_concurrently,
+)
+
+
+@dataclass(frozen=True)
+class PreparedListicleBatch:
+    critical_fields_by_target_id: dict[str, CriticalFieldsResult]
+    research_by_target_id: dict[str, ResearchProfile]
+    research_trace_by_target_id: dict[str, ResearchProfileTrace]
+    effective_angle_by_target_id: dict[str, AssignmentAngle | None]
+
+
+def evaluate_target_critical_fields(
+    request_target: GenerateListicleTargetRequest,
+) -> CriticalFieldsResult:
+    if request_target.field_type == "intro":
+        return CriticalFieldsResult(passed=True, missing=[])
+    return evaluate_critical_fields(
+        name=request_target.display_name or request_target.research_subject,
+        category=request_target.category,
+        location_label=request_target.location_label,
+        payload_doc_id=request_target.payload_doc_id,
+    )
+
+
+def is_skipped_existing_target(
+    target: GenerateListicleTargetRequest,
+    *,
+    skip_existing: bool,
+) -> bool:
+    return skip_existing and bool((target.current_content or "").strip())
+
+
+def build_research_profile_requests(
+    targets: list[GenerateListicleTargetRequest],
+    cf_by_target_id: dict[str, CriticalFieldsResult],
+    *,
+    article_location: str,
+    skip_existing: bool,
+) -> list[ResearchProfileRequest]:
+    requests: list[ResearchProfileRequest] = []
+    for target in targets:
+        if target.field_type != "blurb":
+            continue
+        if is_skipped_existing_target(target, skip_existing=skip_existing):
+            continue
+        critical_fields = cf_by_target_id.get(target.target_id)
+        if critical_fields is None or not critical_fields.passed:
+            continue
+        if target.category not in ANTI_AI_PROMPT_CATEGORIES:
+            continue
+        requests.append(
+            ResearchProfileRequest(
+                target_id=target.target_id,
+                venue_name=(
+                    target.display_name or target.research_subject or ""
+                ).strip(),
+                location_label=(target.location_label or article_location).strip(),
+                category=target.category,
+                requested_angle=target.angle,
+            )
+        )
+    return requests
+
+
+def prepare_listicle_batch(
+    targets: list[GenerateListicleTargetRequest],
+    *,
+    article_location: str,
+    skip_existing: bool,
+) -> PreparedListicleBatch:
+    critical_fields_by_target_id = {
+        target.target_id: evaluate_target_critical_fields(target) for target in targets
+    }
+    requests = build_research_profile_requests(
+        targets,
+        critical_fields_by_target_id,
+        article_location=article_location,
+        skip_existing=skip_existing,
+    )
+    research_results = run_research_profiles_concurrently(requests) if requests else {}
+    research_by_target_id = {
+        target_id: pair[0] for target_id, pair in research_results.items()
+    }
+    research_trace_by_target_id = {
+        target_id: pair[1] for target_id, pair in research_results.items()
+    }
+    effective_angle_by_target_id = {
+        target.target_id: research_by_target_id[target.target_id].effective_angle
+        for target in targets
+        if target.target_id in research_by_target_id
+    }
+    return PreparedListicleBatch(
+        critical_fields_by_target_id=critical_fields_by_target_id,
+        research_by_target_id=research_by_target_id,
+        research_trace_by_target_id=research_trace_by_target_id,
+        effective_angle_by_target_id=effective_angle_by_target_id,
+    )
+
+
+__all__ = [
+    "PreparedListicleBatch",
+    "build_research_profile_requests",
+    "evaluate_target_critical_fields",
+    "is_skipped_existing_target",
+    "prepare_listicle_batch",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_contracts.py
@@ -1,0 +1,137 @@
+"""HTTP contracts for Listicle Content Generation."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .contracts import (
+    MAX_ARTICLE_CONTEXT_CHARS,
+    MAX_ARTICLE_TITLE_CHARS,
+    MAX_BLOCK_CHARS,
+    MAX_PROMPT_CHARS,
+    ListTone,
+)
+from .listicle_writer_contracts import (
+    ListicleArticleType,
+    ListicleCategory,
+)
+
+PayloadCollectionSlug = Literal[
+    "dining", "accommodations", "attractions", "nightlife", "key-locations"
+]
+ListicleAngleRequest = Literal[
+    # Dining
+    "signature-dish",
+    "atmosphere",
+    "founders-backstory",
+    "insider-tip",
+    "best-for",
+    "whats-different",
+    # Accommodations (ADR 0011)
+    "location-and-setting",
+    "view-and-vista",
+    "design-and-aesthetic",
+    "signature-amenity",
+    "food-and-beverage",
+    "trip-fit",
+    "property-backstory",
+    "booking-tip",
+    # Attractions
+    "signature-feature",
+    "setting",
+    "history-built",
+    "visit-time-tip",
+    "best-for-visit-type",
+    # Nightlife (single-angle pool per ADR 0008)
+    "best-for-night",
+]
+
+
+class GenerateListicleTargetRequest(BaseModel):
+    target_id: str = Field(min_length=1, max_length=200)
+    field_type: Literal["intro", "blurb"]
+    category: ListicleCategory | None = None
+    display_name: str | None = Field(default=None, max_length=240)
+    research_subject: str | None = Field(default=None, max_length=240)
+    location_label: str | None = Field(default=None, max_length=300)
+    current_content: str = Field(default="", max_length=MAX_BLOCK_CHARS)
+    supporting_context: str | None = Field(default=None, max_length=12000)
+    payload_doc_id: str | None = Field(default=None, max_length=64)
+    payload_collection: PayloadCollectionSlug | None = None
+    angle: ListicleAngleRequest | None = None
+
+
+class GenerateListicleContentRequest(BaseModel):
+    article_title: str = Field(min_length=1, max_length=MAX_ARTICLE_TITLE_CHARS)
+    article_type: ListicleArticleType
+    location_label: str = Field(min_length=1, max_length=300)
+    article_context: str | None = Field(
+        default=None, max_length=MAX_ARTICLE_CONTEXT_CHARS
+    )
+    model_name: str | None = Field(default=None, max_length=120)
+    custom_instruction: str | None = Field(default=None, max_length=MAX_PROMPT_CHARS)
+    skip_existing: bool = False
+    list_tone: ListTone | None = None
+    targets: list[GenerateListicleTargetRequest] = Field(default_factory=list)
+
+
+StepEventName = Literal[
+    "critical_fields_evaluated",
+    "research_profile_completed",
+    "writer_brief_completed",
+    "writer_called",
+    "validated",
+    "retry_called",
+    "finalized",
+]
+StepEventStatus = Literal["ok", "skipped", "failed"]
+
+
+class StepEvent(BaseModel):
+    name: StepEventName
+    status: StepEventStatus
+    prompt: str | None = None
+    output: str | None = None
+    model: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+    duration_ms: int = 0
+
+
+class GenerateListicleTargetResponse(BaseModel):
+    target_id: str
+    status: Literal["generated", "skipped", "error"]
+    markdown: str | None = None
+    model_used: str
+    source_urls: list[str] = Field(default_factory=list)
+    validation_errors: list[str] = Field(default_factory=list)
+    error_message: str | None = None
+    low_confidence: bool = False
+    warnings: list[str] = Field(default_factory=list)
+    requested_angle: ListicleAngleRequest | None = None
+    effective_angle: ListicleAngleRequest | None = None
+    steps: list[StepEvent] = Field(default_factory=list)
+
+
+class GenerateListicleContentResponse(BaseModel):
+    results: dict[str, GenerateListicleTargetResponse]
+
+
+class ListicleGuidelinesResponse(BaseModel):
+    angles: dict[str, str]
+    tones: dict[str, str]
+
+
+__all__ = [
+    "GenerateListicleContentRequest",
+    "GenerateListicleContentResponse",
+    "GenerateListicleTargetRequest",
+    "GenerateListicleTargetResponse",
+    "ListicleAngleRequest",
+    "ListicleGuidelinesResponse",
+    "PayloadCollectionSlug",
+    "StepEvent",
+    "StepEventName",
+    "StepEventStatus",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_generation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_generation.py
@@ -1,0 +1,102 @@
+"""Batch orchestration for Listicle Content Generation."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+
+from .contracts import DEFAULT_MODEL
+from .dependencies import EditorAssistDependencies
+from .listicle_content_batch import prepare_listicle_batch
+from .listicle_content_contracts import (
+    GenerateListicleContentRequest,
+    GenerateListicleContentResponse,
+    GenerateListicleTargetResponse,
+)
+from .listicle_content_target import generate_listicle_target
+
+logger = logging.getLogger(__name__)
+
+
+def generate_listicle_content(
+    request: GenerateListicleContentRequest,
+    dependencies: EditorAssistDependencies,
+) -> GenerateListicleContentResponse:
+    article_title = request.article_title.strip()
+    article_location = request.location_label.strip()
+    article_context = request.article_context.strip() if request.article_context else ""
+    custom_instruction = (
+        request.custom_instruction.strip() if request.custom_instruction else ""
+    )
+
+    if not article_title:
+        raise HTTPException(status_code=400, detail="article_title is required")
+    if not article_location:
+        raise HTTPException(status_code=400, detail="location_label is required")
+    if not request.targets:
+        raise HTTPException(status_code=400, detail="At least one target is required")
+
+    model_used = (request.model_name or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+    prepared = prepare_listicle_batch(
+        request.targets,
+        article_location=article_location,
+        skip_existing=request.skip_existing,
+    )
+    results: dict[str, GenerateListicleTargetResponse] = {}
+
+    for request_target in request.targets:
+        current_content = (request_target.current_content or "").strip()
+        if request.skip_existing and current_content:
+            results[request_target.target_id] = GenerateListicleTargetResponse(
+                target_id=request_target.target_id,
+                status="skipped",
+                model_used=model_used,
+                markdown=current_content,
+            )
+            continue
+
+        try:
+            results[request_target.target_id] = generate_listicle_target(
+                article_title=article_title,
+                article_type=request.article_type,
+                article_location=article_location,
+                article_context=article_context,
+                request_target=request_target,
+                custom_instruction=custom_instruction,
+                model_name=model_used,
+                cf_result=prepared.critical_fields_by_target_id[
+                    request_target.target_id
+                ],
+                research_profile=prepared.research_by_target_id.get(
+                    request_target.target_id
+                ),
+                research_profile_trace=prepared.research_trace_by_target_id.get(
+                    request_target.target_id
+                ),
+                list_tone=request.list_tone,
+                requested_angle=request_target.angle,
+                effective_angle=prepared.effective_angle_by_target_id.get(
+                    request_target.target_id
+                ),
+                dependencies=dependencies,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "Listicle generation failed for target %s: %s",
+                request_target.target_id,
+                exc,
+            )
+            results[request_target.target_id] = GenerateListicleTargetResponse(
+                target_id=request_target.target_id,
+                status="error",
+                model_used=model_used,
+                error_message=str(exc),
+            )
+
+    return GenerateListicleContentResponse(results=results)
+
+
+__all__ = ["generate_listicle_content"]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_target.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_content_target.py
@@ -1,0 +1,126 @@
+"""Composition adapter for one Listicle Content Generation target."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from .angle_assignment import ListicleAngle as AssignmentAngle
+from .blurb_composer import (
+    ListicleCompositionDeps,
+    ListicleCompositionResult,
+    ListicleCompositionSettings,
+    ListicleCompositionStep,
+    ListicleCompositionTarget,
+    ListicleCompositionWriterError,
+    compose_listicle_target,
+)
+from .contracts import ListTone
+from .critical_fields import CriticalFieldsResult
+from .dependencies import EditorAssistDependencies
+from .listicle_content_contracts import (
+    GenerateListicleTargetRequest,
+    GenerateListicleTargetResponse,
+    StepEvent,
+)
+from .listicle_writer_contracts import ListicleArticleType
+from .research_profile import ResearchProfile, ResearchProfileTrace
+from .writer_brief import run_writer_brief
+
+
+def to_composition_target(
+    request_target: GenerateListicleTargetRequest,
+) -> ListicleCompositionTarget:
+    return ListicleCompositionTarget(
+        target_id=request_target.target_id,
+        field_type=request_target.field_type,
+        category=request_target.category,
+        display_name=request_target.display_name,
+        research_subject=request_target.research_subject,
+        location_label=request_target.location_label,
+        current_content=request_target.current_content or "",
+        supporting_context=request_target.supporting_context,
+    )
+
+
+def to_step_event(step: ListicleCompositionStep) -> StepEvent:
+    return StepEvent(
+        name=step.name,
+        status=step.status,
+        prompt=step.prompt,
+        output=step.output,
+        model=step.model,
+        details=step.details,
+        duration_ms=step.duration_ms,
+    )
+
+
+def to_target_response(
+    result: ListicleCompositionResult,
+) -> GenerateListicleTargetResponse:
+    return GenerateListicleTargetResponse(
+        target_id=result.target_id,
+        status=result.status,
+        markdown=result.markdown,
+        model_used=result.model_used,
+        source_urls=result.source_urls,
+        validation_errors=result.validation_errors,
+        error_message=result.error_message,
+        low_confidence=result.low_confidence,
+        warnings=result.warnings,
+        requested_angle=result.requested_angle,
+        effective_angle=result.effective_angle,
+        steps=[to_step_event(step) for step in result.steps],
+    )
+
+
+def generate_listicle_target(
+    *,
+    article_title: str,
+    article_type: ListicleArticleType,
+    article_location: str,
+    article_context: str,
+    request_target: GenerateListicleTargetRequest,
+    custom_instruction: str,
+    model_name: str,
+    cf_result: CriticalFieldsResult,
+    research_profile: ResearchProfile | None,
+    research_profile_trace: ResearchProfileTrace | None,
+    dependencies: EditorAssistDependencies,
+    list_tone: ListTone | None = None,
+    requested_angle: AssignmentAngle | None = None,
+    effective_angle: AssignmentAngle | None = None,
+) -> GenerateListicleTargetResponse:
+    settings = ListicleCompositionSettings(
+        article_title=article_title,
+        article_type=article_type,
+        article_location=article_location,
+        article_context=article_context,
+        custom_instruction=custom_instruction,
+        model_name=model_name,
+        list_tone=list_tone,
+        requested_angle=requested_angle,
+        effective_angle=effective_angle,
+    )
+    try:
+        result = compose_listicle_target(
+            target=to_composition_target(request_target),
+            settings=settings,
+            cf_result=cf_result,
+            research_profile=research_profile,
+            research_profile_trace=research_profile_trace,
+            deps=ListicleCompositionDeps(
+                invoke_writer=dependencies.invoke_writer,
+                run_writer_brief=run_writer_brief,
+            ),
+        )
+    except ListicleCompositionWriterError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return to_target_response(result)
+
+
+__all__ = [
+    "generate_listicle_target",
+    "to_composition_target",
+    "to_step_event",
+    "to_target_response",
+]

--- a/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_guidelines.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/editor_assist/listicle_guidelines.py
@@ -1,0 +1,23 @@
+"""Writer vocabulary endpoint for Listicle Content Generation."""
+
+from fastapi import APIRouter
+
+from .listicle_content_contracts import ListicleGuidelinesResponse
+from .listicle_prompt_policy import (
+    LIST_TONE_GUIDANCE,
+    LISTICLE_ANGLE_GUIDANCE,
+)
+
+router = APIRouter()
+
+
+@router.get("/listicle-guidelines", response_model=ListicleGuidelinesResponse)
+async def get_listicle_guidelines() -> ListicleGuidelinesResponse:
+    """Return the exact angle and tone guidance strings used by the writer."""
+    return ListicleGuidelinesResponse(
+        angles=dict(LISTICLE_ANGLE_GUIDANCE),
+        tones=dict(LIST_TONE_GUIDANCE),
+    )
+
+
+__all__ = ["get_listicle_guidelines", "router"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_editor_assist_architecture.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from fastapi import FastAPI
 
+import app.features.editor_assist.listicle_content as listicle_content
+import app.features.editor_assist.listicle_content_contracts as listicle_contracts
 from app.features.editor_assist.routes import router
 
 
@@ -177,6 +179,55 @@ def test_writer_brief_remains_a_thin_compatible_facade():
         "writer_brief_prompt",
         "writer_brief_rendering",
     }.issubset(imported_modules)
+
+
+def test_listicle_content_remains_a_thin_compatible_http_facade():
+    feature_path = Path(__file__).parents[1] / "app" / "features" / "editor_assist"
+    facade_path = feature_path / "listicle_content.py"
+    source = facade_path.read_text()
+    module = ast.parse(source)
+
+    top_level_defs = [
+        node
+        for node in module.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    imported_modules = {
+        node.module
+        for node in module.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert len(source.splitlines()) <= 120
+    assert [node.name for node in top_level_defs] == ["generate_listicle_content"]
+    assert {
+        "listicle_content_contracts",
+        "listicle_content_generation",
+        "listicle_guidelines",
+    }.issubset(imported_modules)
+
+
+def test_listicle_content_facade_preserves_http_contract_imports():
+    assert (
+        listicle_content.GenerateListicleContentRequest
+        is listicle_contracts.GenerateListicleContentRequest
+    )
+    assert (
+        listicle_content.GenerateListicleContentResponse
+        is listicle_contracts.GenerateListicleContentResponse
+    )
+    assert (
+        listicle_content.GenerateListicleTargetRequest
+        is listicle_contracts.GenerateListicleTargetRequest
+    )
+    assert (
+        listicle_content.GenerateListicleTargetResponse
+        is listicle_contracts.GenerateListicleTargetResponse
+    )
+    assert (
+        listicle_content.ListicleGuidelinesResponse
+        is listicle_contracts.ListicleGuidelinesResponse
+    )
 
 
 def test_editor_assist_internals_do_not_depend_on_listicle_writer_facade():


### PR DESCRIPTION
## Original issue

`editor_assist/listicle_content.py` had grown to 432 lines and combined the FastAPI contract, request/response mapping, Critical Fields evaluation, Research Profile batch selection and execution, per-target composition, response assembly, and the guidelines endpoint. That made unrelated changes converge on one high-risk module.

## Root cause

The Listicle Content Generation feature grew vertically in its original route module. HTTP schemas, pre-composition batch work, domain adaptation, orchestration, and a separate read-only endpoint accumulated without module ownership boundaries.

## Refactor

- Keep `listicle_content.py` as a 92-line compatible HTTP facade and family router.
- Move stable Pydantic request/response schemas to `listicle_content_contracts.py` and re-export them from the facade.
- Move Critical Fields evaluation and Research Profile batch preparation to `listicle_content_batch.py`.
- Move one-target composition and composition-result-to-HTTP mapping to `listicle_content_target.py`.
- Move batch generation flow to `listicle_content_generation.py`.
- Move `/listicle-guidelines` to `listicle_guidelines.py` while including its router through the existing family facade.
- Add architecture tests that cap facade size, enforce its module boundaries, preserve contract import identity, and retain all nine Editor Assist routes.

## Why this design is better

Each module now owns one cohesive reason to change, while the existing router import and Pydantic contract imports remain stable. The batch layer exposes a prepared immutable result, the target adapter continues to reuse the existing blurb composer boundary, and the HTTP facade only handles dependency injection, graph execution, and HTTP error mapping. This reduces merge pressure and makes behavior testable without introducing a second writer path or circular imports.

## Validation

- `python -m pytest ...test_editor_assist_listicle_content_routes.py ...test_editor_assist_listicle_blurb_routes.py ...test_editor_assist_architecture.py` — 19 passed.
- `python -m pytest apps/backend/tests` — 369 passed, with two existing dependency/deprecation warnings.
- `python -m flake8 apps/backend/app packages/shared/src packages/utils/src` — passed.
- `python -m black --check` on all changed Python files — passed.
- `PYTHONPYCACHEPREFIX=.cache/pycache python -m compileall -q apps/backend/app` — passed.
- `git diff --check` — passed.

## Risks, tradeoffs, and follow-ups

This is a structural refactor, so the primary risk is import or route compatibility. Contract identity and the complete route set are protected by tests, and the full backend suite passes. The change adds several small feature modules and therefore more navigation, but each stays below 140 lines and maps to an explicit responsibility. No frontend contract, writer policy, or itinerary composition code changes are included; no follow-up is required.