### PR TITLE
fix(staging): give newly added content blocks collision-free ids

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/create-staged-id.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/create-staged-id.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createStagedId } from './create-staged-id'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createStagedId', () => {
+  it('keeps ids unique when the clock does not move', () => {
+    // The original `block_${Date.now()}` collided here: adding two blocks in
+    // one millisecond produced the same id twice.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'))
+
+    const ids = Array.from({ length: 1000 }, () => createStagedId('block'))
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('keeps ids from different prefixes apart', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-28T00:00:00.000Z'))
+
+    const block = createStagedId('block')
+    const media = createStagedId('media')
+
+    expect(block.startsWith('block_')).toBe(true)
+    expect(media.startsWith('media_')).toBe(true)
+    expect(block).not.toBe(media)
+  })
+
+  it('cannot collide with the markdown parser\'s positional ids', () => {
+    // parseMarkdownToBlocks emits block_0, block_1, ... for a freshly parsed
+    // article; a generated id must never land on one of those.
+    const id = createStagedId('block')
+    expect(id).not.toMatch(/^block_\d+$/)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/create-staged-id.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/create-staged-id.ts
@@ -1,0 +1,20 @@
+let sequence = 0
+
+/**
+ * A unique id for something the author just added to a staged draft.
+ *
+ * The timestamp keeps ids sortable and distinct across sessions; the counter
+ * makes uniqueness exact rather than probabilistic, because a burst of adds
+ * lands inside a single millisecond; the random tail keeps two tabs editing at
+ * the same instant apart.
+ *
+ * Ids are only ever compared, never parsed, so the shape is free to change —
+ * but it must stay collision-free: content blocks, editorial blocks and media
+ * blocks are all keyed and cross-referenced by these strings, and a duplicate
+ * silently anchors the wrong content together.
+ */
+export function createStagedId(prefix: string): string {
+  sequence += 1
+  const random = Math.random().toString(36).slice(2, 8)
+  return `${prefix}_${Date.now()}_${sequence.toString(36)}_${random}`
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialBlockActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialBlockActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react'
 import type { EditorialBlock, StagedArticle } from '../../../types'
 import type { SupportedEditorialComponent } from '../types'
+import { createStagedId } from '../create-staged-id'
 import { buildDefaultEditorialTemplate } from '../editorial-markdown.service'
 import {
   repairEditorialBlock,
@@ -20,7 +21,7 @@ type UseEditorialBlockActionsParams = {
 }
 
 function createEditorialBlockId() {
-  return `editorial_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+  return createStagedId('editorial')
 }
 
 export function useEditorialBlockActions({

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageContentBlockActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageContentBlockActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react'
 import type { ContentBlock, StagedArticle } from '../../../types'
+import { createStagedId } from '../create-staged-id'
 import {
   findHeaderSplitPoints,
   insertContentBlock,
@@ -21,7 +22,7 @@ type UseEditorialStageContentBlockActionsParams = {
 }
 
 function createContentBlockId() {
-  return `block_${Date.now()}`
+  return createStagedId('block')
 }
 
 export function useEditorialStageContentBlockActions({

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageMediaBlockActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageMediaBlockActions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import type { MediaAsset } from '../../../api'
 import type { StagedArticle } from '../../../types'
+import { createStagedId } from '../create-staged-id'
 import {
   removeMediaBlock,
   updateMediaGroupBlockCaption
@@ -19,7 +20,7 @@ type UseEditorialStageMediaBlockActionsParams = {
 }
 
 function createMediaBlockId() {
-  return `media_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+  return createStagedId('media')
 }
 
 export function useEditorialStageMediaBlockActions({


### PR DESCRIPTION
## Problem

```ts
function createContentBlockId() {
  return `block_${Date.now()}`   // two adds in one millisecond → same id
}
```

Blocks are keyed by id, and editorial blocks anchor to one via `afterBlockId`. A duplicate quietly ties unrelated content together: editing one block edits both, deleting one deletes both, and an anchored editorial block attaches to whichever wins the lookup.

Reachable by clicking **+** twice quickly, or any programmatic double-add.

## Change

`media_` and `editorial_` ids already avoided this with a timestamp + random suffix — content blocks were the single site that had drifted. Rather than copy the expression a third time, extract `createStagedId(prefix)` and point all three at it.

The helper adds a **monotonic counter**, which makes uniqueness exact rather than probabilistic within a session — and lets the test assert it without depending on `Math.random`. The random tail is kept for two tabs generating at the same instant.

## Notes for review

- **Id format changes** (`block_<ts>_<seq>_<rand>`). Safe: I grepped for any parsing of these strings and they are only ever compared. Existing persisted drafts keep their old ids and are unaffected — nothing re-derives them.
- **Cannot collide with the parser's positional ids.** `parseMarkdownToBlocks` emits `block_0`, `block_1`, … for freshly parsed articles; the new shape can never land on one. There's a test pinning that.
- **Out of scope, deliberately:** reset-to-original still re-anchors editorial blocks to the top of the article when their target id is gone. I traced it — `buildTimelineItems` hoists orphans into `editorialBeforeFirst` rather than dropping them, which is existing designed degradation, not a bug I should quietly change here.

## Verification

- `create-staged-id.test.ts` — 3 tests, including 1000 ids generated under a frozen clock (the exact case that used to collide).
- `vitest run` — 128 files / 564 tests (was 127/561). `eslint`, boundary check clean. `tsc --noEmit` still 7, same as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)