### PR TITLE
fix(youtube2blog): route around stage_2 when the article type is forced

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/classification.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/classification.py
@@ -113,20 +113,21 @@ def build_classification_nodes(context: YouTube2BlogNodeContext) -> dict[str, Gr
         _write_running_status("stage_3_guideline")
         forced_type = (state.get("forced_article_type") or "").strip()
         if forced_type:
-            # User pre-selected an article type — fetch its guideline from DB directly,
-            # bypassing stage_2 classification
-            guideline = stage_3_retrieve_guideline(forced_type)
+            # A forced type routes around stage_2 entirely, so there is no
+            # classification to read here and none to pay for upstream.
             article_type = forced_type
             source = "user_selected"
+            input_refs = {"stage_1": _stage_ref(run_id, "stage_1")}
         else:
             stage2 = Stage2Output.model_validate(state["stage2"])
-            guideline = stage_3_retrieve_guideline(stage2.classification)
             article_type = stage2.classification
             source = "auto_classified"
+            input_refs = {"stage_2": _stage_ref(run_id, "stage_2")}
+        guideline = stage_3_retrieve_guideline(article_type)
         stage_results = _record_stage_result(
             state,
             stage_name="stage_3_guideline",
-            input_refs={"stage_2": _stage_ref(run_id, "stage_2")},
+            input_refs=input_refs,
             data={
                 "article_type": article_type,
                 "guideline": guideline,
@@ -135,6 +136,7 @@ def build_classification_nodes(context: YouTube2BlogNodeContext) -> dict[str, Gr
             },
         )
         return {
+            "article_type": article_type,
             "stage3_guideline": guideline,
             "stage_results": stage_results,
         }

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/composition.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/composition.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from shared import Stage1Output, Stage2Output, Stage3Output
+from shared import Stage1Output, Stage3Output
 
 from app.features.youtube2blog.stages import (
     stage_3_assess_article_quality,
@@ -53,7 +53,7 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
     ) -> YouTube2BlogGraphState:
         _write_running_status("stage_3_supplement")
         stage1 = Stage1Output.model_validate(state["stage1"])
-        stage2 = Stage2Output.model_validate(state["stage2"])
+        article_type = str(state["article_type"])
         coverage = dict(state.get("stage3_coverage") or {})
         missing_sections_value = coverage.get("missing_sections")
         missing_sections = (
@@ -64,7 +64,7 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
         supplement = stage_3_generate_supplement(
             transcript=stage1.cleaned_transcript,
             missing_sections=missing_sections,
-            article_type=stage2.classification,
+            article_type=article_type,
             model_name=_active_model,
             tone_guidance=_tone_guidance,
         )
@@ -82,7 +82,7 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
     def stage_3_compose_node(state: YouTube2BlogGraphState) -> YouTube2BlogGraphState:
         _write_running_status("stage_3")
         stage1 = Stage1Output.model_validate(state["stage1"])
-        stage2 = Stage2Output.model_validate(state["stage2"])
+        article_type = str(state["article_type"])
         guideline = str(state.get("stage3_guideline") or "")
         coverage = dict(state.get("stage3_coverage") or {})
         supplement = dict(state.get("stage3_supplement") or {})
@@ -99,7 +99,7 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
             transcript=stage1.cleaned_transcript,
             supplemental=supplemental_content_or_none,
             guideline=guideline,
-            article_type=stage2.classification,
+            article_type=article_type,
             title=stage1.title,
             model_name=_active_model,
             writing_model=_writing_model,
@@ -109,7 +109,7 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
         stage3 = Stage3Output(
             video_id=stage1.video_id,
             title=stage1.title,
-            article_type=stage2.classification,
+            article_type=article_type,
             coverage_sufficient=bool(coverage.get("coverage_sufficient", False)),
             coverage_analysis=str(coverage.get("coverage_analysis") or ""),
             missing_sections=list(coverage.get("missing_sections") or []),
@@ -134,10 +134,11 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
 
         input_refs = {
             "stage_1": _stage_ref(run_id, "stage_1"),
-            "stage_2": _stage_ref(run_id, "stage_2"),
             "stage_3_guideline": _stage_ref(run_id, "stage_3_guideline"),
             "stage_3_coverage": _stage_ref(run_id, "stage_3_coverage"),
         }
+        if "stage2" in state:
+            input_refs["stage_2"] = _stage_ref(run_id, "stage_2")
         if supplemental_content_or_none:
             input_refs["stage_3_supplement"] = _stage_ref(run_id, "stage_3_supplement")
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/routing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/routing.py
@@ -4,7 +4,18 @@ from .state import YouTube2BlogGraphState
 
 
 def route_stage_1_gate(state: YouTube2BlogGraphState) -> str:
-    return str(state.get("stage1_gate_decision") or "pass")
+    """Send a clean transcript to classification, or straight past it.
+
+    A user-forced article type makes stage_2 dead work: its answer is
+    discarded by stage_3_guideline, but the run still pays for a
+    full-transcript classification call plus a possible retry, and its
+    confidence gate can still fail the run over a verdict nobody uses.
+    """
+    if str(state.get("stage1_gate_decision") or "pass") == "retry":
+        return "retry"
+    if str(state.get("forced_article_type") or "").strip():
+        return "skip_classification"
+    return "classify"
 
 
 def route_stage_2_gate(state: YouTube2BlogGraphState) -> str:

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/state.py
@@ -13,6 +13,10 @@ class YouTube2BlogGraphState(TypedDict, total=False):
     stage2: dict[str, Any]
     stage2_retry_count: int
     stage2_gate_decision: str
+    # The article type every downstream stage composes against. Resolved once by
+    # stage_3_guideline from either the user's forced type or stage_2's
+    # classification, so the two can never disagree.
+    article_type: str
     stage3_guideline: str
     stage3_coverage: dict[str, Any]
     stage3_supplement: dict[str, str]

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/topology.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/topology.py
@@ -63,7 +63,11 @@ def build_youtube2blog_graph(nodes: dict[str, GraphNode]) -> Any:
     builder.add_conditional_edges(
         "stage_1_quality_gate",
         route_stage_1_gate,
-        {"pass": "stage_2", "retry": "stage_1_repair"},
+        {
+            "classify": "stage_2",
+            "skip_classification": "stage_3_guideline",
+            "retry": "stage_1_repair",
+        },
     )
     builder.add_edge("stage_1_repair", "stage_1_quality_gate")
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_article_type_resolution.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_article_type_resolution.py
@@ -1,0 +1,88 @@
+"""The article type every downstream stage composes against."""
+
+from types import SimpleNamespace
+
+from app.features.youtube2blog.graph.nodes import classification as classification_nodes
+
+
+class _Recorder:
+    def __init__(self):
+        self.started: list[str] = []
+
+    def start_stage(self, stage: str) -> None:
+        self.started.append(stage)
+
+
+def _context(monkeypatch, guidelines: dict[str, str]):
+    monkeypatch.setattr(
+        classification_nodes,
+        "stage_3_retrieve_guideline",
+        lambda article_type: guidelines.get(article_type, ""),
+    )
+    recorded: dict[str, dict] = {}
+
+    def record_stage(state, *, stage_name, input_refs, data):
+        recorded[stage_name] = {"input_refs": input_refs, "data": data}
+        return dict(state.get("stage_results") or {})
+
+    context = SimpleNamespace(
+        run_id="run-1",
+        active_model="model",
+        start_stage=lambda _stage: None,
+        record_stage=record_stage,
+        stage_ref=lambda run_id, stage: f"data/runs/{run_id}/{stage}.json",
+        dependencies=SimpleNamespace(article_type_names_reader=lambda: ["News"]),
+    )
+    return context, recorded
+
+
+def test_forced_type_drives_both_the_guideline_and_the_resolved_type(monkeypatch):
+    """The guideline came from the forced type while every downstream stage
+    read stage_2's classification, so composition followed a Listicle guideline
+    while labelling the article News."""
+    context, recorded = _context(
+        monkeypatch,
+        {"Listicle": "LISTICLE GUIDELINE", "News": "NEWS GUIDELINE"},
+    )
+    node = classification_nodes.build_classification_nodes(context)["stage_3_guideline"]
+
+    result = node(
+        {
+            "forced_article_type": "Listicle",
+            "stage2": {
+                "video_id": "v",
+                "title": "t",
+                "classification": "News",
+                "confidence": 0.99,
+                "reasoning": "r",
+            },
+        }
+    )
+
+    assert result["article_type"] == "Listicle"
+    assert result["stage3_guideline"] == "LISTICLE GUIDELINE"
+    assert recorded["stage_3_guideline"]["data"]["source"] == "user_selected"
+    # stage_2 may not have run at all, so it must not be claimed as an input.
+    assert "stage_2" not in recorded["stage_3_guideline"]["input_refs"]
+
+
+def test_auto_classified_type_is_published_to_state(monkeypatch):
+    context, recorded = _context(monkeypatch, {"News": "NEWS GUIDELINE"})
+    node = classification_nodes.build_classification_nodes(context)["stage_3_guideline"]
+
+    result = node(
+        {
+            "stage2": {
+                "video_id": "v",
+                "title": "t",
+                "classification": "News",
+                "confidence": 0.99,
+                "reasoning": "r",
+            },
+        }
+    )
+
+    assert result["article_type"] == "News"
+    assert result["stage3_guideline"] == "NEWS GUIDELINE"
+    assert recorded["stage_3_guideline"]["data"]["source"] == "auto_classified"
+    assert "stage_2" in recorded["stage_3_guideline"]["input_refs"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_graph_runner.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_graph_runner.py
@@ -204,3 +204,56 @@ def test_graph_topology_executes_expected_branches(
 def test_graph_topology_rejects_incomplete_node_registry():
     with pytest.raises(ValueError, match="missing="):
         build_youtube2blog_graph({})
+
+
+def test_forced_article_type_routes_around_classification():
+    """A forced type makes stage_2 dead work: stage_3_guideline discards its
+    verdict, but the run still paid for a full-transcript classification call
+    and could still be killed by its confidence gate."""
+    nodes, visited = _topology_nodes(
+        supplement=False,
+        rollback=False,
+        augment=False,
+    )
+    result = (
+        build_youtube2blog_graph(nodes)
+        .compile()
+        .invoke({"forced_article_type": "Listicle"})
+    )
+
+    assert result["markdown"] == "# Complete"
+    assert "stage_3_guideline" in visited
+    assert "stage_2" not in visited
+    assert "stage_2_quality_gate" not in visited
+    assert "stage_2_retry" not in visited
+
+
+def test_auto_classification_still_runs_without_a_forced_type():
+    nodes, visited = _topology_nodes(
+        supplement=False,
+        rollback=False,
+        augment=False,
+    )
+    build_youtube2blog_graph(nodes).compile().invoke({"forced_article_type": "   "})
+
+    assert "stage_2" in visited
+    assert "stage_2_quality_gate" in visited
+
+
+def test_transcript_repair_still_wins_over_a_forced_type():
+    """A forced type must not let a failed transcript skip its repair loop."""
+    from app.features.youtube2blog.graph.routing import route_stage_1_gate
+
+    assert (
+        route_stage_1_gate(
+            {"stage1_gate_decision": "retry", "forced_article_type": "Listicle"}
+        )
+        == "retry"
+    )
+    assert (
+        route_stage_1_gate(
+            {"stage1_gate_decision": "pass", "forced_article_type": "Listicle"}
+        )
+        == "skip_classification"
+    )
+    assert route_stage_1_gate({"stage1_gate_decision": "pass"}) == "classify"

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/constants/pipeline.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/constants/pipeline.constants.ts
@@ -58,8 +58,9 @@ export const PIPELINE_TIMELINE = [
   { key: 'stage_1', label: '1. Clean Transcript', optional: false },
   { key: 'stage_1_quality_gate', label: '2. Transcript Quality Gate', optional: false },
   { key: 'stage_1_repair', label: '2b. Transcript Repair (If Needed)', optional: true },
-  { key: 'stage_2', label: '3. Classify Article Type', optional: false },
-  { key: 'stage_2_quality_gate', label: '4. Classification Confidence Gate', optional: false },
+  // Skipped outright when the user forces an article type on the upload panel.
+  { key: 'stage_2', label: '3. Classify Article Type', optional: true },
+  { key: 'stage_2_quality_gate', label: '4. Classification Confidence Gate', optional: true },
   { key: 'stage_2_retry', label: '4b. Re-classify (If Needed)', optional: true },
   { key: 'stage_3_guideline', label: '5. Retrieve Guideline', optional: false },
   { key: 'stage_3_coverage', label: '6. Coverage Analysis', optional: false },


### PR DESCRIPTION
## Problem

Two bugs sharing one root cause: the article type was derived in two places.

**Wasted work.** The topology ran `stage_2` unconditionally. `stage_3_guideline` then discarded its answer whenever `forced_article_type` was set. The run still paid for a full-transcript classification call plus a possible retry — and `evaluate_classification_gate` could still `RuntimeError` the whole run over a low-confidence verdict nobody reads.

**Inconsistent state.** The *guideline* came from the forced type, but composition read `stage2.classification`:

```python
article_type=stage2.classification,   # stage_3_supplement
article_type=stage2.classification,   # stage_3 compose
article_type=stage2.classification,   # stored Stage3Output
```

Force `Listicle` on a video the classifier calls `News` and you compose against the listicle guideline while labelling the article news. That mislabel then feeds SEO enrichment and the frontend.

## Fix

Resolve the article type **once**, in `stage_3_guideline`, and publish it to graph state as `article_type`. Composition reads that. `stage_1_quality_gate` routes a clean transcript straight to `stage_3_guideline` when a type is forced.

Transcript repair still takes priority — a forced type cannot let a failed transcript skip its repair loop.

`stage_2` is no longer claimed in `input_refs` when it did not run. The frontend already treated `stage_2` as optional in its types; its two timeline steps are now marked `optional: true` so they render as "Conditional" rather than stuck "Pending".

## Tests

5 new: topology skips all three stage_2 nodes when forced and still runs them when not, repair beats the skip, the forced type drives both guideline and resolved type, and the auto-classified path still publishes its type.

Backend 474 passed · frontend 514 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)