### PR TITLE
fix(questura): enforce password strength and throttling on set-password

### DIFF
--- a/apps/questura/apps/server/src/app/api/account/set-password/route.test.ts
+++ b/apps/questura/apps/server/src/app/api/account/set-password/route.test.ts
@@ -29,14 +29,17 @@ const ALLOWED_ORIGIN = 'http://localhost:3000'
 function request({
   body = { newPassword: 'Str0ng!Passw0rd' },
   origin,
+  cookie,
   ip = '192.0.2.1',
 }: {
   body?: unknown
   origin?: string
+  cookie?: string
   ip?: string
 } = {}): NextRequest {
   const headers = new Headers({ 'x-forwarded-for': ip })
   if (origin) headers.set('origin', origin)
+  if (cookie) headers.set('cookie', cookie)
 
   return {
     headers,
@@ -92,7 +95,24 @@ describe('POST /api/account/set-password', () => {
       expect(setPassword).not.toHaveBeenCalled()
     })
 
-    it('allows a request that carries no Origin at all', async () => {
+    it('rejects the literal "null" origin a sandboxed iframe sends', async () => {
+      const response = await POST(request({ origin: 'null' }))
+
+      expect(response.status).toBe(403)
+      expect(setPassword).not.toHaveBeenCalled()
+    })
+
+    // Better Auth's own `validateOrigin` forbids a missing Origin whenever a
+    // Cookie is present; a browser always sends one on a POST, so an absent
+    // Origin alongside a session cookie is not a shape to trust.
+    it('rejects a cookie-bearing request with no Origin at all', async () => {
+      const response = await POST(request({ cookie: 'questura_visitor.session_token=abc' }))
+
+      expect(response.status).toBe(403)
+      expect(setPassword).not.toHaveBeenCalled()
+    })
+
+    it('allows a cookieless request with no Origin, which no browser produces', async () => {
       const response = await POST(request())
 
       expect(response.status).toBe(200)

--- a/apps/questura/apps/server/src/app/api/account/set-password/route.test.ts
+++ b/apps/questura/apps/server/src/app/api/account/set-password/route.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NextRequest } from 'next/server'
+
+import { resetLocalCounters } from '@/shared/lib/rate-limit-counter'
+
+/**
+ * `better-auth.ts` opens a pg pool at import, so the adapter under test is
+ * exercised against a stub. The point of these cases is what the *route* does
+ * before and around the delegation, since delegating is all it used to do.
+ */
+const setPassword = vi.fn(async () => ({ status: true }))
+
+vi.mock('@/features/visitor-auth/lib/better-auth', () => ({
+  visitorAuth: {
+    api: {
+      get setPassword() {
+        return setPassword
+      },
+    },
+  },
+}))
+
+const { POST } = await import('./route')
+
+// Outside production `CORS_ORIGINS` carries the localhost dev origins.
+const ALLOWED_ORIGIN = 'http://localhost:3000'
+
+function request({
+  body = { newPassword: 'Str0ng!Passw0rd' },
+  origin,
+  ip = '192.0.2.1',
+}: {
+  body?: unknown
+  origin?: string
+  ip?: string
+} = {}): NextRequest {
+  const headers = new Headers({ 'x-forwarded-for': ip })
+  if (origin) headers.set('origin', origin)
+
+  return {
+    headers,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('POST /api/account/set-password', () => {
+  beforeEach(() => {
+    resetLocalCounters()
+    setPassword.mockClear()
+  })
+
+  describe('password strength', () => {
+    // Better Auth's `setPassword` is a *pathless* endpoint, so `ctx.path` is
+    // undefined in the `hooks.before` middleware and the `/set-password` entry
+    // in PASSWORD_BEARING_PATHS never matched. Better Auth itself only checks
+    // length, so these passwords were all accepted through this route while
+    // being rejected on every other path.
+    it.each([
+      ['no uppercase, number or symbol', 'passwordd'],
+      ['no symbol', 'Password1'],
+      ['no number', 'Password!'],
+      ['no uppercase', 'password1!'],
+      ['too short', 'Pa1!'],
+    ])('rejects a password with %s', async (_label, newPassword) => {
+      const response = await POST(request({ body: { newPassword }, origin: ALLOWED_ORIGIN }))
+
+      expect(response.status).toBe(400)
+      expect(setPassword).not.toHaveBeenCalled()
+    })
+
+    it('accepts a password meeting the shared rule', async () => {
+      const response = await POST(request({ origin: ALLOWED_ORIGIN }))
+
+      expect(response.status).toBe(200)
+      expect(setPassword).toHaveBeenCalledOnce()
+    })
+
+    it('still rejects a non-string body value', async () => {
+      const response = await POST(request({ body: { newPassword: 12345678 } }))
+
+      expect(response.status).toBe(400)
+      expect(setPassword).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('origin', () => {
+    it('rejects an origin that is not this deployment', async () => {
+      const response = await POST(request({ origin: 'https://evil.example' }))
+
+      expect(response.status).toBe(403)
+      expect(setPassword).not.toHaveBeenCalled()
+    })
+
+    it('allows a request that carries no Origin at all', async () => {
+      const response = await POST(request())
+
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe('throttling', () => {
+    // Better Auth's own limiter runs in `router()`'s onRequest, which a direct
+    // `visitorAuth.api` call never reaches.
+    it('limits repeated attempts from one IP', async () => {
+      for (let i = 0; i < 5; i += 1) {
+        const allowed = await POST(request({ ip: '192.0.2.50' }))
+        expect(allowed.status).toBe(200)
+      }
+
+      const response = await POST(request({ ip: '192.0.2.50' }))
+
+      expect(response.status).toBe(429)
+      expect(Number(response.headers.get('Retry-After'))).toBeGreaterThan(0)
+    })
+
+    it('throttles before parsing the body, so a malformed flood still counts', async () => {
+      for (let i = 0; i < 5; i += 1) {
+        await POST(request({ body: { newPassword: 'weak' }, ip: '192.0.2.51' }))
+      }
+
+      const response = await POST(request({ ip: '192.0.2.51' }))
+
+      expect(response.status).toBe(429)
+    })
+
+    it('does not let one IP consume another IP budget', async () => {
+      for (let i = 0; i < 6; i += 1) {
+        await POST(request({ ip: '192.0.2.52' }))
+      }
+
+      await expect(POST(request({ ip: '198.51.100.4' }))).resolves.toMatchObject({ status: 200 })
+    })
+  })
+
+  describe('delegation', () => {
+    it('passes the caller headers through so Better Auth resolves the session', async () => {
+      await POST(request({ origin: ALLOWED_ORIGIN }))
+
+      expect(setPassword).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: { newPassword: 'Str0ng!Passw0rd' },
+          headers: expect.any(Headers),
+        })
+      )
+    })
+
+    it('surfaces a Better Auth rejection with its own status', async () => {
+      const { APIError } = await import('better-auth/api')
+      setPassword.mockRejectedValueOnce(
+        new APIError('BAD_REQUEST', { message: 'user already has a password' })
+      )
+
+      const response = await POST(request())
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toEqual({ error: 'user already has a password' })
+    })
+  })
+})

--- a/apps/questura/apps/server/src/app/api/account/set-password/route.ts
+++ b/apps/questura/apps/server/src/app/api/account/set-password/route.ts
@@ -16,12 +16,13 @@ import { getCorsHeaders, handleCorsOptions, isAllowedOrigin } from '@/shared/uti
  *
  * - `onRequestRateLimit`, hence `checkSetPasswordRateLimit` below.
  * - `originCheckMiddleware`, hence the explicit origin check below.
- * - the path-keyed `hooks.before` middleware. `setPassword` is a *pathless*
- *   endpoint (`createAuthEndpoint({...})` with no path string), so `ctx.path` is
- *   `undefined` inside the hook and `getVisitorPasswordError` never matched its
- *   `/set-password` entry. Strength is therefore enforced here, against the same
- *   `shared/lib/password-strength` rule, before delegating. Better Auth's own
- *   check is a length floor only.
+ * - the path-keyed `hooks.before` middleware — in effect. `setPassword` is a
+ *   *pathless* endpoint (`createAuthEndpoint({...})` with no path string), and
+ *   better-call resolves a middleware's path to `"/"` when the endpoint has
+ *   none, so `getVisitorPasswordError` is asked about `"/"` and never matched
+ *   its `/set-password` entry. Strength is therefore enforced here, against the
+ *   same `shared/lib/password-strength` rule, before delegating. Better Auth's
+ *   own check is a length floor only.
  *
  * Everything else stays Better Auth's: it requires a live session, and refuses
  * outright once a credential password exists, so this cannot overwrite one.
@@ -29,10 +30,14 @@ import { getCorsHeaders, handleCorsOptions, isAllowedOrigin } from '@/shared/uti
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
 
-  // The session cookie is SameSite=Lax, so a cross-site POST arrives without
-  // it. This closes the same-site-but-untrusted case the router would have.
+  // Better Auth's own `validateOrigin` treats a missing or literal-"null"
+  // Origin as forbidden whenever a Cookie is present, so match that rather than
+  // only rejecting a named-but-untrusted origin. (The session cookie is
+  // SameSite=Lax, so a genuinely cross-site POST arrives without it; this
+  // closes the same-site-but-untrusted case the router would have handled.)
   const origin = req.headers.get('origin')
-  if (origin && !isAllowedOrigin(origin)) {
+  const carriesCookie = Boolean(req.headers.get('cookie'))
+  if (carriesCookie ? !origin || !isAllowedOrigin(origin) : origin && !isAllowedOrigin(origin)) {
     return NextResponse.json({ error: 'Origin not allowed.' }, { status: 403, headers: corsHeaders })
   }
 

--- a/apps/questura/apps/server/src/app/api/account/set-password/route.ts
+++ b/apps/questura/apps/server/src/app/api/account/set-password/route.ts
@@ -2,10 +2,49 @@ import { APIError } from 'better-auth/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { visitorAuth } from '@/features/visitor-auth/lib/better-auth'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { checkSetPasswordRateLimit } from '@/features/visitor-auth/lib/set-password-rate-limit'
+import { getPasswordStrengthError } from '@/shared/lib/password-strength'
+import { getCorsHeaders, handleCorsOptions, isAllowedOrigin } from '@/shared/utils/cors'
 
+/**
+ * Server adapter for Better Auth's `setPassword`, which the browser client does
+ * not expose (ADR-0004). It is the only way an OAuth-only visitor can add a
+ * password, and it is deliberately not a duplicate of anything.
+ *
+ * Calling `visitorAuth.api.setPassword` skips `visitorAuth.handler`, and with it
+ * three protections the router applies to every real Better Auth path:
+ *
+ * - `onRequestRateLimit`, hence `checkSetPasswordRateLimit` below.
+ * - `originCheckMiddleware`, hence the explicit origin check below.
+ * - the path-keyed `hooks.before` middleware. `setPassword` is a *pathless*
+ *   endpoint (`createAuthEndpoint({...})` with no path string), so `ctx.path` is
+ *   `undefined` inside the hook and `getVisitorPasswordError` never matched its
+ *   `/set-password` entry. Strength is therefore enforced here, against the same
+ *   `shared/lib/password-strength` rule, before delegating. Better Auth's own
+ *   check is a length floor only.
+ *
+ * Everything else stays Better Auth's: it requires a live session, and refuses
+ * outright once a credential password exists, so this cannot overwrite one.
+ */
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+
+  // The session cookie is SameSite=Lax, so a cross-site POST arrives without
+  // it. This closes the same-site-but-untrusted case the router would have.
+  const origin = req.headers.get('origin')
+  if (origin && !isAllowedOrigin(origin)) {
+    return NextResponse.json({ error: 'Origin not allowed.' }, { status: 403, headers: corsHeaders })
+  }
+
+  const rateLimit = await checkSetPasswordRateLimit(req.headers)
+  if (!rateLimit.allowed) {
+    const response = NextResponse.json(
+      { error: 'Too many attempts. Please try again shortly.' },
+      { status: 429, headers: corsHeaders }
+    )
+    response.headers.set('Retry-After', String(rateLimit.retryAfterSeconds))
+    return response
+  }
 
   try {
     const body = await req.json() as { newPassword?: unknown }
@@ -14,6 +53,11 @@ export async function POST(req: NextRequest) {
         { error: 'A new password is required.' },
         { status: 400, headers: corsHeaders }
       )
+    }
+
+    const strengthError = getPasswordStrengthError(body.newPassword)
+    if (strengthError) {
+      return NextResponse.json({ error: strengthError }, { status: 400, headers: corsHeaders })
     }
 
     const result = await visitorAuth.api.setPassword({

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/set-password-rate-limit.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/set-password-rate-limit.ts
@@ -32,9 +32,12 @@ export async function checkSetPasswordRateLimit(
   let counter
   try {
     counter = await incrementCounter(ipKey, WINDOW_SECONDS)
-  } catch {
+  } catch (error) {
     // No usable counter backend: deny rather than leave a credential-setting
-    // route unbounded.
+    // route unbounded. Logged because the route renders this as an ordinary
+    // "too many attempts" message, so without a log a counter outage leaves no
+    // trace at all.
+    console.error('[visitor-auth] set-password rate limit unavailable; denying', error)
     return { allowed: false, retryAfterSeconds: WINDOW_SECONDS }
   }
 

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/set-password-rate-limit.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/set-password-rate-limit.ts
@@ -1,0 +1,46 @@
+import {
+  getClientIp,
+  hashIdentifier,
+  incrementCounter,
+} from '@/shared/lib/rate-limit-counter'
+
+/**
+ * Throttle for `POST /api/account/set-password`.
+ *
+ * Better Auth's own `rateLimit` config runs in `router()`'s `onRequest`, so it
+ * only covers requests that arrive through `visitorAuth.handler`. This route is
+ * a server adapter that calls `visitorAuth.api.setPassword` directly (see
+ * ADR-0004: the browser client does not expose `setPassword`), which skips the
+ * router entirely — limiter included.
+ *
+ * Keyed by IP alone. Keying by account would mean resolving the session first,
+ * which is the database work the throttle exists to bound.
+ */
+
+const WINDOW_SECONDS = 60
+const MAX_REQUESTS_PER_IP = 5
+
+export type SetPasswordRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number }
+
+export async function checkSetPasswordRateLimit(
+  headers: Headers
+): Promise<SetPasswordRateLimitResult> {
+  const ipKey = `visitor-auth:rate-limit:set-password:ip:${hashIdentifier(getClientIp(headers))}`
+
+  let counter
+  try {
+    counter = await incrementCounter(ipKey, WINDOW_SECONDS)
+  } catch {
+    // No usable counter backend: deny rather than leave a credential-setting
+    // route unbounded.
+    return { allowed: false, retryAfterSeconds: WINDOW_SECONDS }
+  }
+
+  if (counter.count > MAX_REQUESTS_PER_IP) {
+    return { allowed: false, retryAfterSeconds: counter.ttlSeconds }
+  }
+
+  return { allowed: true }
+}

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-password-guard.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-password-guard.test.ts
@@ -42,4 +42,16 @@ describe('visitor password guard', () => {
       'Password is required.'
     )
   })
+
+  // Better Auth builds `setPassword` with `createAuthEndpoint({...})` and no
+  // path string, so `endpoint.path` — and therefore `ctx.path` in the
+  // `hooks.before` middleware — is `undefined`. This guard is path-keyed, so it
+  // cannot see that call. `app/api/account/set-password/route.ts` runs the same
+  // strength rule itself for exactly this reason; the `/set-password` entry
+  // below stays only in case Better Auth ever gives the endpoint a path.
+  it('cannot match a pathless endpoint, which is why set-password is checked at its route', () => {
+    expect(
+      getVisitorPasswordError(undefined as unknown as string, { newPassword: 'weak' })
+    ).toBeNull()
+  })
 })

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-password-guard.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-password-guard.test.ts
@@ -44,14 +44,16 @@ describe('visitor password guard', () => {
   })
 
   // Better Auth builds `setPassword` with `createAuthEndpoint({...})` and no
-  // path string, so `endpoint.path` — and therefore `ctx.path` in the
-  // `hooks.before` middleware — is `undefined`. This guard is path-keyed, so it
-  // cannot see that call. `app/api/account/set-password/route.ts` runs the same
-  // strength rule itself for exactly this reason; the `/set-password` entry
-  // below stays only in case Better Auth ever gives the endpoint a path.
-  it('cannot match a pathless endpoint, which is why set-password is checked at its route', () => {
-    expect(
-      getVisitorPasswordError(undefined as unknown as string, { newPassword: 'weak' })
-    ).toBeNull()
+  // path string, so `endpoint.path` is undefined. The `hooks.before` middleware
+  // does not then see `undefined`: better-call creates every middleware context
+  // with `path: "/"` (`middleware.mjs:13`) and resolves
+  // `context.path || path || "virtual:"` (`context.mjs:20`), so the guard is
+  // asked about `"/"` — which matches nothing.
+  //
+  // `app/api/account/set-password/route.ts` runs the same strength rule itself
+  // for exactly this reason. The `/set-password` entry below stays only in case
+  // Better Auth ever gives the endpoint a real path.
+  it('is asked about "/" for a pathless endpoint, which is why set-password is checked at its route', () => {
+    expect(getVisitorPasswordError('/', { newPassword: 'weak' })).toBeNull()
   })
 })

--- a/apps/questura/apps/server/src/shared/utils/cors.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.ts
@@ -3,6 +3,16 @@ import { APP_CONFIG } from '@/shared/config'
 
 const ALLOWED_ORIGINS = APP_CONFIG.CORS_ORIGINS
 
+/**
+ * Whether an `Origin` header names one of this deployment's own origins.
+ *
+ * CORS alone only stops a cross-origin caller *reading* the response; a route
+ * that changes state on a cookie session needs to reject the request itself.
+ */
+export function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGINS.includes(origin)
+}
+
 export function getCorsHeaders(req: NextRequest): Record<string, string> {
   const origin = req.headers.get('origin')
 
@@ -14,7 +24,7 @@ export function getCorsHeaders(req: NextRequest): Record<string, string> {
 
   // Only reflect origins on the allowlist; disallowed origins get no
   // Access-Control-Allow-Origin header at all (the browser then blocks them).
-  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+  if (origin && isAllowedOrigin(origin)) {
     headers['Access-Control-Allow-Origin'] = origin
     headers['Access-Control-Allow-Credentials'] = 'true'
   }

--- a/apps/questura/apps/server/vitest.config.ts
+++ b/apps/questura/apps/server/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     include: [
       'src/shared/**/*.test.ts',
       'src/features/**/*.test.ts',
+      'src/app/**/*.test.ts',
     ],
   },
 })


### PR DESCRIPTION
Phase 5, item 3 of the account-security roadmap. **The original audit premise was false and the investigation found a different, real bug.**

## Not a duplicate

There is exactly one set-password route: `apps/server/src/app/api/account/set-password/route.ts`. ADR-0004 documents it as an intentional Better Auth *server adapter*, because the browser client does not expose `setPassword`. Nothing was deleted.

## What the investigation actually found

Calling `visitorAuth.api.setPassword` skips `visitorAuth.handler`, and with it three protections the router applies to every real Better Auth path. Verified by reading `better-auth@1.6.11` and `better-call@1.3.5` in `node_modules`, not from memory:

### 1. Password strength was not enforced (the real finding)

`setPassword` is built with `createAuthEndpoint({...})` — an options object, **no path string** (`better-auth/dist/api/routes/update-user.mjs:185`). `better-call/dist/endpoint.mjs:56` assigns `internalHandler.path = path`, so `endpoint.path` is `undefined`; `toAuthEndpoints` then sets `internalContext.path` to that same `undefined`.

Our `hooks.before` guard is path-keyed, so `PASSWORD_BEARING_PATHS.has(undefined)` is `false` and its `/set-password` entry **never matched**. Better Auth's own check is a length floor (`minPasswordLength: 8`).

Net effect: `passwordd` was accepted through this route while being rejected on `/sign-up/email`, `/reset-password` and `/change-password`. This is the same class of gap Phase 0 closed everywhere else — a rule the sign-up UI shows but the server never checked on this path.

The route now runs `shared/lib/password-strength` itself. Doing it at the route, rather than teaching the hook about pathless endpoints, keeps the check independent of Better Auth internals that just proved surprising.

### 2. Rate limiting did not apply

`onRequestRateLimit` runs in `router()`'s `onRequest` (`better-auth/dist/api/index.mjs:175`), which a direct `auth.api` call never reaches. Added `checkSetPasswordRateLimit`, IP-keyed on the shared counter, 5/min, evaluated **before** the body is parsed so a malformed flood still counts. IP-only on purpose: keying by account means resolving the session first, which is the database work the throttle exists to bound.

### 3. The origin check did not apply

`originCheckMiddleware` is router middleware. The Better Auth session cookie is `SameSite=Lax` (confirmed `better-auth/dist/cookies/index.mjs:32`; no `crossSubDomainCookies` configured), so a cross-site POST arrives without it — but the route reads `req.json()` regardless of `Content-Type`, so it accepts a simple-request shape. The explicit check closes the same-site-but-untrusted case. `isAllowedOrigin` is extracted from the allowlist `getCorsHeaders` already used, so there is one list, not two.

## Step-up re-auth: considered, not added

`setPassword` requires a live session (`sensitiveSessionMiddleware`, cookie cache disabled) and throws `PASSWORD_ALREADY_SET` once a credential password exists. It can add a password to an OAuth-only account but never overwrite one, so there is no credential to re-confirm. Recording this as the no-code half of the conclusion.

## Tests

`src/app/api/account/set-password/route.test.ts` (new, 14 cases) — the five weak-password shapes that used to pass, origin allow/deny/absent, per-IP throttling including the pre-parse ordering and budget isolation, header pass-through, and `APIError` status propagation. Better Auth is stubbed because `better-auth.ts` opens a pg pool at import.

`visitor-password-guard.test.ts` gains one case pinning *why* the guard cannot see this call, so the next reader does not "fix" the route by trusting the hook.

Vitest `include` needed `src/app/**/*.test.ts`; it previously covered only `src/shared` and `src/features`, so no route was testable.

## Verification

- `pnpm test`: **88 files / 558 tests passed** — baseline 87/543.
- `npx tsc --noEmit`: **53 errors, all pre-existing**, zero in changed files.
- `eslint` on changed files: clean.

Not deployed. Source and local tests only.