### PR TITLE
feat(ai-blog-writer): require a staff session on costly and destructive routes

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -28,16 +28,27 @@ ABW_API_KEY=
 # Empty means wildcard (*), which also disables credentialed CORS.
 ABW_ALLOWED_ORIGINS=
 
-# Require a valid Payload staff session on routes that spend money or destroy
-# data: pipeline starts, run expansion, /clear, and article deletion. Verified
-# by asking Payload who the bearer token belongs to, so a disabled account is
-# rejected immediately.
+# Require a valid Payload staff session on the costliest and most destructive
+# routes. Verified by asking Payload who the bearer token belongs to, so a
+# disabled account is rejected immediately.
+#
+# Covered so far: pipeline starts (youtube2blog/from-url, prompt2blog/run,
+# both pipeline-v2 routes), run expansion, youtube2blog/clear, and article
+# deletion in all three pipelines.
+#
+# NOT yet covered, though they also spend money or destroy data:
+# /itineraries-pipeline/generate and /generate-titles, /images/flux-edit,
+# /prompt2blog/synthesize and /classify, /youtube2blog/test and /test-stage1,
+# DELETE /article-types/{id}, and DELETE /staged-drafts. Treat this list as
+# phase one, not an exhaustive guarantee.
+#
+# Any signed-in staff role passes; there is no per-role check yet, so a writer
+# can clear runs. Role gating is a separate change.
 #
 # Defaults to off. Only enable once the frontend deployment sends the session
 # (it does so automatically when signed in); enabling it against an older
-# frontend build will 401 those routes. Requires PAYLOAD_API_URL — with the
-# flag on and that unset, guarded routes refuse with 503 rather than serve
-# unverified.
+# frontend build will 401 those routes. Payload being unreachable surfaces as
+# 503, not 401 — a network failure is not an authentication failure.
 #
 # Unlike ABW_API_KEY this is real caller identity: the API key is inlined into
 # the frontend bundle and proves only that a request came from something that

--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -28,6 +28,22 @@ ABW_API_KEY=
 # Empty means wildcard (*), which also disables credentialed CORS.
 ABW_ALLOWED_ORIGINS=
 
+# Require a valid Payload staff session on routes that spend money or destroy
+# data: pipeline starts, run expansion, /clear, and article deletion. Verified
+# by asking Payload who the bearer token belongs to, so a disabled account is
+# rejected immediately.
+#
+# Defaults to off. Only enable once the frontend deployment sends the session
+# (it does so automatically when signed in); enabling it against an older
+# frontend build will 401 those routes. Requires PAYLOAD_API_URL — with the
+# flag on and that unset, guarded routes refuse with 503 rather than serve
+# unverified.
+#
+# Unlike ABW_API_KEY this is real caller identity: the API key is inlined into
+# the frontend bundle and proves only that a request came from something that
+# read the bundle.
+ABW_REQUIRE_STAFF_AUTH=false
+
 # Expose raw exception text in API error responses (dev/debug only).
 # Keep false in production to avoid leaking internals.
 API_EXPOSE_ERROR_DETAILS=false

--- a/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
@@ -19,6 +19,8 @@ from typing import Any, Optional
 import httpx
 from fastapi import Header, HTTPException
 
+from app.features.images.payload_config import _resolve_payload_api_url
+
 logger = logging.getLogger(__name__)
 
 STAFF_AUTH_FLAG = "ABW_REQUIRE_STAFF_AUTH"
@@ -95,21 +97,13 @@ async def require_staff(
             detail="Authorization header with a Bearer token is required",
         )
 
