### PR TITLE
feat(prompt2blog): make brand voice carry the house non-negotiables

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/local-insider.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/local-insider.md
@@ -1,9 +1,23 @@
 ---
 id: local-insider
 label: Local Insider
-description: Helpful on-the-ground guidance with cultural nuance.
+description: House rules plus sourced ground-level detail and no stereotypes.
 order: 3
 ---
 ## Local Insider Voice
 
-Write like an informed local guide: specific, warm, and practical. Preserve factual accuracy and avoid stereotypes.
+These rules hold regardless of the selected tone, and they win where the tone profile seems to conflict.
+
+Never use, in any form: nestled, hidden gem, must-visit, boasts, unlock, delve, tapestry, vibrant, bustling, charming, treasure trove, "whether you're X or Y", "when it comes to", "in conclusion", "look no further", "the perfect blend of", "something for everyone", "not only... but also". Also banned here: "like a local", "off the beaten path", "the real" plus a place name, "authentic", "undiscovered", "locals know", "city of contrasts", "sleepy fishing village", and "tourist trap" used as a verdict. No throat-clearing openers, no em-dash asides, no rhetorical questions as headings.
+
+Familiarity is earned from the sources, not performed. Every ground-level specific must trace to something in the sources: the street, the entrance, the hours, the fare, the queue, which bus, which window. If the sources do not support the specific, write the general version or leave it out. Do not manufacture detail to sound like you have been there, and never invent a visit, a vendor, a friend, or an overheard conversation. Unconfirmed detail is attributed in the sentence or cut.
+
+Anti-stereotype rule: do not characterize a nationality, ethnicity, religion, or neighborhood by temperament. No "famously warm people", "laid-back pace", "chaotic but charming". Do not render poverty, informality, or aging infrastructure as picturesque. Do not rank one place as more authentic than another, and never tell the reader they will blend in.
+
+Point of view: address the reader as "you". First-person singular only when the tone profile invites it and only for source-supported judgment.
+
+Facts: prices with currency and an as-of frame, dates in full, hours as sourced with day ranges. Local proper name on first mention with a gloss where it helps, then the local name alone, transliterated consistently. Do not round what the sources did not round.
+
+Structure: sentence case headings, no one-sentence sections, lists only for parallel items, no closing recap.
+
+Hedging: say it or cut it. No "may or may not", no fake balance. A caveat names its condition.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/news-desk.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/news-desk.md
@@ -1,9 +1,23 @@
 ---
 id: news-desk
 label: News Desk
-description: Neutral and fact-led newsroom voice.
+description: House rules, attribution-first, third person, zero promotion.
 order: 2
 ---
 ## News Desk Voice
 
-Lead with verified facts and clear attribution. Keep sentence construction clean and avoid emotional or promotional phrasing.
+These rules hold regardless of the selected tone, and they win where the tone profile seems to conflict.
+
+Attribution comes first. Every claim carries its source inside the sentence that makes it: who said it, in what document or statement, and when. Separate confirmed from reported by verb choice: confirmed, said, announced, according to, has not confirmed. Never present one party's position as established fact. Where sourcing is thin, write what is known and name what is not.
+
+No promotion of any kind. No recommendations, rankings, superlatives, or calls to action. Do not address the reader: never "you", never imperatives aimed at the reader. Third person throughout, no first person singular or plural, regardless of what the tone profile allows.
+
+Never use, in any form: nestled, hidden gem, must-visit, boasts, unlock, delve, tapestry, vibrant, bustling, iconic, world-class, beloved, stunning, "whether you're X or Y", "when it comes to", "in conclusion", "not only... but also". Also banned: slammed, sparked outrage, amid growing concerns, "many are saying", "some critics argue" without a named critic.
+
+Facts: full name and title on first mention, surname alone after. Prices with currency and an as-of frame. Dates written in full. Hours as sourced with day ranges. Figures exactly as the source gives them, unrounded. Local proper names on first mention with a gloss where it helps, then the local name, transliterated consistently across the piece.
+
+Sentence construction stays tight: one idea per sentence, subject first, active voice. Passive only when the actor is genuinely unknown. Cut intensifying adverbs. No em-dash asides; end the sentence instead.
+
+Structure: sentence case headings, no terminal punctuation. The opening paragraph carries what happened, where, when, and on whose authority. No one-sentence sections, no closing summary, lists only for parallel items such as figures or sequences.
+
+Hedging: state it with attribution or leave it out. No "may or may not", no manufactured balance, no two-sided framing where the sources do not actually disagree.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/questurian-default.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/questurian-default.md
@@ -1,10 +1,20 @@
 ---
 id: questurian-default
 label: Questurian Default
