### PR TITLE
refactor(ai-blog-writer): route backend calls through apiFetch

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../shared/api/client/config'
+import { apiFetch } from '../../shared/api/client/apiFetch'
 import { parseErrorResponse } from '../../shared/api/client/error-parser'
 
 export type GenerateItineraryTitlesResponse = {
@@ -10,7 +10,7 @@ export async function generateItineraryTitles(params: {
   prompt: string
   modelName?: string | null
 }): Promise<GenerateItineraryTitlesResponse> {
-  const response = await fetch(`${API_BASE_URL}/itineraries-pipeline/generate-titles`, {
+  const response = await apiFetch('/itineraries-pipeline/generate-titles', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/autobuild.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/autobuild.api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../../../shared/api/client/config'
+import { apiFetch } from '../../../../shared/api/client/apiFetch'
 import { parseErrorResponse } from '../../../../shared/api/client/error-parser'
 import type { DayShellTemplate, ItineraryBlockType, ShellSlotDaypart } from '../../types'
 
@@ -80,7 +80,7 @@ export type GenerateItineraryParams = {
 
 /** Call the ABW backend's Itinerary Autobuild pipeline (slots only). */
 export async function generateItinerary(params: GenerateItineraryParams): Promise<AutobuildResponse> {
-  const response = await fetch(`${API_BASE_URL}/itineraries-pipeline/generate`, {
+  const response = await apiFetch('/itineraries-pipeline/generate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/day-shell-library.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/day-shell-library.api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../../../shared/api/client/config'
+import { apiFetch } from '../../../../shared/api/client/apiFetch'
 import { parseErrorResponse } from '../../../../shared/api/client/error-parser'
 import type { DayShellSlot, DayShellTemplate } from '../../types'
 
@@ -70,14 +70,14 @@ async function requireOk(response: Response, fallback: string): Promise<void> {
 
 /** List the Day Shell Library (Custom Day Shells; built-ins are frontend constants). */
 export async function listLibraryDayShells(): Promise<DayShellTemplate[]> {
-  const response = await fetch(`${API_BASE_URL}/itineraries-pipeline/day-shells`)
+  const response = await apiFetch('/itineraries-pipeline/day-shells')
   await requireOk(response, 'Failed to load the day shell library')
   const payload: { shells: ApiDayShell[] } = await response.json()
   return payload.shells.map(fromApiShell)
 }
 
 export async function createLibraryDayShell(shell: DayShellTemplate): Promise<DayShellTemplate> {
-  const response = await fetch(`${API_BASE_URL}/itineraries-pipeline/day-shells`, {
+  const response = await apiFetch('/itineraries-pipeline/day-shells', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(toApiShell(shell)),
@@ -87,7 +87,7 @@ export async function createLibraryDayShell(shell: DayShellTemplate): Promise<Da
 }
 
 export async function updateLibraryDayShell(shell: DayShellTemplate): Promise<DayShellTemplate> {
-  const response = await fetch(`${API_BASE_URL}/itineraries-pipeline/day-shells/${encodeURIComponent(shell.id)}`, {
+  const response = await apiFetch(`/itineraries-pipeline/day-shells/${encodeURIComponent(shell.id)}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(toApiShell(shell)),
@@ -97,7 +97,7 @@ export async function updateLibraryDayShell(shell: DayShellTemplate): Promise<Da
 }
 
 export async function deleteLibraryDayShell(shellId: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/itineraries-pipeline/day-shells/${encodeURIComponent(shellId)}`, {
+  const response = await apiFetch(`/itineraries-pipeline/day-shells/${encodeURIComponent(shellId)}`, {
     method: 'DELETE',
   })
   await requireOk(response, 'Failed to delete the layout')

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/api/mediaLibraryApi.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/api/mediaLibraryApi.ts
@@ -1,4 +1,4 @@
-import { API_URL } from '../../../shared/images/api/client/imageApiClient'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
 
 export async function generateAltTextFromUrl(
   imageUrl: string,
@@ -11,7 +11,7 @@ export async function generateAltTextFromUrl(
     formData.append('narrative_focus', narrativeFocus.trim())
   }
 
-  const response = await fetch(`${API_URL}/images/generate-alt-text-from-url`, {
+  const response = await apiFetch('/images/generate-alt-text-from-url', {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
     body: formData,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/article-types.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/article-types.api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../constants/prompt2blog.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
 import { parseError } from '../../../shared/api/errors/parse-error'
 import type {
   ArticleTypeGuidelines,
@@ -6,7 +6,7 @@ import type {
 } from '../types/article-types.types'
 
 export async function fetchArticleTypes(): Promise<ArticleTypeOption[]> {
-  const response = await fetch(`${API_BASE_URL}/article-types/name-definitions`)
+  const response = await apiFetch('/article-types/name-definitions')
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch article types')
@@ -18,7 +18,7 @@ export async function fetchArticleTypes(): Promise<ArticleTypeOption[]> {
 export async function fetchArticleTypeGuidelinesById(
   articleTypeId: number,
 ): Promise<ArticleTypeGuidelines> {
-  const response = await fetch(`${API_BASE_URL}/article-types/${articleTypeId}/guidelines`)
+  const response = await apiFetch(`/article-types/${articleTypeId}/guidelines`)
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch article guidelines')

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/articles.api.ts
@@ -1,9 +1,10 @@
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/prompt2blog.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/prompt2blog.constants'
 import type { Prompt2BlogSavedArticle } from '../types/articles.types'
 import { parseError } from '../../../shared/api/errors/parse-error'
 
 export async function fetchArticles(): Promise<Prompt2BlogSavedArticle[]> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/articles`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/articles`)
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch Prompt2Blog articles')
@@ -13,7 +14,7 @@ export async function fetchArticles(): Promise<Prompt2BlogSavedArticle[]> {
 }
 
 export async function deleteArticle(runId: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/articles/${runId}`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/articles/${runId}`, {
     method: 'DELETE',
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.ts
@@ -1,4 +1,5 @@
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/prompt2blog.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/prompt2blog.constants'
 import { parseError } from '../../../shared/api/errors/parse-error'
 import type {
   Prompt2BlogDebugResponse,
@@ -38,7 +39,7 @@ export function normalizePrompt2BlogStatusResponse(
 export async function startPrompt2BlogRun(
   payload: Prompt2BlogRunRequest,
 ): Promise<Prompt2BlogRunResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/run`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/run`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -52,7 +53,7 @@ export async function startPrompt2BlogRun(
 }
 
 export async function getPrompt2BlogInputOptions(): Promise<Prompt2BlogInputOptionsResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/input-options`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/input-options`)
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch Prompt2Blog input options')
@@ -64,8 +65,8 @@ export async function getPrompt2BlogInputOptions(): Promise<Prompt2BlogInputOpti
 export async function getPrompt2BlogGuidelinePreview(
   articleTypeId: number,
 ): Promise<Prompt2BlogGuidelinePreviewResponse> {
-  const response = await fetch(
-    `${API_BASE_URL}${FEATURE_PREFIX}/article-types/${articleTypeId}/guideline-preview`,
+  const response = await apiFetch(
+    `${FEATURE_PREFIX}/article-types/${articleTypeId}/guideline-preview`,
   )
 
   if (!response.ok) {
@@ -76,7 +77,7 @@ export async function getPrompt2BlogGuidelinePreview(
 }
 
 export async function getPrompt2BlogStatus(runId: string): Promise<Prompt2BlogStatusResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/status/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/status/${runId}`)
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch Prompt2Blog run status')
@@ -86,7 +87,7 @@ export async function getPrompt2BlogStatus(runId: string): Promise<Prompt2BlogSt
 }
 
 export async function getPrompt2BlogResult(runId: string): Promise<Prompt2BlogResultResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/result/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/result/${runId}`)
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch Prompt2Blog run result')
@@ -107,7 +108,7 @@ export async function fetchResult(runId: string): Promise<Prompt2BlogResultRespo
 }
 
 export async function getPrompt2BlogDebug(runId: string): Promise<Prompt2BlogDebugResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/debug/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/debug/${runId}`)
 
   if (!response.ok) {
     throw await parseError(response, 'Failed to fetch Prompt2Blog debug output')

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
@@ -1,8 +1,6 @@
 import { CLAUDE_MODELS_ENABLED } from '../../../shared/api/ai/models'
 import type { Prompt2BlogModelName, Prompt2BlogWriterModel } from '../types/pipeline.types'
 
-export { API_BASE_URL } from '../../../shared/api/client/config'
-
 export const FEATURE_PREFIX = '/prompt2blog'
 
 export const DEFAULT_PROMPT2BLOG_MODEL: Prompt2BlogModelName = 'gemini-2.5-flash-lite'

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/ai/editor-assist.request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/ai/editor-assist.request.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../../../shared/api/client/config'
+import { apiFetch } from '../../../../shared/api/client/apiFetch'
 import { parseErrorResponse } from '../../../../shared/api/client/error-parser'
 
 type EditorAssistRequestOptions = {
@@ -11,7 +11,7 @@ export async function requestEditorAssist<TResponse>(
   path: string,
   { method = 'POST', body, errorMessage }: EditorAssistRequestOptions
 ): Promise<TResponse> {
-  const response = await fetch(`${API_BASE_URL}/editor-assist/${path}`, {
+  const response = await apiFetch(`/editor-assist/${path}`, {
     method,
     headers: {
       'Content-Type': 'application/json'

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
@@ -1,4 +1,5 @@
-import { API_BASE_URL, PAYLOAD_API_URL } from '../../../../shared/api/client/config'
+import { PAYLOAD_API_URL } from '../../../../shared/api/client/config'
+import { apiFetch } from '../../../../shared/api/client/apiFetch'
 import { parseErrorResponse } from '../../../../shared/api/client/error-parser'
 import type { CreateArticlePayload, PayloadArticleDoc } from './articles.types'
 
@@ -117,8 +118,8 @@ export async function markArticleSynced(
   runId: string,
   payloadArticleId: number,
 ): Promise<{ message: string; run_id: string; payload_article_id: number }> {
-  const response = await fetch(
-    `${API_BASE_URL}${featurePrefix}/articles/${runId}/sync`,
+  const response = await apiFetch(
+    `${featurePrefix}/articles/${runId}/sync`,
     {
       method: 'POST',
       headers: {
@@ -144,7 +145,7 @@ export async function getArticleSyncStatus(
   payload_article_id: number | null
   synced_at: string | null
 }> {
-  const response = await fetch(`${API_BASE_URL}${featurePrefix}/articles/${runId}/sync`)
+  const response = await apiFetch(`${featurePrefix}/articles/${runId}/sync`)
 
   if (!response.ok) {
     throw new Error(`Failed to get sync status: ${response.status}`)

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/staged-drafts/staged-drafts.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/staged-drafts/staged-drafts.api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../../../shared/api/client/config'
+import { apiFetch } from '../../../../shared/api/client/apiFetch'
 import { parseErrorResponse } from '../../../../shared/api/client/error-parser'
 import type { StagedArticle } from '../../types'
 
@@ -9,7 +9,7 @@ import type { StagedArticle } from '../../types'
  * previous localStorage-only storage that made links non-portable.
  */
 
-const STAGED_DRAFTS_URL = `${API_BASE_URL}/staged-drafts`
+const STAGED_DRAFTS_URL = '/staged-drafts'
 
 function draftsEndpoint(storageKey: string, draftId?: string): string {
   const base = draftId
@@ -38,7 +38,7 @@ export type PutStagedDraftOptions = {
 }
 
 export async function fetchStagedDrafts(storageKey: string): Promise<StagedArticle[]> {
-  const response = await fetch(draftsEndpoint(storageKey))
+  const response = await apiFetch(draftsEndpoint(storageKey))
   if (!response.ok) {
     const message = await parseErrorResponse(response, `Failed to load staged drafts: ${response.status}`, { detail: 'Unknown error' })
     throw new Error(message)
@@ -51,7 +51,7 @@ export async function fetchStagedDraft(
   storageKey: string,
   draftId: string,
 ): Promise<StagedArticle | null> {
-  const response = await fetch(draftsEndpoint(storageKey, draftId))
+  const response = await apiFetch(draftsEndpoint(storageKey, draftId))
   if (response.status === 404) {
     return null
   }
@@ -71,7 +71,7 @@ export async function putStagedDraft(
   if (options?.expectedUpdatedAt) {
     endpoint += `&expectedUpdatedAt=${encodeURIComponent(options.expectedUpdatedAt)}`
   }
-  const response = await fetch(endpoint, {
+  const response = await apiFetch(endpoint, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(draft),
@@ -88,7 +88,7 @@ export async function putStagedDraft(
 }
 
 export async function deleteStagedDraft(storageKey: string, draftId: string): Promise<void> {
-  const response = await fetch(draftsEndpoint(storageKey, draftId), { method: 'DELETE' })
+  const response = await apiFetch(draftsEndpoint(storageKey, draftId), { method: 'DELETE' })
   if (!response.ok && response.status !== 404) {
     const message = await parseErrorResponse(response, `Failed to delete staged draft: ${response.status}`, { detail: 'Unknown error' })
     throw new Error(message)
@@ -96,7 +96,7 @@ export async function deleteStagedDraft(storageKey: string, draftId: string): Pr
 }
 
 export async function clearStagedDrafts(storageKey: string): Promise<void> {
-  const response = await fetch(draftsEndpoint(storageKey), { method: 'DELETE' })
+  const response = await apiFetch(draftsEndpoint(storageKey), { method: 'DELETE' })
   if (!response.ok) {
     const message = await parseErrorResponse(response, `Failed to clear staged drafts: ${response.status}`, { detail: 'Unknown error' })
     throw new Error(message)

--- a/apps/ai-blog-writer/apps/frontend/src/features/url2blog/api/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/url2blog/api/articles.api.ts
@@ -1,9 +1,10 @@
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/url2blog.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/url2blog.constants'
 import type { Url2BlogSavedArticle } from '../types/articles.types'
 import { resolveErrorMessage } from './request-error'
 
 export async function fetchArticles(): Promise<Url2BlogSavedArticle[]> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/articles`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/articles`)
   if (!response.ok) {
     throw new Error('Failed to fetch URL2Blog articles')
   }
@@ -11,7 +12,7 @@ export async function fetchArticles(): Promise<Url2BlogSavedArticle[]> {
 }
 
 export async function deleteArticle(runId: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/articles/${runId}`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/articles/${runId}`, {
     method: 'DELETE',
   })
   if (!response.ok) {

--- a/apps/ai-blog-writer/apps/frontend/src/features/url2blog/api/pipeline.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/url2blog/api/pipeline.api.ts
@@ -1,4 +1,5 @@
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/url2blog.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/url2blog.constants'
 import type { ArticleType } from '@shared/types'
 import type { ToneProfile } from '../../../shared/api/ai/models'
 import type {
@@ -38,7 +39,7 @@ function normalizeUrl2BlogStatusResponse(
 export async function runUrl2BlogPipelineV2(
   payload: Url2BlogPipelineV2Request,
 ): Promise<Url2BlogPipelineV2Response> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/pipeline-v2`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/pipeline-v2`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -54,7 +55,7 @@ export async function runUrl2BlogPipelineV2(
 }
 
 export async function fetchToneProfiles(): Promise<ToneProfile[]> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/tones`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/tones`)
   if (!response.ok) {
     throw new Error(await resolveErrorMessage(response, 'URL2Blog tone fetch failed'))
   }
@@ -63,7 +64,7 @@ export async function fetchToneProfiles(): Promise<ToneProfile[]> {
 }
 
 export async function fetchArticleTypes(): Promise<ArticleType[]> {
-  const response = await fetch(`${API_BASE_URL}/article-types`)
+  const response = await apiFetch('/article-types')
   if (!response.ok) {
     throw new Error(await resolveErrorMessage(response, 'Article type fetch failed'))
   }
@@ -74,7 +75,7 @@ export async function fetchStatus(
   runId: string,
   options: { allowNotFound?: boolean } = {},
 ): Promise<Url2BlogStatusResponse | null> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/status/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/status/${runId}`)
 
   if (response.status === 404) {
     if (options.allowNotFound) {
@@ -94,7 +95,7 @@ export async function fetchStatus(
 }
 
 export async function fetchLatestStatus(): Promise<Url2BlogStatusResponse | null> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/status-latest`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/status-latest`)
   if (response.status === 404) {
     return null
   }
@@ -105,7 +106,7 @@ export async function fetchLatestStatus(): Promise<Url2BlogStatusResponse | null
 }
 
 export async function fetchRunDebug(runId: string): Promise<Url2BlogDebugRunResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/debug/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/debug/${runId}`)
   if (!response.ok) {
     throw new Error(await resolveErrorMessage(response, 'URL2Blog run debug fetch failed'))
   }
@@ -113,7 +114,7 @@ export async function fetchRunDebug(runId: string): Promise<Url2BlogDebugRunResp
 }
 
 export async function fetchResult(runId: string): Promise<Url2BlogResultResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/result/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/result/${runId}`)
   if (!response.ok) {
     throw new Error('Result fetch failed')
   }

--- a/apps/ai-blog-writer/apps/frontend/src/features/url2blog/constants/url2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/url2blog/constants/url2blog.constants.ts
@@ -1,3 +1,1 @@
-export { API_BASE_URL } from '../../../shared/api/client/config'
-
 export const FEATURE_PREFIX = '/url2blog'

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api.ts
@@ -26,7 +26,6 @@ export {
   fetchResult,
   fetchStatus,
   fetchToneProfiles,
-  resultDownloadUrl,
   startFromYoutubeUrl
 } from './api/pipeline.api'
 export type {

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/article-types.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/article-types.api.ts
@@ -1,8 +1,9 @@
 import type { ArticleType } from '@shared/types'
-import { API_BASE_URL, ARTICLE_TYPES_PREFIX } from '../constants/api.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { ARTICLE_TYPES_PREFIX } from '../constants/api.constants'
 
 export async function fetchArticleTypes(): Promise<ArticleType[]> {
-  const response = await fetch(`${API_BASE_URL}${ARTICLE_TYPES_PREFIX}`)
+  const response = await apiFetch(ARTICLE_TYPES_PREFIX)
 
   if (!response.ok) {
     throw new Error('Failed to fetch article types')
@@ -12,7 +13,7 @@ export async function fetchArticleTypes(): Promise<ArticleType[]> {
 }
 
 export async function createArticleType(name: string, definition: string): Promise<ArticleType> {
-  const response = await fetch(`${API_BASE_URL}${ARTICLE_TYPES_PREFIX}`, {
+  const response = await apiFetch(ARTICLE_TYPES_PREFIX, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -32,7 +33,7 @@ export async function updateArticleType(
   name: string,
   definition: string,
 ): Promise<ArticleType> {
-  const response = await fetch(`${API_BASE_URL}${ARTICLE_TYPES_PREFIX}/${id}`, {
+  const response = await apiFetch(`${ARTICLE_TYPES_PREFIX}/${id}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -48,7 +49,7 @@ export async function updateArticleType(
 }
 
 export async function deleteArticleType(id: number): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}${ARTICLE_TYPES_PREFIX}/${id}`, {
+  const response = await apiFetch(`${ARTICLE_TYPES_PREFIX}/${id}`, {
     method: 'DELETE',
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/articles.api.ts
@@ -1,9 +1,10 @@
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/api.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/api.constants'
 import type { SavedArticle } from '../types/articles.types'
 import { resolveErrorMessage } from './request-error'
 
 export async function fetchArticles(): Promise<SavedArticle[]> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/articles`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/articles`)
 
   if (!response.ok) {
     throw new Error('Failed to fetch articles')
@@ -13,7 +14,7 @@ export async function fetchArticles(): Promise<SavedArticle[]> {
 }
 
 export async function deleteArticle(runId: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/articles/${runId}`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/articles/${runId}`, {
     method: 'DELETE',
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/expansion.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/expansion.api.ts
@@ -1,4 +1,5 @@
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/api.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/api.constants'
 import type {
   ExpandResultResponse,
   ExpandStatusResponse,
@@ -12,7 +13,7 @@ export async function detectArticleListicle(
   title: string,
   model?: string,
 ): Promise<ListicleDetectionResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/${runId}/expand/detect`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/${runId}/expand/detect`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ article, title, ...(model ? { model } : {}) }),
@@ -33,7 +34,7 @@ export async function startArticleExpansion(
   model?: string,
   rewriteItems?: string[],
 ): Promise<{ expand_job_id: string }> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/${runId}/expand`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/${runId}/expand`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -53,7 +54,7 @@ export async function startArticleExpansion(
 }
 
 export async function fetchExpandStatus(expandJobId: string): Promise<ExpandStatusResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/expand/${expandJobId}/status`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/expand/${expandJobId}/status`)
 
   if (!response.ok) {
     throw new Error('Expansion status fetch failed')
@@ -63,7 +64,7 @@ export async function fetchExpandStatus(expandJobId: string): Promise<ExpandStat
 }
 
 export async function fetchExpandResult(expandJobId: string): Promise<ExpandResultResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/expand/${expandJobId}/result`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/expand/${expandJobId}/result`)
 
   if (!response.ok) {
     throw new Error('Expansion result fetch failed')

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/pipeline.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/api/pipeline.api.ts
@@ -1,6 +1,7 @@
 import type { ResultResponse, StatusResponse, UploadResponse } from '@shared/types'
 import type { ToneProfile } from '../../../shared/api/ai/models'
-import { API_BASE_URL, FEATURE_PREFIX } from '../constants/api.constants'
+import { apiFetch } from '../../../shared/api/client/apiFetch'
+import { FEATURE_PREFIX } from '../constants/api.constants'
 import { STAGE_ORDER } from '../constants/pipeline.constants'
 import type { DebugResponse } from '../types/pipeline.types'
 import { resolveErrorMessage } from './request-error'
@@ -29,7 +30,7 @@ export async function startFromYoutubeUrl(
   writingModel?: string,
   toneId?: string,
 ): Promise<UploadResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/from-url`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/from-url`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -51,7 +52,7 @@ export async function startFromYoutubeUrl(
 }
 
 export async function fetchStatus(runId: string): Promise<StatusResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/status/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/status/${runId}`)
 
   if (!response.ok) {
     throw new Error('Status fetch failed')
@@ -61,7 +62,7 @@ export async function fetchStatus(runId: string): Promise<StatusResponse> {
 }
 
 export async function fetchToneProfiles(): Promise<ToneProfile[]> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/tones`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/tones`)
 
   if (!response.ok) {
     throw new Error('Tone profile fetch failed')
@@ -72,7 +73,7 @@ export async function fetchToneProfiles(): Promise<ToneProfile[]> {
 }
 
 export async function fetchResult(runId: string): Promise<ResultResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/result/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/result/${runId}`)
 
   if (!response.ok) {
     throw new Error('Result fetch failed')
@@ -81,15 +82,11 @@ export async function fetchResult(runId: string): Promise<ResultResponse> {
   return response.json()
 }
 
-export function resultDownloadUrl(runId: string): string {
-  return `${API_BASE_URL}${FEATURE_PREFIX}/result/${runId}?format=md`
-}
-
 export async function clearDatabase(): Promise<{
   message: string
   deleted_runs: number
 }> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/clear`, {
+  const response = await apiFetch(`${FEATURE_PREFIX}/clear`, {
     method: 'POST',
   })
 
@@ -101,7 +98,7 @@ export async function clearDatabase(): Promise<{
 }
 
 export async function fetchDebug(runId: string): Promise<DebugResponse> {
-  const response = await fetch(`${API_BASE_URL}${FEATURE_PREFIX}/debug/${runId}`)
+  const response = await apiFetch(`${FEATURE_PREFIX}/debug/${runId}`)
 
   if (!response.ok) {
     throw new Error('Debug fetch failed')

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/constants/api.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/constants/api.constants.ts
@@ -1,4 +1,2 @@
-export { API_BASE_URL } from '../../../shared/api/client/config'
-
 export const FEATURE_PREFIX = '/youtube2blog'
 export const ARTICLE_TYPES_PREFIX = '/article-types'

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { apiFetch } from './apiFetch'
+import { API_BASE_URL } from './config'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function mockFetch(): ReturnType<typeof vi.fn> {
+  const spy = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', spy)
+  return spy
+}
+
+describe('apiFetch', () => {
+  it('prefixes the path with the backend base URL', async () => {
+    const spy = mockFetch()
+
+    await apiFetch('/youtube2blog/tones')
+
+    expect(spy).toHaveBeenCalledWith(`${API_BASE_URL}/youtube2blog/tones`, undefined)
+  })
+
+  it('forwards init untouched', async () => {
+    const spy = mockFetch()
+    const init: RequestInit = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://example.com' }),
+    }
+
+    await apiFetch('/youtube2blog/from-url', init)
+
+    expect(spy).toHaveBeenCalledWith(`${API_BASE_URL}/youtube2blog/from-url`, init)
+  })
+
+  it('does not add Content-Type to multipart requests', async () => {
+    const spy = mockFetch()
+    const body = new FormData()
+    body.append('file', new Blob(['x']), 'x.png')
+
+    await apiFetch('/images/upload', { method: 'POST', body })
+
+    const [, forwardedInit] = spy.mock.calls[0] as [string, RequestInit]
+    expect(forwardedInit.headers).toBeUndefined()
+  })
+
+  it('returns the underlying response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('body', { status: 418 })))
+
+    const response = await apiFetch('/health')
+
+    expect(response.status).toBe(418)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.ts
@@ -1,0 +1,21 @@
+import { API_BASE_URL } from './config'
+
+/**
+ * Single entry point for every request to the AI Blog Writer backend.
+ *
+ * Call sites pass a path relative to the backend root (`/youtube2blog/tones`,
+ * `/images/upload`) rather than building the base URL themselves. Routing all
+ * backend traffic through one function means request-wide concerns — the
+ * `X-API-Key` header, and anything after it — have exactly one place to live.
+ *
+ * Requests to Payload and to the converter service are deliberately NOT routed
+ * here: they are different origins with different credentials, and must not
+ * receive backend headers.
+ *
+ * This is a transparent pass-through to `fetch`. `init` is forwarded untouched,
+ * which matters for the multipart call sites: they omit `Content-Type` so the
+ * browser can generate the multipart boundary, and nothing here may add it.
+ */
+export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${API_BASE_URL}${path}`, init)
+}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/client/imageApiClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/client/imageApiClient.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL as API_URL } from '../../../api/client/config';
+import { apiFetch } from '../../../api/client/apiFetch';
 
 export { API_URL };
 
@@ -14,7 +15,7 @@ export async function postFormData(
     headers.Authorization = `Bearer ${token}`;
   }
 
-  return fetch(`${API_URL}${path}`, {
+  return apiFetch(path, {
     method: 'POST',
     headers,
     body: formData,
@@ -36,7 +37,7 @@ export async function postJson<TBody extends Record<string, unknown>>(
     headers.Authorization = `Bearer ${token}`;
   }
 
-  return fetch(`${API_URL}${path}`, {
+  return apiFetch(path, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/composites/composite-image.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/composites/composite-image.api.ts
@@ -1,4 +1,4 @@
-import { API_URL } from '../client/imageApiClient'
+import { apiFetch } from '../../../api/client/apiFetch'
 
 export type CompositeImageLayout = 'two-up' | 'four-up'
 
@@ -43,7 +43,7 @@ export async function previewCompositeImage(
   request: CompositeImageRequest,
   token: string,
 ): Promise<{ blob: Blob; warnings: string[] }> {
-  const response = await fetch(`${API_URL}/images/composites/preview`, {
+  const response = await apiFetch('/images/composites/preview', {
     method: 'POST',
     headers: {
       Accept: 'image/webp',
@@ -86,7 +86,7 @@ export type CleanupCompositesResponse = {
 }
 
 export async function fetchHangingComposites(token: string): Promise<HangingCompositesResponse> {
-  const response = await fetch(`${API_URL}/images/composites/hanging`, {
+  const response = await apiFetch('/images/composites/hanging', {
     method: 'GET',
     headers: {
       Accept: 'application/json',
@@ -103,7 +103,7 @@ export async function cleanupHangingComposites(
   mediaSetIds: number[],
   token: string,
 ): Promise<CleanupCompositesResponse> {
-  const response = await fetch(`${API_URL}/images/composites/cleanup`, {
+  const response = await apiFetch('/images/composites/cleanup', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -122,7 +122,7 @@ export async function createCompositeImage(
   request: CompositeImageRequest,
   token: string,
 ): Promise<CompositeImageCreateResponse> {
-  const response = await fetch(`${API_URL}/images/composites/create`, {
+  const response = await apiFetch('/images/composites/create', {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/external/external-images.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/external/external-images.api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '../../api/client/config'
+import { apiFetch } from '../../api/client/apiFetch'
 import { parseErrorResponse } from '../../api/client/error-parser'
 import {
   buildExternalFallbackFileName,
@@ -35,8 +35,8 @@ export async function searchPexelsImages(
     queryParams.append('orientation', params.orientation)
   }
 
-  const response = await fetch(
-    `${API_BASE_URL}/images/pexels/search?${queryParams.toString()}`,
+  const response = await apiFetch(
+    `/images/pexels/search?${queryParams.toString()}`,
   )
 
   if (!response.ok) {
@@ -68,8 +68,8 @@ export async function searchUnsplashImages(
     queryParams.append('orientation', params.orientation)
   }
 
-  const response = await fetch(
-    `${API_BASE_URL}/images/unsplash/search?${queryParams.toString()}`,
+  const response = await apiFetch(
+    `/images/unsplash/search?${queryParams.toString()}`,
   )
 
   if (!response.ok) {
@@ -100,7 +100,7 @@ export async function importExternalImage(
     formData.append('photo_id', String(input.photoId))
   }
 
-  const response = await fetch(`${API_BASE_URL}/images/import-external`, {
+  const response = await apiFetch('/images/import-external', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -132,8 +132,8 @@ export async function fetchExternalImageSource(
     queryParams.append('photo_id', String(input.photoId))
   }
 
-  const response = await fetch(
-    `${API_BASE_URL}/images/external-source?${queryParams.toString()}`,
+  const response = await apiFetch(
+    `/images/external-source?${queryParams.toString()}`,
     {
       method: 'GET',
       headers: {


### PR DESCRIPTION
Stacked on #210. No behavior change.

## Why

60 call sites concatenated the backend base URL inline (`fetch(\`${API_BASE_URL}${FEATURE_PREFIX}/from-url\`, …)`), and there is no interceptor anywhere in the app. So there was no single place to attach a request-wide header — which the next PR needs.

## Change

Adds `shared/api/client/apiFetch.ts`:

```ts
export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
  return fetch(`${API_BASE_URL}${path}`, init)
}
```

and migrates all 60 backend call sites across 20 files to it. `init` is forwarded untouched.

**Payload (18 sites) and converter (2 sites) are deliberately not migrated.** They are different origins with different credentials and must not receive backend headers.

### Load-bearing detail: multipart

Three call sites send `FormData` and deliberately omit `Content-Type` so the browser generates the multipart boundary — `mediaLibraryApi.ts:14`, `imageApiClient.postFormData`, `external-images.api.ts:103`. The wrapper forwards `init` verbatim and must never add a `Content-Type`; there is a test pinning this.

### Deletion: `resultDownloadUrl`

`youtube2blog/api/pipeline.api.ts` exported a function returning a bare backend URL intended for an `<a href download>`. A URL used outside `fetch` cannot carry a custom header, so once the key is required this would have broken silently — a latent trap rather than a live bug, since a grep across the tree found **zero consumers** (only the definition and its barrel re-export). Both removed.

### Follow-on cleanup

The three feature-local `API_BASE_URL` re-exports added in #210 have no importers after this migration and are removed. `imageApiClient` keeps `API_URL` because `image-api-error.utils.ts:104` still renders it in an error message.

## Verification

```
tsc:    7 errors, all pre-existing, none in changed files (baseline 7)
vitest: 134 files, 610 tests passed (baseline 133/606; +1 file/+4 tests are apiFetch's own)
```

The existing `global.fetch` mocks in `articles.api.test.ts` and `prompt2blog/api/pipeline.api.test.ts` still pass, because `apiFetch` calls `fetch` at call time rather than capturing a reference.