### PR TITLE
fix(abw): unify the title length constraint across title guidelines

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/title/Adventure Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Adventure Guide.md
@@ -16,7 +16,7 @@
         
     - Include a clear subject (mountain, trail, island, region) and what makes it noteworthy, such as difficulty level, unique features or cultural context.
         
-    - Keep titles concise (8–14 words) and in title case; capitalize only the first word and proper nouns.
+    - Keep titles concise (8–10 words) and in title case; capitalize only the first word and proper nouns.
         
     - Use active voice for immediacy and clarity.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Beginner’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Beginner’s Guide.md
@@ -20,7 +20,7 @@
         
     - Use active verbs and concise phrasing; avoid leading with modifiers that delay the subject.
         
-    - Limit length to about 8–12 words to maintain readability.
+    - Limit length to about 8–10 words to maintain readability.
         
     - Include a key benefit (“…Without Stress,” “…That Saves Money”) only if the article truly provides that benefit.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Best Of.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Best Of.md
@@ -18,7 +18,7 @@
         
     - Include distinguishing criteria when relevant (e.g., “Editors’ Choice,” “Readers’ Picks,” “Sustainable”).
         
-    - Keep titles concise (8–12 words) and in title case; avoid unnecessary adjectives or puns.
+    - Keep titles concise (8–10 words) and in title case; avoid unnecessary adjectives or puns.
         
     - Use active voice and clear nouns; avoid ambiguous categories (“Best Things”) in favor of specifics (“Best Hikes,” “Best Vegan Restaurants”).
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Buyer’s Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Buyer’s Guide.md
@@ -20,7 +20,7 @@
         
     - Highlight important differentiators (“Affordable,” “Premium,” “Eco‑Friendly”) only when the article specifically compares based on those attributes.
         
-    - Keep titles between 8–14 words; avoid extraneous adjectives or industry jargon.
+    - Keep titles between 8–10 words; avoid extraneous adjectives or industry jargon.
         
     - Include the publication year when products evolve rapidly (technology, vehicles) to emphasise currency.
         
@@ -130,7 +130,7 @@
         
     - Are there no clichés, clickbait terms or vague promises?
         
-    - Is the length appropriate for SEO and social sharing (8–14 words)?
+    - Is the length appropriate for SEO and social sharing (8–10 words)?
         
     - Has the title been reviewed by editors, SEO specialists and compliance/legal teams as needed?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Case Study.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Case Study.md
@@ -12,7 +12,7 @@
         
     - Highlight the main benefit or result using a hard number where possible.
         
-    - Use a clear, concise structure such as “Client/Industry – Result – Method,” keeping it under roughly 70–80 characters.
+    - Use a clear, concise structure such as “Client/Industry – Result – Method,” keeping it under 60 characters.
         
     - Consider a subtitle to provide extra detail if the main title is short.
         
@@ -92,7 +92,7 @@
         
     - Is the result expressed with a specific number or clear benefit?
         
-    - Is the title free of clickbait and hype and under roughly 70–80 characters?
+    - Is the title free of clickbait and hype and under 60 characters?
         
     - Have you used active, plain language and avoided jargon?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Checklist.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Checklist.md
@@ -14,7 +14,7 @@
         
     - Mention the specific topic or context (e.g., “travel packing,” “product launch”) so users know what the list covers.
         
-    - Keep the title under about 60–70 characters to remain scannable on search and social feeds.
+    - Keep the title under 60 characters to remain scannable on search and social feeds.
         
     - Place the number toward the beginning along with the keyword when it feels natural.
         
@@ -102,7 +102,7 @@
         
     - Have you included a strong descriptor and the specific subject of the list?
         
-    - Is the title concise, within 60–70 characters, and free of filler words?
+    - Is the title concise, under 60 characters, and free of filler words?
         
     - Does it promise a concrete benefit or outcome without clickbait?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Comparison Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Comparison Article.md
@@ -14,7 +14,7 @@
         
     - Maintain parity between the compared items; don’t favour one with adjectives in the title.
         
-    - Limit the title to around 60–70 characters; ensure both names are fully visible in search results.
+    - Limit the title to under 60 characters; ensure both names are fully visible in search results.
         
     - Avoid adding unnecessary modifiers that obscure the comparison.
         
