### PR TITLE
NOJIRA: Decompose place details field

### DIFF
--- a/apps/questura/apps/server/src/features/places/components/PlaceDetailsField.tsx
+++ b/apps/questura/apps/server/src/features/places/components/PlaceDetailsField.tsx
@@ -1,253 +1,36 @@
 'use client'
 
-/**
- * Place Details Field Component
- *
- * A custom Payload CMS field component that shows type selectors based on selected categories.
- * When a category (Dining, Accommodations, etc.) is selected, the corresponding type dropdown appears.
- */
+import { useDocumentInfo, useField } from '@payloadcms/ui'
+import { useMemo } from 'react'
+import type { FC } from 'react'
 
-import React, { useEffect, useState, useMemo } from 'react'
-import { useField, useDocumentInfo } from '@payloadcms/ui'
-import {
-  diningTypeOptions,
-  accommodationTypeOptions,
-  nightlifeTypeOptions,
-  attractionTypeOptions,
-} from '../collections/details'
+import { getActivePlaceDetailConfigs } from '../lib/placeDetailsState'
+import { useExistingPlaceDetails } from '../hooks/useExistingPlaceDetails'
+import { usePlaceCategories } from '../hooks/usePlaceCategories'
+import { usePlaceDetailFields } from '../hooks/usePlaceDetailFields'
+import { PlaceDetailsPanel } from './place-details/PlaceDetailsPanel'
 
 type Props = {
   path: string
 }
 
