### PR TITLE
fix(youtube2blog): run full-article rewrites on the writing model

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/config.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-# Always-strong model policy for YouTube2Blog.
+# Base model for classification, coverage analysis, quality assessment and
+# other structured/judging work. Cheap by design -- it is not a writing model.
 Y2B_PRIMARY_MODEL = "gemini-2.5-flash-lite"
 VALID_Y2B_MODELS = {Y2B_PRIMARY_MODEL}
 
-# Stage-specific overrides: article composition and editorial augmentation are
-# the writing-quality stages, pinned to a stronger model than the run's base.
+# Stage-specific overrides: every stage that writes or rewrites the full
+# article body runs here rather than on the base model. That covers
+# composition, the Stage 3 quality rewrite, SEO enrichment and editorial
+# augmentation -- handing a draft composed here to a weaker rewriter threw
+# away the quality this model was chosen for.
 # Both were "claude-opus-4-8" until Anthropic billing ran out; restore those
 # values (and set ANTHROPIC_MODELS_ENABLED=1) once it is funded again.
 Y2B_COMPOSE_MODEL = "gemini-3.1-pro-preview"

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/composition.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/composition.py
@@ -243,7 +243,10 @@ def build_composition_nodes(context: YouTube2BlogNodeContext) -> dict[str, Graph
             rewrite_brief=list(targeted_feedback.get("rewrite_brief") or rewrite_brief),
             mode=mode,
             focus_dimensions=list(targeted_feedback.get("focus_dimensions") or []),
-            model_name=_active_model,
+            # A full rewrite of a draft composed on the writing model belongs on
+            # the writing model. Running it on the cheaper base model handed the
+            # pro composition to a weaker writer and shipped the result.
+            model_name=_writing_model,
             tone_guidance=_tone_guidance,
         )
 

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/seo.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/seo.py
@@ -16,6 +16,10 @@ from ..state import GraphNode, YouTube2BlogGraphState
 def build_seo_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
     run_id = context.run_id
     _active_model = context.active_model
+    # SEO enrichment rewrites the whole article, so it belongs on the writing
+    # model. Brief generation is structured keyword extraction and stays on the
+    # cheaper base model.
+    _writing_model = context.writing_model
     _tone_guidance = context.tone_guidance
     _write_running_status = context.start_stage
     _record_stage_result = context.record_stage
@@ -45,7 +49,7 @@ def build_seo_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
             stage3=stage3,
             seo_brief=seo_brief,
             mode="primary",
-            model_name=_active_model,
+            model_name=_writing_model,
             tone_guidance=_tone_guidance,
         )
 
@@ -126,7 +130,7 @@ def build_seo_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
             seo_brief=seo_brief,
             mode="retry",
             feedback=feedback,
