### PR TITLE
fix(abw): send the Payload session cookie on every authenticated call

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
@@ -61,6 +61,7 @@ export async function payloadRequest<T>(
 ): Promise<T> {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     ...init,
+    credentials: 'include',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
@@ -28,6 +28,7 @@ async function payloadRequest<T>(
   try {
     const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
       ...init,
+      credentials: 'include',
       signal: controller.signal,
       headers: {
         Accept: 'application/json',

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
@@ -16,6 +16,7 @@ const PAYLOAD_API_URL = import.meta.env.VITE_PAYLOAD_API_URL || 'http://localhos
 async function payloadRequest<T>(endpoint: string, token: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     ...init,
+    credentials: 'include',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
@@ -100,7 +100,7 @@ export async function uploadAvatarAsset(file: File, token: string): Promise<Avat
   const response = await fetch(`${PAYLOAD_API_URL}/api/media-assets`, {
     method: 'POST',
     mode: 'cors',
-    credentials: 'omit',
+    credentials: 'include',
     headers: { Authorization: `Bearer ${token}` },
     body: formData,
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
@@ -151,6 +151,11 @@ export async function createStaffUser(
  * went to a mailbox that didn't exist yet.
  */
 export async function requestPasswordSetEmail(email: string): Promise<void> {
+  // The one call here that passes no token. It now carries the caller's session
+  // cookie anyway, via the shared client. Harmless: Payload's `forgotPassword`
+  // never reads `req.user`, and questura throttles it on IP plus email, not on
+  // identity — so an authenticated caller gets the same bucket as an anonymous
+  // one.
   await payloadMutation('/api/users/forgot-password', 'POST', { email })
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/http.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/http.ts
@@ -13,7 +13,7 @@ export async function payloadRequest(endpoint: string, token?: string) {
     method: 'GET',
     mode: 'cors',
     cache: 'no-store',
-    credentials: 'omit',
+    credentials: 'include',
     headers,
   })
 
@@ -42,7 +42,7 @@ export async function payloadMutation(
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     method,
     mode: 'cors',
-    credentials: 'omit',
+    credentials: 'include',
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
   })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { payloadRequest, payloadMutation } from './client/http'
+import { fetchStaffUsers, uploadAvatarAsset } from '../../features/staff/api/staff.api'
+import { fetchMediaSetOptions } from '../../features/locationDocuments/api'
+import { fetchListicles } from '../../features/singleTypeListicles/api'
+import { payloadRequest as itineraryPayloadRequest } from '../../features/listicleItineraries/api/payloadClient'
+import { getArticleLocationScope } from '../locationScope/scope'
+
+/**
+ * Every authenticated call to Payload must send the session cookie.
+ *
+ * These clients grew independently and disagreed: some passed
+ * `credentials: 'include'`, some passed `'omit'`, and some named no option at
+ * all — which means `'same-origin'`, and Payload is never the same origin as
+ * this app. They all worked anyway, because each one carries a `Bearer` header
+ * read out of `localStorage`. That header is the thing being removed, so the
+ * cookie has to be a real alternative on every path first.
+ *
+ * Assert on the option rather than on any one call site, so a new Payload
+ * client that forgets it is caught here.
+ */
+
+const fetchMock = vi.fn()
+
+function jsonResponse(body: unknown = { docs: [] }): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response
+}
+
+function lastCredentials(): RequestCredentials | undefined {
+  const calls = fetchMock.mock.calls
+  const init = calls[calls.length - 1]?.[1] as RequestInit | undefined
+  return init?.credentials
+}
+
+describe('Payload clients send the session cookie', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(jsonResponse())
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shared payloadRequest', async () => {
+    await payloadRequest('/api/articles', 'token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('shared payloadMutation', async () => {
+    await payloadMutation('/api/articles/1', 'PATCH', { title: 'x' }, 'token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('staff avatar upload', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ doc: { id: 1, filename: 'a.png' } }))
+
+    await uploadAvatarAsset(new File(['x'], 'a.png'), 'token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('staff list', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
+
+    await fetchStaffUsers('token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('location documents', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
+
+    await fetchMediaSetOptions('token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('single-type listicles', async () => {
+    await fetchListicles('token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('listicle itineraries', async () => {
+    await itineraryPayloadRequest('/api/itineraries', 'token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('location scope', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [{ id: 1 }] }))
+
+    await getArticleLocationScope({ locationKey: 'lima', token: 'token' })
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('leaves the unauthenticated health check uncredentialed', async () => {
+    const { checkPayloadHealth } = await import('../../features/auth/payload-auth-client')
+
+    fetchMock.mockResolvedValue({ ok: true, status: 200 } as Response)
+    await checkPayloadHealth()
+
+    // Nothing to authenticate, so nothing to send.
+    expect(lastCredentials()).toBe('omit')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
@@ -13,12 +13,20 @@ import { getArticleLocationScope } from '../locationScope/scope'
  * These clients grew independently and disagreed: some passed
  * `credentials: 'include'`, some passed `'omit'`, and some named no option at
  * all — which means `'same-origin'`, and Payload is never the same origin as
- * this app. They all worked anyway, because each one carries a `Bearer` header
- * read out of `localStorage`. That header is the thing being removed, so the
- * cookie has to be a real alternative on every path first.
+ * this app. None of it showed, because each one also carries an
+ * `Authorization: Bearer` header.
  *
- * Assert on the option rather than on any one call site, so a new Payload
- * client that forgets it is caught here.
+ * The cookie is *not* a fallback today, and that is worth being exact about:
+ * Payload's `extractJWT` returns the first token it finds in `jwtOrder`
+ * (`JWT`, `Bearer`, `cookie`) and `JWTAuthentication` verifies only that one.
+ * A present-but-invalid Bearer fails outright rather than falling through to
+ * the cookie. So while the header is sent these calls behave exactly as
+ * before — the change is consistency, and it is what makes eventually dropping
+ * the header a one-line change rather than an eight-file one.
+ *
+ * Every Payload client in the app is listed below, including the four that
+ * were already correct, so the set is checkable by reading rather than by
+ * remembering.
  */
 
 const fetchMock = vi.fn()
@@ -101,6 +109,44 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [{ id: 1 }] }))
 
     await getArticleLocationScope({ locationKey: 'lima', token: 'token' })
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('staging articles', async () => {
+    const { fetchPayloadArticles } = await import('../../features/staging/api/articles/articles.api')
+
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
+    await fetchPayloadArticles('token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('access permissions', async () => {
+    const { fetchAccessPermissions } = await import('../../features/auth/permissions-client')
+
+    fetchMock.mockResolvedValue(jsonResponse({}))
+    await fetchAccessPermissions('token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('homepage featured content', async () => {
+    const { mainHomepageRequest } = await import(
+      '../../features/homepageFeaturedContent/mainHomepage/request')
+
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
+    await mainHomepageRequest('/api/pages', 'token')
+
+    expect(lastCredentials()).toBe('include')
+  })
+
+  it('location homepages', async () => {
+    const { locationHomepageRequest } = await import(
+      '../../features/homepageFeaturedContent/locationHomepages/request')
+
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
+    await locationHomepageRequest('/api/pages', 'token')
 
     expect(lastCredentials()).toBe('include')
   })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
@@ -65,6 +65,7 @@ function buildScopeWhere(parts: string[]): URLSearchParams {
 
 async function payloadRequest<T>(endpoint: string, token: string): Promise<T> {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
+    credentials: 'include',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',


### PR DESCRIPTION
Phase 5, item 1 of the account-security roadmap — **step 1 of 2**. Groundwork only; no behaviour changes today.

## Why

The goal is to stop `localStorage` holding a live Staff JWT that any XSS can read. Before the `Authorization: Bearer` header can go away, the cookie has to actually work everywhere it is used.

The frontend's Payload clients grew independently and disagree:

| Client | Before |
|---|---|
| `shared/api/client/http.ts` (×2) | `credentials: 'omit'` |
| `features/staff/api/staff.api.ts` (avatar upload) | `credentials: 'omit'` |
| `shared/locationScope/scope.ts` | *unset* → `'same-origin'` |
| `features/locationDocuments/api.ts` | *unset* |
| `features/singleTypeListicles/api.ts` | *unset* |
| `features/listicleItineraries/api/payloadClient.ts` | *unset* |
| `features/staging/api/articles/*`, `auth/*`, `homepageFeaturedContent/*` | `'include'` already |

Payload is never same-origin with this app (`:3003` vs `:4000` in dev), so "unset" meant no cookie. None of it mattered while every call also carried a Bearer header.

All authenticated Payload calls now pass `credentials: 'include'`.

## Why this is safe

- **The Bearer header is untouched.** Payload's `extractJWT` tries `JWT`, then `Bearer`, then the cookie, so the header still wins and behaviour is identical today.
- **No CORS breakage.** Adding `credentials: 'include'` breaks a cross-origin request if the server does not return `Access-Control-Allow-Credentials: true` with a non-wildcard origin. Payload's `headersWithCors` (`payload@3.79.1/dist/utilities/headersWithCors.js`) only emits `Access-Control-Allow-Origin` for an exact match against the configured array, never `*`, and pairs it with `Access-Control-Allow-Credentials: true`. Our `cors` is `APP_CONFIG.CORS_ORIGINS`, an array — so the `*` branch is unreachable. Any of these calls that works today is already exact-match allowlisted, and therefore already gets the credentials header.

`checkPayloadHealth` deliberately keeps `credentials: 'omit'` — there is nothing to authenticate.

## Tests

`src/shared/api/payload-credentials.test.ts` (new, 9 cases) asserts the `credentials` option on each of the eight clients plus the health-check exception. It asserts the option rather than any one call site, so a new Payload client that forgets it is caught here.

## Verification

- `npx vitest run --config vite.config.ts --no-file-parallelism`: **135 files / 630 tests passed** — baseline 134/621, exactly +1 file / +9 tests from this PR, so no pre-existing test changed behaviour.
- `npx tsc --noEmit`: **7 errors, all pre-existing**, zero in changed files.

Not deployed.

## What is still open

Removing the token from `localStorage` is the follow-up PR. A third step — teaching FastAPI to accept the `payload-token` cookie so JS need not hold the token at all — is blocked on a production origin decision and is called out separately.