### PR TITLE
fix(youtube2blog): settle on the best draft, not the last one

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/composition.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/composition.py
@@ -13,7 +13,7 @@ from app.features.youtube2blog.stages import (
 )
 from ..context import YouTube2BlogNodeContext
 from ..state import GraphNode, YouTube2BlogGraphState
-from ...quality.policies import evaluate_article_quality_gate
+from ...quality.policies import evaluate_article_quality_gate, is_better_article
 
 
 def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
@@ -160,22 +160,44 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
         stage3 = Stage3Output.model_validate(state["stage3"])
         retry_count = int(state.get("stage3_quality_retry_count", 0))
         assessment = stage_3_assess_article_quality(stage3=stage3, model_name=_active_model)
+
+        # Keep the best draft the loop has produced, not the most recent one.
+        best_quality = dict(state.get("stage3_best_quality") or {})
+        best_stage3 = dict(state.get("stage3_best") or {})
+        candidate_improved = is_better_article(assessment, best_quality or None)
+        if candidate_improved:
+            best_quality = assessment
+            best_stage3 = stage3.model_dump()
+
+        # Gate on what would actually ship. A rewrite worse than the draft it
+        # replaced must not spend another attempt chasing its own regression.
         decision, gate_data = evaluate_article_quality_gate(
-            assessment,
+            best_quality,
             retry_count=retry_count,
         )
+        gate_data["kept_earlier_draft"] = not candidate_improved
+        gate_data["candidate_overall_quality_score"] = assessment.get(
+            "overall_quality_score"
+        )
+
         stage_results = _record_stage_result(
             state,
             stage_name="stage_3_quality_gate",
             input_refs={"stage_3": _stage_ref(run_id, "stage_3")},
             data=gate_data,
         )
-        return {
+        updates: YouTube2BlogGraphState = {
+            "stage3_best": best_stage3,
+            "stage3_best_quality": best_quality,
             "stage3_quality_gate": gate_data,
             "stage3_quality_feedback": gate_data,
             "stage3_quality_gate_decision": decision,
             "stage_results": stage_results,
         }
+        if decision == "pass":
+            # Settle on the winner, which may be an earlier draft.
+            updates["stage3"] = best_stage3
+        return updates
 
     def stage_3_improve_node(state: YouTube2BlogGraphState) -> YouTube2BlogGraphState:
         _write_running_status("stage_3_improve")

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/title.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/title.py
@@ -9,7 +9,7 @@ from app.features.youtube2blog.stages import (
 )
 from ..context import YouTube2BlogNodeContext
 from ..state import GraphNode, YouTube2BlogGraphState
-from ...quality.policies import evaluate_title_gate
+from ...quality.policies import evaluate_title_gate, is_better_title
 
 
 def build_title_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
@@ -57,23 +57,42 @@ def build_title_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
             baseline_title=stage3_for_title.title,
         )
         retry_count = int(state.get("stage5_retry_count", 0))
+
+        # Keep the best title the loop has produced, not the most recent one.
+        best_evaluation = dict(state.get("stage5_best_evaluation") or {})
+        best_stage4 = dict(state.get("stage4_best") or {})
+        candidate_improved = is_better_title(evaluation, best_evaluation or None)
+        if candidate_improved:
+            best_evaluation = evaluation
+            best_stage4 = stage4.model_dump()
+
+        best_title = str(best_stage4.get("title") or stage4.title)
         decision, gate_data = evaluate_title_gate(
-            evaluation,
+            best_evaluation,
             retry_count=retry_count,
-            title=stage4.title,
+            title=best_title,
         )
+        gate_data["kept_earlier_title"] = not candidate_improved
+        gate_data["candidate_title"] = stage4.title
+
         stage_results = _record_stage_result(
             state,
             stage_name="stage_5_quality_gate",
             input_refs={"stage_4": _stage_ref(run_id, "stage_4")},
             data=gate_data,
         )
