### PR TITLE
feat(questura): grant Location Manager collection access

### DIFF
--- a/apps/questura/apps/server/src/features/auth/lib/service-account-collection-access.test.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/service-account-collection-access.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { CollectionConfig } from 'payload'
+
+import { Locations } from '@/features/location/collections/Locations'
+import { Dining } from '@/features/data/dining/collections/Dining'
+import { Accommodations } from '@/features/data/accommodations/collections/Accommodations'
+import { Attractions } from '@/features/data/attractions/collections/Attractions'
+import { Nightlife } from '@/features/data/nightlife/collections/Nightlife'
+import { KeyLocations } from '@/features/data/key-locations/collections/KeyLocations'
+import { Tours } from '@/features/data/tours/collections/Tours'
+import { InstagramPosts } from '@/features/data/instagram/collections/InstagramPosts'
+import { AffiliateProducts } from '@/features/data/affiliate/collections/AffiliateProducts'
+import { MediaSet } from '@/features/media/collections/MediaSet'
+import { MediaAsset } from '@/features/media/collections/MediaAsset'
+import { Places } from '@/features/places/collections/Places'
+import { LOCATION_MANAGER_SERVICE_ACCOUNT } from './service-account-grants'
+
+type Operation = 'read' | 'create' | 'update' | 'delete'
+type AccessFunction = (args: unknown) => unknown
+
+const locationManager = {
+  id: 1,
+  collection: 'service-accounts',
+  name: LOCATION_MANAGER_SERVICE_ACCOUNT,
+}
+
+const collectionAccess = (collection: CollectionConfig): Record<Operation, AccessFunction> =>
+  collection.access as Record<Operation, AccessFunction>
+
+const allowed: Array<[CollectionConfig, Operation[]]> = [
+  [Locations, ['read', 'create']],
+  [Dining, ['read', 'create', 'update']],
+  [Accommodations, ['read', 'create', 'update']],
+  [Attractions, ['read', 'create', 'update']],
+  [Nightlife, ['read', 'create', 'update']],
+  [KeyLocations, ['read', 'create', 'update']],
+  [Tours, ['read', 'create', 'update']],
+  [MediaAsset, ['read', 'create', 'update']],
+  [MediaSet, ['read', 'create', 'update']],
+  [InstagramPosts, ['read', 'create']],
+]
+
+const invoke = async (collection: CollectionConfig, operation: Operation, user = locationManager) =>
+  collectionAccess(collection)[operation]({ req: { user } })
+
+describe('Location Manager collection access', () => {
+  it('allows the complete sync matrix through collection access', async () => {
+    for (const [collection, operations] of allowed) {
+      for (const operation of operations) {
+        await expect(
+          invoke(collection, operation),
+          `${collection.slug}:${operation}`,
+        ).resolves.toBe(true)
+      }
+    }
+  })
+
+  it('denies delete on every synced collection', async () => {
+    for (const [collection] of allowed) {
+      await expect(invoke(collection, 'delete'), `${collection.slug}:delete`).resolves.toBe(false)
+    }
+  })
+
+  it('denies ungranted authenticated reads instead of exposing drafts', async () => {
+    await expect(invoke(AffiliateProducts, 'read')).resolves.toBe(false)
+    await expect(invoke(Places, 'read')).resolves.toBe(false)
+  })
+
+  it('defaults an unknown service account to no private access', async () => {
+    const unknown = { ...locationManager, name: 'Unknown integration' }
+
+    for (const [collection, operations] of allowed) {
+      for (const operation of operations) {
+        // Locations is public by design; only its create grant is private.
+        if (collection === Locations && operation === 'read') continue
+
+        await expect(
+          invoke(collection, operation, unknown),
+          `${collection.slug}:${operation}`,
+        ).resolves.toBe(false)
+      }
+    }
+  })
+})

