### PR TITLE
fix(location-manager): verify Payload sync permission

### DIFF
--- a/apps/location-manager/packages/server/src/features/locations/controllers/integration/payload.controller.ts
+++ b/apps/location-manager/packages/server/src/features/locations/controllers/integration/payload.controller.ts
@@ -105,7 +105,7 @@ export async function getPayloadMediaSets(c: Context) {
 
 /**
  * GET /api/payload/test-connection
- * Test connection to Payload CMS by attempting authentication
+ * Test the configured Payload credential and its required sync permission.
  */
 export async function getTestConnection(c: Context) {
   try {
@@ -116,7 +116,7 @@ export async function getTestConnection(c: Context) {
       });
     }
 
-    await payloadApi.authenticate();
+    await payloadApi.testConnection();
 
     return c.json({
       connected: true,

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload-api.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload-api.client.ts
@@ -60,8 +60,8 @@ export class PayloadApiClient {
     return this.authClient.isConfigured();
   }
 
-  async authenticate(): Promise<string> {
-    return await this.authClient.authenticate();
+  async testConnection(): Promise<void> {
+    await this.authClient.testConnection();
   }
 
   async uploadImage(

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.test.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.test.ts
@@ -29,4 +29,79 @@ describe("PayloadAuthClient", () => {
       Authorization: "JWT test-token",
     });
   });
+
+  test("verifies the credential has Location Manager access", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({ url, init });
+
+      if (url.endsWith("/api/users/login")) {
+        return new Response(
+          JSON.stringify({
+            token: "test-token",
+            exp: Math.floor(Date.now() / 1000) + 3600,
+          }),
+          { status: 200 }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          collections: {
+            locations: { create: true },
+          },
+        }),
+        { status: 200 }
+      );
+    }) as unknown as typeof fetch;
+
+    const client = new PayloadAuthClient({
+      PAYLOAD_API_URL: "https://payload.example.com",
+      PAYLOAD_SERVICE_EMAIL: "service@example.com",
+      PAYLOAD_SERVICE_PASSWORD: "secret",
+    } as EnvConfig);
+
+    await expect(client.testConnection()).resolves.toBeUndefined();
+    expect(requests[1]).toEqual({
+      url: "https://payload.example.com/api/access",
+      init: {
+        method: "GET",
+        headers: { Authorization: "JWT test-token" },
+      },
+    });
+  });
+
+  test("rejects an anonymous or underprivileged access response", async () => {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      if (String(input).endsWith("/api/users/login")) {
+        return new Response(
+          JSON.stringify({
+            token: "invalid-or-underprivileged-token",
+            exp: Math.floor(Date.now() / 1000) + 3600,
+          }),
+          { status: 200 }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          collections: {
+            locations: { read: true },
+          },
+        }),
+        { status: 200 }
+      );
+    }) as unknown as typeof fetch;
+
+    const client = new PayloadAuthClient({
+      PAYLOAD_API_URL: "https://payload.example.com",
+      PAYLOAD_SERVICE_EMAIL: "service@example.com",
+      PAYLOAD_SERVICE_PASSWORD: "secret",
+    } as EnvConfig);
+
+    await expect(client.testConnection()).rejects.toThrow(
+      "Payload credential lacks required locations:create access"
+    );
+  });
 });

--- a/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.ts
+++ b/apps/location-manager/packages/server/src/features/locations/services/integrations/clients/payload/payload-auth.client.ts
@@ -28,6 +28,24 @@ export class PayloadAuthClient {
     return { Authorization: `JWT ${token}` };
   }
 
+  async testConnection(): Promise<void> {
+    const response = await fetch(`${this.apiUrl}/api/access`, {
+      method: "GET",
+      headers: await this.authHeader(),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Payload access check failed (${response.status})`);
+    }
+
+    const permissions = (await response.json()) as {
+      collections?: { locations?: { create?: true } };
+    };
+    if (permissions.collections?.locations?.create !== true) {
+      throw new Error("Payload credential lacks required locations:create access");
+    }
+  }
+
   async authenticate(): Promise<string> {
     if (!this.isConfigured()) {
       throw new ServiceUnavailableError("Payload CMS");


### PR DESCRIPTION
## What changed

- Replaced the login-only connection check with GET /api/access.
- Require locations.create === true before reporting connected.
- Kept the existing JWT credential behavior for this preparatory PR.

## Why

Public collection probes return 200 for anonymous callers, and a future static API-key authenticate method would perform no network request. The permission probe validates both identity and required non-mutating authorization.

## Security

- Underprivileged/anonymous-shaped 200 responses fail.
- No upstream auth response body is logged.
- Probe performs no writes.

## Checks

- Location Manager tests: 255 passed.
- Location Manager typecheck: unchanged known baseline, 6 errors.