### PR TITLE
chore(abw): drop self-disarming General Notes tail from guidelines

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Beginner’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Beginner’s Guide.md
@@ -46,16 +46,3 @@ A beginner’s guide introduces a subject to readers who have little or no prior
 - Structure does not need to follow a rigid template; narrative storytelling, Q&A format or step‑by‑step lists are all acceptable if they support clarity.
     
 - Writers may incorporate personal anecdotes or analogies to engage readers, provided they serve the instructional purpose.
-
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Best Of.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Best Of.md
@@ -56,18 +56,3 @@ A “best of” article curates the **top recommendations** in a category. Reade
 ### Editorial Flexibility Notes
 
 Writers can decide whether to **rank** items or present them as unranked favourites. The number of picks can vary (Top 5, Top 10, Top 15, etc.), and the tone may range from playful to earnest. Creativity in angles—such as focusing on niche subcategories or blending humour with analysis—is encouraged. However, the list must still provide clear value: justify each choice and avoid filler entries. Freshness matters; revisit and update “best of” lists regularly to stay relevant.
-
----
-
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Buyer’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Buyer’s Guide.md
@@ -48,18 +48,3 @@ A buyer’s guide helps readers understand **what matters when choosing between 
 ### Editorial Flexibility Notes
 
 Writers don’t need to rigidly follow the exact order of the sections above. They can combine or expand sections depending on the complexity of the category or the audience’s sophistication. A buyer’s guide can be **agnostic** or **product‑specific**. Tone may vary from formal to conversational, but the narrative must always be **educational, neutral and helpful**. Long guides should be broken up with design elements, sidebars or linked companion pieces. Creativity in presentation is welcome as long as the essential questions are answered.
-
----
-
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Comparison Article (A vs. B).md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Comparison Article (A vs. B).md
@@ -48,18 +48,3 @@ Comparison articles help readers evaluate multiple options—products, services,
 - The tone should be neutral and informative, though injecting personality or humor is acceptable if it doesn’t compromise objectivity.
     
 - The conclusion can either declare a “winner” or emphasize that the best choice depends on individual needs. Both approaches are acceptable provided reasoning is transparent.
-    
-
----
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Cost Breakdown.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Cost Breakdown.md
@@ -50,19 +50,3 @@ A cost breakdown article **transparently details prices or budgets** so readers 
 ### Editorial Flexibility Notes
 
 Writers may choose a narrative or tabular format. The level of granularity depends on the complexity of the purchase—high‑stakes purchases warrant more detail. Tone can range from utilitarian to conversational, but clarity and honesty are non‑negotiable. Writers can incorporate personal anecdotes or expert quotes to illustrate cost considerations. Creative visualisations (e.g., pie charts) are welcome as long as they support rather than replace thorough explanation.
-
----
-
-These guidelines are intended to enable a later AI stage to judge whether a transcript contains enough information to produce a high‑quality article. They emphasise **completeness, clarity and reader value** over mechanical word counts or rigid templates. An article may deviate from these suggestions, but it should never omit the core informational elements that allow readers to make informed decisions.
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/FAQ Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/FAQ Article.md
@@ -46,17 +46,3 @@ A FAQ article compiles short, direct answers to common questions about a single 
 - The number of questions can vary widely. There’s no need to force a specific count—include as many as are genuinely useful.
     
 - Writers may choose to group questions by theme or chronology; both are acceptable if the logic is clear to readers
-
-
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/How-to Guides.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/How-to Guides.md
@@ -53,17 +53,3 @@
 - **Word count should not dictate quality.** Focus on completeness and reader comprehension rather than length. If the process is simple, a short guide is acceptable.
     
 - Creative flourishes (metaphors, analogies) can be used when they help demystify a task. However, avoid tangents that distract from the reader's goal or mislead about the complexity of the process.
