### PR TITLE
fix(abw): drop output asks the composer cannot produce from guidelines

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Adventure Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Adventure Guide.md
@@ -29,7 +29,7 @@ An adventure guide aims to inspire and equip readers to undertake specific outdo
     
 - **Environmental stewardship and sustainability:** Explain conservation efforts, trail maintenance programs or how tourism supports local economies. Encourage readers to minimize environmental impact.
     
-- **Gear reviews or packing lists:** A sidebar with recommended gear brands, packing checklist or budget ranges can be useful for readers planning their own trips.
+- **Gear reviews or packing lists:** Recommended gear brands, a packing checklist or budget ranges can be useful for readers planning their own trips.
     
 - **Personal anecdotes and challenges:** A brief story of overcoming an obstacle (e.g., unexpected storm, altitude sickness) can illustrate preparation and resilience.
     
@@ -57,6 +57,6 @@ An adventure guide aims to inspire and equip readers to undertake specific outdo
     
 - The level of technicality should suit the target audience. Beginners appreciate accessible explanations, while seasoned adventurers may desire more technical detail. Writers can choose their angle but must signal the intended audience.
     
-- Creativity is encouraged—integrate quotes, sidebars, maps or multimedia. However, avoid hyperbole and clichés; unique descriptions and candid observations will differentiate the piece.
+- Creativity is encouraged—integrate quotes. However, avoid hyperbole and clichés; unique descriptions and candid observations will differentiate the piece.
     
 - Always prioritize safety and sustainability. Articles should inspire readers to explore responsibly and respect local communities and environments.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Beginner’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Beginner’s Guide.md
@@ -19,11 +19,9 @@ A beginner’s guide introduces a subject to readers who have little or no prior
 
 - **Analogies and real‑world examples:** These make abstract concepts relatable and help beginners grasp ideas more easily.
     
-- **Visuals and diagrams:** Charts, screenshots or simple diagrams can clarify complex information.
-    
 - **Common pitfalls:** Briefly mention frequent mistakes beginners make and how to avoid them.
     
-- **Links to further resources:** Point readers to reputable tutorials, books, or websites for continued learning. If external research is incorporated, clearly cite it.
+- **Further resources:** Point readers to reputable tutorials, books, or websites for continued learning. If external research is incorporated, clearly cite it.
     
 
 ### Signs the Source Material Is Insufficient

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Best Of.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Best Of.md
@@ -31,11 +31,7 @@ A “best of” article curates the **top recommendations** in a category. Reade
 
 ### Optional Enhancing Elements
 
-- **Data visualisations:** Use charts or infographics to illustrate rankings or scoring.
-    
 - **Historical or cultural context:** Briefly mention how trends have evolved or why certain items are popular now.
-    
-- **Mini‑reviews:** Link to full reviews for readers who want deeper analysis.
     
 - **Quotes or anecdotes:** Use brief quotes from experts or users for colour.
     

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Buyer’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Buyer’s Guide.md
@@ -27,7 +27,7 @@ A buyer’s guide helps readers understand **what matters when choosing between 
 
 - **Market and trend context:** Briefly describe industry trends or recent innovations that shape buyer expectations.
     
-- **Glossaries, templates or sidebars:** Supplemental tools (like checklists or glossaries) can sit in sidebars or appendices to keep the main narrative lean.
+- **Glossaries or templates:** Supplemental tools (like checklists or glossaries) can sit in appendices to keep the main narrative lean.
     
 - **Comparisons or competitor snapshots:** Short comparisons to alternative solutions or approaches can increase trust as long as they remain neutral.
     
@@ -47,4 +47,4 @@ A buyer’s guide helps readers understand **what matters when choosing between 
 
 ### Editorial Flexibility Notes
 
