### PR TITLE
fix(editor): sanitize paste and stop clobbering inline typing state

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/MarkdownBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/MarkdownBlockEditor.tsx
@@ -139,6 +139,7 @@ export function MarkdownBlockEditor({
         ariaLabel={ariaLabel}
         onInput={toolbar.syncEditorToMarkdown}
         onKeyDown={toolbar.handleEditorKeyDown}
+        onPaste={toolbar.handleEditorPaste}
       />
     </div>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/components/RichContentEditable.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/components/RichContentEditable.tsx
@@ -1,4 +1,7 @@
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import type {
+  ClipboardEvent as ReactClipboardEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 import type { MutableRefObject } from 'react'
 
 type RichContentEditableProps = {
@@ -8,6 +11,7 @@ type RichContentEditableProps = {
   ariaLabel?: string
   onInput: () => void
   onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void
+  onPaste: (event: ReactClipboardEvent<HTMLDivElement>) => void
 }
 
 export function RichContentEditable({
@@ -17,43 +21,31 @@ export function RichContentEditable({
   ariaLabel,
   onInput,
   onKeyDown,
+  onPaste,
 }: RichContentEditableProps) {
-  const normalizeInlineTypingState = () => {
-    const selection = window.getSelection()
-    if (!selection || !selection.isCollapsed) return
-
-    try {
-      if (document.queryCommandState('bold')) {
-        document.execCommand('bold')
-      }
-      if (document.queryCommandState('italic')) {
-        document.execCommand('italic')
-      }
-    } catch {
-      // Some browsers can throw for queryCommandState; ignore safely.
-    }
-  }
-
   return (
     <div
       ref={editorRef}
       className={`block-rich-editor ${isEditorEmpty ? 'is-empty' : ''}`}
       contentEditable
       role="textbox"
-      aria-label={ariaLabel}
+      aria-label={ariaLabel ?? 'Block content'}
       aria-multiline="true"
-      spellCheck={false}
+      /* Long-form prose: misspellings are worth flagging. autoCorrect and
+         autoCapitalize stay off — they fight the author over proper nouns. */
+      spellCheck
       autoCorrect="off"
       autoCapitalize="off"
       suppressContentEditableWarning
       data-placeholder={placeholder || 'Write your content...'}
+      /* Grammarly injects its own nodes into the contenteditable, which the
+         markdown serializer would walk and write back into the document. */
       data-gramm="false"
       data-gramm_editor="false"
       data-enable-grammarly="false"
       onInput={onInput}
       onKeyDown={onKeyDown}
-      onFocus={normalizeInlineTypingState}
-      onMouseUp={normalizeInlineTypingState}
+      onPaste={onPaste}
     />
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useToolbarCommands.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/hooks/useToolbarCommands.ts
@@ -1,10 +1,14 @@
 import { useCallback, useMemo } from 'react'
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import type {
+  ClipboardEvent as ReactClipboardEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 import type { MutableRefObject } from 'react'
 import { BASE_TOOLBAR_ACTIONS } from '../constants/toolbar-actions.constants'
 import { editorElementToMarkdown } from '../richMarkdown'
 import { execEditorCommand } from '../services/editor-command.service'
 import { matchMarkdownInputRule } from '../services/markdown-input-rules.service'
+import { buildPasteInsertion } from '../services/paste.service'
 import type { ToolbarAction, ToolbarActionKey } from '../types'
 import {
   collapseSelectionTo,
@@ -29,6 +33,7 @@ type UseToolbarCommandsResult = {
   syncEditorToMarkdown: () => void
   handleToolbarAction: (key: ToolbarActionKey) => void
   handleEditorKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void
+  handleEditorPaste: (event: ReactClipboardEvent<HTMLDivElement>) => void
 }
 
 export function useToolbarCommands({
@@ -227,10 +232,33 @@ export function useToolbarCommands({
     [applyMarkdownInputRule, exitHeadingOnEnter, handleToolbarAction, syncEditorToMarkdown],
   )
 
+  /**
+   * Always intercepts. The clipboard's `text/html` flavour never reaches the
+   * document, so no amount of foreign markup can get in, and a paste that
+   * carries no text at all (an image, a file) inserts nothing rather than
+   * planting an <img> the markdown serializer would silently drop.
+   */
+  const handleEditorPaste = useCallback(
+    (event: ReactClipboardEvent<HTMLDivElement>) => {
+      event.preventDefault()
+
+      const insertion = buildPasteInsertion(event.clipboardData.getData('text/plain'))
+      if (!insertion) return
+
+      execEditorCommand(
+        insertion.kind === 'html' ? 'insertHTML' : 'insertText',
+        insertion.value,
+      )
+      syncEditorToMarkdown()
+    },
+    [syncEditorToMarkdown],
+  )
+
   return {
     toolbarActions,
     syncEditorToMarkdown,
     handleToolbarAction,
     handleEditorKeyDown,
+    handleEditorPaste,
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/paste.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/paste.service.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { buildPasteInsertion } from './paste.service'
+
+describe('buildPasteInsertion', () => {
+  it('inserts a single line as literal text so an inline paste does not split the paragraph', () => {
+    expect(buildPasteInsertion('a pasted phrase')).toEqual({
+      kind: 'text',
+      value: 'a pasted phrase',
+    })
+  })
+
+  it('does not interpret markdown on a single line', () => {
+    // Wrapping this in a block would break the surrounding sentence.
+    expect(buildPasteInsertion('## not a heading here')).toEqual({
+      kind: 'text',
+      value: '## not a heading here',
+    })
+  })
+
+  it('reads a multi-line paste as markdown', () => {
+    const insertion = buildPasteInsertion('## Section\n\nBody copy.')
+    expect(insertion?.kind).toBe('html')
+    expect(insertion?.value).toContain('<h2>Section</h2>')
+    expect(insertion?.value).toContain('<p>Body copy.</p>')
+  })
+
+  it('converts pasted lists into real list markup', () => {
+    const insertion = buildPasteInsertion('- one\n- two')
+    expect(insertion?.value).toContain('<ul>')
+    expect(insertion?.value).toContain('<li>one</li>')
+  })
+
+  it('normalizes CRLF and lone CR line endings', () => {
+    const crlf = buildPasteInsertion('## Section\r\n\r\nBody.')
+    const cr = buildPasteInsertion('## Section\r\rBody.')
+    expect(crlf?.value).toContain('<h2>Section</h2>')
+    expect(cr?.value).toContain('<h2>Section</h2>')
+  })
+
+  it('escapes markup rather than trusting it', () => {
+    const insertion = buildPasteInsertion('line one\n<script>alert(1)</script>')
+    expect(insertion?.value).not.toContain('<script>')
+    expect(insertion?.value).toContain('&lt;script&gt;')
+  })
+
+  it('returns nothing for an empty clipboard', () => {
+    expect(buildPasteInsertion('')).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/paste.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/markdown-editor/services/paste.service.ts
@@ -1,0 +1,29 @@
+import { markdownToEditorHtml } from '../richMarkdown'
+
+export type PasteInsertion =
+  | { kind: 'text'; value: string }
+  | { kind: 'html'; value: string }
+
+/**
+ * Decides what a paste should actually insert.
+ *
+ * Only the clipboard's plain-text flavour is ever used. Letting the browser
+ * drop its `text/html` flavour into the contenteditable is what made pasting
+ * from Docs or a web page produce styled span/font/div soup that the markdown
+ * serializer then had to guess its way through.
+ *
+ * Plain text is re-read as markdown, which is the format this editor stores, so
+ * pasting a markdown draft yields real headings and lists rather than literal
+ * `##`. A single-line paste stays literal text: it is an inline paste into an
+ * existing sentence, and wrapping it in a block would split the paragraph.
+ */
+export function buildPasteInsertion(clipboardText: string): PasteInsertion | null {
+  const normalized = clipboardText.replace(/\r\n?/g, '\n')
+  if (!normalized) return null
+
+  if (!normalized.includes('\n')) {
+    return { kind: 'text', value: normalized }
+  }
+
+  return { kind: 'html', value: markdownToEditorHtml(normalized) }
+}


### PR DESCRIPTION
## Problem

**1. There was no `onPaste` handler anywhere in the editor.**

Pasting from Docs / Word / a web page dropped the clipboard's `text/html` flavour straight into the contenteditable — styled `<span>`, `<font>`, nested `<div>` — and `editorElementToMarkdown` then had to guess its way through. Pasted images hit `serializeInlineNode`'s default branch and **vanished silently**.

This is also *why* `.stl-page .block-rich-editor * { font-size: inherit }` existed: the paste problem was being paid for in CSS, at the cost of heading sizes (fixed in #184).

**2. `normalizeInlineTypingState` fought the author.**

```tsx
// RichContentEditable.tsx (before) — ran on every focus AND mouseup
if (document.queryCommandState('bold')) document.execCommand('bold')
```

Click into a bold word → bold silently switches off for whatever you type next, with no sync. A collapsed `execCommand('bold')` inside a `<strong>` can also split the element outright. Clicking inside bold text should *continue* bold.

**3. `spellCheck={false}`** on a long-form blog prose editor.

## Change

- Intercept every paste; use only the plain-text flavour. **Multi-line** text is re-read as markdown (the format this editor stores), so pasting a markdown draft yields real headings and lists instead of literal `##`. **Single-line** stays literal text — it's an inline paste into an existing sentence, and wrapping it in a block would split the paragraph.
- Delete `normalizeInlineTypingState`.
- `spellCheck` on.

## Notes for review

- **Paste always calls `preventDefault`**, including when the clipboard carries no text. That means pasting an image inserts nothing — deliberate: inline images aren't part of this block model (they're separate timeline items via `BlockImageModal`), and the old behaviour planted an `<img>` the serializer dropped on the next keystroke anyway. Failing visibly-empty beats failing silently-later.
- **`autoCorrect` / `autoCapitalize` stay off** — they fight the author over proper nouns.
- **The Grammarly opt-out attributes stay.** Grammarly injects its own nodes into the contenteditable, which the serializer would walk and write back into the document. That one is load-bearing.
- The CSS comment about Firefox visually emboldening on focus refers to a separate problem and is still handled in CSS.

## Verification

- `paste.service.test.ts` — 7 tests: inline vs block behaviour, markdown conversion, CRLF/CR normalization, and that `<script>` is escaped rather than trusted.
- `vitest run` — 126 files / 552 tests (was 125/545). `eslint` + boundary check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)