### PR TITLE
feat(ai-blog-writer): send X-API-Key from the frontend

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/.env.example
+++ b/apps/ai-blog-writer/apps/frontend/.env.example
@@ -1,4 +1,9 @@
 VITE_API_BASE_URL=http://localhost:4003
+# Must match the backend's ABW_API_KEY. Leave empty for local development.
+# NOT a secret: Vite inlines this into the bundle, so anyone who loads the app
+# can read it. It keeps non-browser callers out of an otherwise open API; it
+# does not identify a user and grants no per-user authority.
+VITE_ABW_API_KEY=
 VITE_CONVERTER_URL=http://localhost:4010
 VITE_SCHEMA_SITE_NAME=
 VITE_SCHEMA_PUBLISHER_LOGO_URL=

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.test.ts
@@ -54,3 +54,74 @@ describe('apiFetch', () => {
     expect(response.status).toBe(418)
   })
 })
+
+describe('apiFetch with VITE_ABW_API_KEY configured', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function withKey(key = 'secret-key'): void {
+    vi.stubEnv('VITE_ABW_API_KEY', key)
+  }
+
+  function headersOf(spy: ReturnType<typeof vi.fn>): Headers {
+    const [, init] = spy.mock.calls[0] as [string, RequestInit]
+    return new Headers(init.headers)
+  }
+
+  it('attaches the X-API-Key header', async () => {
+    withKey()
+    const spy = mockFetch()
+
+    await apiFetch('/youtube2blog/tones')
+
+    expect(headersOf(spy).get('X-API-Key')).toBe('secret-key')
+  })
+
+  it('preserves headers the call site already set', async () => {
+    withKey()
+    const spy = mockFetch()
+
+    await apiFetch('/images/upload-variants', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer staff-token' },
+    })
+
+    const headers = headersOf(spy)
+    expect(headers.get('Authorization')).toBe('Bearer staff-token')
+    expect(headers.get('X-API-Key')).toBe('secret-key')
+  })
+
+  it('does not add Content-Type to multipart requests', async () => {
+    withKey()
+    const spy = mockFetch()
+    const body = new FormData()
+    body.append('file', new Blob(['x']), 'x.png')
+
+    await apiFetch('/images/upload', { method: 'POST', body })
+
+    expect(headersOf(spy).get('Content-Type')).toBeNull()
+  })
+
+  it('preserves the rest of init', async () => {
+    withKey()
+    const spy = mockFetch()
+    const signal = new AbortController().signal
+
+    await apiFetch('/youtube2blog/from-url', { method: 'POST', body: 'x', signal })
+
+    const [, init] = spy.mock.calls[0] as [string, RequestInit]
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe('x')
+    expect(init.signal).toBe(signal)
+  })
+
+  it('treats a whitespace-only key as unset', async () => {
+    withKey('   ')
+    const spy = mockFetch()
+
+    await apiFetch('/health')
+
+    expect(spy).toHaveBeenCalledWith(`${API_BASE_URL}/health`, undefined)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.ts
@@ -1,4 +1,6 @@
-import { API_BASE_URL } from './config'
+import { abwApiKey, API_BASE_URL } from './config'
+
+const API_KEY_HEADER = 'X-API-Key'
 
 /**
  * Single entry point for every request to the AI Blog Writer backend.
@@ -12,10 +14,26 @@ import { API_BASE_URL } from './config'
  * here: they are different origins with different credentials, and must not
  * receive backend headers.
  *
- * This is a transparent pass-through to `fetch`. `init` is forwarded untouched,
- * which matters for the multipart call sites: they omit `Content-Type` so the
- * browser can generate the multipart boundary, and nothing here may add it.
+ * When `VITE_ABW_API_KEY` is configured this attaches the `X-API-Key` header
+ * the backend's `ABW_API_KEY` gate expects. Only that header is added: the
+ * multipart call sites omit `Content-Type` so the browser can generate the
+ * boundary, and nothing here may set it.
+ *
+ * With no key configured this is a transparent pass-through and `init` is
+ * forwarded byte-identical, so local development is unaffected.
  */
 export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
-  return fetch(`${API_BASE_URL}${path}`, init)
+  const url = `${API_BASE_URL}${path}`
+  const key = abwApiKey()
+
+  if (!key) {
+    return fetch(url, init)
+  }
+
+  // `Headers` normalizes the three shapes `HeadersInit` allows, so an existing
+  // Authorization header survives regardless of how the call site wrote it.
+  const headers = new Headers(init?.headers)
+  headers.set(API_KEY_HEADER, key)
+
+  return fetch(url, { ...init, headers })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/config.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/config.ts
@@ -1,3 +1,19 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4003'
+
+/**
+ * Shared key sent to the backend as `X-API-Key`, matching its `ABW_API_KEY`.
+ *
+ * This is NOT a secret. Vite inlines it into the bundle, so anyone who loads
+ * the app can read it. It is a coarse gate that keeps non-browser callers out
+ * of an otherwise fully open API — it does not identify a user and grants no
+ * per-user authority. Anything that depends on *who* is calling must be
+ * checked server-side against the Payload staff session instead.
+ *
+ * Read at call time rather than captured at module load so the value can be
+ * stubbed in tests.
+ */
+export function abwApiKey(): string {
+  return import.meta.env.VITE_ABW_API_KEY?.trim() || ''
+}
 export const CONVERTER_URL = import.meta.env.VITE_CONVERTER_URL || 'http://localhost:4010'
 export const PAYLOAD_API_URL = import.meta.env.VITE_PAYLOAD_API_URL || 'http://localhost:4000'

--- a/apps/ai-blog-writer/apps/frontend/src/vite-env.d.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_ABW_API_KEY?: string
   readonly VITE_API_BASE_URL?: string
   readonly VITE_CONVERTER_URL?: string
   readonly VITE_FRONTEND_URL?: string


### PR DESCRIPTION
Stacked on #211.

## Why

The backend has had an `ABW_API_KEY` gate for a while, but the frontend never sent the header — so turning the key on server-side would 401 the entire UI. The handoff notes this has to be fixed at both ends together. #211 created the single seam; this fills it in.

## Change

`apiFetch` attaches `X-API-Key` when `VITE_ABW_API_KEY` is set:

```ts
const key = abwApiKey()
if (!key) return fetch(url, init)          // byte-identical pass-through

const headers = new Headers(init?.headers) // normalizes all HeadersInit shapes
headers.set(API_KEY_HEADER, key)
return fetch(url, { ...init, headers })
```

- **Multipart is safe.** Only `X-API-Key` is set; `Content-Type` is never touched, so the browser still generates the boundary. Pinned by a test.
- **Existing headers survive.** `Headers` normalizes the object/array/`Headers` shapes call sites use, so `Authorization: Bearer <staff token>` is preserved. Pinned by a test.
- **No-op when unset**, so local dev and every current deployment are unaffected.
- Read at call time rather than captured at module load, so `vi.stubEnv` works in tests.

## This key is not a secret — please read

Vite inlines `VITE_*` into the bundle, so anyone who loads the app can read this value. It is a **coarse gate** that keeps non-browser callers out of an otherwise fully open API. It does not identify a user and grants no per-user authority.

That is called out in both `.env.example` and the `abwApiKey()` docstring so nobody later mistakes it for authentication. Real per-user authorization is the next PR, which verifies the Payload staff session server-side on the expensive and destructive routes.

## Verification

```
vitest: 134 files, 615 tests passed  (baseline 610 on #211; +5 new)
tsc:    7 errors, all pre-existing (baseline 7)
```

Note: run vitest with `--no-file-parallelism` if the machine is loaded — several component tests are timeout-sensitive under CPU contention and flake unrelated to this change.