-A buyer’s guide can be **agnostic** or **product‑specific**. The narrative must always be **educational, neutral and helpful**. Long guides should be broken up with design elements, sidebars or linked companion pieces. Creativity in presentation is welcome as long as the essential questions are answered.
+A buyer’s guide can be **agnostic** or **product‑specific**. The narrative must always be **educational, neutral and helpful**. Creativity in presentation is welcome as long as the essential questions are answered.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Case Study.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Case Study.md
@@ -19,7 +19,7 @@ A case study demonstrates **how a specific problem was solved**, typically for b
 
 ### Optional Enhancing Elements
 
-- **Visuals or tables** that summarise key metrics or before‑and‑after comparisons.
+- **Tables** that summarise key metrics or before‑and‑after comparisons.
     
 - **Quotes from stakeholders** (client, team members, customers) to humanize the story and provide social proof.
     

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Checklist.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Checklist.md
@@ -19,9 +19,7 @@ A checklist article provides readers with a clear, scannable list of tasks or it
 
 - **Tips or recommendations** – Offer short tips for selecting or using items (e.g., choose neutral‑colored clothes for versatility, pack a portable charger).
     
-- **Visual aids** – A printable table or simple infographic summarizing the checklist can enhance usability.
-    
-- **Links to related resources** – Provide internal links to deeper articles (e.g., a guide to money belts or medications) when appropriate.
+- **Summary table** – A table summarizing the checklist can enhance usability.
     
 
 ### Signs the source material is insufficient

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Comparison Article (A vs. B).md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Comparison Article (A vs. B).md
@@ -23,7 +23,7 @@ Comparison articles help readers evaluate multiple options—products, services,
     
 - **User scenarios or case studies:** Illustrate how different users might experience each option, which helps readers envision their own use case.
     
-- **Visual aids:** Tables or charts comparing features side‑by‑side can enhance comprehension.
+- **Comparison tables:** A table comparing features side‑by‑side can enhance comprehension.
     
 - **Expert or user quotes:** Credible testimonials can add nuance to the evaluation, provided sources are cited.
     

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Cost Breakdown.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Cost Breakdown.md
@@ -25,7 +25,7 @@ A cost breakdown article **transparently details prices or budgets** so readers 
 
 ### Optional Enhancing Elements
 
-- **Visual aids:** Use tables, charts or diagrams to make numbers easier to digest. Visuals help clarify how different components contribute to the total.
+- **Tables:** Use tables to make numbers easier to digest. Tables help clarify how different components contribute to the total.
     
 - **Case studies or examples:** Include a short vignette demonstrating how the costs play out in a real situation.
     
@@ -49,4 +49,4 @@ A cost breakdown article **transparently details prices or budgets** so readers 
 
 ### Editorial Flexibility Notes
 
-Writers may choose a narrative or tabular format. The level of granularity depends on the complexity of the purchase—high‑stakes purchases warrant more detail. Clarity and honesty are non‑negotiable. Writers can incorporate expert quotes to illustrate cost considerations. Creative visualisations (e.g., pie charts) are welcome as long as they support rather than replace thorough explanation.
+Writers may choose a narrative or tabular format. The level of granularity depends on the complexity of the purchase—high‑stakes purchases warrant more detail. Clarity and honesty are non‑negotiable. Writers can incorporate expert quotes to illustrate cost considerations.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Destination Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Destination Guide.md
@@ -19,7 +19,7 @@ Destination guides provide a comprehensive overview of a place—ranging from to
 
 ### Optional enhancing elements
 
-- **Maps and itineraries** – Embed a simple map or suggest sample routes to help readers visualize where things are located.
+- **Sample itineraries** – Suggest sample routes to help readers visualize where things are located.
     
 - **Historical or cultural background** – Brief history or context about the destination's development, traditions or local customs.
     
@@ -43,4 +43,4 @@ Destination guides provide a comprehensive overview of a place—ranging from to
 
 ### Editorial flexibility notes
 
-Ensure clarity by using consistent headings and avoid overloading readers with exhaustive lists; prioritize quality recommendations and provide links for deeper research.
+Ensure clarity by using consistent headings and avoid overloading readers with exhaustive lists; prioritize quality recommendations.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Disqualifiers.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Disqualifiers.md
@@ -24,8 +24,6 @@
 
 **Optional Enhancing Elements**
 
