### PR TITLE
perf(staging): stop re-parsing every block's markdown on each keystroke

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/ContentBlockPreview.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/ContentBlockPreview.tsx
@@ -1,0 +1,87 @@
+import { memo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+/* Hoisted: an inline array is a new reference on every render, which defeats
+   any memoization inside react-markdown. */
+const REMARK_PLUGINS = [remarkGfm]
+
+type HeaderSplitPoint = { lineIndex: number; headerText: string }
+
+type ContentBlockPreviewProps = {
+  blockId: string
+  content: string
+  isEditingLocked: boolean
+  findHeaderSplitPoints: (content: string) => HeaderSplitPoint[]
+  onSplitAtLine: (blockId: string, lineIndex: number) => void
+}
+
+/**
+ * Read-only render of one content block, with a Split affordance at each
+ * heading after the first.
+ *
+ * Memoized because it is the article view's hot path: react-markdown re-parses
+ * the block's markdown on every render, and this renders once per block. Editing
+ * any single block replaces the `blocks` array, so without this every keystroke
+ * re-parsed every other block in the article.
+ */
+function ContentBlockPreviewComponent({
+  blockId,
+  content,
+  isEditingLocked,
+  findHeaderSplitPoints,
+  onSplitAtLine,
+}: ContentBlockPreviewProps) {
+  const splitPoints = isEditingLocked ? [] : findHeaderSplitPoints(content)
+
+  if (splitPoints.length === 0) {
+    return (
+      <div className="block-preview">
+        <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>
+      </div>
+    )
+  }
+
+  const lines = content.split('\n')
+  const segments: { content: string; splitLineIndex: number | null }[] = []
+  let lastIndex = 0
+
+  for (const point of splitPoints) {
+    segments.push({
+      content: lines.slice(lastIndex, point.lineIndex).join('\n'),
+      splitLineIndex: point.lineIndex,
+    })
+    lastIndex = point.lineIndex
+  }
+  segments.push({
+    content: lines.slice(lastIndex).join('\n'),
+    splitLineIndex: null,
+  })
+
+  return (
+    <div className="block-preview">
+      {segments.map((segment, index) => (
+        <div key={index}>
+          <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{segment.content}</ReactMarkdown>
+          {segment.splitLineIndex !== null && (
+            <div className="block-split-zone">
+              <button
+                type="button"
+                className="block-split-btn"
+                onClick={() => onSplitAtLine(blockId, segment.splitLineIndex!)}
+                title="Split here"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M16 3h5v5M8 3H3v5M3 16v5h5M21 16v5h-5"/>
+                </svg>
+                Split
+              </button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export const ContentBlockPreview = memo(ContentBlockPreviewComponent)

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialBlockPreview.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialBlockPreview.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { EditorialBlock } from '../../types'
@@ -26,7 +27,7 @@ type EditorialBlockPreviewProps = {
   normalizedComponent: string
 }
 
-export function EditorialBlockPreview({
+function EditorialBlockPreviewComponent({
   block,
   normalizedComponent,
 }: EditorialBlockPreviewProps) {
@@ -119,3 +120,10 @@ export function EditorialBlockPreview({
     </p>
   )
 }
+
+/*
+ * Memoized for the same reason as ContentBlockPreview: editing a content block
+ * replaces the blocks array and re-renders the whole timeline, but the editorial
+ * blocks themselves are untouched, so their markdown should not be re-parsed.
+ */
+export const EditorialBlockPreview = memo(EditorialBlockPreviewComponent)

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialTimelineList.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialTimelineList.tsx
@@ -1,5 +1,4 @@
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import { useCallback, useRef } from 'react'
 import type { MediaAsset } from '../../api'
 import type { ContentBlock, EditorialBlock, StagedArticle } from '../../types'
 import type { EditorialPublishValidation } from '../../features/editorial-stage-article/editorial-markdown.service'
@@ -9,6 +8,7 @@ import { getMediaAssetAltText } from '../../features/editorial-stage-article/med
 import { MarkdownBlockEditor } from '../../../../shared/markdown-editor'
 import { isStagedArticleEditingLocked } from '../../utils/staged-article-sync'
 import { BlockActionZone } from './BlockActionZone'
+import { ContentBlockPreview } from './ContentBlockPreview'
 import { renderEditorialBlockCard } from './renderEditorialBlockCard'
 
 type EditorialTimelineListProps = {
@@ -150,6 +150,18 @@ export function EditorialTimelineList({
     removeImageAfterBlock,
   } = media
   const isEditingLocked = isStagedArticleEditingLocked(stagedArticle)
+
+  /*
+   * splitBlockAtHeader closes over the staged article, so it is a new function
+   * on every keystroke and would defeat ContentBlockPreview's memo. Hold the
+   * latest one in a ref behind a stable wrapper: the identity never changes, and
+   * a click always runs the current closure rather than a captured stale one.
+   */
+  const splitBlockAtHeaderRef = useRef(splitBlockAtHeader)
+  splitBlockAtHeaderRef.current = splitBlockAtHeader
+  const stableSplitBlockAtHeader = useCallback((blockId: string, lineIndex: number) => {
+    splitBlockAtHeaderRef.current(blockId, lineIndex)
+  }, [])
 
   return (
     <div className="stage-article-section">
@@ -652,57 +664,13 @@ export function EditorialTimelineList({
                     <p>{block.content}</p>
                   </div>
                 ) : (
-                  <div className="block-preview">
-                    {(() => {
-                      const splitPoints = findHeaderSplitPoints(block.content)
-                      if (splitPoints.length === 0 || isEditingLocked) {
-                        return (
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                            {block.content}
-                          </ReactMarkdown>
-                        )
-                      }
-
-                      const lines = block.content.split('\n')
-                      const segments: { content: string; splitLineIndex: number | null }[] = []
-                      let lastIndex = 0
-
-                      for (const point of splitPoints) {
-                        segments.push({
-                          content: lines.slice(lastIndex, point.lineIndex).join('\n'),
-                          splitLineIndex: point.lineIndex,
-                        })
-                        lastIndex = point.lineIndex
-                      }
-                      segments.push({
-                        content: lines.slice(lastIndex).join('\n'),
-                        splitLineIndex: null,
-                      })
-
-                      return segments.map((segment, index) => (
-                        <div key={index}>
-                          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                            {segment.content}
-                          </ReactMarkdown>
-                          {segment.splitLineIndex !== null && (
-                            <div className="block-split-zone">
-                              <button
-                                type="button"
-                                className="block-split-btn"
-                                onClick={() => splitBlockAtHeader(block.id, segment.splitLineIndex!)}
-                                title="Split here"
-                              >
-                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                                  <path d="M16 3h5v5M8 3H3v5M3 16v5h5M21 16v5h-5"/>
-                                </svg>
-                                Split
-                              </button>
-                            </div>
-                          )}
-                        </div>
-                      ))
-                    })()}
-                  </div>
+                  <ContentBlockPreview
+                    blockId={block.id}
+                    content={block.content}
+                    isEditingLocked={isEditingLocked}
+                    findHeaderSplitPoints={findHeaderSplitPoints}
+                    onSplitAtLine={stableSplitBlockAtHeader}
+                  />
                 )}
               </div>
               {!isEditingLocked


### PR DESCRIPTION
## Problem

Typing in a block was laggy on long articles.

`updateBlockContent` replaces the whole `blocks` array → `EditorialTimelineList` re-renders → **every non-editing block re-runs `<ReactMarkdown>`**. react-markdown re-parses its input with remark on each render, so one keystroke re-parsed every block in the article. Nothing in the list was memoized.

## Change

- Extract the content-block preview into a memoized `ContentBlockPreview`.
- Memoize `EditorialBlockPreview` (same hot path, same cost).
- Hoist `remarkPlugins={[remarkGfm]}` to a module constant — an inline array is a fresh reference every render and defeats memoization inside react-markdown.

Only the block being edited now re-renders.

## Notes for review

**The stale-closure hazard is the interesting part.** `splitBlockAtHeader` closes over `stagedArticle`, so it's a new function identity every keystroke and would defeat `memo` outright. The tempting fix — a custom comparator that ignores function props — is wrong: the memoized component would then hold a *stale* callback and split against an outdated article.

Instead it uses the latest-ref pattern:

```ts
const splitBlockAtHeaderRef = useRef(splitBlockAtHeader)
splitBlockAtHeaderRef.current = splitBlockAtHeader
const stableSplitBlockAtHeader = useCallback((blockId, lineIndex) => {
  splitBlockAtHeaderRef.current(blockId, lineIndex)
}, [])
```

Stable identity, always the current closure. `findHeaderSplitPoints` needed no such treatment — it's the raw imported pure function and already stable.

Extracting the preview also lifts a ~50-line IIFE out of the middle of the list's JSX, which is most of the diff.

## Verification

- Behaviour-preserving refactor: the preview markup, split-point maths and split-zone buttons are moved verbatim.
- `vitest run` — 127 files / 561 tests, unchanged. `eslint`, boundary check, `vite build` clean. `tsc --noEmit` still 7 errors, same as `main`.
- Worth a click-through on a long article to feel the difference; there is no perf assertion in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)