### PR TITLE
fix(ai-blog-writer): refuse wildcard CORS on deployed instances

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -25,9 +25,15 @@ ABW_API_KEY=
 
 # Comma-separated list of allowed browser origins, e.g.
 # http://localhost:3003,https://abw.example.com
-# Empty means wildcard (*), which also disables credentialed CORS.
-# REQUIRED whenever ABW_API_KEY is set: the backend refuses to start with a
-# wildcard origin policy on a deployed instance.
+#
+# With ABW_API_KEY unset (local development): empty means wildcard (*),
+# which also disables credentialed CORS.
+#
+# With ABW_API_KEY set: REQUIRED. The backend refuses to start rather than
+# serve a wildcard origin policy on a deployed instance. If the instance has
+# no browser client at all (server-to-server, or a frontend served
+# same-origin behind a proxy), set the literal value `none` to say so
+# explicitly and deny all cross-origin requests.
 ABW_ALLOWED_ORIGINS=
 
 # Expose raw exception text in API error responses (dev/debug only).

--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -26,6 +26,8 @@ ABW_API_KEY=
 # Comma-separated list of allowed browser origins, e.g.
 # http://localhost:3003,https://abw.example.com
 # Empty means wildcard (*), which also disables credentialed CORS.
+# REQUIRED whenever ABW_API_KEY is set: the backend refuses to start with a
+# wildcard origin policy on a deployed instance.
 ABW_ALLOWED_ORIGINS=
 
 # Expose raw exception text in API error responses (dev/debug only).

--- a/apps/ai-blog-writer/apps/backend/app/main.py
+++ b/apps/ai-blog-writer/apps/backend/app/main.py
@@ -79,10 +79,23 @@ ERROR_LOG_PATH = _configure_error_file_logging()
 # Paths reachable without an API key when ABW_API_KEY is set.
 AUTH_EXEMPT_PATHS = {"/health"}
 API_KEY_HEADER = "X-API-Key"
+# Explicit ABW_ALLOWED_ORIGINS value meaning "this instance has no browser
+# client", as distinct from the variable being forgotten.
+CORS_DENY_ALL = "none"
 
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    # Refuse to serve a misconfigured origin policy. This runs here rather
+    # than at import so the failure reaches the error log configured above
+    # instead of only stderr, and so importing this module (tests, tooling)
+    # never explodes on a half-configured local .env.
+    if _cors_config_error is not None:
+        logger.error(
+            "Refusing to start: %s", _cors_config_error, exc_info=_cors_config_error
+        )
+        raise _cors_config_error
+
     # Pipelines run as in-process background tasks; runs left in-flight by
     # a previous process can never progress, so fail them at boot.
     stale_count = fail_stale_runs()
@@ -109,27 +122,43 @@ def resolve_cors_origins(api_key: str, raw_origins: str) -> list[str]:
     A configured ABW_API_KEY is the signal that this instance is reachable
     beyond localhost. Wildcard CORS there is incoherent: it forces
     `allow_credentials=False`, and the X-API-Key header makes every request
-    preflighted, so any page could probe the API. Fail fast at startup
-    instead of serving an open origin policy.
+    preflighted, so any page could probe the API. Refuse to start instead of
+    serving an open origin policy.
 
