### PR TITLE
fix(prompt2blog): route rewrite stages to the writer model

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -11,6 +11,11 @@ DEFAULT_MODEL = "gemini-2.5-flash-lite"
 # Anthropic was funded; shared model resolution still supports that selection.
 P2B_COMPOSE_MODEL = "gemini-3.1-pro-preview"
 
+# The quality audit judges prose written by the writer model. A judge weaker
+# than the writer produces noisy scores and spurious repair triggers, so the
+# audit runs a tier above DEFAULT_MODEL rather than on the analysis model.
+P2B_AUDIT_MODEL = "gemini-2.5-flash"
+
 EDITORIAL_COMPONENT_LABELS = {
     "pull_quote": "Pull Quote",
     "in_the_know_box": "In The Know",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -11,6 +11,7 @@ class Prompt2BlogGraphState(TypedDict, total=False):
     request: PipelineV2RuntimeRequest
     model_name: str
     writing_model: str
+    audit_model: str
     cleaned_data: str
     raw_sources: list[str]
     raw_sources_text: str

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from .config import DEFAULT_MODEL, P2B_COMPOSE_MODEL
+from .config import DEFAULT_MODEL, P2B_AUDIT_MODEL, P2B_COMPOSE_MODEL
 from .dependencies import PipelineDependencies
 from .graph.runner import GraphNode, run_prompt2blog_stage_graph
 from .graph.state import Prompt2BlogGraphState
@@ -47,6 +47,7 @@ def _initial_generation_state(
             request.writing_model,
             default=P2B_COMPOSE_MODEL,
         ),
+        "audit_model": P2B_AUDIT_MODEL,
         "cleaned_data": _safe_str(request.cleaned_data),
         "raw_sources": raw_sources,
         "raw_sources_text": _format_raw_sources(raw_sources),

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -39,7 +39,7 @@ def _audit_rewrite(
         prompt=prompt,
         max_tokens=1536,
         temperature=0.05,
-        model_name=state["model_name"],
+        model_name=state["audit_model"],
     )
     quality = _sanitize_quality(parsed)
     computed_checks = _build_constraint_checks(
@@ -82,7 +82,7 @@ def run_quality_audit_stage(
         state["trace"],
         state["include_debug"],
         stage=stage,
-        model_name=state["model_name"],
+        model_name=state["audit_model"],
         prompt=prompt,
         raw_response=raw_response,
         parsed=parsed,
@@ -125,11 +125,13 @@ def run_repair_stage(
             narrative_focus=state["narrative_focus"],
         )
         prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
+        # Repair rewrites the whole article, so it runs on the writer model.
+        # Routing it to the analysis model downgraded every repaired run.
         parsed, raw_response = dependencies.llm.invoke_json(
             prompt=prompt,
             max_tokens=6144,
             temperature=0.1,
-            model_name=state["model_name"],
+            model_name=state["writing_model"],
         )
         rewrite = _sanitize_rewrite(
             parsed,
@@ -138,7 +140,7 @@ def run_repair_stage(
         )
         rewrite["improved_content"] = dependencies.llm.enforce_anti_ai(
             rewrite["improved_content"],
-            model_name=state["model_name"],
+            model_name=state["writing_model"],
             max_tokens=6144,
             context="prompt2blog repair",
         )
@@ -152,7 +154,7 @@ def run_repair_stage(
             state["trace"],
             state["include_debug"],
             stage=stage,
-            model_name=state["model_name"],
+            model_name=state["writing_model"],
             prompt=prompt,
             raw_response=raw_response,
             parsed=parsed,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
@@ -117,6 +117,9 @@ def run_finalize_stage(
             "stage_model_overrides": {
                 "stage_compose": state["writing_model"],
                 "stage_editorial_augmentation": state["writing_model"],
+                "stage_repair": state["writing_model"],
+                "stage_title": state["writing_model"],
+                "stage_quality_audit": state["audit_model"],
             },
         },
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/title.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/title.py
@@ -10,6 +10,8 @@ from ..prompts.editorial import P2B_TITLE_PROMPT
 from ..support import _json
 
 
+# The title is the highest-leverage single string the pipeline emits, so it is
+# written by the writer model rather than the cheaper analysis model.
 def run_title_stage(
     state: Prompt2BlogGraphState,
     dependencies: PipelineDependencies,
@@ -30,7 +32,7 @@ def run_title_stage(
         prompt=prompt,
         max_tokens=512,
         temperature=0.1,
-        model_name=state["model_name"],
+        model_name=state["writing_model"],
     )
     final_title = _clean_title(raw_response) or rewrite["improved_title"]
     dependencies.recorder.record_stage(
@@ -42,7 +44,7 @@ def run_title_stage(
         state["trace"],
         state["include_debug"],
         stage=stage,
-        model_name=state["model_name"],
+        model_name=state["writing_model"],
         prompt=prompt,
         raw_response=raw_response,
         output={"final_title": final_title},

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from app.features.prompt2blog.config import P2B_AUDIT_MODEL
 from app.features.prompt2blog.dependencies import PipelineDependencies
 from app.features.prompt2blog.models import (
     PipelineV2RuntimeRequest,
@@ -57,6 +58,7 @@ def _pipeline_fakes(
         "artifacts": [],
         "json_prompts": [],
         "text_prompts": [],
+        "calls": [],
     }
     quality_score_iter = iter(quality_scores)
 
@@ -164,9 +166,15 @@ def _pipeline_fakes(
 
     class FakeLLM:
         def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
+            recorded["calls"].append(
+                {"prompt": kwargs["prompt"], "model_name": kwargs.get("model_name")}
+            )
             return invoke_json(**kwargs)
 
         def invoke_text(self, **kwargs: Any) -> str:
+            recorded["calls"].append(
+                {"prompt": kwargs["prompt"], "model_name": kwargs.get("model_name")}
+            )
             return invoke_text(**kwargs)
 
         @staticmethod
@@ -255,6 +263,50 @@ def test_pipeline_contract_repairs_then_reaudits():
     )
     assert repair_payload["quality"]["overall_score"] == 9
     assert sum("quality auditor" in prompt for prompt in recorded["json_prompts"]) == 2
+
+
+def _model_for(recorded: dict[str, Any], marker: str) -> str | None:
+    return next(
+        call["model_name"] for call in recorded["calls"] if marker in call["prompt"]
+    )
+
+
+def test_writer_model_serves_compose_repair_and_title():
+    recorded, dependencies = _pipeline_fakes(quality_scores=[6, 9])
+
+    run_pipeline_v2(f"run-tiering-{uuid4()}", _runtime_request(), dependencies)
+
+    assert _model_for(recorded, "expert editor creating a publish-ready article") == (
+        "test-writer"
+    )
+    assert _model_for(recorded, "hard rewrite repair pass") == "test-writer"
+    assert _model_for(recorded, "headline editor") == "test-writer"
+
+
+def test_quality_audit_runs_on_the_audit_model_not_the_analysis_model():
+    recorded, dependencies = _pipeline_fakes(quality_scores=[9])
+
+    run_pipeline_v2(f"run-audit-model-{uuid4()}", _runtime_request(), dependencies)
+
+    assert _model_for(recorded, "quality auditor") == P2B_AUDIT_MODEL
+    assert _model_for(recorded, "quality auditor") != "test-model"
+
+
+def test_finalize_records_actual_stage_model_routing():
+    recorded, dependencies = _pipeline_fakes(quality_scores=[9])
+
+    run_pipeline_v2(f"run-overrides-{uuid4()}", _runtime_request(), dependencies)
+
+    overrides = recorded["artifacts"][0][1]["pipeline_v2"]["quality_review"][
+        "stage_model_overrides"
+    ]
+    assert overrides == {
+        "stage_compose": "test-writer",
+        "stage_editorial_augmentation": "test-writer",
+        "stage_repair": "test-writer",
+        "stage_title": "test-writer",
+        "stage_quality_audit": P2B_AUDIT_MODEL,
+    }
 
 
 def test_pipeline_contract_falls_back_when_augmentation_fails():


### PR DESCRIPTION
## Problem

Prompt2Blog tiered its models upside down. `DEFAULT_MODEL` (`gemini-2.5-flash-lite`) drove the quality audit, the repair rewrite and the title stage. Only compose and editorial augmentation used the writer model (`gemini-3.1-pro-preview`).

That made the failure path actively harmful:

> writer model drafts it → weaker model judges it → weaker model rewrites the whole thing

Any run that tripped the repair gate shipped **worse** prose than a run that sailed through.

## Changes

| Stage | Before | After |
|---|---|---|
| `stage_repair` | `model_name` (flash-lite) | `writing_model` |
| `stage_title` | `model_name` (flash-lite) | `writing_model` |
| `stage_quality_audit` | `model_name` (flash-lite) | new `P2B_AUDIT_MODEL` (`gemini-2.5-flash`) |

- Repair is a full-article rewrite — the single highest-leverage writing call in the pipeline. It belongs on the writer model.
- The title is the highest-leverage string the pipeline emits.
- The audit judges writer-model prose. A judge weaker than the writer produces noisy scores and spurious repair triggers, which is what made the inverted repair path fire so often.

`finalize` now records the real per-stage routing in `stage_model_overrides` instead of only the two compose-side entries, so the artifact stops under-reporting which model wrote what.

## Compatibility

Per ADR-0024: REST contracts, persisted stage names, artifact shapes and the canonical `Stage[N]Output` vocabulary are unchanged. `P2B_AUDIT_MODEL` is a module constant, not a new request field.

## Verification

- 380 backend tests pass (377 baseline + 3 new).
- `flake8` clean.
- New tests assert compose/repair/title all resolve to the writer model, that the audit does **not** run on the analysis model, and that `stage_model_overrides` reflects actual routing.