### PR TITLE
fix(abw): stop guidelines leaking baked-in facts across destinations

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Budget Travel Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Budget Travel Guide.md
@@ -9,7 +9,7 @@
 
 ### Core Content Expectations
 
-- **Typical costs and budget tiers** – Provide ballpark figures for accommodation (hostel dorms, private rooms, motels, budget hotels, camping), food (street food, groceries, restaurant meals) and transportation. For example, U.S. hostel dorms often cost $25–55, budget hotels $90–125 per night and camping $20–30. Describe suggested budgets (backpacker vs. midrange vs. upscale) and what each includes (hostel dorm with cooking vs. midrange hotels with some dining out).
+- **Typical costs and budget tiers** – Provide ballpark figures for accommodation (hostel dorms, private rooms, motels, budget hotels, camping), food (street food, groceries, restaurant meals) and transportation. Give figures only where the source material supplies them, in the destination's currency, and state what each one covers (per person, per night, per day). Where the source material has no figures, say costs are unconfirmed rather than supplying them. Describe suggested budgets (backpacker vs. midrange vs. upscale) and what each includes (hostel dorm with cooking vs. midrange hotels with some dining out).
     
 - **Money‑saving strategies** – Recommend strategies such as traveling in off‑peak or shoulder seasons; being flexible with dates and destinations; signing up for deal alerts; using cash‑back sites; comparing flight prices; booking flights or trains early; and opting for budget airlines or buses. Encourage slower travel and longer stays to reduce transportation costs and access weekly discounts.
     

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Packing Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Packing Guide.md
@@ -13,7 +13,7 @@
     
 - **Categories of essentials.** Expect at minimum: clothing (mix‑and‑match layers, neutral colours, quick‑dry materials), toiletries, electronics (chargers, adapters, power bank) and travel documents. Packing lists like SmarterTravel's highlight customizing the categories and using checklists.
     
-- **Luggage strategy.** Discuss the benefits of carry‑on‑only travel, using a 35–40 L backpack plus daypack and packing cubes. Stress not overpacking; only pack items used regularly and opt for versatile, quality gear.
+- **Luggage strategy.** Discuss the benefits of carry‑on‑only travel, stating a bag capacity in litres only when the source material or the trip profile supports it, plus daypack and packing cubes. Stress not overpacking; only pack items used regularly and opt for versatile, quality gear.
     
 - **Activity‑specific gear.** The source material should cover specialized gear for adventure activities—cycling, kayaking, hiking or skiing—and emphasize safety equipment like helmets, hydration packs, bug spray and headlamps.
     

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/Visa & Entry Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/Visa & Entry Guide.md
@@ -9,15 +9,21 @@
 
 ### Core Content Expectations
 
-- **Research and planning.** The guide should instruct readers to check official travel advisories, destination entry and exit requirements, and local laws. It should emphasise enrolling in services like the U.S. STEP program for alerts and having copies of passports, visas and essential documents.
+- **Every requirement must be sourced or flagged as unverified.** No fee, threshold, processing time, visa type or eligibility rule may appear in the article unless the source material states it. Where the source material is silent, say the requirement could not be confirmed and direct the reader to the named official authority — the destination's immigration department, embassy or consulate — rather than supplying a figure.
     
-- **Visa application processes.** Outline typical timelines (start six months in advance) and required documents such as invitation letters, proof of accommodation, financial statements and ties to the home country. Note that requirements vary widely by region—Schengen visa rules differ from Asia or Africa—and advise verifying with embassies.
+- **State that requirements depend on nationality.** Entry rules differ by the traveller's passport. Say so explicitly, and never present one country's rules as universal.
     
-- **Passport and validity rules.** Explain that many countries require passports valid at least six months beyond travel dates and may require blank pages.
+- **Date the information.** Give the year or date the requirements were current according to the source material, and note that entry rules change without notice.
+    
+- **Research and planning.** The guide should instruct readers to check official travel advisories, destination entry and exit requirements, and local laws. Where the source material names the reader's own government traveller-registration or advisory service, name it; otherwise describe the category rather than naming a specific programme. Advise keeping copies of passports, visas and essential documents.
+    
+- **Visa application processes.** Give the application lead time the source material states, in weeks or months, and the required documents it lists — invitation letters, proof of accommodation, financial statements, ties to the home country. Note that requirements vary widely by region and advise verifying with the relevant embassy or consulate.
+    
+- **Passport and validity rules.** Explain the destination's passport validity requirement and any blank-page requirement, using the destination's actual rule when the source material gives it. Do not generalise one country's validity window to others.
     
 - **Border procedures.** Describe what happens at immigration: follow signage, complete customs declarations, present documents, answer questions truthfully and cooperate with biometric checks. Remind travellers that baggage may be inspected and secondary screening can occur; staying calm and prepared is key.
     