-- **Interactive checklists or self‑assessment:** A yes/no questionnaire can help readers quickly determine fit.
-    
 - **Expert or user quotes:** Hearing from someone who faced a misfit scenario lends authenticity.
     
 - **Transparency about motives:** Explaining why you are disqualifying readers (to save their time, to uphold ethical standards, etc.) strengthens trust.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Explainer.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Explainer.md
@@ -17,8 +17,6 @@ Explainers **break down complex topics or news events into clear, accessible lan
 - **Use of Evidence and Expert Insight.** Incorporate data, research and quotes from subject‑matter experts to support explanations.
     
 - **Structure for Readability.** Divide the article into bite‑sized sections with clear sub‑headings; question‑based sub‑heds are common.
-    
-- **Visual Aids.** Charts, diagrams, timelines or other graphics can clarify the explanation.
 
 
 ### Optional Enhancing Elements
@@ -27,9 +25,7 @@ Explainers **break down complex topics or news events into clear, accessible lan
     
 - **FAQs or myth‑busting sections** that address common misconceptions.
     
-- **Interactive elements**, such as embedded calculators or quizzes.
-    
-- **Links to further reading** or authoritative sources for readers who want deeper detail.
+- **Authoritative sources** for readers who want deeper detail.
     
 - **Case examples or anecdotes** that illustrate how the concept applies in real life.
 
@@ -49,4 +45,4 @@ Explainers **break down complex topics or news events into clear, accessible lan
 
 ### Editorial Flexibility Notes
 
-Some explainers use chronological narratives, while others adopt Q&A or thematic structures. Writers should choose the structure that best helps readers grasp the material. Headings and sub‑heds often take the form of questions. The focus should be on clarity and reader comprehension. When appropriate, incorporate multimedia, data visualization and interactive components to enrich the explanation
+Some explainers use chronological narratives, while others adopt Q&A or thematic structures. Writers should choose the structure that best helps readers grasp the material. Headings and sub‑heds often take the form of questions. The focus should be on clarity and reader comprehension.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/FAQ Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/FAQ Article.md
@@ -8,13 +8,13 @@ A FAQ article compiles short, direct answers to common questions about a single 
 
 - **List of relevant questions:** Identify the most frequently asked questions through user feedback, support tickets or community forums.
     
-- **Concise answers:** Provide clear, to‑the‑point responses. If a question requires extensive detail, link to a more comprehensive resource instead of overloading the answer.
+- **Concise answers:** Provide clear, to‑the‑point responses.
     
 - **Logical organization:** Arrange questions in a sequence that makes sense—group by theme or move from general to specific.
     
 - **Descriptive headings:** Use the questions themselves as section headings (usually H2). This helps users scan and find relevant information quickly.
     
-- **Links to further reading:** Where appropriate, include links to in‑depth articles, documentation or external sources for readers seeking more detail.
+- **Further reading:** Where appropriate, cite in‑depth articles, documentation or external sources for readers seeking more detail.
     
 
 ### Optional Enhancing Elements

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Feature Story.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Feature Story.md
@@ -21,13 +21,11 @@ A feature story tells a **compelling narrative** about people, trends or issues.
 
 ### Optional Enhancing Elements
 
-- **Data visualizations or research findings** that support the theme.
+- **Research findings** that support the theme.
     
 - **Historical background** to show how the issue evolved.
     
-- **Sidebars or profiles** of additional characters.
-    
-- **Multimedia**, such as photos or audio snippets, to immerse readers.
+- **Profiles** of additional characters.
     
 - **Foreshadowing or literary techniques** to heighten narrative tension.
 

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/How-to Guides.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/How-to Guides.md
@@ -26,7 +26,7 @@
 
 **Optional Enhancing Elements**
 