@@ -98,7 +98,7 @@
         
     - Have you included the main decision factor or context to guide the reader?
         
-    - Is the title concise (around 60–70 characters) and scannable?
+    - Is the title concise (under 60 characters) and scannable?
         
     - Does it reflect how users search for comparison information (e.g., “X vs Y”)?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Cost Breakdown.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Cost Breakdown.md
@@ -8,7 +8,7 @@
     
     - Mirror the core cost question people type into search engines (“How Much Does [X] Cost?”).
         
-    - Keep the title under about 70 characters so it isn’t truncated on search results.
+    - Keep the title under 60 characters so it isn’t truncated on search results.
         
     - Start with the exact query, then use a colon or dash to add context (“Factors, Considerations & Examples”).
         
@@ -92,7 +92,7 @@
     
     - Does the title mirror the exact cost question searchers ask (“How much does X cost?”)?
         
-    - Is the title under 70 characters and free of unnecessary filler?
+    - Is the title under 60 characters and free of unnecessary filler?
         
     - Have you added a succinct secondary phrase to preview the article’s scope (factors, examples)?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Cultural Etiquette Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Cultural Etiquette Guide.md
@@ -10,7 +10,7 @@
         
     - Use a subtitle or secondary phrase to highlight the focus on respect, customs, or travel tips (“Respectful Travel in [Place]”).
         
-    - Keep the title under about 70 characters to ensure full display in search results.
+    - Keep the title under 60 characters to ensure full display in search results.
         
     - Use descriptive adjectives such as “Essential,” “Respectful,” “Comprehensive,” or “Insider” to indicate value.
         
@@ -98,7 +98,7 @@
         
     - Is the tone respectful, free of stereotypes and sensationalism?
         
-    - Is the title concise (under 70 characters) and informative?
+    - Is the title concise (under 60 characters) and informative?
         
     - Have you included a subtitle or phrase that highlights respect or key customs?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Destination Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Destination Guide.md
@@ -14,7 +14,7 @@
         
     - Include numeric hooks where appropriate (e.g., “10 Best Things to Do…”), but avoid using numbers for the sake of clickbait.
         
-    - Keep titles under ~60–65 characters to ensure they display fully in search results.
+    - Keep titles under 60 characters to ensure they display fully in search results.
         
     - Use title case (capitalising main words); omit unnecessary articles and punctuation per headline style conventions.
         
@@ -82,7 +82,7 @@
         
     - Are strong, specific verbs used instead of vague descriptors?
         
-    - Is the length appropriate for search display (≤65 characters)?
+    - Is the length appropriate for search display (under 60 characters)?
         
     - Have you avoided clickbait and sensationalism while still offering a compelling hook?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Digital Nomad Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Digital Nomad Guide.md
@@ -12,7 +12,7 @@
         
     - Use concise descriptors separated by colons or em dashes to organise multiple elements (e.g., “Lisbon Digital Nomad Guide: Visas, Coworking & Cost of Living”).
         
-    - Limit length to ~60–70 characters; trim secondary details rather than the core promise.
+    - Limit length to under 60 characters; trim secondary details rather than the core promise.
         
     - Use active verbs where possible (“Work Remotely in…,” “Live and Work in…”).
         
@@ -84,7 +84,7 @@
         
     - Are keywords integrated naturally and without stuffing?
         
-    - Is the length within ~70 characters and easily scannable?
+    - Is the length under 60 characters and easily scannable?
         
     - Does the title avoid sensationalism and misrepresentation?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Disqualifiers (e.g., “No List” Articles).md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Disqualifiers (e.g., “No List” Articles).md
@@ -16,7 +16,7 @@
         
     - If referencing a list of locations, indicate the purpose (“5 Destinations to Skip in 2026 for Sustainable Travel”).
         
-    - Limit the title to ~60–70 characters; longer explanations can go in the sub‑headline.
+    - Limit the title to under 60 characters; longer explanations can go in the sub‑headline.
         
     - Use title case and avoid abbreviations or slang.
         
