### PR TITLE
fix(youtube2blog): stop truncating the article SEO enrichment rewrites

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_seo_enrichment.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_seo_enrichment.py
@@ -105,7 +105,11 @@ def enrich_seo_article(
         article_type=stage3.article_type,
         guideline=stage3.guideline_used[:8000],
         feedback=safe_text(feedback) if mode == "retry" else "N/A",
-        article=stage3.final_article[:24_000],
+        # Never truncate the article being rewritten. Clipping the input made
+        # the model rewrite a fragment, the short result tripped the retention
+        # guard below, and the whole SEO branch rolled back having spent its
+        # calls for nothing. The output token cap already bounds the response.
+        article=stage3.final_article,
     )
     if tone_guidance:
         full_prompt = f"{full_prompt}\n\n{tone_guidance.strip()}"

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage_seo.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage_seo.py
@@ -379,3 +379,36 @@ def test_stage_seo_quality_accepts_balanced_enrichment():
     assert checks["no_keyword_stuffing"] is True
     assert checks["article_length_retained"] is True
     assert result["score"] >= 7.0
+
+
+def test_seo_enrichment_sends_the_whole_article_to_the_model():
+    """The article was clipped to 24,000 chars before being sent. The model
+    rewrote a fragment, the short result tripped the retention guard, and the
+    whole SEO branch rolled back having spent its calls for nothing."""
+    tail_marker = "FINAL PARAGRAPH MARKER"
+    original = "\n\n".join(
+        [
+            "# City Guide",
+            _repeat_sentence(
+                "Travelers can plan each neighborhood with realistic timing.",
+                700,
+            ),
+            "## Closing",
+            f"{tail_marker} closes the guide with practical advice.",
+        ]
+    )
+    assert len(original) > 24_000, "fixture must exceed the old truncation cap"
+
+    llm = _FakeLlm([original + "\n\nCity travel planning tips."])
+
+    result = enrichment.enrich_seo_article(
+        stage3=_stage3(original),
+        seo_brief={"focus_keyword": "city travel planning"},
+        mode="primary",
+        model_name="enrichment-model",
+        llm_factory=lambda **_kwargs: llm,
+        anti_ai_enforcer=lambda content, *, repair, context: content.strip(),
+    )
+
+    assert tail_marker in llm.prompts[0]
+    assert result["seo_article"].endswith("City travel planning tips.")


### PR DESCRIPTION
## Problem

```python
article=stage3.final_article[:24_000],
```

For any article longer than that, the model rewrites a **fragment**. The short result then either:

- trips the existing 60% retention guard inside the stage and reverts to the source article, or
- fails the SEO gate's `article_length_retained` critical check and rolls the whole branch back

Either way `stage_seo_brief`, `stage_seo_enrich` and possibly `stage_seo_retry` have all been paid for and produced nothing. After #180 those are pro-rate calls.

The cap was never meaningful cost control — 24,000 characters is roughly 6,000 tokens.

## Fix

Send the whole article. The output token cap (`Y2B_STAGE3_QUALITY_IMPROVEMENT_MAX_OUTPUT_TOKENS`) already bounds the response, and a response too short to be credible still hits the retention guard that follows. So the failure path is unchanged — what changes is that articles which *can* be enriched now actually are.

## Scope

Only the article body. The `guideline_used[:8000]` caps elsewhere are left alone: guidelines are authored documents of bounded size, and clipping a reference doc is not the same as clipping the thing being rewritten.

## Test

`test_seo_enrichment_sends_the_whole_article_to_the_model` builds a >24,000 char article with a tail marker and asserts the marker reaches the prompt. Verified it fails on the pre-fix code and passes after.

Backend suite: 488 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)