### PR TITLE
fix(questura): protect staff media attribution

### DIFF
--- a/apps/questura/apps/server/src/features/auth/lib/service-account-grants.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/service-account-grants.ts
@@ -37,7 +37,7 @@ const SERVICE_ACCOUNT_GRANTS: Record<string, ServiceAccountGrants> = {
   },
 }
 
-function serviceAccount(user: PayloadRequest['user']): ServiceAccount | null {
+function asServiceAccount(user: PayloadRequest['user']): ServiceAccount | null {
   if (!user || user.collection !== 'service-accounts') return null
   return user as ServiceAccount
 }
@@ -53,7 +53,7 @@ export function serviceAccountHasCollectionGrant(
   collection: CollectionSlug,
   operation: ServiceAccountCollectionOperation,
 ): boolean {
-  const account = serviceAccount(user)
+  const account = asServiceAccount(user)
   if (!account) return false
 
   return SERVICE_ACCOUNT_GRANTS[account.name]?.collections[collection]?.includes(operation) ?? false
@@ -63,7 +63,7 @@ export function serviceAccountHasCapability(
   user: PayloadRequest['user'],
   capability: ServiceAccountCapability,
 ): boolean {
-  const account = serviceAccount(user)
+  const account = asServiceAccount(user)
   if (!account) return false
 
   return SERVICE_ACCOUNT_GRANTS[account.name]?.capabilities.includes(capability) ?? false

--- a/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.test.ts
+++ b/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.test.ts
@@ -24,8 +24,12 @@ describe('setUploadedBy', () => {
     })
   })
 
-  it('does not attribute a machine upload to a staff user', async () => {
-    const data = { alt: 'Lima skyline' }
+  it('strips forged staff attribution from a machine create', async () => {
+    const data = {
+      alt: 'Lima skyline',
+      user: 11,
+      uploadedBy: '11',
+    }
 
     const result = await setUploadedBy({
       operation: 'create',
@@ -40,5 +44,34 @@ describe('setUploadedBy', () => {
     } as never)
 
     expect(result).toEqual({ alt: 'Lima skyline' })
+  })
+
+  it('strips forged staff attribution from a machine update', async () => {
+    const result = await setUploadedBy({
+      operation: 'update',
+      data: {
+        alt: 'Updated Lima skyline',
+        user: 11,
+        uploadedBy: '11',
+      },
+      originalDoc: {
+        alt: 'Lima skyline',
+        user: 23,
+        uploadedBy: '23',
+      },
+      req: {
+        user: {
+          id: 7,
+          collection: 'service-accounts',
+          name: 'Location Manager',
+        },
+      },
+    } as never)
+
+    expect(result).toEqual({
+      alt: 'Updated Lima skyline',
+      user: 23,
+      uploadedBy: '23',
+    })
   })
 })

--- a/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.ts
+++ b/apps/questura/apps/server/src/features/media/collections/hooks/setUploadedBy.ts
@@ -1,7 +1,23 @@
 import type { CollectionBeforeChangeHook } from 'payload'
 import { staffUser } from '@/features/auth/lib/staff-user'
 
-export const setUploadedBy: CollectionBeforeChangeHook = ({ req, operation, data }) => {
+export const setUploadedBy: CollectionBeforeChangeHook = ({
+  req,
+  operation,
+  data,
+  originalDoc,
+}) => {
+  if (req.user?.collection === 'service-accounts' && data) {
+    if (operation === 'update' && originalDoc) {
+      data.user = originalDoc.user
+      data.uploadedBy = originalDoc.uploadedBy
+    } else {
+      delete data.user
+      delete data.uploadedBy
+    }
+    return data
+  }
+
   const uploader = staffUser(req.user)
 
   if (operation === 'create' && uploader && data) {


### PR DESCRIPTION
## Summary

- strip caller-supplied `user` and `uploadedBy` from service-account media creates
- preserve the original staff attribution during service-account media updates
- cover forged create/update payloads and use a verb-named service-account narrowing helper

## Verification

- focused Vitest: 8 passed
- TypeScript: unchanged baseline (54 existing errors)
- Payload migration check: no schema migration generated; all existing migrations applied
- `pnpm generate:types`: no diff