-- **Declarations and prohibited items.** Inform readers they must declare purchases, food, plants, animals and currency over certain thresholds (e.g., over CAD $10,000 in Canada) and that some items like cannabis are prohibited. Include customs guidance for traveling with minors or pets (consent letters, vaccination records).
+- **Declarations and prohibited items.** Inform readers they must declare purchases, food, plants, animals and currency above the destination's declaration threshold, naming that threshold and its currency only when the source material states it. Note that items legal at home may be prohibited on arrival. Include customs guidance for travelling with minors or pets (consent letters, vaccination records).
     
 - **Remote‑worker visas and long‑stay permits.** Mention the rise of digital nomad visas and that applicants must understand income thresholds and application steps; emphasize verifying details on official portals.
 

--- a/apps/ai-blog-writer/apps/backend/data/guidelines/When to Visit Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/guidelines/When to Visit Article.md
@@ -13,7 +13,7 @@
     
 - **Pros and cons of each season** – Explain advantages and drawbacks: comfortable temperatures, festivals and natural phenomena vs. crowds, accommodation costs and availability. Highlight shoulder season benefits such as lower prices and manageable crowds.
     
-- **Monthly or regional variations** – Provide month‑by‑month or regional notes when conditions vary widely (e.g., cherry blossom season in Japan draws huge crowds and requires early booking; wildflowers bloom in Greece's shoulder season; many U.S. national parks have optimal months for wildlife, hiking or cooler temperatures).
+- **Monthly or regional variations** – Provide month‑by‑month or regional notes when conditions vary widely. Name the destination's own peak events, bloom or wildlife windows and booking pressure from the source material; do not import another destination's seasonal pattern.
     
 - **Special events and festivals** – Mention major events, holidays or wildlife migrations that can influence travel timing. Advise readers to book early for popular events or avoid them if seeking quiet.
     


### PR DESCRIPTION
## The bug

Four guideline files stated jurisdiction- or destination-specific facts as **universal content requirements**. Each file is injected verbatim into the compose prompt, so an article about any destination inherited them.

### `Visa & Entry Guide.md` — the harmful one

It required the model to:

- "emphasise enrolling in services like **the U.S. STEP program**"
- outline timelines as "**start six months in advance**"
- explain that passports need "**at least six months**" validity
- cite a declaration threshold of "over **CAD $10,000 in Canada**"

An article about Vietnam inherited US and Canadian immigration rules. The groundedness stage classifies visa and entry guidance as **high severity**, so this file reliably produced confidently wrong legal advice — the highest real-world-harm finding in the whole audit.

## The fix

Baked-in *values* become the *shape* of what to state, plus three requirements the file lacked entirely:

- **Every requirement must be sourced or flagged.** No fee, threshold, processing time, visa type or eligibility rule may appear unless the source material states it. Otherwise: say it could not be confirmed and defer to the named official authority.
- **State that requirements depend on nationality.** Never present one country's rules as universal.
- **Date the information**, and note entry rules change without notice.

## Also de-leaked

| File | Was | Now |
|---|---|---|
| `Packing Guide.md` | "using a **35–40 L** backpack" | capacity in litres only when the trip profile supports it |
| `Budget Travel Guide.md` | "**U.S.** hostel dorms often cost **$25–55**, budget hotels **$90–125**" | figures from the source material, in the destination's currency, with an explicit unconfirmed path |
| `When to Visit Article.md` | "cherry blossom season in **Japan**… wildflowers in **Greece**… **U.S.** national parks" | the destination's own peak events, bloom and wildlife windows |

## Prior art in the corpus

`Where to Stay Guide.md` already does this correctly — its Trastevere example is explicitly fenced *as an example* rather than stated as a requirement. That's the pattern the other four now follow.

## Verification

492 backend tests pass. Zero residual occurrences of the removed figures. Trailing-newline state byte-identical for all four files.

Two hidden characters made this trickier than it looks: `CAD $10,000` and `35–40 L` both contain non-breaking spaces, so they don't match a naive search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)