-            model_name=_active_model,
+            model_name=_writing_model,
             tone_guidance=_tone_guidance,
         )
         seo_article = str(

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_model_routing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_model_routing.py
@@ -1,0 +1,102 @@
+"""Which model each stage runs on."""
+
+from types import SimpleNamespace
+
+from shared import Stage3Output
+
+from app.features.youtube2blog.graph.nodes import composition as composition_nodes
+from app.features.youtube2blog.graph.nodes import seo as seo_nodes
+
+BASE_MODEL = "base-model"
+WRITING_MODEL = "writing-model"
+
+
+def _stage3() -> Stage3Output:
+    return Stage3Output(
+        video_id="v1",
+        title="A Title",
+        article_type="News",
+        coverage_sufficient=True,
+        coverage_analysis="",
+        missing_sections=[],
+        supplemental_content=None,
+        final_article="## Section\n\nArticle body.",
+        guideline_used="guideline",
+    )
+
+
+def _context():
+    return SimpleNamespace(
+        run_id="run-1",
+        active_model=BASE_MODEL,
+        writing_model=WRITING_MODEL,
+        tone_guidance="",
+        start_stage=lambda _stage: None,
+        record_stage=lambda state, **_kwargs: dict(state.get("stage_results") or {}),
+        stage_ref=lambda run_id, stage: f"data/runs/{run_id}/{stage}.json",
+        dependencies=SimpleNamespace(),
+    )
+
+
+def test_stage_3_rewrite_runs_on_the_writing_model(monkeypatch):
+    """The improve loop rewrites a draft composed on the writing model. Running
+    it on the cheap base model handed that draft to a weaker writer."""
+    captured: dict[str, object] = {}
+
+    def spy(**kwargs):
+        captured.update(kwargs)
+        return {"improved_article": "Improved.", "debug_improve_prompt": ""}
+
+    monkeypatch.setattr(composition_nodes, "stage_3_improve_article", spy)
+    node = composition_nodes.build_composition_nodes(_context())["stage_3_improve"]
+
+    node(
+        {
+            "stage3": _stage3().model_dump(),
+            "stage3_quality_feedback": {"overall_quality_score": 5.0},
+            "stage3_quality_retry_count": 0,
+        }
+    )
+
+    assert captured["model_name"] == WRITING_MODEL
+
+
+def test_seo_enrichment_and_retry_run_on_the_writing_model(monkeypatch):
+    calls: list[dict] = []
+
+    def spy(**kwargs):
+        calls.append(kwargs)
+        return {"seo_article": "SEO body.", "debug_seo_prompt": ""}
+
+    monkeypatch.setattr(seo_nodes, "stage_seo_enrich_article", spy)
+    nodes = seo_nodes.build_seo_nodes(_context())
+
+    nodes["stage_seo_enrich"](
+        {"stage3": _stage3().model_dump(), "stage_seo_brief": {}}
+    )
+    nodes["stage_seo_retry"](
+        {
+            "stage3_for_editorial": _stage3().model_dump(),
+            "stage_seo_brief": {},
+            "stage_seo_retry_count": 0,
+        }
+    )
+
+    assert [call["model_name"] for call in calls] == [WRITING_MODEL, WRITING_MODEL]
+    assert [call["mode"] for call in calls] == ["primary", "retry"]
+
+
+def test_seo_brief_stays_on_the_cheaper_base_model(monkeypatch):
+    """Brief generation is structured keyword extraction, not a rewrite."""
+    captured: dict[str, object] = {}
+
+    def spy(**kwargs):
+        captured.update(kwargs)
+        return {"focus_keyword": "travel"}
+
+    monkeypatch.setattr(seo_nodes, "stage_seo_generate_brief", spy)
+    node = seo_nodes.build_seo_nodes(_context())["stage_seo_brief"]
+
+    node({"stage3": _stage3().model_dump()})
+
+    assert captured["model_name"] == BASE_MODEL


### PR DESCRIPTION
## Problem

Composition runs on `Y2B_COMPOSE_MODEL` (`gemini-3.1-pro-preview`). Every subsequent rewrite of that draft ran on `Y2B_PRIMARY_MODEL` (`gemini-2.5-flash-lite`):

| Stage | Was | Now |
|---|---|---|
| `stage_3_improve` (×2 max) | base | **writing** |
| `stage_seo_enrich` | base | **writing** |
| `stage_seo_retry` | base | **writing** |
| `stage_editorial_augmentation` | writing | writing (unchanged) |
| `stage_3_quality_gate` (judge) | base | base (unchanged) |
| `stage_seo_brief` | base | base (unchanged) |

Up to **four full-article rewrites by the weakest model in the stack**, on top of a draft paid for at pro rates. The quality the compose model was chosen for was being discarded downstream.

`stage_3_improve` was passing `_active_model` even though the node already had `_writing_model` in scope for other calls — the inconsistency looks unintentional rather than a policy.

## Fix

Route every stage that rewrites the whole article body to the writing model. Structured and judging work stays on the cheaper base model.

**Cost note:** this raises spend. Worst case adds 4 pro-rate full-article calls per run; typical case is 1 (the SEO enrich pass, since the improve loop only fires when the quality gate is unhappy). Confirmed as the intended trade-off before implementing.

Also corrects the config comment that read *"Always-strong model policy for YouTube2Blog"* directly above `= "gemini-2.5-flash-lite"`.

## Follow-up not taken here

The Stage 3 quality **judge** also runs on flash-lite, scoring a pro-written article — and those scores now drive keep-best ranking (#179). Out of scope for a routing PR, but worth its own look.

## Tests

3 new asserting the model each call receives, including that the SEO brief deliberately stays on the base model.

Backend suite: 487 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)