### PR TITLE
feat(prompt2blog): make editorial extras opt in

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
@@ -44,7 +44,7 @@ class PipelineV2RuntimeRequest(BaseModel):
     article_type_id: int
     option_context: dict[str, Any] = Field(default_factory=dict)
     include_debug: bool = True
-    enable_editorial_augmentation: bool = True
+    enable_editorial_augmentation: bool = False
     model_name: str | None = None
     writing_model: str | None = None
 
@@ -68,6 +68,6 @@ class Prompt2BlogInputRequest(BaseModel):
     creativity_level: str = "medium"
     negative_instructions: List[str] = Field(default_factory=list)
     include_debug: bool = True
-    enable_editorial_augmentation: bool = True
+    enable_editorial_augmentation: bool = False
     model_name: str | None = None
     writing_model: str | None = None

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_run_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_run_routes.py
@@ -11,6 +11,7 @@ from tests.prompt2blog_test_support import response_payload
 import app.features.prompt2blog.routes as prompt2blog_routes
 from app.core import read_status
 from app.features.prompt2blog.api import runs as runs_api
+from app.features.prompt2blog.models import PipelineV2RuntimeRequest
 
 pytest_plugins = ["tests.prompt2blog_test_fixtures"]
 
@@ -81,3 +82,22 @@ def test_input_request_rejects_legacy_payload_shape():
                 "writing_brief": {},
             }
         )