--- a/apps/questura/apps/server/src/features/auth/lib/service-account-grants.test.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/service-account-grants.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  LOCATION_MANAGER_SERVICE_ACCOUNT,
+  serviceAccountHasCollectionGrant,
+  type ServiceAccountCollectionOperation,
+} from './service-account-grants'
+
+const locationManager = {
+  id: 1,
+  collection: 'service-accounts',
+  name: LOCATION_MANAGER_SERVICE_ACCOUNT,
+} as const
+
+const allowed: Record<string, ServiceAccountCollectionOperation[]> = {
+  locations: ['create'],
+  dining: ['read', 'create', 'update'],
+  accommodations: ['read', 'create', 'update'],
+  attractions: ['read', 'create', 'update'],
+  nightlife: ['read', 'create', 'update'],
+  'key-locations': ['read', 'create', 'update'],
+  tours: ['read', 'create', 'update'],
+  'media-assets': ['read', 'create', 'update'],
+  'media-sets': ['read', 'create', 'update'],
+  'instagram-posts': ['read', 'create'],
+}
+
+describe('service-account collection grants', () => {
+  it('grants Location Manager only its sync operations', () => {
+    for (const [collection, operations] of Object.entries(allowed)) {
+      for (const operation of operations) {
+        expect(
+          serviceAccountHasCollectionGrant(
+            locationManager as never,
+            collection as never,
+            operation,
+          ),
+          `${collection}:${operation}`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('denies every delete plus unrelated sensitive collections', () => {
+    for (const collection of Object.keys(allowed)) {
+      expect(
+        serviceAccountHasCollectionGrant(locationManager as never, collection as never, 'delete'),
+        `${collection}:delete`,
+      ).toBe(false)
+    }
+
+    for (const collection of ['users', 'service-accounts', 'affiliate-products', 'places']) {
+      for (const operation of ['read', 'create', 'update', 'delete'] as const) {
+        expect(
+          serviceAccountHasCollectionGrant(
+            locationManager as never,
+            collection as never,
+            operation,
+          ),
+          `${collection}:${operation}`,
+        ).toBe(false)
+      }
+    }
+  })
+
+  it('defaults unknown machines and human staff to no machine grants', () => {
+    const unknownMachine = { ...locationManager, name: 'Unknown integration' }
+    const humanAdmin = { id: 2, collection: 'users', role: 'admin', status: 'active' }
+
+    expect(serviceAccountHasCollectionGrant(unknownMachine as never, 'locations', 'create')).toBe(
+      false,
+    )
+    expect(serviceAccountHasCollectionGrant(humanAdmin as never, 'locations', 'create')).toBe(false)
+  })
+})

--- a/apps/questura/apps/server/src/features/auth/lib/service-account-grants.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/service-account-grants.ts
@@ -1,0 +1,51 @@
+import type { CollectionSlug, PayloadRequest } from 'payload'
+
+import type { ServiceAccount } from '@/payload-types'
+
+export const LOCATION_MANAGER_SERVICE_ACCOUNT = 'Location Manager'
+
+export type ServiceAccountCollectionOperation = 'read' | 'create' | 'update' | 'delete'
+
+type CollectionGrants = Partial<
+  Record<CollectionSlug, readonly ServiceAccountCollectionOperation[]>
+>
+
+const SERVICE_ACCOUNT_COLLECTION_GRANTS: Record<string, CollectionGrants> = {
+  [LOCATION_MANAGER_SERVICE_ACCOUNT]: {
+    locations: ['create'],
+    dining: ['read', 'create', 'update'],
+    accommodations: ['read', 'create', 'update'],
+    attractions: ['read', 'create', 'update'],
+    nightlife: ['read', 'create', 'update'],
+    'key-locations': ['read', 'create', 'update'],
+    tours: ['read', 'create', 'update'],
+    'media-assets': ['read', 'create', 'update'],
+    'media-sets': ['read', 'create', 'update'],
+    // Gallery merges populate existing Instagram relationships before an
+    // upsert. Without read access Payload strips them and the next update
+    // silently drops the existing gallery.
+    'instagram-posts': ['read', 'create'],
+  },
+}
+
+function serviceAccount(user: PayloadRequest['user']): ServiceAccount | null {
+  if (!user || user.collection !== 'service-accounts') return null
+  return user as ServiceAccount
+}
+
+/**
+ * One default-deny grant table for machine collection access (ADR-0006).
+ * `name` is currently the only unique, environment-independent identity on
+ * ServiceAccounts. Renaming an account therefore fails closed until its grant
+ * entry is updated.
+ */
+export function serviceAccountHasCollectionGrant(
+  user: PayloadRequest['user'],
+  collection: CollectionSlug,
+  operation: ServiceAccountCollectionOperation,
+): boolean {
+  const account = serviceAccount(user)
+  if (!account) return false
+
+  return SERVICE_ACCOUNT_COLLECTION_GRANTS[account.name]?.[collection]?.includes(operation) ?? false
+}

--- a/apps/questura/apps/server/src/features/data/accommodations/collections/Accommodations.ts
+++ b/apps/questura/apps/server/src/features/data/accommodations/collections/Accommodations.ts
@@ -4,6 +4,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 import { countryCodes } from '@/shared/constants/countryCodes'
 import { createLocationRefField } from '@/shared/location/server/fields'
@@ -30,18 +31,29 @@ export const Accommodations: CollectionConfig = {
           },
         }
       }
-      // Authenticated users can read all
-      return true
+      // Human staff and explicitly granted machines can read all.
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'accommodations', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       // Only editors and admins can create
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'accommodations', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req }) => {
       // Editors and admins can update all accommodations
       const role = staffUser(req.user)?.role
-      return role === 'admin' || role === 'editor'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'accommodations', 'update') ||
+        role === 'admin' ||
+        role === 'editor'
+      )
     },
     delete: ({ req }) => {
       // Only admins can delete

--- a/apps/questura/apps/server/src/features/data/affiliate/collections/AffiliateProducts.ts
+++ b/apps/questura/apps/server/src/features/data/affiliate/collections/AffiliateProducts.ts
@@ -4,6 +4,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 
 export const AffiliateProducts: CollectionConfig = {
@@ -17,7 +18,10 @@ export const AffiliateProducts: CollectionConfig = {
   access: {
     read: ({ req }) => {
       if (!req.user) return { status: { equals: 'published' } }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'affiliate-products', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role

--- a/apps/questura/apps/server/src/features/data/attractions/collections/Attractions.ts
+++ b/apps/questura/apps/server/src/features/data/attractions/collections/Attractions.ts
@@ -4,6 +4,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 import { countryCodes } from '@/shared/constants/countryCodes'
 import { createLocationRefField } from '@/shared/location/server/fields'
@@ -26,16 +27,27 @@ export const Attractions: CollectionConfig = {
       if (!req.user) {
         return { status: { equals: 'published' } }
       }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'attractions', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'attractions', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req }) => {
       // Editors and admins can update all attractions
       const role = staffUser(req.user)?.role
-      return role === 'admin' || role === 'editor'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'attractions', 'update') ||
+        role === 'admin' ||
+        role === 'editor'
+      )
     },
     delete: ({ req }) => staffUser(req.user)?.role === 'admin',
   },

--- a/apps/questura/apps/server/src/features/data/dining/collections/Dining.ts
+++ b/apps/questura/apps/server/src/features/data/dining/collections/Dining.ts
@@ -4,6 +4,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 import { countryCodes } from '@/shared/constants/countryCodes'
 import { createLocationRefField } from '@/shared/location/server/fields'
@@ -49,16 +50,27 @@ export const Dining: CollectionConfig = {
   access: {
     read: ({ req }) => {
       if (!req.user) return { status: { equals: 'published' } }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'dining', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'dining', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req }) => {
       // Editors and admins can update all dining items
       const role = staffUser(req.user)?.role
-      return role === 'admin' || role === 'editor'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'dining', 'update') ||
+        role === 'admin' ||
+        role === 'editor'
+      )
     },
     delete: ({ req }) => staffUser(req.user)?.role === 'admin',
   },

