### PR TITLE
NOJIRA: Split location Payload sync responsibilities

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync.service.ts
@@ -1,507 +1,72 @@
 import type { LocationCategory } from "../../models/location";
-import type { Tour } from "../../models/location";
-import { BadRequestError, NotFoundError, ServiceUnavailableError } from "@shared/errors/http-error";
-import type {
-  PayloadApiClient,
-  PayloadEntryData,
-  PayloadEntryResponse
-} from "./clients/payload-api.client";
-import { ImageStorageService } from "../storage/image-storage.service";
-import { LocationQueryService } from "../core/location-query.service";
-import * as PayloadSyncRepo from "../../repositories/integration";
-import {
-  getAllTours,
-  getAttractionTours,
-  getTourById,
-  getTourSyncState,
-  saveTourSyncState,
-  updateLocationById,
-} from "../../repositories/core";
-
-// Import sub-modules
+import type { ImageStorageService } from "../storage/image-storage.service";
+import type { LocationQueryService } from "../core/location-query.service";
+import type { PayloadApiClient } from "./clients/payload-api.client";
+import { LocationPayloadSyncService } from "./payload-sync/location-payload-sync.service";
+import { LocationPayloadSyncStateService } from "./payload-sync/location-payload-sync-state.service";
+import { PayloadCollectionResolver } from "./payload-sync/payload-collection.resolver";
+import { PayloadEntryUpsertService } from "./payload-sync/payload-entry-upsert.service";
+import { PayloadLocationRefService } from "./payload-sync/payload-location-ref.service";
+import { PayloadSyncOrchestratorService } from "./payload-sync/payload-sync-orchestrator.service";
+import { PayloadSyncStatusService } from "./payload-sync/payload-sync-status.service";
+import { TourPayloadSyncService } from "./payload-sync/tour-payload-sync.service";
 import type { SyncResult, SyncStatusResponse, TourPayloadSyncResult } from "./types";
-import { uploadLocationImages } from "./handlers";
-import type { PayloadCollection } from "./mappers/location-payload.mapper";
-import { mapLocationToPayloadFormat, mapCategoryToCollection } from "./mappers";
-import type { PayloadTourData } from "./clients/payload/payload-tour.types";
-import { ensurePayloadLocationRefForKey } from "./resolvers/payload-location.resolver";
 
