### PR TITLE
feat(abw): image routes authenticate with the cookie too

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/api/mediaLibraryApi.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/api/mediaLibraryApi.ts
@@ -2,7 +2,6 @@ import { apiFetch } from '../../../shared/api/client/apiFetch'
 
 export async function generateAltTextFromUrl(
   imageUrl: string,
-  token: string,
   narrativeFocus?: string,
 ): Promise<string> {
   const formData = new FormData()
@@ -13,7 +12,6 @@ export async function generateAltTextFromUrl(
 
   const response = await apiFetch('/images/generate-alt-text-from-url', {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
     body: formData,
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/CompositeTab.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/CompositeTab.tsx
@@ -13,12 +13,12 @@ function HangingCompositesPanel({ token }: Props) {
   const queryClient = useQueryClient()
   const { data, isLoading, isError, refetch, isFetching } = useQuery({
     queryKey: ['hanging-composites'],
-    queryFn: () => fetchHangingComposites(token),
+    queryFn: () => fetchHangingComposites(),
     enabled: !!token,
   })
 
   const cleanup = useMutation({
-    mutationFn: (mediaSetIds: number[]) => cleanupHangingComposites(mediaSetIds, token),
+    mutationFn: (mediaSetIds: number[]) => cleanupHangingComposites(mediaSetIds),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['hanging-composites'] })
       queryClient.invalidateQueries({ queryKey: ['media-library'] })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/alt-text/generate-alt-text.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/alt-text/generate-alt-text.api.ts
@@ -23,7 +23,7 @@ export async function generateAltTextApi({
       formData.append('narrative_focus', narrativeFocus.trim());
     }
 
-    const response = await postFormData('/images/generate-alt-text', formData, undefined, controller.signal);
+    const response = await postFormData('/images/generate-alt-text', formData, controller.signal);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Alt text generation failed');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/build-edit-prompt.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/build-edit-prompt.api.ts
@@ -23,7 +23,7 @@ export async function buildEditPromptApi({
     formData.append('scene_description', sceneDescription);
     formData.append('change_request', changeRequest);
 
-    const response = await postFormData('/images/build-edit-prompt', formData, undefined, controller.signal);
+    const response = await postFormData('/images/build-edit-prompt', formData, controller.signal);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Edit prompt build failed');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/build-insert-prompt.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/build-insert-prompt.api.ts
@@ -36,7 +36,7 @@ export async function buildInsertPromptApi({
       formData.append('insert_descriptions', insert.description);
     });
 
-    const response = await postFormData('/images/build-insert-prompt', formData, undefined, controller.signal);
+    const response = await postFormData('/images/build-insert-prompt', formData, controller.signal);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Insert prompt build failed');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/client/imageApiClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/client/imageApiClient.ts
@@ -3,21 +3,23 @@ import { apiFetch } from '../../../api/client/apiFetch';
 
 export { API_URL };
 
+/**
+ * Requests to the AI Blog Writer backend's image routes.
+ *
+ * These used to take the caller's Payload JWT and send it as
+ * `Authorization: Bearer`, because the backend forwards it to Payload so that
+ * uploads are created as the acting Staff user. The backend now takes that same
+ * JWT from the httpOnly `payload-token` cookie instead, which `apiFetch` sends
+ * on every request — so there is nothing for a caller to hold or pass.
+ */
+
 export async function postFormData(
   path: string,
   formData: FormData,
-  token?: string,
   signal?: AbortSignal,
 ): Promise<Response> {
-  const headers: Record<string, string> = {};
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   return apiFetch(path, {
     method: 'POST',
-    headers,
     body: formData,
     signal,
   });
@@ -26,20 +28,13 @@ export async function postFormData(
 export async function postJson<TBody extends Record<string, unknown>>(
   path: string,
   body: TBody,
-  token?: string
 ): Promise<Response> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-  };
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   return apiFetch(path, {
     method: 'POST',
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
     body: JSON.stringify(body),
   });
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/composites/composite-image.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/composites/composite-image.api.ts
@@ -41,14 +41,12 @@ async function parseCompositeError(response: Response, fallback: string): Promis
 
 export async function previewCompositeImage(
   request: CompositeImageRequest,
-  token: string,
 ): Promise<{ blob: Blob; warnings: string[] }> {
   const response = await apiFetch('/images/composites/preview', {
     method: 'POST',
     headers: {
       Accept: 'image/webp',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(request),
   })
@@ -85,12 +83,11 @@ export type CleanupCompositesResponse = {
   deletedCount: number
 }
 
-export async function fetchHangingComposites(token: string): Promise<HangingCompositesResponse> {
+export async function fetchHangingComposites(): Promise<HangingCompositesResponse> {
   const response = await apiFetch('/images/composites/hanging', {
     method: 'GET',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
   if (!response.ok) {
@@ -101,14 +98,12 @@ export async function fetchHangingComposites(token: string): Promise<HangingComp
 
 export async function cleanupHangingComposites(
   mediaSetIds: number[],
-  token: string,
 ): Promise<CleanupCompositesResponse> {
   const response = await apiFetch('/images/composites/cleanup', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ mediaSetIds }),
   })
@@ -120,14 +115,12 @@ export async function cleanupHangingComposites(
 
 export async function createCompositeImage(
   request: CompositeImageRequest,
-  token: string,
 ): Promise<CompositeImageCreateResponse> {
   const response = await apiFetch('/images/composites/create', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(request),
   })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/describe-scene.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/describe-scene.api.ts
@@ -11,7 +11,7 @@ export async function describeSceneApi(file: File): Promise<string> {
     const formData = new FormData();
     formData.append('file', file);
 
-    const response = await postFormData('/images/describe-scene', formData, undefined, controller.signal);
+    const response = await postFormData('/images/describe-scene', formData, controller.signal);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Scene description failed');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/describe-subject.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/describe-subject.api.ts
@@ -11,7 +11,7 @@ export async function describeSubjectApi(file: File): Promise<string> {
     const formData = new FormData();
     formData.append('file', file);
 
-    const response = await postFormData('/images/describe-subject', formData, undefined, controller.signal);
+    const response = await postFormData('/images/describe-subject', formData, controller.signal);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Subject description failed');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux-edit.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux-edit.api.ts
@@ -73,7 +73,7 @@ export async function fluxEditApi({
   }
 
   try {
-    const response = await postFormData('/images/flux-edit', formData, token);
+    const response = await postFormData('/images/flux-edit', formData);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Failed to generate image with FLUX.2');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/generate-social-image.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/generate-social-image.api.ts
@@ -17,7 +17,6 @@ export async function generateSocialImageApi({
     const response = await postJson(
       '/images/generate-social-image',
       { featuredAssetId, featuredMediaSetId },
-      token,
     );
 
     if (!response.ok) {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/image-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/image-credentials.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { postFormData, postJson } from './client/imageApiClient'
+
+/**
+ * The image routes are the last backend calls that held a token in JavaScript.
+ *
+ * They are not ordinary API calls: the backend forwards the caller's own
+ * Payload JWT so that uploads are created as the acting Staff user rather than
+ * a service account. That delegation is why an explicit token was threaded
+ * through every one of them, and why they outlived the switch to cookie auth
+ * everywhere else.
+ *
+ * The delegation still happens — the backend now reads the same JWT out of the
+ * `payload-token` cookie instead of a header, so the value it forwards is
+ * unchanged. What is gone is any need for the browser to hold a readable copy.
+ *
+ * Both halves are asserted: the cookie goes, and no header follows it. A
+ * client that dropped the header without sending the cookie would upload as
+ * nobody, and the backend would answer 401 rather than doing something unsafe
+ * — but it would still be broken.
+ */
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function lastInit(): RequestInit {
+  const calls = fetchMock.mock.calls
+  return calls[calls.length - 1]?.[1] as RequestInit
+}
+
+function expectCookieIsTheOnlyCredential(): void {
+  expect(lastInit().credentials).toBe('include')
+  expect(new Headers(lastInit().headers).get('Authorization')).toBeNull()
+}
+
+describe('image routes authenticate with the session cookie', () => {
+  it('postFormData', async () => {
+    const body = new FormData()
+    body.append('file', new Blob(['x']), 'x.png')
+
+    await postFormData('/images/upload', body)
+
+    expectCookieIsTheOnlyCredential()
+  })
+
+  it('postJson', async () => {
+    await postJson('/images/generate-social-image', { featuredAssetId: 1 })
+
+    expectCookieIsTheOnlyCredential()
+  })
+
+  it('keeps the abort signal working now that it has moved up a slot', async () => {
+    const controller = new AbortController()
+    const body = new FormData()
+
+    await postFormData('/images/describe-scene', body, controller.signal)
+
+    expect(lastInit().signal).toBe(controller.signal)
+  })
+
+  it('still lets multipart requests set their own boundary', async () => {
+    const body = new FormData()
+    body.append('file', new Blob(['x']), 'x.png')
+
+    await postFormData('/images/upload', body)
+
+    expect(new Headers(lastInit().headers).get('Content-Type')).toBeNull()
+  })
+
+  it('composite preview sends the cookie and no header', async () => {
+    const { previewCompositeImage } = await import('./composites/composite-image.api')
+
+    fetchMock.mockResolvedValue(
+      new Response(new Blob(['x']), {
+        status: 200,
+        headers: { 'X-Composite-Warnings': '[]' },
+      }),
+    )
+    await previewCompositeImage({
+      layout: 'four-up',
+      sources: [],
+      title: 't',
+      altText: 'a',
+      photographerCredit: 'c',
+      locationRef: 1,
+    } as Parameters<typeof previewCompositeImage>[0])
+
+    expectCookieIsTheOnlyCredential()
+  })
+
+  it('hanging-composite listing sends the cookie and no header', async () => {
+    const { fetchHangingComposites } = await import('./composites/composite-image.api')
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ mediaSets: [] }), { status: 200 }),
+    )
+    await fetchHangingComposites()
+
+    expectCookieIsTheOnlyCredential()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/upload-social-image.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/upload-social-image.api.ts
@@ -24,7 +24,7 @@ export async function uploadSocialImageApi({
     formData.append('photographer_credit', photographerCredit.trim());
     formData.append('location_ref', String(locationRef));
 
-    const response = await postFormData('/images/upload-social-image', formData, token);
+    const response = await postFormData('/images/upload-social-image', formData);
 
     if (!response.ok) {
       const message = await parseErrorMessage(response, 'Failed to upload social image');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-single.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-single.api.ts
@@ -41,7 +41,7 @@ export async function uploadSingleApi({
       message: 'Uploading to server...',
     });
 
-    const response = await postFormData('/images/upload', formData, token);
+    const response = await postFormData('/images/upload', formData);
 
     onProgress?.({
       status: 'processing',

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-variants.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-variants.api.ts
@@ -89,7 +89,7 @@ export async function uploadVariantsApi({
   });
 
   try {
-    const response = await postFormData('/images/upload-variants', formData, token);
+    const response = await postFormData('/images/upload-variants', formData);
 
     onProgress?.({
       status: 'processing',

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/CompositeImageModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/CompositeImageModal.tsx
@@ -106,7 +106,7 @@ export function CompositeImageModal({
     resetPreview()
     setIsPreviewing(true)
     try {
-      const result = await previewCompositeImage(request, token)
+      const result = await previewCompositeImage(request)
       setPreviewUrl(URL.createObjectURL(result.blob))
       setWarnings(result.warnings)
     } catch (err) {
@@ -120,7 +120,7 @@ export function CompositeImageModal({
     setIsCreating(true)
     setError(null)
     try {
-      const response = await createCompositeImage(request, token)
+      const response = await createCompositeImage(request)
       onCreated?.(response)
       onClose()
     } catch (err) {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/external/external-images.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/external/external-images.api.ts
@@ -82,7 +82,6 @@ export async function searchUnsplashImages(
 
 export async function importExternalImage(
   input: ImportExternalImageRequest,
-  token: string,
 ): Promise<ImportExternalImageResponse> {
   const normalizedSourceUrl = input.sourceUrl.trim()
   if (!normalizedSourceUrl) {
@@ -103,7 +102,6 @@ export async function importExternalImage(
   const response = await apiFetch('/images/import-external', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${token}`,
     },
     body: formData,
   })
@@ -118,7 +116,6 @@ export async function importExternalImage(
 
 export async function fetchExternalImageSource(
   input: FetchExternalImageSourceRequest,
-  token: string,
 ): Promise<FetchExternalImageSourceResponse> {
   const normalizedSourceUrl = input.sourceUrl.trim()
   if (!normalizedSourceUrl) {
@@ -137,7 +134,6 @@ export async function fetchExternalImageSource(
     {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${token}`,
       },
     },
   )

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useExternalImageImport.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useExternalImageImport.ts
@@ -115,7 +115,7 @@ export function useExternalImageImport({
       const fileNamePrefix = buildImageFileNamePrefix(fileNameTitle, externalRef)
 
       try {
-        const source = await fetchExternalImageSource({ sourceUrl, provider, photoId: photo.id }, token)
+        const source = await fetchExternalImageSource({ sourceUrl, provider, photoId: photo.id })
         const file = new File([source.blob], source.fileName, {
           type: source.contentType || source.blob.type || 'image/jpeg',
         })


### PR DESCRIPTION
The image routes were the last backend calls holding a token in
JavaScript. They are not ordinary API calls: the backend forwards the
caller's own Payload JWT so uploads are created as the acting Staff user
rather than a service account. That delegation is why an explicit token
was threaded through all of them, and why they outlived the switch to
cookie auth everywhere else.

The delegation is unchanged — the backend now reads the same JWT out of
the `payload-token` cookie instead of a header, so the value it forwards
to Payload is identical. What is gone is any need for the browser to hold
a readable copy.

`postFormData` and `postJson` lose their `token` parameter, which moves
`signal` up a slot. That is a silent-corruption hazard rather than a
compile error waiting to happen — a token string landing in an
`AbortSignal` position — so it is worth saying that TypeScript caught
every one: `Argument of type 'string' is not assignable to parameter of
type 'AbortSignal'` at four call sites. Nothing here relied on
positional luck.

Also removed from `composite-image.api.ts`, `external-images.api.ts` and
`mediaLibraryApi.ts`, plus their direct callers in `CompositeTab`,
`CompositeImageModal` and `useExternalImageImport`.

`image-credentials.test.ts` mirrors `payload-credentials.test.ts`:
per-client, the cookie is sent *and* no header follows it. A client that
dropped the header without sending the cookie would upload as nobody;
asserting only the absence would call that a pass.

Branched on #224 rather than `main` on purpose. Without `apiFetch`
sending `credentials: 'include'`, these calls would carry no credential
at all — so this must not merge first.

abw frontend: 136 files / 643 tests pass (was 639; +6 new, and the
existing suite unchanged). `tsc --noEmit`: exactly 7 errors, the
unchanged pre-existing baseline.

---

Fifth of the series. **Based on #224, not `main`** — merge that first, or this ships image calls with no credential at all.

Remaining after this: `AuthState.token` itself, plus the ~130 files of now-dead `token` parameters.

**Not deployed.**