-description: Premium travel editorial voice with practical clarity.
+description: House rules for banned lexicon, fact formatting, POV, and hedging.
 default: true
 order: 1
 ---
 ## Questurian Default Voice
 
-Use globally minded, service-oriented editorial language. Be concise, trustworthy, and practical while maintaining polish.
+These rules hold regardless of the selected tone. The tone profile sets how the piece sounds. This sets what Questurian always does. Where they seem to conflict, these rules win.
+
+Never use, in any form: nestled, hidden gem, must-visit, must-see, boasts, unlock, delve, tapestry, vibrant, bustling, breathtaking, stunning, charming, treasure trove, gateway to, "whether you're X or Y", "when it comes to", "in conclusion", "in today's world", "look no further", "at the end of the day", "the perfect blend of", "something for everyone", "rich in history and culture", "not only... but also". Do not open a sentence with a throat-clearing clause or an em-dash aside; put the subject first. No rhetorical question as a section opener. Kill any adjective that would survive being deleted.
+
+Point of view: "you" is the reader making the decision, and it is the default address. First-person singular is permitted only when the tone profile invites it, and only to carry judgment the sources support. Never invent a trip, meal, walk, conversation, or visit. Never write "I stayed at" or "we found" unless a source records it. Do not use "we" for the publication; state the recommendation instead of announcing that it is one.
+
+Facts: give prices with currency and an as-of frame, e.g. "COP 38,000 (about USD 9) as of March 2026". Write dates in full. Give hours as sourced, with the day range. Use the local proper name on first mention with an English gloss where it helps, then the local name alone, transliterated consistently throughout. Do not round numbers the sources did not round. An unconfirmed detail is either attributed in the sentence ("the operator's site lists...") or cut.
+
+Structure: sentence case headings, no terminal punctuation, no gerund stacking. No one-sentence sections. Lists only for genuinely parallel items, never to chop up an argument. No closing recap section.
+
+Hedging: say it or cut it. No "may or may not", no "varies widely", no invented two-sidedness. A real caveat names what changes it and when.

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brand_voices.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brand_voices.py
@@ -1,0 +1,67 @@
+"""Invariants for the brand voice catalog.
+
+Brand voice and tone are concatenated into the same STYLE DIRECTIVE block, so
+a brand voice that restates tone sends the model two competing style vectors.
+Brand voice owns only what is invariant across every tone: banned lexicon,
+point of view, fact rendering, structure, and hedging.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.config import PROMPT2BLOG_BRAND_VOICES_DIR
+from app.features.prompt2blog.options import (
+    _default_option,
+    _read_markdown_option_files,
+)
+
+SHIPPED_BRAND_VOICE_IDS = {"local-insider", "news-desk", "questurian-default"}
+
+
+def _voices() -> list[dict]:
+    return _read_markdown_option_files(PROMPT2BLOG_BRAND_VOICES_DIR)
+
+
+def test_every_shipped_brand_voice_id_still_resolves():
+    # Saved composer state and stored runs reference these ids.
+    assert {voice["id"] for voice in _voices()} == SHIPPED_BRAND_VOICE_IDS
+
+
+def test_exactly_one_brand_voice_is_flagged_default():
+    voices = _voices()
+    flagged = [voice["id"] for voice in voices if voice["default"]]
+
+    assert flagged == ["questurian-default"]
+    # brand_voice_id is optional on the request; an unflagged catalog would
+    # make _resolve_input_options fall through to whatever sorted first.
+    assert _default_option(voices)["id"] == "questurian-default"
+
+
+def test_every_brand_voice_declares_precedence_over_tone():
+    # Without this the two blocks read as equally weighted suggestions.
+    for voice in _voices():
+        assert "tone" in voice["instructions"].lower(), voice["id"]
+
+
+def test_every_brand_voice_carries_the_house_rule_categories():
+    # These are the categories that make brand voice distinct from tone. A
+    # voice missing one silently stops constraining that dimension.
+    for voice in _voices():
+        body = voice["instructions"].lower()
+        assert "never use" in body, f"{voice['id']} has no banned lexicon"
+        assert "facts:" in body, f"{voice['id']} has no fact-rendering rules"
+        assert "structure:" in body, f"{voice['id']} has no structural rules"
+        assert "hedging" in body, f"{voice['id']} has no hedging rule"
+
+
+def test_brand_voices_stay_dense_enough_to_be_worth_injecting():
+    # They ship in every prompt call, so they are budgeted, but the previous
+    # one-sentence versions carried almost no signal.
+    for voice in _voices():
+        words = len(voice["instructions"].split())
+        assert 150 <= words <= 400, f"{voice['id']} is {words} words"
+
+
+def test_every_brand_voice_has_a_dropdown_description():
+    for voice in _voices():
+        assert voice["description"], voice["id"]
+        assert len(voice["description"]) <= 80, voice["id"]


### PR DESCRIPTION
## Problem

The three brand-voice files were ~20 words each and they **restated tone**. `questurian-default.md` in full:

> Use globally minded, service-oriented editorial language. Be concise, trustworthy, and practical while maintaining polish.

That is a tone description. Because tone and brand voice are concatenated into the same style block (`input.py`, now the `STYLE DIRECTIVE` from #165), picking a tone *and* a brand voice sent the model two overlapping, competing style vectors — and the brand voice contributed almost no distinct signal.

## Change

Tone owns how the piece sounds. Brand voice now owns what the publication always does, regardless of which of the ten tones is selected:

- **Banned lexicon** — a real list, not a gesture at one (`nestled`, `hidden gem`, `boasts`, `delve`, `tapestry`, `whether you're X or Y`, `in conclusion`, …).
- **Point of view** — when first person is permitted, how `you` is used, and a hard rule against inventing a trip, meal, or conversation the sources do not record.
- **Fact rendering** — prices with currency and an as-of frame, dates in full, hours as sourced, proper names and transliteration, how to phrase an unconfirmed detail.
- **Structure** — sentence case headings, no one-sentence sections, lists only for parallel items.
- **Hedging** — say it or cut it; a real caveat names what changes it.

Each file states explicitly that these rules win where the tone profile appears to conflict, which resolves the precedence question the concatenation left open.

## Keeping the three distinct

- **questurian-default** — the full rule set.
- **local-insider** — adds an anti-stereotype clause (no characterising a nationality or neighbourhood by temperament, no rendering poverty as picturesque), bans authenticity tropes (`like a local`, `off the beaten path`, `undiscovered`), and requires every ground-level specific to trace to a source.
- **news-desk** — overrides rather than extends: attribution inside the claiming sentence, verb choice separating confirmed from reported, no second or first person *regardless of tone*, no promotional framing, plus banned newsroom cliché (`slammed`, `sparked outrage`).

Ids, labels, and the default flag are unchanged, so saved composer state and stored runs still resolve.

## Verification

- `pytest`: 448 passed (442 baseline + 6 new).
- New `test_prompt2blog_brand_voices.py` guards id stability, the single default flag, the presence of each house-rule category, and a density floor so these cannot decay back into one-liners.
- `flake8`: clean.

## Note

The banned-lexicon core is duplicated across all three files (~40 tokens per call). The loader injects exactly one brand-voice body and there is no composition mechanism, so factoring out a shared preamble would need a change in `options.py` — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)