### PR TITLE
fix(abw): reconcile the default tone with the anti-AI voice block

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/local-insider.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/local-insider.md
@@ -6,7 +6,7 @@ order: 3
 ---
 ## Local Insider Voice
 
-These rules hold regardless of the selected tone, and they win where the tone profile seems to conflict.
+These rules hold regardless of the selected tone, and they win where the tone profile seems to conflict. A VOICE RULES block is appended after this directive; where it conflicts with anything here, it wins.
 
 Never use, in any form: nestled, hidden gem, must-visit, boasts, unlock, delve, tapestry, vibrant, bustling, charming, treasure trove, "whether you're X or Y", "when it comes to", "in conclusion", "look no further", "the perfect blend of", "something for everyone", "not only... but also". Also banned here: "like a local", "off the beaten path", "the real" plus a place name, "authentic", "undiscovered", "locals know", "city of contrasts", "sleepy fishing village", and "tourist trap" used as a verdict. No throat-clearing openers, no em-dash asides, no rhetorical questions as headings.
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/news-desk.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/news-desk.md
@@ -6,7 +6,7 @@ order: 2
 ---
 ## News Desk Voice
 
-These rules hold regardless of the selected tone, and they win where the tone profile seems to conflict.
+These rules hold regardless of the selected tone, and they win where the tone profile seems to conflict. A VOICE RULES block is appended after this directive; where it conflicts with anything here, it wins.
 
 Attribution comes first. Every claim carries its source inside the sentence that makes it: who said it, in what document or statement, and when. Separate confirmed from reported by verb choice: confirmed, said, announced, according to, has not confirmed. Never present one party's position as established fact. Where sourcing is thin, write what is known and name what is not.
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/questurian-default.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/questurian-default.md
@@ -7,7 +7,7 @@ order: 1
 ---
 ## Questurian Default Voice
 
-These rules hold regardless of the selected tone. The tone profile sets how the piece sounds. This sets what Questurian always does. Where they seem to conflict, these rules win.
+These rules hold regardless of the selected tone. The tone profile sets how the piece sounds. This sets what Questurian always does. Where they seem to conflict, these rules win. A VOICE RULES block is appended after this directive; where it conflicts with anything here, it wins.
 
 Never use, in any form: nestled, hidden gem, must-visit, must-see, boasts, unlock, delve, tapestry, vibrant, bustling, breathtaking, stunning, charming, treasure trove, gateway to, "whether you're X or Y", "when it comes to", "in conclusion", "in today's world", "look no further", "at the end of the day", "the perfect blend of", "something for everyone", "rich in history and culture", "not only... but also". Do not open a sentence with a throat-clearing clause or an em-dash aside; put the subject first. No rhetorical question as a section opener. Kill any adjective that would survive being deleted.
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/practical.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/tones/practical.md
@@ -12,3 +12,5 @@ Best for general destination guides, how-to explainers, roundups, and any articl
 Write clear, useful prose that answers the question the title promises. Lead each section with the thing the reader came for, then support it with concrete detail: costs, timing, distances, requirements, and the caveats that actually change a decision. Keep sentences plain and paragraphs tight. Cut filler transitions, restated headings, and throat-clearing introductions.
 
 Stay deliberately even-handed. Do not build a thesis or rank options against each other, and do not lead with warnings or strip the piece down to raw logistics. Explain how something works, what it costs, what to expect, and where readers commonly get it wrong, then move on. Competence is the whole voice here: no brochure language, no performative personality, no hype.
+
+Even-handed does not mean hedged. State each cost, requirement and caveat definitively instead of balancing it against a counter-claim in the same sentence. Withholding a ranking is the point of this tone; withholding a commitment is not. Where a detail is genuinely uncertain, attribute it or cut it rather than splitting the difference.


### PR DESCRIPTION
## The bug

`ANTI_AI_TELLS_FULL` is appended **after** the entire prompt (`supplement_compose.py:125`, `audit_repair.py:169`, `augmentation.py:49`) carrying:

> **VOICE RULES** (override any conflicting instruction above — if an earlier guideline asks for a quality these rules forbid, follow these rules)

The module docstring states the intent explicitly: both variants *"are written to be appended **after** any per-article-type guideline, with the precedence statement asserting they override conflicting instructions above."*

The style markdown predates that wiring (ADR-0021) and never acknowledged it.

### The concrete cost landed on the default tone

`practical.md` is `default: true`, so it applies to every run where no other tone is selected. It said:

> "Do not build a thesis or rank options against each other"

…while the appended `_VOICE` block says:

> "Take a side. Risk being wrong. AI prose is recognizable partly because it never commits — every claim is balanced against its counter-claim within the same sentence."

**The default tone was being silently reversed on every default run.**

## The fix

Resolved in favour of *both*, because they were never about the same thing — `_VOICE` attacks **hedging**; `practical.md` wants **no ranking**. Added to `practical.md`:

> Even-handed does not mean hedged. State each cost, requirement and caveat definitively instead of balancing it against a counter-claim in the same sentence. Withholding a ranking is the point of this tone; withholding a commitment is not. Where a detail is genuinely uncertain, attribute it or cut it rather than splitting the difference.

The three brand voices now name the precedence explicitly, so "these rules win" is no longer ambiguous about what it outranks.

## Two corrections to the audit that prompted this

Worth recording, since both would have made this PR bigger and wrong:

1. **The brand voices do not falsely claim global supremacy.** Their claim is scoped to the tone profile — and it's *correct*, since brand voice is concatenated last in the Tone → Length → Brand voice order (`support.py:112-136`).
2. **The ban lists barely overlap.** The audit claimed ~40 duplicated banned strings. Actual overlap: `"in conclusion"` and the em-dash rule. The Questurian lexicon (nestled, hidden gem, vibrant, bustling, "whether you're X or Y") is unique and load-bearing. **Left intact.**

## Blast radius

`practical.md` is shared — `shared/tone_profiles.py` points `TONES_DIR` at this directory for **youtube2blog and url2blog** too. That's intended: the anti-AI block is wired into all three pipelines.

## Verification

- 492 backend tests pass.
- All 16 tone/length/brand-voice files parse via `_load_prompt2blog_option_catalog` with non-empty `instructions` — confirming the silent-skip path at `support.py:129` isn't triggered and frontmatter (`paragraph_length`, `target_word_count`, `default`) is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)