### PR TITLE
refactor(prompt2blog): remove duplicate steering

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
@@ -20,7 +20,6 @@ function resolveCreativityLevel(value: string): P2BFormState['creativityLevel'] 
 }
 
 interface PromptProfilesPanelProps {
-  audienceProfile: string
   brandVoiceId: string
   creativityLevel: 'low' | 'medium' | 'high'
   enableEditorialAugmentation: boolean
@@ -29,7 +28,6 @@ interface PromptProfilesPanelProps {
   modelName: Prompt2BlogModelName
   writingModel: Prompt2BlogWriterModel
   negativeInstructions: string
-  promptEnhance: boolean
   toneId: string
   onChange: <K extends keyof P2BFormState>(field: K, value: P2BFormState[K]) => void
   onClear: () => void
@@ -54,13 +52,9 @@ export function PromptProfilesPanel(props: PromptProfilesPanelProps) {
             <div className="p2b-field"><label htmlFor="p2b-model">Base Draft Model</label><select id="p2b-model" className="p2b-select" value={props.modelName} onChange={event => props.onChange('modelName', resolvePrompt2BlogModelName(event.target.value))}>{PROMPT2BLOG_MODEL_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></div>
             <div className="p2b-field"><label htmlFor="p2b-writer-model">Writer Model</label><select id="p2b-writer-model" className="p2b-select" value={props.writingModel} onChange={event => props.onChange('writingModel', resolvePrompt2BlogWriterModel(event.target.value))}>{PROMPT2BLOG_WRITER_MODEL_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}</select></div>
           </div>
-          <div className="p2b-field-row p2b-field-row--2">
-            <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select></div>
-            <div className="p2b-field"><label htmlFor="p2b-audience-profile">Audience Profile (Optional)</label><input id="p2b-audience-profile" type="text" className="p2b-input" value={props.audienceProfile} onChange={event => props.onChange('audienceProfile', event.target.value)} placeholder="Extra reader detail" /></div>
-          </div>
+          <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select></div>
           <div className="p2b-field"><label htmlFor="p2b-negative">Negative Instructions (one per line)</label><textarea id="p2b-negative" className="p2b-textarea" rows={3} value={props.negativeInstructions} onChange={event => props.onChange('negativeInstructions', event.target.value)} placeholder="What to avoid" /></div>
           <div className="p2b-checkbox-stack">
-            <CheckboxField id="p2b-prompt-enhance" label="Prompt Enhance" checked={props.promptEnhance} onChange={checked => props.onChange('promptEnhance', checked)} />
             <CheckboxField id="p2b-editorial-toggle" label="Enable editorial augmentation" checked={props.enableEditorialAugmentation} onChange={checked => props.onChange('enableEditorialAugmentation', checked)} />
           </div>
         </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
@@ -1,0 +1,45 @@
+/* @vitest-environment jsdom */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { COMPOSER_STORAGE_KEY, loadSavedComposerState } from './composer.storage'
+
+describe('loadSavedComposerState', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('preserves the reader while dropping legacy duplicate steering fields', () => {
+    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
+      targetReader: 'Budget-conscious families',
+      audienceProfile: 'Families seeking free activities',
+      promptEnhance: true,
+    }))
+
+    const state = loadSavedComposerState()
+
+    expect(state.targetReader).toBe(
+      'Budget-conscious families — Families seeking free activities',
+    )
+    expect(state).not.toHaveProperty('audienceProfile')
+    expect(state).not.toHaveProperty('promptEnhance')
+  })
+
+  it('uses legacy audience detail when the saved target reader is empty', () => {
+    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
+      targetReader: '',
+      audienceProfile: 'Families seeking free activities',
+    }))
+
+    expect(loadSavedComposerState().targetReader).toBe(
+      'Families seeking free activities',
+    )
+  })
+
+  it('does not repeat identical legacy audience detail', () => {
+    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
+      targetReader: 'Budget-conscious families',
+      audienceProfile: 'budget-conscious families',
+    }))
+
+    expect(loadSavedComposerState().targetReader).toBe('Budget-conscious families')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -23,10 +23,8 @@ export const DEFAULT_COMPOSER_STATE: P2BFormState = {
   primaryKeyword: '',
   secondaryKeywords: '',
   mustInclude: '',
-  audienceProfile: '',
   creativityLevel: 'medium',
   negativeInstructions: '',
-  promptEnhance: true,
   enableEditorialAugmentation: true,
   blobs: [{ id: 1, content: '' }],
 }
