### PR TITLE
fix(abw): strip authoring scaffold from title guidelines

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/title/Adventure Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Adventure Guide.md
@@ -1,16 +1,16 @@
 ## Adventure Guide
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     - Inspire readers to explore and convey the essence of an adventurous experience while clearly signalling location, activity and unique appeal. Titles should be service‑oriented, promising practical guidance without exaggeration or clickbait.
         
     - Establish credibility and trust by accurately reflecting the content and avoiding over‑statement or misleading cause‑and‑effect claims.
         
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     - Readers are curious, thrill‑seeking travellers looking for authentic experiences and practical information on activities, logistics and safety.
         
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Start with a dynamic verb or adjective (“Hiking,” “Discover,” “Breathtaking”) and immediately mention the destination or activity to ground the reader.
         
@@ -26,7 +26,7 @@
         
     - Place important keywords toward the beginning for SEO, but do not sacrifice readability or accuracy.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Highlight what’s unique or extraordinary about the experience (e.g., “glacier‑fed lakes,” “ancient ruins”) to spark curiosity while maintaining clarity.
         
@@ -40,7 +40,7 @@
         
     - When the guide involves potential risk, be transparent about difficulty and safety considerations; avoid glamorizing danger or implying guaranteed outcomes.
         
-- **Style, tone and formatting rules (5–8 bullet points)**
+- **Style, tone and formatting rules**
     
     - Use an authoritative yet inviting tone—adventurous but grounded in expertise.
         
@@ -56,7 +56,7 @@
         
     - Write multiple headline options and test them with editors or analytics tools when possible.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Hiking,” “Trekking,” “Road‑tripping,” “Cycling”
         
@@ -78,7 +78,7 @@
         
     - Location modifiers: “Pacific Northwest,” “Andes,” “Highlands,” “Desert”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Clickbait phrases (“secret,” “you won’t believe,” “shocking”).
         
@@ -98,7 +98,7 @@
         
     - Unnecessary jargon or abbreviations; avoid “NP” for National Park unless widely known.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the title accurately reflect the article content and avoid exaggeration?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Beginner’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Beginner’s Guide.md
@@ -1,16 +1,16 @@
 ## Beginner’s Guide
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     - Reassure novices that the article offers clear, step‑by‑step information and demystifies a topic they may find intimidating.
         
     - Signal that the content is foundational and avoids jargon, while being thorough and reliable.
         
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     - Readers are likely uncertain, eager to learn, and seeking trusted guidance that simplifies complex topics without dumbing them down.
         
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Begin with “Beginner’s Guide to…,” “How to…,” “Step‑by‑Step Guide,” or similar format to set expectations.
         
@@ -28,7 +28,7 @@
         
     - Ensure the main keyword (topic) appears near the front for SEO.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Empathize with the novice’s challenges; include phrases like “First‑Time,” “No Experience Needed,” or “From Scratch” to highlight accessibility.
         
@@ -46,7 +46,7 @@
         
     - Offer reassurance about common fears (“…Without Breaking the Bank,” “…Without Fear of Failure”).
         
-- **Style, tone and formatting rules (5–8 bullet points)**
+- **Style, tone and formatting rules**
     
     - Maintain a supportive, instructive tone; avoid condescension or inside jokes.
         
@@ -64,7 +64,7 @@
         
     - Test multiple versions to optimise for different channels (search vs. social).
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Beginner’s Guide,” “How to,” “Step‑by‑Step,” “First‑Time”
         
@@ -86,7 +86,7 @@
         
     - “Step‑by‑Step Instructions”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Over‑promising mastery or expertise (“Master Investing Overnight”).
         
@@ -106,7 +106,7 @@
         
     - Titles that bury the main topic at the end of the line.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the title clearly signal that it is for beginners and state the subject?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Best Of.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Best Of.md
@@ -1,16 +1,16 @@
 ## Best Of
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     - Communicate that the article is a curated and authoritative ranking or roundup of top options within a category, timeframe or geography.
         
     - Convey transparency and neutrality by avoiding commercial bias and clearly reflecting the criteria used.
         
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     - Readers expect an impartial, well‑researched list to help them choose among the best options, whether for products, destinations, restaurants or experiences.
         
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Begin with a superlative or numerical indicator (“10 Best…,” “Top Picks for…”), combined with the category and location or timeframe.
         
