### PR TITLE
fix(youtube2blog): keep blocking fetches off the event loop

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/pipeline.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 
 from shared import RawVideoRecord
@@ -59,7 +60,12 @@ async def start_from_youtube_url(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    transcript_result = extract_transcript_sync(source.video_id)
+    # Both of these do blocking network I/O. Called directly they stall the
+    # event loop for the whole fetch, freezing every other request.
+    transcript_result = await run_in_threadpool(
+        extract_transcript_sync,
+        source.video_id,
+    )
     if transcript_result.get("status") != "completed":
         detail = transcript_result.get("error") or "Transcript extraction failed."
         raise HTTPException(status_code=422, detail=detail)
@@ -68,9 +74,8 @@ async def start_from_youtube_url(
     if not isinstance(transcript, str) or not transcript.strip():
         raise HTTPException(status_code=422, detail="Transcript extraction failed.")
 
-    title = (
-        fetch_oembed_title(source.canonical_url) or f"YouTube Video {source.video_id}"
-    )
+    oembed_title = await run_in_threadpool(fetch_oembed_title, source.canonical_url)
+    title = oembed_title or f"YouTube Video {source.video_id}"
     now_iso = datetime.now(timezone.utc).isoformat()
 
     record = RawVideoRecord(

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_routes.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 
 from fastapi import FastAPI
@@ -72,6 +73,66 @@ def test_router_preserves_public_http_contract():
         ("/youtube2blog/expand/{expand_job_id}/status", "GET"),
         ("/youtube2blog/expand/{expand_job_id}/result", "GET"),
     }
+
+
+def test_from_url_keeps_blocking_fetches_off_the_event_loop(monkeypatch):
+    """Transcript extraction and the oEmbed title lookup are blocking network
+    I/O. Awaited on the event loop thread they stall every other request for
+    the length of the fetch, so both must be offloaded to a worker thread."""
+    client = _build_client()
+    ran_on_event_loop: dict[str, bool] = {}
+
+    def _on_event_loop_thread() -> bool:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        return True
+
+    def fake_extract_transcript(_video_id: str):
+        ran_on_event_loop["transcript"] = _on_event_loop_thread()
+        return {"status": "completed", "transcript": "Transcript body"}
+
+    def fake_fetch_oembed_title(_url: str):
+        ran_on_event_loop["oembed"] = _on_event_loop_thread()
+        return "Resolved Title"
+
+    monkeypatch.setattr(
+        youtube2blog_pipeline,
+        "parse_youtube_video_url",
+        lambda _url: YouTubeVideoSource(
+            video_id="abc123DEF45",
+            canonical_url="https://www.youtube.com/watch?v=abc123DEF45",
+        ),
+    )
+    monkeypatch.setattr(
+        youtube2blog_pipeline,
+        "extract_transcript_sync",
+        fake_extract_transcript,
+    )
+    monkeypatch.setattr(
+        youtube2blog_pipeline,
+        "fetch_oembed_title",
+        fake_fetch_oembed_title,
+    )
+    monkeypatch.setattr(
+        youtube2blog_pipeline,
+        "initialize_run",
+        lambda record, source, notes=None: _sample_meta(source=source, notes=notes),
+    )
+    monkeypatch.setattr(
+        youtube2blog_pipeline,
+        "process_run",
+        lambda record, meta, **kwargs: "# done",
+    )
+
+    response = client.post(
+        "/youtube2blog/from-url",
+        json={"url": "https://www.youtube.com/watch?v=abc123DEF45"},
+    )
+
+    assert response.status_code == 200
+    assert ran_on_event_loop == {"transcript": False, "oembed": False}
 
 
 def test_from_url_queues_single_run(monkeypatch):


### PR DESCRIPTION
## Problem

`start_from_youtube_url` is an `async def` handler that called two blocking functions directly:

- `extract_transcript_sync` — synchronous `youtube-transcript-api` network I/O
- `fetch_oembed_title` — synchronous `httpx.get` with a 10s timeout

Both stall the FastAPI event loop for the entire fetch. Every other request to the backend freezes while a transcript downloads.

## Fix

Offload both to a worker thread with `run_in_threadpool`.

## Test

`test_from_url_keeps_blocking_fetches_off_the_event_loop` calls `asyncio.get_running_loop()` inside each patched fetch — it succeeds only on the event loop thread. Verified the test fails on the pre-fix code (`{'transcript': True} != {'transcript': False}`) and passes after.

Backend suite: 459 passed (baseline 458 + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)