### PR TITLE
fix(abw): reconcile brand voices with the required article structure

### DIFF
--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/local-insider.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/local-insider.md
@@ -18,6 +18,6 @@ Point of view: address the reader as "you". First-person singular only when the 
 
 Facts: prices with currency and an as-of frame, dates in full, hours as sourced with day ranges. Local proper name on first mention with a gloss where it helps, then the local name alone, transliterated consistently. Do not round what the sources did not round.
 
-Structure: sentence case headings, no one-sentence sections, lists only for parallel items, no closing recap.
+Structure: sentence case headings, no one-sentence sections, lists only for parallel items, and a closing takeaways section that carries new specifics rather than restating the article.
 
 Hedging: say it or cut it. No "may or may not", no fake balance. A caveat names its condition.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/news-desk.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/news-desk.md
@@ -10,7 +10,7 @@ These rules hold regardless of the selected tone, and they win where the tone pr
 
 Attribution comes first. Every claim carries its source inside the sentence that makes it: who said it, in what document or statement, and when. Separate confirmed from reported by verb choice: confirmed, said, announced, according to, has not confirmed. Never present one party's position as established fact. Where sourcing is thin, write what is known and name what is not.
 
-No promotion of any kind. No recommendations, rankings, superlatives, or calls to action. Do not address the reader: never "you", never imperatives aimed at the reader. Third person throughout, no first person singular or plural, regardless of what the tone profile allows.
+No promotion of any kind. No recommendations, rankings, superlatives, or calls to action. Do not address the reader: never "you", never imperatives aimed at the reader. If the writing brief supplies a call to action, render it as a factual line stating where official guidance or further detail can be found, not as an instruction to the reader. Third person throughout, no first person singular or plural, regardless of what the tone profile allows.
 
 Never use, in any form: nestled, hidden gem, must-visit, boasts, unlock, delve, tapestry, vibrant, bustling, iconic, world-class, beloved, stunning, "whether you're X or Y", "when it comes to", "in conclusion", "not only... but also". Also banned: slammed, sparked outrage, amid growing concerns, "many are saying", "some critics argue" without a named critic.
 
@@ -18,6 +18,6 @@ Facts: full name and title on first mention, surname alone after. Prices with cu
 
 Sentence construction stays tight: one idea per sentence, subject first, active voice. Passive only when the actor is genuinely unknown. Cut intensifying adverbs. No em-dash asides; end the sentence instead.
 
-Structure: sentence case headings, no terminal punctuation. The opening paragraph carries what happened, where, when, and on whose authority. No one-sentence sections, no closing summary, lists only for parallel items such as figures or sequences.
+Structure: sentence case headings, no terminal punctuation. The opening paragraph carries what happened, where, when, and on whose authority. No one-sentence sections, a closing takeaways section limited to new factual specifics rather than a restatement, lists only for parallel items such as figures or sequences.
 
 Hedging: state it with attribution or leave it out. No "may or may not", no manufactured balance, no two-sided framing where the sources do not actually disagree.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/questurian-default.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/brand-voices/questurian-default.md
@@ -15,6 +15,6 @@ Point of view: "you" is the reader making the decision, and it is the default ad
 
 Facts: give prices with currency and an as-of frame, e.g. "COP 38,000 (about USD 9) as of March 2026". Write dates in full. Give hours as sourced, with the day range. Use the local proper name on first mention with an English gloss where it helps, then the local name alone, transliterated consistently throughout. Do not round numbers the sources did not round. An unconfirmed detail is either attributed in the sentence ("the operator's site lists...") or cut.
 
-Structure: sentence case headings, no terminal punctuation, no gerund stacking. No one-sentence sections. Lists only for genuinely parallel items, never to chop up an argument. No closing recap section.
+Structure: sentence case headings, no terminal punctuation, no gerund stacking. No one-sentence sections. Lists only for genuinely parallel items, never to chop up an argument. The article structure requires a short closing takeaways section: make it carry new specifics such as a price, a time, a named place, or the one thing to do differently, never a restatement of what the article already said.
 
 Hedging: say it or cut it. No "may or may not", no "varies widely", no invented two-sidedness. A real caveat names what changes it and when.


### PR DESCRIPTION
## Two conflicts where the voice markdown told the model the opposite of what the pipeline requires

### 1. The closing section — fired on every run

All three brand voices banned one outright:

| File | Text |
|---|---|
| `questurian-default.md` | "No closing recap section." |
| `local-insider.md` | "no closing recap." |
| `news-desk.md` | "no closing summary" |

Meanwhile `P2B_COMPOSE_PROMPT` hardcodes:

> "Include a concise takeaway section near the end." (`generation.py:204`)

…and its SEO rules add *"End with concise key takeaways"* (`generation.py:13`). Whichever voice was selected, the model got contradictory orders.

**Resolved by keeping the section and constraining its contents.** What the voices — and the anti-AI `_SUMMARY_PATTERNS` block — actually object to is a *restated thesis*, not a takeaways list. `_SUMMARY_PATTERNS` says "End on a concrete detail or a specific recommendation, not a sweeping verdict", which is entirely compatible with a takeaways section. So the section is now required to carry **new specifics** (a price, a time, a named place, the one thing to do differently) and forbidden from restating the article. All three requirements are now satisfiable simultaneously.

### 2. The news-desk CTA — failed a deterministic gate

`news-desk.md` banned "calls to action" and all reader address. But compose says *"Include CTA naturally near the end when provided"* (`generation.py:208`), and `quality.py:140` computes it deterministically:

```python
cta_present = _keyword_overlap_ratio(cta, combined) >= 0.35 if cta else True
```

A news-desk article that obeyed its own voice **failed a machine check** — conditionally, only when the brief supplied a `call_to_action`, since the gate defaults to `True` otherwise. (Worth stating precisely: the original audit called this unconditional; it isn't.)

`news-desk.md` now renders a supplied CTA as a factual line stating where official guidance or further detail can be found, rather than an instruction to the reader. That clears the keyword-overlap gate while preserving the third-person, no-imperatives voice.

## Note on my own edit

My first draft of the `questurian-default.md` change used a `--` aside — inside a file whose own rules ban em-dash asides. Rewritten as a colon list.

## Verification

- 492 backend tests pass.
- All 16 tone/length/brand-voice files parse via `_load_prompt2blog_option_catalog` with non-empty `instructions`.
- Zero residual closing-section bans across the brand voices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)