### PR TITLE
fix(questura): guard Staff and Visitor email ownership

### DIFF
--- a/apps/questura/CONTEXT.md
+++ b/apps/questura/CONTEXT.md
@@ -252,6 +252,7 @@ _Avoid_: public auth, visitor auth
 - Payload `Users.role = "user"` is legacy and removed before launch.
 - `VisitorProfiles` is the Visitor profile collection.
 - Staff email addresses cannot become Visitor accounts.
+- Staff write paths reject email addresses already owned by Visitor accounts.
 - Staff email blocking uses both known staff-domain checks and Payload `Users` lookup.
 - Visitor auth flows avoid account-discovery responses except where a user has explicitly submitted a create/update action.
 - Visitor auth uses a single email-first entry flow: a visitor enters an email, then Questura determines whether to continue an existing Visitor account sign-in or create a new Visitor account.

--- a/apps/questura/apps/server/src/features/auth/collections/hooks/beforeValidate/index.ts
+++ b/apps/questura/apps/server/src/features/auth/collections/hooks/beforeValidate/index.ts
@@ -1,5 +1,6 @@
 import type { CollectionBeforeValidateHook } from 'payload'
 import { passwordStrengthHook } from './passwordStrength'
+import { rejectVisitorEmailCollisionHook } from './rejectVisitorEmailCollision'
 
 /**
  * All beforeValidate hooks for Users collection.
@@ -7,4 +8,7 @@ import { passwordStrengthHook } from './passwordStrength'
  * This lifecycle stage is used rather than beforeChange because it is the only
  * one Payload runs on the `resetPassword` path as well as create/update.
  */
-export const beforeValidateHooks: CollectionBeforeValidateHook[] = [passwordStrengthHook]
+export const beforeValidateHooks: CollectionBeforeValidateHook[] = [
+  passwordStrengthHook,
+  rejectVisitorEmailCollisionHook,
+]

--- a/apps/questura/apps/server/src/features/auth/collections/hooks/beforeValidate/rejectVisitorEmailCollision.test.ts
+++ b/apps/questura/apps/server/src/features/auth/collections/hooks/beforeValidate/rejectVisitorEmailCollision.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { rejectVisitorEmailCollisionHook } from './rejectVisitorEmailCollision'
+
+const query = vi.fn()
+
+function run({
+  data,
+  operation = 'create',
+  originalDoc,
+}: {
+  data: Record<string, unknown>
+  operation?: 'create' | 'update'
+  originalDoc?: Record<string, unknown>
+}) {
+  return rejectVisitorEmailCollisionHook({
+    data,
+    operation,
+    originalDoc,
+    req: {
+      payload: {
+        db: {
+          pool: { query },
+        },
+      },
+    },
+  } as never)
+}
+
+describe('Staff and Visitor email boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    query.mockResolvedValue({ rows: [{ exists: false }] })
+  })
+
+  it('rejects Staff creation when normalized email belongs to a Visitor account', async () => {
+    query.mockResolvedValue({ rows: [{ exists: true }] })
+
+    await expect(
+      run({ data: { email: '  Visitor@Example.com  ' } }),
+    ).rejects.toThrow('This email already belongs to a Visitor account.')
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('visitor_auth_users'), [
+      'visitor@example.com',
+    ])
+  })
+
+  it('rejects Staff email changes that claim a Visitor email', async () => {
+    query.mockResolvedValue({ rows: [{ exists: true }] })
+
+    await expect(
+      run({
+        operation: 'update',
+        originalDoc: { email: 'writer@questurian.com' },
+        data: { email: 'visitor@example.com' },
+      }),
+    ).rejects.toThrow('This email already belongs to a Visitor account.')
+  })
+
+  it('allows a Staff email with no matching Visitor account', async () => {
+    const data = { email: 'writer@questurian.com' }
+
+    await expect(run({ data })).resolves.toBe(data)
+  })
+
+  it('skips an update whose normalized email did not change', async () => {
+    const data = { email: ' Writer@Questurian.com ' }
+
+    await expect(
+      run({
+        operation: 'update',
+        originalDoc: { email: 'writer@questurian.com' },
+        data,
+      }),
+    ).resolves.toBe(data)
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('skips updates that do not carry an email', async () => {
+    const data = { firstName: 'Ada' }
+
+    await expect(
+      run({ operation: 'update', originalDoc: { email: 'ada@questurian.com' }, data }),
+    ).resolves.toBe(data)
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when Visitor ownership cannot be checked', async () => {
+    query.mockRejectedValue(new Error('database unavailable'))
+
+    await expect(run({ data: { email: 'writer@questurian.com' } })).rejects.toThrow(
+      'Unable to verify Staff email ownership.',
+    )
+  })
+})

