### PR TITLE
fix(abw): make Where to Stay's required components satisfiable

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Where to Stay Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Where to Stay Guide.md
@@ -57,19 +57,21 @@ The guide should follow the reader's actual decision flow: **Where** should I st
 Each neighborhood profile must include at least one concrete, verifiable detail that a generic AI-written or scraped guide wouldn't have — a specific street, a named café or market as a landmark, a local quirk (e.g., "the 7 a.m. bell from San Giorgio will wake you if you stay east of the canal"). Recommendations should be grounded in personal experience, local sources, or cited reporting — not vague impressions.
 
 
-### Required Editorial Components
+### Required Coverage
 
-- **key_takeaways_box** – Mandatory. Place near the top. Use it as an at-a-glance traveler-type → neighborhood matchup so decision-shoppers get value without scrolling.
+Write each of these into the article body as prose, a short list, or a table.
 
-- **in_the_know_box** – Mandatory. This is the natural home for local tips and cultural context: tipping norms, check-in customs, unique lodging experiences (ryokan etiquette, riad layouts), local regulations (short-term rental rules, tourist taxes), or neighborhood quirks.
+- **An at-a-glance matchup near the top.** A traveler-type → neighborhood pairing, so decision-shoppers get value without scrolling. A compact table suits this well.
 
-- **faq_block** – Mandatory. Short Q&A covering the most common traveler-type questions: "Best area for families?" "Best for nightlife?" "Where to stay without a car?" "Is X neighborhood safe at night?"
+- **A local-knowledge section.** Tipping norms, check-in customs, unique lodging experiences (ryokan etiquette, riad layouts), local regulations (short-term rental rules, tourist taxes), and neighborhood quirks.
 
-### Optional Editorial Components
+- **A traveler-question Q&A.** Short answers to the questions readers actually arrive with: "Best area for families?" "Best for nightlife?" "Where to stay without a car?" "Is X neighborhood safe at night?"
 
-- **highlight_callout** – Use for a standout property, a seasonal warning, or a specific booking window worth flagging. Don't force it — manufactured emphasis weakens the guide.
+### Optional Emphasis
 
-- **pull_quote** – Only use when there's a genuinely quotable line from a local, the writer's experience, or a traveler — not a fabricated or filler quote.
+- **A standout flag.** Worth calling out: a standout property, a seasonal warning, or a specific booking window. Don't force it — manufactured emphasis weakens the guide.
+
+- **A quoted line.** Only when the source material contains a genuinely quotable line — never a fabricated or filler quote.
 
 
 ### What NOT to Do


### PR DESCRIPTION
## The bug

`Where to Stay Guide.md` marked three editorial components **Mandatory** — `key_takeaways_box`, `in_the_know_box`, `faq_block`. Nothing in the system could satisfy them.

**The text never reaches a stage that can emit components.** The guideline is injected into five prompts (coverage check, outline, compose, audit, repair). None can produce an editorial component. The stage that *can* — prompt2blog's editorial augmentation — interpolates only `{title_guideline}` and never `{guideline}` (`prompts/editorial.py`). The requirement was invisible to the only stage able to honour it.

**It also contradicts that stage's policy.** The augmentation prompt is deliberately built around restraint:

> "Optionally add high-signal editorial components…"
> "Do not add a component unless it measurably improves comprehension, pacing, or emphasis."
> "Use restraint: one component is common, two is acceptable, more is rare."

Three *mandatory* boxes would fight that policy even if the text did arrive.

**The cost.** The audit judge scored `guideline_coverage_score` against a file demanding three artifacts the draft provably could not contain. That score is the keep-best tie-break in `_quality_rank` (`policies.py:18-25`), so it penalised every Where to Stay draft identically and injected noise into which draft ships.

## The fix

Rewrites the block as prose coverage requirements the composer can satisfy inside `improved_content`, preserving the editorial intent:

| Was | Now |
|---|---|
| `key_takeaways_box` – Mandatory | "An at-a-glance matchup near the top" (notes a compact table suits it) |
| `in_the_know_box` – Mandatory | "A local-knowledge section" — same content: tipping norms, check-in customs, ryokan etiquette, tourist taxes |
| `faq_block` – Mandatory | "A traveler-question Q&A" — same four worked questions |

Headings become "Required Coverage" and "Optional Emphasis".

## Two notes

- **No code change.** `EDITORIAL_COMPONENT_LABELS` and the component keys are untouched — the augmentation stage still adds components at its own discretion, which is the correct owner of that decision.
- The `pull_quote` line previously permitted a quote from *"the writer's experience"*. Since the line was being rewritten anyway, it's now sourced from the source material, closing an invented-quote path.

## Verification

492 backend tests pass. Zero remaining component-key mandates in any guideline file; component keys still present in `config.py` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)