### PR TITLE
fix(editor): stop the heading guard from eating keystrokes

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/styles/shared-builder-modals.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/styles/shared-builder-modals.css
@@ -185,6 +185,12 @@
   color: #7f2230;
 }
 
+/* Advisory, not a failure: structure warnings never block the edit. */
+.stl-page .block-markdown-hint.warning {
+  color: #8a5a00;
+  background: rgba(196, 128, 59, 0.08);
+}
+
 .stl-page .block-markdown-link-popover,
 .stl-page .block-markdown-ai-popover {
   border: 0;

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/styles/40-editor.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/styles/40-editor.css
@@ -193,6 +193,12 @@
   color: #7f2230;
 }
 
+/* Advisory, not a failure: structure warnings never block the edit. */
+.stl-page .block-markdown-hint.warning {
+  color: #8a5a00;
+  background: rgba(196, 128, 59, 0.08);
+}
+
 .stl-page .block-markdown-link-popover,
 .stl-page .block-markdown-ai-popover {
   border: 0;

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/styles/stage-article-block-editor.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/styles/stage-article-block-editor.css
@@ -368,6 +368,12 @@
   background: var(--error-soft);
 }
 
+/* Advisory, not a failure: structure warnings never block the edit. */
+.block-markdown-hint.warning {
+  color: var(--warning);
+  background: var(--warning-soft);
+}
+
 .block-markdown-link-popover {
   display: flex;
   align-items: center;

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/MarkdownBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/MarkdownBlockEditor.tsx
@@ -36,14 +36,11 @@ export function MarkdownBlockEditor({
   })
 
   const heading = useHeadingStructureGuard({
-    blockId,
     value,
     enforceHeadingStructure,
-    draftMarkdownRef: state.draftMarkdownRef,
-    commitMarkdown: state.commitMarkdown,
   })
 
-  const syncEditorToMarkdownRef = useRef<() => boolean>(() => true)
+  const syncEditorToMarkdownRef = useRef<() => void>(() => {})
 
   const selection = useEditorSelection({
     editorRef: state.editorRef,
@@ -55,7 +52,7 @@ export function MarkdownBlockEditor({
     onAiRewrite,
     draftMarkdownRef: state.draftMarkdownRef,
     editorRef: state.editorRef,
-    applyValueWithHeadingGuard: heading.applyValueWithHeadingGuard,
+    commitMarkdown: state.commitMarkdown,
   })
 
   const openAiRewritePrompt = useCallback(() => {
@@ -67,7 +64,7 @@ export function MarkdownBlockEditor({
   const toolbar = useToolbarCommands({
     editorRef: state.editorRef,
     draftMarkdownRef: state.draftMarkdownRef,
-    applyValueWithHeadingGuard: heading.applyValueWithHeadingGuard,
+    commitMarkdown: state.commitMarkdown,
     onOpenLinkPopover: selection.openLinkPopover,
     onAiRewrite: onAiRewrite ? openAiRewritePrompt : undefined,
     aiToolbarLabel,
@@ -76,7 +73,6 @@ export function MarkdownBlockEditor({
 
   syncEditorToMarkdownRef.current = toolbar.syncEditorToMarkdown
   resetTransientRef.current = () => {
-    heading.setHeadingRestrictionMessage(null)
     selection.resetSelectionUi()
     ai.resetAiUi()
   }
@@ -87,11 +83,7 @@ export function MarkdownBlockEditor({
         ref={state.setPlainTextareaRef}
         className={className}
         value={value}
-        onChange={(event) => {
-          const nextValue = event.target.value
-          heading.setHeadingRestrictionMessage(null)
-          state.commitMarkdown(nextValue)
-        }}
+        onChange={(event) => state.commitMarkdown(event.target.value)}
         onInput={(event) => resizeTextareaToContent(event.currentTarget)}
         rows={rows}
         placeholder={placeholder}
@@ -104,7 +96,12 @@ export function MarkdownBlockEditor({
     <div className="block-markdown-editor-shell">
       <EditorToolbar blockId={blockId} actions={toolbar.toolbarActions} onAction={toolbar.handleToolbarAction} />
 
-      {heading.headingStructureHint ? <p className="block-markdown-hint">{heading.headingStructureHint}</p> : null}
+      {/* One structure line: the warning supersedes the hint rather than stacking on it. */}
+      {heading.headingStructureWarning ? (
+        <p className="block-markdown-hint warning">{heading.headingStructureWarning}</p>
+      ) : heading.headingStructureHint ? (
+        <p className="block-markdown-hint">{heading.headingStructureHint}</p>
+      ) : null}
 
       <LinkPopover
         isOpen={selection.isLinkPopoverOpen}
@@ -134,9 +131,6 @@ export function MarkdownBlockEditor({
 
       {selection.linkPopoverError ? <p className="block-markdown-hint error">{selection.linkPopoverError}</p> : null}
       {ai.aiRewriteError ? <p className="block-markdown-hint error">{ai.aiRewriteError}</p> : null}
-      {heading.headingRestrictionMessage ? (
-        <p className="block-markdown-hint error">{heading.headingRestrictionMessage}</p>
-      ) : null}
 
       <RichContentEditable
         editorRef={state.editorRef}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useAiRewrite.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useAiRewrite.ts
@@ -13,7 +13,7 @@ type UseAiRewriteParams = {
   }) => Promise<string>
   draftMarkdownRef: MutableRefObject<string>
   editorRef: MutableRefObject<HTMLDivElement | null>
-  applyValueWithHeadingGuard: (nextValue: string) => boolean
+  commitMarkdown: (nextMarkdown: string) => void
 }
 
 type UseAiRewriteResult = {
@@ -36,7 +36,7 @@ export function useAiRewrite({
   onAiRewrite,
   draftMarkdownRef,
   editorRef,
-  applyValueWithHeadingGuard,
+  commitMarkdown,
 }: UseAiRewriteParams): UseAiRewriteResult {
   const [isAiPromptOpen, setIsAiPromptOpen] = useState(false)
   const [aiPromptDraft, setAiPromptDraft] = useState('')
@@ -75,11 +75,7 @@ export function useAiRewrite({
         throw new Error('AI returned empty content.')
       }
 
-      const didApply = applyValueWithHeadingGuard(nextMarkdown)
-      if (!didApply) {
-        setIsAiPromptOpen(false)
-        return
-      }
+      commitMarkdown(nextMarkdown)
 
       const editor = editorRef.current
       if (editor) {
@@ -95,7 +91,7 @@ export function useAiRewrite({
     } finally {
       setIsAiRewriting(false)
     }
-  }, [aiPromptDraft, applyValueWithHeadingGuard, blockId, draftMarkdownRef, editorRef, includeWholeArticleContext, onAiRewrite])
+  }, [aiPromptDraft, blockId, commitMarkdown, draftMarkdownRef, editorRef, includeWholeArticleContext, onAiRewrite])
 
   const resetAiUi = useCallback(() => {
     setIsAiPromptOpen(false)

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useEditorSelection.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useEditorSelection.ts
@@ -9,7 +9,7 @@ import {
 
 type UseEditorSelectionParams = {
   editorRef: MutableRefObject<HTMLDivElement | null>
-  syncEditorToMarkdownRef: MutableRefObject<() => boolean>
+  syncEditorToMarkdownRef: MutableRefObject<() => void>
 }
 
 type UseEditorSelectionResult = {
@@ -76,8 +76,7 @@ export function useEditorSelection({
     }
 
     document.execCommand('createLink', false, normalizedUrl)
-    const didApply = syncEditorToMarkdownRef.current()
-    if (!didApply) return
+    syncEditorToMarkdownRef.current()
 
     setLinkPopoverError(null)
     setIsLinkPopoverOpen(false)

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useHeadingStructureGuard.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useHeadingStructureGuard.ts
@@ -1,87 +1,55 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { MutableRefObject } from 'react'
+import { useMemo } from 'react'
 import {
   buildHeadingStructureHint,
-  findNewHeadingViolation,
-  formatHeadingRestrictionMessage,
+  findRestrictedHeadings,
+  formatHeadingStructureWarning,
   getRootHeadingLevel,
 } from '../services/heading-structure.service'
 
 type UseHeadingStructureGuardParams = {
-  blockId: string
   value: string
   enforceHeadingStructure: boolean
-  draftMarkdownRef: MutableRefObject<string>
-  commitMarkdown: (nextMarkdown: string) => void
 }
 
 type UseHeadingStructureGuardResult = {
   headingStructureHint: string | null
-  headingRestrictionMessage: string | null
-  setHeadingRestrictionMessage: (value: string | null) => void
-  applyValueWithHeadingGuard: (nextValue: string) => boolean
+  headingStructureWarning: string | null
 }
 
+/**
+ * Advisory heading-structure state for the block being edited.
+ *
+ * This used to gate every commit: a keystroke that introduced a sibling heading
+ * was rejected, the editor's innerHTML was rebuilt from the last good draft and
+ * the caret was thrown to the end of the block. That silently ate the author's
+ * text — mid-paragraph edits reappeared at the bottom — and wiped the native
+ * undo stack on the way. It also swallowed AI rewrites whole.
+ *
+ * Structure is a suggestion, not an invariant, so it is now derived state:
+ * everything commits, and a violation only produces a message. Deriving the
+ * anchor level from the live value (rather than freezing it per block id) also
+ * keeps it honest after a split or an AI rewrite changes the first heading.
+ */
 export function useHeadingStructureGuard({
-  blockId,
   value,
   enforceHeadingStructure,
-  draftMarkdownRef,
-  commitMarkdown,
 }: UseHeadingStructureGuardParams): UseHeadingStructureGuardResult {
-  const lastInitializedBlockIdRef = useRef<string | null>(null)
-  const [rootHeadingLevel, setRootHeadingLevel] = useState<number | null>(() =>
-    enforceHeadingStructure ? getRootHeadingLevel(value) : null,
+  const rootHeadingLevel = useMemo(
+    () => (enforceHeadingStructure ? getRootHeadingLevel(value) : null),
+    [enforceHeadingStructure, value],
   )
-  const [headingRestrictionMessage, setHeadingRestrictionMessage] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!enforceHeadingStructure) {
-      lastInitializedBlockIdRef.current = null
-      setRootHeadingLevel(null)
-      setHeadingRestrictionMessage(null)
-      return
-    }
-
-    if (lastInitializedBlockIdRef.current === blockId) return
-
-    lastInitializedBlockIdRef.current = blockId
-    setRootHeadingLevel(getRootHeadingLevel(value))
-    setHeadingRestrictionMessage(null)
-  }, [blockId, enforceHeadingStructure, value])
 
   const headingStructureHint = useMemo(() => {
-    if (!enforceHeadingStructure || rootHeadingLevel === null) return null
+    if (rootHeadingLevel === null) return null
     return buildHeadingStructureHint(rootHeadingLevel)
-  }, [enforceHeadingStructure, rootHeadingLevel])
+  }, [rootHeadingLevel])
 
-  const applyValueWithHeadingGuard = useCallback(
-    (nextValue: string): boolean => {
-      const previousValue = draftMarkdownRef.current
+  const headingStructureWarning = useMemo(() => {
+    if (rootHeadingLevel === null) return null
+    const [restricted] = findRestrictedHeadings(value, rootHeadingLevel)
+    if (!restricted) return null
+    return formatHeadingStructureWarning(rootHeadingLevel, restricted.level)
+  }, [rootHeadingLevel, value])
 
-      if (!enforceHeadingStructure || rootHeadingLevel === null) {
-        setHeadingRestrictionMessage(null)
-        commitMarkdown(nextValue)
-        return true
-      }
-
-      const violation = findNewHeadingViolation(previousValue, nextValue, rootHeadingLevel)
-      if (violation) {
-        setHeadingRestrictionMessage(formatHeadingRestrictionMessage(rootHeadingLevel, violation.level))
-        return false
-      }
-
-      setHeadingRestrictionMessage(null)
-      commitMarkdown(nextValue)
-      return true
-    },
-    [commitMarkdown, draftMarkdownRef, enforceHeadingStructure, rootHeadingLevel],
-  )
-
-  return {
-    headingStructureHint,
-    headingRestrictionMessage,
-    setHeadingRestrictionMessage,
-    applyValueWithHeadingGuard,
-  }
+  return { headingStructureHint, headingStructureWarning }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useToolbarCommands.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useToolbarCommands.ts
@@ -2,15 +2,15 @@ import { useCallback, useMemo } from 'react'
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 import type { MutableRefObject } from 'react'
 import { BASE_TOOLBAR_ACTIONS } from '../constants/toolbar-actions.constants'
-import { editorElementToMarkdown, markdownToEditorHtml } from '../richMarkdown'
+import { editorElementToMarkdown } from '../richMarkdown'
 import { execEditorCommand } from '../services/editor-command.service'
 import type { ToolbarAction, ToolbarActionKey } from '../types'
-import { getActiveBlockTag, placeCaretAtEnd } from '../utils/editor-dom.utils'
+import { getActiveBlockTag } from '../utils/editor-dom.utils'
 
 type UseToolbarCommandsParams = {
   editorRef: MutableRefObject<HTMLDivElement | null>
   draftMarkdownRef: MutableRefObject<string>
-  applyValueWithHeadingGuard: (nextValue: string) => boolean
+  commitMarkdown: (nextMarkdown: string) => void
   onAiRewrite?: () => void
   aiToolbarLabel?: string
   aiToolbarTitle?: string
@@ -19,7 +19,7 @@ type UseToolbarCommandsParams = {
 
 type UseToolbarCommandsResult = {
   toolbarActions: ToolbarAction[]
-  syncEditorToMarkdown: () => boolean
+  syncEditorToMarkdown: () => void
   handleToolbarAction: (key: ToolbarActionKey) => void
   handleEditorKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void
 }
@@ -27,7 +27,7 @@ type UseToolbarCommandsResult = {
 export function useToolbarCommands({
   editorRef,
   draftMarkdownRef,
-  applyValueWithHeadingGuard,
+  commitMarkdown,
   onAiRewrite,
   aiToolbarLabel,
   aiToolbarTitle,
@@ -48,20 +48,15 @@ export function useToolbarCommands({
     ]
   }, [onAiRewrite, aiToolbarLabel, aiToolbarTitle])
 
-  const syncEditorToMarkdown = useCallback((): boolean => {
+  const syncEditorToMarkdown = useCallback((): void => {
     const editor = editorRef.current
-    if (!editor) return false
+    if (!editor) return
 
     const nextMarkdown = editorElementToMarkdown(editor)
-    if (nextMarkdown === draftMarkdownRef.current) return true
+    if (nextMarkdown === draftMarkdownRef.current) return
 
-    const didApply = applyValueWithHeadingGuard(nextMarkdown)
-    if (!didApply) {
-      editor.innerHTML = markdownToEditorHtml(draftMarkdownRef.current)
-      placeCaretAtEnd(editor)
-    }
-    return didApply
-  }, [applyValueWithHeadingGuard, draftMarkdownRef, editorRef])
+    commitMarkdown(nextMarkdown)
+  }, [commitMarkdown, draftMarkdownRef, editorRef])
 
   const toggleBlockFormat = useCallback(
     (tag: 'H2' | 'H3' | 'BLOCKQUOTE') => {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/heading-structure.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/heading-structure.service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildHeadingStructureHint,
+  findRestrictedHeadings,
+  formatHeadingStructureWarning,
+  getRootHeadingLevel,
+} from './heading-structure.service'
+
+describe('getRootHeadingLevel', () => {
+  it('reports the level of the first heading', () => {
+    expect(getRootHeadingLevel('## Section\n\nBody copy.')).toBe(2)
+    expect(getRootHeadingLevel('### Deep\n\n## Shallower')).toBe(3)
+  })
+
+  it('returns null when the block has no heading', () => {
+    expect(getRootHeadingLevel('Just a paragraph.\n\nAnd another.')).toBeNull()
+  })
+
+  it('ignores a bare hash run that is not a heading', () => {
+    expect(getRootHeadingLevel('##NoSpace is not a heading')).toBeNull()
+  })
+})
+
+describe('findRestrictedHeadings', () => {
+  it('flags a later sibling heading at the anchor level', () => {
+    const restricted = findRestrictedHeadings('## First\n\nBody\n\n## Second', 2)
+    expect(restricted).toEqual([{ level: 2, lineIndex: 4 }])
+  })
+
+  it('flags a later heading above the anchor level', () => {
+    const restricted = findRestrictedHeadings('## First\n\n# Bigger', 2)
+    expect(restricted).toEqual([{ level: 1, lineIndex: 2 }])
+  })
+
+  it('permits nested headings below the anchor level', () => {
+    expect(findRestrictedHeadings('## First\n\n### Nested\n\n#### Deeper', 2)).toEqual([])
+  })
+
+  it('never flags the anchor heading itself', () => {
+    expect(findRestrictedHeadings('## Only heading', 2)).toEqual([])
+  })
+
+  it('returns every offender, not just the first', () => {
+    const restricted = findRestrictedHeadings('## A\n\n## B\n\n## C', 2)
+    expect(restricted.map((heading) => heading.lineIndex)).toEqual([2, 4])
+  })
+})
+
+describe('message builders', () => {
+  it('names both levels in the warning', () => {
+    expect(formatHeadingStructureWarning(2, 2)).toContain('H2')
+  })
+
+  it('describes the allowed range in the hint', () => {
+    expect(buildHeadingStructureHint(2)).toContain('H3+')
+    expect(buildHeadingStructureHint(5)).toContain('H6 only')
+    expect(buildHeadingStructureHint(6)).toContain('Add a new block')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/heading-structure.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/heading-structure.service.ts
@@ -12,47 +12,39 @@ function collectMarkdownHeadings(text: string): MarkdownHeading[] {
     .map((line, lineIndex) => {
       const level = getMarkdownHeadingLevel(line)
       if (level === null) return null
-      return {
-        level,
-        lineIndex,
-        signature: `${level}|${lineIndex}|${line.trim()}`,
-      }
+      return { level, lineIndex }
     })
     .filter((heading): heading is MarkdownHeading => heading !== null)
 }
 
+/** The level of the block's own first heading, which anchors its section. */
 export function getRootHeadingLevel(text: string): number | null {
   const firstHeading = collectMarkdownHeadings(text)[0]
   return firstHeading?.level ?? null
 }
 
-function getRestrictedHeadingViolations(text: string, rootHeadingLevel: number): MarkdownHeading[] {
-  const headings = collectMarkdownHeadings(text)
-  if (headings.length === 0) return []
-
-  return headings.filter((heading, index) => {
-    if (index === 0) {
-      return heading.level < rootHeadingLevel
-    }
-    return heading.level <= rootHeadingLevel
-  })
-}
-
-export function findNewHeadingViolation(
-  currentText: string,
-  nextText: string,
+/**
+ * Later headings at or above the block's anchor level.
+ *
+ * The stage splits articles into blocks on the anchor level, so a sibling
+ * heading buried inside a block will not get its own section downstream. That
+ * is worth telling the author about — it is not worth refusing their keystroke,
+ * so this only ever reports.
+ */
+export function findRestrictedHeadings(
+  text: string,
   rootHeadingLevel: number,
-): MarkdownHeading | null {
-  const currentViolations = getRestrictedHeadingViolations(currentText, rootHeadingLevel)
-  const nextViolations = getRestrictedHeadingViolations(nextText, rootHeadingLevel)
-  if (nextViolations.length <= currentViolations.length) return null
-
-  const currentSignatures = new Set(currentViolations.map((heading) => heading.signature))
-  return nextViolations.find((heading) => !currentSignatures.has(heading.signature)) ?? nextViolations[0] ?? null
+): MarkdownHeading[] {
+  return collectMarkdownHeadings(text).filter(
+    (heading, index) => index > 0 && heading.level <= rootHeadingLevel,
+  )
 }
 
-export function formatHeadingRestrictionMessage(rootHeadingLevel: number, violationHeadingLevel: number): string {
-  return `This block is anchored at H${rootHeadingLevel}. H${violationHeadingLevel} headings must be added as a new block, not inside this one.`
+export function formatHeadingStructureWarning(
+  rootHeadingLevel: number,
+  restrictedHeadingLevel: number,
+): string {
+  return `This block is anchored at H${rootHeadingLevel}, so the H${restrictedHeadingLevel} below it won't get its own section. Split it into a new block to give it one.`
 }
 
 export function buildHeadingStructureHint(rootHeadingLevel: number): string {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/types.ts
@@ -18,7 +18,6 @@ export type ToolbarAction = {
 export type MarkdownHeading = {
   level: number
   lineIndex: number
-  signature: string
 }
 
 export type MarkdownBlockEditorProps = {


### PR DESCRIPTION
## Problem

`enforceHeadingStructure` is on for every text block on the stage-article screens. It gated **every commit**, and the rejection path was destructive:

```ts
// useToolbarCommands.ts (before)
const didApply = applyValueWithHeadingGuard(nextMarkdown)
if (!didApply) {
  editor.innerHTML = markdownToEditorHtml(draftMarkdownRef.current)
  placeCaretAtEnd(editor)
}
```

Repro: open a block that starts with `## Something`, put the caret mid-paragraph, type `## X`. The typed text disappears and **the caret teleports to the end of the block** — so you carry on typing in the wrong place. Every rejection also blows away the native undo stack.

Same path swallowed AI rewrites: `useAiRewrite` closed the popover and returned with no error shown if the rewrite introduced a heading. "I ran AI and nothing happened."

Two further bugs in the same hook:
- `rootHeadingLevel` was computed once per `blockId` and never recomputed (`useHeadingStructureGuard.ts:46`), so after a split or an AI rewrite it enforced a level the block no longer had.
- A block with no heading had the guard silently off forever, even after the author added one.

## Change

Heading structure is a suggestion, not an invariant. The guard becomes **derived state**: everything commits, and a violation only produces a message.

- `useHeadingStructureGuard` is now pure derivation — `{ headingStructureHint, headingStructureWarning }`, no callbacks, no state, no effect. Anchor level comes from the live `value`, so it can't go stale.
- Deleted `findNewHeadingViolation` and the `signature` diffing it needed. That machinery existed only to avoid blocking on *pre-existing* violations — moot once nothing blocks. Replaced by `findRestrictedHeadings`, which just reports.
- `syncEditorToMarkdown`, `applyLink` and `runAiRewrite` lose their boolean rejection plumbing and call `commitMarkdown` directly.
- The warning supersedes the hint so the shell keeps one line, styled amber rather than error-red across all three stylesheets that theme it.

## Notes for review

- **Behaviour change, intentional:** it is now possible to save a block containing a sibling heading. That was already reachable (AI output and the markdown parser both produce them); the guard only ever blocked *typing* it. The warning tells the author it won't get its own section and points at Split.
- `MarkdownHeading.signature` dropped from `types.ts` — it had no other consumer.

## Verification

- New `heading-structure.service.test.ts`: 10 tests covering anchor detection, sibling/nested/above-anchor cases, and the message builders.
- `vitest run` — 123 files / 524 tests passing (was 122/514).
- `eslint` on `shared/markdown-editor` clean; frontend boundary check passes.
- `tsc --noEmit` surfaces only the 4 pre-existing errors on main (BuilderSetupPanel, SingleTypeListicleBuilderPage, and two `lib`-target errors in a staging test) — none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)