### PR TITLE
feat(abw): make the cookie the only credential Payload sees

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
@@ -9,7 +9,7 @@ import {
   SESSION_RENEW_REQUESTS,
   SESSION_RESTORE_TIMEOUT_MS,
 } from './auth.constants';
-import { hasActiveSession, normalizeAuthState } from './auth-state';
+import { normalizeAuthState } from './auth-state';
 
 export type PayloadHealthResult = {
   isConnected: boolean;
@@ -27,20 +27,21 @@ async function requestSession(
     const timeoutId = window.setTimeout(() => controller.abort(), SESSION_RESTORE_TIMEOUT_MS);
 
     try {
-      const headers: Record<string, string> = {
-        Accept: 'application/json',
-      };
-
-      if (fallbackAuth?.token && hasActiveSession(fallbackAuth.token, fallbackAuth.expiresAt)) {
-        headers.Authorization = `Bearer ${fallbackAuth.token}`;
-      }
-
+      // No `Authorization` header, for the same reason `logoutPayloadUser`
+      // sends none: `extractJWT` returns the *first* token it finds in
+      // `jwtOrder` (JWT, Bearer, cookie) and verifies only that one. A stale
+      // in-memory token would therefore be extracted, fail to verify, and take
+      // the request down *even though the cookie beside it is still valid* —
+      // turning a renewable session into a forced logout. The cookie is the
+      // credential; letting anything shadow it is how it stops being one.
       const response = await fetch(`${PAYLOAD_API_URL}${request.endpoint}`, {
         method: request.method,
         mode: 'cors',
         cache: 'no-store',
         credentials: 'include',
-        headers,
+        headers: {
+          Accept: 'application/json',
+        },
         signal: controller.signal,
       });
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
@@ -31,7 +31,6 @@ export async function fetchAccessPermissions(token: string): Promise<AccessResul
       credentials: 'include',
       headers: {
         Accept: 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       signal: controller.signal,
     });

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/request.ts
@@ -34,7 +34,6 @@ export async function locationHomepageRequest<T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         ...(init?.headers || {})
       }
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/request.ts
@@ -32,7 +32,6 @@ export async function mainHomepageRequest<T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         ...(init?.headers || {}),
       },
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
@@ -65,7 +65,6 @@ export async function payloadRequest<T>(
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
       ...(init?.headers || {})
     }
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
@@ -33,7 +33,6 @@ async function payloadRequest<T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         ...(init?.headers || {}),
       },
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
@@ -20,7 +20,6 @@ async function payloadRequest<T>(endpoint: string, token: string, init?: Request
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
       ...(init?.headers || {}),
     },
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
@@ -39,7 +39,7 @@ function jsonResponse(body: unknown, ok = true, status = 200) {
 describe('staff.api', () => {
   // depth=0: the account carries no relationships worth populating now that
   // authorship (and its avatar) live on the author record.
-  it('fetches the staff user with auth header', async () => {
+  it('fetches the staff user with the session cookie, not a header', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ id: 3, email: 'w@questurian.com', role: 'writer' }))
 
     const user = await fetchStaffUser(3, 'token-1')
@@ -47,7 +47,8 @@ describe('staff.api', () => {
     expect(user.id).toBe(3)
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/api/users/3?depth=0')
-    expect(init.headers.Authorization).toBe('Bearer token-1')
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
+    expect(init.credentials).toBe('include')
   })
 
   it('updates the staff user and unwraps the doc', async () => {
@@ -122,7 +123,8 @@ describe('staff.api', () => {
     expect(String(url)).toContain('/api/media-assets')
     expect(init.method).toBe('POST')
     expect(init.body).toBeInstanceOf(FormData)
-    expect(init.headers.Authorization).toBe('Bearer token-1')
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
+    expect(init.credentials).toBe('include')
   })
 
   it('surfaces upload failures with status and body', async () => {
@@ -173,10 +175,10 @@ describe('staff.api', () => {
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/api/users/forgot-password')
     expect(JSON.parse(init.body)).toEqual({ email: 'new@questurian.com' })
-    expect(init.headers.Authorization).toBeUndefined()
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
   })
 
-  it('fetches recent email logs newest-first with auth', async () => {
+  it('fetches recent email logs newest-first on the session cookie', async () => {
     fetchMock.mockResolvedValue(
       jsonResponse({
         docs: [
@@ -197,7 +199,8 @@ describe('staff.api', () => {
     expect(logs[0].emailType).toBe('password-set-link')
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/api/email-logs?limit=50&sort=-createdAt')
-    expect(init.headers.Authorization).toBe('Bearer token-1')
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
+    expect(init.credentials).toBe('include')
   })
 
   it('returns an empty log list when the collection has no docs', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types'
 
 export async function fetchStaffUser(id: number | string, token: string): Promise<StaffUser> {
-  return payloadRequest(`/api/users/${id}?depth=0`, token)
+  return payloadRequest(`/api/users/${id}?depth=0`)
 }
 
 /**
@@ -28,7 +28,6 @@ export async function fetchAuthorForUser(
   // depth=1 populates the avatar upload relationship for preview
   const response = (await payloadRequest(
     `/api/authors?where[user][equals]=${userId}&limit=1&depth=1`,
-    token,
   )) as { docs?: Author[] }
   return response.docs?.[0] ?? null
 }
@@ -37,7 +36,6 @@ export async function fetchAuthorForUser(
 export async function fetchAuthors(token: string): Promise<Author[]> {
   const response = (await payloadRequest(
     '/api/authors?limit=200&sort=displayName&depth=0',
-    token,
   )) as { docs?: Author[] }
   return response.docs ?? []
 }
@@ -51,7 +49,6 @@ export async function createAuthorForUser(
     '/api/authors',
     'POST',
     { ...patch, user: Number(userId) },
-    token,
   )) as { doc?: Author }
   if (!response.doc) {
     throw new Error('Payload returned no created author document.')
@@ -64,7 +61,7 @@ export async function updateAuthor(
   patch: AuthorPatch,
   token: string,
 ): Promise<Author> {
-  const response = (await payloadMutation(`/api/authors/${id}`, 'PATCH', patch, token)) as {
+  const response = (await payloadMutation(`/api/authors/${id}`, 'PATCH', patch)) as {
     doc?: Author
   }
   if (!response.doc) {
@@ -78,7 +75,7 @@ export async function updateStaffUser(
   patch: StaffUserPatch,
   token: string,
 ): Promise<StaffUser> {
-  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', patch, token)) as {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', patch)) as {
     doc?: StaffUser
   }
   if (!response.doc) {
@@ -101,7 +98,7 @@ export async function uploadAvatarAsset(file: File, token: string): Promise<Avat
     method: 'POST',
     mode: 'cors',
     credentials: 'include',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { },
     body: formData,
   })
 
@@ -118,7 +115,7 @@ export async function uploadAvatarAsset(file: File, token: string): Promise<Avat
 }
 
 export async function fetchStaffUsers(token: string): Promise<StaffUser[]> {
-  const response = (await payloadRequest('/api/users?limit=200&sort=email&depth=0', token)) as {
+  const response = (await payloadRequest('/api/users?limit=200&sort=email&depth=0')) as {
     docs?: StaffUser[]
   }
   return response.docs ?? []
@@ -137,7 +134,6 @@ export async function createStaffUser(
     '/api/users',
     'POST',
     { ...input, password: generateDiscardedPassword() },
-    token,
   )) as { doc?: StaffUser }
   if (!response.doc) {
     throw new Error('Payload returned no created user document.')
@@ -167,7 +163,6 @@ export async function requestPasswordSetEmail(email: string): Promise<void> {
 export async function fetchEmailLogs(token: string, limit = 50): Promise<EmailLog[]> {
   const response = (await payloadRequest(
     `/api/email-logs?limit=${limit}&sort=-createdAt&depth=0`,
-    token,
   )) as { docs?: EmailLog[] }
   return response.docs ?? []
 }
@@ -182,7 +177,7 @@ export async function changeStaffRole(
   role: AssignableStaffRole,
   token: string,
 ): Promise<StaffUser> {
-  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { role }, token)) as {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { role })) as {
     doc?: StaffUser
   }
   if (!response.doc) {
@@ -201,7 +196,7 @@ export async function setStaffStatus(
   status: StaffStatus,
   token: string,
 ): Promise<StaffUser> {
-  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { status }, token)) as {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { status })) as {
     doc?: StaffUser
   }
   if (!response.doc) {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
@@ -21,7 +21,6 @@ export async function createArticle(
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(article),
   })
@@ -47,7 +46,6 @@ export async function updateArticle(
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(article),
   })
@@ -71,7 +69,6 @@ export async function getArticleById(
     credentials: 'include',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
 
@@ -96,7 +93,6 @@ export async function fetchPayloadArticles(token: string): Promise<PayloadArticl
     credentials: 'include',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/http.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/http.ts
@@ -1,20 +1,31 @@
 import { PAYLOAD_API_URL } from './config'
 
-export async function payloadRequest(endpoint: string, token?: string) {
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-  }
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`
-  }
-
+/**
+ * Requests to Payload.
+ *
+ * The caller is identified by the httpOnly `payload-token` cookie, which
+ * `credentials: 'include'` sends and which no script can read. These used to
+ * take a `token` and set `Authorization: Bearer`, which meant a privileged
+ * Staff JWT had to be readable by JavaScript to reach Payload at all.
+ *
+ * Passing a token here would be worse than redundant: `extractJWT` returns the
+ * *first* credential it finds in `jwtOrder` (JWT, Bearer, cookie) and verifies
+ * only that one, so a stale header shadows a perfectly good cookie and fails
+ * the request.
+ *
+ * Payload gates *cookie* auth on its `csrf` allowlist, not its `cors` list —
+ * this app's origin has to appear in `CORS_ALLOWED_ORIGINS` on the server, or
+ * these come back 401 with nothing else to explain it.
+ */
+export async function payloadRequest(endpoint: string) {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     method: 'GET',
     mode: 'cors',
     cache: 'no-store',
     credentials: 'include',
-    headers,
+    headers: {
+      Accept: 'application/json',
+    },
   })
 
   if (!response.ok) {
@@ -28,22 +39,15 @@ export async function payloadMutation(
   endpoint: string,
   method: 'POST' | 'PATCH' | 'DELETE',
   body?: unknown,
-  token?: string,
 ) {
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  }
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`
-  }
-
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     method,
     mode: 'cors',
     credentials: 'include',
-    headers,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
@@ -8,25 +8,27 @@ import { payloadRequest as itineraryPayloadRequest } from '../../features/listic
 import { getArticleLocationScope } from '../locationScope/scope'
 
 /**
- * Every authenticated call to Payload must send the session cookie.
+ * Every authenticated call to Payload sends the session cookie, and nothing
+ * else.
  *
- * These clients grew independently and disagreed: some passed
- * `credentials: 'include'`, some passed `'omit'`, and some named no option at
- * all — which means `'same-origin'`, and Payload is never the same origin as
- * this app. None of it showed, because each one also carries an
- * `Authorization: Bearer` header.
+ * These clients grew independently and disagreed about `credentials`; that was
+ * unified first, while each one still carried an `Authorization: Bearer`
+ * header. The header is now gone, which is what makes the cookie the actual
+ * credential rather than a redundant second one.
  *
- * The cookie is *not* a fallback today, and that is worth being exact about:
- * Payload's `extractJWT` returns the first token it finds in `jwtOrder`
- * (`JWT`, `Bearer`, `cookie`) and `JWTAuthentication` verifies only that one.
- * A present-but-invalid Bearer fails outright rather than falling through to
- * the cookie. So while the header is sent these calls behave exactly as
- * before — the change is consistency, and it is what makes eventually dropping
- * the header a one-line change rather than an eight-file one.
+ * Both halves are asserted per client, because dropping the header is only
+ * safe where the cookie is genuinely being sent. A client that lost the header
+ * but kept `credentials: 'same-origin'` would authenticate as nobody.
  *
- * Every Payload client in the app is listed below, including the four that
- * were already correct, so the set is checkable by reading rather than by
- * remembering.
+ * Sending both would be worse than redundant. Payload's `extractJWT` returns
+ * the *first* credential it finds in `jwtOrder` (`JWT`, `Bearer`, `cookie`)
+ * and `JWTAuthentication` verifies only that one — so a stale header shadows a
+ * valid cookie and fails the request outright rather than falling through.
+ * That is not hypothetical: it is exactly the bug `logoutPayloadUser` already
+ * had to work around, and the one `requestSession` had until this change.
+ *
+ * Every Payload client in the app is listed below, so the set is checkable by
+ * reading rather than by remembering.
  */
 
 const fetchMock = vi.fn()
@@ -40,10 +42,23 @@ function jsonResponse(body: unknown = { docs: [] }): Response {
   } as Response
 }
 
-function lastCredentials(): RequestCredentials | undefined {
+function lastInit(): RequestInit | undefined {
   const calls = fetchMock.mock.calls
-  const init = calls[calls.length - 1]?.[1] as RequestInit | undefined
-  return init?.credentials
+  return calls[calls.length - 1]?.[1] as RequestInit | undefined
+}
+
+function lastCredentials(): RequestCredentials | undefined {
+  return lastInit()?.credentials
+}
+
+function lastAuthorization(): string | null {
+  return new Headers(lastInit()?.headers).get('Authorization')
+}
+
+/** The cookie is sent, and no header is there to shadow it. */
+function expectCookieIsTheOnlyCredential(): void {
+  expect(lastCredentials()).toBe('include')
+  expect(lastAuthorization()).toBeNull()
 }
 
 describe('Payload clients send the session cookie', () => {
@@ -58,15 +73,15 @@ describe('Payload clients send the session cookie', () => {
   })
 
   it('shared payloadRequest', async () => {
-    await payloadRequest('/api/articles', 'token')
+    await payloadRequest('/api/articles')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('shared payloadMutation', async () => {
-    await payloadMutation('/api/articles/1', 'PATCH', { title: 'x' }, 'token')
+    await payloadMutation('/api/articles/1', 'PATCH', { title: 'x' })
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('staff avatar upload', async () => {
@@ -74,7 +89,7 @@ describe('Payload clients send the session cookie', () => {
 
     await uploadAvatarAsset(new File(['x'], 'a.png'), 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('staff list', async () => {
@@ -82,7 +97,7 @@ describe('Payload clients send the session cookie', () => {
 
     await fetchStaffUsers('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('location documents', async () => {
@@ -90,19 +105,19 @@ describe('Payload clients send the session cookie', () => {
 
     await fetchMediaSetOptions('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('single-type listicles', async () => {
     await fetchListicles('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('listicle itineraries', async () => {
     await itineraryPayloadRequest('/api/itineraries', 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('location scope', async () => {
@@ -110,7 +125,7 @@ describe('Payload clients send the session cookie', () => {
 
     await getArticleLocationScope({ locationKey: 'lima', token: 'token' })
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('staging articles', async () => {
@@ -119,7 +134,7 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await fetchPayloadArticles('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('access permissions', async () => {
@@ -128,7 +143,7 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({}))
     await fetchAccessPermissions('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('homepage featured content', async () => {
@@ -138,7 +153,7 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await mainHomepageRequest('/api/pages', 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('location homepages', async () => {
@@ -148,7 +163,22 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await locationHomepageRequest('/api/pages', 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
+  })
+
+  it('session hydrate and renew', async () => {
+    const { hydratePayloadSession } = await import('../../features/auth/payload-auth-client')
+
+    fetchMock.mockResolvedValue(jsonResponse({ user: { id: 1, email: 'a@b.c' }, exp: 9e12 }))
+    await hydratePayloadSession({
+      token: 'stale-token',
+      expiresAt: Date.now() + 60_000,
+      user: { id: '1', email: 'a@b.c' },
+    })
+
+    // The stale in-memory token must not be offered even when one exists:
+    // `extractJWT` would take it in preference to the live cookie.
+    expectCookieIsTheOnlyCredential()
   })
 
   it('leaves the unauthenticated health check uncredentialed', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload/payload.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload/payload.api.ts
@@ -21,7 +21,7 @@ export async function fetchLocations(
     const queryParams = new URLSearchParams()
     queryParams.append('limit', String(limit))
     queryParams.append('page', String(params.page))
-    return payloadRequest(`/api/locations?${queryParams.toString()}`, token)
+    return payloadRequest(`/api/locations?${queryParams.toString()}`)
   }
 
   const allDocs: Location[] = []
@@ -36,7 +36,6 @@ export async function fetchLocations(
 
     const response = (await payloadRequest(
       `/api/locations?${queryParams.toString()}`,
-      token,
     )) as { docs: Location[]; totalDocs: number; totalPages: number }
 
     allDocs.push(...(response.docs || []))
@@ -55,7 +54,7 @@ export async function fetchArticleCategories(
   const queryParams = new URLSearchParams()
   queryParams.append('limit', String(params?.limit || 100))
   if (params?.status) queryParams.append('where[status][equals]', params.status)
-  return payloadRequest(`/api/article-categories?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/article-categories?${queryParams.toString()}`)
 }
 
 export async function fetchArticleTags(
@@ -65,7 +64,7 @@ export async function fetchArticleTags(
   const queryParams = new URLSearchParams()
   queryParams.append('limit', String(params?.limit || 100))
   if (params?.status) queryParams.append('where[status][equals]', params.status)
-  return payloadRequest(`/api/article-tags?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/article-tags?${queryParams.toString()}`)
 }
 
 export async function fetchMediaAssets(
@@ -105,7 +104,7 @@ export async function fetchMediaAssets(
     }
     return queryParams.toString()
   }
-  return payloadRequest(`/api/media-assets?${buildQuery(params?.page || 1)}`, token)
+  return payloadRequest(`/api/media-assets?${buildQuery(params?.page || 1)}`)
 }
 
 export async function fetchMediaSets(
@@ -138,7 +137,7 @@ export async function fetchMediaSets(
     queryParams.append('where[title][like]', params.search)
   }
 
-  return payloadRequest(`/api/media-sets?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/media-sets?${queryParams.toString()}`)
 }
 
 export async function fetchAuditMediaSets(
@@ -156,7 +155,7 @@ export async function fetchAuditMediaSets(
   queryParams.append('where[or][2][location][exists]', 'false')
   queryParams.append('where[or][3][title][exists]', 'false')
 
-  return payloadRequest(`/api/media-sets?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/media-sets?${queryParams.toString()}`)
 }
 
 export async function fetchOrphanMediaAssets(
@@ -170,7 +169,7 @@ export async function fetchOrphanMediaAssets(
   queryParams.append('sort', '-createdAt')
   queryParams.append('where[mediaSet][exists]', 'false')
 
-  return payloadRequest(`/api/media-assets?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/media-assets?${queryParams.toString()}`)
 }
 
 export async function updateMediaSet(
@@ -178,7 +177,7 @@ export async function updateMediaSet(
   patch: MediaSetPatch,
   token?: string,
 ): Promise<{ doc: MediaSet }> {
-  return payloadMutation(`/api/media-sets/${id}`, 'PATCH', patch, token)
+  return payloadMutation(`/api/media-sets/${id}`, 'PATCH', patch)
 }
 
 export async function updateMediaAsset(
@@ -186,5 +185,5 @@ export async function updateMediaAsset(
   patch: Partial<Pick<MediaAsset, 'alt_text' | 'photographer_credit' | 'location' | 'location_finalized' | 'tags'>>,
   token?: string,
 ): Promise<{ doc: MediaAsset }> {
-  return payloadMutation(`/api/media-assets/${id}`, 'PATCH', patch, token)
+  return payloadMutation(`/api/media-assets/${id}`, 'PATCH', patch)
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
@@ -69,7 +69,6 @@ async function payloadRequest<T>(endpoint: string, token: string): Promise<T> {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
 


### PR DESCRIPTION
Every Payload client sent both `credentials: 'include'` and an
`Authorization: Bearer` header. The header is now gone from all of them.

Sending both is worse than redundant. `extractJWT` returns the *first*
credential it finds in `jwtOrder` (JWT, Bearer, cookie) and
`JWTAuthentication` verifies only that one, so a stale header shadows a
perfectly good cookie and fails the request outright rather than falling
through to it. That is not hypothetical — it is the bug
`logoutPayloadUser` already had to work around, and PR #221 documented.

`requestSession` (session hydrate and renew) had exactly that bug
latent: it attached the in-memory token whenever one existed, so a
token that expired slightly before its cookie turned a renewable
session into a forced logout. Removing the header fixes it as a side
effect, which is why the renew path gets its own test here.

`shared/api/client/http.ts` loses its `token` parameters outright rather
than keeping them unused, because it is the shared entry point and a
dead credential argument there invites someone to start passing one
again. Its callers in `staff.api.ts` and `payload/payload.api.ts` are
updated. The per-feature clients keep their now-unused `token`
parameters for one more change: removing them reaches ~130 files and is
the sweep that also deletes `AuthState.token`.

`payload-credentials.test.ts` now asserts both halves per client — the
cookie is sent *and* no header is there to shadow it. Asserting only the
absence would pass for a client that authenticates as nobody.

The `/api/health` check keeps `credentials: 'omit'`: nothing to
authenticate, so nothing to send.

Note for deployment: Payload gates *cookie* auth on its `csrf` list, not
its `cors` list. This app's origin must be in `CORS_ALLOWED_ORIGINS` on
the questura side or every call here returns 401. `http://localhost:3003`
is already in questura's `DEV_ORIGINS`, so local development is covered.

abw frontend: 135 files / 640 tests pass (was 639; +1 for the renew
path). `tsc --noEmit`: exactly 7 errors, the unchanged pre-existing
baseline.

---

Fourth of the series, after #222, #223, #224. Independent of those in code — this branch touches only the Payload-facing clients — but it only *works* in a deployed environment once #222 has widened the cookie's `Domain`.

Remaining after this: the image clients' explicit token, then `AuthState.token` itself.

**Not deployed.**