### PR TITLE
feat(questura): authorize Location Manager source assembly

### DIFF
--- a/apps/questura/apps/server/src/app/api/media-sets/from-source/route.ts
+++ b/apps/questura/apps/server/src/app/api/media-sets/from-source/route.ts
@@ -111,6 +111,7 @@ export async function POST(req: NextRequest) {
     const authResult = await authenticateRequest(req, {
       requireAuth: true,
       allowedRoles: ['admin', 'editor', 'writer'],
+      serviceAccountCapability: 'media-sets:from-source',
     })
     if (authResult.error) {
       return NextResponse.json(

--- a/apps/questura/apps/server/src/features/auth/lib/auth-middleware.test.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/auth-middleware.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+}))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockResolvedValue({ auth: mocks.auth }),
+}))
+
+vi.mock('@/payload.config', () => ({ default: {} }))
+
+import { authenticateRequest } from './auth-middleware'
+import { LOCATION_MANAGER_SERVICE_ACCOUNT } from './service-account-grants'
+
+const request = () => new NextRequest('http://localhost:4000/api/editorial')
+
+describe('authenticateRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('allows Location Manager when the route requests its explicit capability', async () => {
+    const user = {
+      id: 1,
+      collection: 'service-accounts',
+      name: LOCATION_MANAGER_SERVICE_ACCOUNT,
+    }
+    mocks.auth.mockResolvedValue({ user })
+
+    await expect(
+      authenticateRequest(request(), {
+        requireAuth: true,
+        serviceAccountCapability: 'media-sets:from-source',
+      }),
+    ).resolves.toEqual({ user, error: null, status: 200 })
+  })
+
+  it('denies a service account when the route requests no machine capability', async () => {
+    mocks.auth.mockResolvedValue({
+      user: {
+        id: 1,
+        collection: 'service-accounts',
+        name: LOCATION_MANAGER_SERVICE_ACCOUNT,
+      },
+    })
+
+    await expect(authenticateRequest(request())).resolves.toMatchObject({
+      user: null,
+      status: 403,
+    })
+  })
+
+  it('denies an unknown service account even on a machine-capable route', async () => {
+    mocks.auth.mockResolvedValue({
+      user: { id: 2, collection: 'service-accounts', name: 'Unknown integration' },
+    })
+
+    await expect(
+      authenticateRequest(request(), {
+        serviceAccountCapability: 'media-sets:from-source',
+      }),
+    ).resolves.toMatchObject({ user: null, status: 403 })
+  })
+
+  it('preserves active staff role authorization', async () => {
+    const user = {
+      id: 3,
+      collection: 'users',
+      role: 'editor',
+      status: 'active',
+    }
+    mocks.auth.mockResolvedValue({ user })
+
+    await expect(
+      authenticateRequest(request(), { allowedRoles: ['admin', 'editor'] }),
+    ).resolves.toEqual({ user, error: null, status: 200 })
+  })
+
+  it('still denies disabled staff', async () => {
+    mocks.auth.mockResolvedValue({
+      user: {
+        id: 4,
+        collection: 'users',
+        role: 'admin',
+        status: 'disabled',
+      },
+    })
+
+    await expect(authenticateRequest(request())).resolves.toMatchObject({
+      user: null,
+      error: 'This account has been disabled',
+      status: 403,
+    })
+  })
+})

--- a/apps/questura/apps/server/src/features/auth/lib/auth-middleware.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/auth-middleware.ts
@@ -3,8 +3,10 @@ import { getPayload } from 'payload'
 
 import config from '@/payload.config'
 import type { AuthMiddlewareOptions, AuthResult } from '../types'
-import type { User } from '@/payload-types'
+import type { ServiceAccount, User } from '@/payload-types'
 import { isDisabledStaff } from './staff-status'
