### PR TITLE
refactor(ai-blog-writer): single source of truth for API base URLs

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
@@ -1,7 +1,8 @@
 import { CLAUDE_MODELS_ENABLED } from '../../../shared/api/ai/models'
 import type { Prompt2BlogModelName, Prompt2BlogWriterModel } from '../types/pipeline.types'
 
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4003'
+export { API_BASE_URL } from '../../../shared/api/client/config'
+
 export const FEATURE_PREFIX = '/prompt2blog'
 
 export const DEFAULT_PROMPT2BLOG_MODEL: Prompt2BlogModelName = 'gemini-2.5-flash-lite'

--- a/apps/ai-blog-writer/apps/frontend/src/features/url2blog/constants/url2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/url2blog/constants/url2blog.constants.ts
@@ -1,2 +1,3 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4003'
+export { API_BASE_URL } from '../../../shared/api/client/config'
+
 export const FEATURE_PREFIX = '/url2blog'

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/constants/api.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/constants/api.constants.ts
@@ -1,3 +1,4 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4003'
+export { API_BASE_URL } from '../../../shared/api/client/config'
+
 export const FEATURE_PREFIX = '/youtube2blog'
 export const ARTICLE_TYPES_PREFIX = '/article-types'

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/client/imageApiClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/client/imageApiClient.ts
@@ -1,4 +1,6 @@
-export const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4003';
+import { API_BASE_URL as API_URL } from '../../../api/client/config';
+
+export { API_URL };
 
 export async function postFormData(
   path: string,

--- a/apps/ai-blog-writer/apps/frontend/src/vite-env.d.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/vite-env.d.ts
@@ -1,6 +1,9 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string
+  readonly VITE_CONVERTER_URL?: string
+  readonly VITE_FRONTEND_URL?: string
   readonly VITE_PAYLOAD_API_URL?: string
   readonly VITE_SCHEMA_SITE_NAME?: string
   readonly VITE_SCHEMA_PUBLISHER_LOGO_URL?: string


### PR DESCRIPTION
Groundwork for the X-API-Key work. No behavior change.

## Problem

Five modules each declared their own copy of the backend base URL:

| File | Constant |
|---|---|
| `shared/api/client/config.ts:1` | `API_BASE_URL` (canonical) |
| `features/youtube2blog/constants/api.constants.ts:1` | `API_BASE_URL` |
| `features/prompt2blog/constants/prompt2blog.constants.ts:4` | `API_BASE_URL` |
| `features/url2blog/constants/url2blog.constants.ts:1` | `API_BASE_URL` |
| `shared/images/api/client/imageApiClient.ts:1` | `API_URL` |

All five read `VITE_API_BASE_URL || 'http://localhost:4003'` and agreed, so nothing is broken today. The problem is that changing how the backend URL is resolved requires editing five places, and missing one fails silently — which matters immediately, since the next PR routes backend calls through a single wrapper.

## Change

The four feature-local copies re-export the canonical constant. Exported names are unchanged (`API_BASE_URL`, and `API_URL` in the image client), so no call site moves and the diff stays at 5 files.

Also declares `VITE_API_BASE_URL`, `VITE_CONVERTER_URL`, and `VITE_FRONTEND_URL` in `ImportMetaEnv` (`vite-env.d.ts`). All three are read at runtime — the third by `shared/seo/utils/buildArticleOgUrl.ts:13` — but none were declared, so a typo in any of them was not a type error.

Payload and Converter base URLs are untouched; Payload has its own eight-way duplication that is out of scope here.

## Verification

```
vitest: 133 files, 606 tests passed (unchanged)
tsc:    7 errors on this branch, 7 on main (pre-existing, unchanged)
```