--- a/apps/questura/apps/server/src/features/auth/collections/hooks/beforeValidate/rejectVisitorEmailCollision.ts
+++ b/apps/questura/apps/server/src/features/auth/collections/hooks/beforeValidate/rejectVisitorEmailCollision.ts
@@ -1,0 +1,49 @@
+import { APIError, type CollectionBeforeValidateHook } from 'payload'
+
+import { normalizeEmail } from '@/shared/lib/normalize-email'
+
+/**
+ * Keep one email from identifying both a Payload Staff identity and a
+ * BetterAuth Visitor account (ADR-0004).
+ *
+ * Visitor auth already checks Payload Users. This is the reverse boundary:
+ * every Staff create and changed email checks BetterAuth's owning table using
+ * the request's existing DB pool. Unchanged updates skip the query so a legacy
+ * collision cannot block unrelated account maintenance.
+ */
+export const rejectVisitorEmailCollisionHook: CollectionBeforeValidateHook = async ({
+  data,
+  operation,
+  originalDoc,
+  req,
+}) => {
+  const email = normalizeEmail(data?.email)
+  if (!email) return data
+
+  if (operation === 'update' && email === normalizeEmail(originalDoc?.email)) {
+    return data
+  }
+
+  let exists = false
+  try {
+    const result = await req.payload.db.pool.query<{ exists: boolean }>(
+      `
+        SELECT EXISTS (
+          SELECT 1
+          FROM "visitor_auth_users"
+          WHERE LOWER(TRIM("email")) = $1
+        ) AS "exists";
+      `,
+      [email],
+    )
+    exists = result.rows[0]?.exists === true
+  } catch {
+    throw new APIError('Unable to verify Staff email ownership.', 503)
+  }
+
+  if (exists) {
+    throw new APIError('This email already belongs to a Visitor account.', 400)
+  }
+
+  return data
+}

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
@@ -7,11 +7,11 @@ import { Pool } from 'pg'
 import config from '@/payload.config'
 import { sendPasswordResetLinkEmail, sendVisitorEmailVerificationLinkEmail } from '@/emails'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
+import { normalizeEmail } from '@/shared/lib/normalize-email'
 import { redisSecondaryStorage } from './redis-secondary-storage'
-import { auditVisitorAuthSecurityEvent } from './security-audit'
-import { isStaffEmail, normalizeEmail } from './staff-email-guard'
 import { getVisitorPasswordError } from './visitor-password-guard'
 import { ensureVisitorProfileForAuthUser, splitDisplayName, updateVisitorProfileByAuthUserId } from './visitor-profile'
+import { rejectStaffEmailForVisitorAuth } from './visitor-staff-email-boundary'
 
 const databaseUrl = APP_CONFIG.database.uri
 