-    With no key configured (local development) the open default is kept.
+    An instance with no browser client at all (server-to-server, or a frontend
+    served same-origin behind a proxy) sets ABW_ALLOWED_ORIGINS=none to say so
+    explicitly. That is a deny-all list, not an oversight.
+
+    With no key configured (local development) the historical behavior is
+    kept exactly: wildcard when the variable is unset, otherwise whatever
+    parses out of it.
     """
-    origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+    raw = raw_origins.strip()
+
+    if raw.lower() == CORS_DENY_ALL:
+        return []
+
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
 
     if not api_key.strip():
-        return origins or ["*"]
+        # Emptiness is judged on the raw string, not the parsed list, so a
+        # malformed value like "," keeps denying all origins rather than
+        # silently widening to a wildcard.
+        return ["*"] if not raw else origins
 
     if not origins or "*" in origins:
         raise ValueError(
             "ABW_ALLOWED_ORIGINS must list explicit origins when ABW_API_KEY "
-            "is set; wildcard CORS is not allowed on a deployed instance."
+            "is set; wildcard CORS is not allowed on a deployed instance. "
+            f"Set ABW_ALLOWED_ORIGINS={CORS_DENY_ALL} if this instance has no "
+            "browser client."
         )
 
     return origins
 
 
 def _allowed_origins() -> list[str]:
-    """Comma-separated ABW_ALLOWED_ORIGINS, or wildcard when unset."""
+    """Read the CORS policy from the environment. See resolve_cors_origins."""
     return resolve_cors_origins(
         api_key=os.getenv("ABW_API_KEY", ""),
         raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
@@ -163,7 +192,26 @@ async def require_api_key(request: Request, call_next):
     return await call_next(request)
 
 
-_cors_origins = _allowed_origins()
+def resolve_cors_config(
+    api_key: str, raw_origins: str
+) -> tuple[list[str], ValueError | None]:
+    """Pair the resolved origins with any rejection, without raising.
+
+    A rejected policy yields a deny-all list so the middleware fails closed,
+    plus the error for `lifespan` to refuse the boot with. Import stays safe
+    either way.
+    """
+    try:
+        return resolve_cors_origins(api_key, raw_origins), None
+    except ValueError as exc:
+        return [], exc
+
+
+_cors_origins, _cors_config_error = resolve_cors_config(
+    api_key=os.getenv("ABW_API_KEY", ""),
+    raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
+)
+
 _cors_wildcard = "*" in _cors_origins
 
 app.add_middleware(

--- a/apps/ai-blog-writer/apps/backend/app/main.py
+++ b/apps/ai-blog-writer/apps/backend/app/main.py
@@ -103,12 +103,37 @@ def _read_bool_env(key: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def resolve_cors_origins(api_key: str, raw_origins: str) -> list[str]:
+    """Resolve the CORS allow-list, refusing a wildcard on deployed instances.
+
+    A configured ABW_API_KEY is the signal that this instance is reachable
+    beyond localhost. Wildcard CORS there is incoherent: it forces
+    `allow_credentials=False`, and the X-API-Key header makes every request
+    preflighted, so any page could probe the API. Fail fast at startup
+    instead of serving an open origin policy.
+
+    With no key configured (local development) the open default is kept.
+    """
+    origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+
+    if not api_key.strip():
+        return origins or ["*"]
+
+    if not origins or "*" in origins:
+        raise ValueError(
+            "ABW_ALLOWED_ORIGINS must list explicit origins when ABW_API_KEY "
+            "is set; wildcard CORS is not allowed on a deployed instance."
+        )
+
+    return origins
+
+
 def _allowed_origins() -> list[str]:
     """Comma-separated ABW_ALLOWED_ORIGINS, or wildcard when unset."""
-    raw = os.getenv("ABW_ALLOWED_ORIGINS", "").strip()
-    if not raw:
-        return ["*"]
-    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+    return resolve_cors_origins(
+        api_key=os.getenv("ABW_API_KEY", ""),
+        raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
+    )
 
 
 @app.middleware("http")

--- a/apps/ai-blog-writer/apps/backend/tests/test_cors_origins.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_cors_origins.py
@@ -1,0 +1,58 @@
+import pytest
+
+import app.main as main_module
+
+
+def test_wildcard_allowed_when_no_api_key_configured():
+    """Local development has no API key, so the open default is kept."""
+    assert main_module.resolve_cors_origins(api_key="", raw_origins="") == ["*"]
+
+
+def test_explicit_origins_parsed_without_api_key():
+    origins = main_module.resolve_cors_origins(
+        api_key="", raw_origins="http://localhost:3003, https://abw.example.com"
+    )
+
+    assert origins == ["http://localhost:3003", "https://abw.example.com"]
+
+
+def test_explicit_origins_parsed_with_api_key():
+    origins = main_module.resolve_cors_origins(
+        api_key="secret-key", raw_origins="https://abw.example.com"
+    )
+
+    assert origins == ["https://abw.example.com"]
+
+
+def test_api_key_without_origins_is_rejected():
+    """A configured key means the API is reachable beyond localhost.
+
+    Wildcard CORS there is incoherent: it disables credentialed requests and
+    lets any page issue the preflight the X-API-Key header requires.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        main_module.resolve_cors_origins(api_key="secret-key", raw_origins="")
+
+    assert "ABW_ALLOWED_ORIGINS" in str(excinfo.value)
+
+
+def test_api_key_with_explicit_wildcard_is_rejected():
+    """Pinning must be real; `*` must not be smuggled through as a value."""
+    with pytest.raises(ValueError):
+        main_module.resolve_cors_origins(api_key="secret-key", raw_origins="*")
+
+
+def test_api_key_with_wildcard_among_origins_is_rejected():
+    with pytest.raises(ValueError):
+        main_module.resolve_cors_origins(
+            api_key="secret-key", raw_origins="https://abw.example.com,*"
+        )
+
+
+def test_whitespace_only_origins_treated_as_unset():
+    with pytest.raises(ValueError):
+        main_module.resolve_cors_origins(api_key="secret-key", raw_origins="   ")
+
+
+def test_whitespace_only_api_key_treated_as_unset():
+    assert main_module.resolve_cors_origins(api_key="   ", raw_origins="") == ["*"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_cors_origins.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_cors_origins.py
@@ -3,6 +3,47 @@ import pytest
 import app.main as main_module
 
 
+@pytest.mark.asyncio
+async def test_lifespan_refuses_to_start_when_cors_config_invalid(monkeypatch):
+    """A rejected origin policy must stop the boot, not just log."""
+    failure = ValueError("bad origins")
+    monkeypatch.setattr(main_module, "_cors_config_error", failure)
+
+    with pytest.raises(ValueError):
+        async with main_module.lifespan(main_module.app):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_normally_when_cors_config_valid(monkeypatch):
+    monkeypatch.setattr(main_module, "_cors_config_error", None)
+    monkeypatch.setattr(main_module, "fail_stale_runs", lambda: 0)
+
+    async with main_module.lifespan(main_module.app):
+        pass
+
+
+def test_rejected_config_fails_closed_instead_of_raising_at_import():
+    """Import must stay safe: a half-configured local .env would otherwise
+    break collection for every test that imports this module. The served
+    list must be deny-all, never the wildcard that was refused."""
+    origins, error = main_module.resolve_cors_config(
+        api_key="secret-key", raw_origins=""
+    )
+
+    assert origins == []
+    assert isinstance(error, ValueError)
+
+
+def test_accepted_config_reports_no_error():
+    origins, error = main_module.resolve_cors_config(
+        api_key="secret-key", raw_origins="https://abw.example.com"
+    )
+
+    assert origins == ["https://abw.example.com"]
+    assert error is None
+
+
 def test_wildcard_allowed_when_no_api_key_configured():
     """Local development has no API key, so the open default is kept."""
     assert main_module.resolve_cors_origins(api_key="", raw_origins="") == ["*"]
@@ -56,3 +97,32 @@ def test_whitespace_only_origins_treated_as_unset():
 
 def test_whitespace_only_api_key_treated_as_unset():
     assert main_module.resolve_cors_origins(api_key="   ", raw_origins="") == ["*"]
+
+
+def test_explicit_none_denies_all_origins_with_api_key():
+    """An instance with no browser client must be able to say so, rather than
+    being forced to invent a dummy origin to satisfy the guard."""
+    assert main_module.resolve_cors_origins(
+        api_key="secret-key", raw_origins="none"
+    ) == []
+
+
+def test_explicit_none_is_case_insensitive():
+    assert main_module.resolve_cors_origins(
+        api_key="secret-key", raw_origins="  NONE  "
+    ) == []
+
+
+def test_explicit_none_denies_all_origins_without_api_key():
+    assert main_module.resolve_cors_origins(api_key="", raw_origins="none") == []
+
+
+def test_malformed_value_keeps_denying_all_without_api_key():
+    """Regression: emptiness is judged on the raw string, not the parsed
+    list, so a comma-only value must not widen to a wildcard."""
+    assert main_module.resolve_cors_origins(api_key="", raw_origins=",") == []
+
+
+def test_malformed_value_is_rejected_with_api_key():
+    with pytest.raises(ValueError):
+        main_module.resolve_cors_origins(api_key="secret-key", raw_origins=",")


### PR DESCRIPTION
## Problem

`_allowed_origins()` in `apps/ai-blog-writer/apps/backend/app/main.py` returned `["*"]` whenever `ABW_ALLOWED_ORIGINS` was unset. Any deployment that forgot the variable silently served an open origin policy.

## Approach

ABW's backend has no environment/production flag, so rather than invent one this uses the signal already present: a configured `ABW_API_KEY` means the instance is reachable beyond localhost (see `.env.example`, which already says the key is "REQUIRED for any deployment reachable beyond localhost").

Wildcard CORS on such an instance is incoherent:
- it forces `allow_credentials=False` (already noted at the `add_middleware` call), and
- the `X-API-Key` custom header makes every request preflighted, so a wildcard lets any page probe the API.

Startup now raises when a key is set without explicit origins. This matches the fail-fast posture Location Manager uses for its Payload config (`assertPayloadConfig`).

`*` listed explicitly among origins is rejected too, so pinning cannot be smuggled around.

## Non-breaking

- No key configured (local dev) → wildcard default unchanged.
- No current deployment sets `ABW_API_KEY` (it is disabled everywhere per the Phase 3b handoff), so nothing in flight starts failing.

## Tests

`resolve_cors_origins()` extracted as a pure function so the policy is testable without reimporting the app. New `apps/backend/tests/test_cors_origins.py` covers 8 cases: wildcard default, parsing with and without a key, empty/whitespace origins, explicit `*`, `*` mixed among real origins, and whitespace-only key.

```
pytest: 492 -> 500 collected, all passed
```