### PR TITLE
fix(youtube2blog): stop the retention gate failing translated transcripts

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/config.py
@@ -28,6 +28,15 @@ Y2B_STAGE1_LONG_TRANSCRIPT_CHAR_THRESHOLD = 30_000
 Y2B_STAGE1_LONG_TRANSCRIPT_MIN_RETENTION_RATIO = 0.08
 Y2B_STAGE1_LONG_TRANSCRIPT_MAX_RETENTION_RATIO = 0.98
 Y2B_STAGE1_MAX_RETENTION_RATIO = 1.05
+
+# Character retention only measures compression when the cleaned text is in the
+# same script as the source. Stage 1 translates as it cleans, so a Japanese,
+# Thai or Korean transcript comes back in English with a completely different
+# character economy -- commonly 1.5-3x the character count for identical
+# content. Under the bands above that reads as "the model invented text" and
+# fails the gate, so non-Latin sources are measured against their own band.
+Y2B_STAGE1_TRANSLATED_MIN_RETENTION_RATIO = 0.10
+Y2B_STAGE1_TRANSLATED_MAX_RETENTION_RATIO = 6.00
 Y2B_STAGE1_CHUNKING_CHAR_THRESHOLD = 18_000
 Y2B_STAGE1_CHUNK_TARGET_CHARS = 12_000
 Y2B_LONGFORM_MAX_OUTPUT_TOKENS = 32_768

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/content/script.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/content/script.py
@@ -1,0 +1,47 @@
+"""Writing-script measurements shared by Stage 1 cleaning and its quality gate.
+
+Stage 1 translates as it cleans, so two separate decisions need to know whether
+a piece of text is written in a non-Latin script: whether a cleaning pass
+actually performed the translation it was told to, and whether character-count
+retention means anything for the transcript it just produced.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Scripts that cannot survive a successful translation to English. Latin-script
+# languages are deliberately not detected: every cleaning prompt already orders
+# a translation, and any heuristic strong enough to catch untranslated Spanish
+# would also fire on English text carrying loanwords or accented names.
+NON_LATIN_SCRIPT_PATTERN = re.compile(
+    "["
+    "Ѐ-ӿ"  # Cyrillic
+    "֐-׿"  # Hebrew
+    "؀-ۿ"  # Arabic
+    "ऀ-ॿ"  # Devanagari
+    "฀-๿"  # Thai
+    "぀-ヿ"  # Hiragana and Katakana
+    "一-鿿"  # CJK unified ideographs
+    "가-힯"  # Hangul
+    "]"
+)
+
+# A stray quoted term in an otherwise English article should not count as a
+# different script. Genuinely non-Latin text runs near 100%; prose that merely
+# names a place or dish in its own script sits under 5%. 10% separates the two
+# with room for partly-translated text to still be caught.
+NON_LATIN_SCRIPT_RATIO_THRESHOLD = 0.10
+
+
+def non_latin_script_ratio(text: str) -> float:
+    """Share of the text's non-whitespace characters written in a non-Latin script."""
+    dense = "".join(text.split())
+    if not dense:
+        return 0.0
+    return len(NON_LATIN_SCRIPT_PATTERN.findall(text)) / len(dense)
+
+
+def is_non_latin_script(text: str) -> bool:
+    """True when enough of the text is non-Latin to treat it as another script."""
+    return non_latin_script_ratio(text) > NON_LATIN_SCRIPT_RATIO_THRESHOLD

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/transcript.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/transcript.py
@@ -8,6 +8,7 @@ from app.features.youtube2blog.stages import (
 )
 from ..context import YouTube2BlogNodeContext
 from ..state import GraphNode, YouTube2BlogGraphState
+from ...content.script import is_non_latin_script
 from ...quality.policies import evaluate_transcript_gate
 
 
@@ -47,6 +48,7 @@ def build_transcript_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphN
             cleaned_chars=cleaned_chars,
             original_chars=original_chars,
             retry_count=retry_count,
