### PR TITLE
feat(prompt2blog): rewrite the three stub tone guides

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/aspirational-grounded.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/aspirational-grounded.md
@@ -2,7 +2,7 @@
 id: aspirational-grounded
 label: Aspirational but Grounded
 description: Inspiring destination/lifestyle voice without brochure language.
-order: 10
+order: 9
 ---
 ## Aspirational but Grounded Tone
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/editorial-comparison.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/editorial-comparison.md
@@ -2,7 +2,7 @@
 id: editorial-comparison
 label: Editorial Comparison
 description: Analytical, balanced, and willing to take a clear stance.
-order: 6
+order: 5
 ---
 ## Editorial Comparison Tone
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/editorial.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/editorial.md
@@ -1,9 +1,13 @@
 ---
 id: editorial
 label: Editorial
-description: Polished publication style with strong flow.
-order: 2
+description: Long-form narrative: one throughline, scene, and a building argument.
+order: 6
 ---
 ## Editorial Tone
 
-Write with polished transitions and cohesive structure. Keep authority and clarity high while avoiding hype.
+Best for feature stories, travel essays, reported profiles, and in-depth analysis that has to hold together as a single piece.
+
+Write to a throughline. Open on something specific — a scene, a tension, a claim worth defending — and carry it through every section so the article reads as one argument instead of a stack of headed blocks. Make transitions do real work: each section should change what the reader understands rather than restate it. Use narrative detail where the source supports it, and let structure carry the reasoning.
+
+Keep authority high and hype at zero. Earn conclusions instead of announcing them, and concede what complicates the argument rather than writing around it. This is not the tone for scannable service formatting or for head-to-head verdicts. The value here is depth, sequence, and a point of view that gets clearer the further the reader gets.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/forbes-service-journalism.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/forbes-service-journalism.md
@@ -2,7 +2,7 @@
 id: forbes-service-journalism
 label: Forbes-Style Service Journalism
 description: Polished, structured, neutral, and decisive.
-order: 8
+order: 4
 ---
 ## Forbes-Style Service Journalism Tone
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/inspirational.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/inspirational.md
@@ -1,9 +1,13 @@
 ---
 id: inspirational
 label: Inspirational
-description: Vivid and motivating while staying factual.
-order: 3
+description: Pure wanderlust. Use Aspirational but Grounded if claims need receipts.
+order: 10
 ---
 ## Inspirational Tone
 
-Use evocative but controlled language to inspire action. Keep claims grounded and avoid overstatement.
+Best for destination inspiration, seasonal roundups, bucket-list features, and openers whose only job is to make someone want to go.
+
+Write for desire, not for the decision. Pick the two or three things that actually pull people to a place — a specific light, a specific meal, the hour the streets change character — and render them precisely enough that the reader can picture being there. Momentum matters more than completeness. Leave the logistics to the sections that follow.
+
+Every image still has to be true. No invented sensory detail, no vague transformation claims, and none of the stock travel vocabulary: hidden gem, must-see, nestled, breathtaking, or any line that could describe forty other places. If the piece needs each aspirational claim tied to a concrete reason such as cost, weather, food, access, or daily friction, use Aspirational but Grounded instead. This tone runs lighter on justification, which makes it the easiest one in the set to get wrong.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/no-fluff-field-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/no-fluff-field-guide.md
@@ -2,7 +2,7 @@
 id: no-fluff-field-guide
 label: No-Fluff Field Guide
 description: Direct, blunt, practical, and experience-informed.
-order: 5
+order: 3
 ---
 ## No-Fluff Field Guide Tone
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/practical-authority.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/practical-authority.md
@@ -2,7 +2,7 @@
 id: practical-authority
 label: Practical Authority
 description: Clear, useful, confident, and low-fluff.
-order: 4
+order: 2
 ---
 ## Practical Authority Tone
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/practical.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/practical.md
@@ -1,10 +1,14 @@
 ---
 id: practical
 label: Practical
-description: Clear, actionable, and logistics-first.
+description: Safe general-purpose default. Clear and useful without a stance.
 default: true
 order: 1
 ---
 ## Practical Tone
 
-Write with direct, useful guidance. Prioritize clear steps, realistic caveats, and concrete advice over flourish.
+Best for general destination guides, how-to explainers, roundups, and any article where no stronger editorial angle has been chosen.
+
+Write clear, useful prose that answers the question the title promises. Lead each section with the thing the reader came for, then support it with concrete detail: costs, timing, distances, requirements, and the caveats that actually change a decision. Keep sentences plain and paragraphs tight. Cut filler transitions, restated headings, and throat-clearing introductions.
+
+Stay deliberately even-handed. Do not build a thesis or rank options against each other, and do not lead with warnings or strip the piece down to raw logistics. Explain how something works, what it costs, what to expect, and where readers commonly get it wrong, then move on. Competence is the whole voice here: no brochure language, no performative personality, no hype.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/street-smart-nomad.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/street-smart-nomad.md
@@ -2,7 +2,7 @@
 id: street-smart-nomad
 label: Street-Smart Nomad
 description: Realistic, cautionary, slightly blunt.