-
-
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Myth‑Busting Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Myth‑Busting Article.md
@@ -48,16 +48,3 @@ Myth‑busting articles confront and correct common misconceptions or misinforma
 - Tone should be authoritative yet empathetic; avoid condescension that might alienate readers who hold the misconception.
     
 - Use storytelling or analogies to engage readers, but ensure narratives serve the purpose of explaining the fallacy rather than distracting from it.
-    
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Review.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Review.md
@@ -54,17 +54,3 @@ A review evaluates a single product, service or place in depth to help readers d
 ### Editorial Flexibility Notes
 
 Reviews can vary in tone—from conversational to technical—and may include humour or personal anecdotes. They can be structured with or without formal section headings, but they **must remain transparent and honest**. Affiliate links are acceptable, but the writer should disclose them and maintain independence. Multimedia elements and rating scales are optional, but the core analysis should not be reduced to a score; readers should understand the reasons behind the rating. Writers can focus on aspects most relevant to their audience but should always give enough context for informed decision‑making.
-
----
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Roundup.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Roundup.md
@@ -58,18 +58,3 @@ A roundup is a **curated overview of multiple options** within a product or serv
 ### Editorial Flexibility Notes
 
 Roundups can range from **short lists of three to five items** to long curated guides. The writer can choose to rank entries, group them by themes or simply present them in alphabetical order. Tone may be informal and conversational or more formal depending on the publication. Including multimedia, expert quotes or charts can increase engagement. Creativity in angles—such as focusing on unexpected criteria or including contrarian picks—helps roundups stand out, but writers must always provide clear reasons for inclusion.
-
----
-
-## General Notes 
-
-- **Reader focus:** Regardless of article type, content must be tailored to the target audience’s knowledge level and interests. Avoid jargon, or define it when unavoidable.
-    
-- **Evidence and citations:** Whenever factual claims are made, they should be supported by credible sources. Linking to primary studies, reputable news sites or official documents enhances trust.
-    
-- **Narrative flow:** Each article should have a clear beginning, middle and end. Even FAQ and pros/cons lists benefit from short introductions and conclusions to frame the content.
-    
-- **Avoid redundancy:** Ensure that points are not repeated without adding new information. Repetition can indicate that the transcript lacks sufficient detail and may need enrichment.
-    
-
-These guidelines provide qualitative standards rather than rigid templates, enabling writers and AI systems to craft varied yet high‑quality articles across different formats. Use them to assess whether a transcript contains the necessary material or requires supplementation through research or additional context.


### PR DESCRIPTION
## What

Removes an identical ~11-line `## General Notes` boilerplate tail from 10 article-type guideline files.

## Why

These files are read verbatim off disk and interpolated into five LLM prompts (coverage check, outline, compose, audit/repair, title). The tail worked against all of them:

- **Restated hardcoded rules.** "Each article should have a clear beginning, middle and end", "Avoid jargon" — `P2B_COMPOSE_PROMPT` already mandates these, so repeating them only dilutes each file's type-specific signal.
- **Requested unproduceable output.** "Linking to primary studies, reputable news sites or official documents" — compose emits markdown prose only.
- **Disarmed the judge.** It closed with *"These guidelines provide qualitative standards rather than rigid templates"*, appended to the exact text the audit prompt scores `guideline_coverage_score` against. That score is the tie-break in `_quality_rank` (`policies.py:18-25`), so it decides which draft ships.

`Cost Breakdown.md` carried the block twice, plus its own duplicate closing paragraph.

## Scope

Markdown only — no code, no behaviour flags. Files affected:

Beginner's Guide, Best Of, Buyer's Guide, Comparison Article (A vs. B), Cost Breakdown, FAQ Article, How-to Guides, Myth-Busting Article, Review, Roundup.

## Verification

No test asserts on guideline file contents — `test_article_types_routes.py` and `test_youtube2blog_stage3_facade.py` monkeypatch the directories to `tmp_path`. Guideline-coupled suites pass (23 tests). Full baseline before this change: pytest green, vitest 133 files / 600 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)