### PR TITLE
feat(prompt2blog): name the brief keys honestly and add angle and CTA inputs

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/input.py
@@ -21,7 +21,16 @@ def _build_writing_brief_from_input(
     must_include = _clean_string_list(request.must_include)
     negative_instructions = _clean_string_list(request.negative_instructions)
 
-    profile_lines = [
+    profile_lines = []
+    # The angle leads the block. Several tones -- editorial-comparison and
+    # practical-authority especially -- require the piece to take a stance, and
+    # until now the brief had nowhere to put one, so the model invented its own
+    # or defaulted to fake balance.
+    if request.angle:
+        profile_lines.append(
+            f"Editorial angle - the piece must argue this: {_safe_str(request.angle)}"
+        )
+    profile_lines += [
         f"Destination context: {_safe_str(request.destination_context)}",
         f"Audience intent: {_safe_str(request.target_reader)}",
         f"Creativity level: {creativity_level}",
@@ -50,10 +59,14 @@ def _build_writing_brief_from_input(
         target_word_count = 900
 
     writing_brief: dict[str, Any] = {
-        "topic": _safe_str(request.article_goal),
+        # `topic` used to duplicate `goal` verbatim, and `perspective` was fed
+        # destination_context -- in a JSON brief "perspective" reads as point of
+        # view, so the model was handed a city name under a POV key. Both keys
+        # are named for what they actually carry now.
         "goal": _safe_str(request.article_goal),
         "audience": _safe_str(request.target_reader),
-        "perspective": _safe_str(request.destination_context),
+        "destination_context": _safe_str(request.destination_context),
+        "angle": _safe_str(request.angle),
         "audience_profile": _safe_str(request.audience_profile),
         "voice": {
             "publication_style_reference": _safe_str(brand_voice.get("label")),

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
@@ -55,6 +55,7 @@ class Prompt2BlogInputRequest(BaseModel):
     article_goal: str
     target_reader: str
     destination_context: str
+    angle: str | None = None
     tone_id: str
     length_id: str
     brand_voice_id: str | None = None

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
@@ -80,7 +80,7 @@ Rules:
 - Supplemental context may explain concepts mentioned in the source, but the final article cannot invent unsupported specifics.
 - If details are missing, use cautious phrasing and clearly mark uncertainty.
 - Follow STYLE DIRECTIVE exactly. Tone, length, and brand voice are requirements, not suggestions.
-- Respect writing brief audience and perspective.
+- Respect writing brief audience, destination context, and editorial angle.
 - Use clear logical transitions only where needed; avoid stock transition phrases.
 - Use `##` section headings.
 - Keep sections practical and actionable.
@@ -203,7 +203,7 @@ Hard rules:
 - Include one direct 40-60 word answer near the top.
 - Include a concise takeaway section near the end.
 - Follow STYLE DIRECTIVE exactly. Tone, length, and brand voice are requirements, not suggestions.
-- Respect brief perspective and audience.
+- Respect brief audience, destination context, and editorial angle.
 - Respect formatting brief (paragraph length and target word count).
 - Include CTA naturally near the end when provided.
 - SEO: place keywords naturally, never stuff.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -35,8 +35,12 @@ def _extract_narrative_focus(writing_brief: dict[str, Any]) -> str:
     goal = _safe_str(writing_brief.get("goal"))
     if goal:
         return goal
-    perspective = _safe_str(writing_brief.get("perspective"))
-    return perspective or "No additional narrative focus provided."
+    # `perspective` is still read so briefs posted to the runtime endpoint
+    # before the rename keep resolving.
+    destination = _safe_str(writing_brief.get("destination_context")) or _safe_str(
+        writing_brief.get("perspective")
+    )
+    return destination or "No additional narrative focus provided."
 
 
 # A brief asking for "flights to Lima" is satisfied by prose saying "flight to

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_and_constraints.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_and_constraints.py
@@ -166,6 +166,37 @@ def test_every_generation_prompt_renders_the_style_directive():
         assert "{style_directive}" in prompt
 
 
+def test_brief_keys_are_named_for_what_they_carry():
+    brief = _brief()
+
+    # `perspective` was fed destination_context. In a JSON brief "perspective"
+    # reads as point of view, so the model was handed a city under a POV key.
+    assert brief["destination_context"] == "Peru"
+    assert "perspective" not in brief
+    # `topic` duplicated `goal` verbatim, so one input filled two keys.
+    assert "topic" not in brief
+    assert brief["goal"] == "Explain Peru entry rules."
+
+
+def test_narrative_focus_still_resolves_a_pre_rename_brief():
+    # Callers can post a writing brief straight to the runtime endpoint.
+    legacy = {"perspective": "Kyoto, Japan"}
+
+    assert _extract_narrative_focus(legacy) == "Kyoto, Japan"
+
+
+def test_editorial_angle_leads_the_narrative_focus_when_supplied():
+    focus = _extract_narrative_focus(_brief(angle="Peru is the better first stop"))
+
+    assert focus.startswith("Editorial angle")
+    assert "Peru is the better first stop" in focus
+
+
+def test_brief_omits_the_angle_line_when_none_is_supplied():
+    assert "Editorial angle" not in _extract_narrative_focus(_brief())
+    assert _brief()["angle"] == ""
+
+
 def test_call_to_action_flows_into_the_brief():
     assert _brief(call_to_action="Compare transfer options")["call_to_action"] == (
         "Compare transfer options"

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CoreInputsPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CoreInputsPanel.tsx
@@ -1,15 +1,19 @@
 import type { Prompt2BlogArticleTypeOption } from '../../api'
 
 interface CoreInputsPanelProps {
+  angle: string
   articleGoal: string
   articleTypeId: number | null
+  callToAction: string
   destinationContext: string
   groupedOptions: Array<{ label: string; options: Prompt2BlogArticleTypeOption[] }>
   quickPicks: Prompt2BlogArticleTypeOption[]
   selectedArticleType: Prompt2BlogArticleTypeOption | null
   targetReader: string
+  onAngleChange: (value: string) => void
   onArticleGoalChange: (value: string) => void
   onArticleTypeChange: (value: number | null) => void
+  onCallToActionChange: (value: string) => void
   onClear: () => void
   onDestinationContextChange: (value: string) => void
   onTargetReaderChange: (value: string) => void
@@ -35,9 +39,19 @@ export function CoreInputsPanel(props: CoreInputsPanelProps) {
         <p className={`p2b-field-hint${props.selectedArticleType ? ' is-selected' : ''}`}>{props.selectedArticleType?.definition || 'Choose from travel-first groups or use a quick pick for common trip formats.'}</p>
       </div>
       <div className="p2b-field"><label htmlFor="p2b-goal">Article Goal</label><textarea id="p2b-goal" className="p2b-textarea" rows={2} value={props.articleGoal} onChange={event => props.onArticleGoalChange(event.target.value)} placeholder="What this article should help the reader accomplish" /></div>
+      <div className="p2b-field">
+        <label htmlFor="p2b-angle">Editorial Angle (Optional)</label>
+        <textarea id="p2b-angle" className="p2b-textarea" rows={2} value={props.angle} onChange={event => props.onAngleChange(event.target.value)} placeholder="The stance the piece should argue, e.g. Peru is the better first stop; Colombia has more long-term range" />
+        <p className="p2b-field-hint">Tones that take a position — Editorial Comparison, Practical Authority — need one. Leave blank for even-handed coverage.</p>
+      </div>
       <div className="p2b-field-row p2b-field-row--2">
         <div className="p2b-field"><label htmlFor="p2b-target-reader">Target Reader</label><input id="p2b-target-reader" type="text" className="p2b-input" value={props.targetReader} onChange={event => props.onTargetReaderChange(event.target.value)} placeholder="Who this is written for" /></div>
         <div className="p2b-field"><label htmlFor="p2b-destination">Destination Context</label><input id="p2b-destination" type="text" className="p2b-input" value={props.destinationContext} onChange={event => props.onDestinationContextChange(event.target.value)} placeholder="City / region / country context" /></div>
+      </div>
+      <div className="p2b-field">
+        <label htmlFor="p2b-cta">Call to Action (Optional)</label>
+        <input id="p2b-cta" type="text" className="p2b-input" value={props.callToAction} onChange={event => props.onCallToActionChange(event.target.value)} placeholder="What the reader should do next" />
+        <p className="p2b-field-hint">Woven in near the end and checked by the quality gate.</p>
       </div>
     </div>
   </section>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -13,6 +13,8 @@ export const DEFAULT_COMPOSER_STATE: P2BFormState = {
   articleGoal: '',
   targetReader: '',
   destinationContext: '',
+  angle: '',
+  callToAction: '',
   modelName: DEFAULT_PROMPT2BLOG_MODEL,
   writingModel: DEFAULT_PROMPT2BLOG_WRITER_MODEL,
   toneId: '',

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
@@ -10,6 +10,8 @@ export interface P2BFormState {
   articleGoal: string
   targetReader: string
   destinationContext: string
+  angle: string
+  callToAction: string
   modelName: Prompt2BlogModelName
   writingModel: Prompt2BlogWriterModel
   toneId: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -141,6 +141,8 @@ export function usePrompt2BlogComposer() {
       articleGoal: DEFAULT_COMPOSER_STATE.articleGoal,
       targetReader: DEFAULT_COMPOSER_STATE.targetReader,
       destinationContext: DEFAULT_COMPOSER_STATE.destinationContext,
+      angle: DEFAULT_COMPOSER_STATE.angle,
+      callToAction: DEFAULT_COMPOSER_STATE.callToAction,
     }))
   }, [])
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
@@ -12,6 +12,8 @@ function createState(overrides: Partial<P2BFormState> = {}): P2BFormState {
     articleGoal: 'Help readers plan a trip.',
     targetReader: 'First-time visitors',
     destinationContext: 'Lisbon, Portugal',
+    angle: '',
+    callToAction: '',
     modelName: DEFAULT_PROMPT2BLOG_MODEL,
     writingModel: DEFAULT_PROMPT2BLOG_WRITER_MODEL,
     toneId: 'balanced',
@@ -42,5 +44,27 @@ describe('buildPrompt2BlogPayload', () => {
         source_material: ['Source material'],
       }),
     )
+  })
+
+  it('sends the editorial angle and call to action when supplied', () => {
+    const payload = buildPrompt2BlogPayload(
+      createState({ angle: 'Peru is the better first stop', callToAction: 'Compare fares' }),
+    )
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        angle: 'Peru is the better first stop',
+        call_to_action: 'Compare fares',
+      }),
+    )
+  })
+
+  it('omits the angle and call to action when left blank', () => {
+    // call_to_action is gated by the backend quality check, so an empty string
+    // would register as a constraint the article has to satisfy.
+    const payload = buildPrompt2BlogPayload(createState())
+
+    expect(payload?.angle).toBeUndefined()
+    expect(payload?.call_to_action).toBeUndefined()
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.ts
@@ -18,6 +18,8 @@ export function buildPrompt2BlogPayload(state: P2BFormState): Prompt2BlogRunRequ
     article_goal: state.articleGoal,
     target_reader: state.targetReader,
     destination_context: state.destinationContext,
+    angle: state.angle || undefined,
+    call_to_action: state.callToAction || undefined,
     model_name: state.modelName,
     writing_model: state.writingModel,
     tone_id: state.toneId,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -64,15 +64,19 @@ export default function Prompt2BlogPage() {
       <main className="p2b-form-container">
         <form className="p2b-form" onSubmit={(event) => event.preventDefault()}>
           <CoreInputsPanel
+            angle={state.angle}
             articleGoal={state.articleGoal}
             articleTypeId={state.articleTypeId}
+            callToAction={state.callToAction}
             destinationContext={state.destinationContext}
             groupedOptions={composer.groupedArticleTypeOptions}
             quickPicks={composer.articleTypeQuickPicks}
             selectedArticleType={composer.selectedArticleType}
             targetReader={state.targetReader}
+            onAngleChange={value => composer.updateField('angle', value)}
             onArticleGoalChange={value => composer.updateField('articleGoal', value)}
             onArticleTypeChange={value => composer.updateField('articleTypeId', value)}
+            onCallToActionChange={value => composer.updateField('callToAction', value)}
             onClear={composer.clearCoreInputs}
             onDestinationContextChange={value => composer.updateField('destinationContext', value)}
             onTargetReaderChange={value => composer.updateField('targetReader', value)}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -61,6 +61,7 @@ export type Prompt2BlogRunRequest = {
   article_goal: string
   target_reader: string
   destination_context: string
+  angle?: string
   tone_id: string
   length_id: string
   brand_voice_id?: string


### PR DESCRIPTION
## Problem

Three wiring defects in the writing brief, none of them about prompt wording:

**1. `perspective` was fed `destination_context`.** In a JSON brief that key reads as *point of view*, so the model was handed a city name under a POV key on every single call. Renamed to `destination_context`.

**2. `topic` and `goal` were both `article_goal`.** One input filled two keys and neither carried anything the other did not. Dropped `topic`.

**3. `call_to_action` was a dead wire.** It is in the request model (`models.py:63`), the compose prompt weaves it in near the end, and the deterministic gate scores its keyword overlap (`quality.py:122`) — but **no frontend field ever set it**, so the check passed unconditionally on every run. It now has an input.

## New: editorial angle

Several tones require the piece to take a stance — `editorial-comparison` asks for a thesis, `practical-authority` asks what each option is bad at and who should care. The brief had nowhere to put one, so the model either invented a stance or fell back to exactly the fake balance those tones forbid.

When supplied, the angle leads the narrative focus block. When blank, nothing is emitted.

## UI

Both new inputs land in the Core Inputs panel:

- **Editorial Angle (Optional)** — textarea, with a hint naming which tones need one and that blank means even-handed coverage.
- **Call to Action (Optional)** — text input, with a hint that it is checked by the quality gate.

Both are wired through `P2BFormState`, `DEFAULT_COMPOSER_STATE`, `buildPrompt2BlogPayload`, and `clearCoreInputs`. They send `undefined` rather than an empty string, so a blank CTA does not register as a constraint the article must satisfy.

## Back-compatibility

`_extract_narrative_focus` still reads `perspective` as a fallback — callers can post a writing brief straight to the runtime endpoint, and `test_prompt2blog_pipeline_contract.py` does exactly that. Covered by a test.

## Verification

- `pytest`: 457 passed (453 baseline + 4 new).
- `vitest`: 460 passed (458 baseline + 2 new).
- `tsc --noEmit`: no new errors in `prompt2blog` (the repo has pre-existing errors in `homepageFeaturedContent`, `listicleItineraries`, and `staging`, untouched here).
- `flake8`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)