### PR TITLE
feat(prompt2blog): collapse advanced controls

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
@@ -44,15 +44,27 @@ export function PromptProfilesPanel(props: PromptProfilesPanelProps) {
         <SelectField id="p2b-length" label="Length" value={props.lengthId} options={props.inputOptions?.lengths || []} onChange={value => props.onChange('lengthId', value)} />
         <SelectField id="p2b-brand-voice" label="Brand Voice" value={props.brandVoiceId} options={props.inputOptions?.brand_voices || []} onChange={value => props.onChange('brandVoiceId', value)} />
       </div>
-      <div className="p2b-field-row p2b-field-row--3">
-        <div className="p2b-field"><label htmlFor="p2b-model">Base Draft Model</label><select id="p2b-model" className="p2b-select" value={props.modelName} onChange={event => props.onChange('modelName', resolvePrompt2BlogModelName(event.target.value))}>{PROMPT2BLOG_MODEL_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></div>
-        <div className="p2b-field"><label htmlFor="p2b-writer-model">Writer Model</label><select id="p2b-writer-model" className="p2b-select" value={props.writingModel} onChange={event => props.onChange('writingModel', resolvePrompt2BlogWriterModel(event.target.value))}>{PROMPT2BLOG_WRITER_MODEL_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></div>
-        <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select></div>
-        <div className="p2b-field"><label htmlFor="p2b-audience-profile">Audience Profile (Optional)</label><input id="p2b-audience-profile" type="text" className="p2b-input" value={props.audienceProfile} onChange={event => props.onChange('audienceProfile', event.target.value)} placeholder="Extra reader detail" /></div>
-      </div>
-      <div className="p2b-field"><label htmlFor="p2b-negative">Negative Instructions (one per line)</label><textarea id="p2b-negative" className="p2b-textarea" rows={3} value={props.negativeInstructions} onChange={event => props.onChange('negativeInstructions', event.target.value)} placeholder="What to avoid" /></div>
-      <CheckboxField id="p2b-prompt-enhance" label="Prompt Enhance" checked={props.promptEnhance} onChange={checked => props.onChange('promptEnhance', checked)} />
-      <CheckboxField id="p2b-editorial-toggle" label="Enable editorial augmentation" checked={props.enableEditorialAugmentation} onChange={checked => props.onChange('enableEditorialAugmentation', checked)} />
+      <details className="p2b-disclosure">
+        <summary className="p2b-disclosure-summary">
+          <span>Advanced generation controls</span>
+          <span className="p2b-disclosure-summary-hint">Models, creativity, and optional steering</span>
+        </summary>
+        <div className="p2b-disclosure-body">
+          <div className="p2b-field-row p2b-field-row--2">
+            <div className="p2b-field"><label htmlFor="p2b-model">Base Draft Model</label><select id="p2b-model" className="p2b-select" value={props.modelName} onChange={event => props.onChange('modelName', resolvePrompt2BlogModelName(event.target.value))}>{PROMPT2BLOG_MODEL_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></div>
+            <div className="p2b-field"><label htmlFor="p2b-writer-model">Writer Model</label><select id="p2b-writer-model" className="p2b-select" value={props.writingModel} onChange={event => props.onChange('writingModel', resolvePrompt2BlogWriterModel(event.target.value))}>{PROMPT2BLOG_WRITER_MODEL_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></div>
+          </div>
+          <div className="p2b-field-row p2b-field-row--2">
+            <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select></div>
+            <div className="p2b-field"><label htmlFor="p2b-audience-profile">Audience Profile (Optional)</label><input id="p2b-audience-profile" type="text" className="p2b-input" value={props.audienceProfile} onChange={event => props.onChange('audienceProfile', event.target.value)} placeholder="Extra reader detail" /></div>
+          </div>
+          <div className="p2b-field"><label htmlFor="p2b-negative">Negative Instructions (one per line)</label><textarea id="p2b-negative" className="p2b-textarea" rows={3} value={props.negativeInstructions} onChange={event => props.onChange('negativeInstructions', event.target.value)} placeholder="What to avoid" /></div>
+          <div className="p2b-checkbox-stack">
+            <CheckboxField id="p2b-prompt-enhance" label="Prompt Enhance" checked={props.promptEnhance} onChange={checked => props.onChange('promptEnhance', checked)} />
+            <CheckboxField id="p2b-editorial-toggle" label="Enable editorial augmentation" checked={props.enableEditorialAugmentation} onChange={checked => props.onChange('enableEditorialAugmentation', checked)} />
+          </div>
+        </div>
+      </details>
     </div>
   </section>
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/SeoConstraintsPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/SeoConstraintsPanel.tsx
@@ -12,11 +12,17 @@ export function SeoConstraintsPanel(props: SeoConstraintsPanelProps) {
   return <section className="p2b-panel">
     <div className="p2b-panel-header"><div className="p2b-panel-header-text"><h2>SEO + Constraints</h2></div><button type="button" className="p2b-section-clear-btn" onClick={props.onClear}>Clear section</button></div>
     <div className="p2b-panel-body">
-      <div className="p2b-field-row p2b-field-row--2">
-        <div className="p2b-field"><label htmlFor="p2b-primary-kw">Primary Keyword</label><input id="p2b-primary-kw" type="text" className="p2b-input" value={props.primaryKeyword} onChange={event => props.onPrimaryKeywordChange(event.target.value)} /></div>
-        <div className="p2b-field"><label htmlFor="p2b-secondary-kws">Secondary Keywords (comma-separated)</label><input id="p2b-secondary-kws" type="text" className="p2b-input" value={props.secondaryKeywords} onChange={event => props.onSecondaryKeywordsChange(event.target.value)} /></div>
-      </div>
+      <div className="p2b-field"><label htmlFor="p2b-primary-kw">Primary Keyword</label><input id="p2b-primary-kw" type="text" className="p2b-input" value={props.primaryKeyword} onChange={event => props.onPrimaryKeywordChange(event.target.value)} /></div>
       <div className="p2b-field"><label htmlFor="p2b-must-include">Must Include (one per line)</label><textarea id="p2b-must-include" className="p2b-textarea" rows={3} value={props.mustInclude} onChange={event => props.onMustIncludeChange(event.target.value)} /></div>
+      <details className="p2b-disclosure">
+        <summary className="p2b-disclosure-summary">
+          <span>Advanced SEO controls</span>
+          <span className="p2b-disclosure-summary-hint">Add supporting phrases only when required</span>
+        </summary>
+        <div className="p2b-disclosure-body">
+          <div className="p2b-field"><label htmlFor="p2b-secondary-kws">Secondary Keywords (comma-separated)</label><input id="p2b-secondary-kws" type="text" className="p2b-input" value={props.secondaryKeywords} onChange={event => props.onSecondaryKeywordsChange(event.target.value)} /></div>
+        </div>
+      </details>
     </div>
   </section>
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -187,6 +187,80 @@ describe('Prompt2BlogPage', () => {
     expect(modelSelect).toHaveValue(DEFAULT_PROMPT2BLOG_MODEL)
   })
 
+  it('keeps optional controls collapsed while core choices stay visible', async () => {
+    renderPage()
+
+    const advancedGenerationSummary = await screen.findByText('Advanced generation controls')
+    const advancedGeneration = advancedGenerationSummary.closest('details')
+    const advancedSeoSummary = screen.getByText('Advanced SEO controls')
+    const advancedSeo = advancedSeoSummary.closest('details')
+
+    expect(advancedGeneration).not.toHaveAttribute('open')
+    expect(advancedSeo).not.toHaveAttribute('open')
+    for (const label of [
+      'Tone',
+      'Length',
+      'Brand Voice',
+      'Primary Keyword',
+      'Must Include (one per line)',
+    ]) {
+      expect(screen.getByLabelText(label).closest('details')).toBeNull()
+    }
+    for (const label of [
+      'Base Draft Model',
+      'Writer Model',
+      'Creativity Level',
+      'Audience Profile (Optional)',
+      'Negative Instructions (one per line)',
+      'Prompt Enhance',
+      'Enable editorial augmentation',
+    ]) {
+      expect(screen.getByLabelText(label).closest('details')).toBe(advancedGeneration)
+    }
+    expect(
+      screen.getByLabelText('Secondary Keywords (comma-separated)').closest('details'),
+    ).toBe(advancedSeo)
+
+    fireEvent.click(advancedGenerationSummary)
+    fireEvent.click(advancedSeoSummary)
+
+    expect(advancedGeneration).toHaveAttribute('open')
+    expect(advancedSeo).toHaveAttribute('open')
+  })
+
+  it('preserves advanced values across disclosure toggles and clears them by section', async () => {
+    renderPage()
+
+    const advancedGenerationSummary = await screen.findByText('Advanced generation controls')
+    const advancedSeoSummary = screen.getByText('Advanced SEO controls')
+    const audienceProfile = screen.getByLabelText('Audience Profile (Optional)')
+    const secondaryKeywords = screen.getByLabelText('Secondary Keywords (comma-separated)')
+
+    fireEvent.click(advancedGenerationSummary)
+    fireEvent.change(audienceProfile, { target: { value: 'Budget-conscious families' } })
+    fireEvent.click(advancedGenerationSummary)
+    fireEvent.click(advancedGenerationSummary)
+
+    fireEvent.click(advancedSeoSummary)
+    fireEvent.change(secondaryKeywords, { target: { value: 'family hotels, free museums' } })
+    fireEvent.click(advancedSeoSummary)
+    fireEvent.click(advancedSeoSummary)
+
+    expect(audienceProfile).toHaveValue('Budget-conscious families')
+    expect(secondaryKeywords).toHaveValue('family hotels, free museums')
+
+    const promptProfilesPanel = screen.getByRole('heading', { name: 'Prompt Profiles' })
+      .closest('section')
+    const seoPanel = screen.getByRole('heading', { name: 'SEO + Constraints' })
+      .closest('section')
+
+    fireEvent.click(within(promptProfilesPanel!).getByRole('button', { name: 'Clear section' }))
+    fireEvent.click(within(seoPanel!).getByRole('button', { name: 'Clear section' }))
+
+    expect(audienceProfile).toHaveValue('')
+    expect(secondaryKeywords).toHaveValue('')
+  })
+
   it('sends the selected model in the run payload', async () => {
     renderPage()
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
@@ -251,6 +251,76 @@
   color: var(--ink);
 }
 
+/* Progressive disclosure */
+.p2b-disclosure {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  overflow: clip;
+}
+
+.p2b-disclosure-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2) var(--space-4);
+  padding: var(--space-4);
+  color: var(--ink);
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+
+.p2b-disclosure-summary::-webkit-details-marker {
+  display: none;
+}
+
+.p2b-disclosure-summary::after {
+  content: '+';
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  color: var(--p2b-accent);
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.p2b-disclosure[open] .p2b-disclosure-summary::after {
+  content: '−';
+}
+
+.p2b-disclosure-summary:hover {
+  background: var(--p2b-accent-softer);
+}
+
+.p2b-disclosure-summary:focus-visible {
+  outline: 3px solid var(--p2b-accent-soft);
+  outline-offset: -3px;
+}
+
+.p2b-disclosure-summary-hint {
+  grid-column: 1;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 400;
+}
+
+.p2b-disclosure-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  border-top: 1px solid var(--border);
+  background: white;
+}
+
+.p2b-checkbox-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-5);
+}
+
 /* Raw Input Blobs */
 .p2b-blob-field {
   display: flex;
@@ -445,4 +515,3 @@
   height: 16px;
   accent-color: var(--p2b-accent);
 }
-


### PR DESCRIPTION
## What changed
- keeps Tone, Length, Brand Voice, Primary Keyword, and Must Include prominent
- moves model, creativity, optional steering, and secondary-keyword fields into native collapsed disclosures
- adds keyboard focus, responsive layout, and regression coverage for placement, persistence, and section clearing

## Why
The Prompt2Blog form exposed specialist controls at the same visual priority as core article inputs. Progressive disclosure reduces form noise without changing payloads, defaults, saved values, or clear behavior.

## Validation
- Prompt2Blog page + payload tests: 10 passed
- frontend boundary check + ESLint: passed
- Vite production build: passed
- `git diff --check`: passed
- full frontend TypeScript check remains blocked by 7 pre-existing errors in unrelated homepage/listicle/staging files; this PR adds none