@@ -88,7 +88,7 @@
         
     - Are any claims in the title supported by verified facts within the article?
         
-    - Is the title within 60–70 characters and easily scannable?
+    - Is the title under 60 characters and easily scannable?
         
     - Does the title uphold editorial standards of honesty, accuracy and integrity?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Explainer.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Explainer.md
@@ -14,7 +14,7 @@
         
     - Keep titles straightforward; avoid multi‑layered wordplay that obscures meaning.
         
-    - Limit length to ~60–70 characters to ensure readability and SEO friendliness.
+    - Limit length to under 60 characters to ensure readability and SEO friendliness.
         
     - Use present tense and active voice to convey immediacy.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/FAQ Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/FAQ Article.md
@@ -14,7 +14,7 @@
         
     - When the article addresses a specific number of questions, include that number only if it is meaningful (“Top 10 FAQs About…”). Avoid arbitrarily adding numbers to fabricate curiosity.
         
-    - Keep titles concise and scannable (~60–65 characters); avoid overcrowding with keywords.
+    - Keep titles concise and scannable (under 60 characters); avoid overcrowding with keywords.
         
     - Use capitalisation consistently and avoid unnecessary punctuation.
         
@@ -84,7 +84,7 @@
         
     - Are keywords integrated naturally and appropriately for search engines?
         
-    - Is the length concise and readable (≤65 characters)?
+    - Is the length concise and readable (under 60 characters)?
         
     - Have you avoided unnecessary numbers or exaggerated claims?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Family Travel Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Family Travel Guide.md
@@ -12,7 +12,7 @@
         
     - Use numerals for lists (e.g., “7 Kid‑Friendly Beaches in…”), which improve clarity and SEO.
         
-    - Keep titles under 10–12 words; summarise the benefit in one concise sentence.
+    - Keep titles to roughly 8–10 words; summarise the benefit in one concise sentence.
         
     - Use present tense and active voice; avoid forms of “to be”.
         
@@ -48,7 +48,7 @@
         
     - Do not start titles with “How to” or “Everything you need” – lead with the topic and value.
         
-    - Keep titles within 60–70 characters to ensure full display in search and social feeds.
+    - Keep titles under 60 characters to ensure full display in search and social feeds.
         
     - Ensure the title accurately reflects the article’s content and matches any on‑site categorisation or series naming.
         
@@ -94,7 +94,7 @@
         
     - Are age‑specific or family descriptors included?
         
-    - Is the title under 12 words and free of filler words?
+    - Is the title within roughly 8–10 words and free of filler words?
         
     - Are useful keywords (destination, activity) front‑loaded?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Feature Story.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Feature Story.md
@@ -16,7 +16,7 @@
         
     - Avoid excessive modifiers; let the inherent story provide the intrigue.
         
-    - Keep titles under 12 words; shorten by removing unnecessary articles and conjunctions.
+    - Keep titles to roughly 8–10 words; shorten by removing unnecessary articles and conjunctions.
         
     - Use present tense to convey immediacy and relevance.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Food Travel Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Food Travel Guide.md
@@ -12,7 +12,7 @@
         
     - Use numbers when highlighting lists of eateries or dishes; avoid combining a number with a trigger word like “why” or “how”.
         
-    - Keep titles concise (10–12 words) and descriptive; summarise the promise in one sentence.
+    - Keep titles concise (8–10 words) and descriptive; summarise the promise in one sentence.
         
     - Use present tense and avoid gerunds (no “eating” or “discovering”); choose active voice.
         
@@ -98,7 +98,7 @@
         
     - Are active verbs and present tense employed?
         
-    - Is the title concise (<12 words) and free of filler?
+    - Is the title concise (8–10 words) and free of filler?
         
     - Does it choose either a number or a question/trigger word but not both?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Hidden Gems Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Hidden Gems Article.md
@@ -12,7 +12,7 @@
         
     - Use numbers to promise a concise list or “few” to suggest a curated selection; ensure the count matches the article.
         
-    - Keep titles concise (under 12 words) and free of filler words.
+    - Keep titles concise (roughly 8–10 words) and free of filler words.
         
     - Use present tense and strong verbs (discover, explore, uncover); avoid gerunds and passive constructions.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/How‑to Guides.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/How‑to Guides.md