-- **Visuals and examples:** Screenshots, diagrams or brief anecdotes make abstract instructions concrete. ClickHelp's tutorial recommends incorporating visuals to improve comprehension, and Indeed notes that examples help readers connect instructions to real situations.
+- **Examples:** Brief anecdotes make abstract instructions concrete. Indeed notes that examples help readers connect instructions to real situations.
     
 - **Background context:** A short explanation of why the task matters can motivate readers and provide perspective.
     

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Interview Articles.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Interview Articles.md
@@ -28,11 +28,9 @@
 
 - **Scene‑setting details:** Describe the interview setting or the interviewee's demeanor to create atmosphere.
     
-- **Contextual sidebars:** Brief explanations of references made by the interviewee can help readers unfamiliar with certain topics.
+- **Contextual explanations:** Brief explanations of references made by the interviewee can help readers unfamiliar with certain topics.
     
 - **Narrator's reflection:** The interviewer may weave in reflections or connect interviewee remarks to broader themes.
-    
-- **Multimedia:** Audio clips or video snippets of the interview can enrich digital articles.
     
 - **Humour and personality:** Brafton encourages starting with a hook and using a conversational tone; sprinkling in personality and anecdotes can make the piece more engaging.
 

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Itinerary Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Itinerary Article.md
@@ -14,9 +14,9 @@ An itinerary article presents a day‑by‑day or step‑by‑step travel plan, 
         
     - **Timing and pacing** – Indicate approximate time blocks (morning/afternoon/evening) or durations to help readers understand how long activities may take.
         
-    - **Geographic logic** – Cluster activities by location to minimize transit time, using maps or grouping neighborhoods.
+    - **Geographic logic** – Cluster activities by location to minimize transit time, grouping neighborhoods.
         
-    - **Logistical details** – Provide essential information such as opening hours, required reservations, transit tips, admission costs and addresses. Including flight numbers, hotel addresses or map links can be valuable.
+    - **Logistical details** – Provide essential information such as opening hours, required reservations, transit tips, admission costs and addresses. Including flight numbers or hotel addresses can be valuable.
         
     - **Meals and breaks** – Suggest where to eat or relax, reflecting local cuisine or notable cafes.
         
@@ -29,8 +29,6 @@ An itinerary article presents a day‑by‑day or step‑by‑step travel plan, 
 
 ### Optional enhancing elements
 
-- **Maps and calendar visuals** – A visual schedule or map illustrating the route enhances comprehension.
-    
 - **Variation suggestions** – Offer alternatives (e.g., swap a museum for a hike) for different travelers or weather.
     
 - **Budget and packing tips** – Briefly note estimated daily costs and any special items to pack for the itinerary.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Listicle.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Listicle.md
@@ -23,10 +23,6 @@ A listicle presents **information in a list‑based format**, making it easy to 
 
 - **Relevant statistics, examples or anecdotes** to illustrate each item.
     
-- **Links to additional resources** for deeper reading.
-    
-- **Images or icons** associated with each item to aid visual scanning.
-    
 - **Sections within long lists**, breaking a long list into thematic sub‑lists to improve readability.
     
 - **SEO keywords** to increase discoverability.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Myth‑Busting Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Myth‑Busting Article.md
@@ -23,9 +23,7 @@ Myth‑busting articles confront and correct common misconceptions or misinforma
     
 - **Case studies and examples:** Provide real‑world examples where the myth has caused harm or confusion, and show how correct information improves outcomes.
     
-- **Visual aids:** Charts or infographics can illustrate data that counters myths and aid comprehension.
-    
-- **Additional resources:** Link to studies, expert statements, or institutional reports for readers who want deeper evidence.
+- **Additional resources:** Cite studies, expert statements, or institutional reports for readers who want deeper evidence.
     
 
 ### Signs the Source Material Is Insufficient

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/News Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/News Article.md
@@ -27,11 +27,7 @@ A news article exists to **report timely events or announcements succinctly and 
     
 - **Multiple viewpoints**, including comments from different stakeholders, to provide balance.
     