@@ -35,7 +33,28 @@ export function loadSavedComposerState(): P2BFormState {
   try {
     const raw = localStorage.getItem(COMPOSER_STORAGE_KEY)
     if (!raw) return DEFAULT_COMPOSER_STATE
-    const parsed = JSON.parse(raw) as Partial<P2BFormState>
+    const parsed = JSON.parse(raw) as Partial<P2BFormState> & {
+      audienceProfile?: unknown
+      promptEnhance?: unknown
+    }
+    // Fold removed audience detail into the remaining reader field before
+    // stripping legacy keys, so old drafts keep user-authored guidance.
+    const legacyAudienceProfile = typeof parsed.audienceProfile === 'string'
+      ? parsed.audienceProfile.trim()
+      : ''
+    const savedTargetReader = typeof parsed.targetReader === 'string'
+      ? parsed.targetReader.trim()
+      : ''
+    if (legacyAudienceProfile && !savedTargetReader) {
+      parsed.targetReader = legacyAudienceProfile
+    } else if (
+      legacyAudienceProfile
+      && savedTargetReader.toLocaleLowerCase() !== legacyAudienceProfile.toLocaleLowerCase()
+    ) {
+      parsed.targetReader = `${savedTargetReader} — ${legacyAudienceProfile}`
+    }
+    delete parsed.audienceProfile
+    delete parsed.promptEnhance
     return {
       ...DEFAULT_COMPOSER_STATE,
       ...parsed,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
@@ -20,10 +20,8 @@ export interface P2BFormState {
   primaryKeyword: string
   secondaryKeywords: string
   mustInclude: string
-  audienceProfile: string
   creativityLevel: 'low' | 'medium' | 'high'
   negativeInstructions: string
-  promptEnhance: boolean
   enableEditorialAugmentation: boolean
   blobs: RawBlob[]
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -159,9 +159,7 @@ export function usePrompt2BlogComposer() {
         ? findDefaultOption(inputOptions.brand_voices)
         : DEFAULT_COMPOSER_STATE.brandVoiceId,
       creativityLevel: DEFAULT_COMPOSER_STATE.creativityLevel,
-      audienceProfile: DEFAULT_COMPOSER_STATE.audienceProfile,
       negativeInstructions: DEFAULT_COMPOSER_STATE.negativeInstructions,
-      promptEnhance: DEFAULT_COMPOSER_STATE.promptEnhance,
       enableEditorialAugmentation: DEFAULT_COMPOSER_STATE.enableEditorialAugmentation,
     }))
   }, [inputOptions])

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
@@ -22,10 +22,8 @@ function createState(overrides: Partial<P2BFormState> = {}): P2BFormState {
     primaryKeyword: '',
     secondaryKeywords: '',
     mustInclude: '',
-    audienceProfile: '',
     creativityLevel: 'medium',
     negativeInstructions: '',
-    promptEnhance: true,
     enableEditorialAugmentation: true,
     blobs: [{ id: 1, content: 'Source material' }],
     ...overrides,
@@ -66,5 +64,12 @@ describe('buildPrompt2BlogPayload', () => {
 
     expect(payload?.angle).toBeUndefined()
     expect(payload?.call_to_action).toBeUndefined()
+  })
+
+  it('omits duplicate audience steering and disables generic prompt enhancement', () => {
+    const payload = buildPrompt2BlogPayload(createState())
+
+    expect(payload).not.toHaveProperty('audience_profile')
+    expect(payload?.prompt_enhance).toBe(false)
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.ts
@@ -28,8 +28,8 @@ export function buildPrompt2BlogPayload(state: P2BFormState): Prompt2BlogRunRequ
     primary_keyword: state.primaryKeyword || undefined,
     secondary_keywords: splitCommaSeparated(state.secondaryKeywords),
     must_include: splitLineSeparated(state.mustInclude),
-    audience_profile: state.audienceProfile || undefined,
-    prompt_enhance: state.promptEnhance,
+    // Generic enhancement duplicates the explicit structure and style profiles.
+    prompt_enhance: false,
     creativity_level: state.creativityLevel,
     negative_instructions: splitLineSeparated(state.negativeInstructions),
     include_debug: true,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -210,13 +210,13 @@ describe('Prompt2BlogPage', () => {
       'Base Draft Model',
       'Writer Model',
       'Creativity Level',
-      'Audience Profile (Optional)',
       'Negative Instructions (one per line)',
-      'Prompt Enhance',
       'Enable editorial augmentation',
     ]) {
       expect(screen.getByLabelText(label).closest('details')).toBe(advancedGeneration)
     }
+    expect(screen.queryByLabelText('Audience Profile (Optional)')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Prompt Enhance')).not.toBeInTheDocument()
     expect(
       screen.getByLabelText('Secondary Keywords (comma-separated)').closest('details'),
     ).toBe(advancedSeo)
@@ -233,11 +233,11 @@ describe('Prompt2BlogPage', () => {
 
     const advancedGenerationSummary = await screen.findByText('Advanced generation controls')
     const advancedSeoSummary = screen.getByText('Advanced SEO controls')
-    const audienceProfile = screen.getByLabelText('Audience Profile (Optional)')
+    const negativeInstructions = screen.getByLabelText('Negative Instructions (one per line)')
     const secondaryKeywords = screen.getByLabelText('Secondary Keywords (comma-separated)')
 
     fireEvent.click(advancedGenerationSummary)
-    fireEvent.change(audienceProfile, { target: { value: 'Budget-conscious families' } })
+    fireEvent.change(negativeInstructions, { target: { value: 'Avoid generic praise' } })
     fireEvent.click(advancedGenerationSummary)
     fireEvent.click(advancedGenerationSummary)
 
@@ -246,7 +246,7 @@ describe('Prompt2BlogPage', () => {
     fireEvent.click(advancedSeoSummary)
     fireEvent.click(advancedSeoSummary)
 
-    expect(audienceProfile).toHaveValue('Budget-conscious families')
+    expect(negativeInstructions).toHaveValue('Avoid generic praise')
     expect(secondaryKeywords).toHaveValue('family hotels, free museums')
 
     const promptProfilesPanel = screen.getByRole('heading', { name: 'Prompt Profiles' })
@@ -257,7 +257,7 @@ describe('Prompt2BlogPage', () => {
     fireEvent.click(within(promptProfilesPanel!).getByRole('button', { name: 'Clear section' }))
     fireEvent.click(within(seoPanel!).getByRole('button', { name: 'Clear section' }))
 
-    expect(audienceProfile).toHaveValue('')
+    expect(negativeInstructions).toHaveValue('')
     expect(secondaryKeywords).toHaveValue('')
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -82,7 +82,6 @@ export default function Prompt2BlogPage() {
             onTargetReaderChange={value => composer.updateField('targetReader', value)}
           />
           <PromptProfilesPanel
-            audienceProfile={state.audienceProfile}
             brandVoiceId={state.brandVoiceId}
             creativityLevel={state.creativityLevel}
             enableEditorialAugmentation={state.enableEditorialAugmentation}
@@ -91,7 +90,6 @@ export default function Prompt2BlogPage() {
             modelName={state.modelName}
             writingModel={state.writingModel}
             negativeInstructions={state.negativeInstructions}
-            promptEnhance={state.promptEnhance}
             toneId={state.toneId}
             onChange={composer.updateField}
             onClear={composer.clearPromptProfiles}


### PR DESCRIPTION
## What changed
- removes Audience Profile and Prompt Enhance from the Prompt2Blog form/state
- keeps Target Reader as the single audience control
- omits audience_profile and explicitly disables generic prompt enhancement in frontend-generated requests
- migrates saved Audience Profile text into Target Reader before stripping legacy keys

## Why
Audience Profile duplicated Target Reader, while Prompt Enhance added generic transition/structure guidance already covered by explicit profiles. Removing both reduces ambiguous steering without breaking the backend request schema for other clients.

## Validation
- Prompt2Blog page, payload, and storage tests: 14 passed
- frontend boundary check + ESLint: passed
- Vite production build: passed
- `git diff --check`: passed
- independent standards/spec review: no blockers
- full frontend TypeScript check remains blocked by 7 pre-existing errors in unrelated files