@@ -10,7 +10,7 @@
         
     - Avoid beginning with “How to”; instead, weave the “how” element into the action (“Plan a Budget Trip in 5 Steps”).
         
-    - Keep titles short—ideally fewer than 10–12 words—and summarise the guide’s scope in one sentence.
+    - Keep titles short—ideally 8–10 words—and summarise the guide’s scope in one sentence.
         
     - Use the active voice and avoid gerunds (“planning,” “organizing”); choose verbs in imperative form.
         
@@ -94,7 +94,7 @@
     
     - Does the title state the subject and action clearly without starting with “How to”?
         
-    - Is it concise (≤10–12 words) and free of filler?
+    - Is it concise (8–10 words) and free of filler?
         
     - Are active verbs in imperative form used instead of gerunds?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/In-depth Analysis.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/In-depth Analysis.md
@@ -12,7 +12,7 @@
         
     - Clearly state the subject and the analytical angle; a colon or dash can separate the main topic from the specific focus (e.g., “Climate Policy: Assessing the Impact on Urban Economies”).
         
-    - Keep titles concise—ideally within 50–60 characters but long enough to be specific.
+    - Keep titles concise—ideally under 60 characters but long enough to be specific.
         
     - Use present tense and active voice for relevance and immediacy.
         
@@ -76,7 +76,7 @@
         
     - Are the main keywords or topic front‑loaded for SEO and clarity?
         
-    - Is the title within 50–60 characters and free of jargon or acronyms?
+    - Is the title under 60 characters and free of jargon or acronyms?
         
     - Does it avoid clickbait, puns and overpromising?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Interview.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Interview.md
@@ -10,7 +10,7 @@
         
     - State the core topic or insight gained from the conversation; use a colon or dash to separate subject from theme.
         
-    - Keep titles succinct (about 8–12 words) while conveying the promise of the discussion.
+    - Keep titles succinct (about 8–10 words) while conveying the promise of the discussion.
         
     - Use present tense and active verbs like “discusses,” “reveals,” or “shares.”
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Itinerary Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Itinerary Article.md
@@ -14,7 +14,7 @@
         
     - Front‑load the destination and primary keywords for SEO purposes.
         
-    - Keep titles under 12–15 words to maintain clarity and avoid truncation.
+    - Keep titles to roughly 8–10 words to maintain clarity and avoid truncation.
         
     - Ensure the title can stand alone and accurately reflect the itinerary’s scope and style.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Listicle.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Listicle.md
@@ -10,7 +10,7 @@
         
     - Follow with the subject and qualifier, stating what’s being listed and who it’s for (“10 Best Hikes for Beginners”).
         
-    - Use concise language; keep titles within 8–12 words to ensure readability.
+    - Use concise language; keep titles within 8–10 words to ensure readability.
         
     - Include the primary keyword early for SEO and clarity.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Luxury Travel Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Luxury Travel Guide.md
@@ -12,7 +12,7 @@
         
     - Highlight unique selling points such as private experiences, five‑star resorts or hidden gems.
         
-    - Keep titles within 8–12 words, balancing elegance with clarity; avoid cumbersome phrasing.
+    - Keep titles within 8–10 words, balancing elegance with clarity; avoid cumbersome phrasing.
         
     - Front‑load luxury descriptors and key keywords for SEO and immediate impact.
         
@@ -78,7 +78,7 @@
         
     - Have you used elegant, varied descriptors rather than repeating “luxury”?
         
-    - Is the length within 8–12 words and free of clutter?
+    - Is the length within 8–10 words and free of clutter?
         
     - Does it highlight a unique selling point (e.g., private, bespoke, five‑star)?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Myth‑Busting Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Myth‑Busting Article.md
@@ -114,7 +114,7 @@
     
     - Confirm the headline communicates the correct information rather than the myth.
         
-    - Ensure it is concise (ideally under 12 words) and uses active voice.
+    - Ensure it is concise (ideally 8–10 words) and uses active voice.
         
     - Check that it can stand alone on social media or search results and clearly conveys the topic and benefit.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/News Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/News Article.md
