### PR TITLE
fix(youtube2blog): apply the run's tone to the generated title

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/title.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/graph/nodes/title.py
@@ -15,6 +15,7 @@ from ...quality.policies import evaluate_title_gate, is_better_title
 def build_title_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
     run_id = context.run_id
     _active_model = context.active_model
+    _tone_guidance = context.tone_guidance
     _write_running_status = context.start_stage
     _record_stage_result = context.record_stage
     _stage_ref = context.stage_ref
@@ -24,7 +25,11 @@ def build_title_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
         stage3_for_title = Stage3Output.model_validate(state["stage3_for_title"])
         gate_data = dict(state.get("stage_editorial_gate") or {})
         seo_source_stage = str(gate_data.get("seo_source_stage") or "stage_seo_enrich")
-        stage4 = stage_4_generate_title(stage3_for_title, model_name=_active_model)
+        stage4 = stage_4_generate_title(
+            stage3_for_title,
+            model_name=_active_model,
+            tone_guidance=_tone_guidance,
+        )
         input_refs = {
             "stage_editorial_augmentation": _stage_ref(
                 run_id,
@@ -106,6 +111,7 @@ def build_title_nodes(context: YouTube2BlogNodeContext) -> dict[str, GraphNode]:
             stage3_for_title,
             feedback=feedback,
             model_name=_active_model,
+            tone_guidance=_tone_guidance,
         )
         stage_results = _record_stage_result(
             state,

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/stages/stage_4.py
@@ -65,6 +65,15 @@ Use this original title as a baseline and starting point. Preserve the core subj
 - The title should accurately reflect the key points of the article and avoid any hallucinations or inaccuracies.
 """
 
+TITLE_TONE_SUFFIX = """
+
+## Voice
+{tone_guidance}
+
+Apply this voice only where the title guideline leaves room. The guideline
+remains the primary constraint; never break it to match the voice.
+"""
+
 TITLE_RETRY_FEEDBACK_SUFFIX = """
 
 Previous attempt feedback:
@@ -192,6 +201,7 @@ def _generate_title_impl(
     mode: str,
     retry_feedback: str | None = None,
     model_name: str = Y2B_PRIMARY_MODEL,
+    tone_guidance: str | None = None,
 ) -> Stage4Output:
     if mode not in {"primary", "retry"}:
         raise ValueError(f"Unsupported title generation mode: {mode}")
@@ -219,6 +229,10 @@ def _generate_title_impl(
 
     prompt_template = TITLE_GENERATION_PROMPT
     input_variables = ["original_title", "article", "guideline"]
+    resolved_tone = (tone_guidance or "").strip()
+    if resolved_tone:
+        prompt_template += TITLE_TONE_SUFFIX
+        input_variables.append("tone_guidance")
     if mode == "retry":
         prompt_template += TITLE_RETRY_FEEDBACK_SUFFIX
         input_variables.append("feedback")
@@ -232,6 +246,8 @@ def _generate_title_impl(
         "article": stage3.final_article,
         "guideline": title_guideline,
     }
+    if resolved_tone:
+        prompt_kwargs["tone_guidance"] = resolved_tone
     if mode == "retry":
         prompt_kwargs["feedback"] = retry_feedback or "No additional feedback."
     full_prompt = prompt.format(**prompt_kwargs)
@@ -256,9 +272,19 @@ def _generate_title_impl(
     )
 
 
-def stage_4_generate_title(stage3: Stage3Output, *, model_name: str = Y2B_PRIMARY_MODEL) -> Stage4Output:
+def stage_4_generate_title(
+    stage3: Stage3Output,
+    *,
+    model_name: str = Y2B_PRIMARY_MODEL,
+    tone_guidance: str | None = None,
+) -> Stage4Output:
     """Primary title generation pass."""
-    return _generate_title_impl(stage3=stage3, mode="primary", model_name=model_name)
+    return _generate_title_impl(
+        stage3=stage3,
+        mode="primary",
+        model_name=model_name,
+        tone_guidance=tone_guidance,
+    )
 
 
 def stage_5_generate_title_retry(
@@ -266,6 +292,7 @@ def stage_5_generate_title_retry(
     *,
     feedback: str,
     model_name: str = Y2B_PRIMARY_MODEL,
+    tone_guidance: str | None = None,
 ) -> Stage4Output:
     """Retry title generation with explicit quality feedback."""
     return _generate_title_impl(
@@ -273,4 +300,5 @@ def stage_5_generate_title_retry(
         mode="retry",
         retry_feedback=feedback,
         model_name=model_name,
+        tone_guidance=tone_guidance,
     )

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_keep_best.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_keep_best.py
@@ -129,6 +129,7 @@ def test_stage_5_gate_settles_on_the_best_title_not_the_last(monkeypatch):
     context = SimpleNamespace(
         run_id="run-1",
         active_model="base-model",
+        tone_guidance="",
         start_stage=lambda _stage: None,
         record_stage=lambda state, **_kwargs: dict(state.get("stage_results") or {}),
         stage_ref=lambda run_id, stage: f"data/runs/{run_id}/{stage}.json",

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_model_routing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_model_routing.py
@@ -100,3 +100,26 @@ def test_seo_brief_stays_on_the_cheaper_base_model(monkeypatch):
     node({"stage3": _stage3().model_dump()})
 
     assert captured["model_name"] == BASE_MODEL
+
+
+def test_title_generation_receives_the_run_tone(monkeypatch):
+    """The title is the first line a reader sees and was the one writing stage
+    that ignored the run's tone entirely."""
+    from app.features.youtube2blog.graph.nodes import title as title_nodes
+
+    captured: dict[str, object] = {}
+
+    def spy(stage3, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {"title": "A Title", "title_guideline_used": "g"},
+        )
+
+    context = _context()
+    context.tone_guidance = "Write in a dry, factual newswire voice."
+    monkeypatch.setattr(title_nodes, "stage_4_generate_title", spy)
+    node = title_nodes.build_title_nodes(context)["stage_4"]
+
+    node({"stage3_for_title": _stage3().model_dump(), "stage_editorial_gate": {}})
+
+    assert captured["tone_guidance"] == "Write in a dry, factual newswire voice."

--- a/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage4_tone.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_youtube2blog_stage4_tone.py
@@ -1,0 +1,75 @@
+"""Tone handling in Stage 4/5 title generation."""
+
+from shared import Stage3Output
+
+import app.features.youtube2blog.stages.stage_4 as stage_4_module
+
+
+def _stage3() -> Stage3Output:
+    return Stage3Output(
+        video_id="v1",
+        title="Original Title",
+        article_type="News",
+        coverage_sufficient=True,
+        coverage_analysis="",
+        missing_sections=[],
+        supplemental_content=None,
+        final_article="## Section\n\nArticle body.",
+        guideline_used="guideline",
+    )
+
+
+class _StubLLM:
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    def invoke(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return "A Perfectly Reasonable Generated Headline"
+
+
+def _patch(monkeypatch) -> _StubLLM:
+    llm = _StubLLM()
+    monkeypatch.setattr(stage_4_module, "get_vertex_llm", lambda **_kwargs: llm)
+    monkeypatch.setattr(
+        stage_4_module,
+        "_retrieve_title_guideline",
+        lambda _article_type: "Keep titles under 90 characters.",
+    )
+    return llm
+
+
+def test_title_prompt_carries_the_tone_subordinate_to_the_guideline(monkeypatch):
+    llm = _patch(monkeypatch)
+
+    stage_4_module.stage_4_generate_title(
+        _stage3(),
+        tone_guidance="Write in a dry, factual newswire voice.",
+    )
+
+    prompt = llm.prompts[0]
+    assert "Write in a dry, factual newswire voice." in prompt
+    # The guideline must stay the primary constraint; tone only fills the gaps.
+    assert "The guideline\nremains the primary constraint" in prompt
+
+
+def test_title_prompt_is_unchanged_when_no_tone_is_set(monkeypatch):
+    llm = _patch(monkeypatch)
+
+    stage_4_module.stage_4_generate_title(_stage3(), tone_guidance="   ")
+
+    assert "## Voice" not in llm.prompts[0]
+
+
+def test_title_retry_also_carries_the_tone(monkeypatch):
+    llm = _patch(monkeypatch)
+
+    stage_4_module.stage_5_generate_title_retry(
+        _stage3(),
+        feedback="Too vague.",
+        tone_guidance="Write in a dry, factual newswire voice.",
+    )
+
+    prompt = llm.prompts[0]
+    assert "Write in a dry, factual newswire voice." in prompt
+    assert "Too vague." in prompt


### PR DESCRIPTION
## Problem

Every writing stage appends `tone_guidance` — composition, supplement, Stage 3 rewrite, SEO enrich, editorial augmentation. Title generation took no tone argument at all:

```python
def stage_4_generate_title(stage3, *, model_name=Y2B_PRIMARY_MODEL) -> Stage4Output:
```

The title is the first line a reader sees and the one the article is published under, so it was the most visible place for the run's configured voice to go missing.

## Fix

Thread `tone_guidance` through `stage_4_generate_title` and `stage_5_generate_title_retry` from the node context.

The existing prompt says *"Do not prioritize style, SEO, or creativity unless the guideline requires it"*, so tone is appended as an **explicitly subordinate** block rather than a competing instruction:

> Apply this voice only where the title guideline leaves room. The guideline remains the primary constraint; never break it to match the voice.

With no tone configured the prompt is byte-identical to before — the suffix is only added when a non-empty tone resolves.

## Also

Fixes a test fixture from #179 that built a node context without `tone_guidance`; the real `YouTube2BlogNodeContext` dataclass always carries it, so this was a fixture gap rather than a production path.

## Tests

4 new: tone reaches the prompt with the guideline-primacy framing intact, prompt unchanged when tone is blank, retry mode carries both tone and feedback, and the node passes the context tone through.

Backend suite: 492 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)