-- **Visuals** such as charts, timelines or photos to illustrate the event.
-    
-- **Sidebar or box** providing background information or related resources.
-    
-- **Links to original documents or sources**, where appropriate.
+- **References to original documents or sources**, where appropriate.
 
 
 ### Signs the Source material Is Insufficient

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Opinion Pieces.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Opinion Pieces.md
@@ -31,10 +31,6 @@
 - **Anecdotes and storytelling:** Vivid examples help readers remember arguments.
     
 - **Humour or irony:** When appropriate, a light touch can make serious points more digestible.
-    
-- **Data visualisations or sidebars:** Charts or brief call‑out boxes can illustrate key statistics or quotes.
-    
-- **Multimedia elements:** In digital formats, embedded videos or audio clips can enhance persuasion.
 
 
 **Signs the Source Material Is Insufficient**

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Packing Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Packing Guide.md
@@ -24,8 +24,6 @@
 
 - Tips for reducing luggage weight (e.g., wearing bulkiest items, laundry options).
     
-- Digital checklists or printable templates.
-    
 - Fashion capsules or sample outfits to illustrate mix‑and‑match principles.
     
 - Environmental considerations such as avoiding disposable plastics and packing reusable bags or utensils.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Resource List.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Resource List.md
@@ -14,7 +14,7 @@ Resource lists curate tools, websites, services or references on a specific topi
     
 - **Consistent formatting** – Use bullets or numbered entries with uniform presentation. Consistency helps readers compare options quickly.
     
-- **Links or references** – Provide direct links (where appropriate) so readers can easily access each resource. Ensure the titles accurately reflect the linked content and avoid misleading clickbait.
+- **References** – Name each resource clearly so readers can find it. Ensure the titles accurately reflect the resource and avoid misleading clickbait.
     
 
 ### Optional enhancing elements
@@ -22,8 +22,6 @@ Resource lists curate tools, websites, services or references on a specific topi
 - **Evaluative commentary** – Briefly note pros and cons or situations for which a resource is best suited.
     
 - **Comparison highlights** – For similar resources, mention distinguishing features (e.g., cost, regional focus, user friendliness).
-    
-- **Multimedia embeds** – Screenshots, logos or icons can increase visual interest but should not clutter the list.
     
 - **Supplementary tips** – Offer advice on how to choose among the resources or combine them effectively.
     
@@ -41,4 +39,4 @@ Resource lists curate tools, websites, services or references on a specific topi
 
 ### Editorial flexibility notes
 
-Avoid overt bias. Longer lists should keep descriptions brief and may link to deeper articles for extra details. Maintain readability with short paragraphs and ensure the title accurately reflects the list's scope.
+Avoid overt bias. Longer lists should keep descriptions brief. Maintain readability with short paragraphs and ensure the title accurately reflects the list's scope.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Review.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Review.md
@@ -10,7 +10,7 @@ A review evaluates a single product, service or place in depth to help readers d
     
 2. **User‑centric evaluation:** Assess the product from the reader’s point of view, showing that you understand typical use cases and decision criteria.
     
-3. **Demonstrate expertise:** Explain why you are qualified to review this item—through professional experience or extensive research—and provide evidence such as photos, audio clips or links that show real‑world testing.
+3. **Demonstrate expertise:** Explain why you are qualified to review this item—through professional experience or extensive research.
     
 4. **Quantitative measurements:** Share data on how the product measures up in key performance categories (e.g., battery life, sound quality, comfort). Use numbers, ratings or benchmarks.
     
@@ -24,13 +24,11 @@ A review evaluates a single product, service or place in depth to help readers d
     
 9. **Decision factors and recommendation:** Highlight the most important factors for the reader’s decision (e.g., fuel economy and safety in a car review) and conclude with a clear verdict or recommendation. If recommending the product as “best overall” or “best for a use case,” explain why and provide evidence.
     