@@ -56,7 +56,7 @@
         
     - Avoid clickbait phrases or exaggerated claims.
         
-    - Keep the headline under 8–12 words when possible to maintain punch.
+    - Keep the headline to roughly 8–10 words when possible to maintain punch.
         
 - **Preferred words and phrases**
     

--- a/apps/ai-blog-writer/apps/backend/data/title/Opinion Piece.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Opinion Piece.md
@@ -16,7 +16,7 @@
         
     - Use a colon to add context or clarify the argument when beneficial; capitalize the first word after the colon.
         
-    - Keep the headline concise (8–14 words) and ensure it stands alone on social feeds.
+    - Keep the headline concise (8–10 words) and ensure it stands alone on social feeds.
         
     - Use sentence case; capitalize only the first word and proper nouns.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Packing Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Packing Guide.md
@@ -20,7 +20,7 @@
         
     - Use parentheses or brackets to add clarifying details or benefits (e.g., “carry‑on only,” “weather‑proof gear”).
         
-    - Keep the title concise (under 12–15 words) and make sure it stands alone.
+    - Keep the title concise (roughly 8–10 words) and make sure it stands alone.
         
     - Use sentence case; capitalize only the first word and proper nouns.
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Resource List.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Resource List.md
@@ -16,7 +16,7 @@ Readers are scanning for specific resources and expect quick, trustworthy recomm
     
 - Avoid generic labels; make titles independently meaningful and descriptive.
     
-- Keep within roughly 11 words or 65 characters to optimise visibility and sharing.
+- Keep within roughly 8–10 words or under 60 characters to optimise visibility and sharing.
     
 - Use strong verbs or adjectives that convey value and usefulness.
     

--- a/apps/ai-blog-writer/apps/backend/data/title/Review.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Review.md
@@ -16,7 +16,7 @@ Readers want a trustworthy evaluation to help decide whether a product, service 
     
 - Integrate a key takeaway or angle that hints at the verdict without overselling.
     
-- Keep the title around 11 words or 65 characters for optimal visibility.
+- Keep the title within roughly 8–10 words or under 60 characters for optimal visibility.
     
 - Use active voice and present tense; avoid filler articles.
     

--- a/apps/ai-blog-writer/apps/backend/data/title/Roundup.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Roundup.md
@@ -18,7 +18,7 @@ Readers are looking for a quick overview of current news, trends or opportunitie
     
 - Use strong descriptors (“top,” “notable,” “essential”) to communicate why the items matter.
     
-- Keep the headline concise and scannable (≈11 words/65 characters).
+- Keep the headline concise and scannable (roughly 8–10 words/under 60 characters).
     
 - Separate clauses with a colon or dash if needed; avoid clutter.
     

--- a/apps/ai-blog-writer/apps/backend/data/title/Safety Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Safety Guide.md
@@ -18,7 +18,7 @@ Readers may feel anxious about risks and are seeking reliable, authoritative gui
     
 - Use plain language and familiar words.
     
-- Maintain conciseness (≈11 words/65 characters) and make the title meaningful without the article.
+- Maintain conciseness (roughly 8–10 words/under 60 characters) and make the title meaningful without the article.
     
 - Use active voice and positive statements; avoid negative phrasing.
     

--- a/apps/ai-blog-writer/apps/backend/data/title/Solo Travel Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Solo Travel Guide.md
@@ -16,7 +16,7 @@ Readers are adventurous yet cautious, often seeking self‑discovery, independen
     
 - Use adjectives that emphasise personal growth and confidence (e.g., “empowering,” “stress‑free,” “safe”).
     
-- Keep within approximately 11 words or 65 characters; include numerals when listing tips.
+- Keep within approximately 8–10 words or under 60 characters; include numerals when listing tips.
     
 - Use active, positive voice; avoid negative phrasing and filler articles.
     

--- a/apps/ai-blog-writer/apps/backend/data/title/Survival Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Survival Guide.md
@@ -10,9 +10,9 @@
         
     - Use service‑oriented formats such as “How to…,” “X Essential Tips for…,” or “Guide to…” to indicate actionable content.
         
