### PR TITLE
fix(questura): keep machine uploads out of staff attribution

### DIFF
--- a/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.test.ts
+++ b/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { setUploadedBy } from './setUploadedBy'
+
+describe('setUploadedBy', () => {
+  it('attributes a human upload to its staff user', async () => {
+    const result = await setUploadedBy({
+      operation: 'create',
+      data: { alt: 'Lima skyline' },
+      req: {
+        user: {
+          id: 11,
+          collection: 'users',
+          role: 'editor',
+          status: 'active',
+        },
+      },
+    } as never)
+
+    expect(result).toEqual({
+      alt: 'Lima skyline',
+      uploadedBy: 11,
+      user: 11,
+    })
+  })
+
+  it('does not attribute a machine upload to a staff user', async () => {
+    const data = { alt: 'Lima skyline' }
+
+    const result = await setUploadedBy({
+      operation: 'create',
+      data,
+      req: {
+        user: {
+          id: 7,
+          collection: 'service-accounts',
+          name: 'Location Manager',
+        },
+      },
+    } as never)
+
+    expect(result).toEqual({ alt: 'Lima skyline' })
+  })
+})

--- a/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.ts
+++ b/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.ts
@@ -1,10 +1,13 @@
 import type { CollectionBeforeChangeHook } from 'payload'
+import { staffUser } from '@/features/auth/lib/staff-user'
 
 export const setUploadedBy: CollectionBeforeChangeHook = ({ req, operation, data }) => {
-  if (operation === 'create' && req.user && data) {
-    data.uploadedBy = req.user.id
+  const uploader = staffUser(req.user)
+
+  if (operation === 'create' && uploader && data) {
+    data.uploadedBy = uploader.id
     if (!data.user) {
-      data.user = req.user.id
+      data.user = uploader.id
     }
   }
 


### PR DESCRIPTION
## What changed

- Narrow media upload attribution to human staff principals.
- Leave service-account uploads without staff attribution.
- Add regression coverage for human and machine uploads.

## Why

Service-account IDs come from another table and may overlap users IDs. Writing them into media-assets.user could credit an unrelated person or fail foreign-key validation.

## Checks

- Focused Vitest: 2 passed.
- Questura server typecheck: unchanged known baseline, 54 errors.