### PR TITLE
NOJIRA: Split itinerary builder draft item actions

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-actions.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-actions.test.ts
@@ -1,0 +1,246 @@
+import { createEmptyDraft } from '../../storage'
+import type { ItineraryItemBlock, ListicleItineraryDraft } from '../../types'
+import {
+  addItineraryStop,
+  addWhereStayingItem,
+  createEmptyItineraryStop,
+  createEmptyWhereStayingItem
+} from './itinerary-item-creation.actions'
+import { updateItineraryItem } from './itinerary-item-mutation.actions'
+import { moveItineraryItem } from './itinerary-item-ordering.actions'
+import { removeItineraryItem } from './itinerary-item-removal.actions'
+
+function buildItem(
+  id: string,
+  overrides: Partial<ItineraryItemBlock> = {}
+): ItineraryItemBlock {
+  return {
+    ...createEmptyItineraryStop(() => id),
+    item: 101,
+    selectionReason: `${id} reason`,
+    blurbMarkdown: `${id} blurb`,
+    blurbJsonText: `${id} json`,
+    blurbLexical: { root: {} } as never,
+    ...overrides
+  }
+}
+
+function buildDraft(): ListicleItineraryDraft {
+  const draft = createEmptyDraft()
+  return {
+    ...draft,
+    dayCount: 2,
+    days: [
+      {
+        id: 'day-1',
+        whereStaying: [
+          buildItem('lodging-1', {
+            blockType: 'itinerary-where-staying',
+            item: 201
+          }),
+          buildItem('lodging-2', {
+            blockType: 'itinerary-where-staying',
+            item: 202
+          })
+        ],
+        items: [buildItem('stop-1'), buildItem('stop-2', { item: 102 })]
+      },
+      {
+        id: 'day-2',
+        whereStaying: [],
+        items: [buildItem('stop-3', { item: 103 })]
+      }
+    ]
+  }
+}
+
+describe('itinerary item creation actions', () => {
+  it('creates ordinary and lodging rows with deterministic stable ids', () => {
+    const stop = createEmptyItineraryStop(() => 'new-stop')
+    const lodging = createEmptyWhereStayingItem(() => 'new-lodging')
+
+    expect(stop).toMatchObject({
+      id: 'new-stop',
+      blockType: 'itinerary-dining',
+      item: null,
+      selectionReason: ''
+    })
+    expect(lodging).toMatchObject({
+      id: 'new-lodging',
+      blockType: 'itinerary-where-staying',
+      item: null,
+      selectionReason: ''
+    })
+  })
+
+  it.each([
+    { insertIndex: undefined, expectedIds: ['stop-1', 'stop-2', 'new-stop'] },
+    { insertIndex: -50, expectedIds: ['new-stop', 'stop-1', 'stop-2'] },
+    { insertIndex: 50, expectedIds: ['stop-1', 'stop-2', 'new-stop'] }
+  ])('clamps insertion index $insertIndex', ({ insertIndex, expectedIds }) => {
+    const draft = addItineraryStop(buildDraft(), 0, insertIndex, () =>
+      buildItem('new-stop')
+    )
+
+    expect(draft.days[0].items.map((item) => item.id)).toEqual(expectedIds)
+  })
+
+  it('does not allocate an id when the target day is missing', () => {
+    const draft = buildDraft()
+    const createItem = vi.fn(() => buildItem('unused'))
+
+    const next = addItineraryStop(draft, 99, undefined, createItem)
+
+    expect(next).toBe(draft)
+    expect(createItem).not.toHaveBeenCalled()
+  })
+
+  it('appends lodging without changing ordinary stop order', () => {
+    const draft = addWhereStayingItem(buildDraft(), 0, () =>
+      createEmptyWhereStayingItem(() => 'lodging-3')
+    )
+
+    expect(draft.days[0].whereStaying.map((item) => item.id)).toEqual([
+      'lodging-1',
+      'lodging-2',
+      'lodging-3'
+    ])
+    expect(draft.days[0].items.map((item) => item.id)).toEqual([
+      'stop-1',
+      'stop-2'
+    ])
+  })
+})
+
+describe('itinerary item mutation actions', () => {
+  it('updates lodging and invalidates copy when its related identity changes', () => {
+    const draft = updateItineraryItem(buildDraft(), 'lodging-1', (item) => ({
+      ...item,
+      item: 999
+    }))
+    const lodging = draft.days[0].whereStaying[0]
+
+    expect(lodging.item).toBe(999)
+    expect(lodging.selectionReason).toBe('')
+    expect(lodging.blurbMarkdown).toBe('')
+    expect(lodging.blurbJsonText).toBe('')
+    expect(lodging.blurbLexical).toBeUndefined()
+    expect(draft.days[0].items[0].selectionReason).toBe('stop-1 reason')
+  })
+
+  it('invalidates manual-tour copy when title or operator changes', () => {
+    const draft = buildDraft()
+    draft.days[0].items[0] = buildItem('manual', {
+      blockType: 'itinerary-tour-agency',
+      item: null,
+      title: 'Old title',
+      operator: 'Old operator'
+    })
+
+    const next = updateItineraryItem(draft, 'manual', (item) => ({
+      ...item,
+      operator: 'New operator'
+    }))
+
+    expect(next.days[0].items[0].operator).toBe('New operator')
+    expect(next.days[0].items[0].selectionReason).toBe('')
+    expect(next.days[0].items[0].blurbMarkdown).toBe('')
+  })
+
+  it('preserves copy and sibling identities for non-identity edits', () => {
+    const draft = buildDraft()
+    const originalSibling = draft.days[0].items[1]
+
+    const next = updateItineraryItem(draft, 'stop-1', (item) => ({
+      ...item,
+      price: '$$$'
+    }))
+
+    expect(next.days[0].items[0].price).toBe('$$$')
+    expect(next.days[0].items[0].selectionReason).toBe('stop-1 reason')
+    expect(next.days[0].items[0].blurbMarkdown).toBe('stop-1 blurb')
+    expect(next.days[0].items[1]).toBe(originalSibling)
+  })
+
+  it('keeps lodging precedence when malformed data repeats an id', () => {
+    const draft = buildDraft()
+    draft.days[0].items[0] = buildItem('lodging-1', { item: 303 })
+
+    const next = updateItineraryItem(draft, 'lodging-1', (item) => ({
+      ...item,
+      price: '$$'
+    }))
+
+    expect(next.days[0].whereStaying[0].price).toBe('$$')
+    expect(next.days[0].items[0].price).toBe('')
+  })
+})
+
+describe('itinerary item removal actions', () => {
+  it('removes from the resolved collection without affecting other days', () => {
+    const draft = buildDraft()
+    const dayTwo = draft.days[1]
+
+    const withoutLodging = removeItineraryItem(draft, 'lodging-1')
+    const withoutStop = removeItineraryItem(withoutLodging, 'stop-2')
+
+    expect(withoutStop.days[0].whereStaying.map((item) => item.id)).toEqual([
+      'lodging-2'
+    ])
+    expect(withoutStop.days[0].items.map((item) => item.id)).toEqual(['stop-1'])
+    expect(withoutStop.days[1]).toBe(dayTwo)
+  })
+
+  it('removes only lodging when malformed data repeats an id', () => {
+    const draft = buildDraft()
+    draft.days[0].items[0] = buildItem('lodging-1')
+
+    const next = removeItineraryItem(draft, 'lodging-1')
+
+    expect(next.days[0].whereStaying.map((item) => item.id)).toEqual([
+      'lodging-2'
+    ])
+    expect(next.days[0].items[0].id).toBe('lodging-1')
+  })
+})
+
+describe('itinerary item ordering actions', () => {
+  it('moves ordinary stops while preserving their stable ids and objects', () => {
+    const draft = buildDraft()
+    const movedStop = draft.days[0].items[0]
+
+    const next = moveItineraryItem(draft, 'stop-1', 'down')
+
+    expect(next.days[0].items.map((item) => item.id)).toEqual([
+      'stop-2',
+      'stop-1'
+    ])
+    expect(next.days[0].items[1]).toBe(movedStop)
+    expect(next.days[0].whereStaying).toBe(draft.days[0].whereStaying)
+  })
+
+  it('moves lodging only within the lodging collection', () => {
+    const draft = moveItineraryItem(buildDraft(), 'lodging-2', 'up')
+
+    expect(draft.days[0].whereStaying.map((item) => item.id)).toEqual([
+      'lodging-2',
+      'lodging-1'
+    ])
+    expect(draft.days[0].items.map((item) => item.id)).toEqual([
+      'stop-1',
+      'stop-2'
+    ])
+  })
+
+  it('does not cross collection or day boundaries', () => {
+    const draft = buildDraft()
+
+    const lodgingAtTop = moveItineraryItem(draft, 'lodging-1', 'up')
+    const stopAtBottom = moveItineraryItem(draft, 'stop-2', 'down')
+    const onlyStopOnDayTwo = moveItineraryItem(draft, 'stop-3', 'up')
+
+    expect(lodgingAtTop.days[0]).toBe(draft.days[0])
+    expect(stopAtBottom.days[0]).toBe(draft.days[0])
+    expect(onlyStopOnDayTwo.days[1]).toBe(draft.days[1])
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-collection.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-collection.ts
@@ -1,0 +1,29 @@
+import type { ItineraryDaySlice, ItineraryItemBlock } from '../../types'
+
+export type ItineraryItemCollectionKey = 'whereStaying' | 'items'
+
+/**
+ * Resolve the physical collection for an item within a day.
+ *
+ * Lodging wins when legacy/corrupt data repeats an id in both collections,
+ * matching the builder's long-standing update, remove, and move behavior.
+ */
+export function findItineraryItemCollection(
+  day: ItineraryDaySlice,
+  itemId: string
+): ItineraryItemCollectionKey | null {
+  if (day.whereStaying.some((item) => item.id === itemId)) {
+    return 'whereStaying'
+  }
+  if (day.items.some((item) => item.id === itemId)) {
+    return 'items'
+  }
+  return null
+}
+
+export function getItineraryItemCollection(
+  day: ItineraryDaySlice,
+  collection: ItineraryItemCollectionKey
+): ItineraryItemBlock[] {
+  return day[collection]
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-creation.actions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-creation.actions.ts
@@ -1,0 +1,88 @@
+import type { ItineraryItemBlock, ListicleItineraryDraft } from '../../types'
+import { WHERE_STAYING_BLOCK_TYPE } from '../../types'
+
+export type ItineraryItemIdFactory = () => string
+
+export const createItineraryItemId: ItineraryItemIdFactory = () =>
+  `item_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`
+
+export function createEmptyItineraryStop(
+  createId: ItineraryItemIdFactory = createItineraryItemId
+): ItineraryItemBlock {
+  return {
+    id: createId(),
+    blockType: 'itinerary-dining',
+    item: null,
+    moment: null,
+    momentLabel: '',
+    tours: [],
+    mediaMode: 'photos',
+    selectedPhotos: [],
+    selectedInstagramPost: null,
+    title: '',
+    operator: '',
+    price: '',
+    url: '',
+    tourDuration: 1,
+    startingPoint: {
+      label: '',
+      latitude: '',
+      longitude: ''
+    },
+    keyLocations: [],
+    image: null,
+    instagramPost: null,
+    blurbMarkdown: '',
+    blurbLexical: undefined,
+    blurbJsonText: '',
+    // Operator-added stops have no Autobuild rationale. The empty string keeps
+    // "Why this pick" visible and re-arms the day-compose gate (ADR 0020).
+    selectionReason: ''
+  }
+}
+
+export function createEmptyWhereStayingItem(
+  createId: ItineraryItemIdFactory = createItineraryItemId
+): ItineraryItemBlock {
+  return {
+    ...createEmptyItineraryStop(createId),
+    blockType: WHERE_STAYING_BLOCK_TYPE
+  }
+}
+
+export function addItineraryStop(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  insertIndex?: number,
+  createItem: () => ItineraryItemBlock = createEmptyItineraryStop
+): ListicleItineraryDraft {
+  const day = draft.days[dayIndex]
+  if (!day) return draft
+
+  const items = [...day.items]
+  const at =
+    insertIndex === undefined
+      ? items.length
+      : Math.max(0, Math.min(insertIndex, items.length))
+  items.splice(at, 0, createItem())
+
+  const days = [...draft.days]
+  days[dayIndex] = { ...day, items }
+  return { ...draft, days }
+}
+
+export function addWhereStayingItem(
+  draft: ListicleItineraryDraft,
+  dayIndex: number,
+  createItem: () => ItineraryItemBlock = createEmptyWhereStayingItem
+): ListicleItineraryDraft {
+  const day = draft.days[dayIndex]
+  if (!day) return draft
+
+  const days = [...draft.days]
+  days[dayIndex] = {
+    ...day,
+    whereStaying: [...day.whereStaying, createItem()]
+  }
+  return { ...draft, days }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-mutation.actions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-mutation.actions.ts
@@ -1,0 +1,53 @@
+import type { ItineraryItemBlock, ListicleItineraryDraft } from '../../types'
+import { resolveItineraryStopIdentityKey } from '../../types'
+import {
+  findItineraryItemCollection,
+  getItineraryItemCollection
+} from './itinerary-item-collection'
+
+export type ItineraryItemUpdater = (
+  item: ItineraryItemBlock
+) => ItineraryItemBlock
+
+/**
+ * Identity changes invalidate copy about the previous venue and re-arm the
+ * Selection reason gate. Non-identity edits preserve that editorial work.
+ */
+export function applyItineraryItemUpdate(
+  item: ItineraryItemBlock,
+  updater: ItineraryItemUpdater
+): ItineraryItemBlock {
+  const next = updater(item)
+  if (
+    resolveItineraryStopIdentityKey(next) ===
+    resolveItineraryStopIdentityKey(item)
+  ) {
+    return next
+  }
+  return {
+    ...next,
+    selectionReason: '',
+    blurbMarkdown: '',
+    blurbJsonText: '',
+    blurbLexical: undefined
+  }
+}
+
+export function updateItineraryItem(
+  draft: ListicleItineraryDraft,
+  itemId: string,
+  updater: ItineraryItemUpdater
+): ListicleItineraryDraft {
+  const days = draft.days.map((day) => {
+    const collection = findItineraryItemCollection(day, itemId)
+    if (!collection) return day
+
+    return {
+      ...day,
+      [collection]: getItineraryItemCollection(day, collection).map((item) =>
+        item.id === itemId ? applyItineraryItemUpdate(item, updater) : item
+      )
+    }
+  })
+  return { ...draft, days }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-ordering.actions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-ordering.actions.ts
@@ -1,0 +1,28 @@
+import type { ListicleItineraryDraft } from '../../types'
+import {
+  findItineraryItemCollection,
+  getItineraryItemCollection
+} from './itinerary-item-collection'
+
+export type ItineraryItemMoveDirection = 'up' | 'down'
+
+export function moveItineraryItem(
+  draft: ListicleItineraryDraft,
+  itemId: string,
+  direction: ItineraryItemMoveDirection
+): ListicleItineraryDraft {
+  const days = draft.days.map((day) => {
+    const collection = findItineraryItemCollection(day, itemId)
+    if (!collection) return day
+
+    const items = [...getItineraryItemCollection(day, collection)]
+    const index = items.findIndex((item) => item.id === itemId)
+    const target = direction === 'up' ? index - 1 : index + 1
+    if (target < 0 || target >= items.length) return day
+
+    const [item] = items.splice(index, 1)
+    items.splice(target, 0, item)
+    return { ...day, [collection]: items }
+  })
+  return { ...draft, days }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-removal.actions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/actions/itinerary-item-removal.actions.ts
@@ -1,0 +1,23 @@
+import type { ListicleItineraryDraft } from '../../types'
+import {
+  findItineraryItemCollection,
+  getItineraryItemCollection
+} from './itinerary-item-collection'
+
+export function removeItineraryItem(
+  draft: ListicleItineraryDraft,
+  itemId: string
+): ListicleItineraryDraft {
+  const days = draft.days.map((day) => {
+    const collection = findItineraryItemCollection(day, itemId)
+    if (!collection) return day
+
+    return {
+      ...day,
+      [collection]: getItineraryItemCollection(day, collection).filter(
+        (item) => item.id !== itemId
+      )
+    }
+  })
+  return { ...draft, days }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useBuilderDraftActions.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useBuilderDraftActions.test.ts
@@ -10,7 +10,7 @@ const locations: LocationOption[] = [
     locationKey: 'peru|lima',
     country: 'peru',
     city: 'lima',
-    level: 'city',
+    level: 'city'
   },
   {
     id: 3,
@@ -19,8 +19,8 @@ const locations: LocationOption[] = [
     city: 'lima',
     neighborhood: 'barranco',
     parentKey: 'peru|lima',
-    level: 'neighborhood',
-  },
+    level: 'neighborhood'
+  }
 ]
 
 function buildDraft(): ListicleItineraryDraft {
@@ -34,41 +34,45 @@ function buildDraft(): ListicleItineraryDraft {
   draft.step3_complete = true
   draft.header.introMarkdown = 'Keep this itinerary intro'
   draft.seoSection.metaDescription = 'Keep this itinerary SEO description'
-  draft.days = [{
-    ...draft.days[0],
-    items: [
-      {
-        id: 'stop-1',
-        blockType: 'itinerary-dining',
-        item: 101,
-        tours: [],
-        mediaMode: 'photos',
-        selectedPhotos: [9001],
-        selectedInstagramPost: null,
-        title: '',
-        operator: '',
-        price: '',
-        url: '',
-        tourDuration: 1,
-        startingPoint: {
-          label: '',
-          latitude: '',
-          longitude: '',
-        },
-        keyLocations: [],
-        image: null,
-        instagramPost: null,
-        blurbMarkdown: 'Existing stop copy',
-        blurbJsonText: '',
-        selectionReason: 'original autobuild reason',
-      },
-    ],
-  }]
+  draft.days = [
+    {
+      ...draft.days[0],
+      items: [
+        {
+          id: 'stop-1',
+          blockType: 'itinerary-dining',
+          item: 101,
+          tours: [],
+          mediaMode: 'photos',
+          selectedPhotos: [9001],
+          selectedInstagramPost: null,
+          title: '',
+          operator: '',
+          price: '',
+          url: '',
+          tourDuration: 1,
+          startingPoint: {
+            label: '',
+            latitude: '',
+            longitude: ''
+          },
+          keyLocations: [],
+          image: null,
+          instagramPost: null,
+          blurbMarkdown: 'Existing stop copy',
+          blurbJsonText: '',
+          selectionReason: 'original autobuild reason'
+        }
+      ]
+    }
+  ]
   return draft
 }
 
 function useHarness(initialDraft: ListicleItineraryDraft) {
-  const [draft, setDraft] = useState<ListicleItineraryDraft | null>(initialDraft)
+  const [draft, setDraft] = useState<ListicleItineraryDraft | null>(
+    initialDraft
+  )
   const actions = useBuilderDraftActions({
     draft,
     setDraft,
@@ -80,17 +84,17 @@ function useHarness(initialDraft: ListicleItineraryDraft) {
       'itinerary-attractions': [],
       'itinerary-nightlife': [],
       'itinerary-key-location': [],
-      'itinerary-tour-agency': [],
+      'itinerary-tour-agency': []
     },
     navigate: vi.fn(),
     setSearchParams: vi.fn() as never,
     onError: vi.fn(),
-    setResult: vi.fn(),
+    setResult: vi.fn()
   })
 
   return {
     draft,
-    ...actions,
+    ...actions
   }
 }
 
@@ -129,8 +133,12 @@ describe('listicleItineraries useBuilderDraftActions', () => {
     expect(result.current.draft?.sharedNeighborhoods).toEqual([3])
     expect(result.current.draft?.step2_complete).toBe(false)
     expect(result.current.draft?.step3_complete).toBe(false)
-    expect(result.current.draft?.header.introMarkdown).toBe('Keep this itinerary intro')
-    expect(result.current.draft?.seoSection.metaDescription).toBe('Keep this itinerary SEO description')
+    expect(result.current.draft?.header.introMarkdown).toBe(
+      'Keep this itinerary intro'
+    )
+    expect(result.current.draft?.seoSection.metaDescription).toBe(
+      'Keep this itinerary SEO description'
+    )
     expect(result.current.draft?.days[0]?.items).toEqual([])
   })
 
@@ -138,7 +146,10 @@ describe('listicleItineraries useBuilderDraftActions', () => {
     const { result } = renderHook(() => useHarness(buildDraft()))
 
     act(() => {
-      result.current.updateItem('stop-1', (current) => ({ ...current, item: 202 }))
+      result.current.updateItem('stop-1', (current) => ({
+        ...current,
+        item: 202
+      }))
     })
 
     const item = result.current.draft?.days[0]?.items[0]
@@ -151,7 +162,10 @@ describe('listicleItineraries useBuilderDraftActions', () => {
     const { result } = renderHook(() => useHarness(buildDraft()))
 
     act(() => {
-      result.current.updateItem('stop-1', (current) => ({ ...current, price: '$$$' }))
+      result.current.updateItem('stop-1', (current) => ({
+        ...current,
+        price: '$$$'
+      }))
     })
 
     const item = result.current.draft?.days[0]?.items[0]
@@ -198,5 +212,29 @@ describe('listicleItineraries useBuilderDraftActions', () => {
     expect(items).toHaveLength(2)
     expect(items[0]?.id).toBe('stop-1')
     expect(items[1]?.item).toBeNull()
+  })
+
+  it('preserves the action contract for lodging, ordering, and removal', () => {
+    const { result } = renderHook(() => useHarness(buildDraft()))
+
+    act(() => {
+      result.current.addWhereStayingItem(0)
+      result.current.addItem(0)
+    })
+
+    const newStopId = result.current.draft?.days[0]?.items[1]?.id
+    const lodgingId = result.current.draft?.days[0]?.whereStaying[0]?.id
+    expect(newStopId).toMatch(/^item_/)
+    expect(lodgingId).toMatch(/^item_/)
+
+    act(() => {
+      result.current.moveItem(newStopId!, 'up')
+      result.current.removeItem(lodgingId!)
+    })
+
+    expect(result.current.draft?.days[0]?.items.map((item) => item.id)).toEqual(
+      [newStopId, 'stop-1']
+    )
+    expect(result.current.draft?.days[0]?.whereStaying).toEqual([])
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useBuilderDraftActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useBuilderDraftActions.ts
@@ -11,86 +11,19 @@ import {
   useSelectedLocationRefId
 } from '../../../../shared/builder/hooks/useBuilderStepActions'
 import { createEmptyDraft, removeDraft } from '../../storage'
-import type {
-  ItineraryBlockType,
-  ItineraryItemBlock,
-  ListicleItineraryDraft,
-  LocationOption,
-  RelatedItemOption
+import {
+  createEmptyDaySlice,
+  type ItineraryBlockType,
+  type ListicleItineraryDraft,
+  type LocationOption,
+  type RelatedItemOption
 } from '../../types'
 import { validateStep1 } from '../validators/setup.validators'
 import { validateStep3 } from '../validators/step.validators'
 import {
-  createEmptyDaySlice,
-  resolveItineraryStopIdentityKey,
-  WHERE_STAYING_BLOCK_TYPE
-} from '../../types'
-
-/**
- * Run an item updater, then invalidate the Selection reason and blurb if the
- * stop's resolved identity changed (a swap). Both describe the previous venue,
- * so clearing them re-arms the why-gate and forces a day recompose (ADR 0020).
- */
-function applyItemUpdate(
-  item: ItineraryItemBlock,
-  updater: (item: ItineraryItemBlock) => ItineraryItemBlock
-): ItineraryItemBlock {
-  const next = updater(item)
-  if (
-    resolveItineraryStopIdentityKey(next) ===
-    resolveItineraryStopIdentityKey(item)
-  ) {
-    return next
-  }
-  return {
-    ...next,
-    selectionReason: '',
-    blurbMarkdown: '',
-    blurbJsonText: '',
-    blurbLexical: undefined
-  }
-}
-
-function createNewItem(): ItineraryItemBlock {
-  return {
-    id: `item_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
-    blockType: 'itinerary-dining',
-    item: null,
-    moment: null,
-    momentLabel: '',
-    tours: [],
-    mediaMode: 'photos',
-    selectedPhotos: [],
-    selectedInstagramPost: null,
-    title: '',
-    operator: '',
-    price: '',
-    url: '',
-    tourDuration: 1,
-    startingPoint: {
-      label: '',
-      latitude: '',
-      longitude: ''
-    },
-    keyLocations: [],
-    image: null,
-    instagramPost: null,
-    blurbMarkdown: '',
-    blurbLexical: undefined,
-    blurbJsonText: '',
-    // Operator-added stop: no Autobuild rationale. Empty string (not undefined)
-    // so the "Why this pick" field renders and the day-compose gate sees it as
-    // an unfilled reason to prompt for (ADR 0020).
-    selectionReason: ''
-  }
-}
-
-function createNewWhereStayingItem(): ItineraryItemBlock {
-  return {
-    ...createNewItem(),
-    blockType: WHERE_STAYING_BLOCK_TYPE
-  }
-}
+  useItineraryItemActions,
+  type ItineraryItemActions
+} from './useItineraryItemActions'
 
 type UseBuilderDraftActionsParams = {
   draft: ListicleItineraryDraft | null
@@ -107,14 +40,6 @@ type UseBuilderDraftActionsResult = {
   selectedLocationRefId: number | null
   updateDraft: (next: Partial<ListicleItineraryDraft>) => void
   updateHeader: (next: Partial<ListicleItineraryDraft['header']>) => void
-  updateItem: (
-    itemId: string,
-    updater: (item: ItineraryItemBlock) => ItineraryItemBlock
-  ) => void
-  removeItem: (itemId: string) => void
-  moveItem: (itemId: string, direction: 'up' | 'down') => void
-  addItem: (dayIndex: number, insertIndex?: number) => void
-  addWhereStayingItem: (dayIndex: number) => void
   handleContinue: () => void
   handleUpdateSetup: () => void
   handleSaveSetup: () => void
@@ -129,7 +54,7 @@ type UseBuilderDraftActionsResult = {
   cancelUpdateStep3: () => void
   setEditorModelName: (modelName: string) => void
   handleDiscardLocalDraft: () => void
-}
+} & ItineraryItemActions
 
 export function useBuilderDraftActions({
   draft,
@@ -147,6 +72,7 @@ export function useBuilderDraftActions({
   } | null>(null)
 
   const selectedLocationRefId = useSelectedLocationRefId(draft, locations)
+  const itemActions = useItineraryItemActions(setDraft)
 
   function updateDraft(next: Partial<ListicleItineraryDraft>) {
     setDraft((current) => {
@@ -188,115 +114,6 @@ export function useBuilderDraftActions({
         ...current,
         header: { ...current.header, ...next }
       }
-    })
-  }
-
-  function updateItem(
-    itemId: string,
-    updater: (item: ItineraryItemBlock) => ItineraryItemBlock
-  ) {
-    setDraft((current) => {
-      if (!current) return current
-      const nextDays = current.days.map((day) => {
-        if (day.whereStaying.some((item) => item.id === itemId)) {
-          return {
-            ...day,
-            whereStaying: day.whereStaying.map((item) =>
-              item.id === itemId ? applyItemUpdate(item, updater) : item
-            )
-          }
-        }
-        if (day.items.some((item) => item.id === itemId)) {
-          return {
-            ...day,
-            items: day.items.map((item) =>
-              item.id === itemId ? applyItemUpdate(item, updater) : item
-            )
-          }
-        }
-        return day
-      })
-      return { ...current, days: nextDays }
-    })
-  }
-
-  function removeItem(itemId: string) {
-    setDraft((current) => {
-      if (!current) return current
-      const nextDays = current.days.map((day) => {
-        if (day.whereStaying.some((item) => item.id === itemId)) {
-          return {
-            ...day,
-            whereStaying: day.whereStaying.filter((item) => item.id !== itemId)
-          }
-        }
-        if (day.items.some((item) => item.id === itemId)) {
-          return {
-            ...day,
-            items: day.items.filter((item) => item.id !== itemId)
-          }
-        }
-        return day
-      })
-      return { ...current, days: nextDays }
-    })
-  }
-
-  function moveItem(itemId: string, direction: 'up' | 'down') {
-    setDraft((current) => {
-      if (!current) return current
-      const nextDays = current.days.map((day) => {
-        const wsIndex = day.whereStaying.findIndex((item) => item.id === itemId)
-        if (wsIndex >= 0) {
-          const whereStaying = [...day.whereStaying]
-          const target = direction === 'up' ? wsIndex - 1 : wsIndex + 1
-          if (target < 0 || target >= whereStaying.length) return day
-          const [row] = whereStaying.splice(wsIndex, 1)
-          whereStaying.splice(target, 0, row)
-          return { ...day, whereStaying }
-        }
-        const items = [...day.items]
-        const index = items.findIndex((item) => item.id === itemId)
-        if (index < 0) return day
-        const target = direction === 'up' ? index - 1 : index + 1
-        if (target < 0 || target >= items.length) return day
-        const [item] = items.splice(index, 1)
-        items.splice(target, 0, item)
-        return { ...day, items }
-      })
-      return { ...current, days: nextDays }
-    })
-  }
-
-  function addItem(dayIndex: number, insertIndex?: number) {
-    setDraft((current) => {
-      if (!current) return current
-      const day = current.days[dayIndex]
-      if (!day) return current
-      const items = [...day.items]
-      // Clamp so an out-of-range index can't drop the stop or throw; undefined = append.
-      const at =
-        insertIndex === undefined
-          ? items.length
-          : Math.max(0, Math.min(insertIndex, items.length))
-      items.splice(at, 0, createNewItem())
-      const nextDays = [...current.days]
-      nextDays[dayIndex] = { ...day, items }
-      return { ...current, days: nextDays }
-    })
-  }
-
-  function addWhereStayingItem(dayIndex: number) {
-    setDraft((current) => {
-      if (!current) return current
-      const day = current.days[dayIndex]
-      if (!day) return current
-      const nextDays = [...current.days]
-      nextDays[dayIndex] = {
-        ...day,
-        whereStaying: [...day.whereStaying, createNewWhereStayingItem()]
-      }
-      return { ...current, days: nextDays }
     })
   }
 
@@ -414,11 +231,7 @@ export function useBuilderDraftActions({
     selectedLocationRefId,
     updateDraft,
     updateHeader,
-    updateItem,
-    removeItem,
-    moveItem,
-    addItem,
-    addWhereStayingItem,
+    ...itemActions,
     handleContinue: stepActions.handleContinue,
     handleUpdateSetup,
     handleSaveSetup,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryItemActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryItemActions.ts
@@ -1,0 +1,86 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import type { ItineraryItemBlock, ListicleItineraryDraft } from '../../types'
+import {
+  addItineraryStop,
+  addWhereStayingItem as appendWhereStayingItem
+} from '../actions/itinerary-item-creation.actions'
+import {
+  updateItineraryItem,
+  type ItineraryItemUpdater
+} from '../actions/itinerary-item-mutation.actions'
+import {
+  moveItineraryItem,
+  type ItineraryItemMoveDirection
+} from '../actions/itinerary-item-ordering.actions'
+import { removeItineraryItem } from '../actions/itinerary-item-removal.actions'
+
+type SetItineraryDraft = Dispatch<SetStateAction<ListicleItineraryDraft | null>>
+
+export type ItineraryItemActions = {
+  updateItem: (
+    itemId: string,
+    updater: (item: ItineraryItemBlock) => ItineraryItemBlock
+  ) => void
+  removeItem: (itemId: string) => void
+  moveItem: (itemId: string, direction: ItineraryItemMoveDirection) => void
+  addItem: (dayIndex: number, insertIndex?: number) => void
+  addWhereStayingItem: (dayIndex: number) => void
+}
+
+/** Adapt pure itinerary-item transforms to React's functional state updates. */
+export function useItineraryItemActions(
+  setDraft: SetItineraryDraft
+): ItineraryItemActions {
+  const updateItem = useCallback(
+    (itemId: string, updater: ItineraryItemUpdater) => {
+      setDraft((current) =>
+        current ? updateItineraryItem(current, itemId, updater) : current
+      )
+    },
+    [setDraft]
+  )
+
+  const removeItem = useCallback(
+    (itemId: string) => {
+      setDraft((current) =>
+        current ? removeItineraryItem(current, itemId) : current
+      )
+    },
+    [setDraft]
+  )
+
+  const moveItem = useCallback(
+    (itemId: string, direction: ItineraryItemMoveDirection) => {
+      setDraft((current) =>
+        current ? moveItineraryItem(current, itemId, direction) : current
+      )
+    },
+    [setDraft]
+  )
+
+  const addItem = useCallback(
+    (dayIndex: number, insertIndex?: number) => {
+      setDraft((current) =>
+        current ? addItineraryStop(current, dayIndex, insertIndex) : current
+      )
+    },
+    [setDraft]
+  )
+
+  const addWhereStayingItem = useCallback(
+    (dayIndex: number) => {
+      setDraft((current) =>
+        current ? appendWhereStayingItem(current, dayIndex) : current
+      )
+    },
+    [setDraft]
+  )
+
+  return {
+    updateItem,
+    removeItem,
+    moveItem,
+    addItem,
+    addWhereStayingItem
+  }
+}


### PR DESCRIPTION
## Issue

useBuilderDraftActions mixed setup and step orchestration with creation, collection routing, identity-aware mutation, removal, and ordering for both lodging rows and ordinary itinerary stops. At 437 lines, changes to one item operation required reasoning across unrelated builder state transitions.

## Root cause

The first implementation grew each item kind directly inside the broad hook. The physical whereStaying/items split, stop-identity invalidation rules, item factories, and React state adaptation accumulated together instead of forming explicit domain operations.

## Refactor

- Added a small collection locator that preserves lodging-first behavior for duplicate legacy IDs.
- Extracted pure creation/insertion actions with injectable factories for deterministic ID testing and unchanged clamped insertion.
- Extracted identity-aware mutation, including ADR 0020 invalidation for related records and manual tour title/operator identities.
- Extracted removal and in-collection ordering as independent pure actions.
- Added useItineraryItemActions as a thin functional-setState adapter and composed it into useBuilderDraftActions without changing the returned consumer contract.
- Reduced useBuilderDraftActions from 437 to 250 lines and from fifteen local definitions to three.

## Why this is better

Each operation now has one responsibility and can be tested without rendering React. Collection routing and legacy precedence are explicit, item IDs and object identities survive ordering, and the remaining builder hook only orchestrates higher-level draft/setup/step actions plus the focused item adapter. No replacement action monolith was introduced.

## Validation

- Final-base focused Vitest: 2 files, 23 tests passed.
- AI Blog Writer package lint: all 5 Nx projects passed; final-base boundary check and touched-file ESLint also passed.
- AI Blog Writer package tests: frontend 111 files / 449 tests, backend 377 tests, converter 15 tests passed; shared and utils explicitly have no tests.
- Prettier check for all changed files: passed.
- Production build: passed; 2,683 frontend modules transformed and backend compileall passed. Existing Vite chunk-size warning remains.
- Frontend tsc noEmit: blocked by pre-existing errors in untouched homepage block typing, hotel-grid slots, BuilderSetupPanel nullability, and SingleTypeListicleBuilderPage nullability. No errors are reported in the changed files.

## Risks

Low structural risk. The public action signatures, generated ID format, functional state semantics, collection precedence, insertion clamping, and ordering boundaries are preserved. The adapter callbacks are now stable between renders, which removes unnecessary dependent effect reruns without changing relevant dependencies.

## Follow-ups

Resolve the existing whole-frontend typecheck baseline in dedicated changes; it is intentionally outside this focused refactor.