### PR TITLE
NOJIRA: Split editorial publish workflow phases

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishUi.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishUi.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useEditorialStagePublishUi } from './useEditorialStagePublishUi'
+
+describe('useEditorialStagePublishUi', () => {
+  it('maps workflow lifecycle callbacks to reducer events', () => {
+    const dispatchUi = vi.fn()
+    const { result } = renderHook(() =>
+      useEditorialStagePublishUi({
+        dispatchUi,
+        publishPhase: 'validating',
+        publishResult: null
+      })
+    )
+
+    act(() => {
+      result.current.lifecycle.request()
+      result.current.lifecycle.converting()
+      result.current.lifecycle.submitting()
+      result.current.lifecycle.succeed('Published')
+      result.current.lifecycle.fail('Failed')
+    })
+
+    expect(dispatchUi.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'PUBLISH_REQUEST' },
+      { type: 'PUBLISH_CONVERTING' },
+      { type: 'PUBLISH_SUBMITTING' },
+      { type: 'PUBLISH_SUCCESS', message: 'Published' },
+      { type: 'PUBLISH_FAILURE', message: 'Failed' }
+    ])
+    expect(result.current.isPublishing).toBe(true)
+    expect(result.current.isConverting).toBe(false)
+  })
+
+  it('derives conversion UI state and preserves the publish result', () => {
+    const publishResult = { success: false, message: 'Failed' }
+    const { result } = renderHook(() =>
+      useEditorialStagePublishUi({
+        dispatchUi: vi.fn(),
+        publishPhase: 'converting',
+        publishResult
+      })
+    )
+
+    expect(result.current.isPublishing).toBe(true)
+    expect(result.current.isConverting).toBe(true)
+    expect(result.current.publishResult).toBe(publishResult)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishUi.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishUi.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+import type {
+  EditorialStageUiEvent,
+  PublishPhase,
+  PublishResult
+} from '../state/editorialStageUiMachine'
+import type { EditorialPublishLifecycle } from '../services/editorial-stage-publish-workflow.service'
+
+type UseEditorialStagePublishUiParams = {
+  dispatchUi: (event: EditorialStageUiEvent) => void
+  publishPhase: PublishPhase
+  publishResult: PublishResult
+}
+
+export function useEditorialStagePublishUi({
+  dispatchUi,
+  publishPhase,
+  publishResult
+}: UseEditorialStagePublishUiParams) {
+  const lifecycle = useMemo<EditorialPublishLifecycle>(
+    () => ({
+      request: () => dispatchUi({ type: 'PUBLISH_REQUEST' }),
+      converting: () => dispatchUi({ type: 'PUBLISH_CONVERTING' }),
+      submitting: () => dispatchUi({ type: 'PUBLISH_SUBMITTING' }),
+      succeed: (message) => dispatchUi({ type: 'PUBLISH_SUCCESS', message }),
+      fail: (message) => dispatchUi({ type: 'PUBLISH_FAILURE', message })
+    }),
+    [dispatchUi]
+  )
+
+  return {
+    lifecycle,
+    isPublishing:
+      publishPhase === 'validating' ||
+      publishPhase === 'converting' ||
+      publishPhase === 'publishing',
+    isConverting: publishPhase === 'converting',
+    publishResult
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishWorkflow.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishWorkflow.ts
@@ -1,34 +1,19 @@
 import { useCallback, useMemo } from 'react'
+import { getSchemaPublisherConfig } from '../../../../../shared/seo/services/schema-publisher-config.service'
 import type { Location, MediaAsset } from '../../../api'
 import type { CreateArticlePayload } from '../../../api'
 import type { PayloadArticleDoc } from '../../../api/articles/articles.types'
 import type { StagedArticle } from '../../../types'
-import { getSchemaPublisherConfig } from '../../../../../shared/seo/services/schema-publisher-config.service'
-import { buildSeoPayload } from '../../../../../shared/seo/services/seo-section.service'
 import type { EditorialPublishAnalysis } from '../editorial-markdown.service'
-import { FEATURED_IMAGE_VARIANT } from '../constants'
-import { buildPayloadContentBlocks } from '../services/editorial-stage-publish.service'
-import { buildPayloadArticleMetadataPatch } from '../services/payload-article-metadata.service'
-import {
-  buildLegacyStandardArticleStructuredDataTemplate,
-  buildStandardArticleStructuredDataTemplate,
-  isSeoCoreComplete,
-  serializeStandardArticleStructuredDataTemplate,
-  shouldAutoManageStandardArticleStructuredData,
-  validateStandardArticleSeoSection,
-} from '../services/standard-article-seo.service'
+import { runEditorialStagePublishWorkflow } from '../services/editorial-stage-publish-workflow.service'
+import type { EditorialPublishTargetStatus } from '../services/editorial-stage-publish-validation.service'
+import type {
+  EditorialStageUiEvent,
+  PublishPhase
+} from '../state/editorialStageUiMachine'
 import type { MediaVariant } from '../types'
 import type { TimelineItem } from '../workflow.service'
-import type { EditorialStageUiEvent, PublishPhase } from '../state/editorialStageUiMachine'
-import { getLocationDisplayName } from '../utils/editorial-stage-view.utils'
-import { sanitizeSharedNeighborhoods } from '../utils/sharedNeighborhoods'
-import { markDraftAsPayloadSynced } from '../../../../../shared/payloadSync/draftPayloadSync'
-import {
-  buildStagedArticlePayloadComparableShape,
-  hasPayloadArticleIdentity,
-} from '../services/staged-article-payload-sync.service'
-
-type DispatchUiEvent = (event: EditorialStageUiEvent) => void
+import { useEditorialStagePublishUi } from './useEditorialStagePublishUi'
 
 type UseEditorialStagePublishWorkflowParams = {
   token: string | null | undefined
@@ -43,15 +28,25 @@ type UseEditorialStagePublishWorkflowParams = {
     data?: object
     error?: string
   }>
-  createArticle: (payload: CreateArticlePayload, token: string) => Promise<PayloadArticleDoc>
-  updateArticle?: (id: number, payload: CreateArticlePayload, token: string) => Promise<PayloadArticleDoc>
+  createArticle: (
+    payload: CreateArticlePayload,
+    token: string
+  ) => Promise<PayloadArticleDoc>
+  updateArticle?: (
+    id: number,
+    payload: CreateArticlePayload,
+    token: string
+  ) => Promise<PayloadArticleDoc>
   markArticleSynced: (
     runId: string,
     payloadArticleId: number
   ) => Promise<{ message: string; run_id: string; payload_article_id: number }>
-  findPreferredVariantAsset: (assetId: number, preferredVariant: MediaVariant) => MediaAsset | null
+  findPreferredVariantAsset: (
+    assetId: number,
+    preferredVariant: MediaVariant
+  ) => MediaAsset | null
   updateStagedArticle: (updates: Partial<StagedArticle>) => void
-  dispatchUi: DispatchUiEvent
+  dispatchUi: (event: EditorialStageUiEvent) => void
   publishPhase: PublishPhase
   publishResult: { success: boolean; message: string } | null
 }
@@ -70,323 +65,67 @@ export function useEditorialStagePublishWorkflow({
   markArticleSynced,
   findPreferredVariantAsset,
   updateStagedArticle,
-  dispatchUi,
   publishPhase,
   publishResult,
+  dispatchUi
 }: UseEditorialStagePublishWorkflowParams) {
-  const schemaPublisherConfig = useMemo(() => getSchemaPublisherConfig(), [])
-
-  const handlePublish = useCallback(async (targetStatus: 'draft' | 'published') => {
-    if (!token || !stagedArticle) return
-
-    dispatchUi({ type: 'PUBLISH_REQUEST' })
-
-    const trimmedTitle = stagedArticle.title.trim()
-    const location = locations.find((candidate) => candidate.id === stagedArticle.locationId)
-    const sharedNeighborhoods = sanitizeSharedNeighborhoods(
-      stagedArticle.sharedNeighborhoods,
+  const publisherConfig = useMemo(() => getSchemaPublisherConfig(), [])
+  const workflow = useMemo(
+    () => ({
+      sourceFeature,
+      stagedArticle,
       locations,
-      stagedArticle.locationId
-    )
-    const resolvedFeaturedAsset = stagedArticle.featuredImageId
-      ? findPreferredVariantAsset(stagedArticle.featuredImageId, FEATURED_IMAGE_VARIANT)
-      : null
-    const fallbackFeaturedImageId = Number(stagedArticle.featuredImageId)
-    const featuredImageId = resolvedFeaturedAsset?.id
-      ?? (Number.isFinite(fallbackFeaturedImageId) && fallbackFeaturedImageId > 0
-        ? fallbackFeaturedImageId
-        : null)
-    const seoSection = stagedArticle.seoSection ?? {
-      seoTitle: '',
-      metaDescription: '',
-      openGraph: {
-        title: '',
-        description: '',
-        imageUrl: '',
-        url: '',
-      },
-      twitterCard: {
-        card: 'summary',
-        title: '',
-        description: '',
-        imageUrl: '',
-      },
-      structuredData: '',
-      robots: {
-        index: 'index',
-        follow: 'follow',
-      },
-    }
-
-    if (!trimmedTitle) {
-      dispatchUi({
-        type: 'PUBLISH_FAILURE',
-        message: 'Please enter an article title',
-      })
-      return
-    }
-
-    if (!location || !featuredImageId) {
-      dispatchUi({
-        type: 'PUBLISH_FAILURE',
-        message: !location ? 'Please select a location' : 'Please select a featured image',
-      })
-      return
-    }
-
-    const locationLabel = [
-      location.neighborhoodName,
-      location.cityName,
-      location.countryName,
-    ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0).join(', ')
-      || getLocationDisplayName(location)
-      || location.locationKey
-    const prePublishStructuredData = serializeStandardArticleStructuredDataTemplate(
-      buildStandardArticleStructuredDataTemplate({
-        stagedArticle: {
-          ...stagedArticle,
-          seoSection,
-        },
-        locationLabel,
-        publisherConfig: schemaPublisherConfig,
-      }),
-    )
-    const legacyStructuredData = serializeStandardArticleStructuredDataTemplate(
-      buildLegacyStandardArticleStructuredDataTemplate({
-        stagedArticle: {
-          ...stagedArticle,
-          seoSection,
-        },
-        locationLabel,
-      }),
-    )
-    const shouldRefreshDraftStructuredData = shouldAutoManageStandardArticleStructuredData({
-      existingStructuredData: seoSection.structuredData.trim(),
-      nextStructuredData: prePublishStructuredData,
-      legacyStructuredData,
-    })
-    const seoSectionForSubmit = targetStatus === 'published'
-      ? {
-          ...seoSection,
-          structuredData: prePublishStructuredData,
-        }
-      : shouldRefreshDraftStructuredData
-        ? {
-            ...seoSection,
-            structuredData: prePublishStructuredData,
-          }
-        : seoSection
-
-    if (targetStatus === 'published') {
-      if (!isSeoCoreComplete(seoSectionForSubmit)) {
-        dispatchUi({
-          type: 'PUBLISH_FAILURE',
-          message: 'Publishing requires SEO title and meta description.',
-        })
-        return
-      }
-
-      if (!seoSectionForSubmit.structuredData.trim()) {
-        dispatchUi({
-          type: 'PUBLISH_FAILURE',
-          message: 'Publishing requires structured data.',
-        })
-        return
-      }
-
-      if (!seoSectionForSubmit.openGraph.imageUrl.trim()) {
-        dispatchUi({
-          type: 'PUBLISH_FAILURE',
-          message: 'Publishing requires an Open Graph image URL.',
-        })
-        return
-      }
-
-      const seoIssues = validateStandardArticleSeoSection({
-        seoSection: seoSectionForSubmit,
-        locationLabel,
-      })
-      if (seoIssues.length > 0) {
-        dispatchUi({
-          type: 'PUBLISH_FAILURE',
-          message: seoIssues[0],
-        })
-        return
-      }
-    }
-
-    if (editorialPublishAnalysis.hasBlockingBlocks) {
-      const previewMessage = editorialPublishAnalysis.blockingBlocks
-        .slice(0, 2)
-        .map((block) => block.message)
-        .join(' · ')
-      const remainingCount = editorialPublishAnalysis.blockingBlocks.length - 2
-      const remainingSuffix = remainingCount > 0 ? ` (+${remainingCount} more)` : ''
-      dispatchUi({
-        type: 'PUBLISH_FAILURE',
-        message: previewMessage
-          ? `Fix editorial blocks before publishing: ${previewMessage}${remainingSuffix}`
-          : 'Fix editorial blocks before publishing',
-      })
-      return
-    }
-
-    try {
-      dispatchUi({ type: 'PUBLISH_CONVERTING' })
-
-      const { contentBlocks, textBlocksAdded } = await buildPayloadContentBlocks({
-        stagedArticle,
-        timelineItems,
-        editorialPublishAnalysis,
-        mediaAssets,
-        convertMarkdownToLexical,
-      })
-
-      if (textBlocksAdded === 0) {
-        throw new Error('Add at least one text block with content before publishing')
-      }
-
-      dispatchUi({ type: 'PUBLISH_SUBMITTING' })
-
-      const payload: CreateArticlePayload = {
-        title: trimmedTitle,
-        ...(stagedArticle.payloadSlug?.trim() ? { slug: stagedArticle.payloadSlug.trim() } : {}),
-        location: location.locationKey,
-        locationRef: location.id,
-        sharedNeighborhoods,
-        step1_complete: true,
-        status: targetStatus,
-        ...(sourceFeature ? { sourceFeature } : {}),
-        ...(stagedArticle.runId ? { sourceRunId: stagedArticle.runId } : {}),
-        headerSection: {
-          featuredImage: featuredImageId,
-        },
-        contentBlocks,
-        seoSection: buildSeoPayload(seoSectionForSubmit),
-      }
-
-      let result = (
-        stagedArticle.payloadArticleId && updateArticle
-          ? await updateArticle(stagedArticle.payloadArticleId, payload, token)
-          : await createArticle(payload, token)
-      )
-
-      let nextSeoSection = seoSectionForSubmit
-
-      if (targetStatus === 'published' && updateArticle) {
-        const publishedStructuredData = serializeStandardArticleStructuredDataTemplate(
-          buildStandardArticleStructuredDataTemplate({
-            stagedArticle: {
-              ...stagedArticle,
-              ...buildPayloadArticleMetadataPatch({
-                doc: result,
-                fallbackAuthorName: schemaPublisherConfig.defaultAuthorName,
-              }),
-              seoSection: seoSectionForSubmit,
-            },
-            locationLabel,
-            publisherConfig: schemaPublisherConfig,
-          }),
-        )
-
-        nextSeoSection = {
-          ...seoSectionForSubmit,
-          structuredData: publishedStructuredData,
-        }
-
-        if (publishedStructuredData !== seoSectionForSubmit.structuredData.trim()) {
-          result = await updateArticle(result.id, {
-            ...payload,
-            seoSection: buildSeoPayload(nextSeoSection),
-          }, token)
-        }
-      }
-
-      // Local sync bookkeeping only — the Payload save above already succeeded,
-      // so a missing/deleted local run row must not surface as a publish failure.
-      let syncBookkeepingFailed = false
-      try {
-        await markArticleSynced(stagedArticle.runId, result.id)
-      } catch (syncError) {
-        syncBookkeepingFailed = true
-        console.warn(
-          `Article #${result.id} saved to Payload, but marking run ${stagedArticle.runId} as synced failed:`,
-          syncError,
-        )
-      }
-
-      const payloadMetadataPatch = buildPayloadArticleMetadataPatch({
-        doc: result,
-        fallbackAuthorName: schemaPublisherConfig.defaultAuthorName,
-      })
-      const syncedArticle = markDraftAsPayloadSynced(
-        {
-          ...stagedArticle,
-          ...payloadMetadataPatch,
-          seoSection: nextSeoSection,
-          lexicalConverted: true,
-        },
-        buildStagedArticlePayloadComparableShape,
-        result.updatedAt || new Date().toISOString(),
-        { hasPayloadIdentity: hasPayloadArticleIdentity },
-      )
-
-      updateStagedArticle({
-        ...payloadMetadataPatch,
-        seoSection: nextSeoSection,
-        lexicalConverted: true,
-        currentPayloadSignature: syncedArticle.currentPayloadSignature,
-        lastPayloadSyncSignature: syncedArticle.lastPayloadSyncSignature,
-        lastPayloadSyncAt: syncedArticle.lastPayloadSyncAt,
-        hasUnsyncedPayloadChanges: syncedArticle.hasUnsyncedPayloadChanges,
-      })
-
-      const successMessage = targetStatus === 'published'
-        ? (stagedArticle.payloadStatus === 'published'
-          ? `Updated published article #${result.id}`
-          : `Published article #${result.id}`)
-        : `Saved draft article #${result.id}`
-
-      dispatchUi({
-        type: 'PUBLISH_SUCCESS',
-        message: syncBookkeepingFailed
-          ? `${successMessage} (local run record missing, sync status not recorded)`
-          : successMessage,
-      })
-    } catch (error) {
-      dispatchUi({
-        type: 'PUBLISH_FAILURE',
-        message: error instanceof Error ? error.message : 'Failed to sync article',
-      })
-    }
-  }, [
-    token,
-    sourceFeature,
-    stagedArticle,
-    dispatchUi,
-    locations,
-    findPreferredVariantAsset,
-    mediaAssets,
-    convertMarkdownToLexical,
-    createArticle,
-    updateArticle,
-    editorialPublishAnalysis,
-    markArticleSynced,
-    schemaPublisherConfig,
-    timelineItems,
-    updateStagedArticle,
-  ])
-
-  const isPublishing = useMemo(
-    () => publishPhase === 'validating' || publishPhase === 'converting' || publishPhase === 'publishing',
-    [publishPhase]
+      mediaAssets,
+      timelineItems,
+      editorialPublishAnalysis,
+      convertMarkdownToLexical,
+      createArticle,
+      updateArticle,
+      markArticleSynced,
+      findPreferredVariantAsset,
+      updateStagedArticle
+    }),
+    [
+      sourceFeature,
+      stagedArticle,
+      locations,
+      mediaAssets,
+      timelineItems,
+      editorialPublishAnalysis,
+      convertMarkdownToLexical,
+      createArticle,
+      updateArticle,
+      markArticleSynced,
+      findPreferredVariantAsset,
+      updateStagedArticle
+    ]
   )
-  const isConverting = useMemo(() => publishPhase === 'converting', [publishPhase])
+  const publishUi = useEditorialStagePublishUi({
+    dispatchUi,
+    publishPhase,
+    publishResult
+  })
+
+  const handlePublish = useCallback(
+    async (targetStatus: EditorialPublishTargetStatus) => {
+      if (!token || !stagedArticle) return
+
+      await runEditorialStagePublishWorkflow({
+        ...workflow,
+        token,
+        targetStatus,
+        stagedArticle,
+        publisherConfig,
+        lifecycle: publishUi.lifecycle
+      })
+    },
+    [publisherConfig, publishUi.lifecycle, stagedArticle, token, workflow]
+  )
 
   return {
     handlePublish,
-    isPublishing,
-    isConverting,
-    publishResult,
+    isPublishing: publishUi.isPublishing,
+    isConverting: publishUi.isConverting,
+    publishResult: publishUi.publishResult
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-persistence.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-persistence.service.ts
@@ -1,0 +1,186 @@
+import type { SchemaPublisherConfig } from '../../../../../shared/seo/services/schema-publisher-config.service'
+import { buildSeoPayload } from '../../../../../shared/seo/services/seo-section.service'
+import type { SeoSection } from '../../../../../shared/seo/types'
+import { markDraftAsPayloadSynced } from '../../../../../shared/payloadSync/draftPayloadSync'
+import type { CreateArticlePayload } from '../../../api'
+import type { PayloadArticleDoc } from '../../../api/articles/articles.types'
+import type { StagedArticle } from '../../../types'
+import type { PayloadContentBlock } from '../editorial-markdown.service'
+import { buildPayloadArticleMetadataPatch } from './payload-article-metadata.service'
+import {
+  buildStagedArticlePayloadComparableShape,
+  hasPayloadArticleIdentity
+} from './staged-article-payload-sync.service'
+import { preparePublishedEditorialSeoSection } from './editorial-stage-publish-structured-data.service'
+import type {
+  EditorialPublishInput,
+  EditorialPublishTargetStatus
+} from './editorial-stage-publish-validation.service'
+
+type PersistEditorialStageArticleParams = {
+  token: string
+  sourceFeature: string
+  targetStatus: EditorialPublishTargetStatus
+  stagedArticle: StagedArticle
+  publishInput: EditorialPublishInput
+  seoSection: SeoSection
+  contentBlocks: PayloadContentBlock[]
+  publisherConfig: SchemaPublisherConfig
+  createArticle: (
+    payload: CreateArticlePayload,
+    token: string
+  ) => Promise<PayloadArticleDoc>
+  updateArticle?: (
+    id: number,
+    payload: CreateArticlePayload,
+    token: string
+  ) => Promise<PayloadArticleDoc>
+  markArticleSynced: (
+    runId: string,
+    payloadArticleId: number
+  ) => Promise<{ message: string; run_id: string; payload_article_id: number }>
+}
+
+export type PersistEditorialStageArticleResult = {
+  article: PayloadArticleDoc
+  stagedArticlePatch: Partial<StagedArticle>
+  syncBookkeepingFailed: boolean
+}
+
+function buildArticlePayload(input: {
+  sourceFeature: string
+  targetStatus: EditorialPublishTargetStatus
+  stagedArticle: StagedArticle
+  publishInput: EditorialPublishInput
+  seoSection: SeoSection
+  contentBlocks: PayloadContentBlock[]
+}): CreateArticlePayload {
+  const {
+    sourceFeature,
+    targetStatus,
+    stagedArticle,
+    publishInput,
+    seoSection,
+    contentBlocks
+  } = input
+
+  return {
+    title: publishInput.title,
+    ...(stagedArticle.payloadSlug?.trim()
+      ? { slug: stagedArticle.payloadSlug.trim() }
+      : {}),
+    location: publishInput.location.locationKey,
+    locationRef: publishInput.location.id,
+    sharedNeighborhoods: publishInput.sharedNeighborhoods,
+    step1_complete: true,
+    status: targetStatus,
+    ...(sourceFeature ? { sourceFeature } : {}),
+    ...(stagedArticle.runId ? { sourceRunId: stagedArticle.runId } : {}),
+    headerSection: {
+      featuredImage: publishInput.featuredImageId
+    },
+    contentBlocks,
+    seoSection: buildSeoPayload(seoSection)
+  }
+}
+
+async function persistPayloadArticle(
+  input: PersistEditorialStageArticleParams
+): Promise<{
+  article: PayloadArticleDoc
+  seoSection: SeoSection
+}> {
+  const payload = buildArticlePayload(input)
+  let article =
+    input.stagedArticle.payloadArticleId && input.updateArticle
+      ? await input.updateArticle(
+          input.stagedArticle.payloadArticleId,
+          payload,
+          input.token
+        )
+      : await input.createArticle(payload, input.token)
+  let seoSection = input.seoSection
+
+  if (input.targetStatus !== 'published' || !input.updateArticle) {
+    return { article, seoSection }
+  }
+
+  const publishedSeoSection = preparePublishedEditorialSeoSection({
+    stagedArticle: input.stagedArticle,
+    seoSection,
+    locationLabel: input.publishInput.locationLabel,
+    publisherConfig: input.publisherConfig,
+    publishedArticle: article
+  })
+
+  if (publishedSeoSection.structuredData !== seoSection.structuredData.trim()) {
+    article = await input.updateArticle(
+      article.id,
+      {
+        ...payload,
+        seoSection: buildSeoPayload(publishedSeoSection)
+      },
+      input.token
+    )
+  }
+
+  seoSection = publishedSeoSection
+  return { article, seoSection }
+}
+
+async function recordLocalSync(input: {
+  article: PayloadArticleDoc
+  stagedArticle: StagedArticle
+  markArticleSynced: PersistEditorialStageArticleParams['markArticleSynced']
+}): Promise<boolean> {
+  try {
+    await input.markArticleSynced(input.stagedArticle.runId, input.article.id)
+    return false
+  } catch (error) {
+    console.warn(
+      `Article #${input.article.id} saved to Payload, but marking run ${input.stagedArticle.runId} as synced failed:`,
+      error
+    )
+    return true
+  }
+}
+
+export async function persistEditorialStageArticle(
+  input: PersistEditorialStageArticleParams
+): Promise<PersistEditorialStageArticleResult> {
+  const { article, seoSection } = await persistPayloadArticle(input)
+  const syncBookkeepingFailed = await recordLocalSync({
+    article,
+    stagedArticle: input.stagedArticle,
+    markArticleSynced: input.markArticleSynced
+  })
+  const metadataPatch = buildPayloadArticleMetadataPatch({
+    doc: article,
+    fallbackAuthorName: input.publisherConfig.defaultAuthorName
+  })
+  const syncedArticle = markDraftAsPayloadSynced(
+    {
+      ...input.stagedArticle,
+      ...metadataPatch,
+      seoSection,
+      lexicalConverted: true
+    },
+    buildStagedArticlePayloadComparableShape,
+    article.updatedAt || new Date().toISOString(),
+    { hasPayloadIdentity: hasPayloadArticleIdentity }
+  )
+
+  return {
+    article,
+    syncBookkeepingFailed,
+    stagedArticlePatch: {
+      ...metadataPatch,
+      seoSection,
+      lexicalConverted: true,
+      currentPayloadSignature: syncedArticle.currentPayloadSignature,
+      lastPayloadSyncSignature: syncedArticle.lastPayloadSyncSignature,
+      lastPayloadSyncAt: syncedArticle.lastPayloadSyncAt,
+      hasUnsyncedPayloadChanges: syncedArticle.hasUnsyncedPayloadChanges
+    }
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-structured-data.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-structured-data.service.ts
@@ -1,0 +1,89 @@
+import type { SchemaPublisherConfig } from '../../../../../shared/seo/services/schema-publisher-config.service'
+import type { SeoSection } from '../../../../../shared/seo/types'
+import type { PayloadArticleDoc } from '../../../api/articles/articles.types'
+import type { StagedArticle } from '../../../types'
+import { buildPayloadArticleMetadataPatch } from './payload-article-metadata.service'
+import {
+  buildLegacyStandardArticleStructuredDataTemplate,
+  buildStandardArticleStructuredDataTemplate,
+  serializeStandardArticleStructuredDataTemplate,
+  shouldAutoManageStandardArticleStructuredData
+} from './standard-article-seo.service'
+import type { EditorialPublishTargetStatus } from './editorial-stage-publish-validation.service'
+
+type StructuredDataContext = {
+  stagedArticle: StagedArticle
+  seoSection: SeoSection
+  locationLabel: string
+  publisherConfig: SchemaPublisherConfig
+}
+
+function buildStructuredData({
+  stagedArticle,
+  seoSection,
+  locationLabel,
+  publisherConfig
+}: StructuredDataContext): string {
+  return serializeStandardArticleStructuredDataTemplate(
+    buildStandardArticleStructuredDataTemplate({
+      stagedArticle: {
+        ...stagedArticle,
+        seoSection
+      },
+      locationLabel,
+      publisherConfig
+    })
+  )
+}
+
+export function prepareEditorialPublishSeoSection(
+  input: StructuredDataContext & { targetStatus: EditorialPublishTargetStatus }
+): SeoSection {
+  const nextStructuredData = buildStructuredData(input)
+  const legacyStructuredData = serializeStandardArticleStructuredDataTemplate(
+    buildLegacyStandardArticleStructuredDataTemplate({
+      stagedArticle: {
+        ...input.stagedArticle,
+        seoSection: input.seoSection
+      },
+      locationLabel: input.locationLabel
+    })
+  )
+  const shouldRefreshDraft = shouldAutoManageStandardArticleStructuredData({
+    existingStructuredData: input.seoSection.structuredData.trim(),
+    nextStructuredData,
+    legacyStructuredData
+  })
+
+  if (input.targetStatus !== 'published' && !shouldRefreshDraft) {
+    return input.seoSection
+  }
+
+  return {
+    ...input.seoSection,
+    structuredData: nextStructuredData
+  }
+}
+
+export function preparePublishedEditorialSeoSection(
+  input: StructuredDataContext & {
+    publishedArticle: PayloadArticleDoc
+  }
+): SeoSection {
+  const metadataPatch = buildPayloadArticleMetadataPatch({
+    doc: input.publishedArticle,
+    fallbackAuthorName: input.publisherConfig.defaultAuthorName
+  })
+
+  return {
+    ...input.seoSection,
+    structuredData: buildStructuredData({
+      ...input,
+      stagedArticle: {
+        ...input.stagedArticle,
+        ...metadataPatch,
+        seoSection: input.seoSection
+      }
+    })
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-validation.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-validation.service.ts
@@ -1,0 +1,145 @@
+import { createEmptySeoSection } from '../../../../../shared/seo/services/seo-section.service'
+import type { SeoSection } from '../../../../../shared/seo/types'
+import type { Location, MediaAsset } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import type { EditorialPublishAnalysis } from '../editorial-markdown.service'
+import { FEATURED_IMAGE_VARIANT } from '../constants'
+import type { MediaVariant } from '../types'
+import { getLocationDisplayName } from '../utils/editorial-stage-view.utils'
+import { sanitizeSharedNeighborhoods } from '../utils/sharedNeighborhoods'
+import {
+  isSeoCoreComplete,
+  validateStandardArticleSeoSection
+} from './standard-article-seo.service'
+
+export type EditorialPublishTargetStatus = 'draft' | 'published'
+
+export type EditorialPublishInput = {
+  title: string
+  location: Location
+  locationLabel: string
+  featuredImageId: number
+  sharedNeighborhoods: number[]
+  seoSection: SeoSection
+}
+
+type EditorialPublishInputResult =
+  | { success: true; value: EditorialPublishInput }
+  | { success: false; message: string }
+
+type ResolveEditorialPublishInputParams = {
+  stagedArticle: StagedArticle
+  locations: Location[]
+  findPreferredVariantAsset: (
+    assetId: number,
+    preferredVariant: MediaVariant
+  ) => MediaAsset | null
+}
+
+export function resolveEditorialPublishInput({
+  stagedArticle,
+  locations,
+  findPreferredVariantAsset
+}: ResolveEditorialPublishInputParams): EditorialPublishInputResult {
+  const title = stagedArticle.title.trim()
+  if (!title) {
+    return { success: false, message: 'Please enter an article title' }
+  }
+
+  const location = locations.find(
+    (candidate) => candidate.id === stagedArticle.locationId
+  )
+  if (!location) {
+    return { success: false, message: 'Please select a location' }
+  }
+
+  const resolvedFeaturedAsset = stagedArticle.featuredImageId
+    ? findPreferredVariantAsset(
+        stagedArticle.featuredImageId,
+        FEATURED_IMAGE_VARIANT
+      )
+    : null
+  const fallbackFeaturedImageId = Number(stagedArticle.featuredImageId)
+  const featuredImageId =
+    resolvedFeaturedAsset?.id ??
+    (Number.isFinite(fallbackFeaturedImageId) && fallbackFeaturedImageId > 0
+      ? fallbackFeaturedImageId
+      : null)
+
+  if (!featuredImageId) {
+    return { success: false, message: 'Please select a featured image' }
+  }
+
+  const locationLabel =
+    [location.neighborhoodName, location.cityName, location.countryName]
+      .filter(
+        (value): value is string =>
+          typeof value === 'string' && value.trim().length > 0
+      )
+      .join(', ') ||
+    getLocationDisplayName(location) ||
+    location.locationKey
+
+  return {
+    success: true,
+    value: {
+      title,
+      location,
+      locationLabel,
+      featuredImageId,
+      sharedNeighborhoods: sanitizeSharedNeighborhoods(
+        stagedArticle.sharedNeighborhoods,
+        locations,
+        stagedArticle.locationId
+      ),
+      seoSection: stagedArticle.seoSection ?? createEmptySeoSection()
+    }
+  }
+}
+
+export function validateEditorialPublishReadiness(input: {
+  targetStatus: EditorialPublishTargetStatus
+  seoSection: SeoSection
+  locationLabel: string
+  editorialPublishAnalysis: EditorialPublishAnalysis
+}): string | null {
+  const { targetStatus, seoSection, locationLabel, editorialPublishAnalysis } =
+    input
+
+  if (targetStatus === 'published') {
+    if (!isSeoCoreComplete(seoSection)) {
+      return 'Publishing requires SEO title and meta description.'
+    }
+
+    if (!seoSection.structuredData.trim()) {
+      return 'Publishing requires structured data.'
+    }
+
+    if (!seoSection.openGraph.imageUrl.trim()) {
+      return 'Publishing requires an Open Graph image URL.'
+    }
+
+    const seoIssues = validateStandardArticleSeoSection({
+      seoSection,
+      locationLabel
+    })
+    if (seoIssues.length > 0) {
+      return seoIssues[0]
+    }
+  }
+
+  if (!editorialPublishAnalysis.hasBlockingBlocks) {
+    return null
+  }
+
+  const previewMessage = editorialPublishAnalysis.blockingBlocks
+    .slice(0, 2)
+    .map((block) => block.message)
+    .join(' · ')
+  const remainingCount = editorialPublishAnalysis.blockingBlocks.length - 2
+  const remainingSuffix = remainingCount > 0 ? ` (+${remainingCount} more)` : ''
+
+  return previewMessage
+    ? `Fix editorial blocks before publishing: ${previewMessage}${remainingSuffix}`
+    : 'Fix editorial blocks before publishing'
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Location, MediaAsset } from '../../../api'
+import type { StagedArticle } from '../../../types'
+import type { EditorialPublishAnalysis } from '../editorial-markdown.service'
+import {
+  type EditorialPublishLifecycle,
+  type EditorialStagePublishWorkflowParams,
+  runEditorialStagePublishWorkflow
+} from './editorial-stage-publish-workflow.service'
+
+const location: Location = {
+  id: 7,
+  level: 'neighborhood',
+  country: 'Peru',
+  city: 'Lima',
+  neighborhood: 'Barranco',
+  countryName: 'Peru',
+  cityName: 'Lima',
+  neighborhoodName: 'Barranco',
+  locationKey: 'peru/lima/barranco',
+  updatedAt: '2026-03-01T00:00:00.000Z',
+  createdAt: '2026-03-01T00:00:00.000Z'
+}
+
+const featuredImage: MediaAsset = {
+  id: 99,
+  filename: 'featured.webp',
+  variant: 'hero'
+}
+
+const publishAnalysis: EditorialPublishAnalysis = {
+  byId: {},
+  blockingBlocks: [],
+  hasBlockingBlocks: false
+}
+
+function buildStagedArticle(
+  overrides: Partial<StagedArticle> = {}
+): StagedArticle {
+  return {
+    id: 'draft-1',
+    runId: 'run-1',
+    originalTitle: 'Original title',
+    originalContent: 'Original content',
+    originalType: 'Guide',
+    title: '  Barranco guide  ',
+    content: 'A useful guide.',
+    blocks: [
+      {
+        id: 'text-1',
+        type: 'text',
+        content: 'A useful guide.'
+      }
+    ],
+    editorialBlocks: [],
+    locationId: location.id,
+    sharedNeighborhoods: [],
+    featuredImageId: 12,
+    seoSection: {
+      seoTitle: 'Barranco travel guide',
+      metaDescription: 'A useful guide to Barranco.',
+      openGraph: {
+        title: 'Barranco travel guide',
+        description: 'A useful guide to Barranco.',
+        imageUrl: 'https://example.com/barranco.jpg',
+        url: 'https://example.com/barranco'
+      },
+      twitterCard: {
+        card: 'summary_large_image',
+        title: 'Barranco travel guide',
+        description: 'A useful guide to Barranco.',
+        imageUrl: 'https://example.com/barranco.jpg'
+      },
+      structuredData: '',
+      robots: {
+        index: 'index',
+        follow: 'follow'
+      }
+    },
+    lexicalConverted: false,
+    publishedToPayload: false,
+    createdAt: '2026-03-01T00:00:00.000Z',
+    updatedAt: '2026-03-01T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+function buildLifecycle(events: string[]): EditorialPublishLifecycle {
+  return {
+    request: () => events.push('request'),
+    converting: () => events.push('converting'),
+    submitting: () => events.push('submitting'),
+    succeed: (message) => events.push(`success:${message}`),
+    fail: (message) => events.push(`failure:${message}`)
+  }
+}
+
+function buildWorkflowParams(
+  overrides: Partial<EditorialStagePublishWorkflowParams> = {}
+): EditorialStagePublishWorkflowParams {
+  const events: string[] = []
+
+  return {
+    token: 'token',
+    sourceFeature: 'url2blog',
+    targetStatus: 'draft',
+    stagedArticle: buildStagedArticle(),
+    locations: [location],
+    mediaAssets: [featuredImage],
+    timelineItems: [
+      {
+        id: 'content:text-1',
+        type: 'content',
+        contentBlockId: 'text-1'
+      }
+    ],
+    editorialPublishAnalysis: publishAnalysis,
+    publisherConfig: {
+      siteName: 'Questurian',
+      defaultAuthorName: 'Questurian Editor'
+    },
+    convertMarkdownToLexical: vi.fn().mockResolvedValue({
+      success: true,
+      data: { root: { children: [] } }
+    }),
+    createArticle: vi.fn().mockResolvedValue({
+      id: 42,
+      status: 'draft',
+      slug: 'barranco-guide',
+      updatedAt: '2026-03-02T00:00:00.000Z'
+    }),
+    updateArticle: vi.fn(),
+    markArticleSynced: vi.fn().mockResolvedValue({
+      message: 'synced',
+      run_id: 'run-1',
+      payload_article_id: 42
+    }),
+    findPreferredVariantAsset: vi.fn().mockReturnValue(featuredImage),
+    updateStagedArticle: vi.fn(),
+    lifecycle: buildLifecycle(events),
+    ...overrides
+  }
+}
+
+describe('runEditorialStagePublishWorkflow', () => {
+  it('stops at validation and reports the validation phase failure', async () => {
+    const events: string[] = []
+    const params = buildWorkflowParams({
+      stagedArticle: buildStagedArticle({ title: '  ' }),
+      lifecycle: buildLifecycle(events)
+    })
+
+    await runEditorialStagePublishWorkflow(params)
+
+    expect(events).toEqual(['request', 'failure:Please enter an article title'])
+    expect(params.convertMarkdownToLexical).not.toHaveBeenCalled()
+    expect(params.createArticle).not.toHaveBeenCalled()
+  })
+
+  it('runs conversion, persistence, Sync bookkeeping, and UI success in order', async () => {
+    const events: string[] = []
+    const params = buildWorkflowParams({
+      lifecycle: buildLifecycle(events)
+    })
+
+    await runEditorialStagePublishWorkflow(params)
+
+    expect(events).toEqual([
+      'request',
+      'converting',
+      'submitting',
+      'success:Saved draft article #42'
+    ])
+    expect(params.convertMarkdownToLexical).toHaveBeenCalledWith(
+      'A useful guide.'
+    )
+    expect(params.createArticle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Barranco guide',
+        location: 'peru/lima/barranco',
+        locationRef: 7,
+        status: 'draft',
+        sourceFeature: 'url2blog',
+        sourceRunId: 'run-1',
+        headerSection: { featuredImage: 99 }
+      }),
+      'token'
+    )
+    expect(params.markArticleSynced).toHaveBeenCalledWith('run-1', 42)
+    expect(params.updateStagedArticle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloadArticleId: 42,
+        payloadStatus: 'draft',
+        payloadSlug: 'barranco-guide',
+        lexicalConverted: true,
+        hasUnsyncedPayloadChanges: false
+      })
+    )
+  })
+
+  it('reports conversion errors without entering persistence', async () => {
+    const events: string[] = []
+    const params = buildWorkflowParams({
+      lifecycle: buildLifecycle(events),
+      convertMarkdownToLexical: vi.fn().mockResolvedValue({
+        success: false,
+        error: 'Converter unavailable'
+      })
+    })
+
+    await runEditorialStagePublishWorkflow(params)
+
+    expect(events).toEqual([
+      'request',
+      'converting',
+      'failure:Converter unavailable'
+    ])
+    expect(params.createArticle).not.toHaveBeenCalled()
+    expect(params.updateStagedArticle).not.toHaveBeenCalled()
+  })
+
+  it('reports Payload failures after entering the submitting phase', async () => {
+    const events: string[] = []
+    const params = buildWorkflowParams({
+      lifecycle: buildLifecycle(events),
+      createArticle: vi
+        .fn()
+        .mockRejectedValue(new Error('Payload rejected the article'))
+    })
+
+    await runEditorialStagePublishWorkflow(params)
+
+    expect(events).toEqual([
+      'request',
+      'converting',
+      'submitting',
+      'failure:Payload rejected the article'
+    ])
+    expect(params.markArticleSynced).not.toHaveBeenCalled()
+    expect(params.updateStagedArticle).not.toHaveBeenCalled()
+  })
+
+  it('keeps a successful Payload save successful when local Sync bookkeeping fails', async () => {
+    const events: string[] = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const params = buildWorkflowParams({
+      lifecycle: buildLifecycle(events),
+      markArticleSynced: vi.fn().mockRejectedValue(new Error('Run row missing'))
+    })
+
+    await runEditorialStagePublishWorkflow(params)
+
+    expect(events.at(-1)).toBe(
+      'success:Saved draft article #42 (local run record missing, sync status not recorded)'
+    )
+    expect(params.updateStagedArticle).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('refreshes published structured data with persisted metadata before local Sync', async () => {
+    const events: string[] = []
+    const publishedArticle = {
+      id: 42,
+      status: 'published',
+      slug: 'barranco-guide',
+      publishedAt: '2026-03-02T00:00:00.000Z',
+      updatedAt: '2026-03-02T00:00:00.000Z',
+      author: {
+        firstName: 'Jane',
+        lastName: 'Doe'
+      }
+    } as const
+    const updateArticle = vi.fn().mockResolvedValue(publishedArticle)
+    const params = buildWorkflowParams({
+      targetStatus: 'published',
+      lifecycle: buildLifecycle(events),
+      createArticle: vi.fn().mockResolvedValue(publishedArticle),
+      updateArticle
+    })
+
+    await runEditorialStagePublishWorkflow(params)
+
+    expect(updateArticle).toHaveBeenCalledOnce()
+    const [, secondPayload] = updateArticle.mock.calls[0]
+    expect(secondPayload.seoSection?.structuredData).toEqual(
+      expect.objectContaining({
+        '@context': 'https://schema.org'
+      })
+    )
+    expect(JSON.stringify(secondPayload.seoSection?.structuredData)).toContain(
+      '"datePublished":"2026-03-02T00:00:00.000Z"'
+    )
+    expect(JSON.stringify(secondPayload.seoSection?.structuredData)).toContain(
+      '"name":"Jane Doe"'
+    )
+    expect(events.at(-1)).toBe('success:Published article #42')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.ts
@@ -1,0 +1,146 @@
+import type { SchemaPublisherConfig } from '../../../../../shared/seo/services/schema-publisher-config.service'
+import type { Location, MediaAsset } from '../../../api'
+import type { CreateArticlePayload } from '../../../api'
+import type { PayloadArticleDoc } from '../../../api/articles/articles.types'
+import type { StagedArticle } from '../../../types'
+import type { EditorialPublishAnalysis } from '../editorial-markdown.service'
+import type { MediaVariant } from '../types'
+import type { TimelineItem } from '../workflow.service'
+import { buildPayloadContentBlocks } from './editorial-stage-publish.service'
+import { persistEditorialStageArticle } from './editorial-stage-publish-persistence.service'
+import { prepareEditorialPublishSeoSection } from './editorial-stage-publish-structured-data.service'
+import {
+  type EditorialPublishTargetStatus,
+  resolveEditorialPublishInput,
+  validateEditorialPublishReadiness
+} from './editorial-stage-publish-validation.service'
+
+export type EditorialPublishLifecycle = {
+  request: () => void
+  converting: () => void
+  submitting: () => void
+  succeed: (message: string) => void
+  fail: (message: string) => void
+}
+
+export type EditorialStagePublishWorkflowParams = {
+  token: string
+  sourceFeature: string
+  targetStatus: EditorialPublishTargetStatus
+  stagedArticle: StagedArticle
+  locations: Location[]
+  mediaAssets: MediaAsset[]
+  timelineItems: TimelineItem[]
+  editorialPublishAnalysis: EditorialPublishAnalysis
+  publisherConfig: SchemaPublisherConfig
+  convertMarkdownToLexical: (markdown: string) => Promise<{
+    success: boolean
+    data?: object
+    error?: string
+  }>
+  createArticle: (
+    payload: CreateArticlePayload,
+    token: string
+  ) => Promise<PayloadArticleDoc>
+  updateArticle?: (
+    id: number,
+    payload: CreateArticlePayload,
+    token: string
+  ) => Promise<PayloadArticleDoc>
+  markArticleSynced: (
+    runId: string,
+    payloadArticleId: number
+  ) => Promise<{ message: string; run_id: string; payload_article_id: number }>
+  findPreferredVariantAsset: (
+    assetId: number,
+    preferredVariant: MediaVariant
+  ) => MediaAsset | null
+  updateStagedArticle: (updates: Partial<StagedArticle>) => void
+  lifecycle: EditorialPublishLifecycle
+}
+
+function getSuccessMessage(input: {
+  targetStatus: EditorialPublishTargetStatus
+  stagedArticle: StagedArticle
+  articleId: number
+  syncBookkeepingFailed: boolean
+}): string {
+  const message =
+    input.targetStatus === 'published'
+      ? input.stagedArticle.payloadStatus === 'published'
+        ? `Updated published article #${input.articleId}`
+        : `Published article #${input.articleId}`
+      : `Saved draft article #${input.articleId}`
+
+  return input.syncBookkeepingFailed
+    ? `${message} (local run record missing, sync status not recorded)`
+    : message
+}
+
+export async function runEditorialStagePublishWorkflow(
+  input: EditorialStagePublishWorkflowParams
+): Promise<void> {
+  input.lifecycle.request()
+
+  try {
+    const resolvedInput = resolveEditorialPublishInput(input)
+    if (!resolvedInput.success) {
+      input.lifecycle.fail(resolvedInput.message)
+      return
+    }
+
+    const seoSection = prepareEditorialPublishSeoSection({
+      stagedArticle: input.stagedArticle,
+      seoSection: resolvedInput.value.seoSection,
+      locationLabel: resolvedInput.value.locationLabel,
+      publisherConfig: input.publisherConfig,
+      targetStatus: input.targetStatus
+    })
+    const readinessIssue = validateEditorialPublishReadiness({
+      targetStatus: input.targetStatus,
+      seoSection,
+      locationLabel: resolvedInput.value.locationLabel,
+      editorialPublishAnalysis: input.editorialPublishAnalysis
+    })
+    if (readinessIssue) {
+      input.lifecycle.fail(readinessIssue)
+      return
+    }
+
+    input.lifecycle.converting()
+    const { contentBlocks, textBlocksAdded } = await buildPayloadContentBlocks({
+      stagedArticle: input.stagedArticle,
+      timelineItems: input.timelineItems,
+      editorialPublishAnalysis: input.editorialPublishAnalysis,
+      mediaAssets: input.mediaAssets,
+      convertMarkdownToLexical: input.convertMarkdownToLexical
+    })
+    if (textBlocksAdded === 0) {
+      throw new Error(
+        'Add at least one text block with content before publishing'
+      )
+    }
+
+    input.lifecycle.submitting()
+    const result = await persistEditorialStageArticle({
+      ...input,
+      publishInput: resolvedInput.value,
+      seoSection,
+      contentBlocks
+    })
+
+    input.updateStagedArticle(result.stagedArticlePatch)
+    input.lifecycle.succeed(
+      getSuccessMessage({
+        targetStatus: input.targetStatus,
+        stagedArticle: input.stagedArticle,
+        articleId: result.article.id,
+        syncBookkeepingFailed: result.syncBookkeepingFailed
+      })
+    )
+  } catch (error) {
+    input.lifecycle.fail(
+      error instanceof Error ? error.message : 'Failed to sync article'
+    )
+  }
+}


### PR DESCRIPTION
## Original issue

`useEditorialStagePublishWorkflow.ts` was a 392-line hook whose single publishing callback owned validation, structured-data management, Markdown conversion, Payload create/update behavior, local Sync bookkeeping, draft metadata updates, success-message selection, and UI-state transitions. The hook had 20 dependencies and multiple failure boundaries that could not be tested independently.

## Root cause

The publish flow grew incrementally around the callback. Each new publishing rule was added at the point of invocation, so domain preparation, remote persistence, local state reconciliation, and reducer events became coupled to React closure state.

## Refactor

- Keep `useEditorialStagePublishWorkflow` as a thin, stable React adapter.
- Move reducer event mapping and derived publishing flags into `useEditorialStagePublishUi`.
- Resolve and validate publish input in `editorial-stage-publish-validation.service`.
- Prepare pre-save and post-save JSON-LD in `editorial-stage-publish-structured-data.service`.
- Retain content conversion in the existing focused `editorial-stage-publish.service`.
- Encapsulate Payload create/update, the published metadata second pass, non-fatal run Sync bookkeeping, and local draft Sync signatures in `editorial-stage-publish-persistence.service`.
- Coordinate those explicit phases in `editorial-stage-publish-workflow.service`, with lifecycle callbacks as the UI boundary.
- Add focused orchestration and UI-adapter tests for validation short-circuiting, phase ordering, conversion errors, persistence errors, non-fatal Sync bookkeeping failures, post-save structured-data refresh, and reducer events.

## Why this is better

Each phase now has one reason to change and explicit typed inputs/outputs. The React callback no longer contains publishing policy or persistence mechanics, while the workflow is testable without rendering the full article builder. Remote Payload success remains distinct from local run bookkeeping failure, and the post-save JSON-LD update remains part of the persistence transaction.

## Validation

- `pnpm exec prettier --check <8 changed files>` — passed
- `NX_DAEMON=false ... pnpm exec nx run @questurian/abw-client:lint` — passed, including frontend boundary validation
- `pnpm exec vitest run --config apps/frontend/vite.config.ts` — passed: 110 files, 433 tests
- Focused publish tests — passed: 2 files, 8 tests
- `NX_DAEMON=false ... pnpm exec nx run @questurian/abw-client:build` — passed
- `pnpm exec tsc --noEmit -p apps/frontend/tsconfig.json` — reports five pre-existing errors outside this feature:
  - `homepageFeaturedContent/MainHomepagePage.tsx`
  - `homepageFeaturedContent/homepageHotelGridSlots.utils.ts` (two errors)
  - `listicleItineraries/builder/components/BuilderSetupPanel.tsx`
  - `singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx`

## Risks and tradeoffs

- The workflow has more modules, trading file count for explicit phase ownership and focused tests.
- Publish remains a two-write operation when persisted metadata changes published JSON-LD, matching existing behavior.
- Local run Sync bookkeeping remains deliberately non-fatal after a successful Payload save; failures are logged and surfaced in the success message.
- No API contracts, persistence schema, UI copy, or publish ordering were intentionally changed.

## Follow-ups

- Resolve the unrelated frontend TypeScript errors listed above so `tsc --noEmit` can become a clean required check.
