### PR TITLE
feat(abw): accept the payload-token cookie as caller identity

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -29,6 +29,14 @@ ABW_API_KEY=
 # With ABW_API_KEY unset (local development): empty means wildcard (*),
 # which also disables credentialed CORS.
 #
+# Pin this in local development too if you want the frontend to authenticate
+# with the payload-token session cookie rather than a Bearer header. A wildcard
+# forces allow_credentials=False, so the browser never sends the cookie, and
+# this list is also what the CSRF check validates the Origin against — cookie
+# auth is refused outright under a wildcard. The writer's dev server is pinned
+# to port 3003 in apps/frontend/vite.config.ts:
+#   ABW_ALLOWED_ORIGINS=http://localhost:3003
+#
 # With ABW_API_KEY set: REQUIRED. The backend refuses to start rather than
 # serve a wildcard origin policy on a deployed instance. If the instance has
 # no browser client at all (server-to-server, or a frontend served
@@ -37,8 +45,9 @@ ABW_API_KEY=
 ABW_ALLOWED_ORIGINS=
 
 # Require a valid Payload staff session on the costliest and most destructive
-# routes. Verified by asking Payload who the bearer token belongs to, so a
-# disabled account is rejected immediately.
+# routes. The session arrives as the httpOnly payload-token cookie or as an
+# Authorization: Bearer header, and is verified by asking Payload who it
+# belongs to, so a disabled account is rejected immediately.
 #
 # Covered: pipeline starts (youtube2blog/from-url, prompt2blog/run, both
 # pipeline-v2 routes), run expansion, itinerary generation and title

--- a/apps/ai-blog-writer/apps/backend/app/core/cors.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/cors.py
@@ -1,0 +1,85 @@
+"""The pinned browser-origin allowlist.
+
+Extracted from `app.main` so that request-authentication code can consult the
+same list without importing the application module (which builds the FastAPI
+app and loads `.env` at import time). `app.main` re-exports these names, so the
+historical import paths keep working.
+
+This one list now decides two things: which origins CORS answers, and which
+origins may authenticate with the `payload-token` cookie (see
+`app.core.staff_token`). Widening it widens both.
+"""
+
+import os
+
+CORS_DENY_ALL = "none"
+
+
+def resolve_cors_origins(api_key: str, raw_origins: str) -> list[str]:
+    """Resolve the CORS allow-list, refusing a wildcard on deployed instances.
+
+    A configured ABW_API_KEY is the signal that this instance is reachable
+    beyond localhost. Wildcard CORS there is incoherent: it forces
+    `allow_credentials=False`, and the X-API-Key header makes every request
+    preflighted, so any page could probe the API. Refuse to start instead of
+    serving an open origin policy.
+
+    An instance with no browser client at all (server-to-server, or a frontend
+    served same-origin behind a proxy) sets ABW_ALLOWED_ORIGINS=none to say so
+    explicitly. That is a deny-all list, not an oversight.
+
+    With no key configured (local development) the historical behavior is
+    kept exactly: wildcard when the variable is unset, otherwise whatever
+    parses out of it. Note that a wildcard also disables cookie authentication,
+    so local development that exercises the session cookie has to pin its
+    origins — see `app.core.staff_token`.
+    """
+    raw = raw_origins.strip()
+
+    if raw.lower() == CORS_DENY_ALL:
+        return []
+
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+    if not api_key.strip():
+        # Emptiness is judged on the raw string, not the parsed list, so a
+        # malformed value like "," keeps denying all origins rather than
+        # silently widening to a wildcard.
+        return ["*"] if not raw else origins
+
+    if not origins or "*" in origins:
+        raise ValueError(
+            "ABW_ALLOWED_ORIGINS must list explicit origins when ABW_API_KEY "
+            "is set; wildcard CORS is not allowed on a deployed instance. "
+            f"Set ABW_ALLOWED_ORIGINS={CORS_DENY_ALL} if this instance has no "
+            "browser client."
+        )
+
+    return origins
+
+
+def resolve_cors_config(
+    api_key: str, raw_origins: str
+) -> tuple[list[str], "ValueError | None"]:
+    """Pair the resolved origins with any rejection, without raising.
+
+    A rejected policy yields a deny-all list so the middleware fails closed,
+    plus the error for `lifespan` to refuse the boot with. Import stays safe
+    either way.
+    """
+    try:
+        return resolve_cors_origins(api_key, raw_origins), None
+    except ValueError as exc:
+        return [], exc
+
+
+def allowed_origins() -> list[str]:
+    """Read the CORS policy from the environment. See resolve_cors_origins.
+
+    Read per call rather than cached, so a test that stubs the environment
+    sees its own policy without reimporting the application module.
+    """
+    return resolve_cors_origins(
+        api_key=os.getenv("ABW_API_KEY", ""),
+        raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
+    )

--- a/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
@@ -17,9 +17,10 @@ import os
 from typing import Any, Optional
 
 import httpx
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, HTTPException
 
 from app.core.payload_api import resolve_payload_api_url
+from app.core.staff_token import extract_bearer_token, staff_token
 
 logger = logging.getLogger(__name__)
 