-10. **Resource links and purchasing options:** Include links to additional resources and, if appropriate, multiple sellers so readers can explore further.
+10. **Purchasing options:** Mention, if appropriate, multiple sellers so readers can explore further.
     
 
 ### Optional Enhancing Elements
 
-- **Visuals and multimedia:** Original photos, charts, unboxing videos or audio samples that bring the experience to life.
-    
 - **User anecdotes:** Short stories or quotes from real users can provide additional perspectives and social proof.
     
 - **Comparison tables:** Summaries of how the product stacks up against competitors on key metrics.
@@ -53,4 +51,4 @@ A review evaluates a single product, service or place in depth to help readers d
 
 ### Editorial Flexibility Notes
 
-Reviews can be structured with or without formal section headings, but they **must remain transparent and honest**. Affiliate links are acceptable, but the writer should disclose them and maintain independence. Multimedia elements and rating scales are optional, but the core analysis should not be reduced to a score; readers should understand the reasons behind the rating. Writers can focus on aspects most relevant to their audience but should always give enough context for informed decision‑making.
+Reviews can be structured with or without formal section headings, but they **must remain transparent and honest**. Affiliate links are acceptable, but the writer should disclose them and maintain independence. Rating scales are optional, but the core analysis should not be reduced to a score; readers should understand the reasons behind the rating. Writers can focus on aspects most relevant to their audience but should always give enough context for informed decision‑making.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Roundup.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Roundup.md
@@ -35,7 +35,7 @@ A roundup is a **curated overview of multiple options** within a product or serv
     
 - **Keyword and search context:** Briefly note why the topic matters or what search trends reveal about reader interest.
     
-- **Visuals and tables:** Provide quick‑reference tables summarising key specs or ratings, or include photos of the products.
+- **Tables:** Provide quick‑reference tables summarising key specs or ratings.
     
 - **Buyer’s tips:** Offer advice on how to choose among the options or what to watch out for.
     
@@ -57,4 +57,4 @@ A roundup is a **curated overview of multiple options** within a product or serv
 
 ### Editorial Flexibility Notes
 
-The writer can choose to rank entries, group them by themes or simply present them in alphabetical order. Including multimedia, expert quotes or charts can increase engagement. Creativity in angles—such as focusing on unexpected criteria or including contrarian picks—helps roundups stand out, but writers must always provide clear reasons for inclusion.
+The writer can choose to rank entries, group them by themes or simply present them in alphabetical order. Including expert quotes can increase engagement. Creativity in angles—such as focusing on unexpected criteria or including contrarian picks—helps roundups stand out, but writers must always provide clear reasons for inclusion.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Safety Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Safety Guide.md
@@ -131,8 +131,8 @@ When relevant, include:
 - embassy or consular support
 - insurance considerations
 - helpful local phrases for getting assistance
-- official maps, evacuation routes, or hazard zones
-- visual markers readers can use to identify legitimate services
+- evacuation routes or hazard zones
+- identifying features readers can use to recognise legitimate services
 
 ## Minimum Standard
 

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Survival Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Survival Guide.md
@@ -23,9 +23,7 @@ A survival guide delivers practical advice and critical information to help read
 
 - **Real‑world examples or anecdotes** – Short stories about successful or failed survival attempts can illustrate the importance of preparation and make advice memorable.
     
-- **Illustrations or diagrams** – Visual aids showing how to tie knots, build shelters or read a compass can enhance comprehension.
-    
-- **Additional resources** – Links to more detailed manuals, courses or safety organizations.
+- **Additional resources** – References to more detailed manuals, courses or safety organizations.
     
 - **Seasonal or regional variations** – Customizing gear lists and advice for specific climates or environments (e.g., desert vs. alpine) enriches the guide.
     
@@ -43,4 +41,4 @@ A survival guide delivers practical advice and critical information to help read
 
 ### Editorial flexibility notes
 