-// Category slug to detail field mapping
-const CATEGORY_CONFIG: Record<
-  string,
-  {
-    label: string
-    fieldName: string
-    options: { label: string; value: string }[]
-    detailCollection: string
-  }
-> = {
-  dining: {
-    label: 'Dining Type',
-    fieldName: 'diningType',
-    options: diningTypeOptions,
-    detailCollection: 'dining-details',
-  },
-  accommodations: {
-    label: 'Accommodation Type',
-    fieldName: 'accommodationType',
-    options: accommodationTypeOptions,
-    detailCollection: 'accommodation-details',
-  },
-  nightlife: {
-    label: 'Nightlife Type',
-    fieldName: 'nightlifeType',
-    options: nightlifeTypeOptions,
-    detailCollection: 'nightlife-details',
-  },
-  attractions: {
-    label: 'Attraction Type',
-    fieldName: 'attractionType',
-    options: attractionTypeOptions,
-    detailCollection: 'attraction-details',
-  },
-}
-
-const PlaceDetailsField: React.FC<Props> = () => {
+const PlaceDetailsField: FC<Props> = () => {
   const { id } = useDocumentInfo()
+  const { value: categoriesValue } = useField<unknown>({ path: 'categories' })
+  const { categoryIds, categories } = usePlaceCategories(categoriesValue)
+  const { detailTypes, isLoading: isLoadingDetails } = useExistingPlaceDetails(id)
+  const { values, setValue } = usePlaceDetailFields(detailTypes)
 
-  // Watch the categories field - this updates when user selects categories
-  const { value: categoriesValue } = useField<any[] | null>({ path: 'categories' })
-
-  // Debug logging
-  console.log('[PlaceDetailsField] categoriesValue:', categoriesValue)
-
-  // Virtual fields to store type selections
-  const { value: diningType, setValue: setDiningType } = useField<string>({ path: 'diningType' })
-  const { value: accommodationType, setValue: setAccommodationType } = useField<string>({
-    path: 'accommodationType',
-  })
-  const { value: nightlifeType, setValue: setNightlifeType } = useField<string>({
-    path: 'nightlifeType',
-  })
-  const { value: attractionType, setValue: setAttractionType } = useField<string>({
-    path: 'attractionType',
-  })
-
-  const [categoryData, setCategoryData] = useState<Record<string, any>>({})
-  const [loadingDetails, setLoadingDetails] = useState(false)
-
-  // Get category IDs from the relationship value
-  const categoryIds = useMemo(() => {
-    if (!categoriesValue || !Array.isArray(categoriesValue)) return []
-    return categoriesValue.map((cat: any) => (typeof cat === 'object' ? cat.id : cat)).filter(Boolean)
-  }, [categoriesValue])
-
-  console.log('[PlaceDetailsField] categoryIds:', categoryIds)
-
-  // Fetch category details to get their slugs
-  useEffect(() => {
-    if (categoryIds.length === 0) {
-      setCategoryData({})
-      return
-    }
-
-    const fetchCategories = async () => {
-      const url = `/api/place-categories?where[id][in]=${categoryIds.join(',')}&depth=0`
-      console.log('[PlaceDetailsField] Fetching categories from:', url)
-      try {
-        const response = await fetch(url)
-        console.log('[PlaceDetailsField] Response status:', response.status)
-        if (response.ok) {
-          const data = await response.json()
-          console.log('[PlaceDetailsField] Category data:', data)
-          const categoryMap: Record<string, any> = {}
-          data.docs.forEach((cat: any) => {
-            categoryMap[cat.slug] = cat
-          })
-          console.log('[PlaceDetailsField] Category map:', categoryMap)
-          setCategoryData(categoryMap)
-        }
-      } catch (error) {
-        console.error('[PlaceDetailsField] Error fetching categories:', error)
-      }
-    }
-
-    fetchCategories()
-  }, [categoryIds])
-
-  // Fetch existing detail records when editing
-  useEffect(() => {
-    if (!id) return
-
-    const fetchDetails = async () => {
-      setLoadingDetails(true)
-      try {
-        // Fetch all detail records for this place in parallel
-        const detailCollections = ['dining-details', 'accommodation-details', 'nightlife-details', 'attraction-details']
-        const responses = await Promise.all(
-          detailCollections.map((collection) =>
-            fetch(`/api/${collection}?where[place][equals]=${id}&depth=0`).then((r) => r.json())
-          )
-        )
-
-        // Set the type values from existing records
-        const [dining, accommodation, nightlife, attraction] = responses
-
-        if (dining?.docs?.[0]?.type) setDiningType(dining.docs[0].type)
-        if (accommodation?.docs?.[0]?.type) setAccommodationType(accommodation.docs[0].type)
-        if (nightlife?.docs?.[0]?.type) setNightlifeType(nightlife.docs[0].type)
-        if (attraction?.docs?.[0]?.type) setAttractionType(attraction.docs[0].type)
-      } catch (error) {
-        console.error('Error fetching detail records:', error)
-      }
-      setLoadingDetails(false)
-    }
-
-    fetchDetails()
-  }, [id, setDiningType, setAccommodationType, setNightlifeType, setAttractionType])
-
-  // Get active categories (those that are selected)
-  const activeCategories = useMemo(() => {
-    return Object.keys(CATEGORY_CONFIG).filter((slug) => categoryData[slug])
-  }, [categoryData])
-
-  // Map field names to setters
-  const setters: Record<string, (value: string) => void> = {
-    diningType: setDiningType,
-    accommodationType: setAccommodationType,
-    nightlifeType: setNightlifeType,
-    attractionType: setAttractionType,
-  }
-
-  // Map field names to current values
-  const values: Record<string, string | undefined> = {
-    diningType,
-    accommodationType,
-    nightlifeType,
-    attractionType,
-  }
-
-  if (activeCategories.length === 0) {
-    return (
-      <div className="field-type" style={{ marginTop: '20px' }}>
-        <p style={{ color: 'var(--theme-elevation-500)', fontSize: '14px', fontStyle: 'italic' }}>
-          {categoryIds.length === 0
-            ? 'Select categories above to configure type details'
-            : 'Loading category details...'}
-        </p>
-      </div>
-    )
-  }
-
-  if (loadingDetails) {
-    return (
-      <div className="field-type" style={{ marginTop: '20px' }}>
-        <p style={{ color: 'var(--theme-elevation-500)', fontSize: '14px' }}>Loading details...</p>
-      </div>
-    )
-  }
+  const activeDetails = useMemo(() => getActivePlaceDetailConfigs(categories), [categories])
 
   return (
-    <div className="field-type" style={{ marginTop: '20px' }}>
-      <h4
-        style={{
-          marginBottom: '16px',
-          fontSize: '14px',
-          fontWeight: 600,
-          color: 'var(--theme-elevation-800)',
-        }}
-      >
-        Category Details
-      </h4>
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        {activeCategories.map((slug) => {
-          const config = CATEGORY_CONFIG[slug]
-          const currentValue = values[config.fieldName] || ''
-          const setValue = setters[config.fieldName]
-
-          return (
-            <div key={slug} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-              <label
-                style={{
-                  fontSize: '13px',
-                  fontWeight: 500,
-                  color: 'var(--theme-elevation-700)',
-                }}
-              >
-                {config.label}
-              </label>
-              <select
-                value={currentValue}
-                onChange={(e) => setValue(e.target.value)}
-                style={{
-                  padding: '10px 12px',
-                  fontSize: '14px',
-                  border: '1px solid var(--theme-elevation-150)',
-                  borderRadius: '4px',
-                  backgroundColor: 'var(--theme-input-bg)',
-                  color: 'var(--theme-elevation-800)',
-                  cursor: 'pointer',
-                  width: '100%',
-                  maxWidth: '300px',
-                }}
-              >
-                <option value="">Select type...</option>
-                {config.options.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )
-        })}
-      </div>
-    </div>
+    <PlaceDetailsPanel
+      activeDetails={activeDetails}
+      hasSelectedCategories={categoryIds.length > 0}
+      isLoadingDetails={isLoadingDetails}
+      values={values}
+      onChange={setValue}
+    />
   )
 }
 

--- a/apps/questura/apps/server/src/features/places/components/place-details/PlaceDetailSelect.tsx
+++ b/apps/questura/apps/server/src/features/places/components/place-details/PlaceDetailSelect.tsx
@@ -1,0 +1,29 @@
+import type { PlaceDetailConfig } from '../../types/placeDetails'
+import styles from './place-details.module.css'
+
+type PlaceDetailSelectProps = {
+  config: PlaceDetailConfig
+  value: string
+  onChange: (value: string) => void
+}
+
+export const PlaceDetailSelect = ({ config, value, onChange }: PlaceDetailSelectProps) => (
+  <div className={styles.control}>
+    <label className={styles.label} htmlFor={config.fieldName}>
+      {config.label}
+    </label>
+    <select
+      id={config.fieldName}
+      className={styles.select}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">Select type...</option>
+      {config.options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  </div>
+)

--- a/apps/questura/apps/server/src/features/places/components/place-details/PlaceDetailsPanel.tsx
+++ b/apps/questura/apps/server/src/features/places/components/place-details/PlaceDetailsPanel.tsx
@@ -1,0 +1,55 @@
+import type { DetailFieldName, DetailTypeValues, PlaceDetailConfig } from '../../types/placeDetails'
+import { PlaceDetailSelect } from './PlaceDetailSelect'
+import styles from './place-details.module.css'
+
+type PlaceDetailsPanelProps = {
+  activeDetails: readonly PlaceDetailConfig[]
+  hasSelectedCategories: boolean
+  isLoadingDetails: boolean
+  values: DetailTypeValues
+  onChange: (fieldName: DetailFieldName, value: string) => void
+}
+
+export const PlaceDetailsPanel = ({
+  activeDetails,
+  hasSelectedCategories,
+  isLoadingDetails,
+  values,
+  onChange,
+}: PlaceDetailsPanelProps) => {
+  if (activeDetails.length === 0) {
+    return (
+      <div className={styles.container}>
+        <p className={styles.emptyMessage}>
+          {hasSelectedCategories
+            ? 'Loading category details...'
+            : 'Select categories above to configure type details'}
+        </p>
+      </div>
+    )
+  }
+
+  if (isLoadingDetails) {
+    return (
+      <div className={styles.container}>
+        <p className={styles.loadingMessage}>Loading details...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.container}>
+      <h4 className={styles.heading}>Category Details</h4>
+      <div className={styles.controls}>
+        {activeDetails.map((config) => (
+          <PlaceDetailSelect
+            key={config.categorySlug}
+            config={config}
+            value={values[config.fieldName] ?? ''}
+            onChange={(value) => onChange(config.fieldName, value)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/questura/apps/server/src/features/places/components/place-details/place-details.module.css
+++ b/apps/questura/apps/server/src/features/places/components/place-details/place-details.module.css
@@ -1,0 +1,51 @@
+.container {
+  margin-top: 20px;
+}
+
+.emptyMessage {
+  color: var(--theme-elevation-500);
+  font-size: 14px;
+  font-style: italic;
+}
+
+.loadingMessage {
+  color: var(--theme-elevation-500);
+  font-size: 14px;
+}
+
+.heading {
+  margin-bottom: 16px;
+  color: var(--theme-elevation-800);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  color: var(--theme-elevation-700);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.select {
+  width: 100%;
+  max-width: 300px;
+  padding: 10px 12px;
+  border: 1px solid var(--theme-elevation-150);
+  border-radius: 4px;
+  background-color: var(--theme-input-bg);
+  color: var(--theme-elevation-800);
+  cursor: pointer;
+  font-size: 14px;
+}

--- a/apps/questura/apps/server/src/features/places/hooks/useExistingPlaceDetails.ts
+++ b/apps/questura/apps/server/src/features/places/hooks/useExistingPlaceDetails.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+
+import { mapDetailResponsesToValues } from '../lib/placeDetailsState'
+import { fetchPlaceDetailResponses } from '../services/placeDetailsApi'
+import type { DetailTypeValues, RelationshipId } from '../types/placeDetails'
+
+const EMPTY_DETAIL_TYPES: DetailTypeValues = {}
+
+export const useExistingPlaceDetails = (placeId: RelationshipId | undefined) => {
+  const [detailTypes, setDetailTypes] = useState<DetailTypeValues>(EMPTY_DETAIL_TYPES)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!placeId) {
+      setDetailTypes(EMPTY_DETAIL_TYPES)
+      setIsLoading(false)
+      return
+    }
+
+    setDetailTypes(EMPTY_DETAIL_TYPES)
+    setIsLoading(true)
+    fetchPlaceDetailResponses(placeId)
+      .then((responses) => {
+        if (!cancelled) setDetailTypes(mapDetailResponsesToValues(responses))
+      })
+      .catch((error: unknown) => {
+        console.error('[PlaceDetailsField] Error fetching detail records:', error)
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [placeId])
+
+  return { detailTypes, isLoading }
+}

--- a/apps/questura/apps/server/src/features/places/hooks/usePlaceCategories.ts
+++ b/apps/questura/apps/server/src/features/places/hooks/usePlaceCategories.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { extractRelationshipIds } from '../lib/placeDetailsState'
+import { fetchPlaceCategories } from '../services/placeDetailsApi'
+import type { PlaceCategory } from '../types/placeDetails'
+
+export const usePlaceCategories = (relationshipValue: unknown) => {
+  const categoryIds = useMemo(() => extractRelationshipIds(relationshipValue), [relationshipValue])
+  const categoryKey = JSON.stringify(categoryIds)
+  const [categories, setCategories] = useState<PlaceCategory[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (categoryIds.length === 0) {
+      setCategories([])
+      return
+    }
+
+    setCategories([])
+    fetchPlaceCategories(categoryIds)
+      .then((nextCategories) => {
+        if (!cancelled) setCategories(nextCategories)
+      })
+      .catch((error: unknown) => {
+        console.error('[PlaceDetailsField] Error fetching categories:', error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [categoryKey])
+
+  return { categoryIds, categories }
+}

--- a/apps/questura/apps/server/src/features/places/hooks/usePlaceDetailFields.ts
+++ b/apps/questura/apps/server/src/features/places/hooks/usePlaceDetailFields.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { useField } from '@payloadcms/ui'
+
+import type { DetailFieldName, DetailTypeValues } from '../types/placeDetails'
+
+export const usePlaceDetailFields = (initialValues: DetailTypeValues) => {
+  const dining = useField<string>({ path: 'diningType' })
+  const accommodation = useField<string>({ path: 'accommodationType' })
+  const nightlife = useField<string>({ path: 'nightlifeType' })
+  const attraction = useField<string>({ path: 'attractionType' })
+
+  const setters = useMemo(
+    () => ({
+      diningType: dining.setValue,
+      accommodationType: accommodation.setValue,
+      nightlifeType: nightlife.setValue,
+      attractionType: attraction.setValue,
+    }),
+    [accommodation.setValue, attraction.setValue, dining.setValue, nightlife.setValue],
+  )
+
+  useEffect(() => {
+    for (const [fieldName, value] of Object.entries(initialValues)) {
+      if (value) setters[fieldName as DetailFieldName](value)
+    }
+  }, [initialValues, setters])
+
+  const values = useMemo(
+    () => ({
+      diningType: dining.value,
+      accommodationType: accommodation.value,
+      nightlifeType: nightlife.value,
+      attractionType: attraction.value,
+    }),
+    [accommodation.value, attraction.value, dining.value, nightlife.value],
+  )
+
+  const setValue = useCallback(
+    (fieldName: DetailFieldName, value: string) => {
+      setters[fieldName](value)
+    },
+    [setters],
+  )
+
+  return { values, setValue }
+}

--- a/apps/questura/apps/server/src/features/places/lib/placeDetailsState.test.ts
+++ b/apps/questura/apps/server/src/features/places/lib/placeDetailsState.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { PLACE_DETAIL_CONFIGS } from '../placeDetailsConfig'
+import {
+  extractRelationshipIds,
+  getActivePlaceDetailConfigs,
+  mapDetailResponsesToValues,
+  parsePlaceCategories,
+} from './placeDetailsState'
+
+describe('place details state mapping', () => {
+  it('extracts valid relationship ids from Payload relationship values', () => {
+    expect(
+      extractRelationshipIds([
+        12,
+        'category-id',
+        { id: 42, slug: 'dining' },
+        { id: '' },
+        { slug: 'nightlife' },
+        null,
+      ]),
+    ).toEqual([12, 'category-id', 42])
+    expect(extractRelationshipIds(null)).toEqual([])
+  })
+
+  it('parses category documents and selects known detail configs in display order', () => {
+    const categories = parsePlaceCategories({
+      docs: [
+        { id: 4, slug: 'attractions', name: 'Attractions' },
+        { id: 1, slug: 'dining', name: 'Dining' },
+        { id: 8, slug: 'unknown' },
+        { id: null, slug: 'nightlife' },
+      ],
+    })
+
+    expect(categories).toEqual([
+      { id: 4, slug: 'attractions' },
+      { id: 1, slug: 'dining' },
+      { id: 8, slug: 'unknown' },
+    ])
+    expect(getActivePlaceDetailConfigs(categories)).toEqual([
+      PLACE_DETAIL_CONFIGS[0],
+      PLACE_DETAIL_CONFIGS[3],
+    ])
+  })
+
+  it('maps the first existing detail type to its virtual Payload field', () => {
+    expect(
+      mapDetailResponsesToValues({
+        'dining-details': { docs: [{ type: 'restaurant' }] },
+        'accommodation-details': { docs: [] },
+        'nightlife-details': { docs: [{ type: '' }] },
+        'attraction-details': { docs: [{ type: 'museum' }, { type: 'park' }] },
+      }),
+    ).toEqual({
+      diningType: 'restaurant',
+      attractionType: 'museum',
+    })
+  })
+})

--- a/apps/questura/apps/server/src/features/places/lib/placeDetailsState.ts
+++ b/apps/questura/apps/server/src/features/places/lib/placeDetailsState.ts
@@ -1,0 +1,56 @@
+import { PLACE_DETAIL_CONFIGS } from '../placeDetailsConfig'
+import type {
+  DetailCollectionSlug,
+  DetailTypeValues,
+  PlaceCategory,
+  PlaceDetailApiResponse,
+  PlaceDetailConfig,
+  RelationshipId,
+} from '../types/placeDetails'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+export const extractRelationshipIds = (value: unknown): RelationshipId[] => {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((entry) => {
+    const id = isRecord(entry) ? entry.id : entry
+    return (typeof id === 'string' || typeof id === 'number') && Boolean(id) ? [id] : []
+  })
+}
+
+export const parsePlaceCategories = (response: unknown): PlaceCategory[] => {
+  if (!isRecord(response) || !Array.isArray(response.docs)) return []
+
+  return response.docs.flatMap((doc) => {
+    if (!isRecord(doc)) return []
+
+    const { id, slug } = doc
+    if ((typeof id !== 'string' && typeof id !== 'number') || typeof slug !== 'string') {
+      return []
+    }
+
+    return [{ id, slug }]
+  })
+}
+
+export const getActivePlaceDetailConfigs = (
+  categories: readonly PlaceCategory[],
+): readonly PlaceDetailConfig[] => {
+  const selectedSlugs = new Set(categories.map(({ slug }) => slug))
+  return PLACE_DETAIL_CONFIGS.filter(({ categorySlug }) => selectedSlugs.has(categorySlug))
+}
+
+export const mapDetailResponsesToValues = (
+  responses: Partial<Record<DetailCollectionSlug, PlaceDetailApiResponse>>,
+): DetailTypeValues =>
+  PLACE_DETAIL_CONFIGS.reduce<DetailTypeValues>((values, config) => {
+    const firstDocument = responses[config.detailCollection]?.docs?.[0]
+    if (!isRecord(firstDocument) || typeof firstDocument.type !== 'string' || !firstDocument.type) {
+      return values
+    }
+
+    values[config.fieldName] = firstDocument.type
+    return values
+  }, {})

--- a/apps/questura/apps/server/src/features/places/placeDetailsConfig.ts
+++ b/apps/questura/apps/server/src/features/places/placeDetailsConfig.ts
@@ -1,0 +1,38 @@
+import {
+  accommodationTypeOptions,
+  attractionTypeOptions,
+  diningTypeOptions,
+  nightlifeTypeOptions,
+} from './collections/details'
+import type { PlaceDetailConfig } from './types/placeDetails'
+
+export const PLACE_DETAIL_CONFIGS = [
+  {
+    categorySlug: 'dining',
+    label: 'Dining Type',
+    fieldName: 'diningType',
+    options: diningTypeOptions,
+    detailCollection: 'dining-details',
+  },
+  {
+    categorySlug: 'accommodations',
+    label: 'Accommodation Type',
+    fieldName: 'accommodationType',
+    options: accommodationTypeOptions,
+    detailCollection: 'accommodation-details',
+  },
+  {
+    categorySlug: 'nightlife',
+    label: 'Nightlife Type',
+    fieldName: 'nightlifeType',
+    options: nightlifeTypeOptions,
+    detailCollection: 'nightlife-details',
+  },
+  {
+    categorySlug: 'attractions',
+    label: 'Attraction Type',
+    fieldName: 'attractionType',
+    options: attractionTypeOptions,
+    detailCollection: 'attraction-details',
+  },
+] as const satisfies readonly PlaceDetailConfig[]

--- a/apps/questura/apps/server/src/features/places/services/placeDetailsApi.test.ts
+++ b/apps/questura/apps/server/src/features/places/services/placeDetailsApi.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchPlaceCategories, fetchPlaceDetailResponses } from './placeDetailsApi'
+
+const jsonResponse = (data: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => data,
+})
+
+describe('place details API', () => {
+  it('loads selected categories through the Payload REST filter', async () => {
+    const fetcher = vi.fn(async () =>
+      jsonResponse({ docs: [{ id: 1, slug: 'dining', name: 'Dining' }] }),
+    )
+
+    await expect(fetchPlaceCategories([1, 'category-2'], fetcher)).resolves.toEqual([
+      { id: 1, slug: 'dining' },
+    ])
+    expect(fetcher).toHaveBeenCalledWith('/api/place-categories?where[id][in]=1,category-2&depth=0')
+  })
+
+  it('loads every detail collection in parallel for an existing place', async () => {
+    const fetcher = vi.fn(async (url: string) =>
+      jsonResponse({ docs: [{ type: url.includes('dining-details') ? 'cafe' : null }] }),
+    )
+
+    const result = await fetchPlaceDetailResponses(25, fetcher)
+
+    expect(fetcher).toHaveBeenCalledTimes(4)
+    expect(fetcher).toHaveBeenCalledWith('/api/dining-details?where[place][equals]=25&depth=0')
+    expect(result['dining-details']).toEqual({ docs: [{ type: 'cafe' }] })
+  })
+
+  it('rejects a failed Payload response', async () => {
+    const fetcher = vi.fn(async () => jsonResponse({}, 503))
+
+    await expect(fetchPlaceCategories([1], fetcher)).rejects.toThrow(
+      'Place details request failed (503)',
+    )
+  })
+})

--- a/apps/questura/apps/server/src/features/places/services/placeDetailsApi.ts
+++ b/apps/questura/apps/server/src/features/places/services/placeDetailsApi.ts
@@ -1,0 +1,58 @@
+import { PLACE_DETAIL_CONFIGS } from '../placeDetailsConfig'
+import { parsePlaceCategories } from '../lib/placeDetailsState'
+import type {
+  DetailCollectionSlug,
+  PlaceCategory,
+  PlaceDetailApiResponse,
+  RelationshipId,
+} from '../types/placeDetails'
+
+type JsonResponse = {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+}
+
+export type PlaceDetailsFetcher = (url: string) => Promise<JsonResponse>
+
+const readJson = async (fetcher: PlaceDetailsFetcher, url: string): Promise<unknown> => {
+  const response = await fetcher(url)
+  if (!response.ok) {
+    throw new Error(`Place details request failed (${response.status})`)
+  }
+  return response.json()
+}
+
+export const fetchPlaceCategories = async (
+  ids: readonly RelationshipId[],
+  fetcher: PlaceDetailsFetcher = fetch,
+): Promise<PlaceCategory[]> => {
+  if (ids.length === 0) return []
+
+  const data = await readJson(
+    fetcher,
+    `/api/place-categories?where[id][in]=${ids.join(',')}&depth=0`,
+  )
+  return parsePlaceCategories(data)
+}
+
+export const fetchPlaceDetailResponses = async (
+  placeId: RelationshipId,
+  fetcher: PlaceDetailsFetcher = fetch,
+): Promise<Record<DetailCollectionSlug, PlaceDetailApiResponse>> => {
+  const entries = await Promise.all(
+    PLACE_DETAIL_CONFIGS.map(async ({ detailCollection }) => {
+      const response = await readJson(
+        fetcher,
+        `/api/${detailCollection}?where[place][equals]=${placeId}&depth=0`,
+      )
+      const data =
+        typeof response === 'object' && response !== null
+          ? (response as PlaceDetailApiResponse)
+          : {}
+      return [detailCollection, data] as const
+    }),
+  )
+
+  return Object.fromEntries(entries) as Record<DetailCollectionSlug, PlaceDetailApiResponse>
+}

--- a/apps/questura/apps/server/src/features/places/types/placeDetails.ts
+++ b/apps/questura/apps/server/src/features/places/types/placeDetails.ts
@@ -1,0 +1,35 @@
+export type RelationshipId = string | number
+
+export type DetailFieldName =
+  | 'diningType'
+  | 'accommodationType'
+  | 'nightlifeType'
+  | 'attractionType'
+
+export type DetailCollectionSlug =
+  | 'dining-details'
+  | 'accommodation-details'
+  | 'nightlife-details'
+  | 'attraction-details'
+
+export type DetailTypeValues = Partial<Record<DetailFieldName, string>>
+
+export type PlaceCategory = {
+  id: RelationshipId
+  slug: string
+}
+
+export type PlaceDetailConfig = {
+  categorySlug: string
+  label: string
+  fieldName: DetailFieldName
+  options: readonly {
+    label: string
+    value: string
+  }[]
+  detailCollection: DetailCollectionSlug
+}
+
+export type PlaceDetailApiResponse = {
+  docs?: unknown[]
+}


### PR DESCRIPTION
## Issue

`PlaceDetailsField.tsx` had accumulated category relationship parsing, REST requests, existing-detail hydration, four hidden Payload field bindings, category-to-detail mapping, loading states, and all rendering/styling in one 254-line admin component.

## Root cause

The component grew around the `placeCategoryFields` UI registration without a boundary between Payload form state, asynchronous data access, category/detail transformations, and presentation. Untyped `any` values and inline field/collection maps made those responsibilities difficult to test independently, while overlapping category or document requests could complete out of order.

## Refactor

- Keep `src/features/places/components/PlaceDetailsField.tsx` as the default-exported registration target and reduce it to a 37-line orchestrator.
- Move the shared category/field/collection contract into typed config and domain types.
- Move Payload REST reads into `placeDetailsApi.ts`.
- Move relationship/category/detail response transformations into pure `placeDetailsState.ts` helpers.
- Isolate selected-category loading, existing-detail hydration, and hidden Payload field coordination in dedicated hooks.
- Split rendering into a panel and select component, with the existing visual rules in a scoped CSS module.
- Cancel stale async effects so a response for an earlier category selection or document cannot overwrite the current state.
- Remove development-only console logging while preserving error reporting.

## Design

The data flow is now:

`PlaceDetailsField` → category/detail hooks → API service → pure mapping → Payload field bindings → presentational panel/select.

The existing external contract remains unchanged:

- default component export and registration path
- `categories` relationship field
- `diningType`, `accommodationType`, `nightlifeType`, and `attractionType` virtual fields
- four detail collection REST routes and selected-option values
- category display order and loading/empty copy

## Validation

- `pnpm exec prettier --check <changed files>` — passed
- targeted ESLint for all changed TypeScript/TSX files — passed
- targeted strict TypeScript compile for production files — passed
- focused Vitest run (`placeDetailsState`, `placeDetailsApi`, existing `Places` hook wiring) — 3 files / 9 tests passed
- `pnpm test` — 60 files / 354 tests passed
- Payload type generation under Node 20.19.4 — passed
- Next.js production build under Node 20.19.4 — passed (45 static pages; local Better Auth secret-strength warnings only)
- `git diff --check` — passed

Repository-wide checks with pre-existing failures:

- `pnpm lint` reaches one unrelated error in `FocalPointPickerField.tsx`: the configured `@next/next/no-img-element` rule is unavailable. Changed files pass targeted lint.
- `pnpm exec tsc --noEmit` reaches existing errors across scripts, article fields/tests, homepage modules, shared modules, and the unregistered Places detail hooks. Changed production files pass the targeted strict compile.
- The host Node 18.19.1 is below `@questura/server`'s declared engine and crashes current Undici during Payload generation; generation/build were therefore run with Node 20.19.4.

## Risks

- This is an admin-form structural refactor; no collection schema, migration, REST route, or persistence hook changed.
- Fetch failures retain the existing user-facing loading/empty behavior and are reported to the console.
- Request cancellation is local to state application; it does not abort the underlying HTTP request.

## Follow-ups

`Places`, `PlaceCategories`, and the four detail collections are exported by the feature but are not currently included in `src/payload.config.ts`; consequently Payload's generated import map does not include this component today. Activating those collections is a separate schema/migration decision and intentionally remains outside this PR.
