### PR TITLE
fix(prompt2blog): stop the length gate demanding wall-of-text paragraphs

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -69,7 +69,15 @@ def _contains_phrase(text: str, phrase: str) -> bool:
 
 
 def _estimate_paragraph_sentence_average(content: str) -> float:
-    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", content) if p.strip()]
+    # Headings are not paragraphs. They used to be counted as one-sentence
+    # blocks, so every `##` dragged the average down and a well-sectioned
+    # article measured far shorter than it reads -- which is exactly the
+    # article the length profiles ask for.
+    paragraphs = [
+        block.strip()
+        for block in re.split(r"\n\s*\n", content)
+        if block.strip() and not block.lstrip().startswith("#")
+    ]
     if not paragraphs:
         return 0.0
 
@@ -117,7 +125,12 @@ def _build_constraint_checks(
     elif paragraph_length_pref.lower().startswith("medium"):
         paragraph_length_met = 2.5 <= avg_sentences <= 5.5
     elif paragraph_length_pref.lower().startswith("long"):
-        paragraph_length_met = avg_sentences >= 5.0
+        # Bounded on both sides. This used to be `>= 5.0`, which is unbounded
+        # above and turned the gate into a hard requirement for wall-of-text
+        # paragraphs -- against the long profile's own instruction to keep
+        # structure scannable. Length comes from more sections, not longer
+        # blocks, so an article that stays readable must not fail the check.
+        paragraph_length_met = 3.0 <= avg_sentences <= 6.5
 
     cta = _safe_str(writing_brief.get("call_to_action"))
     cta_present = _keyword_overlap_ratio(cta, combined) >= 0.35 if cta else True

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/lengths/long.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/lengths/long.md
@@ -2,10 +2,12 @@
 id: long
 label: Long
 description: Deeper coverage and richer context.
-paragraph_length: Long (5–8 sentences per paragraph)
+paragraph_length: Long (3–6 sentences per paragraph)
 target_word_count: 1400
 order: 3
 ---
 ## Long Length Profile
 
 Provide deeper context, comparisons, and practical nuance while keeping structure scannable with clear headings.
+
+Depth comes from covering more ground, not from longer paragraphs. Add sections and sharpen the comparisons rather than stacking sentences into blocks the reader has to wade through. A long article earns its length through the number of decisions it helps the reader make.

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_length_profiles.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_length_profiles.py
@@ -1,0 +1,81 @@
+"""The length profiles and the paragraph gate have to agree.
+
+Each length profile declares a `paragraph_length` band in its frontmatter and
+that string is the only thing _build_constraint_checks routes on. When the
+declared band and the gate's band disagree, the gate fails prose that followed
+the instruction it was given -- and a failed check buys a full repair rewrite.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.features.prompt2blog.config import PROMPT2BLOG_LENGTHS_DIR
+from app.features.prompt2blog.options import _read_markdown_option_files
+from app.features.prompt2blog.quality import _build_constraint_checks
+
+SHIPPED_LENGTH_IDS = {"long", "medium", "short"}
+
+
+def _lengths() -> list[dict]:
+    return _read_markdown_option_files(PROMPT2BLOG_LENGTHS_DIR)
+
+
+def _declared_band(paragraph_length: str) -> tuple[int, int]:
+    low, high = re.search(r"(\d+)\D+(\d+)", paragraph_length).groups()
+    return int(low), int(high)
+
+
+def _article(sentences_per_paragraph: int, paragraphs: int = 6) -> str:
+    body = " ".join(
+        f"Sentence {index} carries a concrete detail."
+        for index in range(sentences_per_paragraph)
+    )
+    return "\n\n".join(f"## Section {index}\n\n{body}" for index in range(paragraphs))
+
+
+def _paragraph_check(content: str, paragraph_length: str) -> bool:
+    return _build_constraint_checks(
+        "A Title",
+        content,
+        {"formatting": {"paragraph_length": paragraph_length, "target_word_count": 0}},
+    )["paragraph_length_met"]
+
+
+def test_every_shipped_length_id_still_resolves():
+    assert {length["id"] for length in _lengths()} == SHIPPED_LENGTH_IDS
+
+
+def test_exactly_one_length_is_flagged_default():
+    assert [length["id"] for length in _lengths() if length["default"]] == ["medium"]
+
+
+def test_gate_accepts_prose_written_to_each_declared_band():
+    # The bug this locks: `long` declared 5-8 sentences per paragraph while the
+    # gate required an unbounded `>= 5.0`, so the profile's own instruction to
+    # keep structure scannable could not be satisfied without failing.
+    for length in _lengths():
+        paragraph_length = length["paragraph_length"]
+        low, high = _declared_band(paragraph_length)
+        for sentences in range(low, high + 1):
+            assert _paragraph_check(_article(sentences), paragraph_length), (
+                f"{length['id']} rejects {sentences} sentences per paragraph, "
+                f"inside its own declared band {paragraph_length}"
+            )
+
+
+def test_gate_still_rejects_paragraphs_far_outside_the_declared_band():
+    for length in _lengths():
+        paragraph_length = length["paragraph_length"]
+        _, high = _declared_band(paragraph_length)
+
+        assert not _paragraph_check(_article(high + 6), paragraph_length), (
+            f"{length['id']} accepts wall-of-text paragraphs"
+        )
+
+
+def test_long_profile_does_not_ask_for_wall_of_text_paragraphs():
+    long_profile = next(item for item in _lengths() if item["id"] == "long")
+    _, high = _declared_band(long_profile["paragraph_length"])
+
+    assert high <= 6


### PR DESCRIPTION
## Problem

`long.md` declared:

```yaml
paragraph_length: Long (5–8 sentences per paragraph)
```

and `quality.py` enforced `avg_sentences >= 5.0` — unbounded above. Meanwhile the same file's body asks the writer to keep "structure scannable with clear headings." The profile contradicted itself, and the gate sided with the wall of text.

That is not a cosmetic disagreement: `paragraph_length_met` feeds repair gating, so failing it buys a full rewrite pass.

## The second defect, found by the test

Writing a test that derives each profile's band from its own frontmatter surfaced something I had not planned to fix:

`_estimate_paragraph_sentence_average` split on blank lines and counted **markdown headings as one-sentence paragraphs**. Every `##` pulled the mean down, so a well-sectioned article measured far shorter than it reads. With six sections interleaved, clearing the old `5.0` floor took roughly **nine-sentence paragraphs**.

That is the real reason the long profile was effectively unsatisfiable rather than merely strict — and it skewed the short and medium bands too, just less visibly.

## Change

- `long.md`: band becomes 3–6, and the body now says plainly that depth comes from more sections, not longer paragraphs.
- `quality.py`: the long branch is bounded on both sides (`3.0 <= avg <= 6.5`).
- `_estimate_paragraph_sentence_average` skips heading blocks.

## Verification

- `pytest`: 453 passed (448 baseline + 5 new).
- New `test_prompt2blog_length_profiles.py` reads each profile's declared band out of its own frontmatter and asserts the gate accepts prose written to every sentence count inside it — so a guide and its gate cannot silently drift apart again. It still asserts the gate rejects paragraphs well outside the band.
- `flake8`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)