@@ -39,16 +40,18 @@ def staff_auth_required() -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
-    """Pull the token out of an `Authorization: Bearer <token>` header."""
-    if not authorization:
-        return None
-
-    scheme, _, token = authorization.partition(" ")
-    if scheme.strip().lower() != "bearer":
-        return None
-
-    return token.strip() or None
+# Re-exported: this was defined here before the cookie became a second source
+# of the same token, and callers and tests still import it from this module.
+__all__ = [
+    "STAFF_AUTH_FLAG",
+    "authorize_article_deletion",
+    "extract_bearer_token",
+    "fetch_payload_user",
+    "require_editor",
+    "require_staff",
+    "staff_auth_required",
+    "staff_user_id",
+]
 
 
 async def fetch_payload_user(
@@ -83,21 +86,27 @@ async def fetch_payload_user(
 
 
 async def require_staff(
-    authorization: Optional[str] = Header(default=None),
+    token: Optional[str] = Depends(staff_token),
 ) -> Optional[dict[str, Any]]:
     """FastAPI dependency requiring a valid Payload staff session.
 
     Returns the user so routes can log or authorize further. Returns None when
     the flag is off, in which case nothing is checked.
+
+    The token may arrive as an `Authorization: Bearer` header or as the
+    `payload-token` session cookie; `app.core.staff_token` decides which is
+    acceptable and enforces the origin check the cookie needs.
     """
     if not staff_auth_required():
         return None
 
-    token = extract_bearer_token(authorization)
     if not token:
         raise HTTPException(
             status_code=401,
-            detail="Authorization header with a Bearer token is required",
+            detail=(
+                "A staff session is required: send the payload-token cookie or "
+                "an Authorization: Bearer header"
+            ),
         )
 
     # Resolve through the same helper every other Payload caller uses, so a

--- a/apps/ai-blog-writer/apps/backend/app/core/staff_token.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/staff_token.py
@@ -1,0 +1,151 @@
+"""Where the Payload staff token comes from, and what makes it trustworthy.
+
+Historically this backend only read `Authorization: Bearer <token>`, which
+forced the frontend to hold a readable copy of a privileged Staff credential in
+JavaScript. Payload already sets the same JWT as the `httpOnly` `payload-token`
+cookie, and once Payload and this backend are siblings under one registrable
+domain that cookie reaches us on its own (ADR-0028).
+
+Reading it changes the threat model. A header has to be attached deliberately
+by script, so a cross-site page cannot forge one. A cookie is attached by the
+browser on *any* request to this origin, including one triggered by a page the
+operator did not intend to visit. Accepting the cookie therefore opens a CSRF
+surface that has to be closed here, explicitly.
+
+It is **not** closed by `X-API-Key`. That key is inlined into the Vite bundle
+and is public; forcing a preflight with a header any attacker can also send is
+not an authorization check. The check is the `Origin` header, validated against
+the same pinned allowlist that CORS uses.
+"""
+
+from typing import Iterable, Optional
+
+from fastapi import Cookie, Header, HTTPException, Request
+
+from app.core.cors import allowed_origins
+
+PAYLOAD_TOKEN_COOKIE = "payload-token"
+
+# Methods that cannot change state. A cross-site page can cause these to be
+# sent, but CORS stops it reading the response.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+class StaffTokenRejected(Exception):
+    """A token was present but the request was not allowed to use it."""
+
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+def extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    """Pull the token out of an `Authorization: Bearer <token>` header."""
+    if not authorization:
+        return None
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.strip().lower() != "bearer":
+        return None
+
+    return token.strip() or None
+
+
+def _origin_is_trusted(origin: Optional[str], allowed_origins: Iterable[str]) -> bool:
+    allowed = list(allowed_origins)
+
+    # A wildcard cannot authorize a credentialed request: it would mean
+    # trusting every site on the internet with the operator's session. It is
+    # also the local-development default, so refusing here is what tells an
+    # operator to pin ABW_ALLOWED_ORIGINS rather than leaving cookie auth
+    # quietly unprotected. CORSMiddleware already drops
+    # `Access-Control-Allow-Credentials` under a wildcard for the same reason.
+    if "*" in allowed:
+        return False
+
+    if not origin:
+        return False
+
+    return origin.rstrip("/") in {candidate.rstrip("/") for candidate in allowed}
+
+
+def resolve_staff_token(
+    *,
+    authorization: Optional[str],
+    cookie_token: Optional[str],
+    method: str,
+    origin: Optional[str],
+    allowed_origins: Iterable[str],
+) -> Optional[str]:
+    """Resolve the caller's staff token from the header or the session cookie.
+
+    The header wins when both are present. It is the older contract, it is
+    unambiguous, and — unlike the cookie — it cannot have been attached by a
+    page the operator did not mean to load, so it needs no origin check.
+
+    A cookie-borne token on a state-changing request must come from an
+    allowlisted origin. Raises `StaffTokenRejected` when it does not, rather
+    than falling through to "no token": the difference between "you are not
+    signed in" and "this request was not allowed to use your session" is worth
+    keeping, and silently treating a blocked CSRF attempt as anonymous would
+    hide it from the logs.
+    """
+    header_token = extract_bearer_token(authorization)
+    if header_token:
+        return header_token
+
+    if not cookie_token:
+        return None
+
+    normalized_method = method.upper()
+
+    # Safe methods are checked only when the browser tells us where the request
+    # came from. Same-origin GETs legitimately omit `Origin` in some browsers,
+    # so requiring it would break a same-origin proxy deployment for no gain:
+    # CORS already stops a cross-site page reading the response.
+    if normalized_method in SAFE_METHODS and origin is None:
+        return cookie_token
+
+    if not _origin_is_trusted(origin, allowed_origins):
+        raise StaffTokenRejected(
+            status_code=403,
+            message=(
+                "Cookie-authenticated requests must come from an allowlisted "
+                "origin. Set ABW_ALLOWED_ORIGINS to the exact origins that serve "
+                "the writer UI; a wildcard cannot authorize a credentialed "
+                "request."
+            ),
+        )
+
+    return cookie_token
+
+
+async def staff_token(
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+    payload_token: Optional[str] = Cookie(default=None, alias=PAYLOAD_TOKEN_COOKIE),
+) -> Optional[str]:
+    """FastAPI dependency yielding the caller's staff token, or None.
+
+    Kept optional so each caller keeps its own "missing credential" behavior:
+    the image routes answer with a structured error carrying a `step`, while
+    `require_staff` answers with a plain detail string, and a route running with
+    staff enforcement off needs no token at all.
+    """
+    try:
+        return resolve_staff_token(
+            authorization=authorization,
+            cookie_token=payload_token,
+            method=request.method,
+            origin=request.headers.get("origin"),
+            allowed_origins=allowed_origins(),
+        )
+    except StaffTokenRejected as rejected:
+        # A refused origin is reported the same way whichever route asked, so a
+        # blocked cross-site attempt reads identically in every log line. The
+        # per-route error shapes cover a *missing* credential, which is a
+        # different answer.
+        raise HTTPException(
+            status_code=rejected.status_code, detail=rejected.message
+        ) from rejected

--- a/apps/ai-blog-writer/apps/backend/app/features/images/auth.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/auth.py
@@ -1,12 +1,28 @@
-"""Authentication header validation for image routes."""
+"""Caller credential resolution for image routes.
+
+These routes forward the caller's own Payload JWT so that uploads are created
+as the acting Staff user rather than a service account. The token reaches us
+either as an `Authorization: Bearer` header or as the `payload-token` session
+cookie — `app.core.staff_token` owns that choice and the origin check the
+cookie requires. This module only turns "no credential" into the structured,
+`step`-carrying error shape the image API has always returned.
+"""
 
 from typing import Optional
+
+from fastapi import Depends
+
+from app.core.staff_token import staff_token
 
 from .errors import _raise_http_error
 
 
 def _extract_bearer_token(authorization: Optional[str]) -> str:
-    """Extract and validate the JWT from the Authorization header."""
+    """Extract and validate the JWT from the Authorization header.
+
+    Retained for callers that hold a raw header string. Routes take
+    `require_image_token` instead, which also accepts the session cookie.
+    """
     if not authorization or not authorization.startswith('Bearer '):
         _raise_http_error(
             status_code=401,
@@ -17,5 +33,19 @@ def _extract_bearer_token(authorization: Optional[str]) -> str:
     if not token:
         _raise_http_error(
             status_code=401, message='Bearer token is empty', step='validate_auth'
+        )
+    return token
+
+
+async def require_image_token(token: Optional[str] = Depends(staff_token)) -> str:
+    """Require a staff credential from either the header or the session cookie."""
+    if not token:
+        _raise_http_error(
+            status_code=401,
+            message=(
+                'A staff session is required: send the payload-token cookie or '
+                'an Authorization: Bearer header'
+            ),
+            step='validate_auth',
         )
     return token

--- a/apps/ai-blog-writer/apps/backend/app/features/images/composites/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/composites/routes.py
@@ -5,18 +5,18 @@ import json
 import time
 from typing import Optional
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse, Response
 
 from ..image_processor import ImageVariantType, ProcessedVariant
 from ..payload_client import PayloadClient, PayloadUploadError
 from ..shared import (
-    _extract_bearer_token,
     _raise_http_error,
     _status_from_payload_error,
     _validate_location_ref,
     _validate_photographer_credit,
     logger,
+    require_image_token,
 )
 from .cleanup import (  # noqa: F401
     _find_hanging_composites as _find_hanging_composites,
@@ -84,10 +84,9 @@ async def _upload_variant_with_retry(
 
 
 async def _prepare(
-    request: CompositeRequest, authorization: Optional[str]
-) -> tuple[str, Optional[int], str, list[SourceImage], list[str]]:
+    request: CompositeRequest, jwt_token: str
+) -> tuple[Optional[int], str, list[SourceImage], list[str]]:
     _validate_request_shape(request)
-    jwt_token = _extract_bearer_token(authorization)
     location_ref = _validate_location_ref(request.locationRef)
     photographer_credit = _validate_photographer_credit(
         request.photographerCredit or 'Questurian Composite'
@@ -98,15 +97,15 @@ async def _prepare(
         jwt_token=jwt_token,
         source_ids=[source.mediaSetId for source in request.sources],
     )
-    return (jwt_token, location_ref, photographer_credit, sources, _warnings(sources))
+    return (location_ref, photographer_credit, sources, _warnings(sources))
 
 
 @router.post('/preview')
 async def preview_composite(
-    request: CompositeRequest, authorization: Optional[str] = Header(None)
+    request: CompositeRequest, jwt_token: str = Depends(require_image_token)
 ) -> Response:
     try:
-        _, _, _, sources, warnings = await _prepare(request, authorization)
+        _, _, sources, warnings = await _prepare(request, jwt_token)
     except PayloadUploadError as exc:
         logger.exception('Payload error during /images/composites/preview')
         _raise_http_error(
@@ -131,11 +130,11 @@ async def preview_composite(
 
 @router.post('/create')
 async def create_composite(
-    request: CompositeRequest, authorization: Optional[str] = Header(None)
+    request: CompositeRequest, jwt_token: str = Depends(require_image_token)
 ) -> JSONResponse:
     try:
-        jwt_token, location_ref, photographer_credit, sources, warnings = (
-            await _prepare(request, authorization)
+        location_ref, photographer_credit, sources, warnings = await _prepare(
+            request, jwt_token
         )
     except PayloadUploadError as exc:
         logger.exception('Payload error during /images/composites/create prepare')
@@ -200,10 +199,9 @@ async def create_composite(
 
 @router.get('/hanging')
 async def list_hanging_composites(
-    authorization: Optional[str] = Header(None), min_age_minutes: float = 5.0
+    jwt_token: str = Depends(require_image_token), min_age_minutes: float = 5.0
 ) -> JSONResponse:
     """List composite MediaSets left incomplete by a failed upload."""
-    jwt_token = _extract_bearer_token(authorization)
     client = PayloadClient(jwt_token)
     try:
         hanging = await _find_hanging_composites(
@@ -223,14 +221,13 @@ async def list_hanging_composites(
 
 @router.post('/cleanup')
 async def cleanup_hanging_composites(
-    request: HangingCleanupRequest, authorization: Optional[str] = Header(None)
+    request: HangingCleanupRequest, jwt_token: str = Depends(require_image_token)
 ) -> JSONResponse:
     """Delete the given hanging composite MediaSets and their variant assets.
 
     Only sets that are genuinely hanging (composite-prefixed and below the full
     variant count) are removed — a guard against deleting a healthy MediaSet.
     """
-    jwt_token = _extract_bearer_token(authorization)
     client = PayloadClient(jwt_token)
     try:
         hanging = await _find_hanging_composites(client=client, min_age_minutes=0.0)

--- a/apps/ai-blog-writer/apps/backend/app/features/images/flux/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/flux/routes.py
@@ -3,14 +3,13 @@
 import re
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, File, Form, Header, UploadFile
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 from fastapi.responses import Response
 
 from app.core.staff_auth import require_staff
 
 from ..bfl_client import BflApiError, BflClient
 from ..shared import (
-    _extract_bearer_token,
     _raise_http_error,
     _read_additional_reference_images,
     _read_upload_file,
@@ -20,6 +19,7 @@ from ..shared import (
     _validate_flux_prompt,
     _validate_flux_safety_tolerance,
     logger,
+    require_image_token,
 )
 
 router = APIRouter()
@@ -60,10 +60,9 @@ async def flux_edit_image(
         None,
         description="Optional generation seed for reproducibility",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> Response:
     """Proxy a FLUX.2 edit request with optional multi-reference inputs."""
-    _extract_bearer_token(authorization)
     valid_prompt = _validate_flux_prompt(prompt)
     valid_model_id = _validate_flux_model_id(model_id)
     valid_width, valid_height = _validate_flux_dimensions(width, height)

--- a/apps/ai-blog-writer/apps/backend/app/features/images/shared.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/shared.py
@@ -2,7 +2,10 @@
 
 import logging
 
-from .auth import _extract_bearer_token as _extract_bearer_token  # noqa: F401
+from .auth import (  # noqa: F401
+    _extract_bearer_token as _extract_bearer_token,
+    require_image_token as require_image_token,
+)
 from .errors import (  # noqa: F401
     _build_error_detail as _build_error_detail,
     _raise_http_error as _raise_http_error,

--- a/apps/ai-blog-writer/apps/backend/app/features/images/social/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/social/routes.py
@@ -4,7 +4,7 @@ import re
 import time
 from typing import Optional
 
-from fastapi import APIRouter, File, Form, Header, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 
 from ..image_processor import ImageVariantType, VARIANT_SPECS, process_single_variant
@@ -12,7 +12,6 @@ from ..payload_client import PayloadClient, PayloadUploadError
 from ..schemas import GenerateSocialImageRequest
 from ..shared import (
     _download_media_asset_file,
-    _extract_bearer_token,
     _raise_http_error,
     _read_upload_file,
     _select_social_source_asset,
@@ -22,6 +21,7 @@ from ..shared import (
     _validate_photographer_credit,
     _wait_for_bunny_original_url,
     logger,
+    require_image_token,
 )
 
 router = APIRouter()
@@ -30,7 +30,7 @@ router = APIRouter()
 @router.post("/generate-social-image")
 async def generate_social_image(
     request: GenerateSocialImageRequest,
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Regenerate the open_graph (1200x630) variant from the featured image.
@@ -42,7 +42,6 @@ async def generate_social_image(
 
     Returns the generated asset bunny_original_url for strict SEO social image usage.
     """
-    jwt_token = _extract_bearer_token(authorization)
     featured_asset_id = request.featuredAssetId
     featured_media_set_id = request.featuredMediaSetId
     if featured_media_set_id is not None:
@@ -204,7 +203,7 @@ async def upload_social_image(
         ...,
         description="Payload location id to attach to uploaded image",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Upload one social image for OG/Twitter usage only.
@@ -212,7 +211,6 @@ async def upload_social_image(
     This endpoint processes the source into a single open_graph (1200x630) variant
     and uploads it directly without creating/updating a media set.
     """
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     valid_alt_text = _validate_alt_text(alt_text)

--- a/apps/ai-blog-writer/apps/backend/app/features/images/uploads/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/uploads/routes.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, File, Form, Header, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, Response
 
 from ..image_processor import ImageVariantType, ProcessedVariant, process_image_variants
@@ -14,7 +14,6 @@ from ..shared import (
     VARIANT_DIMENSIONS,
     _derive_external_filename,
     _download_external_image,
-    _extract_bearer_token,
     _normalize_tag_name,
     _parse_tag_ids,
     _raise_http_error,
@@ -26,6 +25,7 @@ from ..shared import (
     _validate_photographer_credit,
     _validate_variant_types,
     logger,
+    require_image_token,
 )
 
 router = APIRouter()
@@ -34,10 +34,9 @@ router = APIRouter()
 @router.post("/tags/resolve")
 async def resolve_tags(
     request: ResolveTagsRequest,
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ):
     """Find or create tags by name. Returns IDs for all provided names."""
-    jwt_token = _extract_bearer_token(authorization)
     client = PayloadClient(jwt_token)
 
     results = []
@@ -70,7 +69,7 @@ async def upload_image(
         ...,
         description="Payload location id to attach to uploaded images",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Upload an image and process it into all required variants server-side.
@@ -82,7 +81,6 @@ async def upload_image(
     3. Uploaded to Payload CMS as media-assets
     4. Linked in a new MediaSet
     """
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     content = await _read_upload_file(file, step="validate_file")
@@ -172,10 +170,9 @@ async def import_external_image(
         None,
         description="Provider photo identifier for filename stability",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """Import an external provider image and upload processed variants to Payload."""
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     valid_provider = _validate_external_provider(provider)
@@ -267,10 +264,9 @@ async def fetch_external_image_source(
     source_url: str,
     provider: str,
     photo_id: Optional[str] = None,
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> Response:
     """Download a validated external image and return raw bytes for client-side cropping."""
-    _extract_bearer_token(authorization)
     valid_provider = _validate_external_provider(provider)
     valid_source_url = _validate_external_source_url(source_url, valid_provider)
     original_filename = _derive_external_filename(
@@ -317,7 +313,7 @@ async def upload_image_variants(
         None,
         description="JSON-encoded list of integer tag IDs, e.g. '[1,2,3]'",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Upload pre-processed image variants (client-side cropped) to Payload CMS.
@@ -326,7 +322,6 @@ async def upload_image_variants(
     1. Uploads each to Payload CMS as media-assets
     2. Creates or reuses a MediaSet linking all variants
     """
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     tag_ids = _parse_tag_ids(tags)

--- a/apps/ai-blog-writer/apps/backend/app/main.py
+++ b/apps/ai-blog-writer/apps/backend/app/main.py
@@ -80,9 +80,17 @@ ERROR_LOG_PATH = _configure_error_file_logging()
 # Paths reachable without an API key when ABW_API_KEY is set.
 AUTH_EXEMPT_PATHS = {"/health"}
 API_KEY_HEADER = "X-API-Key"
-# Explicit ABW_ALLOWED_ORIGINS value meaning "this instance has no browser
-# client", as distinct from the variable being forgotten.
-CORS_DENY_ALL = "none"
+
+# The origin allowlist lives in app.core.cors so that request authentication can
+# read it without importing this module. Re-exported here because that is where
+# it used to live. `CORS_DENY_ALL` is the explicit ABW_ALLOWED_ORIGINS value
+# meaning "this instance has no browser client", as distinct from the variable
+# being forgotten.
+from app.core.cors import (  # noqa: E402,F401
+    CORS_DENY_ALL as CORS_DENY_ALL,
+    resolve_cors_config as resolve_cors_config,
+    resolve_cors_origins as resolve_cors_origins,
+)
 
 
 @asynccontextmanager
@@ -121,55 +129,6 @@ def _read_bool_env(key: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def resolve_cors_origins(api_key: str, raw_origins: str) -> list[str]:
-    """Resolve the CORS allow-list, refusing a wildcard on deployed instances.
-
-    A configured ABW_API_KEY is the signal that this instance is reachable
-    beyond localhost. Wildcard CORS there is incoherent: it forces
-    `allow_credentials=False`, and the X-API-Key header makes every request
-    preflighted, so any page could probe the API. Refuse to start instead of
-    serving an open origin policy.
-
-    An instance with no browser client at all (server-to-server, or a frontend
-    served same-origin behind a proxy) sets ABW_ALLOWED_ORIGINS=none to say so
-    explicitly. That is a deny-all list, not an oversight.
-
-    With no key configured (local development) the historical behavior is
-    kept exactly: wildcard when the variable is unset, otherwise whatever
-    parses out of it.
-    """
-    raw = raw_origins.strip()
-
-    if raw.lower() == CORS_DENY_ALL:
-        return []
-
-    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
-
-    if not api_key.strip():
-        # Emptiness is judged on the raw string, not the parsed list, so a
-        # malformed value like "," keeps denying all origins rather than
-        # silently widening to a wildcard.
-        return ["*"] if not raw else origins
-
-    if not origins or "*" in origins:
-        raise ValueError(
-            "ABW_ALLOWED_ORIGINS must list explicit origins when ABW_API_KEY "
-            "is set; wildcard CORS is not allowed on a deployed instance. "
-            f"Set ABW_ALLOWED_ORIGINS={CORS_DENY_ALL} if this instance has no "
-            "browser client."
-        )
-
-    return origins
-
-
-def _allowed_origins() -> list[str]:
-    """Read the CORS policy from the environment. See resolve_cors_origins."""
-    return resolve_cors_origins(
-        api_key=os.getenv("ABW_API_KEY", ""),
-        raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
-    )
-
-
 @app.middleware("http")
 async def require_api_key(request: Request, call_next):
     """Reject requests without the configured API key.
@@ -195,21 +154,6 @@ async def require_api_key(request: Request, call_next):
         )
 
     return await call_next(request)
-
-
-def resolve_cors_config(
-    api_key: str, raw_origins: str
-) -> tuple[list[str], ValueError | None]:
-    """Pair the resolved origins with any rejection, without raising.
-
-    A rejected policy yields a deny-all list so the middleware fails closed,
-    plus the error for `lifespan` to refuse the boot with. Import stays safe
-    either way.
-    """
-    try:
-        return resolve_cors_origins(api_key, raw_origins), None
-    except ValueError as exc:
-        return [], exc
 
 
 _cors_origins, _cors_config_error = resolve_cors_config(

--- a/apps/ai-blog-writer/apps/backend/tests/test_images_composite_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_images_composite_routes.py
@@ -21,9 +21,9 @@ def _composite_request_body() -> dict:
     }
 
 
-async def _fake_prepare_ok(request, authorization):
+async def _fake_prepare_ok(request, jwt_token):
     """Bypass source download/render machinery for composite route tests."""
-    return "jwt-token", 42, "Questurian Composite", [], []
+    return 42, "Questurian Composite", [], []
 
 
 def test_create_composite_rolls_back_on_partial_failure(monkeypatch):

--- a/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 from app.core import staff_auth
+from app.core.staff_token import resolve_staff_token
 from fastapi import HTTPException
 
 
@@ -107,7 +108,7 @@ def test_later_status_update_cannot_claim_unowned_run(isolated_db):
 async def test_passes_through_when_flag_is_off():
     """With the flag off nothing is checked, so existing deployments and local
     development are untouched."""
-    assert await staff_auth.require_staff(authorization=None) is None
+    assert await staff_auth.require_staff(token=None) is None
 
 
 @pytest.mark.asyncio
@@ -115,17 +116,31 @@ async def test_rejects_missing_token_when_enabled(monkeypatch):
     monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
 
     with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization=None)
+        await staff_auth.require_staff(token=None)
 
     assert excinfo.value.status_code == 401
 
 
 @pytest.mark.asyncio
 async def test_rejects_non_bearer_scheme_when_enabled(monkeypatch):
+    """A non-Bearer scheme yields no token, and no token is a 401.
+
+    The scheme check itself now lives in `staff_token.resolve_staff_token`;
+    this pins that its "no credential" answer still reaches the caller as 401
+    rather than being mistaken for the flag being off.
+    """
     monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
 
+    token = resolve_staff_token(
+        authorization="JWT abc",
+        cookie_token=None,
+        method="POST",
+        origin=None,
+        allowed_origins=["https://abw.questurian.com"],
+    )
+
     with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization="JWT abc")
+        await staff_auth.require_staff(token=token)
 
     assert excinfo.value.status_code == 401
 
@@ -144,7 +159,7 @@ async def test_falls_back_to_the_shared_payload_url_default(monkeypatch):
 
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
-    await staff_auth.require_staff(authorization="Bearer abc")
+    await staff_auth.require_staff(token="abc")
 
     assert seen["url"] == "http://localhost:4000"
 
@@ -161,7 +176,7 @@ async def test_uses_the_configured_payload_url_when_set(monkeypatch):
 
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
-    await staff_auth.require_staff(authorization="Bearer abc")
+    await staff_auth.require_staff(token="abc")
 
     assert seen["url"] == "http://payload.internal:4000"
 
@@ -176,7 +191,7 @@ async def test_accepts_a_session_payload_recognizes(monkeypatch):
 
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
-    user = await staff_auth.require_staff(authorization="Bearer abc")
+    user = await staff_auth.require_staff(token="abc")
 
     assert user["email"] == "staff@example.com"
 
@@ -248,7 +263,7 @@ async def test_rejects_a_session_payload_does_not_recognize(monkeypatch):
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
     with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization="Bearer abc")
+        await staff_auth.require_staff(token="abc")
 
     assert excinfo.value.status_code == 401
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_staff_token.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_staff_token.py
@@ -1,0 +1,204 @@
+"""Where a staff token may come from, and when the cookie is allowed to count."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.staff_token import (
+    PAYLOAD_TOKEN_COOKIE,
+    StaffTokenRejected,
+    extract_bearer_token,
+    resolve_staff_token,
+)
+
+TRUSTED = ["https://abw.questurian.com"]
+
+
+def _resolve(**overrides):
+    kwargs = {
+        "authorization": None,
+        "cookie_token": None,
+        "method": "POST",
+        "origin": None,
+        "allowed_origins": TRUSTED,
+    }
+    kwargs.update(overrides)
+    return resolve_staff_token(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("Bearer abc", "abc"),
+        ("bearer abc", "abc"),
+        ("Bearer   abc  ", "abc"),
+        ("JWT abc", None),
+        ("Bearer", None),
+        ("Bearer ", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_extract_bearer_token(header, expected):
+    assert extract_bearer_token(header) == expected
+
+
+def test_no_credential_at_all_is_no_token():
+    assert _resolve() is None
+
+
+class TestHeader:
+    """A header cannot be attached by a page the operator did not mean to load,
+    so it needs no origin check."""
+
+    def test_header_needs_no_origin(self):
+        assert _resolve(authorization="Bearer abc", origin=None) == "abc"
+
+    def test_header_is_accepted_from_an_untrusted_origin(self):
+        assert (
+            _resolve(authorization="Bearer abc", origin="https://evil.example")
+            == "abc"
+        )
+
+    def test_header_wins_over_the_cookie(self):
+        assert (
+            _resolve(
+                authorization="Bearer from-header",
+                cookie_token="from-cookie",
+                origin=TRUSTED[0],
+            )
+            == "from-header"
+        )
+
+    def test_a_malformed_header_falls_through_to_the_cookie(self):
+        """`JWT abc` yields no header token, so the cookie is the only
+        credential left — and it is then held to the cookie's rules."""
+        assert (
+            _resolve(
+                authorization="JWT abc", cookie_token="from-cookie", origin=TRUSTED[0]
+            )
+            == "from-cookie"
+        )
+
+
+class TestCookieOnStateChange:
+    def test_accepted_from_an_allowlisted_origin(self):
+        assert _resolve(cookie_token="abc", origin=TRUSTED[0]) == "abc"
+
+    def test_trailing_slash_on_either_side_still_matches(self):
+        assert (
+            _resolve(
+                cookie_token="abc",
+                origin="https://abw.questurian.com/",
+                allowed_origins=["https://abw.questurian.com/"],
+            )
+            == "abc"
+        )
+
+    def test_rejected_from_an_unlisted_origin(self):
+        with pytest.raises(StaffTokenRejected) as excinfo:
+            _resolve(cookie_token="abc", origin="https://evil.example")
+
+        assert excinfo.value.status_code == 403
+
+    def test_rejected_when_the_origin_header_is_absent(self):
+        """A cross-site form POST carries no `Origin` in some browsers. Absence
+        is not evidence of trust."""
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin=None)
+
+    def test_rejected_under_a_wildcard_allowlist(self):
+        """A wildcard would mean trusting every site with the operator's
+        session. It is also the local-development default, so this is what
+        tells an operator to pin ABW_ALLOWED_ORIGINS."""
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin=TRUSTED[0], allowed_origins=["*"])
+
+    def test_rejected_under_an_empty_allowlist(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin=TRUSTED[0], allowed_origins=[])
+
+    def test_a_subdomain_of_a_trusted_origin_is_not_trusted(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin="https://evil.abw.questurian.com")
+
+    def test_a_prefix_of_a_trusted_origin_is_not_trusted(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin="https://abw.questurian.com.evil.test")
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "post"])
+    def test_every_unsafe_method_is_guarded(self, method):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", method=method, origin="https://evil.example")
+
+
+class TestCookieOnSafeMethods:
+    @pytest.mark.parametrize("method", ["GET", "HEAD", "get"])
+    def test_allowed_without_an_origin(self, method):
+        """Same-origin GETs legitimately omit `Origin` in some browsers, and
+        CORS already stops a cross-site page reading the response."""
+        assert _resolve(cookie_token="abc", method=method, origin=None) == "abc"
+
+    def test_a_present_origin_is_still_checked(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", method="GET", origin="https://evil.example")
+
+    def test_allowlisted_origin_passes(self):
+        assert _resolve(cookie_token="abc", method="GET", origin=TRUSTED[0]) == "abc"
+
+
+class TestThroughTheApp:
+    """The dependency has to turn a rejection into a response, not a 500."""
+
+    @pytest.fixture(autouse=True)
+    def _pinned_origins(self, monkeypatch):
+        monkeypatch.delenv("ABW_API_KEY", raising=False)
+        monkeypatch.setenv("ABW_ALLOWED_ORIGINS", TRUSTED[0])
+
+    def test_a_forged_origin_gets_403_not_500(self):
+        from app.main import app
+
+        client = TestClient(app)
+        client.cookies.set(PAYLOAD_TOKEN_COOKIE, "abc")
+        response = client.post(
+            "/images/composites/preview",
+            json={},
+            headers={"Origin": "https://evil.example"},
+        )
+
+        assert response.status_code == 403
+        assert "allowlisted origin" in response.json()["detail"]
+
+    def test_no_credential_keeps_the_structured_image_error_shape(self):
+        """The image API has always answered with a `step`-carrying detail;
+        adding a second credential source must not change that contract."""
+        from app.main import app
+
+        response = TestClient(app).post("/images/composites/preview", json={})
+
+        assert response.status_code == 401
+        detail = response.json()["detail"]
+        assert detail["step"] == "validate_auth"
+        assert "payload-token" in detail["message"]
+
+
+def test_rejection_carries_a_message_naming_the_variable_to_fix():
+    with pytest.raises(StaffTokenRejected) as excinfo:
+        _resolve(cookie_token="abc", origin="https://evil.example")
+
+    assert "ABW_ALLOWED_ORIGINS" in excinfo.value.message
+
+
+def test_staff_auth_still_rejects_a_missing_token(monkeypatch):
+    """`require_staff` no longer parses the header itself, so pin that the
+    401 survived the move."""
+    from app.core import staff_auth
+
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    with pytest.raises(HTTPException) as excinfo:
+        import asyncio
+
+        asyncio.run(staff_auth.require_staff(token=None))
+
+    assert excinfo.value.status_code == 401


### PR DESCRIPTION
The backend only read `Authorization: Bearer`, which is why the frontend
still has to hold a readable copy of a privileged Staff JWT in memory
(ADR-0028, "Not done here"). Payload already sets that same JWT as the
httpOnly `payload-token` cookie, and now that the cookie is scoped to the
registrable domain it reaches this backend on its own.

Reading it changes the threat model, so the CSRF surface it opens is
closed here rather than assumed away. A header has to be attached
deliberately by script; a cookie is attached by the browser on any
request to this origin, including one a page the operator never meant to
load caused. Cookie-borne tokens are therefore held to an `Origin` check
against the pinned CORS allowlist:

- unsafe methods always require an allowlisted `Origin`;
- safe methods are checked only when `Origin` is present, because
  same-origin GETs legitimately omit it and CORS already stops a
  cross-site page reading the response;
- a wildcard allowlist refuses cookie auth outright. It would mean
  trusting every site with the operator's session, and `CORSMiddleware`
  already drops `Access-Control-Allow-Credentials` under a wildcard for
  the same reason.

It is explicitly **not** closed by `X-API-Key`. That key is inlined into
the Vite bundle and is public; forcing a preflight with a header any
attacker can also send is not an authorization check.

A refused origin answers 403, distinct from the 401 for "not signed in".
Silently treating a blocked CSRF attempt as anonymous would hide it.

The Bearer header keeps working and still wins when both are present, so
nothing breaks before the frontend switches over, and non-browser callers
(scripts, curl, server-to-server) keep a credential that needs no cookie
jar.

Mechanics:

- `app/core/staff_token.py` — new. `resolve_staff_token` is a pure
  function over (header, cookie, method, origin, allowlist); the FastAPI
  dependency wraps it.
- `app/core/cors.py` — new. The origin allowlist moved out of `app.main`
  so authentication can read it without importing the module that builds
  the app and loads `.env`. `app.main` re-exports the old names.
  `_allowed_origins` was already dead in `app.main` and is not re-exported.
- 12 image routes swap `authorization: Header(None)` plus an in-body
  `_extract_bearer_token` call for one `Depends(require_image_token)`.
  Their structured `step: validate_auth` error shape is preserved.
- `composites._prepare` took the raw header and returned the token as its
  first tuple element; it now takes the resolved token and returns four
  values instead of five.

Also documents in `.env.example` that local development must pin
`ABW_ALLOWED_ORIGINS=http://localhost:3003` (this app's dev port, per
`apps/frontend/vite.config.ts`) to exercise cookie auth at all — the
wildcard default blocks it twice over.

abw backend: 629 passed (was 594; +35 here). Measured 594 on `main` this
session — the 543 recorded in the previous handoff was stale. flake8
clean on the new files.

---

Depends on #222 for the cookie to actually reach this backend in a deployed environment. Independently mergeable: the Bearer header still works, so nothing regresses if this lands first.

**Not deployed.**