### PR TITLE
fix(questura): prevent visitor profile data loss

### DIFF
--- a/apps/questura/CONTEXT.md
+++ b/apps/questura/CONTEXT.md
@@ -239,6 +239,7 @@ _Avoid_: public auth, visitor auth
 - A **Staff identity** has at most one **Author**; an **Author** may exist with no Staff identity at all, and that is a fully valid, renderable state (ADR-0007).
 - A **Staff identity** has a lifecycle **status** of `active` or `disabled`. Disabling, not deleting, is how a person is offboarded: a disabled identity cannot sign in and holds no access, while its **Author**, bylines and author page are untouched.
 - A **Visitor account** has exactly one **Visitor profile**.
+- A **Visitor profile** is durable membership and billing identity. Independent deletion is unsupported until an erasure workflow can coordinate BetterAuth, Stripe, and profile data.
 - A **Staff identity** is separate from a **Visitor account**.
 - A **Staff identity** enters through a **Staff entry point**, not a **Visitor entry point**.
 - An **Operator tool** authenticates Staff identities through a **Staff entry point**.

--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { VisitorProfiles } from './VisitorProfiles'
+import { preventVisitorProfileDelete } from './hooks/preventDelete'
+
+const access = VisitorProfiles.access as Record<
+  string,
+  (args: { req: { user: unknown } }) => boolean
+>
+
+describe('VisitorProfiles deletion', () => {
+  it.each([
+    ['admin', { id: 1, collection: 'users', role: 'admin' }],
+    ['editor', { id: 2, collection: 'users', role: 'editor' }],
+    ['writer', { id: 3, collection: 'users', role: 'writer' }],
+    ['service account', { id: 4, collection: 'service-accounts', name: 'Location Manager' }],
+    ['anonymous caller', null],
+  ])('refuses deletion by %s', (_label, user) => {
+    expect(access.delete({ req: { user } })).toBe(false)
+  })
+
+  it('wires the deletion invariant into the collection lifecycle', () => {
+    expect(VisitorProfiles.hooks?.beforeDelete).toContain(preventVisitorProfileDelete)
+  })
+
+  it('refuses trusted Local API deletion that bypasses collection access', () => {
+    expect(() =>
+      (preventVisitorProfileDelete as (args: unknown) => unknown)({
+        id: 42,
+        req: {},
+      }),
+    ).toThrow('Visitor profiles cannot be deleted independently.')
+  })
+})

--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
@@ -1,5 +1,6 @@
 import { staffUser } from '@/features/auth/lib/staff-user'
 import type { CollectionConfig } from 'payload'
+import { preventVisitorProfileDelete } from './hooks/preventDelete'
 
 export const VisitorProfiles: CollectionConfig = {
   slug: 'visitor-profiles',
@@ -23,7 +24,15 @@ export const VisitorProfiles: CollectionConfig = {
       const role = staffUser(req.user)?.role
       return Boolean(req.user && (role === 'admin' || role === 'editor'))
     },
-    delete: ({ req }) => Boolean(req.user && staffUser(req.user)?.role === 'admin'),
+    // A profile carries membership and Stripe linkage. It cannot be deleted
+    // independently from its BetterAuth Visitor account without silently
+    // losing that state on the next session-driven profile recreation.
+    delete: () => false,
+  },
+  hooks: {
+    // Access control is bypassable by trusted Local API calls. Preserve the
+    // invariant there too; future erasure must be one coordinated workflow.
+    beforeDelete: [preventVisitorProfileDelete],
   },
   fields: [
     {

--- a/apps/questura/apps/server/src/features/visitor-auth/collections/hooks/preventDelete.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/hooks/preventDelete.ts
@@ -1,0 +1,18 @@
+import { APIError, type CollectionBeforeDeleteHook } from 'payload'
+
+/**
+ * A Visitor profile is durable product and billing identity, not an
+ * independently disposable child row. Deleting it while its BetterAuth user
+ * survives makes the next session recreate empty membership and Stripe state.
+ *
+ * Collection access blocks normal callers; this hook also blocks trusted Local
+ * API code using `overrideAccess`. Profile deletion stays unsupported until a
+ * coordinated account-erasure workflow handles BetterAuth, Stripe, and
+ * profile data together.
+ */
+export const preventVisitorProfileDelete: CollectionBeforeDeleteHook = () => {
+  throw new APIError(
+    'Visitor profiles cannot be deleted independently.',
+    400,
+  )
+}

--- a/apps/questura/docs/adr/0004-split-visitor-auth-from-staff-auth.md
+++ b/apps/questura/docs/adr/0004-split-visitor-auth-from-staff-auth.md
@@ -4,6 +4,8 @@ Questura will treat Visitor auth and Staff auth as separate auth surfaces. Bette
 
 VisitorProfiles remains a Payload collection because Staff identities need admin/support visibility into Visitor account membership and Stripe state. BetterAuth tables remain separate auth infrastructure and are not used as Staff-facing support records.
 
+VisitorProfiles is durable product and billing identity. It cannot be deleted independently while its BetterAuth Visitor account survives: session-driven profile recreation would otherwise replace membership and Stripe linkage with blank defaults. Independent profile deletion remains unsupported until account erasure coordinates BetterAuth, Stripe, and VisitorProfiles together.
+
 BetterAuth database tables are managed through committed Questura Server SQL migrations, not Payload `push`. Payload `push` remains scoped to Payload collections; BetterAuth schema changes are deployed deterministically as auth-infrastructure migrations.
 
 This chooses a more explicit boundary over the simpler Payload-only model because public-user scale and OAuth/signup behavior should evolve without widening the CMS admin attack surface. It also avoids making BetterAuth responsible for Payload admin access unless that integration is later proven necessary and maintainable.


### PR DESCRIPTION
## What changed

- Deny independent VisitorProfiles deletion for every caller.
- Enforce same invariant in beforeDelete, including Local API calls using overrideAccess.
- Document profile durability in Questura context and ADR-0004.
- Add regression coverage for every principal, collection wiring, and trusted Local API deletion.

## Why

Deleting a Visitor profile while its BetterAuth account survives causes the next valid session to recreate blank membership and Stripe state. Visitor profiles are durable billing identity; deletion must remain unsupported until account erasure coordinates BetterAuth, Stripe, and profile data.

## Validation

- Questura server: 84 files, 524 tests passed.
- Targeted visitor-profile/current-principal tests: 3 files, 17 tests passed.
- TypeScript: 53 pre-existing errors; none in changed files.
- git diff --check: passed.
- Payload migration workflow: generator produced no migration (access/hooks only; stopped at known stale service_accounts prompt), db:migrate no-op passed, generated types unchanged.
- Standards review: no blockers.
- Spec review: no blockers.