### PR TITLE
fix(prompt2blog): promote hard constraints and stop triple-injecting sources

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -40,6 +40,14 @@ PROMPT2BLOG_BRAND_VOICES_DIR = PROMPT2BLOG_OPTIONS_DIR / "brand-voices"
 
 PROMPT2BLOG_CREATIVITY_LEVELS = {"low", "medium", "high"}
 
+# creativity_level used to be rendered as the literal string "Creativity level:
+# medium" inside an instructions blob while every prose call ran at a hardcoded
+# temperature, so the control did nothing. It now sets the sampling temperature
+# for the stages that actually write prose.
+PROMPT2BLOG_CREATIVITY_TEMPERATURES = {"low": 0.05, "medium": 0.2, "high": 0.45}
+
+PROMPT2BLOG_DEFAULT_COMPOSE_TEMPERATURE = PROMPT2BLOG_CREATIVITY_TEMPERATURES["medium"]
+
 PROMPT2BLOG_CLEANUP_MODE = "ai_always_aggressive_v1"
 
 PROMPT2BLOG_CLEANUP_CHUNKING_CHAR_THRESHOLD = 18_000

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -18,6 +18,8 @@ class Prompt2BlogGraphState(TypedDict, total=False):
     writing_brief: dict[str, Any]
     option_context: dict[str, Any]
     narrative_focus: str
+    hard_constraints: str
+    compose_temperature: float
     include_debug: bool
     enable_editorial_augmentation: bool
     current_stage: str

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
@@ -35,22 +35,10 @@ def _build_writing_brief_from_input(
         f"Audience intent: {_safe_str(request.target_reader)}",
         f"Creativity level: {creativity_level}",
     ]
-    if must_include:
-        profile_lines.extend(
-            [
-                "",
-                "Must include:",
-                *[f"- {item}" for item in must_include],
-            ]
-        )
-    if negative_instructions:
-        profile_lines.extend(
-            [
-                "",
-                "Avoid:",
-                *[f"- {item}" for item in negative_instructions],
-            ]
-        )
+    # must_include and negative_instructions are deliberately absent here. They
+    # are hard requirements and get their own prompt block; folding them into
+    # editorial_instructions buried them inside a field every prompt renders
+    # under the header "NARRATIVE FOCUS (OPTIONAL)".
     if request.prompt_enhance:
         profile_lines.append(
             "\nPrompt enhancement enabled: prefer stronger transitions and clearer sections."
@@ -90,8 +78,9 @@ def _build_writing_brief_from_input(
         ).strip(),
         "must_include": must_include,
         "negative_instructions": negative_instructions,
-        "raw_input": {
-            "blobs": [{"content": source} for source in cleaned_sources],
-        },
     }
+    # The brief is serialized into every prompt. It used to carry the full
+    # cleaned sources under raw_input.blobs, so each call received the sources
+    # three times over: once as {raw_sources}, once as {cleaned_data} and again
+    # inside the brief JSON. Nothing read raw_input.
     return writing_brief

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
@@ -4,7 +4,13 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from .config import DEFAULT_MODEL, P2B_AUDIT_MODEL, P2B_COMPOSE_MODEL
+from .config import (
+    DEFAULT_MODEL,
+    P2B_AUDIT_MODEL,
+    P2B_COMPOSE_MODEL,
+    PROMPT2BLOG_CREATIVITY_TEMPERATURES,
+    PROMPT2BLOG_DEFAULT_COMPOSE_TEMPERATURE,
+)
 from .dependencies import PipelineDependencies
 from .graph.runner import GraphNode, run_prompt2blog_stage_graph
 from .graph.state import Prompt2BlogGraphState
@@ -17,7 +23,12 @@ from .stages.guideline_coverage import run_coverage_stage, run_guideline_stage
 from .stages.preparation import prepare_full_pipeline_request
 from .stages.supplement_compose import run_compose_stage, run_supplement_stage
 from .stages.title import run_title_stage