+
+
+def test_editorial_augmentation_is_opt_in_by_default():
+    request = prompt2blog_routes.Prompt2BlogInputRequest(
+        article_type_id=1,
+        source_material=["One source blob."],
+        article_goal="Generate a practical article.",
+        target_reader="General readers",
+        destination_context="Barcelona, Spain",
+        tone_id="practical",
+        length_id="medium",
+    )
+    runtime_request = PipelineV2RuntimeRequest(
+        cleaned_data="Cleaned source.",
+        article_type_id=1,
+    )
+
+    assert request.enable_editorial_augmentation is False
+    assert runtime_request.enable_editorial_augmentation is False

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CoreInputsPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CoreInputsPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { Prompt2BlogArticleTypeOption } from '../../api'
 
 interface CoreInputsPanelProps {
@@ -20,6 +21,10 @@ interface CoreInputsPanelProps {
 }
 
 export function CoreInputsPanel(props: CoreInputsPanelProps) {
+  const [editorialGuidanceOpen, setEditorialGuidanceOpen] = useState(
+    () => Boolean(props.angle.trim() || props.callToAction.trim()),
+  )
+
   return <section className="p2b-panel">
     <div className="p2b-panel-header"><div className="p2b-panel-header-text"><h2>Core Inputs</h2><p>Select article type and provide intent/context.</p></div>
       <button type="button" className="p2b-section-clear-btn" onClick={props.onClear}>Clear section</button>
@@ -39,20 +44,32 @@ export function CoreInputsPanel(props: CoreInputsPanelProps) {
         <p className={`p2b-field-hint${props.selectedArticleType ? ' is-selected' : ''}`}>{props.selectedArticleType?.definition || 'Choose from travel-first groups or use a quick pick for common trip formats.'}</p>
       </div>
       <div className="p2b-field"><label htmlFor="p2b-goal">Article Goal</label><textarea id="p2b-goal" className="p2b-textarea" rows={2} value={props.articleGoal} onChange={event => props.onArticleGoalChange(event.target.value)} placeholder="What this article should help the reader accomplish" /></div>
-      <div className="p2b-field">
-        <label htmlFor="p2b-angle">Editorial Angle (Optional)</label>
-        <textarea id="p2b-angle" className="p2b-textarea" rows={2} value={props.angle} onChange={event => props.onAngleChange(event.target.value)} placeholder="The stance the piece should argue, e.g. Peru is the better first stop; Colombia has more long-term range" />
-        <p className="p2b-field-hint">Tones that take a position — Editorial Comparison, Practical Authority — need one. Leave blank for even-handed coverage.</p>
-      </div>
       <div className="p2b-field-row p2b-field-row--2">
         <div className="p2b-field"><label htmlFor="p2b-target-reader">Target Reader</label><input id="p2b-target-reader" type="text" className="p2b-input" value={props.targetReader} onChange={event => props.onTargetReaderChange(event.target.value)} placeholder="Who this is written for" /></div>
         <div className="p2b-field"><label htmlFor="p2b-destination">Destination Context</label><input id="p2b-destination" type="text" className="p2b-input" value={props.destinationContext} onChange={event => props.onDestinationContextChange(event.target.value)} placeholder="City / region / country context" /></div>
       </div>
-      <div className="p2b-field">
-        <label htmlFor="p2b-cta">Call to Action (Optional)</label>
-        <input id="p2b-cta" type="text" className="p2b-input" value={props.callToAction} onChange={event => props.onCallToActionChange(event.target.value)} placeholder="What the reader should do next" />
-        <p className="p2b-field-hint">Woven in near the end and checked by the quality gate.</p>
-      </div>
+      <details
+        className="p2b-disclosure"
+        open={editorialGuidanceOpen}
+        onToggle={event => setEditorialGuidanceOpen(event.currentTarget.open)}
+      >
+        <summary className="p2b-disclosure-summary">
+          <span>Optional editorial guidance</span>
+          <span className="p2b-disclosure-summary-hint">Add a point of view or reader action when needed</span>
+        </summary>
+        <div className="p2b-disclosure-body">
+          <div className="p2b-field">
+            <label htmlFor="p2b-angle">Editorial Angle (Optional)</label>
+            <textarea id="p2b-angle" className="p2b-textarea" rows={2} value={props.angle} onChange={event => props.onAngleChange(event.target.value)} placeholder="The stance the piece should argue, e.g. Peru is the better first stop; Colombia has more long-term range" />
+            <p className="p2b-field-hint">Tones that take a position — Editorial Comparison, Practical Authority — need one. Leave blank for even-handed coverage.</p>
+          </div>
+          <div className="p2b-field">
+            <label htmlFor="p2b-cta">Call to Action (Optional)</label>
+            <input id="p2b-cta" type="text" className="p2b-input" value={props.callToAction} onChange={event => props.onCallToActionChange(event.target.value)} placeholder="What the reader should do next" />
+            <p className="p2b-field-hint">Woven in near the end and checked by the quality gate.</p>
+          </div>
+        </div>
+      </details>
     </div>
   </section>
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
@@ -55,7 +55,18 @@ export function PromptProfilesPanel(props: PromptProfilesPanelProps) {
           <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select></div>
           <div className="p2b-field"><label htmlFor="p2b-negative">Negative Instructions (one per line)</label><textarea id="p2b-negative" className="p2b-textarea" rows={3} value={props.negativeInstructions} onChange={event => props.onChange('negativeInstructions', event.target.value)} placeholder="What to avoid" /></div>
           <div className="p2b-checkbox-stack">
-            <CheckboxField id="p2b-editorial-toggle" label="Enable editorial augmentation" checked={props.enableEditorialAugmentation} onChange={checked => props.onChange('enableEditorialAugmentation', checked)} />
+            <div className="p2b-checkbox-option">
+              <label className="p2b-debug-checkbox" htmlFor="p2b-editorial-toggle">
+                <input
+                  id="p2b-editorial-toggle"
+                  type="checkbox"
+                  checked={props.enableEditorialAugmentation}
+                  onChange={event => props.onChange('enableEditorialAugmentation', event.target.checked)}
+                />
+                Add editorial extras
+              </label>
+              <p className="p2b-field-hint">May add a useful pull quote, callout, FAQ, or takeaway box.</p>
+            </div>
           </div>
         </div>
       </details>
@@ -73,8 +84,4 @@ function SelectField({ id, label, value, options, onChange }: { id: string; labe
     <select id={id} className="p2b-select" value={value} onChange={event => onChange(event.target.value)}>{options.map(option => <option key={option.id} value={option.id}>{option.label}</option>)}</select>
     {selected?.description && <p className="p2b-field-hint is-selected">{selected.description}</p>}
   </div>
-}
-
-function CheckboxField({ id, label, checked, onChange }: { id: string; label: string; checked: boolean; onChange: (checked: boolean) => void }) {
-  return <label className="p2b-debug-checkbox" htmlFor={id}><input id={id} type="checkbox" checked={checked} onChange={event => onChange(event.target.checked)} />{label}</label>
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
@@ -1,6 +1,11 @@
 /* @vitest-environment jsdom */
 import { beforeEach, describe, expect, it } from 'vitest'
-import { COMPOSER_STORAGE_KEY, loadSavedComposerState } from './composer.storage'
+import {
+  COMPOSER_STORAGE_KEY,
+  DEFAULT_COMPOSER_STATE,
+  loadSavedComposerState,
+  saveComposerState,
+} from './composer.storage'
 
 describe('loadSavedComposerState', () => {
   beforeEach(() => {
@@ -41,5 +46,35 @@ describe('loadSavedComposerState', () => {
     }))
 
     expect(loadSavedComposerState().targetReader).toBe('Budget-conscious families')
+  })
+
+  it('defaults editorial extras off for a new draft', () => {
+    expect(DEFAULT_COMPOSER_STATE.enableEditorialAugmentation).toBe(false)
+  })
+
+  it('turns off the old unversioned editorial-augmentation default', () => {
+    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
+      enableEditorialAugmentation: true,
+    }))
+
+    expect(loadSavedComposerState().enableEditorialAugmentation).toBe(false)
+  })
+
+  it('preserves editorial augmentation after a user opts in', () => {
+    saveComposerState({
+      ...DEFAULT_COMPOSER_STATE,
+      enableEditorialAugmentation: true,
+    })
+
+    expect(loadSavedComposerState().enableEditorialAugmentation).toBe(true)
+  })
+
+  it('does not reinterpret a draft written by a newer storage version', () => {
+    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
+      composerStorageVersion: 999,
+      enableEditorialAugmentation: true,
+    }))
+
+    expect(loadSavedComposerState().enableEditorialAugmentation).toBe(true)
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -7,6 +7,7 @@ import {
 import type { P2BFormState } from './composer.types'
 
 export const COMPOSER_STORAGE_KEY = 'p2b-form-draft'
+const COMPOSER_STORAGE_VERSION = 2
 
 export const DEFAULT_COMPOSER_STATE: P2BFormState = {
   articleTypeId: null,
@@ -25,8 +26,15 @@ export const DEFAULT_COMPOSER_STATE: P2BFormState = {
   mustInclude: '',
   creativityLevel: 'medium',
   negativeInstructions: '',
-  enableEditorialAugmentation: true,
+  enableEditorialAugmentation: false,
   blobs: [{ id: 1, content: '' }],
+}
+
+export function saveComposerState(state: P2BFormState): void {
+  localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
+    ...state,
+    composerStorageVersion: COMPOSER_STORAGE_VERSION,
+  }))
 }
 
 export function loadSavedComposerState(): P2BFormState {
@@ -35,8 +43,10 @@ export function loadSavedComposerState(): P2BFormState {
     if (!raw) return DEFAULT_COMPOSER_STATE
     const parsed = JSON.parse(raw) as Partial<P2BFormState> & {
       audienceProfile?: unknown
+      composerStorageVersion?: unknown
       promptEnhance?: unknown
     }
+    const isUnversionedDraft = parsed.composerStorageVersion == null
     // Fold removed audience detail into the remaining reader field before
     // stripping legacy keys, so old drafts keep user-authored guidance.
     const legacyAudienceProfile = typeof parsed.audienceProfile === 'string'
@@ -54,7 +64,12 @@ export function loadSavedComposerState(): P2BFormState {
       parsed.targetReader = `${savedTargetReader} — ${legacyAudienceProfile}`
     }
     delete parsed.audienceProfile
+    delete parsed.composerStorageVersion
     delete parsed.promptEnhance
+    if (isUnversionedDraft) {
+      // Earlier drafts stored `true` as the default, not as explicit consent.
+      parsed.enableEditorialAugmentation = false
+    }
     return {
       ...DEFAULT_COMPOSER_STATE,
       ...parsed,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -10,6 +10,7 @@ import {
   COMPOSER_STORAGE_KEY,
   DEFAULT_COMPOSER_STATE,
   loadSavedComposerState,
+  saveComposerState,
 } from '../composer.storage'
 import type { P2BFormState } from '../composer.types'
 import { buildPrompt2BlogPayload } from '../prompt-payload'
@@ -37,7 +38,7 @@ export function usePrompt2BlogComposer() {
   }, [])
 
   useEffect(() => {
-    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify(state))
+    saveComposerState(state)
   }, [state])
 
   useEffect(() => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_PROMPT2BLOG_MODEL,
   DEFAULT_PROMPT2BLOG_WRITER_MODEL,
 } from '../constants/prompt2blog.constants'
+import { DEFAULT_COMPOSER_STATE } from './composer.storage'
 import type { P2BFormState } from './composer.types'
 import { buildPrompt2BlogPayload } from './prompt-payload'
 
@@ -24,7 +25,7 @@ function createState(overrides: Partial<P2BFormState> = {}): P2BFormState {
     mustInclude: '',
     creativityLevel: 'medium',
     negativeInstructions: '',
-    enableEditorialAugmentation: true,
+    enableEditorialAugmentation: false,
     blobs: [{ id: 1, content: 'Source material' }],
     ...overrides,
   }
@@ -71,5 +72,19 @@ describe('buildPrompt2BlogPayload', () => {
 
     expect(payload).not.toHaveProperty('audience_profile')
     expect(payload?.prompt_enhance).toBe(false)
+  })
+
+  it('keeps editorial extras off by default but preserves an explicit opt-in', () => {
+    const defaultPayload = buildPrompt2BlogPayload({
+      ...DEFAULT_COMPOSER_STATE,
+      articleTypeId: 7,
+      blobs: [{ id: 1, content: 'Source material' }],
+    })
+    const optedInPayload = buildPrompt2BlogPayload(
+      createState({ enableEditorialAugmentation: true }),
+    )
+
+    expect(defaultPayload?.enable_editorial_augmentation).toBe(false)
+    expect(optedInPayload?.enable_editorial_augmentation).toBe(true)
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -5,6 +5,10 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as prompt2blogApi from '../api'
+import {
+  DEFAULT_COMPOSER_STATE,
+  saveComposerState,
+} from '../composer/composer.storage'
 import { DEFAULT_PROMPT2BLOG_MODEL } from '../constants/prompt2blog.constants'
 import Prompt2BlogPage from './Prompt2BlogPage'
 
@@ -187,6 +191,21 @@ describe('Prompt2BlogPage', () => {
     expect(modelSelect).toHaveValue(DEFAULT_PROMPT2BLOG_MODEL)
   })
 
+  it('keeps editorial extras off until the operator opts in', async () => {
+    renderPage()
+
+    const editorialExtras = await screen.findByLabelText('Add editorial extras')
+
+    expect(editorialExtras).not.toBeChecked()
+    expect(
+      screen.getByText('May add a useful pull quote, callout, FAQ, or takeaway box.'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(editorialExtras)
+
+    expect(editorialExtras).toBeChecked()
+  })
+
   it('keeps optional controls collapsed while core choices stay visible', async () => {
     renderPage()
 
@@ -194,9 +213,12 @@ describe('Prompt2BlogPage', () => {
     const advancedGeneration = advancedGenerationSummary.closest('details')
     const advancedSeoSummary = screen.getByText('Advanced SEO controls')
     const advancedSeo = advancedSeoSummary.closest('details')
+    const optionalGuidanceSummary = screen.getByText('Optional editorial guidance')
+    const optionalGuidance = optionalGuidanceSummary.closest('details')
 
     expect(advancedGeneration).not.toHaveAttribute('open')
     expect(advancedSeo).not.toHaveAttribute('open')
+    expect(optionalGuidance).not.toHaveAttribute('open')
     for (const label of [
       'Tone',
       'Length',
@@ -211,7 +233,7 @@ describe('Prompt2BlogPage', () => {
       'Writer Model',
       'Creativity Level',
       'Negative Instructions (one per line)',
-      'Enable editorial augmentation',
+      'Add editorial extras',
     ]) {
       expect(screen.getByLabelText(label).closest('details')).toBe(advancedGeneration)
     }
@@ -220,12 +242,63 @@ describe('Prompt2BlogPage', () => {
     expect(
       screen.getByLabelText('Secondary Keywords (comma-separated)').closest('details'),
     ).toBe(advancedSeo)
+    expect(screen.getByLabelText('Editorial Angle (Optional)').closest('details')).toBe(
+      optionalGuidance,
+    )
+    expect(screen.getByLabelText('Call to Action (Optional)').closest('details')).toBe(
+      optionalGuidance,
+    )
 
     fireEvent.click(advancedGenerationSummary)
     fireEvent.click(advancedSeoSummary)
+    fireEvent.click(optionalGuidanceSummary)
 
     expect(advancedGeneration).toHaveAttribute('open')
     expect(advancedSeo).toHaveAttribute('open')
+    expect(optionalGuidance).toHaveAttribute('open')
+  })
+
+  it('opens optional editorial guidance when a saved draft uses it', async () => {
+    saveComposerState({
+      ...DEFAULT_COMPOSER_STATE,
+      angle: 'Peru is the better first stop',
+      callToAction: 'Compare fares',
+    })
+
+    renderPage()
+
+    const optionalGuidanceSummary = await screen.findByText('Optional editorial guidance')
+    const optionalGuidance = optionalGuidanceSummary.closest('details')
+
+    expect(optionalGuidance).toHaveAttribute('open')
+    expect(screen.getByLabelText('Editorial Angle (Optional)')).toHaveValue(
+      'Peru is the better first stop',
+    )
+    expect(screen.getByLabelText('Call to Action (Optional)')).toHaveValue('Compare fares')
+  })
+
+  it('preserves optional guidance across toggles and clears it with core inputs', async () => {
+    renderPage()
+
+    const optionalGuidanceSummary = await screen.findByText('Optional editorial guidance')
+    const angle = screen.getByLabelText('Editorial Angle (Optional)')
+    const callToAction = screen.getByLabelText('Call to Action (Optional)')
+
+    fireEvent.click(optionalGuidanceSummary)
+    fireEvent.change(angle, { target: { value: 'Peru is the better first stop' } })
+    fireEvent.change(callToAction, { target: { value: 'Compare fares' } })
+    fireEvent.click(optionalGuidanceSummary)
+    fireEvent.click(optionalGuidanceSummary)
+
+    expect(angle).toHaveValue('Peru is the better first stop')
+    expect(callToAction).toHaveValue('Compare fares')
+
+    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' })
+      .closest('section')
+    fireEvent.click(within(coreInputsPanel!).getByRole('button', { name: 'Clear section' }))
+
+    expect(angle).toHaveValue('')
+    expect(callToAction).toHaveValue('')
   })
 
   it('preserves advanced values across disclosure toggles and clears them by section', async () => {
@@ -296,6 +369,7 @@ describe('Prompt2BlogPage', () => {
           model_name: 'gemini-2.5-pro',
           tone_id: 'balanced',
           length_id: 'standard',
+          enable_editorial_augmentation: false,
           source_material: ['Alfama is historic. Principe Real is calmer and more upscale.'],
         }),
       )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/validate-pipeline-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/validate-pipeline-payload.test.ts
@@ -18,7 +18,7 @@ function createPayload(overrides: Partial<Prompt2BlogRunRequest> = {}): Prompt2B
     creativity_level: 'medium',
     negative_instructions: [],
     include_debug: true,
-    enable_editorial_augmentation: true,
+    enable_editorial_augmentation: false,
     ...overrides,
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
@@ -321,6 +321,16 @@
   gap: var(--space-3) var(--space-5);
 }
 
+.p2b-checkbox-option {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.p2b-checkbox-option .p2b-field-hint {
+  padding-left: 24px;
+}
+
 /* Raw Input Blobs */
 .p2b-blob-field {
   display: flex;

--- a/apps/ai-blog-writer/docs/routes.md
+++ b/apps/ai-blog-writer/docs/routes.md
@@ -56,6 +56,7 @@ Structured Prompt2Blog run input now uses:
 - `tone_id`, `length_id` (required; loaded from `/prompt2blog/input-options`)
 - `brand_voice_id`, `primary_keyword`, `secondary_keywords`, `must_include`, `audience_profile`, `negative_instructions` (optional)
 - `prompt_enhance`, `creativity_level`, `include_debug`, `enable_editorial_augmentation`, `model_name` (optional controls)
+- `enable_editorial_augmentation` defaults to `false`; callers must opt in to editorial extras
 
 ### Editor Assist (`/editor-assist`)
 


### PR DESCRIPTION
## What changed
- makes editorial augmentation opt-in in frontend and backend request defaults
- versions composer storage so old default-on drafts migrate off while explicit future choices persist
- renames the control to Add editorial extras and explains possible output
- moves Editorial Angle and Call to Action into an optional disclosure that opens for saved values
- documents the API default

## Why
Editorial augmentation can add pull quotes, callouts, FAQs, and takeaway boxes. Default-on behavior created avoidable output fluff. Angle and CTA remain useful, but only for articles that need a stance or reader action.

## Validation
- Prompt2Blog frontend seams: 28 passed
- Prompt2Blog backend suite: 92 passed
- frontend boundary check + ESLint: passed
- backend changed-file flake8: passed
- Vite production build: passed
- `git diff --check`: passed
- independent standards/spec review: no blockers
- full frontend TypeScript check remains blocked by 7 pre-existing errors in unrelated files