-    - Front‑load important keywords (e.g., destination, hazard) within the first 70 characters to aid clarity and SEO.
+    - Front‑load important keywords (e.g., destination, hazard) within the first five words to aid clarity and SEO.
         
-    - Keep titles concise (generally under eight words or ~70 characters) so they are not truncated and remain easy to scan.
+    - Keep titles concise (generally 8–10 words or under 60 characters) so they are not truncated and remain easy to scan.
         
     - Use numerals and abbreviations where appropriate for brevity.
         
@@ -100,7 +100,7 @@
     
     - Does the title clearly state the subject and the survival challenge or hazard?
         
-    - Is the wording concise (under ~70 characters) and free of unnecessary articles or conjunctions?
+    - Is the wording concise (under 60 characters) and free of unnecessary articles or conjunctions?
         
     - Does the headline include a strong, active verb and avoid starting with a verb?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Transportation Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Transportation Guide.md
@@ -12,7 +12,7 @@
         
     - Use “How to…” or “Guide to…” constructions for specific transportation topics (e.g., “How to Travel Italy by Train”).
         
-    - Keep the title around 70–90 characters and roughly eight words for readability and SEO.
+    - Keep the title under 60 characters and roughly 8–10 words for readability and SEO.
         
     - Front‑load destination names and key transport terms so searchers immediately understand relevance.
         
@@ -104,7 +104,7 @@
         
     - Are the primary modes or themes clearly and concisely listed?
         
-    - Is the headline under ~70–90 characters and free of filler words?
+    - Is the headline under 60 characters and free of filler words?
         
     - Does it contain a subject and active verb or clear descriptor, avoiding leading with a verb?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Travel Diary.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Travel Diary.md
@@ -12,7 +12,7 @@
         
     - Highlight what makes the narrative unique – a quest, a personal connection, a challenge overcome.
         
-    - Keep the title within 70–90 characters; ensure the main subject appears early.
+    - Keep the title under 60 characters; ensure the main subject appears early.
         
     - Avoid starting with a verb; instead, include the storyteller or context (“My Solo Trek across…” or implied subject).
         
@@ -102,7 +102,7 @@
     
     - Does the title convey both destination and narrative theme?
         
-    - Is the headline concise and under ~90 characters with a clear subject?
+    - Is the headline concise and under 60 characters with a clear subject?
         
     - Have you used active verbs and avoided starting with a verb?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Travel Inspiration Piece.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Travel Inspiration Piece.md
@@ -10,7 +10,7 @@
         
     - Use numbers, if appropriate, to structure the content (“7 Epic Road Trips”) but avoid inflated lists that promise more than delivered.
         
-    - Front‑load important keywords and keep titles within 70–90 characters.
+    - Front‑load important keywords and keep titles under 60 characters.
         
     - Use adjectives sparingly; choose specific, evocative words over generic clichés.
         
@@ -100,7 +100,7 @@
     
     - Does the title evoke curiosity and inspiration while clearly indicating the destination or theme?
         
-    - Is the headline concise and within ~90 characters, with keywords front‑loaded?
+    - Is the headline concise and under 60 characters, with keywords front‑loaded?
         
     - Have you avoided clichés and hyperbolic adjectives?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Visa & Entry Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Visa & Entry Guide.md
@@ -12,7 +12,7 @@
         
     - Use “Step‑by‑Step” or “Everything You Need to Know” to promise thoroughness when justified.
         
-    - Keep titles concise (70–90 characters) and front‑load keywords such as the country name and “Visa”.
+    - Keep titles concise (under 60 characters) and front‑load keywords such as the country name and “Visa”.
         
     - Use numerals for years, fees or step counts; abbreviate months when mentioning deadlines.
         
@@ -102,7 +102,7 @@
     
     - Does the title clearly state the country and the focus on visa or entry rules?
         
-    - Is the headline concise and within ~90 characters, with key terms front‑loaded?
+    - Is the headline concise and under 60 characters, with key terms front‑loaded?
         
     - Does it avoid unnecessary articles, conjunctions and verbs, adhering to downstyle?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/When to Visit Article.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/When to Visit Article.md
@@ -12,7 +12,7 @@
         
     - If relevant, include the year or range (e.g., “in 2026”) to indicate updated information; avoid unnecessary dates if content is evergreen.
         
