### PR TITLE
fix(youtube2blog): stop re-translating already-English transcripts

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_1.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_1.py
@@ -5,6 +5,7 @@ Stage 1: Clean transcript text from the raw video record.
 from __future__ import annotations
 
 import logging
+import re
 
 from langchain_core.prompts import PromptTemplate
 
@@ -105,10 +106,50 @@ Text:
 {text}"""
 
 
+# Scripts that cannot survive a successful translation to English. Latin-script
+# languages are deliberately not detected: every cleaning prompt already orders
+# a translation, and any heuristic strong enough to catch untranslated Spanish
+# would also fire on English text carrying loanwords or accented names.
+_NON_LATIN_SCRIPT_PATTERN = re.compile(
+    "["
+    "Ѐ-ӿ"  # Cyrillic
+    "֐-׿"  # Hebrew
+    "؀-ۿ"  # Arabic
+    "ऀ-ॿ"  # Devanagari
+    "฀-๿"  # Thai
+    "぀-ヿ"  # Hiragana and Katakana
+    "一-鿿"  # CJK unified ideographs
+    "가-힯"  # Hangul
+    "]"
+)
+
+# A stray quoted term in an otherwise English article should not buy a full
+# re-translation, so the trigger is a share of the text rather than any hit.
+# Genuinely untranslated text runs near 100% non-Latin; prose that merely names
+# a place or dish in its own script sits under 5%. 10% separates the two with
+# room for a partly-translated result to still be caught.
+_UNTRANSLATED_SCRIPT_RATIO = 0.10
+
+
+def _needs_english_enforcement(text: str) -> bool:
+    """True when text still carries enough non-Latin script to look untranslated."""
+    dense = "".join(text.split())
+    if not dense:
+        return False
+    non_latin = len(_NON_LATIN_SCRIPT_PATTERN.findall(text))
+    return (non_latin / len(dense)) > _UNTRANSLATED_SCRIPT_RATIO
+
+
 def _ensure_english(text: str, llm: object) -> str:
     """
