### PR TITLE
feat(editor): turn markdown shorthand into real formatting as you type

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useToolbarCommands.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useToolbarCommands.ts
@@ -4,8 +4,15 @@ import type { MutableRefObject } from 'react'
 import { BASE_TOOLBAR_ACTIONS } from '../constants/toolbar-actions.constants'
 import { editorElementToMarkdown } from '../richMarkdown'
 import { execEditorCommand } from '../services/editor-command.service'
+import { matchMarkdownInputRule } from '../services/markdown-input-rules.service'
 import type { ToolbarAction, ToolbarActionKey } from '../types'
-import { getActiveBlockTag } from '../utils/editor-dom.utils'
+import {
+  collapseSelectionTo,
+  getActiveBlockElement,
+  getActiveBlockTag,
+  getRangeFromBlockStartToCaret,
+  isCaretAtEndOfBlock,
+} from '../utils/editor-dom.utils'
 
 type UseToolbarCommandsParams = {
   editorRef: MutableRefObject<HTMLDivElement | null>
@@ -118,9 +125,87 @@ export function useToolbarCommands({
     [editorRef, onAiRewrite, onOpenLinkPopover, syncEditorToMarkdown, toggleBlockFormat],
   )
 
+  /**
+   * Turns markdown shorthand typed at the start of a block into real structure.
+   *
+   * Without this the editor had no path from typing to formatting at all: the
+   * markdown-to-HTML direction only ran on mount and on block switch, so `##
+   * Title` sat in a paragraph as literal text and only became a heading once
+   * the preview took over. Returns whether the space keypress was consumed.
+   */
+  const applyMarkdownInputRule = useCallback((): boolean => {
+    const editor = editorRef.current
+    if (!editor) return false
+
+    const block = getActiveBlockElement(editor)
+    // Inside a list item the same shorthand means "literal text", not "nest".
+    if (!block || block.tagName.toUpperCase() === 'LI') return false
+
+    const prefixRange = getRangeFromBlockStartToCaret(editor, block)
+    if (!prefixRange) return false
+
+    const rule = matchMarkdownInputRule(prefixRange.toString())
+    if (!rule) return false
+
+    prefixRange.deleteContents()
+    collapseSelectionTo(prefixRange, true)
+
+    switch (rule.type) {
+      case 'heading':
+        execEditorCommand('formatBlock', `h${rule.level}`)
+        break
+      case 'unordered-list':
+        execEditorCommand('insertUnorderedList')
+        break
+      case 'ordered-list':
+        execEditorCommand('insertOrderedList')
+        break
+      case 'blockquote':
+        execEditorCommand('formatBlock', 'blockquote')
+        break
+    }
+
+    return true
+  }, [editorRef])
+
+  /**
+   * Enter at the end of a heading should start body copy. Browsers clone the
+   * current block instead, so a heading begets another heading and the author
+   * has to notice and undo it every single time.
+   */
+  const exitHeadingOnEnter = useCallback((): boolean => {
+    const editor = editorRef.current
+    if (!editor) return false
+
+    const block = getActiveBlockElement(editor)
+    if (!block || !/^H[1-6]$/.test(block.tagName.toUpperCase())) return false
+    if (!isCaretAtEndOfBlock(editor, block)) return false
+
+    execEditorCommand('insertParagraph')
+    execEditorCommand('formatBlock', 'p')
+    return true
+  }, [editorRef])
+
   const handleEditorKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       const isMod = event.metaKey || event.ctrlKey
+
+      if (!isMod && event.key === ' ') {
+        if (applyMarkdownInputRule()) {
+          event.preventDefault()
+          syncEditorToMarkdown()
+        }
+        return
+      }
+
+      if (!isMod && event.key === 'Enter' && !event.shiftKey) {
+        if (exitHeadingOnEnter()) {
+          event.preventDefault()
+          syncEditorToMarkdown()
+        }
+        return
+      }
+
       if (!isMod) return
 
       const lowerKey = event.key.toLowerCase()
@@ -139,7 +224,7 @@ export function useToolbarCommands({
         handleToolbarAction('link')
       }
     },
-    [handleToolbarAction],
+    [applyMarkdownInputRule, exitHeadingOnEnter, handleToolbarAction, syncEditorToMarkdown],
   )
 
   return {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/markdown-input-rules.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/markdown-input-rules.service.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { matchMarkdownInputRule } from './markdown-input-rules.service'
+
+describe('matchMarkdownInputRule', () => {
+  it('matches every heading level', () => {
+    for (let level = 1; level <= 6; level += 1) {
+      expect(matchMarkdownInputRule('#'.repeat(level))).toEqual({ type: 'heading', level })
+    }
+  })
+
+  it('stops at H6 rather than matching a longer hash run', () => {
+    expect(matchMarkdownInputRule('#######')).toBeNull()
+  })
+
+  it('matches each bullet marker', () => {
+    expect(matchMarkdownInputRule('-')).toEqual({ type: 'unordered-list' })
+    expect(matchMarkdownInputRule('*')).toEqual({ type: 'unordered-list' })
+    expect(matchMarkdownInputRule('+')).toEqual({ type: 'unordered-list' })
+  })
+
+  it('matches ordered list markers with either delimiter', () => {
+    expect(matchMarkdownInputRule('1.')).toEqual({ type: 'ordered-list' })
+    expect(matchMarkdownInputRule('42.')).toEqual({ type: 'ordered-list' })
+    expect(matchMarkdownInputRule('3)')).toEqual({ type: 'ordered-list' })
+  })
+
+  it('treats an implausibly long digit run as prose', () => {
+    expect(matchMarkdownInputRule('1234567890.')).toBeNull()
+  })
+
+  it('matches a blockquote marker', () => {
+    expect(matchMarkdownInputRule('>')).toEqual({ type: 'blockquote' })
+  })
+
+  it('ignores shorthand that is not the whole run before the caret', () => {
+    // The caret text is anchored to the block start, so prose that merely
+    // contains a marker must not trigger a rule.
+    expect(matchMarkdownInputRule('Rated 5.')).toBeNull()
+    expect(matchMarkdownInputRule('a #')).toBeNull()
+    expect(matchMarkdownInputRule('# Already a heading')).toBeNull()
+    expect(matchMarkdownInputRule('->')).toBeNull()
+  })
+
+  it('ignores an empty run', () => {
+    expect(matchMarkdownInputRule('')).toBeNull()
+  })
+
+  it('does not match markers that markdown does not define', () => {
+    expect(matchMarkdownInputRule('.')).toBeNull()
+    expect(matchMarkdownInputRule('1')).toBeNull()
+    expect(matchMarkdownInputRule('>>')).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/markdown-input-rules.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/markdown-input-rules.service.ts
@@ -1,0 +1,35 @@
+export type MarkdownInputRule =
+  | { type: 'heading'; level: number }
+  | { type: 'unordered-list' }
+  | { type: 'ordered-list' }
+  | { type: 'blockquote' }
+
+/**
+ * Matches the markdown shorthand typed at the start of a block, at the moment
+ * the author presses space.
+ *
+ * `text` is everything between the block's start and the caret, so a match here
+ * means the whole run is shorthand and nothing else. Anchoring both ends is
+ * what keeps `5. ` in "Rated 5. Best in class" from turning into a list.
+ */
+export function matchMarkdownInputRule(text: string): MarkdownInputRule | null {
+  const heading = text.match(/^(#{1,6})$/)
+  if (heading) {
+    return { type: 'heading', level: heading[1].length }
+  }
+
+  if (/^[-*+]$/.test(text)) {
+    return { type: 'unordered-list' }
+  }
+
+  // Bounded so a long digit run reads as prose, not an ordered list.
+  if (/^\d{1,9}[.)]$/.test(text)) {
+    return { type: 'ordered-list' }
+  }
+
+  if (text === '>') {
+    return { type: 'blockquote' }
+  }
+
+  return null
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/utils/editor-dom.utils.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/utils/editor-dom.utils.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  getActiveBlockTag,
+  getRangeFromBlockStartToCaret,
+  isCaretAtEndOfBlock,
+} from './editor-dom.utils'
+
+function mountEditor(html: string): HTMLDivElement {
+  const editor = document.createElement('div')
+  editor.contentEditable = 'true'
+  editor.innerHTML = html
+  document.body.appendChild(editor)
+  return editor
+}
+
+/** Put a collapsed caret `offset` characters into `node`'s text. */
+function placeCaret(node: Node, offset: number): void {
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  window.getSelection()?.removeAllRanges()
+})
+
+describe('getRangeFromBlockStartToCaret', () => {
+  it('captures exactly the text typed before the caret', () => {
+    const editor = mountEditor('<p>## Heading text</p>')
+    const paragraph = editor.querySelector('p')!
+    const text = paragraph.firstChild!
+
+    placeCaret(text, 2)
+
+    const range = getRangeFromBlockStartToCaret(editor, paragraph)
+    expect(range?.toString()).toBe('##')
+  })
+
+  it('is empty when the caret sits at the block start', () => {
+    const editor = mountEditor('<p>text</p>')
+    const paragraph = editor.querySelector('p')!
+
+    placeCaret(paragraph.firstChild!, 0)
+
+    expect(getRangeFromBlockStartToCaret(editor, paragraph)?.toString()).toBe('')
+  })
+
+  it('deletes precisely the matched prefix', () => {
+    const editor = mountEditor('<p>- item</p>')
+    const paragraph = editor.querySelector('p')!
+
+    placeCaret(paragraph.firstChild!, 1)
+
+    const range = getRangeFromBlockStartToCaret(editor, paragraph)!
+    expect(range.toString()).toBe('-')
+    range.deleteContents()
+    expect(paragraph.textContent).toBe(' item')
+  })
+
+  it('refuses a selection that is not collapsed', () => {
+    const editor = mountEditor('<p>## Heading</p>')
+    const paragraph = editor.querySelector('p')!
+    const range = document.createRange()
+    range.setStart(paragraph.firstChild!, 0)
+    range.setEnd(paragraph.firstChild!, 2)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(getRangeFromBlockStartToCaret(editor, paragraph)).toBeNull()
+  })
+
+  it('refuses a caret outside the given block', () => {
+    const editor = mountEditor('<p id="a">first</p><p id="b">second</p>')
+    const first = editor.querySelector('#a') as HTMLElement
+    const second = editor.querySelector('#b') as HTMLElement
+
+    placeCaret(second.firstChild!, 2)
+
+    expect(getRangeFromBlockStartToCaret(editor, first)).toBeNull()
+  })
+})
+
+describe('isCaretAtEndOfBlock', () => {
+  it('is true at the end of the block text', () => {
+    const editor = mountEditor('<h2>Section</h2>')
+    const heading = editor.querySelector('h2')!
+
+    placeCaret(heading.firstChild!, 'Section'.length)
+
+    expect(isCaretAtEndOfBlock(editor, heading)).toBe(true)
+  })
+
+  it('is false mid-word', () => {
+    const editor = mountEditor('<h2>Section</h2>')
+    const heading = editor.querySelector('h2')!
+
+    placeCaret(heading.firstChild!, 3)
+
+    expect(isCaretAtEndOfBlock(editor, heading)).toBe(false)
+  })
+
+  it('is true in an empty block', () => {
+    const editor = mountEditor('<h2></h2>')
+    const heading = editor.querySelector('h2')!
+
+    placeCaret(heading, 0)
+
+    expect(isCaretAtEndOfBlock(editor, heading)).toBe(true)
+  })
+})
+
+describe('getActiveBlockTag', () => {
+  it('reports the nearest block ancestor of the caret', () => {
+    const editor = mountEditor('<h3>Title</h3>')
+    placeCaret(editor.querySelector('h3')!.firstChild!, 1)
+    expect(getActiveBlockTag(editor)).toBe('H3')
+  })
+
+  it('sees through inline formatting', () => {
+    const editor = mountEditor('<p>plain <strong>bold</strong></p>')
+    placeCaret(editor.querySelector('strong')!.firstChild!, 2)
+    expect(getActiveBlockTag(editor)).toBe('P')
+  })
+
+  it('reports the list item rather than the list', () => {
+    const editor = mountEditor('<ul><li>one</li></ul>')
+    placeCaret(editor.querySelector('li')!.firstChild!, 1)
+    expect(getActiveBlockTag(editor)).toBe('LI')
+  })
+
+  it('returns null when the caret is outside the editor', () => {
+    const editor = mountEditor('<p>inside</p>')
+    const outside = document.createElement('p')
+    outside.textContent = 'outside'
+    document.body.appendChild(outside)
+
+    placeCaret(outside.firstChild!, 2)
+
+    expect(getActiveBlockTag(editor)).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/utils/editor-dom.utils.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/utils/editor-dom.utils.ts
@@ -39,16 +39,70 @@ export function findClosestElementWithinEditor(
   return null
 }
 
-export function getActiveBlockTag(editor: HTMLElement): string | null {
+const BLOCK_TAGS = new Set(['P', 'DIV', 'BLOCKQUOTE', 'LI'])
+
+function isBlockElement(element: HTMLElement): boolean {
+  const tag = element.tagName.toUpperCase()
+  return BLOCK_TAGS.has(tag) || /^H[1-6]$/.test(tag)
+}
+
+/** The block-level element the caret currently sits in, if any. */
+export function getActiveBlockElement(editor: HTMLElement): HTMLElement | null {
   const range = getSelectionRangeWithinEditor(editor)
   if (!range) return null
+  return findClosestElementWithinEditor(range.startContainer, editor, isBlockElement)
+}
 
-  const block = findClosestElementWithinEditor(range.startContainer, editor, (element) => {
-    const tag = element.tagName.toUpperCase()
-    return tag === 'P' || tag === 'DIV' || tag === 'BLOCKQUOTE' || tag === 'LI' || /^H[1-6]$/.test(tag)
-  })
+export function getActiveBlockTag(editor: HTMLElement): string | null {
+  return getActiveBlockElement(editor)?.tagName.toUpperCase() ?? null
+}
 
-  return block?.tagName.toUpperCase() ?? null
+/**
+ * A range covering everything from the start of `block` up to the caret.
+ *
+ * Returned as a live range rather than a string so the caller can both read the
+ * text and delete exactly that span — matching and removing a typed prefix have
+ * to agree on the boundary, and re-deriving it twice invites drift.
+ */
+export function getRangeFromBlockStartToCaret(
+  editor: HTMLElement,
+  block: HTMLElement,
+): Range | null {
+  const selection = window.getSelection()
+  if (!selection || !selection.isCollapsed || selection.rangeCount === 0) return null
+
+  const caretRange = selection.getRangeAt(0)
+  if (!editor.contains(caretRange.startContainer)) return null
+  if (!block.contains(caretRange.startContainer)) return null
+
+  const range = document.createRange()
+  range.selectNodeContents(block)
+  range.setEnd(caretRange.startContainer, caretRange.startOffset)
+  return range
+}
+
+/** True when the caret sits at the very end of `block`'s content. */
+export function isCaretAtEndOfBlock(editor: HTMLElement, block: HTMLElement): boolean {
+  const selection = window.getSelection()
+  if (!selection || !selection.isCollapsed || selection.rangeCount === 0) return false
+
+  const caretRange = selection.getRangeAt(0)
+  if (!editor.contains(caretRange.startContainer)) return false
+
+  const tailRange = document.createRange()
+  tailRange.selectNodeContents(block)
+  tailRange.setStart(caretRange.endContainer, caretRange.endOffset)
+  return tailRange.toString().length === 0
+}
+
+export function collapseSelectionTo(range: Range, toStart: boolean): void {
+  const selection = window.getSelection()
+  if (!selection) return
+
+  const collapsed = range.cloneRange()
+  collapsed.collapse(toStart)
+  selection.removeAllRanges()
+  selection.addRange(collapsed)
 }
 
 export function placeCaretAtEnd(editor: HTMLElement): void {


### PR DESCRIPTION
## Problem

This is the bug that started the audit: **typing `## Title` inside a block does nothing.**

The block editor is a contenteditable whose only input handler is `syncEditorToMarkdown` — DOM → markdown. The other direction, `markdownToEditorHtml`, runs only on mount and on block switch (`useMarkdownEditorState.ts:49-53`). Nothing ever converts what you type.

So `## Title` sits in a `<p>` as literal text forever. It *is* stored correctly (serializing `<p>## Title</p>` yields the markdown `## Title`), which is why it snaps into a real heading the moment you press **Done** and `ReactMarkdown` renders it. The editor and its preview disagreed about identical bytes.

## Change

Input rules on <kbd>Space</kbd> at the start of a block:

| Shorthand | Result |
|---|---|
| `#` … `######` | H1–H6 |
| `-` `*` `+` | bullet list |
| `1.` `1)` | ordered list |
| `>` | blockquote |

Plus: **Enter at the end of a heading now starts a paragraph.** Browsers clone the current block, so a heading begat another heading and the author had to notice and fix it every single time.

## Design notes

- **The matched run is anchored to the block start.** `matchMarkdownInputRule` receives everything between the block start and the caret and anchors both ends of every pattern, so `Rated 5.` + space stays prose. This is the failure mode naive input rules always hit.
- **List items are skipped.** Inside an `<li>`, `- ` means literal text, not "nest a list".
- **Ordered-list digits are bounded to 9.** A 10-digit run is a phone number, not a list.
- `getRangeFromBlockStartToCaret` returns a live `Range` rather than a string, deliberately: matching the prefix and deleting it must agree on the exact boundary, and re-deriving it twice invites drift.

## Verification

- `markdown-input-rules.service.test.ts` — 9 tests, including the prose-that-contains-a-marker cases.
- `editor-dom.utils.test.ts` — 12 tests exercising the range math in jsdom: prefix capture, precise deletion, non-collapsed selections, caret outside the block, empty blocks, inline-formatting descent.
- **`execCommand` is not implemented in jsdom**, so the four command calls are deliberately thin one-liners with the testable logic pulled out around them. Worth a human click-through on `/prompt2blog/stage-article` to confirm the browser behaviour.
- `vitest run` — 125 files / 545 tests (was 123/524). `eslint`, boundary check, `vite build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)