+import { serviceAccountHasCapability } from './service-account-grants'
+import { staffUser } from './staff-user'
 
 function isStaffRole(role: User['role']): role is 'admin' | 'editor' | 'writer' {
   return role === 'admin' || role === 'editor' || role === 'writer'
@@ -21,7 +23,7 @@ export async function authenticateRequest(
   try {
     const payload = await getPayload({ config })
     const authResult = await payload.auth({ headers: req.headers })
-    const user = authResult.user as User | null
+    const user = authResult.user as User | ServiceAccount | null
 
     if (!user) {
       if (options.requireAuth) {
@@ -35,7 +37,23 @@ export async function authenticateRequest(
       return { user: null, error: null, status: 200 }
     }
 
-    if (!isStaffRole(user.role)) {
+    if (user.collection === 'service-accounts') {
+      if (
+        options.serviceAccountCapability &&
+        serviceAccountHasCapability(user, options.serviceAccountCapability)
+      ) {
+        return { user, error: null, status: 200 }
+      }
+
+      return {
+        user: null,
+        error: 'Service account access denied',
+        status: 403,
+      }
+    }
+
+    const staff = staffUser(user)
+    if (!staff || !isStaffRole(staff.role)) {
       return {
         user: null,
         error: 'Staff account required',
@@ -47,7 +65,7 @@ export async function authenticateRequest(
     // (ADR-0007). Session revocation already denies the token, so reaching here
     // means the row was disabled without going through the collection —
     // refuse anyway rather than trusting one layer.
-    if (isDisabledStaff(user)) {
+    if (isDisabledStaff(staff)) {
       return {
         user: null,
         error: 'This account has been disabled',
@@ -55,7 +73,7 @@ export async function authenticateRequest(
       }
     }
 
-    if (options.allowedRoles?.length && !options.allowedRoles.includes(user.role)) {
+    if (options.allowedRoles?.length && !options.allowedRoles.includes(staff.role)) {
       return {
         user: null,
         error: `Access denied. Required roles: ${options.allowedRoles.join(', ')}`,
@@ -64,7 +82,7 @@ export async function authenticateRequest(
     }
 
     return {
-      user,
+      user: staff,
       error: null,
       status: 200,
     }

--- a/apps/questura/apps/server/src/features/auth/lib/service-account-grants.test.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/service-account-grants.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   LOCATION_MANAGER_SERVICE_ACCOUNT,
+  serviceAccountHasCapability,
   serviceAccountHasCollectionGrant,
   type ServiceAccountCollectionOperation,
 } from './service-account-grants'
@@ -71,5 +72,23 @@ describe('service-account collection grants', () => {
       false,
     )
     expect(serviceAccountHasCollectionGrant(humanAdmin as never, 'locations', 'create')).toBe(false)
+  })
+})
+
+describe('service-account route capabilities', () => {
+  it('grants Location Manager source-media assembly', () => {
+    expect(serviceAccountHasCapability(locationManager as never, 'media-sets:from-source')).toBe(
+      true,
+    )
+  })
+
+  it('defaults other machines and human staff to no route capabilities', () => {
+    const unknownMachine = { ...locationManager, name: 'Unknown integration' }
+    const humanAdmin = { id: 2, collection: 'users', role: 'admin', status: 'active' }
+
+    expect(serviceAccountHasCapability(unknownMachine as never, 'media-sets:from-source')).toBe(
+      false,
+    )
+    expect(serviceAccountHasCapability(humanAdmin as never, 'media-sets:from-source')).toBe(false)
   })
 })

--- a/apps/questura/apps/server/src/features/auth/lib/service-account-grants.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/service-account-grants.ts
@@ -5,26 +5,35 @@ import type { ServiceAccount } from '@/payload-types'
 export const LOCATION_MANAGER_SERVICE_ACCOUNT = 'Location Manager'
 
 export type ServiceAccountCollectionOperation = 'read' | 'create' | 'update' | 'delete'
+export type ServiceAccountCapability = 'media-sets:from-source'
 
 type CollectionGrants = Partial<
   Record<CollectionSlug, readonly ServiceAccountCollectionOperation[]>
 >
 
-const SERVICE_ACCOUNT_COLLECTION_GRANTS: Record<string, CollectionGrants> = {
+type ServiceAccountGrants = {
+  collections: CollectionGrants
+  capabilities: readonly ServiceAccountCapability[]
+}
+
+const SERVICE_ACCOUNT_GRANTS: Record<string, ServiceAccountGrants> = {
   [LOCATION_MANAGER_SERVICE_ACCOUNT]: {
-    locations: ['create'],
-    dining: ['read', 'create', 'update'],
-    accommodations: ['read', 'create', 'update'],
-    attractions: ['read', 'create', 'update'],
-    nightlife: ['read', 'create', 'update'],
-    'key-locations': ['read', 'create', 'update'],
-    tours: ['read', 'create', 'update'],
-    'media-assets': ['read', 'create', 'update'],
-    'media-sets': ['read', 'create', 'update'],
-    // Gallery merges populate existing Instagram relationships before an
-    // upsert. Without read access Payload strips them and the next update
-    // silently drops the existing gallery.
-    'instagram-posts': ['read', 'create'],
+    collections: {
+      locations: ['create'],
+      dining: ['read', 'create', 'update'],
+      accommodations: ['read', 'create', 'update'],
+      attractions: ['read', 'create', 'update'],
+      nightlife: ['read', 'create', 'update'],
+      'key-locations': ['read', 'create', 'update'],
+      tours: ['read', 'create', 'update'],
+      'media-assets': ['read', 'create', 'update'],
+      'media-sets': ['read', 'create', 'update'],
+      // Gallery merges populate existing Instagram relationships before an
+      // upsert. Without read access Payload strips them and the next update
+      // silently drops the existing gallery.
+      'instagram-posts': ['read', 'create'],
+    },
+    capabilities: ['media-sets:from-source'],
   },
 }
 
@@ -47,5 +56,15 @@ export function serviceAccountHasCollectionGrant(
   const account = serviceAccount(user)
   if (!account) return false
 
-  return SERVICE_ACCOUNT_COLLECTION_GRANTS[account.name]?.[collection]?.includes(operation) ?? false
+  return SERVICE_ACCOUNT_GRANTS[account.name]?.collections[collection]?.includes(operation) ?? false
+}
+
+export function serviceAccountHasCapability(
+  user: PayloadRequest['user'],
+  capability: ServiceAccountCapability,
+): boolean {
+  const account = serviceAccount(user)
+  if (!account) return false
+
+  return SERVICE_ACCOUNT_GRANTS[account.name]?.capabilities.includes(capability) ?? false
 }

--- a/apps/questura/apps/server/src/features/auth/types/auth.types.ts
+++ b/apps/questura/apps/server/src/features/auth/types/auth.types.ts
@@ -1,7 +1,8 @@
-import type { User } from '@/payload-types'
+import type { ServiceAccount, User } from '@/payload-types'
+import type { ServiceAccountCapability } from '../lib/service-account-grants'
 
 export interface AuthResult {
-  user: User | null
+  user: User | ServiceAccount | null
   error: string | null
   status: number
 }
@@ -9,4 +10,5 @@ export interface AuthResult {
 export interface AuthMiddlewareOptions {
   requireAuth?: boolean
   allowedRoles?: Array<'admin' | 'editor' | 'writer'>
+  serviceAccountCapability?: ServiceAccountCapability
 }

--- a/apps/questura/apps/server/src/features/media/from-source-route.test.ts
+++ b/apps/questura/apps/server/src/features/media/from-source-route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  assemble: vi.fn(),
+}))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockResolvedValue({ auth: mocks.auth }),
+}))
+
+vi.mock('@/payload.config', () => ({ default: {} }))
+
+vi.mock('@/features/media/pipeline/assemble-media-set', () => ({
+  assembleMediaSetFromSource: mocks.assemble,
+}))
+
+import { POST } from '@/app/api/media-sets/from-source/route'
+import { LOCATION_MANAGER_SERVICE_ACCOUNT } from '@/features/auth/lib/service-account-grants'
+
+describe('POST /api/media-sets/from-source', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lets Location Manager reach request validation', async () => {
+    mocks.auth.mockResolvedValue({
+      user: {
+        id: 1,
+        collection: 'service-accounts',
+        name: LOCATION_MANAGER_SERVICE_ACCOUNT,
+      },
+    })
+    const response = await POST(
+      new NextRequest('http://localhost:4000/api/media-sets/from-source', {
+        method: 'POST',
+        headers: { 'content-type': 'multipart/form-data; boundary=probe' },
+        body: [
+          '--probe',
+          'Content-Disposition: form-data; name="probe"',
+          '',
+          'authenticated',
+          '--probe--',
+          '',
+        ].join('\r\n'),
+      }),
+    )
+
+    await expect({
+      status: response.status,
+      body: await response.json(),
+    }).toEqual({
+      status: 400,
+      body: { message: 'source file is required (multipart field "source")' },
+    })
+    expect(mocks.assemble).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What changed

- Added identity-scoped custom-route capabilities beside collection grants.
- Taught authenticateRequest to accept service accounts only for an explicitly requested capability.
- Granted and wired only media-sets:from-source for Location Manager.
- Widened auth result typing to the real staff-or-service principal union.

## Security boundary

- Custom routes without a service capability still deny every machine.
- Unknown service-account names fail closed.
- Staff role checks remain unchanged.
- Disabled staff remain denied.

## Checks

- Focused Vitest: 11 passed, including a route-level 400-not-403 proof.
- Questura server typecheck: unchanged known baseline, 54 errors.