-order: 9
+order: 8
 ---
 ## Street-Smart Nomad Tone
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_tone_catalog.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_tone_catalog.py
@@ -1,0 +1,70 @@
+"""Invariants for the shared tone catalog.
+
+data/prompt2blog/tones lives under prompt2blog but is not prompt2blog's:
+app.shared.tone_profiles points at it, and url2blog and youtube2blog both
+resolve tones through that loader. resolve_tone_profile raises on an unknown
+id, so renaming or deleting a file breaks two other pipelines at runtime and
+invalidates any saved composer state referencing the old id.
+"""
+
+from __future__ import annotations
+
+from app.shared.tone_profiles import (
+    DEFAULT_TONE_ID,
+    load_tone_profiles,
+    resolve_tone_profile,
+)
+
+# Every id that has shipped. Add to this list; never remove from it.
+SHIPPED_TONE_IDS = {
+    "aspirational-grounded",
+    "editorial",
+    "editorial-comparison",
+    "experienced-traveler",
+    "forbes-service-journalism",
+    "inspirational",
+    "no-fluff-field-guide",
+    "practical",
+    "practical-authority",
+    "street-smart-nomad",
+}
+
+
+def test_every_shipped_tone_id_still_resolves():
+    for tone_id in SHIPPED_TONE_IDS:
+        assert resolve_tone_profile(tone_id)["id"] == tone_id
+
+
+def test_default_tone_id_resolves():
+    # url2blog and youtube2blog fall back to this constant when no tone is sent.
+    assert resolve_tone_profile(None)["id"] == DEFAULT_TONE_ID
+
+
+def test_exactly_one_tone_is_flagged_default():
+    flagged = [p["id"] for p in load_tone_profiles() if p["default"]]
+
+    assert flagged == [DEFAULT_TONE_ID]
+
+
+def test_tone_order_values_are_unique():
+    # Ties fall through to label sort, which makes dropdown order incidental.
+    orders = [p["order"] for p in load_tone_profiles()]
+
+    assert len(set(orders)) == len(orders)
+
+
+def test_every_tone_carries_routing_guidance():
+    # The catalog used to mix full guides with one-line stubs, and the stubs
+    # were the default and the first two picks. A tone that cannot tell a
+    # writer when to choose it is not usable steering.
+    for profile in load_tone_profiles():
+        instructions = profile["instructions"]
+        assert "Best for" in instructions, f"{profile['id']} has no routing line"
+        assert len(instructions.split()) >= 50, f"{profile['id']} is a stub"
+
+
+def test_every_tone_has_a_dropdown_description():
+    for profile in load_tone_profiles():
+        description = profile["description"]
+        assert description, f"{profile['id']} has no description"
+        assert len(description) <= 80, f"{profile['id']} description is too long"


### PR DESCRIPTION
## Problem

The tone catalog held two generations of writing:

- **Seven real guides** (`practical-authority`, `no-fluff-field-guide`, `editorial-comparison`, `experienced-traveler`, `forbes-service-journalism`, `street-smart-nomad`, `aspirational-grounded`) — a "Best for …" routing line plus concrete directives.
- **Three one-to-two sentence stubs** (`practical`, `editorial`, `inspirational`).

The three stubs were `order: 1,2,3` — and `practical` is the pipeline default. So the weakest steering in the catalog was what most runs actually used, and the three stubs each had a strictly better twin:

| stub | superseded by |
|---|---|
| `practical` | `practical-authority`, `no-fluff-field-guide` |
| `editorial` | `forbes-service-journalism`, `editorial-comparison` |
| `inspirational` | `aspirational-grounded` |

## Why rewrite in place rather than delete

`data/prompt2blog/tones/` is **not prompt2blog's alone**. `app/shared/tone_profiles.py:10` points `TONES_DIR` at it, and both url2blog (`pipeline_v2/context.py:57`) and youtube2blog (`graph/runner.py:63`) resolve through it. `resolve_tone_profile()` raises `ValueError` on an unknown id, and `DEFAULT_TONE_ID = "practical"` is hardcoded at `tone_profiles.py:11`.

Deleting or renaming a file would break two other pipelines at runtime and invalidate saved composer state in localStorage. **No id, label, or default flag changed here** — only file bodies, descriptions, and `order`.

## Lanes

Each rewritten tone states its boundary behaviourally rather than by naming its neighbours, since these strings are injected into prompts:

- **practical** (default) — neutral-competent baseline for when no stronger angle was chosen. Explicitly does not build a thesis or lead with warnings.
- **editorial** — long-form narrative with one throughline; cedes scannable service formatting and head-to-head verdicts.
- **inspirational** — pure desire framing, logistics deferred. Its `description` points users at Aspirational but Grounded when claims need receipts, and the two are now adjacent at `order` 9/10.

## Ordering

Re-sequenced by editorial deliberateness, default first: practical, practical-authority, no-fluff-field-guide, forbes-service-journalism, editorial-comparison, editorial, experienced-traveler, street-smart-nomad, aspirational-grounded, inspirational.

Selection is driven by the `default: true` flag (`options.py` `_default_option`), not by position, so ordering is presentation-only.

## Verification

- `pytest`: 442 passed (436 baseline + 6 new).
- New `test_shared_tone_catalog.py` locks the cross-pipeline contract: every shipped id still resolves, exactly one default flag, unique order values, plus a floor on guidance depth so a stub cannot reappear.
- `flake8`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)