+            translated_source=is_non_latin_script(record.transcript),
         )
         stage_results = _record_stage_result(
             state,

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/policies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/policies.py
@@ -18,6 +18,8 @@ from ..config import (
     Y2B_STAGE1_MIN_CLEANED_CHARS,
     Y2B_STAGE1_MIN_RETENTION_RATIO,
     Y2B_STAGE1_REPAIR_MAX_RETRIES,
+    Y2B_STAGE1_TRANSLATED_MAX_RETENTION_RATIO,
+    Y2B_STAGE1_TRANSLATED_MIN_RETENTION_RATIO,
     Y2B_STAGE2_CLASSIFICATION_MAX_RETRIES,
     Y2B_STAGE2_MIN_CONFIDENCE,
     Y2B_STAGE3_MIN_CRITICAL_DIMENSION_SCORE,
@@ -29,7 +31,17 @@ from ..config import (
 )
 
 
-def transcript_retention_policy(original_chars: int) -> tuple[str, float, float]:
+def transcript_retention_policy(
+    original_chars: int,
+    *,
+    translated_source: bool = False,
+) -> tuple[str, float, float]:
+    if translated_source:
+        return (
+            "translated",
+            Y2B_STAGE1_TRANSLATED_MIN_RETENTION_RATIO,
+            Y2B_STAGE1_TRANSLATED_MAX_RETENTION_RATIO,
+        )
     if original_chars >= Y2B_STAGE1_LONG_TRANSCRIPT_CHAR_THRESHOLD:
         return (
             "long_form",
@@ -50,9 +62,11 @@ def evaluate_transcript_gate(
     cleaned_chars: int,
     original_chars: int,
     retry_count: int,
+    translated_source: bool = False,
 ) -> tuple[str, dict[str, Any]]:
     profile, minimum_ratio, maximum_ratio = transcript_retention_policy(
-        original_chars
+        original_chars,
+        translated_source=translated_source,
     )
     retention_ratio = cleaned_chars / max(1, original_chars)
     checks = {
@@ -88,6 +102,7 @@ def evaluate_transcript_gate(
             "minimum_retention_ratio_threshold": round(minimum_ratio, 4),
             "maximum_retention_ratio_threshold": round(maximum_ratio, 4),
             "transcript_length_profile": profile,
+            "translated_source": translated_source,
         },
     }
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_1.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_1.py
@@ -5,10 +5,10 @@ Stage 1: Clean transcript text from the raw video record.
 from __future__ import annotations
 
 import logging
-import re
 
 from langchain_core.prompts import PromptTemplate
 
+from app.features.youtube2blog.content.script import is_non_latin_script
 from app.features.youtube2blog.config import (
     Y2B_PRIMARY_MODEL,
     Y2B_STAGE1_CHUNK_TARGET_CHARS,
@@ -106,38 +106,9 @@ Text:
 {text}"""
 
 
-# Scripts that cannot survive a successful translation to English. Latin-script
-# languages are deliberately not detected: every cleaning prompt already orders
-# a translation, and any heuristic strong enough to catch untranslated Spanish
-# would also fire on English text carrying loanwords or accented names.
-_NON_LATIN_SCRIPT_PATTERN = re.compile(
-    "["
-    "Ѐ-ӿ"  # Cyrillic
-    "֐-׿"  # Hebrew
-    "؀-ۿ"  # Arabic
-    "ऀ-ॿ"  # Devanagari
-    "฀-๿"  # Thai
-    "぀-ヿ"  # Hiragana and Katakana
-    "一-鿿"  # CJK unified ideographs
-    "가-힯"  # Hangul
-    "]"
-)
-
-# A stray quoted term in an otherwise English article should not buy a full
-# re-translation, so the trigger is a share of the text rather than any hit.
-# Genuinely untranslated text runs near 100% non-Latin; prose that merely names
-# a place or dish in its own script sits under 5%. 10% separates the two with
-# room for a partly-translated result to still be caught.
-_UNTRANSLATED_SCRIPT_RATIO = 0.10
-
-
 def _needs_english_enforcement(text: str) -> bool:
     """True when text still carries enough non-Latin script to look untranslated."""
-    dense = "".join(text.split())
-    if not dense:
-        return False
-    non_latin = len(_NON_LATIN_SCRIPT_PATTERN.findall(text))
-    return (non_latin / len(dense)) > _UNTRANSLATED_SCRIPT_RATIO
+    return is_non_latin_script(text)
 
 
 def _ensure_english(text: str, llm: object) -> str:

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_transcript_gate.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_transcript_gate.py
@@ -1,0 +1,80 @@
+"""Stage 1 transcript retention gate."""
+
+from app.features.youtube2blog.content.script import (
+    is_non_latin_script,
+    non_latin_script_ratio,
+)
+from app.features.youtube2blog.quality.policies import (
+    evaluate_transcript_gate,
+    transcript_retention_policy,
+)
+
+
+def test_latin_source_keeps_the_standard_retention_band():
+    profile, minimum, maximum = transcript_retention_policy(5_000)
+
+    assert profile == "standard"
+    assert maximum < 1.5
+
+
+def test_translated_source_gets_its_own_retention_band():
+    profile, minimum, maximum = transcript_retention_policy(
+        5_000,
+        translated_source=True,
+    )
+
+    assert profile == "translated"
+    assert minimum < 0.2
+    assert maximum > 2.0
+
+
+def test_translated_transcript_that_grew_still_passes():
+    """Japanese to English roughly triples the character count for identical
+    content. Under the Latin band that trips `maximum_retention_ratio`, burns
+    both repair attempts and then kills the run."""
+    decision, gate_data = evaluate_transcript_gate(
+        cleaned_chars=15_000,
+        original_chars=5_000,
+        retry_count=0,
+        translated_source=True,
+    )
+
+    assert decision == "pass"
+    assert gate_data["checks"]["maximum_retention_ratio"] is True
+    assert gate_data["metrics"]["transcript_length_profile"] == "translated"
+    assert gate_data["metrics"]["translated_source"] is True
+
+
+def test_same_growth_from_a_latin_source_is_still_rejected():
+    """A Latin-script transcript that tripled in size really did gain text."""
+    decision, gate_data = evaluate_transcript_gate(
+        cleaned_chars=15_000,
+        original_chars=5_000,
+        retry_count=0,
+    )
+
+    assert decision == "retry"
+    assert gate_data["checks"]["maximum_retention_ratio"] is False
+
+
+def test_translated_band_still_rejects_a_collapsed_transcript():
+    """The wider band must not turn the gate off; over-compression still fails."""
+    decision, gate_data = evaluate_transcript_gate(
+        cleaned_chars=200,
+        original_chars=40_000,
+        retry_count=0,
+        translated_source=True,
+    )
+
+    assert decision == "retry"
+    assert gate_data["checks"]["minimum_cleaned_chars"] is False
+
+
+def test_script_detection_separates_translated_sources_from_loanwords():
+    assert is_non_latin_script("日本語の書き起こしです。" * 10)
+    assert is_non_latin_script("Транскрипт видео на русском языке." * 10)
+    assert not is_non_latin_script("A normal English transcript about travel.")
+    assert not is_non_latin_script(
+        "The restaurant is called 東京 and serves a tasting menu. " * 20
+    )
+    assert non_latin_script_ratio("") == 0.0


### PR DESCRIPTION
## Problem

Stage 1's prompts translate to English as they clean. Its quality gate then scores the result with `cleaned_chars / original_chars` against `Y2B_STAGE1_MAX_RETENTION_RATIO = 1.05`.

Japanese, Thai and Korean transcripts come back in English at roughly **1.5–3× the character count** for identical content. So:

1. `maximum_retention_ratio` fails
2. Two repair attempts are spent re-cleaning (each a full-transcript call)
3. `evaluate_transcript_gate` raises `RuntimeError` and the run dies

This happens for **every non-Latin-script video** — a case the cleaning prompts explicitly advertise support for.

## Fix

Character retention only measures compression when both sides share a script. Non-Latin sources get a `"translated"` profile with a band sized for translation expansion (0.10–6.00).

The safety properties are kept: `Y2B_STAGE1_MIN_CLEANED_CHARS` still applies, and a collapsed transcript still fails.

Script detection moves into `content/script.py` so this gate and the Stage 1 English-enforcement check (added in #175) share one definition rather than drifting.

## Tests

6 new: the translated band exists and differs, a 3× growth passes when translated and still fails when Latin-script, over-compression still fails under the wide band, and the detector separates real non-Latin text from incidental loanwords.

Backend suite: 469 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)