-        return {
+        updates: YouTube2BlogGraphState = {
+            "stage4_best": best_stage4,
+            "stage5_best_evaluation": best_evaluation,
             "stage5_gate": gate_data,
             "stage5_gate_decision": decision,
-            "stage5_feedback": str(evaluation.get("feedback") or ""),
+            "stage5_feedback": str(best_evaluation.get("feedback") or ""),
             "stage_results": stage_results,
         }
+        if decision == "pass":
+            # Settle on the winner, which may be an earlier title.
+            updates["stage4"] = best_stage4
+        return updates
 
     def stage_5_retry_node(state: YouTube2BlogGraphState) -> YouTube2BlogGraphState:
         _write_running_status("stage_5_retry")

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/state.py
@@ -21,6 +21,11 @@ class YouTube2BlogGraphState(TypedDict, total=False):
     stage3_coverage: dict[str, Any]
     stage3_supplement: dict[str, str]
     stage3: dict[str, Any]
+    # Highest-scoring draft seen across the improve loop, with the assessment
+    # that earned it. Without this a rewrite that scored worse than the draft
+    # it replaced still shipped.
+    stage3_best: dict[str, Any]
+    stage3_best_quality: dict[str, Any]
     stage3_quality_retry_count: int
     stage3_quality_gate: dict[str, Any]
     stage3_quality_feedback: dict[str, Any]
@@ -38,6 +43,8 @@ class YouTube2BlogGraphState(TypedDict, total=False):
     stage_editorial: dict[str, Any]
     stage3_for_title: dict[str, Any]
     stage4: dict[str, Any]
+    stage4_best: dict[str, Any]
+    stage5_best_evaluation: dict[str, Any]
     stage5_retry_count: int
     stage5_gate: dict[str, Any]
     stage5_gate_decision: str

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/policies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/quality/policies.py
@@ -149,6 +149,80 @@ def evaluate_classification_gate(
     }
 
 
+CRITICAL_QUALITY_DIMENSIONS = (
+    "clarity",
+    "structure_coherence",
+    "usefulness_actionability",
+)
+
+
+def article_quality_rank(assessment: dict[str, Any]) -> tuple[float, float]:
+    """Rank a draft for keep-best comparison.
+
+    Overall score first, then the weakest critical dimension as the tie-break:
+    between two drafts scoring the same overall, the one with no severely weak
+    dimension is the better article to ship.
+    """
+    raw_scores = assessment.get("dimension_scores")
+    dimension_scores = dict(raw_scores) if isinstance(raw_scores, dict) else {}
+
+    def _score(key: str) -> float:
+        try:
+            return float(dimension_scores.get(key, 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    try:
+        overall = float(assessment.get("overall_quality_score", 0.0))
+    except (TypeError, ValueError):
+        overall = 0.0
+    weakest_critical = min(
+        (_score(key) for key in CRITICAL_QUALITY_DIMENSIONS),
+        default=0.0,
+    )
+    return (overall, weakest_critical)
+
+
+def is_better_article(
+    candidate: dict[str, Any],
+    incumbent: dict[str, Any] | None,
+) -> bool:
+    """True when ``candidate`` should replace ``incumbent`` as the best draft.
+
+    stage_3_improve overwrote the draft unconditionally, so a rewrite that
+    scored worse than the draft it replaced still shipped -- and once the gate
+    degrades rather than raising, that regression ships silently.
+    """
+    if not incumbent:
+        return True
+    return article_quality_rank(candidate) > article_quality_rank(incumbent)
+
+
+def title_quality_rank(evaluation: dict[str, Any]) -> tuple[int, float]:
+    """Rank a title for keep-best comparison.
+
+    The length range is a hard requirement of the gate, so a title inside it
+    always outranks one outside it regardless of score.
+    """
+    checks = evaluation.get("checks")
+    checks_dict = dict(checks) if isinstance(checks, dict) else {}
+    try:
+        score = float(evaluation.get("score", 0.0))
+    except (TypeError, ValueError):
+        score = 0.0
+    return (1 if checks_dict.get("length_range") else 0, score)
+
+
+def is_better_title(
+    candidate: dict[str, Any],
+    incumbent: dict[str, Any] | None,
+) -> bool:
+    """True when ``candidate`` should replace ``incumbent`` as the best title."""
+    if not incumbent:
+        return True
+    return title_quality_rank(candidate) > title_quality_rank(incumbent)
+
+
 def evaluate_article_quality_gate(
     assessment: dict[str, Any],
     *,
@@ -157,11 +231,7 @@ def evaluate_article_quality_gate(
     raw_scores = assessment.get("dimension_scores")
     dimension_scores = dict(raw_scores) if isinstance(raw_scores, dict) else {}
     overall_score = float(assessment.get("overall_quality_score", 0.0))
-    critical_dimensions = (
-        "clarity",
-        "structure_coherence",
-        "usefulness_actionability",
-    )
+    critical_dimensions = CRITICAL_QUALITY_DIMENSIONS
     critical_failed = [
         key
         for key in critical_dimensions

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_keep_best.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_keep_best.py
@@ -1,0 +1,173 @@
+"""Keep-best behaviour for the Stage 3 and Stage 5 improvement loops."""
+
+from types import SimpleNamespace
+
+from shared import Stage3Output, Stage4Output
+
+from app.features.youtube2blog.graph.nodes import composition as composition_nodes
+from app.features.youtube2blog.graph.nodes import title as title_nodes
+from app.features.youtube2blog.quality.policies import (
+    article_quality_rank,
+    is_better_article,
+    is_better_title,
+    title_quality_rank,
+)
+
+
+def _assessment(overall, clarity=8.0):
+    return {
+        "overall_quality_score": overall,
+        "dimension_scores": {
+            "clarity": clarity,
+            "structure_coherence": 8.0,
+            "usefulness_actionability": 8.0,
+        },
+    }
+
+
+def test_article_rank_prefers_score_then_weakest_critical_dimension():
+    assert article_quality_rank(_assessment(7.0)) == (7.0, 8.0)
+    assert is_better_article(_assessment(8.0), _assessment(7.0))
+    assert not is_better_article(_assessment(6.0), _assessment(7.0))
+    assert is_better_article(_assessment(7.0), None)
+    # Same overall score: the draft without a severely weak dimension wins.
+    assert is_better_article(
+        _assessment(7.0, clarity=8.0), _assessment(7.0, clarity=3.0)
+    )
+
+
+def test_article_rank_tolerates_a_malformed_assessment():
+    assert article_quality_rank({}) == (0.0, 0.0)
+    assert article_quality_rank({"overall_quality_score": "n/a"}) == (0.0, 0.0)
+
+
+def test_title_rank_puts_the_length_requirement_above_score():
+    inside = {"score": 5.0, "checks": {"length_range": True}}
+    outside = {"score": 9.0, "checks": {"length_range": False}}
+
+    assert title_quality_rank(inside) > title_quality_rank(outside)
+    assert is_better_title(inside, outside)
+    assert not is_better_title(outside, inside)
+
+
+def _stage3(body: str) -> Stage3Output:
+    return Stage3Output(
+        video_id="v1",
+        title="A Title",
+        article_type="News",
+        coverage_sufficient=True,
+        coverage_analysis="",
+        missing_sections=[],
+        supplemental_content=None,
+        final_article=body,
+        guideline_used="guideline",
+    )
+
+
+def _composition_context(assessment):
+    return SimpleNamespace(
+        run_id="run-1",
+        active_model="base-model",
+        writing_model="writing-model",
+        tone_guidance="",
+        start_stage=lambda _stage: None,
+        record_stage=lambda state, **_kwargs: dict(state.get("stage_results") or {}),
+        stage_ref=lambda run_id, stage: f"data/runs/{run_id}/{stage}.json",
+        dependencies=SimpleNamespace(),
+    ), assessment
+
+
+def test_stage_3_gate_settles_on_the_best_draft_not_the_last(monkeypatch):
+    """A rewrite that scored worse than the draft it replaced used to ship,
+    because stage_3_improve overwrote final_article unconditionally."""
+    context, _ = _composition_context(None)
+    monkeypatch.setattr(
+        composition_nodes,
+        "stage_3_assess_article_quality",
+        lambda **_kwargs: _assessment(4.0),
+    )
+    node = composition_nodes.build_composition_nodes(context)["stage_3_quality_gate"]
+
+    result = node(
+        {
+            "stage3": _stage3("A worse rewrite.").model_dump(),
+            "stage3_best": _stage3("The good original.").model_dump(),
+            "stage3_best_quality": _assessment(8.5),
+            "stage3_quality_retry_count": 99,
+        }
+    )
+
+    assert result["stage3_quality_gate_decision"] == "pass"
+    assert result["stage3"]["final_article"] == "The good original."
+    assert result["stage3_quality_gate"]["kept_earlier_draft"] is True
+    assert result["stage3_quality_gate"]["candidate_overall_quality_score"] == 4.0
+
+
+def test_stage_3_gate_adopts_a_genuine_improvement(monkeypatch):
+    context, _ = _composition_context(None)
+    monkeypatch.setattr(
+        composition_nodes,
+        "stage_3_assess_article_quality",
+        lambda **_kwargs: _assessment(9.0),
+    )
+    node = composition_nodes.build_composition_nodes(context)["stage_3_quality_gate"]
+
+    result = node(
+        {
+            "stage3": _stage3("A better rewrite.").model_dump(),
+            "stage3_best": _stage3("The weaker original.").model_dump(),
+            "stage3_best_quality": _assessment(6.0),
+            "stage3_quality_retry_count": 99,
+        }
+    )
+
+    assert result["stage3"]["final_article"] == "A better rewrite."
+    assert result["stage3_quality_gate"]["kept_earlier_draft"] is False
+
+
+def test_stage_5_gate_settles_on_the_best_title_not_the_last(monkeypatch):
+    context = SimpleNamespace(
+        run_id="run-1",
+        active_model="base-model",
+        start_stage=lambda _stage: None,
+        record_stage=lambda state, **_kwargs: dict(state.get("stage_results") or {}),
+        stage_ref=lambda run_id, stage: f"data/runs/{run_id}/{stage}.json",
+        dependencies=SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        title_nodes,
+        "stage_5_evaluate_title_quality",
+        lambda **_kwargs: {"score": 2.0, "checks": {"length_range": False}},
+    )
+    node = title_nodes.build_title_nodes(context)["stage_5_quality_gate"]
+
+    good = Stage4Output(
+        video_id="v1",
+        title="A Perfectly Reasonable Generated Headline",
+        content="Body",
+        article_type="News",
+        title_guideline_used="g",
+    )
+    result = node(
+        {
+            "stage4": Stage4Output(
+                video_id="v1",
+                title="bad",
+                content="Body",
+                article_type="News",
+                title_guideline_used="g",
+            ).model_dump(),
+            "stage4_best": good.model_dump(),
+            "stage5_best_evaluation": {
+                "score": 8.0,
+                "checks": {"length_range": True},
+            },
+            "stage3_for_title": _stage3("Body").model_dump(),
+            "stage5_retry_count": 99,
+        }
+    )
+
+    assert result["stage5_gate_decision"] == "pass"
+    assert result["stage4"]["title"] == "A Perfectly Reasonable Generated Headline"
+    assert result["stage5_gate"]["kept_earlier_title"] is True
+    assert result["stage5_gate"]["candidate_title"] == "bad"


### PR DESCRIPTION
## Problem

`stage_3_improve` overwrote `stage3.final_article` unconditionally, and `stage_5_retry` did the same to `stage4`. A rewrite that scored *worse* than the draft it replaced still shipped.

#178 makes this sharper: an exhausted retry budget now passes `best_effort` instead of raising, so the regression ships silently rather than loudly.

This is exactly the bug prompt2blog fixed with `is_better_quality` / `_quality_rank` in `prompt2blog/policies.py`. The SEO branch here already had the right shape via `stage_seo_rollback`; Stages 3 and 5 did not.

## Fix

Both loops track the best output seen and **gate on that** rather than on the newest attempt:

- a rewrite worse than its predecessor no longer spends another attempt chasing its own regression
- when the gate passes, state settles on the winner, which may be an earlier draft

Ranking functions are pure and live in `quality/policies.py`:

- **Article** — overall score, then the weakest critical dimension as tie-break. Between two drafts scoring the same, the one with no severely weak dimension ships.
- **Title** — the gate's hard `length_range` requirement outranks score, so a valid-length 5.0 beats an out-of-range 9.0.

The gate payload records `kept_earlier_draft` / `kept_earlier_title` plus the losing candidate, so the swap is visible in run diagnostics.

Also folds the duplicated critical-dimensions tuple into one `CRITICAL_QUALITY_DIMENSIONS` constant.

## Tests

6 new: rank ordering and tie-breaks for both, malformed-assessment tolerance, and both gate nodes settling on the earlier draft when the newest is worse / adopting it when genuinely better.

Backend suite: 484 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)