### PR TITLE
fix(youtube2blog): degrade instead of destroying finished runs

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/editorial.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/editorial.py
@@ -50,9 +50,12 @@ def build_editorial_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNo
     def stage_editorial_node(state: YouTube2BlogGraphState) -> YouTube2BlogGraphState:
         _write_running_status("stage_editorial_augmentation")
         stage3 = Stage3Output.model_validate(state["stage3_for_editorial"])
+        # Augmentation is additive decoration on a finished article. It already
+        # degrades to the un-augmented draft with `error` set; fail_fast turned
+        # that off and let a malformed callout response destroy the run.
         stage_editorial = stage_editorial_augmentation(
             stage3,
-            fail_fast=True,
+            fail_fast=False,
             model_name=_active_model,
             writing_model=_writing_model,
             tone_guidance=_tone_guidance,

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/policies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/policies.py
@@ -75,15 +75,23 @@ def evaluate_transcript_gate(
         "maximum_retention_ratio": retention_ratio <= maximum_ratio,
     }
     passed = all(checks.values())
+    failed_checks = [name for name, ok in checks.items() if not ok]
     if passed:
-        decision = "pass"
+        decision, pass_mode = "pass", "strict"
     elif retry_count < Y2B_STAGE1_REPAIR_MAX_RETRIES:
-        decision = "retry"
+        decision, pass_mode = "retry", "retry_required"
+    elif checks["minimum_cleaned_chars"]:
+        # Retention ratios are compression heuristics, not correctness checks.
+        # Once the repair budget is spent, a transcript carrying real content
+        # is worth composing from; discarding the run helps nobody.
+        decision, pass_mode = "pass", "best_effort"
     else:
-        failed_checks = [name for name, ok in checks.items() if not ok]
+        # Below the absolute floor there is no article to write, only one to
+        # invent, so this stays a hard failure.
         raise RuntimeError(
-            "Stage 1 quality gate failed after retries; "
+            "Stage 1 produced too little usable transcript to compose from; "
             f"checks_failed={failed_checks}, cleaned_chars={cleaned_chars}, "
+            f"minimum_cleaned_chars={Y2B_STAGE1_MIN_CLEANED_CHARS}, "
             f"retention_ratio={retention_ratio:.3f}, "
             f"minimum_retention_ratio={minimum_ratio:.3f}, "
             f"maximum_retention_ratio={maximum_ratio:.3f}, "
@@ -92,6 +100,8 @@ def evaluate_transcript_gate(
     return decision, {
         "passed": passed,
         "decision": decision,
+        "pass_mode": pass_mode,
+        "checks_failed": failed_checks,
         "retry_count": retry_count,
         "max_retries": Y2B_STAGE1_REPAIR_MAX_RETRIES,
         "checks": checks,
@@ -116,18 +126,18 @@ def evaluate_classification_gate(
 ) -> tuple[str, dict[str, Any]]:
     passed = confidence >= Y2B_STAGE2_MIN_CONFIDENCE
     if passed:
-        decision = "pass"
+        decision, pass_mode = "pass", "strict"
     elif retry_count < Y2B_STAGE2_CLASSIFICATION_MAX_RETRIES:
-        decision = "retry"
+        decision, pass_mode = "retry", "retry_required"
     else:
-        raise RuntimeError(
-            "Stage 2 quality gate failed after retries; "
-            f"confidence={confidence:.3f}, threshold={Y2B_STAGE2_MIN_CONFIDENCE:.3f}, "
-            f"classification={classification!r}"
-        )
+        # An unconfident classification is still the model's best guess, and
+        # guideline retrieval already degrades to a generic brief when the type
+        # does not resolve. Killing the run here threw away a clean transcript.
+        decision, pass_mode = "pass", "low_confidence"
     return decision, {
         "passed": passed,
         "decision": decision,
+        "pass_mode": pass_mode,
         "retry_count": retry_count,
         "max_retries": Y2B_STAGE2_CLASSIFICATION_MAX_RETRIES,
         "metrics": {
@@ -173,12 +183,10 @@ def evaluate_article_quality_gate(
     elif not critical_failed:
         decision, pass_mode = "pass", "best_effort"
     else:
-        raise RuntimeError(
-            "Stage 3 quality gate failed after retries; "
-            f"score={overall_score:.2f}, "
-            f"threshold={Y2B_STAGE3_MIN_QUALITY_SCORE:.2f}, "
-            f"critical_failed={critical_failed}"
-        )
+        # The repair budget is spent and an article exists. Shipping a weak one
+        # with the failure recorded beats destroying a run that has already
+        # paid for composition, and the score travels in the gate payload.
+        decision, pass_mode = "pass", "critical_dimensions_unmet"
     return decision, {
         **assessment,
         "decision": decision,
@@ -262,18 +270,19 @@ def evaluate_title_gate(
     )
     passed = score >= Y2B_STAGE5_MIN_TITLE_SCORE and length_range_ok
     if passed:
-        decision = "pass"
+        decision, pass_mode = "pass", "strict"
     elif retry_count < Y2B_STAGE5_TITLE_MAX_RETRIES:
-        decision = "retry"
+        decision, pass_mode = "retry", "retry_required"
     else:
-        raise RuntimeError(
-            "Stage 5 quality gate failed after retries; "
-            f"score={score:.2f}, threshold={Y2B_STAGE5_MIN_TITLE_SCORE:.2f}, "
-            f"title={title!r}"
-        )
+        # This gate sat at the very end of the graph, so raising here destroyed
+        # a finished, SEO'd, editorially-augmented article over a title
+        # heuristic -- the most expensive possible moment to fail a run.
+        decision, pass_mode = "pass", "best_effort"
     return decision, {
         **evaluation,
         "decision": decision,
+        "passed": passed,
+        "pass_mode": pass_mode,
         "retry_count": retry_count,
         "max_retries": Y2B_STAGE5_TITLE_MAX_RETRIES,
         "score_threshold": Y2B_STAGE5_MIN_TITLE_SCORE,

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_editorial_node.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_editorial_node.py
@@ -1,0 +1,75 @@
+"""Editorial augmentation node degradation contract."""
+
+from types import SimpleNamespace
+
+from shared import Stage3Output, StageEditorialAugmentationOutput
+
+from app.features.youtube2blog.graph.nodes import editorial as editorial_nodes
+
+
+def _stage3() -> Stage3Output:
+    return Stage3Output(
+        video_id="v1",
+        title="A Title",
+        article_type="News",
+        coverage_sufficient=True,
+        coverage_analysis="",
+        missing_sections=[],
+        supplemental_content=None,
+        final_article="## Section\n\nOriginal article body.",
+        guideline_used="guideline",
+    )
+
+
+def _context():
+    return SimpleNamespace(
+        run_id="run-1",
+        active_model="base-model",
+        writing_model="writing-model",
+        tone_guidance="",
+        start_stage=lambda _stage: None,
+        record_stage=lambda state, **_kwargs: dict(state.get("stage_results") or {}),
+        stage_ref=lambda run_id, stage: f"data/runs/{run_id}/{stage}.json",
+        dependencies=SimpleNamespace(),
+    )
+
+
+def test_editorial_node_leaves_the_stage_fallback_enabled(monkeypatch):
+    """Augmentation is additive decoration on a finished article and already
+    degrades to the un-augmented draft. fail_fast=True turned that off, so a
+    malformed callout response destroyed a run that had already paid for
+    composition, SEO and every quality loop."""
+    captured: dict[str, object] = {}
+
+    def spy(stage3, **kwargs):
+        captured.update(kwargs)
+        return StageEditorialAugmentationOutput(
+            video_id=stage3.video_id,
+            title=stage3.title,
+            article_type=stage3.article_type,
+            augmented_content=stage3.final_article,
+            components_added=[],
+            diagnostic={
+                "cognitive_load": "strong",
+                "narrative_density": "strong",
+                "emphasis_clarity": "strong",
+                "reading_behavior_risk": "strong",
+            },
+            augmentation_summary="",
+            augmentation_applied=False,
+            debug_prompt="",
+            debug_raw_response="",
+            error="editorial service unavailable",
+        )
+
+    monkeypatch.setattr(editorial_nodes, "stage_editorial_augmentation", spy)
+    node = editorial_nodes.build_editorial_nodes(_context())[
+        "stage_editorial_augmentation"
+    ]
+
+    result = node({"stage3_for_editorial": _stage3().model_dump()})
+
+    assert captured["fail_fast"] is False
+    # A failed augmentation still hands the finished article to the title stage.
+    assert "Original article body." in result["stage3_for_title"]["final_article"]
+    assert result["stage_editorial"]["error"] == "editorial service unavailable"

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_graph_runner.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_graph_runner.py
@@ -41,16 +41,35 @@ def test_transcript_gate_allows_long_form_retention_profile():
 
 
 @pytest.mark.parametrize("cleaned_chars", [1_500, 39_600])
-def test_transcript_gate_fails_after_long_form_retries(cleaned_chars):
-    with pytest.raises(RuntimeError, match="maximum_retention_ratio=0.980"):
+def test_transcript_gate_degrades_after_long_form_retries(cleaned_chars):
+    """Retention ratios are compression heuristics. With the repair budget
+    spent and real content in hand, the run continues rather than dying."""
+    decision, gate = evaluate_transcript_gate(
+        cleaned_chars=cleaned_chars,
+        original_chars=40_000,
+        retry_count=Y2B_STAGE1_REPAIR_MAX_RETRIES,
+    )
+    assert decision == "pass"
+    assert gate["pass_mode"] == "best_effort"
+    assert gate["passed"] is False
+    assert gate["checks_failed"]
+
+
+def test_transcript_gate_still_fails_with_nothing_to_compose_from():
+    """Below the absolute floor there is no article to write, only one to
+    invent, so this stays a hard failure."""
+    with pytest.raises(RuntimeError, match="too little usable transcript"):
         evaluate_transcript_gate(
-            cleaned_chars=cleaned_chars,
+            cleaned_chars=50,
             original_chars=40_000,
             retry_count=Y2B_STAGE1_REPAIR_MAX_RETRIES,
         )
 
 
-def test_classification_gate_retries_then_fails():
+def test_classification_gate_retries_then_accepts_the_best_guess():
+    """An unconfident classification is still the model's best guess, and
+    guideline retrieval degrades to a generic brief on its own. Raising here
+    threw away an already-cleaned transcript."""
     decision, gate = evaluate_classification_gate(
         confidence=0.5,
         classification="guide",
@@ -59,13 +78,17 @@ def test_classification_gate_retries_then_fails():
     )
     assert decision == "retry"
     assert gate["passed"] is False
-    with pytest.raises(RuntimeError, match="Stage 2 quality gate failed"):
-        evaluate_classification_gate(
-            confidence=0.5,
-            classification="guide",
-            reasoning="uncertain",
-            retry_count=1,
-        )
+
+    decision, gate = evaluate_classification_gate(
+        confidence=0.5,
+        classification="guide",
+        reasoning="uncertain",
+        retry_count=1,
+    )
+    assert decision == "pass"
+    assert gate["pass_mode"] == "low_confidence"
+    assert gate["passed"] is False
+    assert gate["classification"] == "guide"
 
 
 def test_article_quality_gate_preserves_near_pass_and_best_effort_modes():
@@ -257,3 +280,40 @@ def test_transcript_repair_still_wins_over_a_forced_type():
         == "skip_classification"
     )
     assert route_stage_1_gate({"stage1_gate_decision": "pass"}) == "classify"
+
+
+def test_article_quality_gate_ships_a_weak_article_rather_than_no_article():
+    """With the repair budget spent and an article in hand, a critical
+    dimension below threshold is recorded, not fatal -- composition has
+    already been paid for."""
+    decision, gate = evaluate_article_quality_gate(
+        {
+            "overall_quality_score": 4.0,
+            "dimension_scores": {
+                "clarity": 3.0,
+                "structure_coherence": 8.0,
+                "usefulness_actionability": 8.0,
+            },
+        },
+        retry_count=99,
+    )
+
+    assert decision == "pass"
+    assert gate["pass_mode"] == "critical_dimensions_unmet"
+    assert gate["critical_failed"] == ["clarity"]
+    assert gate["overall_quality_score"] == 4.0
+
+
+def test_title_gate_never_destroys_a_finished_article():
+    """Stage 5 sits at the very end of the graph, so raising there discarded a
+    finished, SEO'd, augmented article over a title heuristic."""
+    decision, gate = evaluate_title_gate(
+        {"score": 2.0, "checks": {"length_range": False}},
+        retry_count=99,
+        title="bad",
+    )
+
+    assert decision == "pass"
+    assert gate["pass_mode"] == "best_effort"
+    assert gate["passed"] is False
+    assert gate["title"] == "bad"


### PR DESCRIPTION
## Problem

Four gates in `quality/policies.py` raised `RuntimeError` once their retry budget was spent, and `nodes/editorial.py` passed `fail_fast=True` to a stage that already implements its own fallback.

This is the pattern prompt2blog moved away from in its rework: a stage that can't do its job should degrade, not kill the run.

The Stage 5 case is the worst — it sits at the very end of the graph, so it discarded a finished, SEO'd, editorially-augmented article over a *deterministic title heuristic*, after ~12 LLM calls including two `gemini-3.1-pro` writes.

## Fix

| Gate | After retries |
|---|---|
| Stage 1 | Retention ratios are compression heuristics → `best_effort` pass. The absolute content floor **still fails hard** — below it there's no article to write, only one to invent. |
| Stage 2 | Unconfident classification is still the best guess; guideline retrieval already degrades to a generic brief → `low_confidence` pass. |
| Stage 3 | Repair budget spent, article in hand → `critical_dimensions_unmet` pass. |
| Stage 5 | → `best_effort` pass. |
| Editorial | `fail_fast=False` restores the stage's existing fallback to the un-augmented draft. |

Every degraded decision carries `pass_mode` and `checks_failed` in the recorded gate payload, so the reason stays visible in run diagnostics rather than vanishing.

The Stage 1 hard floor is deliberately kept: this PR removes failures that destroy recoverable work, not the one that reports genuinely unusable input.

## Tests

Two existing tests rewritten from `pytest.raises` to the degrade contract; 4 new covering the Stage 1 floor still raising, Stage 3 shipping a weak article, Stage 5 never destroying a finished one, and the editorial node leaving its fallback enabled.

Backend suite: 478 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)