--- a/apps/questura/apps/server/src/features/data/instagram/collections/InstagramPosts.ts
+++ b/apps/questura/apps/server/src/features/data/instagram/collections/InstagramPosts.ts
@@ -5,6 +5,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 
 export const InstagramPosts: CollectionConfig = {
@@ -22,11 +23,18 @@ export const InstagramPosts: CollectionConfig = {
   access: {
     read: ({ req }) => {
       if (!req.user) return { status: { equals: 'published' } }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'instagram-posts', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'instagram-posts', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req, data }: any) => {
       if (!req.user) return false

--- a/apps/questura/apps/server/src/features/data/key-locations/collections/KeyLocations.ts
+++ b/apps/questura/apps/server/src/features/data/key-locations/collections/KeyLocations.ts
@@ -1,4 +1,5 @@
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 import { countryCodes } from '@/shared/constants/countryCodes'
 import { createLocationRefField } from '@/shared/location/server/fields'
@@ -18,15 +19,26 @@ export const KeyLocations: CollectionConfig = {
   access: {
     read: ({ req }) => {
       if (!req.user) return { status: { equals: 'published' } }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'key-locations', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'key-locations', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'admin' || role === 'editor'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'key-locations', 'update') ||
+        role === 'admin' ||
+        role === 'editor'
+      )
     },
     delete: ({ req }) => staffUser(req.user)?.role === 'admin',
   },

--- a/apps/questura/apps/server/src/features/data/nightlife/collections/Nightlife.ts
+++ b/apps/questura/apps/server/src/features/data/nightlife/collections/Nightlife.ts
@@ -4,6 +4,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 import { countryCodes } from '@/shared/constants/countryCodes'
 import { createLocationRefField } from '@/shared/location/server/fields'
@@ -20,16 +21,27 @@ export const Nightlife: CollectionConfig = {
   access: {
     read: ({ req }) => {
       if (!req.user) return { status: { equals: 'published' } }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'nightlife', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'nightlife', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req }) => {
       // Editors and admins can update all nightlife items
       const role = staffUser(req.user)?.role
-      return role === 'admin' || role === 'editor'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'nightlife', 'update') ||
+        role === 'admin' ||
+        role === 'editor'
+      )
     },
     delete: ({ req }) => staffUser(req.user)?.role === 'admin',
   },