-    - Keep titles concise, ideally within eight to ten words and under 90 characters.
+    - Keep titles concise, ideally within 8–10 words and under 60 characters.
         
     - Use numerals for months or seasons when summarizing (“Spring vs. Fall”) and abbreviate months where space is tight.
         
@@ -102,7 +102,7 @@
     
     - Does the title explicitly state it’s about timing for a specific destination?
         
-    - Is the headline concise (under ~90 characters) with primary keywords front‑loaded?
+    - Is the headline concise (under 60 characters) with primary keywords front‑loaded?
         
     - Have you included relevant seasonal descriptors or events to provide context?
         

--- a/apps/ai-blog-writer/apps/backend/data/title/Where to Stay Guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/title/Where to Stay Guide.md
@@ -12,7 +12,7 @@
         
     - Incorporate categories (e.g., “Family, Budget & Luxury”) when the article segments recommendations; use commas or a colon for separation.
         
-    - Keep the headline within 70–90 characters and roughly eight to ten words for readability.
+    - Keep the headline under 60 characters and roughly 8–10 words for readability.
         
     - Front‑load the destination and key terms (“Stay,” “Best Areas”) for SEO.
         


### PR DESCRIPTION
## The bug

The title length rule was stated **eleven mutually incompatible ways** across the 42 files:

| Cap stated | Files |
|---|---|
| 60–70 chars | 9 |
| 65 chars | 7 |
| 70–90 chars | 6 |
| 70 chars | 6 |
| 90 chars | 4 |
| under 70 / 70–80 / 60–65 / **50–60** | 2 each |
| under 90 / 60 | 1 each |

Word counts ranged from "under eight words" to "12–15 words".

Two consequences:

1. **It wasn't a constraint.** One file per run is injected as `{title_guideline}`, and each disagreed with its neighbours.
2. **Most files instructed the model to write titles that truncate in search results** — several while explicitly calling the 90-character figure an SEO rule. Only 2 of 42 sat in the range that survives SERP truncation.

## The fix

Standardises on **"under 60 characters (roughly 8–10 words)"** — the ~60-character point where Google truncates the title link, which is the purpose these files themselves state ("so it displays fully in search results"). It matches the two files that were already correct.

## Self-contradictions resolved

10 files stated two or three incompatible figures simultaneously:

- **`Family Travel Guide.md`** — "under 10–12 words" *and* "60–70 characters" *and* "under 12 words"
- **`Where to Stay Guide.md`** — "within 70–90 characters and roughly eight to ten words" **in a single sentence** (eight words ≈ 50 chars)
- **`Transportation Guide.md`** — "around 70–90 characters and roughly eight words"
- **`How-to Guides.md`** — "fewer than 10–12 words" against its own "typical 60-character SERP limit"

21 files stated length in two places (structure rules + a final-checklist question). Both now agree.

## Bundled guidance preserved

These sentences mix length with unrelated advice; the rest is kept intact:

```diff
-Use a clear, concise structure such as "Client/Industry – Result – Method," keeping it under roughly 70–80 characters.
+Use a clear, concise structure such as "Client/Industry – Result – Method," keeping it under 60 characters.

-Keep titles concise (70–90 characters) and front-load keywords such as the country name and "Visa".
+Keep titles concise (under 60 characters) and front-load keywords such as the country name and "Visa".
```

`Survival Guide.md`'s "front-load keywords within the first **70 characters**" becomes "within the first **five words**", since 60 characters is now the entire title.

## Scope

40 files changed, **63 insertions / 63 deletions**, insertions equal deletions in every file — a sentence-level substitution with line counts unchanged. `Budget Travel Guide.md` and `Pros & Cons Breakdown.md` state no numeric length rule and are untouched (no rule was added where none existed).

## Known follow-up, deliberately out of scope

`Safety Guide.md:55` carries *"limit each heading to about eight words"* — a body **subheading** rule living in a title file. That's title/body cross-contamination, a separate finding, not a length inconsistency.

## Verification

492 backend tests pass. Only `60 characters` and `8–10 words` remain across all 42 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)