-Survival guides should be pragmatic and safety‑focused. Balance brevity with completeness: key instructions must be clear, but additional commentary can be placed in sidebars or optional sections.
+Survival guides should be pragmatic and safety‑focused. Balance brevity with completeness: key instructions must be clear, but additional commentary can be placed in optional sections.

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Travel Diary.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Travel Diary.md
@@ -28,7 +28,7 @@
     
 - **Practical tips** – Offer incidental advice (e.g., best time to visit a landmark, where to find authentic food) when it naturally fits into the story.
     
-- **Photos or ephemera references** – Mention items collected along the way (ticket stubs, brochures, receipts) to add authenticity and evoke memories.
+- **Ephemera references** – Mention items collected along the way (ticket stubs, brochures, receipts) to add authenticity and evoke memories.
 
 
 ### Signs the Source Material Is Insufficient

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/When to Visit Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/When to Visit Article.md
@@ -24,7 +24,7 @@
 
 ### Optional Enhancing Elements
 
-- **Climate charts or tables** – Simple visuals summarising temperature, rainfall and daylight hours by month can aid planning.
+- **Climate tables** – A simple table summarising temperature, rainfall and daylight hours by month can aid planning.
     
 - **Sample itineraries** – Suggest season‑specific activities or itineraries (e.g., winter skiing vs. summer festivals).
     


### PR DESCRIPTION
## What

Removes requests for output the composer physically cannot emit, across 28 of 42 article-type guideline files. **+37 / −79.**

## Why

`P2B_COMPOSE_PROMPT` returns one JSON field — `improved_content` — containing markdown prose. There is no image, embed, widget, or link-resolution capability anywhere in the stage.

28 files listed such things as content expectations. Two distinct costs:

1. **It permanently depresses the score that picks the winning draft.** The audit judge scores `guideline_coverage_score` against this text and can only ever mark these items as missing. That score is the tie-break in `_quality_rank` (`policies.py:18-25`), so it decides which draft ships out of the keep-best loop.
2. **It induces phantom references.** The model would sometimes write "see the table below" or "as the chart shows" with no such artifact in the output.

## Categories removed

- **Graphics:** charts, pie charts, infographics, diagrams, timelines, screenshots, logos, icons, photos, maps, data visualisations, unboxing videos, audio clips
- **Interactive:** embedded calculators, quizzes, self-assessment questionnaires, printable templates, digital checklists
- **Page furniture:** sidebars, call-out boxes
- **Resolvable hyperlinks:** "provide direct links", "links to further reading", "internal links to deeper articles", "links to primary studies"

## Deliberately kept

- **Markdown tables — the composer can emit these.** 10 table mentions survive, reframed away from graphic framing where they were mixed: `Cost Breakdown.md` "Visual aids: Use tables, charts or diagrams… Visuals help clarify" → "**Tables:** Use tables to make numbers easier to digest. Tables help clarify".
- **Naming sources in prose.** "cite the source", "attribute to named sources", "name the official issuing authority" all stay — only the hyperlink framing goes. `FAQ Article.md` "include links to in-depth articles" → "cite in-depth articles".
- `Where to Stay Guide.md` is untouched — its `key_takeaways_box` / `in_the_know_box` / `faq_block` block is a separate, different bug handled in a follow-up PR.

## One rubric correction worth noting

My original cut list named `Safety Guide.md`'s *"visual markers readers can use to identify legitimate services"*. That was a mis-classification — it asks the article to **describe** recognisable real-world cues in prose (licensed-taxi livery, official medallion numbers), which is precisely the concrete, checkable detail these files are short on. It's retained, reworded to "identifying features" to remove the graphic ambiguity.

Also kept: `Checklist.md`'s "readers may use the article as a reference or printable list" — that describes what a reader does with the finished piece, not an artifact the composer must produce.

## Verification

- 492 backend tests pass.
- No section was emptied, so no headings removed.
- Trailing-newline state byte-identical to HEAD for all 28 files (14 of them intentionally end without one); 4-space bullet padding, curly apostrophes, non-breaking hyphens and `\xa0` heading characters all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)