### PR TITLE
fix(prompt2blog): stop labelling tone and voice as optional

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -18,6 +18,7 @@ class Prompt2BlogGraphState(TypedDict, total=False):
     writing_brief: dict[str, Any]
     option_context: dict[str, Any]
     narrative_focus: str
+    style_directive: str
     hard_constraints: str
     compose_temperature: float
     include_debug: bool

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
@@ -22,15 +22,6 @@ def _build_writing_brief_from_input(
     negative_instructions = _clean_string_list(request.negative_instructions)
 
     profile_lines = [
-        f"Tone profile ({_safe_str(tone.get('label'))}):",
-        _safe_str(tone.get("instructions")),
-        "",
-        f"Length profile ({_safe_str(length.get('label'))}):",
-        _safe_str(length.get("instructions")),
-        "",
-        f"Brand voice ({_safe_str(brand_voice.get('label'))}):",
-        _safe_str(brand_voice.get("instructions")),
-        "",
         f"Destination context: {_safe_str(request.destination_context)}",
         f"Audience intent: {_safe_str(request.target_reader)}",
         f"Creativity level: {creativity_level}",
@@ -39,6 +30,11 @@ def _build_writing_brief_from_input(
     # are hard requirements and get their own prompt block; folding them into
     # editorial_instructions buried them inside a field every prompt renders
     # under the header "NARRATIVE FOCUS (OPTIONAL)".
+    #
+    # The tone, length, and brand voice guides left for the same reason. They
+    # are style requirements, not optional colour, and now render as their own
+    # STYLE DIRECTIVE block built from option_context in the orchestrator.
+    # What stays here is genuine steering: context, intent, and creativity.
     if request.prompt_enhance:
         profile_lines.append(
             "\nPrompt enhancement enabled: prefer stronger transitions and clearer sections."

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
@@ -33,6 +33,7 @@ from .stages.title import run_title_stage
 from .support import (
     _format_hard_constraints,
     _format_raw_sources,
+    _format_style_directive,
     _safe_dict,
     _safe_str,
 )
@@ -74,6 +75,7 @@ def _initial_generation_state(
         "writing_brief": writing_brief,
         "option_context": option_context,
         "narrative_focus": _extract_narrative_focus(writing_brief),
+        "style_directive": _format_style_directive(option_context),
         "hard_constraints": _format_hard_constraints(writing_brief),
         "compose_temperature": PROMPT2BLOG_CREATIVITY_TEMPERATURES.get(
             creativity_level,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial.py
@@ -105,6 +105,9 @@ ARTICLE CONTENT (MARKDOWN):
 ARTICLE TYPE (JSON):
 {article_type_json}
 
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+
 NARRATIVE OR AUDIENCE FOCUS (OPTIONAL):
 {narrative_focus}
 """

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
@@ -60,6 +60,9 @@ TITLE GUIDELINE:
 WRITING BRIEF (JSON):
 {writing_brief_json}
 
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+
 NARRATIVE FOCUS (OPTIONAL):
 {narrative_focus}
 """
@@ -76,7 +79,8 @@ Rules:
 - Do not invent specific facts, numbers, quotes, prices, names, or policies.
 - Supplemental context may explain concepts mentioned in the source, but the final article cannot invent unsupported specifics.
 - If details are missing, use cautious phrasing and clearly mark uncertainty.
-- Respect writing brief tone, audience, and perspective.
+- Follow STYLE DIRECTIVE exactly. Tone, length, and brand voice are requirements, not suggestions.
+- Respect writing brief audience and perspective.
 - Use clear logical transitions only where needed; avoid stock transition phrases.
 - Use `##` section headings.
 - Keep sections practical and actionable.
@@ -99,6 +103,9 @@ MISSING SECTIONS:
 
 WRITING BRIEF (JSON):
 {writing_brief_json}
+
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
 
 NARRATIVE FOCUS (OPTIONAL):
 {narrative_focus}
@@ -166,6 +173,9 @@ SUPPLEMENTAL MATERIAL (OPTIONAL):
 WRITING BRIEF (JSON):
 {writing_brief_json}
 
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+
 NARRATIVE FOCUS (OPTIONAL):
 {narrative_focus}
 """
@@ -192,7 +202,8 @@ Hard rules:
 - Use at least 3 `##` headings.
 - Include one direct 40-60 word answer near the top.
 - Include a concise takeaway section near the end.
-- Respect brief voice/tone/perspective/audience.
+- Follow STYLE DIRECTIVE exactly. Tone, length, and brand voice are requirements, not suggestions.
+- Respect brief perspective and audience.
 - Respect formatting brief (paragraph length and target word count).
 - Include CTA naturally near the end when provided.
 - SEO: place keywords naturally, never stuff.
@@ -232,6 +243,9 @@ WRITING BRIEF (JSON):
 
 SEO-SAFE RULES:
 {seo_guideline}
+
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
 
 NARRATIVE FOCUS (OPTIONAL):
 {narrative_focus}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
@@ -123,6 +123,9 @@ TITLE GUIDELINE:
 WRITING BRIEF (JSON):
 {writing_brief_json}
 
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+
 SEO-SAFE RULES:
 {seo_guideline}
 """
@@ -182,6 +185,9 @@ WRITING BRIEF (JSON):
 
 SEO-SAFE RULES:
 {seo_guideline}
+
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
 
 NARRATIVE FOCUS (OPTIONAL):
 {narrative_focus}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -36,6 +36,7 @@ def _audit_rewrite(
         writing_brief_json=_json(state["writing_brief"]),
         seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
         hard_constraints=state["hard_constraints"],
+        style_directive=state["style_directive"],
     )
     parsed, raw_response = dependencies.llm.invoke_json(
         prompt=prompt,
@@ -162,6 +163,7 @@ def run_repair_stage(
         writing_brief_json=_json(state["writing_brief"]),
         seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
         narrative_focus=state["narrative_focus"],
+        style_directive=state["style_directive"],
         hard_constraints=state["hard_constraints"],
     )
     prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/augmentation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/augmentation.py
@@ -44,6 +44,7 @@ def run_augmentation_stage(
                 }
             ),
             narrative_focus=state["narrative_focus"],
+            style_directive=state["style_directive"],
         )
         prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
         try:
@@ -76,6 +77,7 @@ def run_augmentation_stage(
                         "name": guideline["name"],
                     },
                     "narrative_focus": state["narrative_focus"],
+                    "style_directive": state["style_directive"],
                 },
                 prompt=prompt,
                 raw_response=raw_response,
@@ -96,6 +98,7 @@ def run_augmentation_stage(
                         "name": guideline["name"],
                     },
                     "narrative_focus": state["narrative_focus"],
+                    "style_directive": state["style_directive"],
                 },
                 prompt=prompt,
                 error=str(exc),

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/guideline_coverage.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/guideline_coverage.py
@@ -80,6 +80,7 @@ def run_coverage_stage(
         title_guideline=guideline["title_guideline"] or "No title guideline provided.",
         writing_brief_json=_json(state["writing_brief"]),
         narrative_focus=state["narrative_focus"],
+        style_directive=state["style_directive"],
         hard_constraints=state["hard_constraints"],
     )
     parsed, raw_response = dependencies.llm.invoke_json(
@@ -102,6 +103,7 @@ def run_coverage_stage(
         input_payload={
             "article_type": guideline,
             "narrative_focus": state["narrative_focus"],
+            "style_directive": state["style_directive"],
         },
         prompt=prompt,
         raw_response=raw_response,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/outline.py
@@ -67,6 +67,7 @@ def run_outline_stage(
         or "No supplemental material generated.",
         writing_brief_json=_json(state["writing_brief"]),
         narrative_focus=state["narrative_focus"],
+        style_directive=state["style_directive"],
     )
 
     try:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/supplement_compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/supplement_compose.py
@@ -52,6 +52,7 @@ def run_supplement_stage(
             ),
             writing_brief_json=_json(state["writing_brief"]),
             narrative_focus=state["narrative_focus"],
+            style_directive=state["style_directive"],
             hard_constraints=state["hard_constraints"],
         )
         prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
@@ -117,6 +118,7 @@ def run_compose_stage(
         writing_brief_json=_json(state["writing_brief"]),
         seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
         narrative_focus=state["narrative_focus"],
+        style_directive=state["style_directive"],
         hard_constraints=state["hard_constraints"],
         outline=state["outline_text"],
     )
@@ -151,6 +153,7 @@ def run_compose_stage(
         input_payload={
             "article_type": guideline,
             "narrative_focus": state["narrative_focus"],
+            "style_directive": state["style_directive"],
         },
         prompt=prompt,
         raw_response=raw_response,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
@@ -109,6 +109,33 @@ def _format_hard_constraints(writing_brief: dict[str, Any]) -> str:
     return "\n\n".join(sections)
 
 
+def _format_style_directive(option_context: dict[str, Any]) -> str:
+    """Render the resolved tone, length, and brand voice guides as a required
+    style block. These used to travel inside ``editorial_instructions``, which
+    every prompt renders under the header "NARRATIVE FOCUS (OPTIONAL)" -- so the
+    whole tone guide reached the model labelled optional. Built from
+    ``option_context`` rather than the writing brief so the runtime-run path
+    gets the same directive as a full run."""
+    context = _safe_dict(option_context)
+
+    sections: list[str] = []
+    for key, heading in (
+        ("tone", "Tone"),
+        ("length", "Length"),
+        ("brand_voice", "Brand voice"),
+    ):
+        option = _safe_dict(context.get(key))
+        instructions = _safe_str(option.get("instructions"))
+        if not instructions:
+            continue
+        label = _safe_str(option.get("label")) or _safe_str(option.get("id"))
+        sections.append(f"{heading} profile ({label}):\n{instructions}")
+
+    if not sections:
+        return "No style profiles were resolved. Use clear, neutral editorial prose."
+    return "\n\n".join(sections)
+
+
 def _clean_string_list(items: list[str]) -> list[str]:
     cleaned: list[str] = []
     for item in items:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_and_constraints.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_and_constraints.py
@@ -10,7 +10,10 @@ from app.features.prompt2blog.quality import (
     _extract_narrative_focus,
     _should_run_repair,
 )
-from app.features.prompt2blog.support import _format_hard_constraints
+from app.features.prompt2blog.support import (
+    _format_hard_constraints,
+    _format_style_directive,
+)
 
 
 def _option_context() -> dict[str, Any]:
@@ -115,6 +118,52 @@ def test_creativity_level_reaches_the_brief_profile():
     assert PROMPT2BLOG_CREATIVITY_TEMPERATURES["high"] > (
         PROMPT2BLOG_CREATIVITY_TEMPERATURES["low"]
     )
+
+
+def test_style_profiles_are_not_folded_into_narrative_focus():
+    # Tone, length, and brand voice used to ride inside editorial_instructions,
+    # which every prompt renders under the header "NARRATIVE FOCUS (OPTIONAL)" --
+    # so the entire tone guide reached the model labelled optional.
+    focus = _extract_narrative_focus(_brief())
+
+    assert "Be direct." not in focus
+    assert "Balance depth." not in focus
+    assert "Stay globally minded." not in focus
+    # Genuine steering stays.
+    assert "Creativity level: high" in focus
+
+
+def test_style_directive_block_carries_every_resolved_profile():
+    rendered = _format_style_directive(_option_context())
+
+    assert "Tone profile (Practical):" in rendered
+    assert "Be direct." in rendered
+    assert "Length profile (Medium):" in rendered
+    assert "Balance depth." in rendered
+    assert "Brand voice profile (Questurian Default):" in rendered
+    assert "Stay globally minded." in rendered
+
+
+def test_style_directive_block_is_explicit_when_unresolved():
+    assert _format_style_directive({}).startswith("No style profiles were resolved")
+
+
+def test_every_generation_prompt_renders_the_style_directive():
+    # A prompt that omits the placeholder silently drops tone from that stage.
+    from app.features.prompt2blog.prompts import editorial, generation, quality
+
+    rendering = [
+        generation.P2B_COVERAGE_CHECK_PROMPT,
+        generation.P2B_SUPPLEMENT_PROMPT,
+        generation.P2B_OUTLINE_PROMPT,
+        generation.P2B_COMPOSE_PROMPT,
+        quality.P2B_QUALITY_AUDIT_PROMPT,
+        quality.P2B_REPAIR_PROMPT,
+        editorial.P2B_EDITORIAL_AUGMENTATION_PROMPT,
+    ]
+    for prompt in rendering:
+        assert "STYLE DIRECTIVE (REQUIRED):" in prompt
+        assert "{style_directive}" in prompt
 
 
 def test_call_to_action_flows_into_the_brief():


### PR DESCRIPTION
## Problem

Tone, length, and brand-voice instructions were concatenated into `writing_brief.editorial_instructions` (`input.py`), which `_extract_narrative_focus` returns verbatim (`quality.py:31`), which every prompt renders under:

```
NARRATIVE FOCUS (OPTIONAL):
```

So the entire tone guide reached the model labelled *optional*.

#161 already found this exact failure mode for `must_include` / `negative_instructions` — the comment at `input.py:38-41` records it — and fixed those by promoting them to a `HARD CONSTRAINTS` block. The style profiles were left behind in the same buried field.

Worth noting url2blog and youtube2blog never had this bug: they inject tone via `build_tone_guidance` as a plain `TONE PROFILE (label):` block. Prompt2Blog was the only outlier.

## Change

- New `_format_style_directive(option_context)` in `support.py`, mirroring `_format_hard_constraints`.
- Built from `option_context`, not the writing brief, so the runtime-run path gets the same directive as a full run.
- Rendered as `STYLE DIRECTIVE (REQUIRED):` in all seven prompts that write or evaluate prose: coverage, supplement, outline, compose, quality audit, repair, editorial augmentation.
- `editorial_instructions` keeps what is genuinely steering — destination context, audience intent, creativity level.
- Compose/supplement hard rules now point at the block explicitly instead of the vaguer "respect brief voice/tone".
- Threaded into debug traces so the resolved directive stays inspectable.

## Note on the quality auditor

`P2B_QUALITY_AUDIT_PROMPT` never received narrative focus at all, so **nothing in the pipeline scored tone adherence**. A new test asserting every prose prompt renders the placeholder is what surfaced this. The auditor now gets the directive too — that is what turns tone into an enforced requirement rather than a request. The audit JSON schema is unchanged.

## Verification

- `pytest`: 436 passed (432 baseline + 4 new).
- `flake8` on the touched tree: clean.
- No option-file, request/response, or persisted-stage contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)