@@ -36,16 +36,7 @@ const googleProvider =
           redirectURI: `${APP_URLS.backend}/api/visitor-auth/callback/google`,
           mapProfileToUser: async (profile: { email?: string; email_verified?: boolean }) => {
             const email = normalizeEmail(profile.email)
-            if (await isStaffEmail(email)) {
-              auditVisitorAuthSecurityEvent({
-                type: 'visitor_auth_staff_email_blocked',
-                email,
-                path: '/callback/google',
-              })
-              throw new APIError('FORBIDDEN', {
-                message: 'Please use the staff login.',
-              })
-            }
+            await rejectStaffEmailForVisitorAuth({ path: '/callback/google', email })
 
             return {
               email,
@@ -189,24 +180,7 @@ export const visitorAuth = betterAuth({
         }
       }
 
-      if (
-        ctx.path === '/sign-up/email' ||
-        ctx.path === '/sign-in/social' ||
-        ctx.path === '/link-social' ||
-        ctx.path === '/change-email'
-      ) {
-        const email = normalizeEmail(ctx.path === '/change-email' ? ctx.body?.newEmail : ctx.body?.email)
-        if (email && (await isStaffEmail(email))) {
-          auditVisitorAuthSecurityEvent({
-            type: 'visitor_auth_staff_email_blocked',
-            email,
-            path: ctx.path,
-          })
-          throw new APIError('FORBIDDEN', {
-            message: 'Please use the staff login.',
-          })
-        }
-      }
+      await rejectStaffEmailForVisitorAuth({ path: ctx.path, body: ctx.body })
     }),
     after: createAuthMiddleware(async (ctx) => {
       if (!ctx.path.startsWith('/sign-up') && !ctx.path.startsWith('/callback')) {

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/legacy-auth-compat.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/legacy-auth-compat.ts
@@ -1,6 +1,6 @@
 import { findVisitorAccountByEmail } from './account-query'
 import type { AuthProvider, VisitorAccountLookup } from './account-query'
-import { normalizeEmail } from './staff-email-guard'
+import { normalizeEmail } from '@/shared/lib/normalize-email'
 
 export type LegacyAccountCheckResult = {
   exists: boolean

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/staff-email-guard.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/staff-email-guard.test.ts
@@ -14,7 +14,8 @@ vi.mock('@/payload.config', () => ({
   default: {},
 }))
 
-import { isStaffEmail, normalizeEmail } from './staff-email-guard'
+import { normalizeEmail } from '@/shared/lib/normalize-email'
+import { isStaffEmail } from './staff-email-guard'
 
 describe('staff email guard', () => {
   beforeEach(() => {

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/staff-email-guard.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/staff-email-guard.ts
@@ -1,12 +1,9 @@
 import { getPayload } from 'payload'
 
 import config from '@/payload.config'
+import { normalizeEmail } from '@/shared/lib/normalize-email'
 
 const STAFF_EMAIL_DOMAIN = '@questurian.com'
-
-export function normalizeEmail(email: unknown): string {
-  return typeof email === 'string' ? email.trim().toLowerCase() : ''
-}
 
 /**
  * Whether an address belongs to Staff, and is therefore barred from Visitor

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.ts
@@ -1,7 +1,7 @@
 import { getPayload } from 'payload'
 
 import config from '@/payload.config'
-import { normalizeEmail } from './staff-email-guard'
+import { normalizeEmail } from '@/shared/lib/normalize-email'
 
 type BetterAuthUser = {
   id: string

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-staff-email-boundary.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-staff-email-boundary.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isStaffEmail: vi.fn(),
+  audit: vi.fn(),
+}))
+
+vi.mock('./staff-email-guard', () => ({
+  isStaffEmail: mocks.isStaffEmail,
+}))
+
+vi.mock('./security-audit', () => ({
+  auditVisitorAuthSecurityEvent: mocks.audit,
+}))
+
+import { rejectStaffEmailForVisitorAuth } from './visitor-staff-email-boundary'
+
+describe('Visitor auth Staff-email boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.isStaffEmail.mockResolvedValue(false)
+  })
+
+  it.each([
+    '/sign-up/email',
+    '/sign-in/social',
+    '/link-social',
+  ])('refuses a Staff email on %s', async (path) => {
+    mocks.isStaffEmail.mockResolvedValue(true)
+
+    await expect(
+      rejectStaffEmailForVisitorAuth({
+        path,
+        body: { email: ' Staff@Example.com ' },
+      }),
+    ).rejects.toThrow('Please use the staff login.')
+
+    expect(mocks.isStaffEmail).toHaveBeenCalledWith('staff@example.com')
+    expect(mocks.audit).toHaveBeenCalledWith({
+      type: 'visitor_auth_staff_email_blocked',
+      email: 'staff@example.com',
+      path,
+    })
+  })
+
+  it('leaves email/password sign-in to BetterAuth credential verification', async () => {
+    await expect(
+      rejectStaffEmailForVisitorAuth({
+        path: '/sign-in/email',
+        body: { email: ' Staff@Example.com ' },
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mocks.isStaffEmail).not.toHaveBeenCalled()
+    expect(mocks.audit).not.toHaveBeenCalled()
+  })
+
+  it('guards the verified email returned by Google', async () => {
+    mocks.isStaffEmail.mockResolvedValue(true)
+
+    await expect(
+      rejectStaffEmailForVisitorAuth({
+        path: '/callback/google',
+        email: ' Staff@Example.com ',
+      }),
+    ).rejects.toThrow('Please use the staff login.')
+
+    expect(mocks.isStaffEmail).toHaveBeenCalledWith('staff@example.com')
+  })
+
+  it('checks the new email on Visitor email changes', async () => {
+    mocks.isStaffEmail.mockResolvedValue(true)
+
+    await expect(
+      rejectStaffEmailForVisitorAuth({
+        path: '/change-email',
+        body: { newEmail: ' Staff@Example.com ' },
+      }),
+    ).rejects.toThrow('Please use the staff login.')
+
+    expect(mocks.isStaffEmail).toHaveBeenCalledWith('staff@example.com')
+  })
+
+  it('leaves unrelated Visitor auth paths alone', async () => {
+    await expect(
+      rejectStaffEmailForVisitorAuth({
+        path: '/request-password-reset',
+        body: { email: 'staff@example.com' },
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mocks.isStaffEmail).not.toHaveBeenCalled()
+  })
+})

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-staff-email-boundary.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-staff-email-boundary.ts
@@ -1,0 +1,37 @@
+import { APIError } from 'better-auth/api'
+
+import { normalizeEmail } from '@/shared/lib/normalize-email'
+import { auditVisitorAuthSecurityEvent } from './security-audit'
+import { isStaffEmail } from './staff-email-guard'
+
+const STAFF_EMAIL_GUARDED_PATHS = new Set([
+  '/sign-up/email',
+  '/sign-in/social',
+  '/link-social',
+  '/change-email',
+  '/callback/google',
+])
+
+export async function rejectStaffEmailForVisitorAuth({
+  path,
+  body,
+  email: suppliedEmail,
+}: {
+  path: string
+  body?: Record<string, unknown> | null
+  email?: unknown
+}): Promise<void> {
+  if (!STAFF_EMAIL_GUARDED_PATHS.has(path)) return
+
+  const email = normalizeEmail(
+    suppliedEmail ?? (path === '/change-email' ? body?.newEmail : body?.email),
+  )
+  if (!email || !(await isStaffEmail(email))) return
+
+  auditVisitorAuthSecurityEvent({
+    type: 'visitor_auth_staff_email_blocked',
+    email,
+    path,
+  })
+  throw new APIError('FORBIDDEN', { message: 'Please use the staff login.' })
+}

--- a/apps/questura/apps/server/src/shared/lib/normalize-email.ts
+++ b/apps/questura/apps/server/src/shared/lib/normalize-email.ts
@@ -1,0 +1,3 @@
+export function normalizeEmail(email: unknown): string {
+  return typeof email === 'string' ? email.trim().toLowerCase() : ''
+}

--- a/apps/questura/docs/adr/0004-split-visitor-auth-from-staff-auth.md
+++ b/apps/questura/docs/adr/0004-split-visitor-auth-from-staff-auth.md
@@ -32,6 +32,8 @@ BetterAuth launch parity includes public email/password signup and login, Google
 
 Staff email blocking uses both a known staff-domain fast path and a Payload `Users` lookup. The domain check handles obvious staff attempts early; the Payload lookup protects staff identities using custom domains, contractor addresses, or future non-`@questurian.com` emails.
 
+Application guards check email ownership in both directions. Visitor signup, social sign-in/linking, and email changes refuse addresses owned by Staff; Staff creation and changed Staff emails refuse addresses already owned by BetterAuth Visitor accounts. Email/password sign-in remains entirely inside BetterAuth's credential verifier so Staff ownership cannot be inferred from response shape or timing. Unchanged Staff-email writes skip the Visitor lookup so a legacy collision does not block unrelated account maintenance. Disabled Staff identities continue to reserve their addresses. These checks provide early, useful errors, but do not close a simultaneous cross-surface creation race. Phase 4 remains incomplete until a following database constraint makes normalized email ownership atomic.
+
 Visitor account linking requires matching provider and email/password email addresses. Different-email linking is not allowed because it creates ambiguous ownership and recovery boundaries.
 
 A Visitor must explicitly unlink Google before changing their email address. Email change is blocked while Google remains linked so a provider identity cannot silently diverge from the Visitor account email.


### PR DESCRIPTION
## What changed

- Reject Staff creates and changed Staff emails when BetterAuth already owns normalized email.
- Fail closed when Visitor ownership lookup is unavailable.
- Centralize audited Staff-email rejection for Visitor signup, social auth/linking, email changes, and Google callback.
- Leave email/password login entirely to BetterAuth to avoid account-discovery response/timing leaks.
- Share one email-normalization helper across auth surfaces.
- Document application-level boundary and remaining concurrent-create race in ADR-0004.

## Why

Staff/Visitor email ownership was enforced only from Visitor toward Staff. Payload could create or update Staff identity onto email already owned by Visitor account.

## Validation

- Questura server: 86 files, 538 tests passed.
- Targeted boundary tests: 2 files, 13 tests passed; broader focused set: 5 files, 26 tests passed.
- TypeScript: 53 pre-existing errors; none in changed files.
- git diff --check: passed.
- Live read-only audit: zero Staff/Visitor collisions.
- Payload migration workflow: no migration generated (hooks only; known stale service_accounts prompt), db:migrate no-op passed, generated types unchanged.
- Standards review: no blockers.
- Spec review: no blockers.

## Follow-up

A dependent migration PR will make normalized email ownership atomic across simultaneous Staff and Visitor creation.