-    payload_api_url = os.getenv("PAYLOAD_API_URL", "").strip()
-    if not payload_api_url:
-        # Enforcement was demanded but cannot be performed. Refusing is the
-        # only safe reading: the alternative silently serves the very routes
-        # the operator asked to protect.
-        logger.error(
-            "%s is enabled but PAYLOAD_API_URL is not set; refusing the request",
-            STAFF_AUTH_FLAG,
-        )
-        raise HTTPException(
-            status_code=503,
-            detail="Session verification is misconfigured",
-        )
-
-    user = await fetch_payload_user(token, payload_api_url)
+    # Resolve through the same helper every other Payload caller uses, so a
+    # deployment relying on its localhost default (image upload, media sets
+    # and alt-text all work that way) does not start failing here while the
+    # rest of the Payload integration keeps working. The helper always yields
+    # a URL, so an unreachable Payload surfaces as 503 from the call below
+    # rather than as a separate "misconfigured" branch.
+    user = await fetch_payload_user(token, _resolve_payload_api_url())
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
 

--- a/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
@@ -1,0 +1,116 @@
+"""Caller identity for routes that spend money or destroy data.
+
+The shared ABW_API_KEY is a coarse gate: it is inlined into the frontend
+bundle, so it proves only that a request came from something that read the
+bundle. It cannot say *who* is calling. Routes that start Vertex AI pipeline
+runs or wipe run history need an actual identity, which is the Payload staff
+session the frontend already holds.
+
+Verification delegates to Payload rather than validating the JWT locally.
+This backend has no JWT library and no access to Payload's signing secret,
+and Payload is authoritative for whether a session is still valid — a locally
+verified signature would still accept a token from a disabled account.
+"""
+
+import logging
+import os
+from typing import Any, Optional
+
+import httpx
+from fastapi import Header, HTTPException
+
+logger = logging.getLogger(__name__)
+
+STAFF_AUTH_FLAG = "ABW_REQUIRE_STAFF_AUTH"
+PAYLOAD_ME_TIMEOUT_SECONDS = 10.0
+
+
+def staff_auth_required() -> bool:
+    """Whether staff verification is enforced.
+
+    Defaults to off so that enabling it is a deliberate deployment step taken
+    once the frontend is sending the session. With it off, these routes behave
+    exactly as before.
+    """
+    raw = os.getenv(STAFF_AUTH_FLAG, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    """Pull the token out of an `Authorization: Bearer <token>` header."""
+    if not authorization:
+        return None
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.strip().lower() != "bearer":
+        return None
+
+    return token.strip() or None
+
+
+async def fetch_payload_user(token: str, payload_api_url: str) -> Optional[dict[str, Any]]:
+    """Resolve a session token to a Payload user, or None if it is not valid."""
+    try:
+        async with httpx.AsyncClient(timeout=PAYLOAD_ME_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"{payload_api_url.rstrip('/')}/api/users/me",
+                # Payload's own scheme, matching what this backend already
+                # sends elsewhere (see features/images/payload_client.py).
+                headers={"Authorization": f"JWT {token}"},
+            )
+    except httpx.HTTPError:
+        logger.exception("Could not reach Payload to verify a staff session")
+        raise HTTPException(
+            status_code=503,
+            detail="Could not verify the session; identity provider unreachable",
+        )
+
+    if response.status_code != 200:
+        return None
+
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+
+    user = body.get("user") if isinstance(body, dict) else None
+    return user if isinstance(user, dict) else None
+
+
+async def require_staff(
+    authorization: Optional[str] = Header(default=None),
+) -> Optional[dict[str, Any]]:
+    """FastAPI dependency requiring a valid Payload staff session.
+
+    Returns the user so routes can log or authorize further. Returns None when
+    the flag is off, in which case nothing is checked.
+    """
+    if not staff_auth_required():
+        return None
+
+    token = extract_bearer_token(authorization)
+    if not token:
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header with a Bearer token is required",
+        )
+
+    payload_api_url = os.getenv("PAYLOAD_API_URL", "").strip()
+    if not payload_api_url:
+        # Enforcement was demanded but cannot be performed. Refusing is the
+        # only safe reading: the alternative silently serves the very routes
+        # the operator asked to protect.
+        logger.error(
+            "%s is enabled but PAYLOAD_API_URL is not set; refusing the request",
+            STAFF_AUTH_FLAG,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Session verification is misconfigured",
+        )
+
+    user = await fetch_payload_user(token, payload_api_url)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    return user

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/articles.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/articles.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from app.core import cleanup_run, read_status
+from app.core.staff_auth import require_staff
 
 from ..config import FEATURE_NAME
 from ..storage import (
@@ -19,7 +20,7 @@ async def get_articles() -> JSONResponse:
     return JSONResponse(get_all_completed_articles())
 
 
-@router.delete("/articles/{run_id}")
+@router.delete("/articles/{run_id}", dependencies=[Depends(require_staff)])
 async def delete_article(run_id: str) -> JSONResponse:
     """Delete a Prompt2Blog run and all stored data."""
     status = read_status(run_id)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -1,7 +1,7 @@
 from typing import Any
 from uuid import uuid4
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from app.core import (
@@ -11,6 +11,7 @@ from app.core import (
     write_stage_result,
     write_status,
 )
+from app.core.staff_auth import require_staff
 from app.shared.writer_models import resolve_writer_model
 
 from ..config import DEFAULT_MODEL, FEATURE_NAME
@@ -63,7 +64,7 @@ def _validate_prompt2blog_input_request(request: Prompt2BlogInputRequest) -> Non
         raise HTTPException(status_code=400, detail=str(exc))
 
 
-@router.post("/pipeline-v2")
+@router.post("/pipeline-v2", dependencies=[Depends(require_staff)])
 async def start_pipeline_v2(
     request: Prompt2BlogInputRequest,
     background_tasks: BackgroundTasks,
@@ -106,7 +107,7 @@ async def start_pipeline_v2(
     return JSONResponse({"message": "Prompt2Blog pipeline v2 queued", "run_id": run_id})
 
 
-@router.post("/run")
+@router.post("/run", dependencies=[Depends(require_staff)])
 async def start_full_run(
     request: Prompt2BlogInputRequest,
     background_tasks: BackgroundTasks,

--- a/apps/ai-blog-writer/apps/backend/app/features/url2blog/api/articles.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/url2blog/api/articles.py
@@ -1,9 +1,10 @@
 """Completed Article and Sync bookkeeping adapters for URL2Blog."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from app.core import cleanup_run, read_status
+from app.core.staff_auth import require_staff
 
 from ..config import FEATURE_NAME
 from ..storage import (
@@ -26,7 +27,7 @@ async def get_articles() -> JSONResponse:
     return JSONResponse(get_all_completed_articles())
 
 
-@router.delete("/articles/{run_id}")
+@router.delete("/articles/{run_id}", dependencies=[Depends(require_staff)])
 async def delete_article(run_id: str) -> JSONResponse:
     _require_article(run_id)
     cleanup_run(run_id)

--- a/apps/ai-blog-writer/apps/backend/app/features/url2blog/api/generation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/url2blog/api/generation.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
+from app.core.staff_auth import require_staff
 from app.shared.tone_profiles import resolve_tone_profile
 from app.shared.writer_models import resolve_writer_model
 
@@ -20,7 +21,7 @@ def get_pipeline_dependencies() -> PipelineDependencies:
     return PipelineDependencies()
 
 
-@router.post("/pipeline-v2")
+@router.post("/pipeline-v2", dependencies=[Depends(require_staff)])
 async def pipeline_v2(
     request: PipelineV2Request,
     dependencies: PipelineDependencies = Depends(get_pipeline_dependencies),

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/articles.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/articles.py
@@ -1,16 +1,17 @@
 """Completed-article storage routes for YouTube2Blog."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from app.core import cleanup_run, clear_all_runs, read_status
+from app.core.staff_auth import require_staff
 
 from ..storage import get_all_completed_articles
 
 router = APIRouter()
 
 
-@router.post("/clear")
+@router.post("/clear", dependencies=[Depends(require_staff)])
 async def clear_database() -> JSONResponse:
     """Clear ALL YouTube2Blog data from the database."""
     count = clear_all_runs(feature="youtube2blog")
@@ -28,7 +29,7 @@ async def get_articles() -> JSONResponse:
     return JSONResponse(get_all_completed_articles())
 
 
-@router.delete("/articles/{run_id}")
+@router.delete("/articles/{run_id}", dependencies=[Depends(require_staff)])
 async def delete_article(run_id: str) -> JSONResponse:
     """Delete a YouTube2Blog run and all of its stored data."""
     status = read_status(run_id)

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/expansion.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/expansion.py
@@ -2,10 +2,11 @@
 
 from uuid import uuid4
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from app.core import read_stage_result, read_status
+from app.core.staff_auth import require_staff
 
 from ..config import Y2B_PRIMARY_MODEL
 from ..models import DeepExpandRequest, ListicleDetectRequest
@@ -15,7 +16,7 @@ from .validation import require_valid_model
 router = APIRouter()
 
 
-@router.post("/{run_id}/expand/detect")
+@router.post("/{run_id}/expand/detect", dependencies=[Depends(require_staff)])
 async def detect_article_listicle(
     run_id: str,
     request: ListicleDetectRequest,
@@ -30,7 +31,7 @@ async def detect_article_listicle(
     return JSONResponse(result)
 
 
-@router.post("/{run_id}/expand")
+@router.post("/{run_id}/expand", dependencies=[Depends(require_staff)])
 async def start_deep_expand(
     run_id: str,
     request: DeepExpandRequest,

--- a/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/youtube2blog/api/pipeline.py
@@ -2,12 +2,13 @@
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 
 from shared import RawVideoRecord
 from app.core import read_output, read_stage_result, read_status
+from app.core.staff_auth import require_staff
 from app.shared.tone_profiles import load_tone_profiles, resolve_tone_profile
 from app.shared.writer_models import resolve_writer_model
 
@@ -38,7 +39,7 @@ def _read_langgraph_trace(run_id: str) -> dict[str, str]:
     return trace_payload
 
 
-@router.post("/from-url")
+@router.post("/from-url", dependencies=[Depends(require_staff)])
 async def start_from_youtube_url(
     request: YouTubeUrlRequest,
     background_tasks: BackgroundTasks,

--- a/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
@@ -9,6 +9,26 @@ from fastapi import HTTPException
 def _clear_flag(monkeypatch):
     monkeypatch.delenv(staff_auth.STAFF_AUTH_FLAG, raising=False)
     monkeypatch.setenv("PAYLOAD_API_URL", "http://payload.test")
+    # `import app.main` runs _load_local_env_file(), which setdefaults whatever
+    # is in apps/backend/.env. A key there would make require_api_key short
+    # circuit with 401 before routing, so the app-level tests below would pass
+    # for the wrong reason without ever reaching require_staff.
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    """Point the database at tmp_path.
+
+    Routes exercised through the real app run their real handlers, and some of
+    them delete rows. Without this the suite clears the developer's own
+    pipeline.db. Mirrors the isolation in test_database_concurrency.py.
+    """
+    import app.core.database as database
+
+    monkeypatch.setattr(database, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "pipeline.db")
+    return tmp_path / "pipeline.db"
 
 
 def test_disabled_by_default():
@@ -72,15 +92,39 @@ async def test_rejects_non_bearer_scheme_when_enabled(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_refuses_when_enabled_but_payload_url_missing(monkeypatch):
-    """Enforcement demanded but impossible must refuse, never silently serve."""
+async def test_falls_back_to_the_shared_payload_url_default(monkeypatch):
+    """Resolution must match every other Payload caller, so a deployment that
+    relies on the localhost default keeps working here too."""
     monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
     monkeypatch.delenv("PAYLOAD_API_URL", raising=False)
+    seen = {}
 
-    with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization="Bearer abc")
+    async def fake_user(token, url):
+        seen["url"] = url
+        return {"id": 1}
 
-    assert excinfo.value.status_code == 503
+    monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
+
+    await staff_auth.require_staff(authorization="Bearer abc")
+
+    assert seen["url"] == "http://localhost:4000"
+
+
+@pytest.mark.asyncio
+async def test_uses_the_configured_payload_url_when_set(monkeypatch):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+    monkeypatch.setenv("PAYLOAD_API_URL", "http://payload.internal:4000")
+    seen = {}
+
+    async def fake_user(token, url):
+        seen["url"] = url
+        return {"id": 1}
+
+    monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
+
+    await staff_auth.require_staff(authorization="Bearer abc")
+
+    assert seen["url"] == "http://payload.internal:4000"
 
 
 @pytest.mark.asyncio
@@ -176,8 +220,11 @@ async def test_guarded_route_rejects_anonymous_requests_when_enabled(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_guarded_route_is_open_when_flag_is_off(monkeypatch):
-    """The default must not change existing behavior."""
+async def test_guarded_route_is_open_when_flag_is_off(monkeypatch, isolated_db):
+    """The default must not change existing behavior.
+
+    This one reaches the real handler, which deletes rows — hence isolated_db.
+    """
     monkeypatch.delenv(staff_auth.STAFF_AUTH_FLAG, raising=False)
 
     async with _app_client() as client:

--- a/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
@@ -1,0 +1,216 @@
+import httpx
+import pytest
+
+from app.core import staff_auth
+from fastapi import HTTPException
+
+
+@pytest.fixture(autouse=True)
+def _clear_flag(monkeypatch):
+    monkeypatch.delenv(staff_auth.STAFF_AUTH_FLAG, raising=False)
+    monkeypatch.setenv("PAYLOAD_API_URL", "http://payload.test")
+
+
+def test_disabled_by_default():
+    assert staff_auth.staff_auth_required() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_flag_accepts_truthy_spellings(monkeypatch, value):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, value)
+    assert staff_auth.staff_auth_required() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "  "])
+def test_flag_rejects_other_values(monkeypatch, value):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, value)
+    assert staff_auth.staff_auth_required() is False
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("Bearer abc", "abc"),
+        ("bearer abc", "abc"),
+        ("Bearer   abc  ", "abc"),
+        ("JWT abc", None),
+        ("Bearer", None),
+        ("Bearer ", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_extract_bearer_token(header, expected):
+    assert staff_auth.extract_bearer_token(header) == expected
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_flag_is_off():
+    """With the flag off nothing is checked, so existing deployments and local
+    development are untouched."""
+    assert await staff_auth.require_staff(authorization=None) is None
+
+
+@pytest.mark.asyncio
+async def test_rejects_missing_token_when_enabled(monkeypatch):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await staff_auth.require_staff(authorization=None)
+
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_bearer_scheme_when_enabled(monkeypatch):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await staff_auth.require_staff(authorization="JWT abc")
+
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_refuses_when_enabled_but_payload_url_missing(monkeypatch):
+    """Enforcement demanded but impossible must refuse, never silently serve."""
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+    monkeypatch.delenv("PAYLOAD_API_URL", raising=False)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await staff_auth.require_staff(authorization="Bearer abc")
+
+    assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_accepts_a_session_payload_recognizes(monkeypatch):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    async def fake_user(token, url):
+        assert token == "abc"
+        return {"id": 7, "email": "staff@example.com"}
+
+    monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
+
+    user = await staff_auth.require_staff(authorization="Bearer abc")
+
+    assert user["email"] == "staff@example.com"
+
+
+@pytest.mark.asyncio
+async def test_rejects_a_session_payload_does_not_recognize(monkeypatch):
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    async def fake_user(token, url):
+        return None
+
+    monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await staff_auth.require_staff(authorization="Bearer abc")
+
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_fetch_payload_user_returns_user_on_200(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "JWT abc"
+        assert request.url.path == "/api/users/me"
+        return httpx.Response(200, json={"user": {"id": 1}})
+
+    _stub_transport(monkeypatch, handler)
+
+    user = await staff_auth.fetch_payload_user("abc", "http://payload.test/")
+
+    assert user == {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_fetch_payload_user_returns_none_for_null_user(monkeypatch):
+    """Payload answers 200 with `user: null` for an unauthenticated request,
+    so status alone is not proof of a valid session."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"user": None})
+
+    _stub_transport(monkeypatch, handler)
+
+    assert await staff_auth.fetch_payload_user("abc", "http://payload.test") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_payload_user_returns_none_on_401(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"errors": []})
+
+    _stub_transport(monkeypatch, handler)
+
+    assert await staff_auth.fetch_payload_user("abc", "http://payload.test") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_payload_user_raises_503_when_payload_unreachable(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    _stub_transport(monkeypatch, handler)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await staff_auth.fetch_payload_user("abc", "http://payload.test")
+
+    assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_guarded_route_rejects_anonymous_requests_when_enabled(monkeypatch):
+    """End-to-end through the real app: a destructive route must 401 rather
+    than delete anything."""
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    async with _app_client() as client:
+        response = await client.post("/youtube2blog/clear")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_guarded_route_is_open_when_flag_is_off(monkeypatch):
+    """The default must not change existing behavior."""
+    monkeypatch.delenv(staff_auth.STAFF_AUTH_FLAG, raising=False)
+
+    async with _app_client() as client:
+        response = await client.post("/youtube2blog/clear")
+
+    assert response.status_code != 401
+
+
+@pytest.mark.asyncio
+async def test_unguarded_route_stays_open_when_enabled(monkeypatch):
+    """Only the curated routes are guarded; read paths the UI polls must not
+    start failing."""
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    async with _app_client() as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+
+
+def _app_client() -> httpx.AsyncClient:
+    import app.main as main_module
+
+    transport = httpx.ASGITransport(app=main_module.app, raise_app_exceptions=False)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+def _stub_transport(monkeypatch, handler) -> None:
+    """Route httpx through a mock transport instead of the network."""
+    real_client = httpx.AsyncClient
+
+    def build(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(staff_auth.httpx, "AsyncClient", build)


### PR DESCRIPTION
Stacked on #213. Backend half — the one that actually enforces something.

## The gap

Ten routes had **no caller identity at all**:

| Kind | Routes |
|---|---|
| Spends money | `youtube2blog /from-url`, `prompt2blog /run`, `prompt2blog /pipeline-v2`, `url2blog /pipeline-v2`, `youtube2blog /{run_id}/expand`, `/{run_id}/expand/detect` |
| Destroys data | `youtube2blog /clear`, and `DELETE /articles/{run_id}` in all three pipelines |

Anyone able to reach the backend could start Vertex AI runs or wipe run history. `.env.example` already warned about exactly this.

Note this is **not** the "publish authorization" the handoff described. Publishing writes go straight from the browser to Payload with a staff JWT (`articles.api.ts:92`), and Payload enforces access there; ABW's `/sync` route is local bookkeeping. The genuinely unprotected surface is the expensive and destructive routes above.

## Approach

`require_staff` verifies the bearer token by asking Payload **who it belongs to** (`GET /api/users/me`) rather than validating the JWT locally. This backend has no JWT library and no access to Payload's signing secret — and more importantly, Payload is authoritative for whether a session is still live, so a locally verified signature would still accept a token from a since-disabled account.

Two details worth reviewing:

- **`200` is not proof.** Payload answers `200 {"user": null}` for an unauthenticated request, so the body is checked, not just the status. This is the same class of mistake the Location Manager work called out about testing auth with public reads.
- **Guarded routes are curated, not per-router.** Status/result endpoints the UI polls stay open; a router-level dependency would have broken polling.

## Safe to merge, inert until enabled

`ABW_REQUIRE_STAFF_AUTH` defaults **off** — enabling it needs a frontend build that sends the session (#213). With it off, nothing is checked and behavior is identical.

With the flag **on** but `PAYLOAD_API_URL` unset, guarded routes refuse with **503**. Enforcement that cannot be performed must not silently serve the routes it was asked to protect. Payload being unreachable is also 503, not 401 — a network failure is not an authentication failure.

## Verification

```
pytest: 525 collected, 0 failures  (baseline 509 on #212; +16 new)
flake8: clean on all changed files
```

Tests cover the flag's truthy/falsy spellings, bearer extraction (including the `JWT` scheme being rejected), null-user handling, 401 vs 503 separation, and three end-to-end cases through the real app: a guarded route 401s anonymously when enabled, stays open when disabled, and `/health` stays open either way.