@@ -28,7 +28,7 @@
         
     - Do not imply exclusivity or completeness unless the article justifies it (“Our Complete List…” should deliver completeness).
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Emphasize what sets the list apart—unique criteria, expert judging, insider knowledge—to build trust and authority.
         
@@ -46,7 +46,7 @@
         
     - Do not tease with withheld information (“You Won’t Guess What’s #1”)—such gimmicks are clickbait.
         
-- **Style, tone and formatting rules (5–8 bullet points)**
+- **Style, tone and formatting rules**
     
     - Adopt a confident, authoritative tone that reflects rigorous research rather than personal preference.
         
@@ -64,7 +64,7 @@
         
     - Create alternative headlines for social channels that fit character limits without losing essential information.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Best,” “Top,” “Top Picks,” “Top [Number]”
         
@@ -86,7 +86,7 @@
         
     - “Sustainable,” “Eco‑Friendly,” “Women‑Owned” (when relevant)
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Misleading superlatives (“World’s Greatest”) without supporting evidence.
         
@@ -106,7 +106,7 @@
         
     - Clichés like “Ultimate List” unless truly comprehensive.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the title clearly state the scope, category and, if applicable, timeframe?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Budget Travel Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Budget Travel Guide.md
@@ -1,16 +1,16 @@
 ## Budget Travel Guide
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     - Signal that the article offers practical, money‑saving tips for traveling to a destination or type of trip without sacrificing quality or experience.
         
     - Attract value‑conscious readers who want to explore affordably while maintaining transparency about costs.
         
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     - Readers are cost‑sensitive travellers seeking trustworthy advice on how to maximize experience while minimizing expenses.
         
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Start with keywords that combine destination or type (“Paris,” “Island Hopping,” “Road Trip”) with budget focus (“on $50 a Day,” “For Under $500”).
         
@@ -28,7 +28,7 @@
         
     - Place the main keywords at the beginning to improve search visibility.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Promise tangible benefits such as “Save Money,” “Spend Less,” “Free Attractions,” while providing enough context to avoid clickbait.
         
@@ -46,7 +46,7 @@
         
     - Clarify whether prices are per person, per day, or total trip to avoid misunderstanding.
         
-- **Style, tone and formatting rules (5–8 bullet points)**
+- **Style, tone and formatting rules**
     
     - Use a friendly, resourceful tone that emphasizes possibility and practicality.
         
@@ -64,7 +64,7 @@
         
     - Test alternative headlines for different distribution channels and adjust accordingly.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Budget‑Friendly,” “Affordable,” “Low‑Cost,” “Cost‑Effective”
         
@@ -88,7 +88,7 @@
         
     - “Guide,” “Plan,” “Itinerary”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - “Cheap” used pejoratively; opt for positive terms like “affordable” or “value.”
         
@@ -110,7 +110,7 @@
         
     - Jargon or abbreviations not commonly understood by an international audience.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the title clearly convey that the guide is budget‑focused and name the destination or theme?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Buyer’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Buyer’s Guide.md
@@ -1,16 +1,16 @@
 ## Buyer’s Guide
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     - Communicate that the article helps readers make informed purchasing decisions by comparing options, explaining features and providing expert recommendations.
         
     - Establish trust through transparency about methodology and any commercial relationships, ensuring the guide serves the reader rather than sales.
         
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     - Readers are researching products or services, seeking unbiased insights, value considerations and potential pitfalls before making a purchase.
         
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Lead with the product category or problem to be solved (“Best Noise‑Cancelling Headphones,” “Electric Car Buyer’s Guide”), followed by context such as year or target user (“2026,” “for Commuters”).
         
@@ -28,7 +28,7 @@
         
     - For series with affiliate links, the headline should not include promotional calls-to-action (“Buy Now”) but may use objective descriptors (“Best Budget,” “Top Performance”).
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Emphasize the problem the guide solves (“Quietest Headphones for Open Offices”) to resonate with readers’ needs.
         
@@ -46,7 +46,7 @@
         
     - Where appropriate, mention whether products were tested in-house or curated from research; transparency builds trust.
         
-- **Style, tone and formatting rules (5–8 bullet points)**
+- **Style, tone and formatting rules**
     
     - Adopt an objective, informative tone; avoid overt sales language or personal bias.
         
@@ -64,7 +64,7 @@
         
     - Collaborate with legal or compliance teams when necessary to ensure compliance with advertising and disclosure regulations.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Buyer’s Guide,” “Shopping Guide,” “Ultimate Guide,” “Complete Guide”
         
@@ -94,7 +94,7 @@
         
     - “Specifications,” “Specs,” “Features”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Promotional phrases (“Buy Now,” “Limited Time Offer,” “Act Fast”) that belong in ads, not editorial titles.
         
@@ -116,7 +116,7 @@
         
     - Terms like “One Weird Trick” or “Life Hack” that signal clickbait.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the title clearly state the product category, scope and target audience or year?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Myth‑Busting Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Myth‑Busting Article.md
@@ -1,14 +1,14 @@
 ## Myth‑Busting Article
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     Titles for myth‑busting pieces should quickly signal that the article will correct a misconception and deliver trustworthy information. The focus is on revealing the truth rather than sensationalizing or repeating false claims.
     
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     Readers are curious but may hold misconceptions; they want clear facts and reassurance from credible sources.
     
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Begin with the correct fact or conclusion; avoid leading with the myth itself because repeating falsehoods can reinforce them.
         
@@ -26,7 +26,7 @@
         
     - Ensure the title answers the reader’s question “Why should I read this?”.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Use an “against popular belief” angle to allude to a widely held assumption and flip it with an opposing fact.
         
@@ -42,7 +42,7 @@
         
     - Highlight benefits or consequences (“why it matters” or “what you should know”) to create urgency.
         
-- **Style, tone, and formatting rules (5–8 bullet points)**
+- **Style, tone, and formatting rules**
     
     - Maintain a neutral, authoritative tone; avoid sensational adjectives and clickbait language.
         
@@ -58,7 +58,7 @@
         
     - Include keywords that align with the topic for searchability.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Fact check”
         
@@ -90,7 +90,7 @@
         
     - “Clarifying”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Repeating the myth in full or using quotes of misinformation.
         
@@ -110,7 +110,7 @@
         
     - Passive constructions (“It is said that…”).
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Confirm the headline communicates the correct information rather than the myth.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/News Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/News Article.md
@@ -1,14 +1,14 @@
 ## News Article
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     News headlines should succinctly convey the most important facts about an event or announcement and entice readers to learn more. They set expectations for timely, accurate reporting.
     
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     Readers scan headlines for quick updates and expect clarity, timeliness and impartiality.
     
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Summarize who and what happened, and include where or when if essential.
         
@@ -26,7 +26,7 @@
         
     - Ensure consistency in headline style across the publication; avoid mixing verb‑driven headlines with simple labels.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Highlight the most newsworthy element or impact of the story (e.g., scale, consequences, novelty).
         
@@ -42,7 +42,7 @@
         
     - For breaking news, emphasize immediacy (“now,” “today,” “new”).
         
-- **Style, tone, and formatting rules (5–8 bullet points)**
+- **Style, tone, and formatting rules**
     
     - Maintain an objective, unbiased tone; avoid opinion or speculation in news headlines.
         
@@ -58,7 +58,7 @@
         
     - Keep the headline under 8–12 words when possible to maintain punch.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Announces”
         
@@ -90,7 +90,7 @@
         
     - “Votes to”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Articles (“a,” “an,” “the”).
         
@@ -112,7 +112,7 @@
         
     - Ambiguous headlines that could apply to multiple stories.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Verify that the headline reflects the key facts—who, what, where, and sometimes when.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Opinion Piece.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Opinion Piece.md
@@ -1,14 +1,14 @@
 ## Opinion Piece
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     Titles for opinion pieces should clearly communicate the author’s argument or perspective and invite readers into a thoughtful commentary. They signal that the content is subjective and designed to persuade or provoke reflection.
     
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     Readers expect a strong viewpoint backed by reasoning; they are open to new perspectives but want to know the author’s stance before clicking.
     
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - State the central argument or thesis up front using a strong verb or directive.
         
@@ -26,7 +26,7 @@
         
     - Use active voice; avoid forms of “to be” unless essential.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Pose a provocative or thought‑provoking question that reflects the article’s main argument.
         
@@ -44,7 +44,7 @@
         
     - Make the reader feel included by highlighting shared values or concerns.
         
-- **Style, tone, and formatting rules (5–8 bullet points)**
+- **Style, tone, and formatting rules**
     
     - Adopt a persuasive yet respectful tone; avoid inflammatory or derogatory language.
         
@@ -62,7 +62,7 @@
         
     - Steer clear of hyperbolic superlatives unless supported by evidence.
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Why” / “How”
         
@@ -94,7 +94,7 @@
         
     - “To the editor” (if used for letters)
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Clickbait phrases (“You won’t believe,” “Shocking truth”).
         
@@ -116,7 +116,7 @@
         
     - Sensational adjectives (“amazing,” “crazy”) not suitable for serious commentary.
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the headline state or clearly imply the author’s position?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Packing Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Packing Guide.md
@@ -1,14 +1,14 @@
 ## Packing Guide
 
-- **Purpose of titles (1–2 lines)**
+- **Purpose of titles**
     
     Titles for packing guides should make it clear that the article delivers practical checklists or instructions tailored to a destination or occasion. They promise completeness and ease for readers preparing for a trip.
     
-- **Audience mindset (1 line)**
+- **Audience mindset**
     
     Readers are planning a trip and want a reliable, easy‑to‑follow list of what to bring; they seek convenience and assurance that nothing essential will be forgotten.
     
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
     
     - Include “packing list,” “packing guide,” “what to pack” or similar phrase so the intent is obvious.
         
@@ -26,7 +26,7 @@
         
     - Avoid articles and forms of “to be” to keep the headline tight.
         
-- **Hook and angle strategy (5–8 bullet points)**
+- **Hook and angle strategy**
     
     - Emphasize the benefit of being prepared (“essential items,” “save space,” “no stress”).
         
@@ -44,7 +44,7 @@
         
     - Consider including a targeted audience (“for first‑time travelers,” “for business trips”).
         
-- **Style, tone, and formatting rules (5–8 bullet points)**
+- **Style, tone, and formatting rules**
     
     - Use a friendly, helpful tone that reassures readers.
         
@@ -62,7 +62,7 @@
         
     - Use parentheses or brackets to clarify specifics (e.g., “(+ downloadable checklist)”).
         
-- **Preferred words and phrases (8–15 bullet points)**
+- **Preferred words and phrases**
     
     - “Packing list”
         
@@ -94,7 +94,7 @@
         
     - “Step‑by‑step”
         
-- **Words and patterns to avoid (8–15 bullet points)**
+- **Words and patterns to avoid**
     
     - Vague titles (“Packing list”) without specifying destination or context.
         
@@ -116,7 +116,7 @@
         
     - Redundant phrases (“packing list list”).
         
-- **Final quality checklist (6–10 bullet points)**
+- **Final quality checklist**
     
     - Does the title clearly indicate that the article is a packing guide or list?
         


### PR DESCRIPTION
## The bug

Nine title guideline files shipped the instructions written for **their own author** into the model's prompt:

```
- **Purpose of titles (1–2 lines)**
- **Title structure rules (5–8 bullet points)**
- **Preferred words and phrases (8–15 bullet points)**
- **Final quality checklist (6–10 bullet points)**
```

These files are interpolated verbatim as `{title_guideline}`. In `P2B_TITLE_PROMPT` the model is told:

> "Return exactly one line. No quotes, no markdown, no alternatives, no explanation."

…while simultaneously reading a template instructing it to produce 8–15 bullet points. The same text also lands in `P2B_OUTLINE_PROMPT` and `P2B_COMPOSE_PROMPT`, where the model is planning sections or writing body prose — so the scaffold reads there as instructions about the *article*.

## The fix

Removes **only** the parenthetical count annotation from each bold label. Every line of actual guidance is untouched:

```diff
-- **Title structure rules (5–8 bullet points)**
+- **Title structure rules**
```

72 annotations across 9 files (8 labels each) — 72 insertions, 72 deletions, a pure label-level edit.

**Affected:** Adventure Guide, Beginner's Guide, Best Of, Budget Travel Guide, Buyer's Guide, Myth-Busting Article, News Article, Opinion Piece, Packing Guide.

## Reviewer note

`title/Best Of.md` has a **non-breaking space in its filename** (`Best\302\240Of.md`), unlike `guidelines/Best Of.md` which uses a regular space. Harmless today — `normalize_guideline_key` strips non-alphanumerics before matching — but worth knowing before anyone writes a script that pairs the two directories by filename.

## Verification

492 backend tests pass. Zero residual scaffold annotations across all 42 title files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)