### PR TITLE
refactor(location-manager): centralize Payload authorization

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { EnvConfig } from "@server/shared/config/env.config";
+import { PayloadAuthClient } from "./payload-auth.client";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("PayloadAuthClient", () => {
+  test("builds the Payload authorization header", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          token: "test-token",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        }),
+        { status: 200 }
+      )) as unknown as typeof fetch;
+
+    const client = new PayloadAuthClient({
+      PAYLOAD_API_URL: "https://payload.example.com",
+      PAYLOAD_SERVICE_EMAIL: "service@example.com",
+      PAYLOAD_SERVICE_PASSWORD: "secret",
+    } as EnvConfig);
+
+    await expect(client.authHeader()).resolves.toEqual({
+      Authorization: "JWT test-token",
+    });
+  });
+});

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.ts
@@ -23,6 +23,11 @@ export class PayloadAuthClient {
     return this.apiUrl;
   }
 
+  async authHeader(): Promise<{ Authorization: string }> {
+    const token = await this.ensureAuthenticated();
+    return { Authorization: `JWT ${token}` };
+  }
+
   async authenticate(): Promise<string> {
     if (!this.isConfigured()) {
       throw new ServiceUnavailableError("Payload CMS");

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-entries.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-entries.client.ts
@@ -15,7 +15,7 @@ export class PayloadEntriesClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const params = new URLSearchParams({
       "where[title][equals]": title,
       limit: "1",
@@ -31,7 +31,7 @@ export class PayloadEntriesClient {
     const response = await fetch(`${apiUrl}/api/${collection}?${params.toString()}`, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -65,7 +65,7 @@ export class PayloadEntriesClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     console.log("[Payload] Fetch entry by ID", {
@@ -77,7 +77,7 @@ export class PayloadEntriesClient {
     const response = await fetch(`${apiUrl}/api/${collection}/${docId}`, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -125,7 +125,7 @@ export class PayloadEntriesClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     console.log("[Payload] Create entry", {
@@ -145,7 +145,7 @@ export class PayloadEntriesClient {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });
@@ -195,7 +195,7 @@ export class PayloadEntriesClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     console.log("[Payload] Update entry", {
@@ -215,7 +215,7 @@ export class PayloadEntriesClient {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-instagram.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-instagram.client.ts
@@ -14,14 +14,14 @@ export class PayloadInstagramClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     const response = await fetch(`${apiUrl}/api/instagram-posts`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-locations.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-locations.client.ts
@@ -19,7 +19,7 @@ export class PayloadLocationsClient {
       return null;
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const params = new URLSearchParams({
       "where[locationKey][equals]": locationKey,
     });
@@ -33,7 +33,7 @@ export class PayloadLocationsClient {
     const response = await fetch(`${apiUrl}/api/locations?${params.toString()}`, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -65,7 +65,7 @@ export class PayloadLocationsClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     console.log("[Payload] Create location", data);
@@ -74,7 +74,7 @@ export class PayloadLocationsClient {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-media-sets.client.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-media-sets.client.test.ts
@@ -52,7 +52,7 @@ describe("PayloadMediaSetsClient", () => {
 
     const client = new PayloadMediaSetsClient({
       isConfigured: () => true,
-      ensureAuthenticated: async () => "test-token",
+      authHeader: async () => ({ Authorization: "JWT test-token" }),
       getApiUrl: () => "https://payload.example.com",
     } as never);
 
@@ -92,7 +92,7 @@ describe("PayloadMediaSetsClient", () => {
 
     const client = new PayloadMediaSetsClient({
       isConfigured: () => true,
-      ensureAuthenticated: async () => "test-token",
+      authHeader: async () => ({ Authorization: "JWT test-token" }),
       getApiUrl: () => "https://payload.example.com",
     } as never);
 

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-media-sets.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-media-sets.client.ts
@@ -95,7 +95,7 @@ export class PayloadMediaSetsClient {
       return null;
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const params = new URLSearchParams({
       "where[externalRef][equals]": externalRef,
       limit: "1",
@@ -110,7 +110,7 @@ export class PayloadMediaSetsClient {
     const response = await fetch(`${apiUrl}/api/media-sets?${params.toString()}`, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -143,7 +143,7 @@ export class PayloadMediaSetsClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     console.log("[Payload] Create media-set", {
@@ -156,7 +156,7 @@ export class PayloadMediaSetsClient {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });
@@ -197,14 +197,14 @@ export class PayloadMediaSetsClient {
       throw new Error(`Invalid locationRef for media-set update: ${locationRef}`);
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     const response = await fetch(`${apiUrl}/api/media-sets/${mediaSetId}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify({
         locationRef: parsedLocationRef,
@@ -228,13 +228,13 @@ export class PayloadMediaSetsClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     const response = await fetch(`${apiUrl}/api/media-sets/${mediaSetId}?depth=0`, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -276,7 +276,7 @@ export class PayloadMediaSetsClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
     const trimmedQuery = params.query?.trim() ?? "";
     const ids = Array.from(new Set((params.ids ?? []).map((id) => id.trim()).filter(Boolean)));
@@ -307,7 +307,7 @@ export class PayloadMediaSetsClient {
     const response = await fetch(url, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -387,7 +387,7 @@ export class PayloadMediaSetsClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     const formData = new FormData();
@@ -408,7 +408,7 @@ export class PayloadMediaSetsClient {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: formData,
     });

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-media.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-media.client.ts
@@ -22,7 +22,7 @@ export class PayloadMediaClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
 
     const formData = new FormData();
     const blob = new Blob([fileBuffer], { type: this.getMimeType(filename) });
@@ -80,7 +80,7 @@ export class PayloadMediaClient {
     const response = await fetch(`${apiUrl}/api/media-assets`, {
       method: "POST",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: formData,
     });
@@ -117,14 +117,14 @@ export class PayloadMediaClient {
       throw new Error(`Invalid locationRef for media asset update: ${locationRef}`);
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     const response = await fetch(`${apiUrl}/api/media-assets/${mediaAssetId}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify({
         locationRef: parsedLocationRef,
@@ -148,14 +148,14 @@ export class PayloadMediaClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
 
     const response = await fetch(`${apiUrl}/api/media-assets/${mediaAssetId}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify({
         mediaSet: null,

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-tours.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-tours.client.ts
@@ -11,7 +11,7 @@ export class PayloadToursClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const params = new URLSearchParams({
       "where[title][equals]": title,
       limit: "1",
@@ -20,7 +20,7 @@ export class PayloadToursClient {
     const response = await fetch(`${apiUrl}/api/tours?${params.toString()}`, {
       method: "GET",
       headers: {
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
     });
 
@@ -39,13 +39,13 @@ export class PayloadToursClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
     const response = await fetch(`${apiUrl}/api/tours`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });
@@ -70,13 +70,13 @@ export class PayloadToursClient {
       throw new ServiceUnavailableError("Payload CMS");
     }
 
-    const token = await this.authClient.ensureAuthenticated();
+    const authHeader = await this.authClient.authHeader();
     const apiUrl = this.authClient.getApiUrl();
     const response = await fetch(`${apiUrl}/api/tours/${docId}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `JWT ${token}`,
+        ...authHeader,
       },
       body: JSON.stringify(data),
     });


### PR DESCRIPTION
## What changed

- Added one PayloadAuthClient.authHeader() boundary.
- Routed all 19 production Payload requests through it.
- Kept current JWT login behavior unchanged.
- Updated client fakes and added focused auth-header coverage.

## Why

Credential formatting was duplicated across six clients. Centralization makes the later service-account switch atomic and reviewable.

## Safety

Multipart media uploads still omit Content-Type so fetch supplies the boundary.

## Checks

- Location Manager tests: 253 passed.
- Location Manager typecheck: unchanged known baseline, 6 errors.