--- a/apps/questura/apps/server/src/features/data/tours/collections/Tours.ts
+++ b/apps/questura/apps/server/src/features/data/tours/collections/Tours.ts
@@ -1,4 +1,5 @@
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import { CollectionConfig } from 'payload'
 
 const urlValidationMessage = 'Enter a valid absolute URL, for example https://example.com/tour.'
@@ -28,15 +29,26 @@ export const Tours: CollectionConfig = {
   access: {
     read: ({ req }) => {
       if (!req.user) return { status: { equals: 'published' } }
-      return true
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'tours', 'read') ||
+        Boolean(staffUser(req.user))
+      )
     },
     create: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'editor' || role === 'admin'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'tours', 'create') ||
+        role === 'editor' ||
+        role === 'admin'
+      )
     },
     update: ({ req }) => {
       const role = staffUser(req.user)?.role
-      return role === 'admin' || role === 'editor'
+      return (
+        serviceAccountHasCollectionGrant(req.user, 'tours', 'update') ||
+        role === 'admin' ||
+        role === 'editor'
+      )
     },
     delete: ({ req }) => staffUser(req.user)?.role === 'admin',
   },

--- a/apps/questura/apps/server/src/features/location/collections/Locations.ts
+++ b/apps/questura/apps/server/src/features/location/collections/Locations.ts
@@ -5,6 +5,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import type { CollectionConfig } from 'payload'
 import { beforeValidateLocation } from '../hooks/beforeValidateLocation'
 import { ensureParentLocation } from '../hooks/ensureParentLocation'