-from .support import _format_raw_sources, _safe_dict, _safe_str
+from .support import (
+    _format_hard_constraints,
+    _format_raw_sources,
+    _safe_dict,
+    _safe_str,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +50,8 @@ def _initial_generation_state(
         _safe_str(source) for source in request.raw_sources if _safe_str(source)
     ]
     writing_brief = _safe_dict(request.writing_brief)
+    option_context = _safe_dict(request.option_context)
+    creativity_level = _safe_str(option_context.get("creativity_level")).lower()
     return {
         "run_id": run_id,
         "request": request,
@@ -52,8 +65,13 @@ def _initial_generation_state(
         "raw_sources": raw_sources,
         "raw_sources_text": _format_raw_sources(raw_sources),
         "writing_brief": writing_brief,
-        "option_context": _safe_dict(request.option_context),
+        "option_context": option_context,
         "narrative_focus": _extract_narrative_focus(writing_brief),
+        "hard_constraints": _format_hard_constraints(writing_brief),
+        "compose_temperature": PROMPT2BLOG_CREATIVITY_TEMPERATURES.get(
+            creativity_level,
+            PROMPT2BLOG_DEFAULT_COMPOSE_TEMPERATURE,
+        ),
         "include_debug": request.include_debug,
         "enable_editorial_augmentation": request.enable_editorial_augmentation,
         "current_stage": "stage_guideline_fetch",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
@@ -35,6 +35,11 @@ Rules:
 - Treat non-null writing brief fields as hard constraints.
 - If source support is weak for a required brief element, reflect that in missing_sections.
 - missing_sections must be concrete publishable section titles.
+- Treat HARD CONSTRAINTS as required coverage. If the sources cannot support a
+  must-include item, say so in missing_sections.
+
+HARD CONSTRAINTS:
+{hard_constraints}
 
 RAW SOURCES:
 {raw_sources}
@@ -75,6 +80,10 @@ Rules:
 - Use clear logical transitions only where needed; avoid stock transition phrases.
 - Use `##` section headings.
 - Keep sections practical and actionable.
+- Satisfy every item in HARD CONSTRAINTS. They are not stylistic preferences.
+
+HARD CONSTRAINTS:
+{hard_constraints}
 
 RAW SOURCES:
 {raw_sources}
@@ -122,6 +131,10 @@ Hard rules:
 - Include CTA naturally near the end when provided.
 - SEO: place keywords naturally, never stuff.
 - If required details are missing, explicitly mark them as not confirmed.
+- Satisfy every item in HARD CONSTRAINTS. They are not stylistic preferences.
+
+HARD CONSTRAINTS:
+{hard_constraints}
 
 RAW SOURCES:
 {raw_sources}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
@@ -39,6 +39,10 @@ Rules:
   level of assumed knowledge?
 - tone_match: does the prose sustain the brief's tone and voice?
 - Score honestly. A draft that merely avoids mistakes is a 7, not a 9.
+- A violated hard constraint is a required_revision, not a stylistic note.
+
+HARD CONSTRAINTS:
+{hard_constraints}
 
 RAW SOURCES:
 {raw_sources}
@@ -89,6 +93,10 @@ Rules:
 - Keep complete article prose with clear `##` / `###` structure.
 - Preserve CTA and keyword requirements naturally.
 - If source support is missing, explicitly state uncertainty.
+- Satisfy every item in HARD CONSTRAINTS. They are not stylistic preferences.
+
+HARD CONSTRAINTS:
+{hard_constraints}
 
 RAW SOURCES:
 {raw_sources}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -15,6 +15,10 @@ from .support import (
 # Share of secondary keywords that must appear before the check passes.
 SECONDARY_KEYWORD_COVERAGE_THRESHOLD = 0.6
 
+# must_include items are hard requirements, so the bar is near-total. The
+# per-item test is fuzzy (an item is a phrase, not a keyword), hence not 1.0.
+MUST_INCLUDE_COVERAGE_THRESHOLD = 0.9
+
 # The audit rubric calls 7-8 "acceptable with edits" and <=6 "requires a hard
 # rewrite". Repair therefore fires below 7, not at or below it.
 REPAIR_SCORE_THRESHOLD = 7
@@ -140,11 +144,27 @@ def _build_constraint_checks(
         secondary_keyword_coverage >= SECONDARY_KEYWORD_COVERAGE_THRESHOLD
     )
 
+    # must_include items are user-stated hard requirements. Nothing used to
+    # verify them, so "must mention visa-on-arrival" was silently droppable.
+    must_include = [
+        _safe_str(item)
+        for item in (writing_brief.get("must_include") or [])
+        if _safe_str(item)
+    ]
+    must_include_coverage = 1.0
+    if must_include:
+        matched = sum(
+            1 for item in must_include if _keyword_overlap_ratio(item, combined) >= 0.6
+        )
+        must_include_coverage = matched / len(must_include)
+
     # audience_match and tone_match are deliberately absent. They are semantic
     # judgements and belong to the quality auditor; the token-overlap heuristic
     # that used to compute them here overrode the model on the two questions it
     # is actually good at. See _audit_rewrite.
     return {
+        "must_include_covered": must_include_coverage >= MUST_INCLUDE_COVERAGE_THRESHOLD,
+        "must_include_coverage": round(must_include_coverage, 3),
         "target_word_count_met": target_word_count_met,
         "paragraph_length_met": paragraph_length_met,
         "cta_present": cta_present,
@@ -268,6 +288,7 @@ def _should_run_repair(quality: dict[str, Any], checks: dict[str, Any]) -> bool:
         "cta_present",
         "primary_keyword_present",
         "secondary_keywords_present",
+        "must_include_covered",
     ):
         if not _safe_bool(checks.get(key), default=True):
             return True

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -34,6 +34,7 @@ def _audit_rewrite(
         title_guideline=guideline["title_guideline"] or "No title guideline provided.",
         writing_brief_json=_json(state["writing_brief"]),
         seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
+        hard_constraints=state["hard_constraints"],
     )
     parsed, raw_response = dependencies.llm.invoke_json(
         prompt=prompt,
@@ -50,7 +51,11 @@ def _audit_rewrite(
     # The auditor supplies the semantic checks; everything measurable is
     # computed here and wins. Non-boolean measurements are reported alongside
     # the checks rather than inside them.
-    measurements = {"word_count_estimate", "secondary_keyword_coverage"}
+    measurements = {
+        "word_count_estimate",
+        "secondary_keyword_coverage",
+        "must_include_coverage",
+    }
     quality_checks = {
         **quality.get("constraint_checks", {}),
         **{
@@ -130,6 +135,7 @@ def run_repair_stage(
             writing_brief_json=_json(state["writing_brief"]),
             seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
             narrative_focus=state["narrative_focus"],
+            hard_constraints=state["hard_constraints"],
         )
         prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
         # Repair rewrites the whole article, so it runs on the writer model.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
@@ -105,8 +105,10 @@ def run_finalize_stage(
                 "secondary_keywords_present": final_checks[
                     "secondary_keywords_present"
                 ],
+                "must_include_covered": final_checks["must_include_covered"],
             },
             "secondary_keyword_coverage": final_checks["secondary_keyword_coverage"],
+            "must_include_coverage": final_checks["must_include_coverage"],
             "word_count_estimate": final_checks["word_count_estimate"],
             "repair_applied": state["repair_applied"],
             "editorial_augmentation_applied": augmentation["augmentation_applied"],

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/guideline_coverage.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/guideline_coverage.py
@@ -80,6 +80,7 @@ def run_coverage_stage(
         title_guideline=guideline["title_guideline"] or "No title guideline provided.",
         writing_brief_json=_json(state["writing_brief"]),
         narrative_focus=state["narrative_focus"],
+        hard_constraints=state["hard_constraints"],
     )
     parsed, raw_response = dependencies.llm.invoke_json(
         prompt=prompt,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/supplement_compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/supplement_compose.py
@@ -52,12 +52,13 @@ def run_supplement_stage(
             ),
             writing_brief_json=_json(state["writing_brief"]),
             narrative_focus=state["narrative_focus"],
+            hard_constraints=state["hard_constraints"],
         )
         prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
         raw_response = dependencies.llm.invoke_text(
             prompt=prompt,
             max_tokens=4096,
-            temperature=0.2,
+            temperature=state["compose_temperature"],
             model_name=state["model_name"],
         )
         supplemental_content = dependencies.llm.enforce_anti_ai(
@@ -117,12 +118,13 @@ def run_compose_stage(
         writing_brief_json=_json(state["writing_brief"]),
         seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
         narrative_focus=state["narrative_focus"],
+        hard_constraints=state["hard_constraints"],
     )
     prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
     parsed, raw_response = dependencies.llm.invoke_json(
         prompt=prompt,
         max_tokens=6144,
-        temperature=0.1,
+        temperature=state["compose_temperature"],
         model_name=state["writing_model"],
     )
     rewrite = _sanitize_rewrite(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
@@ -83,6 +83,32 @@ def _format_raw_sources(raw_sources: list[str]) -> str:
     return "\n\n---\n\n".join(cleaned)
 
 
+def _format_hard_constraints(writing_brief: dict[str, Any]) -> str:
+    """Render must-include and must-avoid items as an explicit requirement
+    block. These are hard constraints and must never be presented to a model
+    as optional narrative colour."""
+    must_include = _clean_string_list(_safe_dict(writing_brief).get("must_include") or [])
+    negative = _clean_string_list(
+        _safe_dict(writing_brief).get("negative_instructions") or []
+    )
+
+    sections: list[str] = []
+    if must_include:
+        sections.append(
+            "MUST INCLUDE - every item below has to appear in the article:\n"
+            + "\n".join(f"- {item}" for item in must_include)
+        )
+    if negative:
+        sections.append(
+            "MUST AVOID - none of the following may appear:\n"
+            + "\n".join(f"- {item}" for item in negative)
+        )
+
+    if not sections:
+        return "No hard constraints were supplied."
+    return "\n\n".join(sections)
+
+
 def _clean_string_list(items: list[str]) -> list[str]:
     cleaned: list[str] = []
     for item in items:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_and_constraints.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_and_constraints.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.config import PROMPT2BLOG_CREATIVITY_TEMPERATURES
+from app.features.prompt2blog.input import _build_writing_brief_from_input
+from app.features.prompt2blog.models import Prompt2BlogInputRequest
+from app.features.prompt2blog.quality import (
+    _build_constraint_checks,
+    _extract_narrative_focus,
+    _should_run_repair,
+)
+from app.features.prompt2blog.support import _format_hard_constraints
+
+
+def _option_context() -> dict[str, Any]:
+    return {
+        "tone": {"id": "practical", "label": "Practical", "instructions": "Be direct."},
+        "length": {
+            "id": "medium",
+            "label": "Medium",
+            "instructions": "Balance depth.",
+            "paragraph_length": "Medium (3-5 sentences per paragraph)",
+            "target_word_count": 900,
+        },
+        "brand_voice": {
+            "id": "questurian-default",
+            "label": "Questurian Default",
+            "instructions": "Stay globally minded.",
+        },
+        "creativity_level": "high",
+    }
+
+
+def _request(**overrides: Any) -> Prompt2BlogInputRequest:
+    payload: dict[str, Any] = {
+        "article_type_id": 7,
+        "source_material": ["Peru source material."],
+        "article_goal": "Explain Peru entry rules.",
+        "target_reader": "First-time visitors",
+        "destination_context": "Peru",
+        "tone_id": "practical",
+        "length_id": "medium",
+        "must_include": ["Mention visa on arrival"],
+        "negative_instructions": ["Never say hidden gem"],
+    }
+    payload.update(overrides)
+    return Prompt2BlogInputRequest(**payload)
+
+
+def _brief(**overrides: Any) -> dict[str, Any]:
+    return _build_writing_brief_from_input(
+        _request(**overrides),
+        option_context=_option_context(),
+        cleaned_sources=["Peru source material about entry rules."],
+    )
+
+
+def test_brief_no_longer_carries_a_copy_of_the_sources():
+    brief = _brief()
+
+    # The brief is serialized into every prompt. Carrying raw_input.blobs meant
+    # each call received the sources three times over.
+    assert "raw_input" not in brief
+
+
+def test_hard_constraints_are_not_folded_into_narrative_focus():
+    brief = _brief()
+    focus = _extract_narrative_focus(brief)
+
+    assert "visa on arrival" not in focus.lower()
+    assert "hidden gem" not in focus.lower()
+    assert brief["must_include"] == ["Mention visa on arrival"]
+    assert brief["negative_instructions"] == ["Never say hidden gem"]
+
+
+def test_hard_constraint_block_states_requirements_explicitly():
+    rendered = _format_hard_constraints(_brief())
+
+    assert "MUST INCLUDE" in rendered
+    assert "Mention visa on arrival" in rendered
+    assert "MUST AVOID" in rendered
+    assert "Never say hidden gem" in rendered
+
+
+def test_hard_constraint_block_is_explicit_when_empty():
+    brief = _brief(must_include=[], negative_instructions=[])
+
+    assert _format_hard_constraints(brief) == "No hard constraints were supplied."
+
+
+def test_must_include_coverage_is_measured_and_gates_repair():
+    brief = _brief()
+    covered = _build_constraint_checks(
+        "Peru Entry Rules",
+        "## Entry\n\nTravelers should mention visa on arrival paperwork at the desk.",
+        brief,
+    )
+    missing = _build_constraint_checks(
+        "Peru Entry Rules",
+        "## Entry\n\nBring a passport valid for six months.",
+        brief,
+    )
+
+    assert covered["must_include_covered"] is True
+    assert missing["must_include_covered"] is False
+    assert missing["must_include_coverage"] == 0.0
+    assert _should_run_repair({"audit_complete": True, "overall_score": 9}, missing)
+
+
+def test_creativity_level_reaches_the_brief_profile():
+    brief = _brief()
+
+    assert "Creativity level: high" in brief["editorial_instructions"]
+    assert PROMPT2BLOG_CREATIVITY_TEMPERATURES["high"] > (
+        PROMPT2BLOG_CREATIVITY_TEMPERATURES["low"]
+    )
+
+
+def test_call_to_action_flows_into_the_brief():
+    assert _brief(call_to_action="Compare transfer options")["call_to_action"] == (
+        "Compare transfer options"
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
@@ -6,7 +6,10 @@ from uuid import uuid4
 
 import pytest
 
-from app.features.prompt2blog.config import P2B_AUDIT_MODEL
+from app.features.prompt2blog.config import (
+    P2B_AUDIT_MODEL,
+    PROMPT2BLOG_CREATIVITY_TEMPERATURES,
+)
 from app.features.prompt2blog.dependencies import PipelineDependencies
 from app.features.prompt2blog.models import (
     PipelineV2RuntimeRequest,
@@ -167,13 +170,21 @@ def _pipeline_fakes(
     class FakeLLM:
         def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
             recorded["calls"].append(
-                {"prompt": kwargs["prompt"], "model_name": kwargs.get("model_name")}
+                {
+                    "prompt": kwargs["prompt"],
+                    "model_name": kwargs.get("model_name"),
+                    "temperature": kwargs.get("temperature"),
+                }
             )
             return invoke_json(**kwargs)
 
         def invoke_text(self, **kwargs: Any) -> str:
             recorded["calls"].append(
-                {"prompt": kwargs["prompt"], "model_name": kwargs.get("model_name")}
+                {
+                    "prompt": kwargs["prompt"],
+                    "model_name": kwargs.get("model_name"),
+                    "temperature": kwargs.get("temperature"),
+                }
             )
             return invoke_text(**kwargs)
 
@@ -307,6 +318,48 @@ def test_finalize_records_actual_stage_model_routing():
         "stage_title": "test-writer",
         "stage_quality_audit": P2B_AUDIT_MODEL,
     }
+
+
+def test_creativity_level_sets_the_compose_temperature():
+    compose_marker = "expert editor creating a publish-ready article"
+    temperatures = {}
+    for level in ("low", "high"):
+        recorded, dependencies = _pipeline_fakes(quality_scores=[9])
+        request = _runtime_request()
+        request.option_context["creativity_level"] = level
+        run_pipeline_v2(f"run-creativity-{level}-{uuid4()}", request, dependencies)
+        temperatures[level] = next(
+            call["temperature"]
+            for call in recorded["calls"]
+            if compose_marker in call["prompt"]
+        )
+
+    # The control used to be inert: it was rendered into an instructions blob
+    # while compose ran at a hardcoded 0.1 regardless.
+    assert temperatures["low"] == PROMPT2BLOG_CREATIVITY_TEMPERATURES["low"]
+    assert temperatures["high"] == PROMPT2BLOG_CREATIVITY_TEMPERATURES["high"]
+    assert temperatures["low"] < temperatures["high"]
+
+
+def test_hard_constraints_reach_the_compose_prompt():
+    # An uncovered must_include now fails a constraint check and triggers
+    # repair, so the audit runs twice.
+    recorded, dependencies = _pipeline_fakes(quality_scores=[9, 9])
+    request = _runtime_request()
+    request.writing_brief["must_include"] = ["Mention visa on arrival"]
+    request.writing_brief["negative_instructions"] = ["Never say hidden gem"]
+
+    run_pipeline_v2(f"run-hard-constraints-{uuid4()}", request, dependencies)
+
+    compose_prompt = next(
+        call["prompt"]
+        for call in recorded["calls"]
+        if "expert editor creating a publish-ready article" in call["prompt"]
+    )
+    assert "HARD CONSTRAINTS:" in compose_prompt
+    assert "MUST INCLUDE" in compose_prompt
+    assert "Mention visa on arrival" in compose_prompt
+    assert "MUST AVOID" in compose_prompt
 
 
 def test_pipeline_contract_falls_back_when_augmentation_fails():

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -174,8 +174,10 @@ export type Prompt2BlogPipelinePayload = {
       secondary_keywords_present: boolean
       audience_match: boolean
       tone_match: boolean
+      must_include_covered: boolean
     }
     secondary_keyword_coverage: number
+    must_include_coverage: number
     word_count_estimate: number
     repair_applied: boolean
     editorial_augmentation_applied: boolean


### PR DESCRIPTION
## Three fixes to what the model actually receives

### 1. The sources were in every prompt three times

`_build_writing_brief_from_input` put the full cleaned sources into `writing_brief["raw_input"]["blobs"]`. Since the brief is serialized into every prompt via `_json(state["writing_brief"])`, each call received the sources as `{raw_sources}`, again as `{cleaned_data}`, and again inside the brief JSON.

The quality audit was worst hit — the call whose entire job is careful discrimination got the most diluted context, on top of already carrying the full draft, the guideline and the SEO rules.

Nothing read `raw_input`. Removed.

### 2. Hard requirements were labeled "OPTIONAL"

`must_include` and `negative_instructions` were folded into `editorial_instructions`, which `_extract_narrative_focus` returns as `narrative_focus`, which every prompt renders under:

```
NARRATIVE FOCUS (OPTIONAL):
```

So "mention visa on arrival" and "never say hidden gem" arrived as bullets inside an explicitly optional blob, mixed in with tone/length/brand-voice prose. Nothing in `_build_constraint_checks` ever verified them.

Now:
- They render as a dedicated `HARD CONSTRAINTS` block in the coverage, supplement, compose, audit and repair prompts, stated as requirements.
- A new deterministic `must_include_covered` check measures them against the draft and **gates repair**.
- The auditor is told a violated hard constraint is a `required_revision`, not a stylistic note.
- Coverage prompts are told to flag a must-include the sources can't support, rather than inventing it.

### 3. `creativity_level` was inert

The operator picks low/medium/high in the UI. It was rendered as the literal string `"Creativity level: medium"` inside an instructions blob, while compose ran at a hardcoded `temperature=0.1` regardless. A control that existed and did nothing.

It now sets the sampling temperature for the two stages that write prose:

| Level | Temperature |
|---|---|
| low | 0.05 |
| medium | 0.2 |
| high | 0.45 |

## Compatibility

`constraint_checks` gains `must_include_covered`; `must_include_coverage` and `secondary_keyword_coverage` are reported as measurements alongside. Existing keys are unchanged. Frontend types updated.

## Verification

- 399 backend tests pass (390 → 399).
- `flake8` clean.
- New `test_prompt2blog_brief_and_constraints.py` covers brief slimming, the constraint block, `must_include` gating and CTA flow-through; contract tests assert the constraint block reaches the compose prompt and that creativity actually changes the compose temperature.