### PR TITLE
feat(prompt2blog): show option descriptions where the choice is made

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/article-type-options.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/article-type-options.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { Prompt2BlogArticleTypeOption } from '../api'
+import { buildGroupedArticleTypes, getArticleTypeQuickPicks } from './article-type-options'
+
+// The 42 names seeded by apps/backend/scripts/populate_article_types.py.
+const ARTICLE_TYPE_NAMES = [
+  'How-to Guides', 'Disqualifiers', 'Opinion Piece', 'In-depth Analysis', 'Interview',
+  'News Article', 'Feature Story', 'Case Study', 'Listicle', 'Explainer',
+  "Beginner's Guide", 'FAQ Article', 'Myth-Busting Article', 'Comparison Article',
+  'Pros & Cons Breakdown', "Buyer's Guide", 'Review', 'Roundup', 'Best Of',
+  'Cost Breakdown', 'Checklist', 'Resource List', 'Survival Guide', 'Destination Guide',
+  'Itinerary Article', 'Travel Diary', 'Where to Stay Guide', 'When to Visit Article',
+  'Budget Travel Guide', 'Luxury Travel Guide', 'Solo Travel Guide', 'Family Travel Guide',
+  'Digital Nomad Guide', 'Packing Guide', 'Visa & Entry Guide', 'Safety Guide',
+  'Cultural Etiquette Guide', 'Transportation Guide', 'Travel Inspiration Piece',
+  'Hidden Gems Article', 'Food Travel Guide', 'Adventure Guide',
+]
+
+const ARTICLE_TYPES: Prompt2BlogArticleTypeOption[] = ARTICLE_TYPE_NAMES.map(
+  (name, index) => ({ id: index + 1, name, definition: `${name} definition` }),
+)
+
+describe('buildGroupedArticleTypes', () => {
+  it('places every article type in a curated group', () => {
+    // Anything the curated lists miss falls through to a "More Formats" bucket,
+    // which is where Pros & Cons Breakdown silently sat.
+    const groups = buildGroupedArticleTypes(ARTICLE_TYPES)
+
+    expect(groups.map(group => group.label)).not.toContain('More Formats')
+  })
+
+  it('accounts for every article type exactly once', () => {
+    const grouped = buildGroupedArticleTypes(ARTICLE_TYPES).flatMap(group =>
+      group.options.map(option => option.name),
+    )
+
+    expect(grouped).toHaveLength(ARTICLE_TYPE_NAMES.length)
+    expect(new Set(grouped).size).toBe(ARTICLE_TYPE_NAMES.length)
+  })
+
+  it('still buckets an unrecognised article type rather than dropping it', () => {
+    const groups = buildGroupedArticleTypes([
+      ...ARTICLE_TYPES,
+      { id: 999, name: 'Brand New Format', definition: 'Something new' },
+    ])
+
+    expect(groups[groups.length - 1]).toMatchObject({
+      label: 'More Formats',
+      options: [expect.objectContaining({ name: 'Brand New Format' })],
+    })
+  })
+
+  it('omits a group when none of its article types are available', () => {
+    const groups = buildGroupedArticleTypes(
+      ARTICLE_TYPES.filter(option => option.name === 'Destination Guide'),
+    )
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('Travel Planning')
+  })
+})
+
+describe('getArticleTypeQuickPicks', () => {
+  it('resolves every quick pick against the catalog', () => {
+    // A typo here yields a silently shorter chip row rather than an error.
+    expect(getArticleTypeQuickPicks(ARTICLE_TYPES)).toHaveLength(10)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/article-type-options.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/article-type-options.ts
@@ -20,15 +20,18 @@ const ARTICLE_TYPE_GROUPS: Array<{ label: string; names: string[] }> = [
     names: [
       'Transportation Guide', 'Packing Guide', 'Visa & Entry Guide', 'Safety Guide',
       'Cultural Etiquette Guide', 'Checklist', 'Cost Breakdown', 'Resource List',
+      // Filters an audience out rather than serving one, so it sits with the
+      // other decision-support formats rather than under Editorial Formats.
+      'Disqualifiers',
     ],
   },
   {
     label: 'Editorial Formats',
     names: [
       'Explainer', 'Beginner\'s Guide', 'FAQ Article', 'How-to Guides', 'Comparison Article',
-      'Review', 'Myth-Busting Article', 'Feature Story', 'Travel Diary', 'In-depth Analysis',
-      'Opinion Piece', 'Interview', 'Case Study', 'News Article', 'Disqualifiers',
-      'Buyer\'s Guide', 'Survival Guide',
+      'Pros & Cons Breakdown', 'Review', 'Myth-Busting Article', 'Feature Story',
+      'Travel Diary', 'In-depth Analysis', 'Opinion Piece', 'Interview', 'Case Study',
+      'News Article', 'Buyer\'s Guide', 'Survival Guide',
     ],
   },
 ]

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
@@ -57,8 +57,16 @@ export function PromptProfilesPanel(props: PromptProfilesPanelProps) {
   </section>
 }
 
-function SelectField({ id, label, value, options, onChange }: { id: string; label: string; value: string; options: Array<{ id: string; label: string }>; onChange: (value: string) => void }) {
-  return <div className="p2b-field"><label htmlFor={id}>{label}</label><select id={id} className="p2b-select" value={value} onChange={event => onChange(event.target.value)}>{options.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select></div>
+function SelectField({ id, label, value, options, onChange }: { id: string; label: string; value: string; options: Array<{ id: string; label: string; description?: string }>; onChange: (value: string) => void }) {
+  // The catalogs carry a description per option explaining when to pick it.
+  // Rendering only the label meant that routing was invisible at the point of
+  // choice, which is the only place it is any use.
+  const selected = options.find(option => option.id === value)
+  return <div className="p2b-field">
+    <label htmlFor={id}>{label}</label>
+    <select id={id} className="p2b-select" value={value} onChange={event => onChange(event.target.value)}>{options.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select>
+    {selected?.description && <p className="p2b-field-hint is-selected">{selected.description}</p>}
+  </div>
 }
 
 function CheckboxField({ id, label, checked, onChange }: { id: string; label: string; checked: boolean; onChange: (checked: boolean) => void }) {


### PR DESCRIPTION
## Problem

Every tone, length, and brand-voice option carries a `description` explaining when to pick it. The API returns it (`api/options.py`), the frontend type declares it (`Prompt2BlogInputOption.description`) — and `SelectField` rendered only `option.label` and threw the description away.

So the routing guidance existed everywhere except the one place it is any use: the point of choice. After #166 the ten tones are differentiated by *lane* rather than by adjective, which makes picking from labels alone guesswork:

> Practical · Practical Authority · No-Fluff Field Guide · Forbes-Style Service Journalism · Editorial Comparison · Editorial …

Now each dropdown shows the selected option's description beneath it — e.g. selecting Inspirational surfaces *"Pure wanderlust. Use Aspirational but Grounded if claims need receipts."*, which is exactly the distinction that keeps those two apart.

Uses the existing `.p2b-field-hint.is-selected` style, matching how Core Inputs already surfaces the article-type definition. No new CSS.

## Article-type grouping

Two slips in the curated groups:

- **Pros & Cons Breakdown** was in no group at all, so it fell through to the ungrouped "More Formats" bucket despite belonging directly beside Comparison Article.
- **Disqualifiers** sat under Editorial Formats, but its definition is *"Warns who should NOT do something or filters an audience"* — it filters an audience out rather than serving one, so it moves in with the other decision-support formats under Logistics & Practical.

## Verification

- `vitest`: 465 passed (460 baseline + 5 new).
- New `article-type-options.test.ts` asserts every one of the 42 seeded article types lands in a curated group — the condition that quietly broke — while confirming the fallback bucket still catches a type the frontend does not know about yet, and that empty groups are dropped rather than rendered blank.
- `tsc --noEmit`: no errors in `prompt2blog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)