@@ -30,7 +31,9 @@ export const Locations: CollectionConfig = {
 
   access: {
     read: () => true,
-    create: ({ req }) => staffUser(req.user)?.role === 'admin',
+    create: ({ req }) =>
+      serviceAccountHasCollectionGrant(req.user, 'locations', 'create') ||
+      staffUser(req.user)?.role === 'admin',
     update: ({ req }) => staffUser(req.user)?.role === 'admin',
     delete: ({ req }) => staffUser(req.user)?.role === 'admin',
   },

--- a/apps/questura/apps/server/src/features/media/collections/MediaSet.ts
+++ b/apps/questura/apps/server/src/features/media/collections/MediaSet.ts
@@ -3,6 +3,7 @@
  */
 
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import type { CollectionConfig, Field } from 'payload'
 import { createLocationRefField } from '@/shared/location/server/fields'
 import { syncLocationFields } from '@/shared/location/server/syncLocationFields'
@@ -62,6 +63,7 @@ export const MediaSet: CollectionConfig = {
     read: ({ req }) => {
       if (!req.user) return true
       if (
+        serviceAccountHasCollectionGrant(req.user, 'media-sets', 'read') ||
         staffUser(req.user)?.role === 'admin' ||
         staffUser(req.user)?.role === 'editor' ||
         staffUser(req.user)?.role === 'writer'
@@ -71,6 +73,7 @@ export const MediaSet: CollectionConfig = {
     },
     create: ({ req }) => {
       return (
+        serviceAccountHasCollectionGrant(req.user, 'media-sets', 'create') ||
         staffUser(req.user)?.role === 'editor' ||
         staffUser(req.user)?.role === 'admin' ||
         staffUser(req.user)?.role === 'writer'
@@ -78,6 +81,7 @@ export const MediaSet: CollectionConfig = {
     },
     update: ({ req }) => {
       if (!req.user) return false
+      if (serviceAccountHasCollectionGrant(req.user, 'media-sets', 'update')) return true
       const role = staffUser(req.user)?.role
       if (role === 'admin' || role === 'editor') return true
       if (staffUser(req.user)?.role === 'writer') {

--- a/apps/questura/apps/server/src/features/media/collections/access/mediaAssetAccess.ts
+++ b/apps/questura/apps/server/src/features/media/collections/access/mediaAssetAccess.ts
@@ -1,4 +1,5 @@
 import { staffUser } from '@/features/auth/lib/staff-user'
+import { serviceAccountHasCollectionGrant } from '@/features/auth/lib/service-account-grants'
 import type { CollectionConfig } from 'payload'
 
 export const mediaAssetAccess: CollectionConfig['access'] = {
@@ -8,7 +9,12 @@ export const mediaAssetAccess: CollectionConfig['access'] = {
 
     // Admins, Editors, and Writers can see everything
     const role = staffUser(req.user)?.role
-    if (role === 'admin' || role === 'editor' || role === 'writer')
+    if (
+      serviceAccountHasCollectionGrant(req.user, 'media-assets', 'read') ||
+      role === 'admin' ||
+      role === 'editor' ||
+      role === 'writer'
+    )
       return true
 
     return false
@@ -16,9 +22,16 @@ export const mediaAssetAccess: CollectionConfig['access'] = {
   create: ({ req }) => {
     // Editors, admins, and writers can upload
     const role = staffUser(req.user)?.role
-    return role === 'editor' || role === 'admin' || role === 'writer'
+    return (
+      serviceAccountHasCollectionGrant(req.user, 'media-assets', 'create') ||
+      role === 'editor' ||
+      role === 'admin' ||
+      role === 'writer'
+    )
   },
   update: ({ req }) => {
+    if (serviceAccountHasCollectionGrant(req.user, 'media-assets', 'update')) return true
+
     const user = staffUser(req.user)
     if (!user) return false
 

--- a/apps/questura/apps/server/src/features/places/access/index.ts
+++ b/apps/questura/apps/server/src/features/places/access/index.ts
@@ -12,7 +12,7 @@ import type { Access } from 'payload'
  */
 export const placesReadAccess: Access = ({ req }) => {
   if (!req.user) return { status: { equals: 'published' } }
-  return true
+  return Boolean(staffUser(req.user))
 }
 
 /**


### PR DESCRIPTION
## What changed

- Added one identity-scoped, default-deny service-account grant table.
- Granted Location Manager only required collection operations.
- Wired grants into locations, six travel collections, media assets/sets, and Instagram posts.
- Closed generic authenticated draft-read leaks on ungranted affiliate and places surfaces.

## Permission boundary

- No delete grants.
- No users or service-accounts grants.
- No affiliate-products or places grants.
- Unknown service-account names fail closed.
- Instagram read is intentional: gallery merge must retain populated existing relationships.

## Schema verification

- Payload migration generator produced no migration file; changes are access-only.
- Migration status was current; db:migrate completed as a no-op.
- generate:types produced no diff.

## Checks

- Focused Vitest: 7 passed.
- Questura server typecheck: unchanged known baseline, 54 errors.