-    Always run an idempotent English enforcement pass.
-    The LLM returns English text unchanged and translates anything else.
+    Repair a cleaning pass that failed to translate.
+
+    This used to run unconditionally on both the transcript and the title. The
+    transcript call re-emitted the entire cleaned transcript through the model
+    on every run -- the expensive output tokens -- to almost always receive a
+    byte-identical copy, because all three cleaning prompts already order a
+    translation to English. Callers now gate it on evidence the translation did
+    not happen.
     """
     logger.info("  Running English enforcement pass...")
     prompt = PromptTemplate(input_variables=["text"], template=TRANSLATION_ENFORCEMENT_PROMPT)
@@ -273,8 +314,11 @@ def _clean_transcript_impl(
         )
     logger.info("  Received response from Vertex AI")
 
-    cleaned_transcript = _ensure_english(cleaned_transcript, llm)
-    english_title = _ensure_english(record.title, llm)
+    if _needs_english_enforcement(cleaned_transcript):
+        cleaned_transcript = _ensure_english(cleaned_transcript, llm)
+    english_title = record.title
+    if _needs_english_enforcement(english_title):
+        english_title = _ensure_english(english_title, llm)
 
     output = Stage1Output(
         video_id=record.video_id,

--- a/apps/ai-blog-writer/apps/backend/tests/test_pipeline_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_pipeline_stages.py
@@ -97,3 +97,86 @@ def test_stage_1_clean_transcript_chunks_long_inputs(monkeypatch):
     assert output.cleaned_transcript == "\n\n".join(
         f"Cleaned chunk {index}" for index in range(1, len(prompts) + 1)
     )
+
+
+def test_stage_1_skips_english_enforcement_for_latin_output(monkeypatch):
+    """The cleaning prompts already order a translation, so re-sending a clean
+    English transcript through the model is a full output-token bill for a
+    byte-identical copy."""
+    enforcement_prompts: list[str] = []
+
+    class StubLLM:
+        def invoke(self, prompt: str) -> str:
+            if _is_translation_enforcement(prompt):
+                enforcement_prompts.append(prompt)
+                return _enforcement_input_text(prompt)
+            return "Cleaned transcript output."
+
+    monkeypatch.setattr(
+        stage_1_module,
+        "get_vertex_llm",
+        lambda **_kwargs: StubLLM(),
+    )
+
+    output = stage_1_clean_transcript(sample_record())
+
+    assert enforcement_prompts == []
+    assert output.cleaned_transcript == "Cleaned transcript output."
+
+
+def test_stage_1_enforces_english_when_translation_did_not_happen(monkeypatch):
+    """A cleaning pass that ignored the translation instruction leaves non-Latin
+    script behind, which is the one case worth paying the extra pass for."""
+    enforced: list[str] = []
+
+    class StubLLM:
+        def invoke(self, prompt: str) -> str:
+            if _is_translation_enforcement(prompt):
+                enforced.append(_enforcement_input_text(prompt))
+                return "Translated to English."
+            return "これは翻訳されていない書き起こしです。" * 5
+
+    monkeypatch.setattr(
+        stage_1_module,
+        "get_vertex_llm",
+        lambda **_kwargs: StubLLM(),
+    )
+
+    record = sample_record()
+    output = stage_1_clean_transcript(record)
+
+    assert len(enforced) == 1
+    assert output.cleaned_transcript == "Translated to English."
+
+
+def test_stage_1_translates_non_latin_titles_only(monkeypatch):
+    """An English title needs no round trip; a Japanese one still does."""
+
+    class StubLLM:
+        def invoke(self, prompt: str) -> str:
+            if _is_translation_enforcement(prompt):
+                return "Translated Title"
+            return "Cleaned transcript output."
+
+    monkeypatch.setattr(
+        stage_1_module,
+        "get_vertex_llm",
+        lambda **_kwargs: StubLLM(),
+    )
+
+    ascii_title = stage_1_clean_transcript(sample_record())
+    assert ascii_title.title == "Test Video"
+
+    record = sample_record()
+    japanese = record.model_copy(update={"title": "日本語のタイトル"})
+    assert stage_1_clean_transcript(japanese).title == "Translated Title"
+
+
+def test_needs_english_enforcement_ignores_incidental_foreign_terms():
+    """One quoted term in an English article must not buy a re-translation."""
+    english_with_loanword = (
+        "The restaurant is called 東京 and serves a tasting menu. " * 20
+    )
+
+    assert not stage_1_module._needs_english_enforcement(english_with_loanword)
+    assert stage_1_module._needs_english_enforcement("東京の美味しいレストランの話")


### PR DESCRIPTION
## Problem

`stage_1.py` ran `_ensure_english` unconditionally on both the cleaned transcript and the title:

```python
cleaned_transcript = _ensure_english(cleaned_transcript, llm)
english_title = _ensure_english(record.title, llm)
```

All three cleaning prompts already say *"If the transcript is not in English, translate it to English as you clean it."* So the transcript call re-emits the whole cleaned transcript through the model on every run — the expensive output tokens — to almost always get a byte-identical copy back. Two LLM round trips per run for ~zero information.

It also has a truncation edge: chunked cleaning rejoins N chunks and pushes the whole thing through one call capped at `Y2B_STAGE1_MAX_OUTPUT_TOKENS` (32,768). For a long transcript that call is where the tail goes missing.

## Fix

Gate both calls on evidence the translation actually failed — a non-Latin-script share above 10%. Latin-script languages are deliberately not detected: the cleaning prompt covers them, and any heuristic strong enough to catch untranslated Spanish also fires on English prose with accented names. Stage 4 regenerates the title from the finished article regardless, so a passed-through Latin title has no downstream effect.

## Tests

4 new, covering: no enforcement for English output, enforcement when the model returned untranslated Japanese, title translated only when non-Latin, and the ratio threshold ignoring an incidental foreign term.

Backend suite: 463 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)