+/**
+ * Backwards-compatible facade for the Payload sync API used by controllers.
+ *
+ * Sync policies live in focused collaborators; this class only wires and delegates
+ * the four public operations exposed by the existing service contract.
+ */
 export class PayloadSyncService {
+  private readonly locationSync: LocationPayloadSyncService;
+  private readonly orchestrator: PayloadSyncOrchestratorService;
+  private readonly status: PayloadSyncStatusService;
+  private readonly tourSync: TourPayloadSyncService;
+
   constructor(
-    private readonly payloadClient: PayloadApiClient,
-    private readonly imageStorage: ImageStorageService,
-    private readonly locationQuery: LocationQueryService
-  ) {}
+    payloadClient: PayloadApiClient,
+    imageStorage: ImageStorageService,
+    locationQuery: LocationQueryService
+  ) {
+    const collectionResolver = new PayloadCollectionResolver(locationQuery);
+    const entryUpsert = new PayloadEntryUpsertService(payloadClient);
+    const locationRef = new PayloadLocationRefService(payloadClient);
+    const locationSyncState = new LocationPayloadSyncStateService(locationQuery);
 
-  /**
-   * Sync a single location to Payload CMS
-   */
-  async syncLocation(locationId: number): Promise<SyncResult> {
-    // Check if Payload is configured
-    if (!this.payloadClient.isConfigured()) {
-      throw new ServiceUnavailableError("Payload CMS");
-    }
-
-    // Diagnostic context — populated as we go, available in catch block
-    let locationRefSource = "unknown";
-    let locationRef: string | null = null;
-    let galleryIds: string[] = [];
-    let instagramIds: string[] = [];
-
-    try {
-      // Mark sync as pending
-      const collection = await this.getCollectionForLocation(locationId);
-      PayloadSyncRepo.saveSyncState(locationId, collection, "", "pending");
-
-      // Fetch location data
-      const location = this.locationQuery.getLocationById(locationId);
-      if (!location) {
-        throw new NotFoundError("Location", locationId);
-      }
-
-      // Use stored locationRef (or auto-resolve if missing)
-      locationRef = location.payload_location_ref;
-      locationRefSource = locationRef ? "stored" : "pending-resolve";
-
-      // If missing, auto-resolve (graceful handling for legacy locations)
-      if (!locationRef) {
-        locationRefSource = "auto-resolved (was null)";
-        console.warn(`⚠️  Location ${locationId} missing payload_location_ref, auto-resolving...`);
-
-        // Dynamic import to avoid circular dependencies
-        const { resolvePayloadLocationRef } = await import('./resolvers');
-        locationRef = await resolvePayloadLocationRef(location, this.payloadClient);
-
-        if (!locationRef) {
-          throw new BadRequestError(
-            `Failed to resolve Payload location for locationKey: ${location.locationKey || "none"}. ` +
-            `Ensure the location hierarchy exists in Payload CMS.`
-          );
-        }
-
-        // Update local database with resolved ref
-        const updated = updateLocationById(locationId, { payload_location_ref: locationRef });
-        if (!updated) {
-          console.warn(`⚠️  Failed to save payload_location_ref to database for location ${locationId}`);
-        } else {
-          console.log(`✅ Auto-resolved and saved locationRef: ${locationRef}`);
-        }
-      } else {
-        console.log(`✓ Using stored locationRef for location ${locationId}: ${locationRef}`);
-      }
-
-      // Keep the in-memory location aligned so downstream upload logic sees the resolved ref.
-      location.payload_location_ref = locationRef;
-
-      // Upload images and create Instagram posts
-      const uploadedImages = await uploadLocationImages(
-        location,
-        this.payloadClient,
-        this.imageStorage,
-        locationRef
-      );
-      galleryIds = uploadedImages.galleryImageIds;
-      instagramIds = uploadedImages.instagramPostIds;
-
-      const tourPayloadIds = location.category === "attractions"
-        ? await this.syncLinkedTours(locationId)
-        : undefined;
-
-      // Map location data to Payload format (locationRef is guaranteed at this point)
-      const payloadData = mapLocationToPayloadFormat(location, uploadedImages, locationRef, {
-        tourPayloadIds,
-      });
-
-      console.log(`🔄 [SYNC] Location ${locationId} type value:`, location.type);
-      console.log(`🔄 [SYNC] Payload data type:`, payloadData.type);
-
-      // Check if this location has a stored Payload document ID
-      const existingSyncState = PayloadSyncRepo.getSyncState(locationId, collection);
-
-      const existingDocId = existingSyncState?.payload_doc_id;
-      if (existingDocId) {
-        // Update existing document using stored payload_doc_id (regardless of previous sync status)
-        console.log(`✓ Updating existing Payload document: ${existingDocId}`);
-      } else {
-        // Create new document (first time sync)
-        console.log(`✓ Creating new Payload document`);
-      }
-
-      // Pre-send diagnostics — log everything that will be sent to Payload
-      console.log(`🔍 [SYNC DIAGNOSTICS] location ${locationId} → ${collection}`, {
-        operation: existingDocId ? `PATCH ${existingDocId}` : "POST (new)",
-        locationRef: payloadData.locationRef,
-        locationRefSource,
-        locationKey: location.locationKey,
-        galleryIds: uploadedImages.galleryImageIds,
-        instagramIds: uploadedImages.instagramPostIds,
-        galleryCount: uploadedImages.galleryImageIds.length,
-        instagramCount: uploadedImages.instagramPostIds.length,
-      });
-
-      const response = await this.upsertPayloadEntryWithTypeFallback(
-        collection,
-        payloadData,
-        existingDocId
-      );
-
-      // Log and save the Payload document ID
-      console.log(`📄 Payload document ID: ${response.doc.id} (location ${locationId})`);
-
-      // If any image-set upload silently failed, the Payload gallery is incomplete.
-      // Record a FAILED state (preserving the real doc id) instead of a false "success",
-      // so the location surfaces as not-synced and gets retried — see media-upload.handler.
-      if (uploadedImages.galleryUploadFailures > 0) {
-        const failedCount = uploadedImages.galleryUploadFailures;
-        const message =
-          `Gallery upload incomplete: ${failedCount} image set(s) failed to upload to Payload. ` +
-          `Document ${response.doc.id} was saved with a partial gallery — re-run sync to retry.`;
-        console.error(`❌ [SYNC] Location ${locationId}: ${message}`);
-        // saveSyncState preserves this doc id even though the overall sync failed.
-        PayloadSyncRepo.saveSyncState(locationId, collection, response.doc.id, "failed", message);
-        // Intentionally do NOT touch updated_at — leaving it ahead of last_synced_at
-        // keeps the location flagged rather than equalizing it into a false green.
-        return {
-          locationId,
-          payloadDocId: response.doc.id,
-          status: "failed",
-          error: message,
-        };
-      }
-
-      // Generate a single timestamp for both sync state and location update
-      // Use SQLite's datetime format (YYYY-MM-DD HH:MM:SS) without timezone
-      // This matches how SQLite stores DATETIME columns and prevents timezone parsing issues
-      const now = new Date();
-      now.setMilliseconds(0); // Remove milliseconds
-      const syncTimestamp = now.toISOString().replace('T', ' ').replace('.000Z', '');
-      console.log(`🕐 Generated sync timestamp (SQLite format): ${syncTimestamp}`);
-
-      // Update location's updated_at FIRST
-      const updateSuccess = updateLocationById(locationId, { updated_at: syncTimestamp });
-      console.log(`📝 Updated location ${locationId} updated_at: ${updateSuccess ? syncTimestamp : 'FAILED'}`);
-
-      // Save sync state using the SAME timestamp
-      PayloadSyncRepo.saveSyncState(
-        locationId,
-        collection,
-        response.doc.id,
-        "success",
-        undefined, // no error message
-        syncTimestamp // use the same timestamp
-      );
-      console.log(`💾 Saved sync state for location ${locationId} with timestamp: ${syncTimestamp}`);
-
-      // Verify what was actually saved to the database
-      const verifyLocation = this.locationQuery.getLocationById(locationId);
-      const verifySyncState = PayloadSyncRepo.getSyncState(locationId, collection);
-      console.log(`✅ VERIFICATION for location ${locationId}:`);
-      console.log(`   DB location.updated_at: ${verifyLocation?.updated_at}`);
-      console.log(`   DB syncState.last_synced_at: ${verifySyncState?.last_synced_at}`);
-      console.log(`   Match: ${verifyLocation?.updated_at === verifySyncState?.last_synced_at}`);
-
-      return {
-        locationId,
-        payloadDocId: response.doc.id,
-        status: "success",
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      const diagnostics = `[locationRef=${locationRef ?? "null"} source=${locationRefSource} gallery=[${galleryIds.join(",")}] instagram=[${instagramIds.join(",")}]]`;
-      console.error(`❌ Failed to sync location ${locationId}: ${errorMessage} ${diagnostics}`);
-
-      // Save failed state
-      try {
-        const collection = await this.getCollectionForLocation(locationId);
-        PayloadSyncRepo.saveSyncState(locationId, collection, "", "failed", `${errorMessage} ${diagnostics}`);
-      } catch {
-        // Ignore error if we can't save sync state
-      }
-
-      return {
-        locationId,
-        payloadDocId: "",
-        status: "failed",
-        error: `${errorMessage} ${diagnostics}`,
-      };
-    }
+    this.tourSync = new TourPayloadSyncService(payloadClient);
+    this.locationSync = new LocationPayloadSyncService(
+      payloadClient,
+      imageStorage,
+      locationQuery,
+      collectionResolver,
+      locationRef,
+      this.tourSync,
+      entryUpsert,
+      locationSyncState
+    );
+    this.orchestrator = new PayloadSyncOrchestratorService(
+      payloadClient,
+      locationQuery,
+      this.locationSync,
+      this.tourSync
+    );
+    this.status = new PayloadSyncStatusService(locationQuery, collectionResolver);
   }
 
-  /**
-   * Sync all locations, optionally filtered by category
-   */
-  async syncAllLocations(category?: LocationCategory): Promise<SyncResult[]> {
-    if (!this.payloadClient.isConfigured()) {
-      throw new ServiceUnavailableError("Payload CMS");
-    }
-
-    if (category === undefined || category === "attractions") {
-      await this.syncAllTours();
-    }
-
-    // Get all locations
-    const locations = this.locationQuery.listLocations(category);
-
-    const results: SyncResult[] = [];
-
-    for (const location of locations) {
-      const result = await this.syncLocation(location.id!);
-      results.push(result);
-
-      // Small delay to avoid overwhelming Payload
-      await new Promise(resolve => setTimeout(resolve, 500));
-    }
-
-    return results;
+  syncLocation(locationId: number): Promise<SyncResult> {
+    return this.locationSync.syncLocation(locationId);
   }
 
-  private toPayloadRelationshipId(id: string): string | number {
-    const trimmed = id.trim();
-    if (/^\d+$/.test(trimmed)) {
-      return Number(trimmed);
-    }
-    return trimmed;
+  syncAllLocations(category?: LocationCategory): Promise<SyncResult[]> {
+    return this.orchestrator.syncAllLocations(category);
   }
 
-  private async buildPayloadTourData(tour: Tour): Promise<PayloadTourData> {
-    const base: PayloadTourData = {
-      title: tour.title,
-      img: this.toPayloadRelationshipId(tour.imgPayloadMediaSetId),
-      bookingLink: tour.bookingLink,
-      price: tour.price,
-      status: "published",
-    };
-    const locationRef = await ensurePayloadLocationRefForKey(tour.locationKey, this.payloadClient);
-    if (locationRef) {
-      base.locationRef = this.toPayloadRelationshipId(locationRef);
-    }
-    return base;
+  syncTourToPayload(tourId: number): Promise<TourPayloadSyncResult> {
+    return this.tourSync.syncTourToPayload(tourId);
   }
 
-  private async syncAllTours(): Promise<void> {
-    const tours = getAllTours();
-
-    for (const tour of tours) {
-      await this.syncTour(tour.id);
-      await new Promise(resolve => setTimeout(resolve, 250));
-    }
-  }
-
-  private async syncLinkedTours(locationId: number): Promise<string[]> {
-    const tours = getAttractionTours(locationId);
-    const payloadIds: string[] = [];
-
-    for (const tour of tours) {
-      payloadIds.push(await this.syncTour(tour.id));
-    }
-
-    return payloadIds;
-  }
-
-  /**
-   * Create or update one tour in Payload. Returns result (does not throw on Payload failure).
-   */
-  async syncTourToPayload(tourId: number): Promise<TourPayloadSyncResult> {
-    if (!this.payloadClient.isConfigured()) {
-      throw new ServiceUnavailableError("Payload CMS");
-    }
-
-    const tour = getTourById(tourId);
-    if (!tour) {
-      throw new NotFoundError("Tour", tourId);
-    }
-
-    saveTourSyncState(tourId, "", "pending");
-
-    try {
-      const payloadData = await this.buildPayloadTourData(tour);
-      const existingSyncState = getTourSyncState(tourId);
-      const existingDocId =
-        existingSyncState?.payloadDocId || await this.payloadClient.findTourByTitle(tour.title);
-
-      const response = existingDocId
-        ? await this.payloadClient.updateTour(existingDocId, payloadData)
-        : await this.payloadClient.createTour(payloadData);
-
-      const now = new Date();
-      now.setMilliseconds(0);
-      const syncTimestamp = now.toISOString().replace("T", " ").replace(".000Z", "");
-      saveTourSyncState(tourId, response.doc.id, "success", undefined, syncTimestamp);
-      return { tourId, payloadDocId: response.doc.id, status: "success" };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      saveTourSyncState(tourId, "", "failed", errorMessage);
-      return { tourId, payloadDocId: "", status: "failed", error: errorMessage };
-    }
-  }
-
-  private async syncTour(tourId: number): Promise<string> {
-    const result = await this.syncTourToPayload(tourId);
-    if (result.status === "failed") {
-      throw new Error(result.error || `Failed to sync tour ${tourId}`);
-    }
-    return result.payloadDocId;
-  }
-
-  /**
-   * Get sync status for location(s)
-   */
   getSyncStatus(locationId?: number): SyncStatusResponse[] {
-    if (locationId) {
-      const location = this.locationQuery.getLocationById(locationId);
-      if (!location) {
-        throw new NotFoundError("Location", locationId);
-      }
-
-      const collection = mapCategoryToCollection(location.category);
-      const syncState = PayloadSyncRepo.getSyncState(locationId, collection);
-
-      // Check if location has been modified since last successful sync
-      const needsResync = this.hasLocationChangedSinceLastSync(location, syncState);
-
-      return [{
-        locationId,
-        title: location.title || location.source.name,
-        category: location.category,
-        synced: !!syncState && syncState.sync_status === "success",
-        needsResync,
-        syncState: syncState || undefined,
-      }];
-    }
-
-    // Get all locations with sync state
-    const allLocations = this.locationQuery.listLocations();
-    const allSyncStates = PayloadSyncRepo.getAllSyncedLocations();
-
-    // Create a map for quick lookup
-    const syncStateMap = new Map<number, any>();
-    allSyncStates.forEach(state => {
-      syncStateMap.set(state.location_id, state);
-    });
-
-    return allLocations.map(location => {
-      const syncState = syncStateMap.get(location.id!);
-      const needsResync = this.hasLocationChangedSinceLastSync(location, syncState);
-
-      return {
-        locationId: location.id!,
-        title: location.title || location.source.name,
-        category: location.category,
-        synced: !!syncState && syncState.sync_status === "success",
-        needsResync,
-        syncState,
-      };
-    });
-  }
-
-  /**
-   * Helper: Check if location has been modified since last successful sync
-   */
-  private hasLocationChangedSinceLastSync(location: any, syncState: any): boolean {
-    // If there's no sync state or no successful sync, it doesn't need resync (needs initial sync)
-    if (!syncState || syncState.sync_status !== "success") {
-      console.log(`🔍 Location ${location.id}: No sync state or not successful - needsResync=false`);
-      return false;
-    }
-
-    // If location has no updated_at, assume it hasn't changed
-    if (!location.updated_at) {
-      console.log(`🔍 Location ${location.id}: No updated_at - needsResync=false`);
-      return false;
-    }
-
-    // Compare timestamps - if location was modified after last successful sync, it needs resync
-    const lastModified = new Date(location.updated_at);
-    const lastSynced = new Date(syncState.last_synced_at);
-
-    console.log(`🔍 Location ${location.id} timestamp comparison:`);
-    console.log(`   location.updated_at: ${location.updated_at} (Date: ${lastModified.toISOString()})`);
-    console.log(`   syncState.last_synced_at: ${syncState.last_synced_at} (Date: ${lastSynced.toISOString()})`);
-    console.log(`   needsResync: ${lastModified > lastSynced}`);
-
-    return lastModified > lastSynced;
-  }
-
-  /**
-   * Helper: Create/update a Payload entry with type fallback handling.
-   */
-  private async upsertPayloadEntryWithTypeFallback(
-    collection: PayloadCollection,
-    payloadData: PayloadEntryData,
-    existingDocId?: string
-  ): Promise<PayloadEntryResponse> {
-    try {
-      return await this.upsertPayloadEntry(collection, payloadData, existingDocId);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      if (!payloadData.type || !this.isPayloadTypeSelectionError(errorMessage)) {
-        throw error;
-      }
-
-      const normalizedType = this.toNormalizedType(payloadData.type);
-      if (normalizedType !== payloadData.type) {
-        console.warn(
-          `⚠️  Payload rejected type "${payloadData.type}" for ${collection}. ` +
-          `Retrying with "${normalizedType}".`
-        );
-
-        try {
-          return await this.upsertPayloadEntry(
-            collection,
-            { ...payloadData, type: normalizedType },
-            existingDocId
-          );
-        } catch (fallbackError) {
-          const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
-          if (!this.isPayloadTypeSelectionError(fallbackMessage)) {
-            throw fallbackError;
-          }
-        }
-      }
-
-      console.warn(
-        `⚠️  Payload rejected type "${payloadData.type}" for ${collection}. Retrying without type.`
-      );
-
-      const { type, ...payloadDataWithoutType } = payloadData;
-      return await this.upsertPayloadEntry(collection, payloadDataWithoutType, existingDocId);
-    }
-  }
-
-  private async upsertPayloadEntry(
-    collection: PayloadCollection,
-    payloadData: PayloadEntryData,
-    existingDocId?: string
-  ): Promise<PayloadEntryResponse> {
-    if (existingDocId) {
-      return await this.payloadClient.updateEntry(collection, existingDocId, payloadData);
-    }
-
-    return await this.payloadClient.upsertEntry(collection, payloadData, {
-      replaceGallery: collection === "attractions",
-    });
-  }
-
-  private isPayloadTypeSelectionError(errorMessage: string): boolean {
-    return errorMessage.includes("Details > Type") || errorMessage.includes("\"path\":\"type\"");
-  }
-
-  private toNormalizedType(value: string): string {
-    return value.trim().toLowerCase().replace(/[_\s]+/g, "-");
-  }
-
-  /**
-   * Helper: Get collection for a location
-   */
-  private async getCollectionForLocation(
-    locationId: number
-  ): Promise<PayloadCollection> {
-    const location = this.locationQuery.getLocationById(locationId);
-    if (!location) {
-      throw new NotFoundError("Location", locationId);
-    }
-
-    return mapCategoryToCollection(location.category);
+    return this.status.getSyncStatus(locationId);
   }
 }

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/location-payload-sync-state.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/location-payload-sync-state.service.ts
@@ -1,0 +1,102 @@
+import { updateLocationById } from "../../../repositories/core";
+import * as PayloadSyncRepo from "../../../repositories/integration";
+import type { LocationQueryService } from "../../core/location-query.service";
+import type { PayloadCollection } from "../mappers/location-payload.mapper";
+import type { SyncResult } from "../types";
+
+/** Owns location sync-state transitions and their timestamp invariant. */
+export class LocationPayloadSyncStateService {
+  constructor(private readonly locationQuery: LocationQueryService) {}
+
+  markPending(locationId: number, collection: PayloadCollection): void {
+    PayloadSyncRepo.saveSyncState(locationId, collection, "", "pending");
+  }
+
+  getExistingDocumentId(locationId: number, collection: PayloadCollection): string | undefined {
+    return PayloadSyncRepo.getSyncState(locationId, collection)?.payload_doc_id || undefined;
+  }
+
+  markGalleryIncomplete(
+    locationId: number,
+    collection: PayloadCollection,
+    payloadDocId: string,
+    failureCount: number
+  ): SyncResult {
+    const message =
+      `Gallery upload incomplete: ${failureCount} image set(s) failed to upload to Payload. ` +
+      `Document ${payloadDocId} was saved with a partial gallery — re-run sync to retry.`;
+    console.error(`❌ [SYNC] Location ${locationId}: ${message}`);
+
+    // Preserve the real document id and leave updated_at ahead of last_synced_at.
+    PayloadSyncRepo.saveSyncState(locationId, collection, payloadDocId, "failed", message);
+    return {
+      locationId,
+      payloadDocId,
+      status: "failed",
+      error: message,
+    };
+  }
+
+  markSuccess(
+    locationId: number,
+    collection: PayloadCollection,
+    payloadDocId: string
+  ): SyncResult {
+    const syncTimestamp = this.sqliteTimestamp();
+    console.log(`🕐 Generated sync timestamp (SQLite format): ${syncTimestamp}`);
+
+    const updateSuccess = updateLocationById(locationId, {
+      updated_at: syncTimestamp,
+    });
+    console.log(
+      `📝 Updated location ${locationId} updated_at: ${
+        updateSuccess ? syncTimestamp : "FAILED"
+      }`
+    );
+
+    PayloadSyncRepo.saveSyncState(
+      locationId,
+      collection,
+      payloadDocId,
+      "success",
+      undefined,
+      syncTimestamp
+    );
+    console.log(`💾 Saved sync state for location ${locationId} with timestamp: ${syncTimestamp}`);
+
+    const verifyLocation = this.locationQuery.getLocationById(locationId);
+    const verifySyncState = PayloadSyncRepo.getSyncState(locationId, collection);
+    console.log(`✅ VERIFICATION for location ${locationId}:`);
+    console.log(`   DB location.updated_at: ${verifyLocation?.updated_at}`);
+    console.log(`   DB syncState.last_synced_at: ${verifySyncState?.last_synced_at}`);
+    console.log(
+      `   Match: ${verifyLocation?.updated_at === verifySyncState?.last_synced_at}`
+    );
+
+    return {
+      locationId,
+      payloadDocId,
+      status: "success",
+    };
+  }
+
+  markFailure(
+    locationId: number,
+    collection: PayloadCollection,
+    error: string
+  ): SyncResult {
+    PayloadSyncRepo.saveSyncState(locationId, collection, "", "failed", error);
+    return {
+      locationId,
+      payloadDocId: "",
+      status: "failed",
+      error,
+    };
+  }
+
+  private sqliteTimestamp(): string {
+    const now = new Date();
+    now.setMilliseconds(0);
+    return now.toISOString().replace("T", " ").replace(".000Z", "");
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/location-payload-sync.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/location-payload-sync.service.ts
@@ -1,0 +1,151 @@
+import { NotFoundError, ServiceUnavailableError } from "@shared/errors/http-error";
+import type { ImageStorageService } from "../../storage/image-storage.service";
+import type { LocationQueryService } from "../../core/location-query.service";
+import type { PayloadApiClient } from "../clients/payload-api.client";
+import { uploadLocationImages } from "../handlers";
+import { mapLocationToPayloadFormat } from "../mappers";
+import type { SyncResult } from "../types";
+import type { LocationPayloadSyncStateService } from "./location-payload-sync-state.service";
+import type { PayloadCollectionResolver } from "./payload-collection.resolver";
+import type { PayloadEntryUpsertService } from "./payload-entry-upsert.service";
+import type { PayloadLocationRefService } from "./payload-location-ref.service";
+import type { TourPayloadSyncService } from "./tour-payload-sync.service";
+
+interface LocationSyncDiagnostics {
+  locationRef: string | null;
+  locationRefSource: string;
+  galleryIds: string[];
+  instagramIds: string[];
+}
+
+/** Executes the steps needed to synchronize one location. */
+export class LocationPayloadSyncService {
+  constructor(
+    private readonly payloadClient: PayloadApiClient,
+    private readonly imageStorage: ImageStorageService,
+    private readonly locationQuery: LocationQueryService,
+    private readonly collectionResolver: PayloadCollectionResolver,
+    private readonly locationRef: PayloadLocationRefService,
+    private readonly tourSync: TourPayloadSyncService,
+    private readonly entryUpsert: PayloadEntryUpsertService,
+    private readonly syncState: LocationPayloadSyncStateService
+  ) {}
+
+  async syncLocation(locationId: number): Promise<SyncResult> {
+    if (!this.payloadClient.isConfigured()) {
+      throw new ServiceUnavailableError("Payload CMS");
+    }
+
+    const diagnostics: LocationSyncDiagnostics = {
+      locationRef: null,
+      locationRefSource: "unknown",
+      galleryIds: [],
+      instagramIds: [],
+    };
+
+    try {
+      const collection = this.collectionResolver.forLocation(locationId);
+      this.syncState.markPending(locationId, collection);
+
+      const location = this.locationQuery.getLocationById(locationId);
+      if (!location) {
+        throw new NotFoundError("Location", locationId);
+      }
+
+      diagnostics.locationRef = location.payload_location_ref;
+      diagnostics.locationRefSource = diagnostics.locationRef ? "stored" : "pending-resolve";
+      if (!diagnostics.locationRef) {
+        diagnostics.locationRefSource = "auto-resolved (was null)";
+      }
+      const resolvedRef = await this.locationRef.resolve(location);
+      diagnostics.locationRef = resolvedRef.value;
+      diagnostics.locationRefSource = resolvedRef.source;
+
+      // Downstream upload behavior reads the in-memory ref.
+      location.payload_location_ref = resolvedRef.value;
+      const uploadedImages = await uploadLocationImages(
+        location,
+        this.payloadClient,
+        this.imageStorage,
+        resolvedRef.value
+      );
+      diagnostics.galleryIds = uploadedImages.galleryImageIds;
+      diagnostics.instagramIds = uploadedImages.instagramPostIds;
+
+      const tourPayloadIds =
+        location.category === "attractions"
+          ? await this.tourSync.syncLinkedTours(locationId)
+          : undefined;
+      const payloadData = mapLocationToPayloadFormat(
+        location,
+        uploadedImages,
+        resolvedRef.value,
+        { tourPayloadIds }
+      );
+
+      console.log(`🔄 [SYNC] Location ${locationId} type value:`, location.type);
+      console.log("🔄 [SYNC] Payload data type:", payloadData.type);
+
+      const existingDocId = this.syncState.getExistingDocumentId(locationId, collection);
+      console.log(
+        existingDocId
+          ? `✓ Updating existing Payload document: ${existingDocId}`
+          : "✓ Creating new Payload document"
+      );
+      console.log(`🔍 [SYNC DIAGNOSTICS] location ${locationId} → ${collection}`, {
+        operation: existingDocId ? `PATCH ${existingDocId}` : "POST (new)",
+        locationRef: payloadData.locationRef,
+        locationRefSource: diagnostics.locationRefSource,
+        locationKey: location.locationKey,
+        galleryIds: uploadedImages.galleryImageIds,
+        instagramIds: uploadedImages.instagramPostIds,
+        galleryCount: uploadedImages.galleryImageIds.length,
+        instagramCount: uploadedImages.instagramPostIds.length,
+      });
+
+      const response = await this.entryUpsert.upsertWithTypeFallback(
+        collection,
+        payloadData,
+        existingDocId
+      );
+      console.log(`📄 Payload document ID: ${response.doc.id} (location ${locationId})`);
+
+      if (uploadedImages.galleryUploadFailures > 0) {
+        return this.syncState.markGalleryIncomplete(
+          locationId,
+          collection,
+          response.doc.id,
+          uploadedImages.galleryUploadFailures
+        );
+      }
+
+      return this.syncState.markSuccess(locationId, collection, response.doc.id);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      const diagnosticMessage = this.formatDiagnostics(diagnostics);
+      const failureMessage = `${errorMessage} ${diagnosticMessage}`;
+      console.error(`❌ Failed to sync location ${locationId}: ${failureMessage}`);
+
+      try {
+        const collection = this.collectionResolver.forLocation(locationId);
+        return this.syncState.markFailure(locationId, collection, failureMessage);
+      } catch {
+        return {
+          locationId,
+          payloadDocId: "",
+          status: "failed",
+          error: failureMessage,
+        };
+      }
+    }
+  }
+
+  private formatDiagnostics(diagnostics: LocationSyncDiagnostics): string {
+    return (
+      `[locationRef=${diagnostics.locationRef ?? "null"} ` +
+      `source=${diagnostics.locationRefSource} ` +
+      `gallery=[${diagnostics.galleryIds.join(",")}] ` +
+      `instagram=[${diagnostics.instagramIds.join(",")}]]`
+    );
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-collection.resolver.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-collection.resolver.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { NotFoundError } from "@shared/errors/http-error";
+import { PayloadCollectionResolver } from "./payload-collection.resolver";
+
+describe("PayloadCollectionResolver", () => {
+  test("maps the local key_locations category to Payload's collection slug", () => {
+    const resolver = new PayloadCollectionResolver({
+      getLocationById: () => ({ category: "key_locations" }),
+    } as never);
+
+    expect(resolver.forLocation(42)).toBe("key-locations");
+  });
+
+  test("reports a missing location before sync state is written", () => {
+    const resolver = new PayloadCollectionResolver({
+      getLocationById: () => null,
+    } as never);
+
+    expect(() => resolver.forLocation(404)).toThrow(NotFoundError);
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-collection.resolver.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-collection.resolver.ts
@@ -1,0 +1,23 @@
+import { NotFoundError } from "@shared/errors/http-error";
+import type { LocationCategory } from "../../../models/location";
+import type { LocationQueryService } from "../../core/location-query.service";
+import type { PayloadCollection } from "../mappers/location-payload.mapper";
+import { mapCategoryToCollection } from "../mappers";
+
+/** Resolves the Payload collection independently of sync execution policy. */
+export class PayloadCollectionResolver {
+  constructor(private readonly locationQuery: LocationQueryService) {}
+
+  forLocation(locationId: number): PayloadCollection {
+    const location = this.locationQuery.getLocationById(locationId);
+    if (!location) {
+      throw new NotFoundError("Location", locationId);
+    }
+
+    return this.forCategory(location.category);
+  }
+
+  forCategory(category: LocationCategory): PayloadCollection {
+    return mapCategoryToCollection(category);
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-entry-upsert.service.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-entry-upsert.service.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { PayloadEntryData, PayloadEntryResponse } from "../clients/payload-api.client";
+import { PayloadEntryUpsertService } from "./payload-entry-upsert.service";
+
+const payloadData = (type: string | null = "Fine Dining"): PayloadEntryData => ({
+  title: "Test location",
+  type,
+  gallery: [],
+  status: "published",
+});
+
+const response = (id: string): PayloadEntryResponse =>
+  ({
+    message: "ok",
+    doc: { id },
+  }) as PayloadEntryResponse;
+
+describe("PayloadEntryUpsertService", () => {
+  test("updates a stored document id instead of running title-based upsert", async () => {
+    const updateEntry = mock(
+      async (_collection: string, _docId: string, _data: PayloadEntryData) =>
+        response("stored-doc")
+    );
+    const upsertEntry = mock(
+      async (
+        _collection: string,
+        _data: PayloadEntryData,
+        _options?: { replaceGallery?: boolean }
+      ) => response("new-doc")
+    );
+    const service = new PayloadEntryUpsertService({
+      updateEntry,
+      upsertEntry,
+    } as never);
+
+    const result = await service.upsertWithTypeFallback(
+      "dining",
+      payloadData(),
+      "stored-doc"
+    );
+
+    expect(result.doc.id).toBe("stored-doc");
+    expect(updateEntry).toHaveBeenCalledTimes(1);
+    expect(updateEntry.mock.calls[0]?.[0]).toBe("dining");
+    expect(updateEntry.mock.calls[0]?.[1]).toBe("stored-doc");
+    expect(upsertEntry).not.toHaveBeenCalled();
+  });
+
+  test("replaces attraction galleries when creating or finding an entry", async () => {
+    const upsertEntry = mock(
+      async (
+        _collection: string,
+        _data: PayloadEntryData,
+        _options?: { replaceGallery?: boolean }
+      ) => response("attraction-doc")
+    );
+    const service = new PayloadEntryUpsertService({ upsertEntry } as never);
+
+    await service.upsertWithTypeFallback("attractions", payloadData());
+
+    expect(upsertEntry.mock.calls[0]?.[2]).toEqual({ replaceGallery: true });
+  });
+
+  test("normalizes a rejected type before retrying", async () => {
+    const updateEntry = mock(async (_collection, _docId, data: PayloadEntryData) => {
+      if (data.type === "Fine Dining") {
+        throw new Error("Validation failed: Details > Type");
+      }
+      return response("stored-doc");
+    });
+    const service = new PayloadEntryUpsertService({ updateEntry } as never);
+
+    await service.upsertWithTypeFallback("dining", payloadData(), "stored-doc");
+
+    expect(updateEntry).toHaveBeenCalledTimes(2);
+    expect(updateEntry.mock.calls[1]?.[2]).toMatchObject({ type: "fine-dining" });
+  });
+
+  test("removes type only when both original and normalized values are rejected", async () => {
+    const updateEntry = mock(async (_collection, _docId, data: PayloadEntryData) => {
+      if (data.type) {
+        throw new Error('Validation failed: {"path":"type"}');
+      }
+      return response("stored-doc");
+    });
+    const service = new PayloadEntryUpsertService({ updateEntry } as never);
+
+    await service.upsertWithTypeFallback("dining", payloadData(), "stored-doc");
+
+    expect(updateEntry).toHaveBeenCalledTimes(3);
+    expect(updateEntry.mock.calls[2]?.[2]).not.toHaveProperty("type");
+  });
+
+  test("does not retry failures unrelated to type selection", async () => {
+    const updateEntry = mock(async () => {
+      throw new Error("Payload timed out");
+    });
+    const service = new PayloadEntryUpsertService({ updateEntry } as never);
+
+    await expect(
+      service.upsertWithTypeFallback("dining", payloadData(), "stored-doc")
+    ).rejects.toThrow("Payload timed out");
+    expect(updateEntry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-entry-upsert.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-entry-upsert.service.ts
@@ -1,0 +1,81 @@
+import type {
+  PayloadApiClient,
+  PayloadEntryData,
+  PayloadEntryResponse,
+} from "../clients/payload-api.client";
+import type { PayloadCollection } from "../mappers/location-payload.mapper";
+
+/**
+ * Owns Payload entry create/update selection and the legacy type fallback policy.
+ */
+export class PayloadEntryUpsertService {
+  constructor(private readonly payloadClient: PayloadApiClient) {}
+
+  async upsertWithTypeFallback(
+    collection: PayloadCollection,
+    payloadData: PayloadEntryData,
+    existingDocId?: string
+  ): Promise<PayloadEntryResponse> {
+    try {
+      return await this.upsert(collection, payloadData, existingDocId);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      if (!payloadData.type || !this.isTypeSelectionError(errorMessage)) {
+        throw error;
+      }
+
+      const normalizedType = this.normalizeType(payloadData.type);
+      if (normalizedType !== payloadData.type) {
+        console.warn(
+          `⚠️  Payload rejected type "${payloadData.type}" for ${collection}. ` +
+            `Retrying with "${normalizedType}".`
+        );
+
+        try {
+          return await this.upsert(
+            collection,
+            { ...payloadData, type: normalizedType },
+            existingDocId
+          );
+        } catch (fallbackError) {
+          const fallbackMessage =
+            fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+          if (!this.isTypeSelectionError(fallbackMessage)) {
+            throw fallbackError;
+          }
+        }
+      }
+
+      console.warn(
+        `⚠️  Payload rejected type "${payloadData.type}" for ${collection}. Retrying without type.`
+      );
+
+      const payloadDataWithoutType = { ...payloadData };
+      delete payloadDataWithoutType.type;
+      return await this.upsert(collection, payloadDataWithoutType, existingDocId);
+    }
+  }
+
+  private async upsert(
+    collection: PayloadCollection,
+    payloadData: PayloadEntryData,
+    existingDocId?: string
+  ): Promise<PayloadEntryResponse> {
+    if (existingDocId) {
+      return await this.payloadClient.updateEntry(collection, existingDocId, payloadData);
+    }
+
+    return await this.payloadClient.upsertEntry(collection, payloadData, {
+      replaceGallery: collection === "attractions",
+    });
+  }
+
+  private isTypeSelectionError(errorMessage: string): boolean {
+    return errorMessage.includes("Details > Type") || errorMessage.includes("\"path\":\"type\"");
+  }
+
+  private normalizeType(value: string): string {
+    return value.trim().toLowerCase().replace(/[_\s]+/g, "-");
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-location-ref.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-location-ref.service.ts
@@ -1,0 +1,50 @@
+import { BadRequestError } from "@shared/errors/http-error";
+import { updateLocationById } from "../../../repositories/core";
+import type { LocationResponse } from "../../../models/location";
+import type { PayloadApiClient } from "../clients/payload-api.client";
+
+export interface ResolvedLocationRef {
+  value: string;
+  source: "stored" | "auto-resolved (was null)";
+}
+
+/** Resolves and persists the Payload hierarchy reference required by location sync. */
+export class PayloadLocationRefService {
+  constructor(private readonly payloadClient: PayloadApiClient) {}
+
+  async resolve(location: LocationResponse): Promise<ResolvedLocationRef> {
+    const storedRef = location.payload_location_ref;
+    if (storedRef) {
+      console.log(`✓ Using stored locationRef for location ${location.id}: ${storedRef}`);
+      return { value: storedRef, source: "stored" };
+    }
+
+    console.warn(
+      `⚠️  Location ${location.id} missing payload_location_ref, auto-resolving...`
+    );
+
+    // Keep this dynamic import to avoid the circular dependency guarded by the legacy service.
+    const { resolvePayloadLocationRef } = await import("../resolvers");
+    const resolvedRef = await resolvePayloadLocationRef(location, this.payloadClient);
+
+    if (!resolvedRef) {
+      throw new BadRequestError(
+        `Failed to resolve Payload location for locationKey: ${location.locationKey || "none"}. ` +
+          "Ensure the location hierarchy exists in Payload CMS."
+      );
+    }
+
+    const updated = updateLocationById(location.id, {
+      payload_location_ref: resolvedRef,
+    });
+    if (!updated) {
+      console.warn(
+        `⚠️  Failed to save payload_location_ref to database for location ${location.id}`
+      );
+    } else {
+      console.log(`✅ Auto-resolved and saved locationRef: ${resolvedRef}`);
+    }
+
+    return { value: resolvedRef, source: "auto-resolved (was null)" };
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-change-detector.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-change-detector.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { LocationResponse } from "../../../models/location";
+import type { PayloadSyncState } from "../../../repositories/integration";
+import { hasLocationChangedSinceLastSync } from "./payload-sync-change-detector";
+
+const location = (updatedAt = "2026-07-26 12:00:00"): LocationResponse =>
+  ({
+    id: 42,
+    updated_at: updatedAt,
+  }) as LocationResponse;
+
+const syncState = (
+  status: PayloadSyncState["sync_status"] = "success",
+  lastSyncedAt = "2026-07-26 11:59:59"
+): PayloadSyncState =>
+  ({
+    location_id: 42,
+    sync_status: status,
+    last_synced_at: lastSyncedAt,
+  }) as PayloadSyncState;
+
+describe("hasLocationChangedSinceLastSync", () => {
+  test("does not label an unsynced or failed location as needing resync", () => {
+    expect(hasLocationChangedSinceLastSync(location(), undefined)).toBe(false);
+    expect(hasLocationChangedSinceLastSync(location(), syncState("failed"))).toBe(false);
+  });
+
+  test("does not require resync when the location has no update timestamp", () => {
+    const locationWithoutTimestamp = {
+      ...location(),
+      updated_at: undefined,
+    } as unknown as LocationResponse;
+
+    expect(
+      hasLocationChangedSinceLastSync(locationWithoutTimestamp, syncState())
+    ).toBe(false);
+  });
+
+  test("requires resync only when the location timestamp is later", () => {
+    expect(hasLocationChangedSinceLastSync(location(), syncState())).toBe(true);
+    expect(
+      hasLocationChangedSinceLastSync(
+        location("2026-07-26 12:00:00"),
+        syncState("success", "2026-07-26 12:00:00")
+      )
+    ).toBe(false);
+    expect(
+      hasLocationChangedSinceLastSync(
+        location("2026-07-26 11:59:59"),
+        syncState("success", "2026-07-26 12:00:00")
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-change-detector.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-change-detector.ts
@@ -1,0 +1,38 @@
+import type { LocationResponse } from "../../../models/location";
+import type { PayloadSyncState } from "../../../repositories/integration";
+
+/**
+ * Compares location and successful-sync timestamps.
+ *
+ * A missing or failed state represents "needs initial sync", not "needs resync".
+ */
+export function hasLocationChangedSinceLastSync(
+  location: LocationResponse,
+  syncState: PayloadSyncState | null | undefined
+): boolean {
+  if (!syncState || syncState.sync_status !== "success") {
+    console.log(
+      `🔍 Location ${location.id}: No sync state or not successful - needsResync=false`
+    );
+    return false;
+  }
+
+  if (!location.updated_at) {
+    console.log(`🔍 Location ${location.id}: No updated_at - needsResync=false`);
+    return false;
+  }
+
+  const lastModified = new Date(location.updated_at);
+  const lastSynced = new Date(syncState.last_synced_at);
+
+  console.log(`🔍 Location ${location.id} timestamp comparison:`);
+  console.log(
+    `   location.updated_at: ${location.updated_at} (Date: ${lastModified.toISOString()})`
+  );
+  console.log(
+    `   syncState.last_synced_at: ${syncState.last_synced_at} (Date: ${lastSynced.toISOString()})`
+  );
+  console.log(`   needsResync: ${lastModified > lastSynced}`);
+
+  return lastModified > lastSynced;
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-orchestrator.service.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-orchestrator.service.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, mock, test } from "bun:test";
+import { PayloadSyncOrchestratorService } from "./payload-sync-orchestrator.service";
+
+describe("PayloadSyncOrchestratorService", () => {
+  test("synchronizes tours before listing locations for an unfiltered batch", async () => {
+    const events: string[] = [];
+    const service = new PayloadSyncOrchestratorService(
+      { isConfigured: () => true } as never,
+      {
+        listLocations: () => {
+          events.push("list-locations");
+          return [];
+        },
+      } as never,
+      { syncLocation: mock(async () => ({ status: "success" })) } as never,
+      {
+        syncAllTours: mock(async () => {
+          events.push("sync-tours");
+        }),
+      } as never
+    );
+
+    expect(await service.syncAllLocations()).toEqual([]);
+    expect(events).toEqual(["sync-tours", "list-locations"]);
+  });
+
+  test("skips the tour batch for non-attraction categories", async () => {
+    const syncAllTours = mock(async () => {});
+    const listLocations = mock(() => []);
+    const service = new PayloadSyncOrchestratorService(
+      { isConfigured: () => true } as never,
+      { listLocations } as never,
+      { syncLocation: mock(async () => ({ status: "success" })) } as never,
+      { syncAllTours } as never
+    );
+
+    await service.syncAllLocations("dining");
+
+    expect(syncAllTours).not.toHaveBeenCalled();
+    expect(listLocations).toHaveBeenCalledWith("dining");
+  });
+
+  test("rejects the batch before reading local data when Payload is unavailable", async () => {
+    const listLocations = mock(() => []);
+    const service = new PayloadSyncOrchestratorService(
+      { isConfigured: () => false } as never,
+      { listLocations } as never,
+      { syncLocation: mock(async () => ({ status: "success" })) } as never,
+      { syncAllTours: mock(async () => {}) } as never
+    );
+
+    await expect(service.syncAllLocations()).rejects.toThrow("Payload CMS");
+    expect(listLocations).not.toHaveBeenCalled();
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-orchestrator.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-orchestrator.service.ts
@@ -1,0 +1,35 @@
+import { ServiceUnavailableError } from "@shared/errors/http-error";
+import type { LocationCategory } from "../../../models/location";
+import type { LocationQueryService } from "../../core/location-query.service";
+import type { PayloadApiClient } from "../clients/payload-api.client";
+import type { SyncResult } from "../types";
+import type { LocationPayloadSyncService } from "./location-payload-sync.service";
+import type { TourPayloadSyncService } from "./tour-payload-sync.service";
+
+/** Coordinates batch ordering and throttling without owning per-entity sync policy. */
+export class PayloadSyncOrchestratorService {
+  constructor(
+    private readonly payloadClient: PayloadApiClient,
+    private readonly locationQuery: LocationQueryService,
+    private readonly locationSync: LocationPayloadSyncService,
+    private readonly tourSync: TourPayloadSyncService
+  ) {}
+
+  async syncAllLocations(category?: LocationCategory): Promise<SyncResult[]> {
+    if (!this.payloadClient.isConfigured()) {
+      throw new ServiceUnavailableError("Payload CMS");
+    }
+
+    if (category === undefined || category === "attractions") {
+      await this.tourSync.syncAllTours();
+    }
+
+    const results: SyncResult[] = [];
+    for (const location of this.locationQuery.listLocations(category)) {
+      results.push(await this.locationSync.syncLocation(location.id));
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    return results;
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-status.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/payload-sync-status.service.ts
@@ -1,0 +1,52 @@
+import { NotFoundError } from "@shared/errors/http-error";
+import type { LocationResponse } from "../../../models/location";
+import * as PayloadSyncRepo from "../../../repositories/integration";
+import type { LocationQueryService } from "../../core/location-query.service";
+import type { SyncStatusResponse } from "../types";
+import type { PayloadCollectionResolver } from "./payload-collection.resolver";
+import { hasLocationChangedSinceLastSync } from "./payload-sync-change-detector";
+
+/** Builds the public location sync status view. */
+export class PayloadSyncStatusService {
+  constructor(
+    private readonly locationQuery: LocationQueryService,
+    private readonly collectionResolver: PayloadCollectionResolver
+  ) {}
+
+  getSyncStatus(locationId?: number): SyncStatusResponse[] {
+    if (locationId) {
+      const location = this.locationQuery.getLocationById(locationId);
+      if (!location) {
+        throw new NotFoundError("Location", locationId);
+      }
+
+      const syncState = PayloadSyncRepo.getSyncState(
+        locationId,
+        this.collectionResolver.forCategory(location.category)
+      );
+      return [this.toStatus(location, syncState || undefined)];
+    }
+
+    const syncStateMap = new Map(
+      PayloadSyncRepo.getAllSyncedLocations().map((state) => [state.location_id, state])
+    );
+
+    return this.locationQuery
+      .listLocations()
+      .map((location) => this.toStatus(location, syncStateMap.get(location.id)));
+  }
+
+  private toStatus(
+    location: LocationResponse,
+    syncState?: PayloadSyncRepo.PayloadSyncState
+  ): SyncStatusResponse {
+    return {
+      locationId: location.id,
+      title: location.title || location.source.name,
+      category: location.category,
+      synced: syncState?.sync_status === "success",
+      needsResync: hasLocationChangedSinceLastSync(location, syncState),
+      syncState,
+    };
+  }
+}

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/tour-payload-sync.service.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/payload-sync/tour-payload-sync.service.ts
@@ -1,0 +1,110 @@
+import { NotFoundError, ServiceUnavailableError } from "@shared/errors/http-error";
+import type { Tour } from "../../../models/location";
+import {
+  getAllTours,
+  getAttractionTours,
+  getTourById,
+  getTourSyncState,
+  saveTourSyncState,
+} from "../../../repositories/core";
+import type { PayloadApiClient } from "../clients/payload-api.client";
+import type { PayloadTourData } from "../clients/payload/payload-tour.types";
+import { ensurePayloadLocationRefForKey } from "../resolvers/payload-location.resolver";
+import type { TourPayloadSyncResult } from "../types";
+
+/** Creates, updates, and batches Payload tour documents. */
+export class TourPayloadSyncService {
+  constructor(private readonly payloadClient: PayloadApiClient) {}
+
+  async syncTourToPayload(tourId: number): Promise<TourPayloadSyncResult> {
+    if (!this.payloadClient.isConfigured()) {
+      throw new ServiceUnavailableError("Payload CMS");
+    }
+
+    const tour = getTourById(tourId);
+    if (!tour) {
+      throw new NotFoundError("Tour", tourId);
+    }
+
+    saveTourSyncState(tourId, "", "pending");
+
+    try {
+      const payloadData = await this.buildPayloadData(tour);
+      const existingSyncState = getTourSyncState(tourId);
+      const existingDocId =
+        existingSyncState?.payloadDocId ||
+        (await this.payloadClient.findTourByTitle(tour.title));
+
+      const response = existingDocId
+        ? await this.payloadClient.updateTour(existingDocId, payloadData)
+        : await this.payloadClient.createTour(payloadData);
+
+      saveTourSyncState(
+        tourId,
+        response.doc.id,
+        "success",
+        undefined,
+        this.sqliteTimestamp()
+      );
+      return { tourId, payloadDocId: response.doc.id, status: "success" };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      saveTourSyncState(tourId, "", "failed", errorMessage);
+      return { tourId, payloadDocId: "", status: "failed", error: errorMessage };
+    }
+  }
+
+  async syncAllTours(): Promise<void> {
+    for (const tour of getAllTours()) {
+      await this.syncTourOrThrow(tour.id);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  async syncLinkedTours(locationId: number): Promise<string[]> {
+    const payloadIds: string[] = [];
+
+    for (const tour of getAttractionTours(locationId)) {
+      payloadIds.push(await this.syncTourOrThrow(tour.id));
+    }
+
+    return payloadIds;
+  }
+
+  private async syncTourOrThrow(tourId: number): Promise<string> {
+    const result = await this.syncTourToPayload(tourId);
+    if (result.status === "failed") {
+      throw new Error(result.error || `Failed to sync tour ${tourId}`);
+    }
+    return result.payloadDocId;
+  }
+
+  private async buildPayloadData(tour: Tour): Promise<PayloadTourData> {
+    const payloadData: PayloadTourData = {
+      title: tour.title,
+      img: this.toRelationshipId(tour.imgPayloadMediaSetId),
+      bookingLink: tour.bookingLink,
+      price: tour.price,
+      status: "published",
+    };
+    const locationRef = await ensurePayloadLocationRefForKey(
+      tour.locationKey,
+      this.payloadClient
+    );
+    if (locationRef) {
+      payloadData.locationRef = this.toRelationshipId(locationRef);
+    }
+    return payloadData;
+  }
+
+  private toRelationshipId(id: string): string | number {
+    const trimmed = id.trim();
+    return /^\d+$/.test(trimmed) ? Number(trimmed) : trimmed;
+  }
+
+  private sqliteTimestamp(): string {
+    const now = new Date();
+    now.setMilliseconds(0);
+    return now.toISOString().replace("T", " ").replace(".000Z", "");
+  }
+}


### PR DESCRIPTION
## Original issue

`payload-sync.service.ts` was a 507-line, 19,323-byte service (bloat score 11) combining batch orchestration, single-location synchronization, tour synchronization, change detection/status projection, collection resolution, hierarchy-ref persistence, sync-state transitions, and Payload upsert fallback policy.

## Root cause

Payload integration behavior accumulated behind one controller-facing service. New tour, media, status, and compatibility policies were added as private methods, so unrelated responsibilities shared dependencies and could only be changed or tested through the broad service.

## Refactor

- Keep `PayloadSyncService` as a 72-line compatible facade with the same constructor and four public methods.
- Extract batch ordering/throttling, location sync, tour sync, location-ref resolution, sync-state transitions, collection resolution, status projection/change detection, and entry upsert fallback into focused modules.
- Preserve existing ordering and failure semantics, including tour-before-attraction sync, stored document updates, type normalization/removal retries, partial-gallery failed states with preserved document IDs, and shared SQLite success timestamps.
- Add 13 focused tests for collection mapping, change detection, upsert/fallback behavior, configured-state handling, and batch ordering.

## Why better

Each integration policy now has one reason to change and can be tested directly. The controller/container contract remains unchanged, while the largest implementation module is 151 lines instead of 507 and no broad replacement file hides the original bloat.

## Validation

- `pnpm --filter @questurian/lm-server test` — 252 passed, 0 failed (57 files, 572 expectations).
- `bun test src/features/locations/services/integrations/payload-sync` — 13 passed, 0 failed.
- `pnpm --filter @questurian/lm-server exec tsc --noEmit -p tsconfig.json --rootDir ../..` — passed.
- Standard server `tsc --noEmit -p tsconfig.json` remains blocked by the pre-existing TS6059 `rootDir`/shared-package configuration baseline; no errors remain with the established root override.
- `pnpm --filter @questurian/lm-server lint` — completed; package script reports lint intentionally skipped because the TypeScript baseline is not clean.
- `pnpm --filter @questurian/lm-server build` — completed; package script reports no build step is needed for Bun.
- No server formatting script/config exists; `.editorconfig` conventions and `git diff --check` pass.

## Risks / tradeoffs / follow-ups

- This is a structural refactor and intentionally retains current console diagnostics, sequential throttling delays, repository calls, and error-return behavior.
- Internal collaborators are composed by the facade rather than added to the shared service container, keeping the public dependency graph stable.
- The existing server TypeScript `rootDir` configuration and intentionally skipped lint command remain repository-level follow-ups outside this finding.