### PR TITLE
fix(prompt2blog): trigger repair on real quality signals

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
@@ -80,7 +80,7 @@ def _build_writing_brief_from_input(
             "paragraph_length": paragraph_length,
             "target_word_count": target_word_count,
         },
-        "call_to_action": "",
+        "call_to_action": _safe_str(request.call_to_action),
         "seo": {
             "primary_keyword": _safe_str(request.primary_keyword),
             "secondary_keywords": secondary_keywords,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
@@ -60,6 +60,7 @@ class Prompt2BlogInputRequest(BaseModel):
     brand_voice_id: str | None = None
     primary_keyword: str | None = None
     secondary_keywords: List[str] = Field(default_factory=list)
+    call_to_action: str | None = None
     must_include: List[str] = Field(default_factory=list)
     audience_profile: str | None = None
     prompt_enhance: bool = True

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
@@ -17,11 +17,6 @@ Return strict JSON only:
   "too_close_to_source": false,
   "word_count_estimate": 0,
   "constraint_checks": {{
-    "target_word_count_met": false,
-    "paragraph_length_met": false,
-    "cta_present": false,
-    "primary_keyword_present": false,
-    "secondary_keywords_present": false,
     "audience_match": false,
     "tone_match": false
   }},
@@ -37,6 +32,13 @@ Scoring rubric:
 Rules:
 - required_revisions must be specific and actionable.
 - Mark too_close_to_source=true when structure/phrasing is too similar to source.
+- Judge only audience_match and tone_match. Word count, paragraph length, CTA
+  and keyword presence are measured deterministically outside this prompt, so
+  do not report them.
+- audience_match: does the draft address the brief's audience at the right
+  level of assumed knowledge?
+- tone_match: does the prose sustain the brief's tone and voice?
+- Score honestly. A draft that merely avoids mistakes is a 7, not a 9.
 
 RAW SOURCES:
 {raw_sources}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -6,11 +6,22 @@ from typing import Any
 from .content.markdown import _clean_title
 from .support import (
     _safe_bool,
+    _safe_dict,
     _safe_int,
     _safe_str,
     _tokenize_words,
-    _normalize_text,
 )
+
+# Share of secondary keywords that must appear before the check passes.
+SECONDARY_KEYWORD_COVERAGE_THRESHOLD = 0.6
+
+# The audit rubric calls 7-8 "acceptable with edits" and <=6 "requires a hard
+# rewrite". Repair therefore fires below 7, not at or below it.
+REPAIR_SCORE_THRESHOLD = 7
+
+# Used when the auditor omitted a score. Neutral, and above the repair
+# threshold, so a gap in the response is never itself a repair trigger.
+NEUTRAL_QUALITY_SCORE = 7
 
 
 def _extract_narrative_focus(writing_brief: dict[str, Any]) -> str:
@@ -24,12 +35,33 @@ def _extract_narrative_focus(writing_brief: dict[str, Any]) -> str:
     return perspective or "No additional narrative focus provided."
 
 
+# A brief asking for "flights to Lima" is satisfied by prose saying "flight to
+# Lima". Raw substring matching failed those, which drove keyword checks false
+# and bought a full repair rewrite for a plural.
+def _canonical_tokens(value: str) -> list[str]:
+    tokens: list[str] = []
+    for token in _tokenize_words(value):
+        token = token.removesuffix("'s").rstrip("'")
+        if len(token) > 4 and token.endswith(("ses", "xes", "zes", "ches", "shes")):
+            token = token[:-2]
+        elif len(token) > 3 and token.endswith("s"):
+            token = token[:-1]
+        if token:
+            tokens.append(token)
+    return tokens
+
+
 def _contains_phrase(text: str, phrase: str) -> bool:
-    normalized_text = _normalize_text(text)
-    normalized_phrase = _normalize_text(phrase)
-    if not normalized_phrase:
+    phrase_tokens = _canonical_tokens(phrase)
+    if not phrase_tokens:
         return True
-    return normalized_phrase in normalized_text
+
+    text_tokens = _canonical_tokens(text)
+    window = len(phrase_tokens)
+    for start in range(len(text_tokens) - window + 1):
+        if text_tokens[start : start + window] == phrase_tokens:
+            return True
+    return False
 
 
 def _estimate_paragraph_sentence_average(content: str) -> float:
@@ -97,27 +129,28 @@ def _build_constraint_checks(
             _safe_str(item) for item in secondary_raw if _safe_str(item)
         ]
 
-    secondary_keywords_present = True
+    # Requiring every secondary keyword verbatim made the check fail on almost
+    # any realistic keyword set, and repair is told to satisfy it "naturally" --
+    # which is a direct instruction to keyword-stuff against the SEO guidance.
+    secondary_keyword_coverage = 1.0
     if secondary_keywords:
-        secondary_keywords_present = all(
-            _contains_phrase(combined, kw) for kw in secondary_keywords
-        )
-
-    audience = _safe_str(writing_brief.get("audience"))
-    tone = _safe_str((writing_brief.get("voice") or {}).get("tone"))
-    audience_match = (
-        _keyword_overlap_ratio(audience, combined) >= 0.2 if audience else True
+        matched = sum(1 for kw in secondary_keywords if _contains_phrase(combined, kw))
+        secondary_keyword_coverage = matched / len(secondary_keywords)
+    secondary_keywords_present = (
+        secondary_keyword_coverage >= SECONDARY_KEYWORD_COVERAGE_THRESHOLD
     )
-    tone_match = _keyword_overlap_ratio(tone, combined) >= 0.2 if tone else True
 
+    # audience_match and tone_match are deliberately absent. They are semantic
+    # judgements and belong to the quality auditor; the token-overlap heuristic
+    # that used to compute them here overrode the model on the two questions it
+    # is actually good at. See _audit_rewrite.
     return {
         "target_word_count_met": target_word_count_met,
         "paragraph_length_met": paragraph_length_met,
         "cta_present": cta_present,
         "primary_keyword_present": primary_keyword_present,
         "secondary_keywords_present": secondary_keywords_present,
-        "audience_match": audience_match,
-        "tone_match": tone_match,
+        "secondary_keyword_coverage": round(secondary_keyword_coverage, 3),
         "word_count_estimate": word_count,
     }
 
@@ -179,46 +212,36 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
             _safe_str(item) for item in required_revisions_raw if _safe_str(item)
         ]
 
-    checks_raw = parsed.get("constraint_checks")
-    checks = {}
-    if isinstance(checks_raw, dict):
-        checks = {
-            "target_word_count_met": _safe_bool(
-                checks_raw.get("target_word_count_met"), default=True
-            ),
-            "paragraph_length_met": _safe_bool(
-                checks_raw.get("paragraph_length_met"), default=True
-            ),
-            "cta_present": _safe_bool(checks_raw.get("cta_present"), default=True),
-            "primary_keyword_present": _safe_bool(
-                checks_raw.get("primary_keyword_present"), default=True
-            ),
-            "secondary_keywords_present": _safe_bool(
-                checks_raw.get("secondary_keywords_present"), default=True
-            ),
-            "audience_match": _safe_bool(
-                checks_raw.get("audience_match"), default=True
-            ),
-            "tone_match": _safe_bool(checks_raw.get("tone_match"), default=True),
-        }
+    # Only the semantic checks are read from the auditor. Word count, paragraph
+    # length, CTA and keyword presence are measured deterministically in
+    # _build_constraint_checks and overwrite anything the model claims, so the
+    # prompt no longer asks for them.
+    checks_raw = _safe_dict(parsed.get("constraint_checks"))
+    checks = {
+        "audience_match": _safe_bool(checks_raw.get("audience_match"), default=True),
+        "tone_match": _safe_bool(checks_raw.get("tone_match"), default=True),
+    }
+
+    # A missing or unparseable score used to default to 6, which sits below the
+    # repair threshold -- so a malformed audit response silently bought a full
+    # article rewrite. Absent scores now default to neutral and are reported as
+    # incomplete, and _should_run_repair ignores the score signal entirely when
+    # the audit did not actually produce one.
+    audit_complete = _safe_int(parsed.get("overall_score"), default=0) > 0
+
+    def _score(key: str) -> int:
+        return max(
+            1, min(10, _safe_int(parsed.get(key), default=NEUTRAL_QUALITY_SCORE))
+        )
 
     return {
-        "overall_score": max(
-            1, min(10, _safe_int(parsed.get("overall_score"), default=6))
-        ),
-        "guideline_coverage_score": max(
-            1, min(10, _safe_int(parsed.get("guideline_coverage_score"), default=6))
-        ),
-        "informativeness_score": max(
-            1, min(10, _safe_int(parsed.get("informativeness_score"), default=6))
-        ),
-        "originality_score": max(
-            1, min(10, _safe_int(parsed.get("originality_score"), default=6))
-        ),
-        "brief_adherence_score": max(
-            1, min(10, _safe_int(parsed.get("brief_adherence_score"), default=6))
-        ),
-        "seo_score": max(1, min(10, _safe_int(parsed.get("seo_score"), default=6))),
+        "audit_complete": audit_complete,
+        "overall_score": _score("overall_score"),
+        "guideline_coverage_score": _score("guideline_coverage_score"),
+        "informativeness_score": _score("informativeness_score"),
+        "originality_score": _score("originality_score"),
+        "brief_adherence_score": _score("brief_adherence_score"),
+        "seo_score": _score("seo_score"),
         "too_close_to_source": _safe_bool(
             parsed.get("too_close_to_source"), default=False
         ),
@@ -233,8 +256,10 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
 
 
 def _should_run_repair(quality: dict[str, Any], checks: dict[str, Any]) -> bool:
-    if quality.get("overall_score", 0) <= 7:
-        return True
+    # Only trust the score when the auditor actually returned one.
+    if _safe_bool(quality.get("audit_complete"), default=True):
+        if quality.get("overall_score", NEUTRAL_QUALITY_SCORE) < REPAIR_SCORE_THRESHOLD:
+            return True
     if _safe_bool(quality.get("too_close_to_source"), default=False):
         return True
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -47,16 +47,23 @@ def _audit_rewrite(
         rewrite["improved_content"],
         state["writing_brief"],
     )
+    # The auditor supplies the semantic checks; everything measurable is
+    # computed here and wins. Non-boolean measurements are reported alongside
+    # the checks rather than inside them.
+    measurements = {"word_count_estimate", "secondary_keyword_coverage"}
     quality_checks = {
         **quality.get("constraint_checks", {}),
         **{
             key: value
             for key, value in computed_checks.items()
-            if key != "word_count_estimate"
+            if key not in measurements
         },
     }
     quality["constraint_checks"] = quality_checks
     quality["word_count_estimate"] = computed_checks["word_count_estimate"]
+    quality["secondary_keyword_coverage"] = computed_checks[
+        "secondary_keyword_coverage"
+    ]
     return quality, quality_checks, prompt, raw_response, parsed
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
@@ -94,6 +94,8 @@ def run_finalize_stage(
                 "brief_adherence": quality["brief_adherence_score"],
                 "seo": quality["seo_score"],
             },
+            # audience_match and tone_match come from the auditor and pass
+            # through; the measurable checks are recomputed on the final text.
             "constraint_checks": {
                 **quality_checks,
                 "target_word_count_met": final_checks["target_word_count_met"],
@@ -103,9 +105,8 @@ def run_finalize_stage(
                 "secondary_keywords_present": final_checks[
                     "secondary_keywords_present"
                 ],
-                "audience_match": final_checks["audience_match"],
-                "tone_match": final_checks["tone_match"],
             },
+            "secondary_keyword_coverage": final_checks["secondary_keyword_coverage"],
             "word_count_estimate": final_checks["word_count_estimate"],
             "repair_applied": state["repair_applied"],
             "editorial_augmentation_applied": augmentation["augmentation_applied"],

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.quality import (
+    NEUTRAL_QUALITY_SCORE,
+    _build_constraint_checks,
+    _contains_phrase,
+    _sanitize_quality,
+    _should_run_repair,
+)
+
+
+def _brief(**overrides: Any) -> dict[str, Any]:
+    brief: dict[str, Any] = {
+        "audience": "First-time solo travelers",
+        "voice": {"tone": "Practical"},
+        "formatting": {"paragraph_length": "", "target_word_count": 0},
+        "seo": {"primary_keyword": "", "secondary_keywords": []},
+        "call_to_action": "",
+    }
+    brief.update(overrides)
+    return brief
+
+
+CONTENT = (
+    "## Getting Around\n\n"
+    "Book flights to Lima early. Buses run to the coast every morning.\n\n"
+    "## Where to Stay\n\n"
+    "Miraflores suits first-time visitors who want walkable streets.\n"
+)
+
+
+def test_keyword_match_tolerates_plural_inflection():
+    assert _contains_phrase("Book flights to Lima early.", "flight to Lima")
+    assert _contains_phrase("Take the bus to Cusco.", "buses to Cusco")
+    assert not _contains_phrase("Book flights to Quito early.", "flight to Lima")
+
+
+def test_primary_keyword_check_uses_inflection_tolerant_match():
+    checks = _build_constraint_checks(
+        "Peru Guide",
+        CONTENT,
+        _brief(seo={"primary_keyword": "flight to Lima", "secondary_keywords": []}),
+    )
+    assert checks["primary_keyword_present"] is True
+
+
+def test_secondary_keywords_pass_on_partial_coverage():
+    brief = _brief(
+        seo={
+            "primary_keyword": "",
+            "secondary_keywords": ["buses", "Miraflores", "Machu Picchu"],
+        }
+    )
+    checks = _build_constraint_checks("Peru Guide", CONTENT, brief)
+
+    # Two of three appear. Requiring all three used to fail this and hand repair
+    # an instruction to work the missing keyword in "naturally".
+    assert checks["secondary_keyword_coverage"] == round(2 / 3, 3)
+    assert checks["secondary_keywords_present"] is True
+
+
+def test_secondary_keywords_fail_when_coverage_is_genuinely_low():
+    brief = _brief(
+        seo={
+            "primary_keyword": "",
+            "secondary_keywords": ["Machu Picchu", "Sacred Valley", "Titicaca"],
+        }
+    )
+    checks = _build_constraint_checks("Peru Guide", CONTENT, brief)
+
+    assert checks["secondary_keyword_coverage"] == 0.0
+    assert checks["secondary_keywords_present"] is False
+
+
+def test_semantic_checks_are_not_computed_deterministically():
+    checks = _build_constraint_checks("Peru Guide", CONTENT, _brief())
+
+    # Tone and audience fit belong to the auditor, not to token overlap.
+    assert "audience_match" not in checks
+    assert "tone_match" not in checks
+
+
+def test_audit_keeps_only_semantic_constraint_checks():
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "constraint_checks": {
+                "audience_match": False,
+                "tone_match": True,
+                "primary_keyword_present": True,
+            },
+        }
+    )
+
+    assert quality["constraint_checks"] == {
+        "audience_match": False,
+        "tone_match": True,
+    }
+
+
+def test_repair_fires_below_seven_not_at_seven():
+    passing_checks = {
+        "target_word_count_met": True,
+        "cta_present": True,
+        "primary_keyword_present": True,
+        "secondary_keywords_present": True,
+    }
+
+    # The rubric calls 7 "acceptable with edits", so 7 must not buy a rewrite.
+    assert not _should_run_repair(
+        {"audit_complete": True, "overall_score": 7}, passing_checks
+    )
+    assert _should_run_repair(
+        {"audit_complete": True, "overall_score": 6}, passing_checks
+    )
+
+
+def test_unparseable_audit_does_not_trigger_repair_on_its_own():
+    quality = _sanitize_quality({"quality_summary": "no scores returned"})
+    passing_checks = {
+        "target_word_count_met": True,
+        "cta_present": True,
+        "primary_keyword_present": True,
+        "secondary_keywords_present": True,
+    }
+
+    assert quality["audit_complete"] is False
+    assert quality["overall_score"] == NEUTRAL_QUALITY_SCORE
+    assert not _should_run_repair(quality, passing_checks)
+
+
+def test_failed_deterministic_check_still_triggers_repair_when_audit_is_broken():
+    quality = _sanitize_quality({})
+
+    assert _should_run_repair(quality, {"primary_keyword_present": False})
+
+
+def test_cta_check_reads_a_configured_call_to_action():
+    brief = _brief(call_to_action="Compare Lima airport transfer options before you fly")
+
+    assert _build_constraint_checks("Peru Guide", CONTENT, brief)["cta_present"] is False
+    assert (
+        _build_constraint_checks(
+            "Peru Guide",
+            CONTENT + "\nCompare Lima airport transfer options before you fly.",
+            brief,
+        )["cta_present"]
+        is True
+    )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -66,6 +66,7 @@ export type Prompt2BlogRunRequest = {
   brand_voice_id?: string
   primary_keyword?: string
   secondary_keywords?: string[]
+  call_to_action?: string
   must_include?: string[]
   audience_profile?: string
   prompt_enhance?: boolean
@@ -174,6 +175,7 @@ export type Prompt2BlogPipelinePayload = {
       audience_match: boolean
       tone_match: boolean
     }
+    secondary_keyword_coverage: number
     word_count_estimate: number
     repair_applied: boolean
     editorial_augmentation_applied: boolean


### PR DESCRIPTION
## Problem

The repair gate — which decides whether to spend a full article rewrite — fired on checks that measured almost nothing, while the audit prompt spent its schema on booleans the pipeline immediately discarded.

## Changes

### Semantic checks belong to the auditor

`audience_match` and `tone_match` were computed as **≥20% token overlap** between the audience/tone string and the article body. That measures nothing about tone. Worse, the heuristic then *overwrote* the auditor's own values — the pipeline was using token overlap to override the model on exactly the two questions a model is good at.

They're now the auditor's judgement, and the prompt asks for nothing else, since the other five checks are measured deterministically and always win. Net effect: the audit prompt got shorter *and* more useful.

### Secondary keywords pass on coverage, not unanimity

`all(kw in text for kw in secondary_keywords)` failed on basically any realistic keyword set, and repair is then told to satisfy it "naturally" — a direct instruction to keyword-stuff, against the SEO guidance in the same prompt. Now 60% coverage passes, and `secondary_keyword_coverage` is reported.

### Keyword matching tolerates inflection

A brief asking for `flight to Lima` was failed by prose saying "flights to Lima". Matching is now token-based with plural normalization (including the sibilant `-es` case, so `buses` matches `bus`).

### A broken audit no longer buys a rewrite

Every score defaulted to `6` on a parse gap — *below* the repair threshold. So a malformed audit response silently triggered a full rewrite. Absent scores now default to neutral (7), the payload carries `audit_complete`, and `_should_run_repair` ignores the score signal when the audit didn't produce one. Deterministic checks still trigger repair normally.

### The threshold matches the published rubric

The prompt says 7-8 is "acceptable with edits"; the gate fired at `<= 7`. It now fires below 7.

### `call_to_action` becomes reachable

`cta_present` was **permanently true** — `_build_writing_brief_from_input` hardcoded `"call_to_action": ""`, and the check returns `True` when empty. Meanwhile compose, audit and repair all spent lines instructing around a CTA that could never exist.

`Prompt2BlogInputRequest` now takes an optional `call_to_action` and the brief carries it through, so the existing machinery works for any caller that sends one.

**Follow-up:** the composer UI has no CTA field yet, so the API accepts it but the form can't send it. Deliberately out of scope here to keep this PR to pipeline logic — the type is added on the frontend request interface.

## Compatibility

Response shape is unchanged: all seven `constraint_checks` keys are still emitted (five deterministic, two from the auditor), with `secondary_keyword_coverage` added alongside. Frontend types updated to match.

## Verification

- 390 backend tests pass (380 → 390, 10 new in `test_prompt2blog_quality_signals.py`).
- 458 frontend tests pass.
- `flake8` clean.
- `tsc --noEmit` shows no new errors; the pre-existing failures are in `homepageFeaturedContent`, `listicleItineraries`, `singleTypeListicles` and `staging`, untouched here.