### PR TITLE
feat(ai-blog-writer): send the staff session on backend requests

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/main.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/main.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { readStoredAuth } from './features/auth/auth-storage'
+import { setApiAuthTokenProvider } from './shared/api/client/auth-token'
+
+// Backend requests carry the staff session so the server can authorize the
+// caller itself. Registered here rather than imported inside `apiFetch` so
+// `shared/` keeps no dependency on `features/`. `readStoredAuth` returns null
+// for an expired session, so a stale token is never sent.
+setApiAuthTokenProvider(() => readStoredAuth()?.token ?? null)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { apiFetch } from './apiFetch'
+import { resetApiAuthTokenProvider, setApiAuthTokenProvider } from './auth-token'
 import { API_BASE_URL } from './config'
 
 afterEach(() => {
   vi.restoreAllMocks()
+  resetApiAuthTokenProvider()
 })
 
 function mockFetch(): ReturnType<typeof vi.fn> {
@@ -123,5 +125,79 @@ describe('apiFetch with VITE_ABW_API_KEY configured', () => {
     await apiFetch('/health')
 
     expect(spy).toHaveBeenCalledWith(`${API_BASE_URL}/health`, undefined)
+  })
+})
+
+describe('apiFetch with a staff session', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function headersOf(spy: ReturnType<typeof vi.fn>): Headers {
+    const [, init] = spy.mock.calls[0] as [string, RequestInit]
+    return new Headers(init.headers)
+  }
+
+  it('attaches the session token as a Bearer credential', async () => {
+    setApiAuthTokenProvider(() => 'staff-token')
+    const spy = mockFetch()
+
+    await apiFetch('/youtube2blog/from-url', { method: 'POST' })
+
+    expect(headersOf(spy).get('Authorization')).toBe('Bearer staff-token')
+  })
+
+  it('does not override a token the call site set itself', async () => {
+    setApiAuthTokenProvider(() => 'ambient-token')
+    const spy = mockFetch()
+
+    await apiFetch('/images/upload', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer explicit-token' },
+    })
+
+    expect(headersOf(spy).get('Authorization')).toBe('Bearer explicit-token')
+  })
+
+  it('sends both credentials when a key is configured too', async () => {
+    vi.stubEnv('VITE_ABW_API_KEY', 'secret-key')
+    setApiAuthTokenProvider(() => 'staff-token')
+    const spy = mockFetch()
+
+    await apiFetch('/prompt2blog/run', { method: 'POST' })
+
+    const headers = headersOf(spy)
+    expect(headers.get('X-API-Key')).toBe('secret-key')
+    expect(headers.get('Authorization')).toBe('Bearer staff-token')
+  })
+
+  it('passes through untouched when there is no session', async () => {
+    const spy = mockFetch()
+
+    await apiFetch('/youtube2blog/tones')
+
+    expect(spy).toHaveBeenCalledWith(`${API_BASE_URL}/youtube2blog/tones`, undefined)
+  })
+
+  it('does not add Content-Type to multipart requests', async () => {
+    setApiAuthTokenProvider(() => 'staff-token')
+    const spy = mockFetch()
+    const body = new FormData()
+    body.append('file', new Blob(['x']), 'x.png')
+
+    await apiFetch('/images/upload', { method: 'POST', body })
+
+    expect(headersOf(spy).get('Content-Type')).toBeNull()
+  })
+
+  it('sends nothing when the provider throws', async () => {
+    setApiAuthTokenProvider(() => {
+      throw new Error('storage unavailable')
+    })
+    const spy = mockFetch()
+
+    await apiFetch('/youtube2blog/tones')
+
+    expect(spy).toHaveBeenCalledWith(`${API_BASE_URL}/youtube2blog/tones`, undefined)
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/apiFetch.ts
@@ -1,3 +1,4 @@
+import { apiAuthToken } from './auth-token'
 import { abwApiKey, API_BASE_URL } from './config'
 
 const API_KEY_HEADER = 'X-API-Key'
@@ -14,26 +15,42 @@ const API_KEY_HEADER = 'X-API-Key'
  * here: they are different origins with different credentials, and must not
  * receive backend headers.
  *
- * When `VITE_ABW_API_KEY` is configured this attaches the `X-API-Key` header
- * the backend's `ABW_API_KEY` gate expects. Only that header is added: the
- * multipart call sites omit `Content-Type` so the browser can generate the
- * boundary, and nothing here may set it.
+ * Two headers are attached when available, and nothing else:
  *
- * With no key configured this is a transparent pass-through and `init` is
+ * - `X-API-Key` from `VITE_ABW_API_KEY`, satisfying the backend's coarse
+ *   `ABW_API_KEY` gate. Not a secret; see `abwApiKey`.
+ * - `Authorization: Bearer <staff token>` from the registered auth provider,
+ *   which is what actually identifies the caller. Never overrides a token the
+ *   call site set itself.
+ *
+ * `Content-Type` is deliberately never set: the multipart call sites omit it
+ * so the browser can generate the boundary.
+ *
+ * With neither configured this is a transparent pass-through and `init` is
  * forwarded byte-identical, so local development is unaffected.
  */
 export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const url = `${API_BASE_URL}${path}`
   const key = abwApiKey()
+  const token = apiAuthToken()
 
-  if (!key) {
+  if (!key && !token) {
     return fetch(url, init)
   }
 
   // `Headers` normalizes the three shapes `HeadersInit` allows, so an existing
   // Authorization header survives regardless of how the call site wrote it.
   const headers = new Headers(init?.headers)
-  headers.set(API_KEY_HEADER, key)
+
+  if (key) {
+    headers.set(API_KEY_HEADER, key)
+  }
+
+  // Never override a token the call site chose deliberately — the image routes
+  // pass an explicit one, and it may differ from the ambient session.
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
 
   return fetch(url, { ...init, headers })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/auth-token.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/auth-token.ts
@@ -1,0 +1,29 @@
+type TokenProvider = () => string | null
+
+let provider: TokenProvider = () => null
+
+/**
+ * Registers where `apiFetch` reads the staff session token from.
+ *
+ * Injected rather than imported so `shared/` does not depend on `features/`.
+ * The app wires this to the auth feature's storage at bootstrap; tests and
+ * Storybook can supply their own provider, or none at all.
+ */
+export function setApiAuthTokenProvider(next: TokenProvider): void {
+  provider = next
+}
+
+/** Resets to the default "no session" provider. Intended for tests. */
+export function resetApiAuthTokenProvider(): void {
+  provider = () => null
+}
+
+export function apiAuthToken(): string | null {
+  try {
+    return provider()
+  } catch {
+    // A broken provider must not take down every backend request; the call
+    // simply goes out unauthenticated and the server decides.
+    return null
+  }
+}


### PR DESCRIPTION
Stacked on #212. Frontend half of the server-side authorization work; inert on its own.

## Why

The backend can't authorize a caller it can't identify. Right now the staff JWT reaches **only the image routes** — every pipeline-start and destructive route sees an anonymous request. Requiring a session server-side without this would 401 the UI, the same both-ends trap as the API key.

## Change

`apiFetch` attaches `Authorization: Bearer <staff token>` when a session exists.

The token source is **injected**, not imported:

```ts
// main.tsx
setApiAuthTokenProvider(() => readStoredAuth()?.token ?? null)
```

`apiFetch` lives in `shared/` and the session lives in `features/auth/`; importing it directly would invert the layering. Injection keeps `shared/` dependency-free and lets tests supply their own provider.

Three behaviors worth reviewing:

- **The call site always wins.** If `init.headers` already has an `Authorization`, it is not overridden — the image routes pass an explicit token that may differ from the ambient session.
- **Expired sessions are never sent.** `readStoredAuth()` returns `null` past `expiresAt` and clears storage, so that check is inherited rather than reimplemented.
- **A throwing provider degrades to anonymous** rather than failing the request. Losing access to `localStorage` shouldn't take down every backend call.

`Content-Type` is still never set, so multipart uploads keep generating their own boundary.

## Not addressed here

The token still lives in `localStorage`, which is Phase 5 in the handoff and deliberately out of scope — this PR changes where the existing token is *sent*, not where it is stored.

## Verification

```
vitest: 621 tests passed  (baseline 615 on #212; +6 new)
tsc:    7 errors, all pre-existing (baseline 7)
```