### PR TITLE
feat(abw): remove the Staff token from JavaScript entirely

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -29,6 +29,14 @@ ABW_API_KEY=
 # With ABW_API_KEY unset (local development): empty means wildcard (*),
 # which also disables credentialed CORS.
 #
+# Pin this in local development too if you want the frontend to authenticate
+# with the payload-token session cookie rather than a Bearer header. A wildcard
+# forces allow_credentials=False, so the browser never sends the cookie, and
+# this list is also what the CSRF check validates the Origin against — cookie
+# auth is refused outright under a wildcard. The writer's dev server is pinned
+# to port 3003 in apps/frontend/vite.config.ts:
+#   ABW_ALLOWED_ORIGINS=http://localhost:3003
+#
 # With ABW_API_KEY set: REQUIRED. The backend refuses to start rather than
 # serve a wildcard origin policy on a deployed instance. If the instance has
 # no browser client at all (server-to-server, or a frontend served
@@ -37,8 +45,9 @@ ABW_API_KEY=
 ABW_ALLOWED_ORIGINS=
 
 # Require a valid Payload staff session on the costliest and most destructive
-# routes. Verified by asking Payload who the bearer token belongs to, so a
-# disabled account is rejected immediately.
+# routes. The session arrives as the httpOnly payload-token cookie or as an
+# Authorization: Bearer header, and is verified by asking Payload who it
+# belongs to, so a disabled account is rejected immediately.
 #
 # Covered: pipeline starts (youtube2blog/from-url, prompt2blog/run, both
 # pipeline-v2 routes), run expansion, itinerary generation and title

--- a/apps/ai-blog-writer/apps/backend/app/core/cors.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/cors.py
@@ -1,0 +1,85 @@
+"""The pinned browser-origin allowlist.
+
+Extracted from `app.main` so that request-authentication code can consult the
+same list without importing the application module (which builds the FastAPI
+app and loads `.env` at import time). `app.main` re-exports these names, so the
+historical import paths keep working.
+
+This one list now decides two things: which origins CORS answers, and which
+origins may authenticate with the `payload-token` cookie (see
+`app.core.staff_token`). Widening it widens both.
+"""
+
+import os
+
+CORS_DENY_ALL = "none"
+
+
+def resolve_cors_origins(api_key: str, raw_origins: str) -> list[str]:
+    """Resolve the CORS allow-list, refusing a wildcard on deployed instances.
+
+    A configured ABW_API_KEY is the signal that this instance is reachable
+    beyond localhost. Wildcard CORS there is incoherent: it forces
+    `allow_credentials=False`, and the X-API-Key header makes every request
+    preflighted, so any page could probe the API. Refuse to start instead of
+    serving an open origin policy.
+
+    An instance with no browser client at all (server-to-server, or a frontend
+    served same-origin behind a proxy) sets ABW_ALLOWED_ORIGINS=none to say so
+    explicitly. That is a deny-all list, not an oversight.
+
+    With no key configured (local development) the historical behavior is
+    kept exactly: wildcard when the variable is unset, otherwise whatever
+    parses out of it. Note that a wildcard also disables cookie authentication,
+    so local development that exercises the session cookie has to pin its
+    origins — see `app.core.staff_token`.
+    """
+    raw = raw_origins.strip()
+
+    if raw.lower() == CORS_DENY_ALL:
+        return []
+
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+    if not api_key.strip():
+        # Emptiness is judged on the raw string, not the parsed list, so a
+        # malformed value like "," keeps denying all origins rather than
+        # silently widening to a wildcard.
+        return ["*"] if not raw else origins
+
+    if not origins or "*" in origins:
+        raise ValueError(
+            "ABW_ALLOWED_ORIGINS must list explicit origins when ABW_API_KEY "
+            "is set; wildcard CORS is not allowed on a deployed instance. "
+            f"Set ABW_ALLOWED_ORIGINS={CORS_DENY_ALL} if this instance has no "
+            "browser client."
+        )
+
+    return origins
+
+
+def resolve_cors_config(
+    api_key: str, raw_origins: str
+) -> tuple[list[str], "ValueError | None"]:
+    """Pair the resolved origins with any rejection, without raising.
+
+    A rejected policy yields a deny-all list so the middleware fails closed,
+    plus the error for `lifespan` to refuse the boot with. Import stays safe
+    either way.
+    """
+    try:
+        return resolve_cors_origins(api_key, raw_origins), None
+    except ValueError as exc:
+        return [], exc
+
+
+def allowed_origins() -> list[str]:
+    """Read the CORS policy from the environment. See resolve_cors_origins.
+
+    Read per call rather than cached, so a test that stubs the environment
+    sees its own policy without reimporting the application module.
+    """
+    return resolve_cors_origins(
+        api_key=os.getenv("ABW_API_KEY", ""),
+        raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
+    )

--- a/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/staff_auth.py
@@ -17,9 +17,10 @@ import os
 from typing import Any, Optional
 
 import httpx
-from fastapi import Depends, Header, HTTPException
+from fastapi import Depends, HTTPException
 
 from app.core.payload_api import resolve_payload_api_url
+from app.core.staff_token import extract_bearer_token, staff_token
 
 logger = logging.getLogger(__name__)
 
@@ -39,16 +40,18 @@ def staff_auth_required() -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
-    """Pull the token out of an `Authorization: Bearer <token>` header."""
-    if not authorization:
-        return None
-
-    scheme, _, token = authorization.partition(" ")
-    if scheme.strip().lower() != "bearer":
-        return None
-
-    return token.strip() or None
+# Re-exported: this was defined here before the cookie became a second source
+# of the same token, and callers and tests still import it from this module.
+__all__ = [
+    "STAFF_AUTH_FLAG",
+    "authorize_article_deletion",
+    "extract_bearer_token",
+    "fetch_payload_user",
+    "require_editor",
+    "require_staff",
+    "staff_auth_required",
+    "staff_user_id",
+]
 
 
 async def fetch_payload_user(
@@ -83,21 +86,27 @@ async def fetch_payload_user(
 
 
 async def require_staff(
-    authorization: Optional[str] = Header(default=None),
+    token: Optional[str] = Depends(staff_token),
 ) -> Optional[dict[str, Any]]:
     """FastAPI dependency requiring a valid Payload staff session.
 
     Returns the user so routes can log or authorize further. Returns None when
     the flag is off, in which case nothing is checked.
+
+    The token may arrive as an `Authorization: Bearer` header or as the
+    `payload-token` session cookie; `app.core.staff_token` decides which is
+    acceptable and enforces the origin check the cookie needs.
     """
     if not staff_auth_required():
         return None
 
-    token = extract_bearer_token(authorization)
     if not token:
         raise HTTPException(
             status_code=401,
-            detail="Authorization header with a Bearer token is required",
+            detail=(
+                "A staff session is required: send the payload-token cookie or "
+                "an Authorization: Bearer header"
+            ),
         )
 
     # Resolve through the same helper every other Payload caller uses, so a

--- a/apps/ai-blog-writer/apps/backend/app/core/staff_token.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/staff_token.py
@@ -1,0 +1,151 @@
+"""Where the Payload staff token comes from, and what makes it trustworthy.
+
+Historically this backend only read `Authorization: Bearer <token>`, which
+forced the frontend to hold a readable copy of a privileged Staff credential in
+JavaScript. Payload already sets the same JWT as the `httpOnly` `payload-token`
+cookie, and once Payload and this backend are siblings under one registrable
+domain that cookie reaches us on its own (ADR-0028).
+
+Reading it changes the threat model. A header has to be attached deliberately
+by script, so a cross-site page cannot forge one. A cookie is attached by the
+browser on *any* request to this origin, including one triggered by a page the
+operator did not intend to visit. Accepting the cookie therefore opens a CSRF
+surface that has to be closed here, explicitly.
+
+It is **not** closed by `X-API-Key`. That key is inlined into the Vite bundle
+and is public; forcing a preflight with a header any attacker can also send is
+not an authorization check. The check is the `Origin` header, validated against
+the same pinned allowlist that CORS uses.
+"""
+
+from typing import Iterable, Optional
+
+from fastapi import Cookie, Header, HTTPException, Request
+
+from app.core.cors import allowed_origins
+
+PAYLOAD_TOKEN_COOKIE = "payload-token"
+
+# Methods that cannot change state. A cross-site page can cause these to be
+# sent, but CORS stops it reading the response.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+class StaffTokenRejected(Exception):
+    """A token was present but the request was not allowed to use it."""
+
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+def extract_bearer_token(authorization: Optional[str]) -> Optional[str]:
+    """Pull the token out of an `Authorization: Bearer <token>` header."""
+    if not authorization:
+        return None
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.strip().lower() != "bearer":
+        return None
+
+    return token.strip() or None
+
+
+def _origin_is_trusted(origin: Optional[str], allowed_origins: Iterable[str]) -> bool:
+    allowed = list(allowed_origins)
+
+    # A wildcard cannot authorize a credentialed request: it would mean
+    # trusting every site on the internet with the operator's session. It is
+    # also the local-development default, so refusing here is what tells an
+    # operator to pin ABW_ALLOWED_ORIGINS rather than leaving cookie auth
+    # quietly unprotected. CORSMiddleware already drops
+    # `Access-Control-Allow-Credentials` under a wildcard for the same reason.
+    if "*" in allowed:
+        return False
+
+    if not origin:
+        return False
+
+    return origin.rstrip("/") in {candidate.rstrip("/") for candidate in allowed}
+
+
+def resolve_staff_token(
+    *,
+    authorization: Optional[str],
+    cookie_token: Optional[str],
+    method: str,
+    origin: Optional[str],
+    allowed_origins: Iterable[str],
+) -> Optional[str]:
+    """Resolve the caller's staff token from the header or the session cookie.
+
+    The header wins when both are present. It is the older contract, it is
+    unambiguous, and — unlike the cookie — it cannot have been attached by a
+    page the operator did not mean to load, so it needs no origin check.
+
+    A cookie-borne token on a state-changing request must come from an
+    allowlisted origin. Raises `StaffTokenRejected` when it does not, rather
+    than falling through to "no token": the difference between "you are not
+    signed in" and "this request was not allowed to use your session" is worth
+    keeping, and silently treating a blocked CSRF attempt as anonymous would
+    hide it from the logs.
+    """
+    header_token = extract_bearer_token(authorization)
+    if header_token:
+        return header_token
+
+    if not cookie_token:
+        return None
+
+    normalized_method = method.upper()
+
+    # Safe methods are checked only when the browser tells us where the request
+    # came from. Same-origin GETs legitimately omit `Origin` in some browsers,
+    # so requiring it would break a same-origin proxy deployment for no gain:
+    # CORS already stops a cross-site page reading the response.
+    if normalized_method in SAFE_METHODS and origin is None:
+        return cookie_token
+
+    if not _origin_is_trusted(origin, allowed_origins):
+        raise StaffTokenRejected(
+            status_code=403,
+            message=(
+                "Cookie-authenticated requests must come from an allowlisted "
+                "origin. Set ABW_ALLOWED_ORIGINS to the exact origins that serve "
+                "the writer UI; a wildcard cannot authorize a credentialed "
+                "request."
+            ),
+        )
+
+    return cookie_token
+
+
+async def staff_token(
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+    payload_token: Optional[str] = Cookie(default=None, alias=PAYLOAD_TOKEN_COOKIE),
+) -> Optional[str]:
+    """FastAPI dependency yielding the caller's staff token, or None.
+
+    Kept optional so each caller keeps its own "missing credential" behavior:
+    the image routes answer with a structured error carrying a `step`, while
+    `require_staff` answers with a plain detail string, and a route running with
+    staff enforcement off needs no token at all.
+    """
+    try:
+        return resolve_staff_token(
+            authorization=authorization,
+            cookie_token=payload_token,
+            method=request.method,
+            origin=request.headers.get("origin"),
+            allowed_origins=allowed_origins(),
+        )
+    except StaffTokenRejected as rejected:
+        # A refused origin is reported the same way whichever route asked, so a
+        # blocked cross-site attempt reads identically in every log line. The
+        # per-route error shapes cover a *missing* credential, which is a
+        # different answer.
+        raise HTTPException(
+            status_code=rejected.status_code, detail=rejected.message
+        ) from rejected

--- a/apps/ai-blog-writer/apps/backend/app/features/images/auth.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/auth.py
@@ -1,12 +1,28 @@
-"""Authentication header validation for image routes."""
+"""Caller credential resolution for image routes.
+
+These routes forward the caller's own Payload JWT so that uploads are created
+as the acting Staff user rather than a service account. The token reaches us
+either as an `Authorization: Bearer` header or as the `payload-token` session
+cookie — `app.core.staff_token` owns that choice and the origin check the
+cookie requires. This module only turns "no credential" into the structured,
+`step`-carrying error shape the image API has always returned.
+"""
 
 from typing import Optional
+
+from fastapi import Depends
+
+from app.core.staff_token import staff_token
 
 from .errors import _raise_http_error
 
 
 def _extract_bearer_token(authorization: Optional[str]) -> str:
-    """Extract and validate the JWT from the Authorization header."""
+    """Extract and validate the JWT from the Authorization header.
+
+    Retained for callers that hold a raw header string. Routes take
+    `require_image_token` instead, which also accepts the session cookie.
+    """
     if not authorization or not authorization.startswith('Bearer '):
         _raise_http_error(
             status_code=401,
@@ -17,5 +33,19 @@ def _extract_bearer_token(authorization: Optional[str]) -> str:
     if not token:
         _raise_http_error(
             status_code=401, message='Bearer token is empty', step='validate_auth'
+        )
+    return token
+
+
+async def require_image_token(token: Optional[str] = Depends(staff_token)) -> str:
+    """Require a staff credential from either the header or the session cookie."""
+    if not token:
+        _raise_http_error(
+            status_code=401,
+            message=(
+                'A staff session is required: send the payload-token cookie or '
+                'an Authorization: Bearer header'
+            ),
+            step='validate_auth',
         )
     return token

--- a/apps/ai-blog-writer/apps/backend/app/features/images/composites/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/composites/routes.py
@@ -5,18 +5,18 @@ import json
 import time
 from typing import Optional
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse, Response
 
 from ..image_processor import ImageVariantType, ProcessedVariant
 from ..payload_client import PayloadClient, PayloadUploadError
 from ..shared import (
-    _extract_bearer_token,
     _raise_http_error,
     _status_from_payload_error,
     _validate_location_ref,
     _validate_photographer_credit,
     logger,
+    require_image_token,
 )
 from .cleanup import (  # noqa: F401
     _find_hanging_composites as _find_hanging_composites,
@@ -84,10 +84,9 @@ async def _upload_variant_with_retry(
 
 
 async def _prepare(
-    request: CompositeRequest, authorization: Optional[str]
-) -> tuple[str, Optional[int], str, list[SourceImage], list[str]]:
+    request: CompositeRequest, jwt_token: str
+) -> tuple[Optional[int], str, list[SourceImage], list[str]]:
     _validate_request_shape(request)
-    jwt_token = _extract_bearer_token(authorization)
     location_ref = _validate_location_ref(request.locationRef)
     photographer_credit = _validate_photographer_credit(
         request.photographerCredit or 'Questurian Composite'
@@ -98,15 +97,15 @@ async def _prepare(
         jwt_token=jwt_token,
         source_ids=[source.mediaSetId for source in request.sources],
     )
-    return (jwt_token, location_ref, photographer_credit, sources, _warnings(sources))
+    return (location_ref, photographer_credit, sources, _warnings(sources))
 
 
 @router.post('/preview')
 async def preview_composite(
-    request: CompositeRequest, authorization: Optional[str] = Header(None)
+    request: CompositeRequest, jwt_token: str = Depends(require_image_token)
 ) -> Response:
     try:
-        _, _, _, sources, warnings = await _prepare(request, authorization)
+        _, _, sources, warnings = await _prepare(request, jwt_token)
     except PayloadUploadError as exc:
         logger.exception('Payload error during /images/composites/preview')
         _raise_http_error(
@@ -131,11 +130,11 @@ async def preview_composite(
 
 @router.post('/create')
 async def create_composite(
-    request: CompositeRequest, authorization: Optional[str] = Header(None)
+    request: CompositeRequest, jwt_token: str = Depends(require_image_token)
 ) -> JSONResponse:
     try:
-        jwt_token, location_ref, photographer_credit, sources, warnings = (
-            await _prepare(request, authorization)
+        location_ref, photographer_credit, sources, warnings = await _prepare(
+            request, jwt_token
         )
     except PayloadUploadError as exc:
         logger.exception('Payload error during /images/composites/create prepare')
@@ -200,10 +199,9 @@ async def create_composite(
 
 @router.get('/hanging')
 async def list_hanging_composites(
-    authorization: Optional[str] = Header(None), min_age_minutes: float = 5.0
+    jwt_token: str = Depends(require_image_token), min_age_minutes: float = 5.0
 ) -> JSONResponse:
     """List composite MediaSets left incomplete by a failed upload."""
-    jwt_token = _extract_bearer_token(authorization)
     client = PayloadClient(jwt_token)
     try:
         hanging = await _find_hanging_composites(
@@ -223,14 +221,13 @@ async def list_hanging_composites(
 
 @router.post('/cleanup')
 async def cleanup_hanging_composites(
-    request: HangingCleanupRequest, authorization: Optional[str] = Header(None)
+    request: HangingCleanupRequest, jwt_token: str = Depends(require_image_token)
 ) -> JSONResponse:
     """Delete the given hanging composite MediaSets and their variant assets.
 
     Only sets that are genuinely hanging (composite-prefixed and below the full
     variant count) are removed — a guard against deleting a healthy MediaSet.
     """
-    jwt_token = _extract_bearer_token(authorization)
     client = PayloadClient(jwt_token)
     try:
         hanging = await _find_hanging_composites(client=client, min_age_minutes=0.0)

--- a/apps/ai-blog-writer/apps/backend/app/features/images/flux/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/flux/routes.py
@@ -3,14 +3,13 @@
 import re
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, File, Form, Header, UploadFile
+from fastapi import APIRouter, Depends, File, Form, UploadFile
 from fastapi.responses import Response
 
 from app.core.staff_auth import require_staff
 
 from ..bfl_client import BflApiError, BflClient
 from ..shared import (
-    _extract_bearer_token,
     _raise_http_error,
     _read_additional_reference_images,
     _read_upload_file,
@@ -20,6 +19,7 @@ from ..shared import (
     _validate_flux_prompt,
     _validate_flux_safety_tolerance,
     logger,
+    require_image_token,
 )
 
 router = APIRouter()
@@ -60,10 +60,9 @@ async def flux_edit_image(
         None,
         description="Optional generation seed for reproducibility",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> Response:
     """Proxy a FLUX.2 edit request with optional multi-reference inputs."""
-    _extract_bearer_token(authorization)
     valid_prompt = _validate_flux_prompt(prompt)
     valid_model_id = _validate_flux_model_id(model_id)
     valid_width, valid_height = _validate_flux_dimensions(width, height)

--- a/apps/ai-blog-writer/apps/backend/app/features/images/shared.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/shared.py
@@ -2,7 +2,10 @@
 
 import logging
 
-from .auth import _extract_bearer_token as _extract_bearer_token  # noqa: F401
+from .auth import (  # noqa: F401
+    _extract_bearer_token as _extract_bearer_token,
+    require_image_token as require_image_token,
+)
 from .errors import (  # noqa: F401
     _build_error_detail as _build_error_detail,
     _raise_http_error as _raise_http_error,

--- a/apps/ai-blog-writer/apps/backend/app/features/images/social/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/social/routes.py
@@ -4,7 +4,7 @@ import re
 import time
 from typing import Optional
 
-from fastapi import APIRouter, File, Form, Header, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 
 from ..image_processor import ImageVariantType, VARIANT_SPECS, process_single_variant
@@ -12,7 +12,6 @@ from ..payload_client import PayloadClient, PayloadUploadError
 from ..schemas import GenerateSocialImageRequest
 from ..shared import (
     _download_media_asset_file,
-    _extract_bearer_token,
     _raise_http_error,
     _read_upload_file,
     _select_social_source_asset,
@@ -22,6 +21,7 @@ from ..shared import (
     _validate_photographer_credit,
     _wait_for_bunny_original_url,
     logger,
+    require_image_token,
 )
 
 router = APIRouter()
@@ -30,7 +30,7 @@ router = APIRouter()
 @router.post("/generate-social-image")
 async def generate_social_image(
     request: GenerateSocialImageRequest,
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Regenerate the open_graph (1200x630) variant from the featured image.
@@ -42,7 +42,6 @@ async def generate_social_image(
 
     Returns the generated asset bunny_original_url for strict SEO social image usage.
     """
-    jwt_token = _extract_bearer_token(authorization)
     featured_asset_id = request.featuredAssetId
     featured_media_set_id = request.featuredMediaSetId
     if featured_media_set_id is not None:
@@ -204,7 +203,7 @@ async def upload_social_image(
         ...,
         description="Payload location id to attach to uploaded image",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Upload one social image for OG/Twitter usage only.
@@ -212,7 +211,6 @@ async def upload_social_image(
     This endpoint processes the source into a single open_graph (1200x630) variant
     and uploads it directly without creating/updating a media set.
     """
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     valid_alt_text = _validate_alt_text(alt_text)

--- a/apps/ai-blog-writer/apps/backend/app/features/images/uploads/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/images/uploads/routes.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, File, Form, Header, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, Response
 
 from ..image_processor import ImageVariantType, ProcessedVariant, process_image_variants
@@ -14,7 +14,6 @@ from ..shared import (
     VARIANT_DIMENSIONS,
     _derive_external_filename,
     _download_external_image,
-    _extract_bearer_token,
     _normalize_tag_name,
     _parse_tag_ids,
     _raise_http_error,
@@ -26,6 +25,7 @@ from ..shared import (
     _validate_photographer_credit,
     _validate_variant_types,
     logger,
+    require_image_token,
 )
 
 router = APIRouter()
@@ -34,10 +34,9 @@ router = APIRouter()
 @router.post("/tags/resolve")
 async def resolve_tags(
     request: ResolveTagsRequest,
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ):
     """Find or create tags by name. Returns IDs for all provided names."""
-    jwt_token = _extract_bearer_token(authorization)
     client = PayloadClient(jwt_token)
 
     results = []
@@ -70,7 +69,7 @@ async def upload_image(
         ...,
         description="Payload location id to attach to uploaded images",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Upload an image and process it into all required variants server-side.
@@ -82,7 +81,6 @@ async def upload_image(
     3. Uploaded to Payload CMS as media-assets
     4. Linked in a new MediaSet
     """
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     content = await _read_upload_file(file, step="validate_file")
@@ -172,10 +170,9 @@ async def import_external_image(
         None,
         description="Provider photo identifier for filename stability",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """Import an external provider image and upload processed variants to Payload."""
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     valid_provider = _validate_external_provider(provider)
@@ -267,10 +264,9 @@ async def fetch_external_image_source(
     source_url: str,
     provider: str,
     photo_id: Optional[str] = None,
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> Response:
     """Download a validated external image and return raw bytes for client-side cropping."""
-    _extract_bearer_token(authorization)
     valid_provider = _validate_external_provider(provider)
     valid_source_url = _validate_external_source_url(source_url, valid_provider)
     original_filename = _derive_external_filename(
@@ -317,7 +313,7 @@ async def upload_image_variants(
         None,
         description="JSON-encoded list of integer tag IDs, e.g. '[1,2,3]'",
     ),
-    authorization: Optional[str] = Header(None),
+    jwt_token: str = Depends(require_image_token),
 ) -> JSONResponse:
     """
     Upload pre-processed image variants (client-side cropped) to Payload CMS.
@@ -326,7 +322,6 @@ async def upload_image_variants(
     1. Uploads each to Payload CMS as media-assets
     2. Creates or reuses a MediaSet linking all variants
     """
-    jwt_token = _extract_bearer_token(authorization)
     valid_location_ref = _validate_location_ref(location_ref)
     valid_photographer_credit = _validate_photographer_credit(photographer_credit)
     tag_ids = _parse_tag_ids(tags)

--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from app.core.staff_auth import require_staff
+from app.core.staff_token import staff_token
 from app.shared.writer_invocation import invoke_writer_model
 
 from .day_shells import BUILT_IN_DAY_SHELL_IDS
@@ -141,13 +142,29 @@ async def remove_day_shell(shell_id: str) -> dict[str, bool]:
 )
 async def generate_itinerary(
     request: GenerateItineraryRequest,
+    session_token: str | None = Depends(staff_token),
 ) -> GenerateItineraryResponse:
     """Itinerary Autobuild: fill an itinerary's day slots from the brief.
 
     Reads candidate records from Payload with the operator's JWT, scores and
     selects them, orders each day, and returns the plan (slots + reasons only —
     no blurbs/images). The frontend persists the result.
+
+    The JWT comes from the session cookie unless the body supplied one. The
+    frontend stopped sending it once the Staff credential left JavaScript, and
+    the cookie carries the same token, so the Payload reads are unaffected.
     """
+    payload_jwt = request.payload_jwt or session_token
+    if not payload_jwt:
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "Reading Payload candidates needs the operator's session: send "
+                "the payload-token cookie or payload_jwt in the body"
+            ),
+        )
+    request = request.model_copy(update={"payload_jwt": payload_jwt})
+
     try:
         return await run_itinerary_pipeline(request)
     except Exception as exc:  # noqa: BLE001

--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/schemas.py
@@ -70,10 +70,16 @@ class DayShellSelection(BaseModel):
 
 
 class GenerateItineraryRequest(BaseModel):
-    """Inputs from Step 1 of the builder plus the operator's Payload JWT.
+    """Inputs from Step 1 of the builder.
 
     `payload_jwt` is used only to read candidate records over Payload REST; the
     backend never writes. `brief` is the Generation Brief (core creative input).
+
+    The JWT is optional in the body because the frontend no longer has one to
+    send: the operator's credential is an httpOnly cookie it cannot read. The
+    route fills this in from that cookie (`app.core.staff_token`), which carries
+    the same JWT. A body-supplied value still wins, so non-browser callers and
+    older frontend builds keep working.
     """
 
     location: str = Field(
@@ -87,7 +93,7 @@ class GenerateItineraryRequest(BaseModel):
         ..., min_length=1, max_length=MAX_BRIEF_CHARS, description="Generation Brief"
     )
     day_count: int = Field(..., ge=MIN_DAYS, le=MAX_DAYS)
-    payload_jwt: str = Field(..., min_length=1)
+    payload_jwt: str | None = Field(default=None, min_length=1)
     shared_neighborhoods: list[int] = Field(default_factory=list)
     day_shells: list[DayShellSelection] = Field(..., min_length=1)
     model_name: str | None = Field(default=None, max_length=120)

--- a/apps/ai-blog-writer/apps/backend/app/main.py
+++ b/apps/ai-blog-writer/apps/backend/app/main.py
@@ -80,9 +80,17 @@ ERROR_LOG_PATH = _configure_error_file_logging()
 # Paths reachable without an API key when ABW_API_KEY is set.
 AUTH_EXEMPT_PATHS = {"/health"}
 API_KEY_HEADER = "X-API-Key"
-# Explicit ABW_ALLOWED_ORIGINS value meaning "this instance has no browser
-# client", as distinct from the variable being forgotten.
-CORS_DENY_ALL = "none"
+
+# The origin allowlist lives in app.core.cors so that request authentication can
+# read it without importing this module. Re-exported here because that is where
+# it used to live. `CORS_DENY_ALL` is the explicit ABW_ALLOWED_ORIGINS value
+# meaning "this instance has no browser client", as distinct from the variable
+# being forgotten.
+from app.core.cors import (  # noqa: E402,F401
+    CORS_DENY_ALL as CORS_DENY_ALL,
+    resolve_cors_config as resolve_cors_config,
+    resolve_cors_origins as resolve_cors_origins,
+)
 
 
 @asynccontextmanager
@@ -121,55 +129,6 @@ def _read_bool_env(key: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def resolve_cors_origins(api_key: str, raw_origins: str) -> list[str]:
-    """Resolve the CORS allow-list, refusing a wildcard on deployed instances.
-
-    A configured ABW_API_KEY is the signal that this instance is reachable
-    beyond localhost. Wildcard CORS there is incoherent: it forces
-    `allow_credentials=False`, and the X-API-Key header makes every request
-    preflighted, so any page could probe the API. Refuse to start instead of
-    serving an open origin policy.
-
-    An instance with no browser client at all (server-to-server, or a frontend
-    served same-origin behind a proxy) sets ABW_ALLOWED_ORIGINS=none to say so
-    explicitly. That is a deny-all list, not an oversight.
-
-    With no key configured (local development) the historical behavior is
-    kept exactly: wildcard when the variable is unset, otherwise whatever
-    parses out of it.
-    """
-    raw = raw_origins.strip()
-
-    if raw.lower() == CORS_DENY_ALL:
-        return []
-
-    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
-
-    if not api_key.strip():
-        # Emptiness is judged on the raw string, not the parsed list, so a
-        # malformed value like "," keeps denying all origins rather than
-        # silently widening to a wildcard.
-        return ["*"] if not raw else origins
-
-    if not origins or "*" in origins:
-        raise ValueError(
-            "ABW_ALLOWED_ORIGINS must list explicit origins when ABW_API_KEY "
-            "is set; wildcard CORS is not allowed on a deployed instance. "
-            f"Set ABW_ALLOWED_ORIGINS={CORS_DENY_ALL} if this instance has no "
-            "browser client."
-        )
-
-    return origins
-
-
-def _allowed_origins() -> list[str]:
-    """Read the CORS policy from the environment. See resolve_cors_origins."""
-    return resolve_cors_origins(
-        api_key=os.getenv("ABW_API_KEY", ""),
-        raw_origins=os.getenv("ABW_ALLOWED_ORIGINS", ""),
-    )
-
-
 @app.middleware("http")
 async def require_api_key(request: Request, call_next):
     """Reject requests without the configured API key.
@@ -195,21 +154,6 @@ async def require_api_key(request: Request, call_next):
         )
 
     return await call_next(request)
-
-
-def resolve_cors_config(
-    api_key: str, raw_origins: str
-) -> tuple[list[str], ValueError | None]:
-    """Pair the resolved origins with any rejection, without raising.
-
-    A rejected policy yields a deny-all list so the middleware fails closed,
-    plus the error for `lifespan` to refuse the boot with. Import stays safe
-    either way.
-    """
-    try:
-        return resolve_cors_origins(api_key, raw_origins), None
-    except ValueError as exc:
-        return [], exc
 
 
 _cors_origins, _cors_config_error = resolve_cors_config(

--- a/apps/ai-blog-writer/apps/backend/tests/test_images_composite_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_images_composite_routes.py
@@ -21,9 +21,9 @@ def _composite_request_body() -> dict:
     }
 
 
-async def _fake_prepare_ok(request, authorization):
+async def _fake_prepare_ok(request, jwt_token):
     """Bypass source download/render machinery for composite route tests."""
-    return "jwt-token", 42, "Questurian Composite", [], []
+    return 42, "Questurian Composite", [], []
 
 
 def test_create_composite_rolls_back_on_partial_failure(monkeypatch):

--- a/apps/ai-blog-writer/apps/backend/tests/test_itineraries_pipeline_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_itineraries_pipeline_routes.py
@@ -40,3 +40,100 @@ def test_generate_titles_rejects_short_prompt():
         json={"prompt": "short"},
     )
     assert response.status_code == 422
+
+
+def _generate_body(**overrides) -> dict:
+    body = {
+        "location": "peru|lima|miraflores",
+        "title": "Three days in Miraflores",
+        "brief": "A walkable long weekend for a first-time visitor.",
+        "day_count": 1,
+        "shared_neighborhoods": [],
+        "day_shells": [
+            {
+                "day_index": 0,
+                "shell_id": "classic",
+                "shell_name": "Classic",
+                "shell_description": "A standard day",
+                "slots": [
+                    {
+                        "id": "s1",
+                        "label": "Morning",
+                        "daypart": "morning",
+                        "acceptable_collections": ["attractions"],
+                    }
+                ],
+            }
+        ],
+    }
+    body.update(overrides)
+    return body
+
+
+def _capture_pipeline(monkeypatch) -> dict:
+    """Record the request the pipeline receives, without running it."""
+    seen: dict = {}
+
+    async def fake_pipeline(request):
+        seen["payload_jwt"] = request.payload_jwt
+        return itineraries_pipeline_routes.GenerateItineraryResponse(
+            days=[], model_used="stub"
+        )
+
+    monkeypatch.setattr(
+        itineraries_pipeline_routes, "run_itinerary_pipeline", fake_pipeline
+    )
+    return seen
+
+
+def test_generate_takes_the_jwt_from_the_session_cookie(monkeypatch):
+    """The frontend has no token to put in the body any more.
+
+    `payload_jwt` used to be a required field; the cookie carries the same JWT,
+    so the Payload reads are unaffected.
+    """
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+    monkeypatch.setenv("ABW_ALLOWED_ORIGINS", "https://abw.questurian.com")
+    seen = _capture_pipeline(monkeypatch)
+
+    client = _build_client()
+    client.cookies.set("payload-token", "cookie-jwt")
+    response = client.post(
+        "/itineraries-pipeline/generate",
+        json=_generate_body(),
+        headers={"Origin": "https://abw.questurian.com"},
+    )
+
+    assert response.status_code == 200
+    assert seen["payload_jwt"] == "cookie-jwt"
+
+
+def test_generate_prefers_an_explicit_body_jwt(monkeypatch):
+    """Non-browser callers and older frontend builds keep working."""
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+    monkeypatch.setenv("ABW_ALLOWED_ORIGINS", "https://abw.questurian.com")
+    seen = _capture_pipeline(monkeypatch)
+
+    client = _build_client()
+    client.cookies.set("payload-token", "cookie-jwt")
+    response = client.post(
+        "/itineraries-pipeline/generate",
+        json=_generate_body(payload_jwt="body-jwt"),
+        headers={"Origin": "https://abw.questurian.com"},
+    )
+
+    assert response.status_code == 200
+    assert seen["payload_jwt"] == "body-jwt"
+
+
+def test_generate_401s_with_no_credential_at_all(monkeypatch):
+    """Neither a cookie nor a body field means there is nothing to read Payload
+    with — a 401, not a 500 deep inside the retrieval stage."""
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+    _capture_pipeline(monkeypatch)
+
+    client = _build_client()
+    response = client.post("/itineraries-pipeline/generate", json=_generate_body())
+
+    assert response.status_code == 401
+    assert "session" in response.json()["detail"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_staff_auth.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 from app.core import staff_auth
+from app.core.staff_token import resolve_staff_token
 from fastapi import HTTPException
 
 
@@ -107,7 +108,7 @@ def test_later_status_update_cannot_claim_unowned_run(isolated_db):
 async def test_passes_through_when_flag_is_off():
     """With the flag off nothing is checked, so existing deployments and local
     development are untouched."""
-    assert await staff_auth.require_staff(authorization=None) is None
+    assert await staff_auth.require_staff(token=None) is None
 
 
 @pytest.mark.asyncio
@@ -115,17 +116,31 @@ async def test_rejects_missing_token_when_enabled(monkeypatch):
     monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
 
     with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization=None)
+        await staff_auth.require_staff(token=None)
 
     assert excinfo.value.status_code == 401
 
 
 @pytest.mark.asyncio
 async def test_rejects_non_bearer_scheme_when_enabled(monkeypatch):
+    """A non-Bearer scheme yields no token, and no token is a 401.
+
+    The scheme check itself now lives in `staff_token.resolve_staff_token`;
+    this pins that its "no credential" answer still reaches the caller as 401
+    rather than being mistaken for the flag being off.
+    """
     monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
 
+    token = resolve_staff_token(
+        authorization="JWT abc",
+        cookie_token=None,
+        method="POST",
+        origin=None,
+        allowed_origins=["https://abw.questurian.com"],
+    )
+
     with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization="JWT abc")
+        await staff_auth.require_staff(token=token)
 
     assert excinfo.value.status_code == 401
 
@@ -144,7 +159,7 @@ async def test_falls_back_to_the_shared_payload_url_default(monkeypatch):
 
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
-    await staff_auth.require_staff(authorization="Bearer abc")
+    await staff_auth.require_staff(token="abc")
 
     assert seen["url"] == "http://localhost:4000"
 
@@ -161,7 +176,7 @@ async def test_uses_the_configured_payload_url_when_set(monkeypatch):
 
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
-    await staff_auth.require_staff(authorization="Bearer abc")
+    await staff_auth.require_staff(token="abc")
 
     assert seen["url"] == "http://payload.internal:4000"
 
@@ -176,7 +191,7 @@ async def test_accepts_a_session_payload_recognizes(monkeypatch):
 
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
-    user = await staff_auth.require_staff(authorization="Bearer abc")
+    user = await staff_auth.require_staff(token="abc")
 
     assert user["email"] == "staff@example.com"
 
@@ -248,7 +263,7 @@ async def test_rejects_a_session_payload_does_not_recognize(monkeypatch):
     monkeypatch.setattr(staff_auth, "fetch_payload_user", fake_user)
 
     with pytest.raises(HTTPException) as excinfo:
-        await staff_auth.require_staff(authorization="Bearer abc")
+        await staff_auth.require_staff(token="abc")
 
     assert excinfo.value.status_code == 401
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_staff_token.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_staff_token.py
@@ -1,0 +1,204 @@
+"""Where a staff token may come from, and when the cookie is allowed to count."""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.staff_token import (
+    PAYLOAD_TOKEN_COOKIE,
+    StaffTokenRejected,
+    extract_bearer_token,
+    resolve_staff_token,
+)
+
+TRUSTED = ["https://abw.questurian.com"]
+
+
+def _resolve(**overrides):
+    kwargs = {
+        "authorization": None,
+        "cookie_token": None,
+        "method": "POST",
+        "origin": None,
+        "allowed_origins": TRUSTED,
+    }
+    kwargs.update(overrides)
+    return resolve_staff_token(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("Bearer abc", "abc"),
+        ("bearer abc", "abc"),
+        ("Bearer   abc  ", "abc"),
+        ("JWT abc", None),
+        ("Bearer", None),
+        ("Bearer ", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_extract_bearer_token(header, expected):
+    assert extract_bearer_token(header) == expected
+
+
+def test_no_credential_at_all_is_no_token():
+    assert _resolve() is None
+
+
+class TestHeader:
+    """A header cannot be attached by a page the operator did not mean to load,
+    so it needs no origin check."""
+
+    def test_header_needs_no_origin(self):
+        assert _resolve(authorization="Bearer abc", origin=None) == "abc"
+
+    def test_header_is_accepted_from_an_untrusted_origin(self):
+        assert (
+            _resolve(authorization="Bearer abc", origin="https://evil.example")
+            == "abc"
+        )
+
+    def test_header_wins_over_the_cookie(self):
+        assert (
+            _resolve(
+                authorization="Bearer from-header",
+                cookie_token="from-cookie",
+                origin=TRUSTED[0],
+            )
+            == "from-header"
+        )
+
+    def test_a_malformed_header_falls_through_to_the_cookie(self):
+        """`JWT abc` yields no header token, so the cookie is the only
+        credential left — and it is then held to the cookie's rules."""
+        assert (
+            _resolve(
+                authorization="JWT abc", cookie_token="from-cookie", origin=TRUSTED[0]
+            )
+            == "from-cookie"
+        )
+
+
+class TestCookieOnStateChange:
+    def test_accepted_from_an_allowlisted_origin(self):
+        assert _resolve(cookie_token="abc", origin=TRUSTED[0]) == "abc"
+
+    def test_trailing_slash_on_either_side_still_matches(self):
+        assert (
+            _resolve(
+                cookie_token="abc",
+                origin="https://abw.questurian.com/",
+                allowed_origins=["https://abw.questurian.com/"],
+            )
+            == "abc"
+        )
+
+    def test_rejected_from_an_unlisted_origin(self):
+        with pytest.raises(StaffTokenRejected) as excinfo:
+            _resolve(cookie_token="abc", origin="https://evil.example")
+
+        assert excinfo.value.status_code == 403
+
+    def test_rejected_when_the_origin_header_is_absent(self):
+        """A cross-site form POST carries no `Origin` in some browsers. Absence
+        is not evidence of trust."""
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin=None)
+
+    def test_rejected_under_a_wildcard_allowlist(self):
+        """A wildcard would mean trusting every site with the operator's
+        session. It is also the local-development default, so this is what
+        tells an operator to pin ABW_ALLOWED_ORIGINS."""
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin=TRUSTED[0], allowed_origins=["*"])
+
+    def test_rejected_under_an_empty_allowlist(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin=TRUSTED[0], allowed_origins=[])
+
+    def test_a_subdomain_of_a_trusted_origin_is_not_trusted(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin="https://evil.abw.questurian.com")
+
+    def test_a_prefix_of_a_trusted_origin_is_not_trusted(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", origin="https://abw.questurian.com.evil.test")
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "post"])
+    def test_every_unsafe_method_is_guarded(self, method):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", method=method, origin="https://evil.example")
+
+
+class TestCookieOnSafeMethods:
+    @pytest.mark.parametrize("method", ["GET", "HEAD", "get"])
+    def test_allowed_without_an_origin(self, method):
+        """Same-origin GETs legitimately omit `Origin` in some browsers, and
+        CORS already stops a cross-site page reading the response."""
+        assert _resolve(cookie_token="abc", method=method, origin=None) == "abc"
+
+    def test_a_present_origin_is_still_checked(self):
+        with pytest.raises(StaffTokenRejected):
+            _resolve(cookie_token="abc", method="GET", origin="https://evil.example")
+
+    def test_allowlisted_origin_passes(self):
+        assert _resolve(cookie_token="abc", method="GET", origin=TRUSTED[0]) == "abc"
+
+
+class TestThroughTheApp:
+    """The dependency has to turn a rejection into a response, not a 500."""
+
+    @pytest.fixture(autouse=True)
+    def _pinned_origins(self, monkeypatch):
+        monkeypatch.delenv("ABW_API_KEY", raising=False)
+        monkeypatch.setenv("ABW_ALLOWED_ORIGINS", TRUSTED[0])
+
+    def test_a_forged_origin_gets_403_not_500(self):
+        from app.main import app
+
+        client = TestClient(app)
+        client.cookies.set(PAYLOAD_TOKEN_COOKIE, "abc")
+        response = client.post(
+            "/images/composites/preview",
+            json={},
+            headers={"Origin": "https://evil.example"},
+        )
+
+        assert response.status_code == 403
+        assert "allowlisted origin" in response.json()["detail"]
+
+    def test_no_credential_keeps_the_structured_image_error_shape(self):
+        """The image API has always answered with a `step`-carrying detail;
+        adding a second credential source must not change that contract."""
+        from app.main import app
+
+        response = TestClient(app).post("/images/composites/preview", json={})
+
+        assert response.status_code == 401
+        detail = response.json()["detail"]
+        assert detail["step"] == "validate_auth"
+        assert "payload-token" in detail["message"]
+
+
+def test_rejection_carries_a_message_naming_the_variable_to_fix():
+    with pytest.raises(StaffTokenRejected) as excinfo:
+        _resolve(cookie_token="abc", origin="https://evil.example")
+
+    assert "ABW_ALLOWED_ORIGINS" in excinfo.value.message
+
+
+def test_staff_auth_still_rejects_a_missing_token(monkeypatch):
+    """`require_staff` no longer parses the header itself, so pin that the
+    401 survived the move."""
+    from app.core import staff_auth
+
+    monkeypatch.setenv(staff_auth.STAFF_AUTH_FLAG, "true")
+
+    with pytest.raises(HTTPException) as excinfo:
+        import asyncio
+
+        asyncio.run(staff_auth.require_staff(token=None))
+
+    assert excinfo.value.status_code == 401

--- a/apps/ai-blog-writer/apps/frontend/src/components/FeaturedImagePicker/FeaturedImagePicker.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/components/FeaturedImagePicker/FeaturedImagePicker.test.tsx
@@ -32,7 +32,6 @@ describe('FeaturedImagePicker (adapter over ImagePicker)', () => {
       <FeaturedImagePicker
         isOpen
         selectedId={7}
-        token="t"
         locationRef={10}
         payloadSourceMode="mediaSets"
         payloadVariant="wide"
@@ -53,7 +52,7 @@ describe('FeaturedImagePicker (adapter over ImagePicker)', () => {
   it('emits the asset id when an asset is selected', () => {
     const onSelect = vi.fn()
     render(
-      <FeaturedImagePicker isOpen selectedId={null} token="t" locationRef={10} onSelect={onSelect} onClose={vi.fn()} />,
+      <FeaturedImagePicker isOpen selectedId={null} locationRef={10} onSelect={onSelect} onClose={vi.fn()} />,
     )
 
     captured.props?.onSelect({ kind: 'assets', assets: [{ id: 42 } as MediaAsset] })
@@ -66,7 +65,6 @@ describe('FeaturedImagePicker (adapter over ImagePicker)', () => {
       <FeaturedImagePicker
         isOpen
         selectedId={null}
-        token="t"
         locationRef={10}
         payloadSourceMode="mediaSets"
         onSelect={onSelect}
@@ -85,7 +83,6 @@ describe('FeaturedImagePicker (adapter over ImagePicker)', () => {
       <FeaturedImagePicker
         isOpen
         selectedId={null}
-        token="t"
         locationRef={10}
         payloadVariant="wide"
         onSelect={onSelect}

--- a/apps/ai-blog-writer/apps/frontend/src/components/FeaturedImagePicker/FeaturedImagePicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/components/FeaturedImagePicker/FeaturedImagePicker.tsx
@@ -9,7 +9,6 @@ import type { MediaAsset } from '../../shared/api/payload/payload.types'
 type FeaturedImagePickerProps = {
   isOpen: boolean
   selectedId: number | null
-  token: string
   locationRef: number | null
   payloadSourceMode?: 'assets' | 'mediaSets'
   payloadVariant?: MediaAsset['variant']
@@ -32,7 +31,6 @@ type FeaturedImagePickerProps = {
 export function FeaturedImagePicker({
   isOpen,
   selectedId,
-  token,
   locationRef,
   payloadSourceMode = 'assets',
   payloadVariant,
@@ -73,7 +71,6 @@ export function FeaturedImagePicker({
   return (
     <ImagePicker
       isOpen={isOpen}
-      token={token}
       locationRef={locationRef}
       selectedId={selectedId}
       query={{ browseUnit: payloadSourceMode, variant: payloadVariant, requireMediaSet }}

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/AuthProvider.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/AuthProvider.test.tsx
@@ -8,16 +8,13 @@ import { useAuth } from './useAuth';
 import { getLiveAuthState, purgeLegacyStoredAuth, setLiveAuthState } from './auth-session-store';
 import { LEGACY_AUTH_STORAGE_KEY } from './auth.constants';
 
-function toBase64Url(value: string): string {
-  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-}
-
-function createToken(expiresAtMs: number): string {
-  return [
-    toBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' })),
-    toBase64Url(JSON.stringify({ exp: Math.floor(expiresAtMs / 1000) })),
-    'signature',
-  ].join('.');
+/**
+ * Payload reports session expiry as `exp` (seconds) on login, refresh-token and
+ * me. The app reads that field; it no longer decodes a JWT, because it no longer
+ * has one. Mocked responses therefore carry `exp`, not a token.
+ */
+function expSeconds(expiresAtMs: number): number {
+  return Math.floor(expiresAtMs / 1000);
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -79,7 +76,7 @@ describe('AuthProvider', () => {
   });
 
   it('waits for session restoration before redirecting to login', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     let resolveRestore: ((response: Response) => void) | null = null;
 
     vi.stubGlobal(
@@ -109,7 +106,7 @@ describe('AuthProvider', () => {
     const completeRestore = resolveRestore as ((response: Response) => void) | null;
     completeRestore?.(
       jsonResponse({
-        token,
+        exp,
         user: {
           id: 17,
           email: 'writer@example.com',
@@ -126,7 +123,7 @@ describe('AuthProvider', () => {
   });
 
   it('uses Payload users endpoints for staff restore, login, and logout', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
 
@@ -136,7 +133,7 @@ describe('AuthProvider', () => {
 
       if (url.endsWith('/api/users/login')) {
         return Promise.resolve(jsonResponse({
-          token,
+          exp,
           user: {
             id: 17,
             email: 'writer@example.com',
@@ -184,9 +181,8 @@ describe('AuthProvider', () => {
   });
 
   it('refreshes a stale role from /api/users/me on hydrate', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     setLiveAuthState({
-      token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       user: {
         id: '17',
@@ -202,7 +198,7 @@ describe('AuthProvider', () => {
 
         if (url.endsWith('/api/users/me')) {
           return Promise.resolve(jsonResponse({
-            token,
+            exp,
             user: {
               id: 17,
               email: 'writer@example.com',
@@ -233,9 +229,8 @@ describe('AuthProvider', () => {
   });
 
   it('logs out when the session is rejected by /me and refresh fails', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     setLiveAuthState({
-      token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       user: {
         id: '17',
@@ -281,7 +276,7 @@ describe('AuthProvider', () => {
  * credential, and a reload restores the session from the httpOnly cookie
  * instead of from disk.
  */
-describe('the Staff token never reaches disk', () => {
+describe('the Staff token exists nowhere in JavaScript', () => {
   beforeEach(() => {
     setLiveAuthState(null);
   });
@@ -293,7 +288,7 @@ describe('the Staff token never reaches disk', () => {
   });
 
   it('writes nothing to localStorage on login', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
 
     vi.stubGlobal(
       'fetch',
@@ -302,7 +297,7 @@ describe('the Staff token never reaches disk', () => {
 
         if (url.endsWith('/api/users/login')) {
           return Promise.resolve(jsonResponse({
-            token,
+            exp,
             user: { id: 17, email: 'writer@example.com', role: 'writer' },
           }));
         }
@@ -329,18 +324,19 @@ describe('the Staff token never reaches disk', () => {
     });
 
     expect(localStorage.length).toBe(0);
-    // Belt and braces: the token must not appear under any key.
-    expect(JSON.stringify(localStorage)).not.toContain(token);
+    // Stronger than "not on disk": the in-memory session has no token field at
+    // all, so there is no credential for an XSS payload to read from anywhere.
+    expect(getLiveAuthState()).not.toHaveProperty('token');
   });
 
   it('restores the session from the cookie alone, without writing it back to disk', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
 
       if (url.endsWith('/api/users/me')) {
         return Promise.resolve(jsonResponse({
-          token,
+          exp,
           user: { id: 17, email: 'writer@example.com', role: 'editor' },
         }));
       }
@@ -369,9 +365,10 @@ describe('the Staff token never reaches disk', () => {
     expect(init?.credentials).toBe('include');
     // ...and no Authorization header can have been derived from storage.
     expect(new Headers(init?.headers).has('Authorization')).toBe(false);
-    // The restored session lands in memory and nowhere else. This is the half
-    // that fails without the change: the old code wrote it straight back out.
-    expect(getLiveAuthState()?.token).toBe(token);
+    // The restored session lands in memory and nowhere else — and carries no
+    // token at all, which is the point: there is nothing left to exfiltrate.
+    expect(getLiveAuthState()?.user.email).toBe('writer@example.com');
+    expect(getLiveAuthState()).not.toHaveProperty('token');
     expect(localStorage.length).toBe(0);
   });
 
@@ -402,13 +399,13 @@ describe('the Staff token never reaches disk', () => {
   });
 
   it('logs out on the cookie, not on a token that may already be expired', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
 
       if (url.endsWith('/api/users/login')) {
         return Promise.resolve(jsonResponse({
-          token,
+          exp,
           user: { id: 17, email: 'writer@example.com', role: 'writer' },
         }));
       }

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-context.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-context.ts
@@ -8,14 +8,21 @@ export interface User {
   lastName?: string;
 }
 
+/**
+ * The live Staff session as this app knows it.
+ *
+ * Deliberately holds no token. The credential is the httpOnly `payload-token`
+ * cookie, which no script can read; what the app needs is only who the
+ * operator is and when the session lapses. `expiresAt` comes from the `exp`
+ * every Payload session endpoint returns (`login`, `refresh-token`, `me`), not
+ * from decoding a JWT this app no longer has.
+ */
 export interface AuthState {
-  token: string;
   expiresAt: number;
   user: User;
 }
 
 export interface AuthContextValue {
-  token: string | null;
   expiresAt: number | null;
   user: User | null;
   isAuthenticated: boolean;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-session-store.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-session-store.ts
@@ -10,16 +10,18 @@ import { hasActiveSession } from './auth-state';
  * token out of it with one line, and the token outlived the tab, the window and
  * the browser restart.
  *
- * Nothing is written to disk now. A reload starts with no session and
- * rehydrates from the httpOnly `payload-token` cookie Payload already sets on
- * login (`/api/users/me` returns the user *and* the current token, so the
- * cookie is sufficient to restore a session). The token still exists in JS
- * while the page is open — the FastAPI backend reads it from an
- * `Authorization` header, and that is a separate change — but it is no longer
- * sitting at rest behind a well-known key.
+ * Nothing is written to disk now, and there is no longer a token to write. The
+ * credential is the httpOnly `payload-token` cookie; what this holds is who
+ * the operator is and when the session lapses. A reload starts empty and
+ * rehydrates from that cookie via `/api/users/me`.
  *
- * Module scope rather than React state because `apiFetch` needs to read it from
- * outside the component tree; `useAuthSessionState` is the only writer.
+ * That is the whole point of the change: an XSS payload has nothing to read
+ * here. It can still *act* as the operator while the page is open — the cookie
+ * rides along on any request it makes — but it cannot extract a credential and
+ * use it elsewhere, later.
+ *
+ * Module scope rather than React state because it is read from outside the
+ * component tree; `useAuthSessionState` is the only writer.
  */
 
 let liveAuthState: AuthState | null = null;
@@ -33,7 +35,7 @@ export function getLiveAuthState(): AuthState | null {
     return null;
   }
 
-  if (!hasActiveSession(liveAuthState.token, liveAuthState.expiresAt)) {
+  if (!hasActiveSession(liveAuthState.expiresAt)) {
     liveAuthState = null;
     return null;
   }

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-state.ts
@@ -1,11 +1,7 @@
 import type { AuthState } from './auth-context';
-import { SESSION_DURATION_FALLBACK_MS } from './auth.constants';
 
-export function hasActiveSession(
-  token: string | null | undefined,
-  expiresAt: number | null | undefined,
-): boolean {
-  if (!token || !expiresAt) {
+export function hasActiveSession(expiresAt: number | null | undefined): boolean {
+  if (!expiresAt) {
     return false;
   }
 
@@ -24,34 +20,25 @@ export function readNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
-export function decodeTokenExpiry(token: string): number | null {
-  try {
-    const [, base64Url] = token.split('.');
-    if (!base64Url) {
-      return null;
-    }
-
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const jsonPayload = decodeURIComponent(
-      atob(base64)
-        .split('')
-        .map((char) => `%${(`00${char.charCodeAt(0).toString(16)}`).slice(-2)}`)
-        .join(''),
-    );
-    const decoded = JSON.parse(jsonPayload) as { exp?: unknown };
-    const exp = readNumber(decoded.exp);
-
-    return exp ? exp * 1000 : null;
-  } catch {
-    return null;
-  }
-}
-
+/**
+ * When the session lapses, according to the server.
+ *
+ * Every Payload session endpoint returns `exp` — `loginOperation`,
+ * `refreshOperation` and `meOperation` all set it — so this does not need the
+ * which is the point: the app no longer has one to decode.
+ *
+ * Returns null when the server named no expiry, and the caller treats that as
+ * "no session". The previous code decoded the JWT and, failing that, invented
+ * seven days. That was already wrong — `payload-token` lives two hours — and
+ * without a token to decode it would now be the *common* path rather than the
+ * unreachable one. A session whose end is unknown is not a session worth
+ * holding: the cookie will be rejected at that point anyway, so guessing long
+ * only delays the discovery.
+ */
 export function resolveExpiresAt(
   source: Record<string, unknown>,
-  token: string,
   fallbackExpiresAt?: number | null,
-): number {
+): number | null {
   const numericExpiresAt = readNumber(source.expiresAt);
   if (numericExpiresAt) {
     return numericExpiresAt;
@@ -70,16 +57,11 @@ export function resolveExpiresAt(
     }
   }
 
-  const tokenExpiry = decodeTokenExpiry(token);
-  if (tokenExpiry) {
-    return tokenExpiry;
-  }
-
   if (fallbackExpiresAt && fallbackExpiresAt > Date.now()) {
     return fallbackExpiresAt;
   }
 
-  return Date.now() + SESSION_DURATION_FALLBACK_MS;
+  return null;
 }
 
 export function normalizeAuthState(
@@ -99,19 +81,8 @@ export function normalizeAuthState(
     return null;
   }
 
-  const token =
-    readString(response.token)
-    || readString(response.refreshedToken)
-    || readString(response.accessToken)
-    || readString(response.jwt)
-    || (fallbackAuth && hasActiveSession(fallbackAuth.token, fallbackAuth.expiresAt) ? fallbackAuth.token : null);
-
-  if (!token) {
-    return null;
-  }
-
-  const expiresAt = resolveExpiresAt(response, token, fallbackAuth?.expiresAt ?? null);
-  if (!hasActiveSession(token, expiresAt)) {
+  const expiresAt = resolveExpiresAt(response, fallbackAuth?.expiresAt ?? null);
+  if (!hasActiveSession(expiresAt)) {
     return null;
   }
 
@@ -121,8 +92,7 @@ export function normalizeAuthState(
   }
 
   return {
-    token,
-    expiresAt,
+    expiresAt: expiresAt as number,
     user: {
       id: String(userSource.id ?? fallbackAuth?.user.id ?? ''),
       email,

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth.constants.ts
@@ -7,7 +7,6 @@ export const LEGACY_AUTH_STORAGE_KEY = 'payload_auth';
 export const DEFAULT_PAYLOAD_URL = 'http://localhost:4000';
 export const PAYLOAD_API_URL = import.meta.env.VITE_PAYLOAD_API_URL || DEFAULT_PAYLOAD_URL;
 export const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
-export const SESSION_DURATION_FALLBACK_MS = 7 * 24 * 60 * 60 * 1000;
 export const REVALIDATION_TIMEOUT_MS = 5000;
 export const LOGIN_TIMEOUT_MS = 10000;
 export const SESSION_RESTORE_TIMEOUT_MS = 8000;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
@@ -9,7 +9,7 @@ import {
   SESSION_RENEW_REQUESTS,
   SESSION_RESTORE_TIMEOUT_MS,
 } from './auth.constants';
-import { hasActiveSession, normalizeAuthState } from './auth-state';
+import { normalizeAuthState } from './auth-state';
 
 export type PayloadHealthResult = {
   isConnected: boolean;
@@ -27,20 +27,21 @@ async function requestSession(
     const timeoutId = window.setTimeout(() => controller.abort(), SESSION_RESTORE_TIMEOUT_MS);
 
     try {
-      const headers: Record<string, string> = {
-        Accept: 'application/json',
-      };
-
-      if (fallbackAuth?.token && hasActiveSession(fallbackAuth.token, fallbackAuth.expiresAt)) {
-        headers.Authorization = `Bearer ${fallbackAuth.token}`;
-      }
-
+      // No `Authorization` header, for the same reason `logoutPayloadUser`
+      // sends none: `extractJWT` returns the *first* token it finds in
+      // `jwtOrder` (JWT, Bearer, cookie) and verifies only that one. A stale
+      // in-memory token would therefore be extracted, fail to verify, and take
+      // the request down *even though the cookie beside it is still valid* —
+      // turning a renewable session into a forced logout. The cookie is the
+      // credential; letting anything shadow it is how it stops being one.
       const response = await fetch(`${PAYLOAD_API_URL}${request.endpoint}`, {
         method: request.method,
         mode: 'cors',
         cache: 'no-store',
         credentials: 'include',
-        headers,
+        headers: {
+          Accept: 'application/json',
+        },
         signal: controller.signal,
       });
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
@@ -4,7 +4,6 @@ import {
   LOGOUT_ENDPOINTS,
   PAYLOAD_API_URL,
   REVALIDATION_TIMEOUT_MS,
-  SESSION_DURATION_FALLBACK_MS,
   SESSION_HYDRATE_REQUESTS,
   SESSION_RENEW_REQUESTS,
   SESSION_RESTORE_TIMEOUT_MS,
@@ -151,9 +150,11 @@ export async function loginPayloadUser(email: string, password: string): Promise
       throw new Error(message);
     }
 
+    // Only the email is carried in: Payload's login response names the `exp`
+    // and the user itself, and inventing a fallback expiry here would mean
+    // holding a session the server never agreed to.
     const nextState = normalizeAuthState(await response.json(), {
-      token: '',
-      expiresAt: Date.now() + SESSION_DURATION_FALLBACK_MS,
+      expiresAt: 0,
       user: {
         id: '',
         email,
@@ -161,7 +162,7 @@ export async function loginPayloadUser(email: string, password: string): Promise
     });
 
     if (!nextState) {
-      throw new Error('Login failed - no token received');
+      throw new Error('Login failed - the server returned no usable session');
     }
 
     return nextState;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
@@ -19,7 +19,7 @@ export type AccessResult = {
   >;
 };
 
-export async function fetchAccessPermissions(token: string): Promise<AccessResult | null> {
+export async function fetchAccessPermissions(): Promise<AccessResult | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REVALIDATION_TIMEOUT_MS);
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
@@ -31,7 +31,6 @@ export async function fetchAccessPermissions(token: string): Promise<AccessResul
       credentials: 'include',
       headers: {
         Accept: 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       signal: controller.signal,
     });

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/useAuthSessionState.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/useAuthSessionState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AuthContextValue, AuthState } from './auth-context';
 import { EXPIRY_BUFFER_MS } from './auth.constants';
 import { hasActiveSession } from './auth-state';
+import { clearPermissionsCache } from './usePermissions';
 import { getLiveAuthState, setLiveAuthState } from './auth-session-store';
 import {
   checkPayloadHealth,
@@ -18,8 +19,8 @@ export function useAuthSessionState(): AuthContextValue {
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
   const applyAuthState = useCallback((nextState: AuthState | null) => {
-    // `apiFetch` reads the token from outside the component tree, so the store
-    // has to be updated synchronously rather than waiting for a re-render.
+    // The store is read from outside the component tree, so it is updated
+    // synchronously rather than waiting for a re-render.
     setLiveAuthState(nextState);
     setAuthState(nextState);
   }, []);
@@ -84,21 +85,41 @@ export function useAuthSessionState(): AuthContextValue {
   const logout = useCallback(() => {
     applyAuthState(null);
     setIsRestoringSession(false);
+    // The access cache is module-scoped and keyed by Staff id, so it outlives
+    // both the component tree and a session renewal. Without this, signing out
+    // and signing in as someone else on the same page load would serve the
+    // previous operator's permissions. `clearPermissionsCache` was exported but
+    // never called from app code — flagged as pre-existing on PR #221, and now
+    // load-bearing because the cache no longer turns over with the token.
+    clearPermissionsCache();
     logoutPayloadUser();
   }, [applyAuthState]);
 
   useEffect(() => {
-    if (!authState?.token || !authState?.expiresAt) {
+    if (!authState?.expiresAt) {
       return;
     }
+
+    // The hydrate effect above has always had this guard; the renewal effect
+    // did not, which was a real bug rather than an asymmetry: logging out
+    // while `/api/users/refresh-token` was in flight applied the renewed
+    // session on top of the logout and signed the operator back in, in both
+    // the UI and the module store. Flagged as pre-existing on PR #221 and
+    // fixed here because this effect is being rewritten anyway.
+    let isCancelled = false;
 
     const remainingMs = authState.expiresAt - EXPIRY_BUFFER_MS - Date.now();
     const refreshSession = async () => {
       setIsRestoringSession(true);
       const restoredState = await renewPayloadSession(authState);
+
+      if (isCancelled) {
+        return;
+      }
+
       if (restoredState) {
         applyAuthState(restoredState);
-      } else if (!hasActiveSession(authState.token, authState.expiresAt)) {
+      } else if (!hasActiveSession(authState.expiresAt)) {
         applyAuthState(null);
       }
       setIsRestoringSession(false);
@@ -106,24 +127,27 @@ export function useAuthSessionState(): AuthContextValue {
 
     if (remainingMs <= 0) {
       void refreshSession();
-      return;
+      return () => {
+        isCancelled = true;
+      };
     }
 
     const timeoutId = window.setTimeout(() => {
       void refreshSession();
     }, remainingMs);
 
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(timeoutId);
+    };
   }, [applyAuthState, authState]);
 
   return useMemo(() => {
-    const token = authState?.token ?? null;
     const expiresAt = authState?.expiresAt ?? null;
     const user = authState?.user ?? null;
-    const isAuthenticated = hasActiveSession(token, expiresAt);
+    const isAuthenticated = hasActiveSession(expiresAt);
 
     return {
-      token,
       expiresAt,
       user,
       isAuthenticated,

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.test.tsx
@@ -10,12 +10,11 @@ vi.mock('./permissions-client');
 const mockUseAuth = vi.mocked(useAuth);
 const mockFetchAccess = vi.mocked(fetchAccessPermissions);
 
-function stubAuth(role: string | undefined, token: string | null = 'token-1') {
+function stubAuth(role: string | undefined, isSignedIn = true) {
   mockUseAuth.mockReturnValue({
-    token,
-    expiresAt: Date.now() + 60_000,
-    user: token ? { id: '1', email: 'user@example.com', role } : null,
-    isAuthenticated: Boolean(token),
+    expiresAt: isSignedIn ? Date.now() + 60_000 : null,
+    user: isSignedIn ? { id: '1', email: 'user@example.com', role } : null,
+    isAuthenticated: isSignedIn,
     isRestoringSession: false,
     isConnected: true,
     connectionError: null,
@@ -68,7 +67,7 @@ describe('usePermissions', () => {
   });
 
   it('denies everything without a token', async () => {
-    stubAuth(undefined, null);
+    stubAuth(undefined, false);
 
     const { result } = renderHook(() => usePermissions());
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.ts
@@ -12,14 +12,20 @@ export type Permissions = {
 };
 
 // Shared across all consumers so six components on one page trigger a single
-// /api/access request per token.
+// /api/access request per signed-in operator.
+//
+// Keyed by Staff id rather than by token: the credential is now an httpOnly
+// cookie this code cannot read, and the identity is what the answer actually
+// depends on. A session renewal used to mint a new token and therefore a new
+// cache key, silently re-fetching; keying on identity means the entry survives
+// renewal, which is the correct lifetime for "what may this person do".
 const accessCache = new Map<string, Promise<AccessResult | null>>();
 
-function getAccessForToken(token: string): Promise<AccessResult | null> {
-  let cached = accessCache.get(token);
+function getAccessForStaff(staffId: string): Promise<AccessResult | null> {
+  let cached = accessCache.get(staffId);
   if (!cached) {
-    cached = fetchAccessPermissions(token);
-    accessCache.set(token, cached);
+    cached = fetchAccessPermissions();
+    accessCache.set(staffId, cached);
   }
   return cached;
 }
@@ -33,12 +39,12 @@ function roleAllowsManagePublished(role: string | undefined | null): boolean {
 }
 
 export function usePermissions(): Permissions {
-  const { token, user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const [access, setAccess] = useState<AccessResult | null>(null);
-  const [isLoading, setIsLoading] = useState(Boolean(token));
+  const [isLoading, setIsLoading] = useState(isAuthenticated);
 
   useEffect(() => {
-    if (!token) {
+    if (!isAuthenticated || !user) {
       setAccess(null);
       setIsLoading(false);
       return;
@@ -47,7 +53,7 @@ export function usePermissions(): Permissions {
     let isCancelled = false;
     setIsLoading(true);
 
-    void getAccessForToken(token).then((result) => {
+    void getAccessForStaff(user.id).then((result) => {
       if (isCancelled) {
         return;
       }
@@ -58,7 +64,7 @@ export function usePermissions(): Permissions {
     return () => {
       isCancelled = true;
     };
-  }, [token]);
+  }, [isAuthenticated, user]);
 
   return useMemo(() => {
     const articlesUpdate = access?.collections?.articles?.update;

--- a/apps/ai-blog-writer/apps/frontend/src/features/batchImageRecreation/BatchImageRecreationPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/batchImageRecreation/BatchImageRecreationPage.tsx
@@ -8,7 +8,7 @@ import { FLUX_MODEL_OPTIONS } from './fluxModelOptions'
 const MAX_IMAGES = 8 // 1 primary + 7 additional (API limit)
 
 export default function BatchImageRecreationPage() {
-  const { token } = useAuth()
+  const { isAuthenticated } = useAuth()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [isDragging, setIsDragging] = useState(false)
 
@@ -87,7 +87,7 @@ export default function BatchImageRecreationPage() {
   }, [])
 
   const handleGenerate = useCallback(async () => {
-    if (!token || referenceImages.length === 0 || !prompt.trim() || isGenerating) return
+    if (!isAuthenticated || referenceImages.length === 0 || !prompt.trim() || isGenerating) return
     setIsGenerating(true)
     setError(null)
     if (result) {
@@ -98,7 +98,6 @@ export default function BatchImageRecreationPage() {
       const response = await generateFluxEditedImage(
         prompt.trim(),
         referenceImages[0],
-        token,
         {
           additionalReferenceImages: referenceImages.slice(1),
           modelId,
@@ -110,9 +109,9 @@ export default function BatchImageRecreationPage() {
     } finally {
       setIsGenerating(false)
     }
-  }, [token, referenceImages, prompt, modelId, isGenerating, result])
+  }, [isAuthenticated, referenceImages, prompt, modelId, isGenerating, result])
 
-  const canGenerate = referenceImages.length > 0 && prompt.trim().length > 0 && !isGenerating && Boolean(token)
+  const canGenerate = referenceImages.length > 0 && prompt.trim().length > 0 && !isGenerating && isAuthenticated
   const atLimit = referenceImages.length >= MAX_IMAGES
 
   return (

--- a/apps/ai-blog-writer/apps/frontend/src/features/blogArticles/components/PayloadDocumentsTable.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/blogArticles/components/PayloadDocumentsTable.tsx
@@ -14,7 +14,7 @@ export type PayloadDocumentsTableProps = {
   buildDraftUrl: (stagedId: string) => string
   isLoading: boolean
   loadErrorMessage: string | null
-  hasToken: boolean
+  isSignedIn: boolean
 }
 
 function findLocalDraftForPayloadDoc(
@@ -33,7 +33,7 @@ export function PayloadDocumentsTable({
   buildDraftUrl,
   isLoading,
   loadErrorMessage,
-  hasToken,
+  isSignedIn,
 }: PayloadDocumentsTableProps) {
   return (
     <section className="stl-panel">
@@ -41,7 +41,7 @@ export function PayloadDocumentsTable({
         <h2>Payload Documents ({docs.length})</h2>
       </div>
       <div className="panel-body">
-        {!hasToken ? (
+        {!isSignedIn ? (
           <div className="stl-empty">
             <p>Sign in to load articles from Payload.</p>
           </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/blogArticles/components/SavedArticlesPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/blogArticles/components/SavedArticlesPage.test.tsx
@@ -122,7 +122,7 @@ describe('SavedArticlesPage', () => {
       buildDraftUrl: (stagedId) => `/testblog/stage-article?stagedId=${stagedId}`,
     }
 
-    mockUseAuth.mockReturnValue({ token: 'token-1' })
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: '1', email: 'w@questurian.com' } })
     mockGetAllStagedArticles.mockReturnValue([
       makeDraft({ id: 'draft-local' }),
     ])
@@ -147,7 +147,7 @@ describe('SavedArticlesPage', () => {
     // Payload Documents come straight from Payload, combined across features,
     // and edit through the dedicated Payload article editor.
     await waitFor(() => expect(screen.getByText('Payload Documents (1)')).toBeTruthy())
-    expect(mockFetchPayloadArticles).toHaveBeenCalledWith('token-1')
+    expect(mockFetchPayloadArticles).toHaveBeenCalledWith()
     expect(screen.getByRole('link', { name: 'Edit' }).getAttribute('href')).toBe(
       '/payload-articles/stage-article?payloadId=44',
     )

--- a/apps/ai-blog-writer/apps/frontend/src/features/blogArticles/components/SavedArticlesPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/blogArticles/components/SavedArticlesPage.tsx
@@ -17,7 +17,7 @@ export default function SavedArticlesPage<TArticle extends SavedBlogArticle>({
   config: SavedArticlesPageConfig<TArticle>
 }) {
   const queryClient = useQueryClient()
-  const { token } = useAuth()
+  const { isAuthenticated, user } = useAuth()
 
   const { localDrafts, discardLocalDraft, clearAllLocalDrafts } = useLocalStagedDrafts(config.storageKey)
   const [generatedDeleteTarget, setGeneratedDeleteTarget] = useState<TArticle | null>(null)
@@ -33,9 +33,9 @@ export default function SavedArticlesPage<TArticle extends SavedBlogArticle>({
   // not by the backend's local sync bookkeeping — one combined list across all
   // blog-writer pipelines.
   const payloadDocsQuery = useQuery({
-    queryKey: ['payload-articles', token || 'no-token'],
-    enabled: Boolean(token),
-    queryFn: () => fetchPayloadArticles(token as string),
+    queryKey: ['payload-articles', user?.id ?? 'anonymous'],
+    enabled: isAuthenticated,
+    queryFn: () => fetchPayloadArticles(),
   })
   const payloadDocs = payloadDocsQuery.data ?? EMPTY_ARTICLES
 
@@ -141,7 +141,7 @@ export default function SavedArticlesPage<TArticle extends SavedBlogArticle>({
             ? (payloadDocsQuery.error instanceof Error ? payloadDocsQuery.error.message : 'Unknown error')
             : null
         }
-        hasToken={Boolean(token)}
+        isSignedIn={isAuthenticated}
       />
 
       <GeneratedArticlesTable

--- a/apps/ai-blog-writer/apps/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -23,7 +23,6 @@ const OCCASIONAL_CARD_TITLES = [
 
 function createAuthValue(role = 'admin'): AuthContextValue {
   return {
-    token: 'landing-token',
     expiresAt: Date.now() + 60_000,
     user: {
       id: 'user-1',

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockEditor.tsx
@@ -27,28 +27,24 @@ import type {
 type Props = {
   block: ArticleCuratedHomepageBlockResponse
   blockIndex: number
-  token: string | null
   canManage: boolean
   selectionQueryKey: unknown[]
   saveSelection: (
-    token: string,
     items: HomepageFeaturedItemRef[],
     slotCount?: number,
   ) => Promise<HomepageFeaturedSelection>
-  saveSectionHeading?: (token: string, value: string | null) => Promise<void>
-  saveSectionSubheading?: (token: string, value: string | null) => Promise<void>
-  saveSlot3Layout?: (token: string, value: FeaturedArticlesSlot3Layout) => Promise<void>
-  saveSlot4Layout?: (token: string, value: FeaturedArticlesSlot4Layout) => Promise<void>
-  saveSlot5Layout?: (token: string, value: FeaturedArticlesSlot5Layout) => Promise<void>
-  saveArticleGridFourLayout?: (token: string, value: ArticleGridFourLayout) => Promise<void>
+  saveSectionHeading?: (value: string | null) => Promise<void>
+  saveSectionSubheading?: (value: string | null) => Promise<void>
+  saveSlot3Layout?: (value: FeaturedArticlesSlot3Layout) => Promise<void>
+  saveSlot4Layout?: (value: FeaturedArticlesSlot4Layout) => Promise<void>
+  saveSlot5Layout?: (value: FeaturedArticlesSlot5Layout) => Promise<void>
+  saveArticleGridFourLayout?: (value: ArticleGridFourLayout) => Promise<void>
   convertEmptyFeaturedArticlesTargets?: CuratedHomepageBlockType[]
   onConvertEmptyFeaturedArticlesBlock?: (
-    token: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) => Promise<void>
   fetchCandidates: (
-    token: string,
     params: CandidateParams,
   ) => Promise<HomepageFeaturedCandidatesResponse>
   onDeleteBlock: (blockId: string) => void
@@ -61,7 +57,6 @@ type Props = {
 export default function CuratedHomepageBlockEditor({
   block,
   blockIndex,
-  token,
   canManage,
   selectionQueryKey,
   saveSelection,
@@ -84,14 +79,12 @@ export default function CuratedHomepageBlockEditor({
   const blockConfig = HOMEPAGE_PAGE_BLOCK_CONFIG[block.blockType]
   const layouts = useCuratedHomepageLayouts({
     block,
-    token,
     saveSlot3Layout,
     saveSlot4Layout,
     saveSlot5Layout,
     saveArticleGridFourLayout,
   })
   const slotEditorState = useHomepageFeaturedSlots({
-    token,
     canManage,
     selection: block.selection,
     saveSelection,
@@ -147,7 +140,6 @@ export default function CuratedHomepageBlockEditor({
             className="hf-btn-icon hf-block-settings-gear"
             title="Block settings — save, delete, section title"
             aria-label="Block settings"
-            disabled={!token}
             onClick={() => setSettingsOpen(true)}
           >
             ⚙
@@ -160,7 +152,6 @@ export default function CuratedHomepageBlockEditor({
       <CuratedHomepageBlockSettings
         block={block}
         blockIndex={blockIndex}
-        token={token}
         isOpen={settingsOpen}
         onClose={() => setSettingsOpen(false)}
         layoutState={layouts}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockSettings.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/CuratedHomepageBlockSettings.tsx
@@ -15,12 +15,11 @@ import type { UseHomepageFeaturedSlotsResult } from './useHomepageFeaturedSlots'
 type Props = {
   block: ArticleCuratedHomepageBlockResponse
   blockIndex: number
-  token: string | null
   isOpen: boolean
   onClose: () => void
   layoutState: CuratedHomepageLayoutsState
-  saveSectionHeading?: (token: string, value: string | null) => Promise<void>
-  saveSectionSubheading?: (token: string, value: string | null) => Promise<void>
+  saveSectionHeading?: (value: string | null) => Promise<void>
+  saveSectionSubheading?: (value: string | null) => Promise<void>
   enableSlot3Layout: boolean
   enableSlot4Layout: boolean
   enableSlot5Layout: boolean
@@ -29,7 +28,6 @@ type Props = {
   convertTargets: CuratedHomepageBlockType[]
   canConvert: boolean
   onConvert?: (
-    token: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) => Promise<void>
@@ -41,7 +39,6 @@ type Props = {
 export default function CuratedHomepageBlockSettings({
   block,
   blockIndex,
-  token,
   isOpen,
   onClose,
   layoutState,
@@ -100,7 +97,6 @@ export default function CuratedHomepageBlockSettings({
       </p>
       <HomepageBlockSectionTextFields
         blockId={block.id}
-        token={token}
         sectionHeading={block.sectionHeading}
         sectionSubheading={block.sectionSubheading}
         settingsOpen={isOpen}
@@ -114,7 +110,7 @@ export default function CuratedHomepageBlockSettings({
         savedSlotCount={block.selection.totalSlots}
         slots={slots}
         invalidSlots={savedInvalidItems.map((item) => item.slot)}
-        disabled={!token || saveMutation.isPending}
+        disabled={saveMutation.isPending}
         isPending={saveMutation.isPending}
         onResize={handleResizeSlotCount}
       />
@@ -130,7 +126,6 @@ export default function CuratedHomepageBlockSettings({
             { value: 'hero-left', label: 'Hero left — two stacked on the right' },
             { value: 'featured-center', label: 'Three columns — large feature in the center' },
           ]}
-          disabled={!token}
           dirty={layoutState.slot3.dirty}
           isPending={layoutState.slot3.mutation.isPending}
           error={layoutState.slot3.mutation.error}
@@ -151,7 +146,6 @@ export default function CuratedHomepageBlockSettings({
             { value: 'sidebar-stack', label: 'Hero column + stacked sidebar (default)' },
             { value: 'one-over-three', label: 'Lead row: text + image, then three columns' },
           ]}
-          disabled={!token}
           dirty={layoutState.slot4.dirty}
           isPending={layoutState.slot4.mutation.isPending}
           error={layoutState.slot4.mutation.error}
@@ -172,7 +166,6 @@ export default function CuratedHomepageBlockSettings({
             { value: 'card-grid', label: 'Card grid (default)' },
             { value: 'hero-sidebar', label: 'Magazine — hero + sidebar stack' },
           ]}
-          disabled={!token}
           dirty={layoutState.slot5.dirty}
           isPending={layoutState.slot5.mutation.isPending}
           error={layoutState.slot5.mutation.error}
@@ -193,7 +186,6 @@ export default function CuratedHomepageBlockSettings({
             { value: 'four-across', label: 'One row × four — wide images' },
             { value: 'two-by-two', label: '2×2 grid — square images' },
           ]}
-          disabled={!token}
           dirty={layoutState.articleGridFour.dirty}
           isPending={layoutState.articleGridFour.mutation.isPending}
           error={layoutState.articleGridFour.mutation.error}
@@ -218,12 +210,11 @@ export default function CuratedHomepageBlockSettings({
         blockId={block.id}
         currentBlockType={block.blockType}
         currentSlotCount={block.selection.totalSlots}
-        token={token}
         convertTargetOptions={convertTargets}
         canConvert={canConvert}
-        onConvert={async (currentToken, blockType, slotCount) => {
+        onConvert={async (blockType, slotCount) => {
           if (!onConvert) return
-          await onConvert(currentToken, blockType, slotCount)
+          await onConvert(blockType, slotCount)
         }}
         onConverted={onClose}
       />

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockConvertSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockConvertSection.tsx
@@ -9,12 +9,10 @@ type Props = {
   currentBlockType: CuratedHomepageBlockType
   /** Saved slot count for this block (`selection.totalSlots`). */
   currentSlotCount: number
-  token: string | null
   /** Allowed types in the dropdown, including {@link currentBlockType} for empty resize. */
   convertTargetOptions: CuratedHomepageBlockType[]
   canConvert: boolean
   onConvert: (
-    token: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) => Promise<void>
@@ -25,7 +23,6 @@ export default function HomepageBlockConvertSection({
   blockId,
   currentBlockType,
   currentSlotCount,
-  token,
   convertTargetOptions,
   canConvert,
   onConvert,
@@ -75,8 +72,7 @@ export default function HomepageBlockConvertSection({
       blockType: CuratedHomepageBlockType
       slotCount: number
     }) => {
-      if (!token) return
-      await onConvert(token, blockType, slotCount)
+      await onConvert(blockType, slotCount)
     },
     onSuccess: () => {
       onConverted?.()
@@ -100,7 +96,7 @@ export default function HomepageBlockConvertSection({
     convertTargetType === currentBlockType && normalizedChosen === currentSlotCount
 
   function handleConvert() {
-    if (!canConvert || !token || isNoOp) return
+    if (!canConvert || isNoOp) return
     convertMutation.mutate({ blockType: convertTargetType, slotCount: normalizedChosen })
   }
 
@@ -172,7 +168,7 @@ export default function HomepageBlockConvertSection({
         <button
           type="button"
           className="hf-btn-primary"
-          disabled={!token || convertMutation.isPending || isNoOp}
+          disabled={convertMutation.isPending || isNoOp}
           onClick={handleConvert}
         >
           {actionLabel}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockLayoutSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockLayoutSection.tsx
@@ -12,7 +12,8 @@ type Props<T extends string> = {
   ariaLabel: string
   value: T
   options: Option<T>[]
-  disabled: boolean
+  /** Optional: the only caller's gate was the always-true Staff token. */
+  disabled?: boolean
   dirty: boolean
   isPending: boolean
   error: unknown
@@ -28,7 +29,7 @@ export default function HomepageBlockLayoutSection<T extends string>({
   ariaLabel,
   value,
   options,
-  disabled,
+  disabled = false,
   dirty,
   isPending,
   error,

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockSectionTextFields.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockSectionTextFields.tsx
@@ -6,19 +6,17 @@ const SECTION_SUBHEADING_MAX_LEN = 200
 
 type Props = {
   blockId: string
-  token: string | null
   /** Saved values from the server (react to block identity + refetch). */
   sectionHeading: string | null | undefined
   sectionSubheading: string | null | undefined
   /** When the modal opens, focus the heading field. */
   settingsOpen: boolean
-  saveSectionHeading?: (token: string, value: string | null) => Promise<void>
-  saveSectionSubheading?: (token: string, value: string | null) => Promise<void>
+  saveSectionHeading?: (value: string | null) => Promise<void>
+  saveSectionSubheading?: (value: string | null) => Promise<void>
 }
 
 export default function HomepageBlockSectionTextFields({
   blockId,
-  token,
   sectionHeading,
   sectionSubheading,
   settingsOpen,
@@ -50,15 +48,15 @@ export default function HomepageBlockSectionTextFields({
 
   const headingMutation = useMutation({
     mutationFn: async (value: string | null) => {
-      if (!token || !saveSectionHeading) return
-      await saveSectionHeading(token, value)
+      if (!saveSectionHeading) return
+      await saveSectionHeading(value)
     },
   })
 
   const subMutation = useMutation({
     mutationFn: async (value: string | null) => {
-      if (!token || !saveSectionSubheading) return
-      await saveSectionSubheading(token, value)
+      if (!saveSectionSubheading) return
+      await saveSectionSubheading(value)
     },
   })
 
@@ -84,14 +82,14 @@ export default function HomepageBlockSectionTextFields({
         placeholder="e.g. Featured reporting"
         value={headingDraft}
         onChange={(e) => setHeadingDraft(e.target.value)}
-        disabled={!token || headingMutation.isPending}
+        disabled={headingMutation.isPending}
         autoComplete="off"
       />
       <div className="hf-block-section-heading-row">
         <button
           type="button"
           className="hf-btn-ghost"
-          disabled={!token || !headingDirty || headingMutation.isPending}
+          disabled={!headingDirty || headingMutation.isPending}
           onClick={() => setHeadingDraft(savedHeading)}
         >
           Reset
@@ -99,7 +97,7 @@ export default function HomepageBlockSectionTextFields({
         <button
           type="button"
           className="hf-btn-primary"
-          disabled={!token || !headingDirty || headingMutation.isPending}
+          disabled={!headingDirty || headingMutation.isPending}
           onClick={() => headingMutation.mutate(headingTrimmed === '' ? null : headingTrimmed)}
         >
           {headingMutation.isPending ? 'Saving…' : 'Save title'}
@@ -130,14 +128,14 @@ export default function HomepageBlockSectionTextFields({
             placeholder="e.g. Fresh picks from our editors this week"
             value={subDraft}
             onChange={(e) => setSubDraft(e.target.value)}
-            disabled={!token || subMutation.isPending}
+            disabled={subMutation.isPending}
             autoComplete="off"
           />
           <div className="hf-block-section-heading-row">
             <button
               type="button"
               className="hf-btn-ghost"
-              disabled={!token || !subDirty || subMutation.isPending}
+              disabled={!subDirty || subMutation.isPending}
               onClick={() => setSubDraft(savedSub)}
             >
               Reset
@@ -145,7 +143,7 @@ export default function HomepageBlockSectionTextFields({
             <button
               type="button"
               className="hf-btn-primary"
-              disabled={!token || !subDirty || subMutation.isPending}
+              disabled={!subDirty || subMutation.isPending}
               onClick={() => subMutation.mutate(subTrimmed === '' ? null : subTrimmed)}
             >
               {subMutation.isPending ? 'Saving…' : 'Save subheading'}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageFeaturedContentPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageFeaturedContentPage.test.tsx
@@ -8,7 +8,6 @@ import { AuthContext, type AuthContextValue } from '../auth'
 
 function createAuthValue(role: string): AuthContextValue {
   return {
-    token: 'test-token',
     expiresAt: Date.now() + 60_000,
     user: {
       id: 'user-1',

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageFeaturedContentPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageFeaturedContentPage.tsx
@@ -18,28 +18,28 @@ import { buildHomepageGroups } from './locationHomepageList.utils'
 const EMPTY_LOCATION_HOMEPAGES: LocationHomepageListItem[] = []
 
 export default function HomepageFeaturedContentPage() {
-  const { token } = useAuth()
+  const { isAuthenticated, user } = useAuth()
   const queryClient = useQueryClient()
   const { canManagePublished: canManage } = usePermissions()
 
   const [editingCountryKey, setEditingCountryKey] = useState<string | null>(null)
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
 
-  const listQueryKey = ['location-homepages-list', token]
+  const listQueryKey = ['location-homepages-list', user?.id ?? 'anonymous']
 
   const listQuery = useQuery({
     queryKey: listQueryKey,
-    queryFn: () => fetchLocationHomepagesList(token!),
-    enabled: Boolean(token && canManage),
+    queryFn: () => fetchLocationHomepagesList(),
+    enabled: isAuthenticated && canManage,
   })
 
   const toggleMutation = useMutation({
-    mutationFn: ({ id }: { id: number }) => toggleLocationHomepage(token!, id),
+    mutationFn: ({ id }: { id: number }) => toggleLocationHomepage(id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: listQueryKey }),
   })
 
   const deleteMutation = useMutation({
-    mutationFn: ({ id }: { id: number }) => deleteLocationHomepage(token!, id),
+    mutationFn: ({ id }: { id: number }) => deleteLocationHomepage(id),
     onSuccess: () => {
       setDeleteTargetId(null)
       queryClient.invalidateQueries({ queryKey: listQueryKey })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HotelGridBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HotelGridBlockEditor.tsx
@@ -46,7 +46,6 @@ function getInvalidMessage(
 export default function HotelGridBlockEditor({
   block,
   blockIndex,
-  token,
   canManage,
   selectionQueryKey,
   saveSelection,
@@ -61,30 +60,24 @@ export default function HotelGridBlockEditor({
 }: {
   block: HotelOrAttractionGridBlockResponse
   blockIndex: number
-  token: string | null
   canManage: boolean
   selectionQueryKey: unknown[]
   saveSelection: (
-    token: string,
     items: HomepageHotelGridItemRef[],
     slotCount?: number
   ) => Promise<HomepageHotelGridSelection>
   fetchCandidates: (
-    token: string,
     params: HotelGridCandidateParams
   ) => Promise<HomepageHotelGridCandidatesResponse>
   /** Persist optional section title (PUT without items). */
   saveHotelGridSectionHeading?: (
-    token: string,
     value: string | null
   ) => Promise<void>
   saveHotelGridSectionSubheading?: (
-    token: string,
     value: string | null
   ) => Promise<void>
   convertBlockTargets?: CuratedHomepageBlockType[]
   onConvertEmptyBlock?: (
-    token: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number
   ) => Promise<void>
@@ -97,7 +90,6 @@ export default function HotelGridBlockEditor({
   const [settingsOpen, setSettingsOpen] = useState(false)
 
   const slotEditorState = useHomepageHotelGridSlots({
-    token,
     canManage,
     selection: block.selection,
     saveSelection,
@@ -193,7 +185,6 @@ export default function HotelGridBlockEditor({
             className="hf-btn-icon hf-block-settings-gear"
             title="Block settings — section title, change type when empty"
             aria-label="Block settings"
-            disabled={!token}
             onClick={() => setSettingsOpen(true)}
           >
             ⚙
@@ -230,7 +221,6 @@ export default function HotelGridBlockEditor({
         </p>
         <HomepageBlockSectionTextFields
           blockId={block.id}
-          token={token}
           sectionHeading={block.sectionHeading}
           sectionSubheading={block.sectionSubheading}
           settingsOpen={settingsOpen}
@@ -244,7 +234,7 @@ export default function HotelGridBlockEditor({
           savedSlotCount={block.selection.totalSlots}
           slots={slots}
           invalidSlots={savedInvalidItems.map((item) => item.slot)}
-          disabled={!token || saveMutation.isPending}
+          disabled={saveMutation.isPending}
           isPending={saveMutation.isPending}
           onResize={handleResizeSlotCount}
         />
@@ -252,12 +242,11 @@ export default function HotelGridBlockEditor({
           blockId={block.id}
           currentBlockType={block.blockType}
           currentSlotCount={block.selection.totalSlots}
-          token={token}
           convertTargetOptions={convertTargetOptions}
           canConvert={canConvertEmptyBlock}
-          onConvert={async (tok, blockType, slotCount) => {
+          onConvert={async (blockType, slotCount) => {
             if (!onConvertEmptyBlock) return
-            await onConvertEmptyBlock(tok, blockType, slotCount)
+            await onConvertEmptyBlock(blockType, slotCount)
           }}
           onConverted={() => setSettingsOpen(false)}
         />

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationGridBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationGridBlockEditor.tsx
@@ -37,36 +37,29 @@ function getInvalidMessage(count: number): string {
 type Props = {
   block: LocationGridBlockResponse
   blockIndex: number
-  token: string | null
   canManage: boolean
   childLevel: HomepageLocationGridLevel
   selectionQueryKey: unknown[]
   saveSelection: (
-    token: string,
     items: HomepageLocationGridItemRef[],
     slotCount?: number
   ) => Promise<HomepageLocationGridSelection>
   fetchCandidates: (
-    token: string,
     params: LocationGridCandidateParams
   ) => Promise<HomepageLocationGridCandidatesResponse>
   /** Persist optional section title (PUT without items). */
   saveLocationGridSectionHeading?: (
-    token: string,
     value: string | null
   ) => Promise<void>
   saveLocationGridSectionSubheading?: (
-    token: string,
     value: string | null
   ) => Promise<void>
   saveLocationGridMediaAspect?: (
-    token: string,
     value: LocationGridMediaAspect
   ) => Promise<void>
   /** When the grid has no saved locations, user may switch block type (section title kept). */
   convertBlockTargets?: CuratedHomepageBlockType[]
   onConvertEmptyBlock?: (
-    token: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number
   ) => Promise<void>
@@ -78,7 +71,6 @@ type Props = {
 export default function LocationGridBlockEditor({
   block,
   blockIndex,
-  token,
   canManage,
   childLevel,
   selectionQueryKey,
@@ -109,13 +101,12 @@ export default function LocationGridBlockEditor({
 
   const mediaAspectMutation = useMutation({
     mutationFn: async (value: LocationGridMediaAspect) => {
-      if (!token || !saveLocationGridMediaAspect) return
-      await saveLocationGridMediaAspect(token, value)
+      if (!saveLocationGridMediaAspect) return
+      await saveLocationGridMediaAspect(value)
     }
   })
 
   const slotEditorState = useHomepageLocationGridSlots({
-    token,
     canManage,
     selection: block.selection,
     saveSelection,
@@ -198,7 +189,7 @@ export default function LocationGridBlockEditor({
   const saveNeedsAllSlots =
     hasUnsavedChanges &&
     !hasAllSlotsFilled &&
-    Boolean(token) &&
+    Boolean() &&
     !saveMutation.isPending
 
   return (
@@ -219,7 +210,6 @@ export default function LocationGridBlockEditor({
             className="hf-btn-icon hf-block-settings-gear"
             title="Block settings — save, delete, section title"
             aria-label="Block settings"
-            disabled={!token}
             onClick={() => setSettingsOpen(true)}
           >
             ⚙
@@ -264,7 +254,6 @@ export default function LocationGridBlockEditor({
         </p>
         <HomepageBlockSectionTextFields
           blockId={block.id}
-          token={token}
           sectionHeading={block.sectionHeading}
           sectionSubheading={block.sectionSubheading}
           settingsOpen={settingsOpen}
@@ -279,7 +268,7 @@ export default function LocationGridBlockEditor({
           savedSlotCount={block.selection.totalSlots}
           slots={slots}
           invalidSlots={savedInvalidItems.map((item) => item.slot)}
-          disabled={!token || saveMutation.isPending}
+          disabled={saveMutation.isPending}
           isPending={saveMutation.isPending}
           onResize={handleResizeSlotCount}
         />
@@ -303,7 +292,7 @@ export default function LocationGridBlockEditor({
                     name={`hf-lg-aspect-${block.id}`}
                     checked={mediaAspectDraft === aspect}
                     onChange={() => setMediaAspectDraft(aspect)}
-                    disabled={!token || mediaAspectMutation.isPending}
+                    disabled={mediaAspectMutation.isPending}
                   />
                   <span>
                     {aspect === 'rectangle'
@@ -319,9 +308,7 @@ export default function LocationGridBlockEditor({
               <button
                 type="button"
                 className="hf-btn-ghost"
-                disabled={
-                  !token || !mediaAspectDirty || mediaAspectMutation.isPending
-                }
+                disabled={!mediaAspectDirty || mediaAspectMutation.isPending}
                 onClick={() => setMediaAspectDraft(savedMediaAspect)}
               >
                 Reset
@@ -329,9 +316,7 @@ export default function LocationGridBlockEditor({
               <button
                 type="button"
                 className="hf-btn-primary"
-                disabled={
-                  !token || !mediaAspectDirty || mediaAspectMutation.isPending
-                }
+                disabled={!mediaAspectDirty || mediaAspectMutation.isPending}
                 onClick={() => mediaAspectMutation.mutate(mediaAspectDraft)}
               >
                 {mediaAspectMutation.isPending ? 'Saving…' : 'Save shape'}
@@ -369,12 +354,11 @@ export default function LocationGridBlockEditor({
           blockId={block.id}
           currentBlockType={block.blockType}
           currentSlotCount={block.selection.totalSlots}
-          token={token}
           convertTargetOptions={convertTargetOptions}
           canConvert={canConvertEmptyBlock}
-          onConvert={async (tok, blockType, slotCount) => {
+          onConvert={async (blockType, slotCount) => {
             if (!onConvertEmptyBlock) return
-            await onConvertEmptyBlock(tok, blockType, slotCount)
+            await onConvertEmptyBlock(blockType, slotCount)
           }}
           onConverted={() => setSettingsOpen(false)}
         />

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationHomepageBlockRenderer.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationHomepageBlockRenderer.tsx
@@ -39,7 +39,6 @@ export type LocationHomepageBlockRendererProps = {
   block: PageBlockResponse
   blockIndex: number
   homepageId: number
-  token: string | null
   canManage: boolean
   locationGridChildLevel: 'neighborhood' | null
   convertTargets: CuratedHomepageBlockType[]
@@ -51,7 +50,6 @@ export type LocationHomepageBlockRendererProps = {
   deleteError: string | null
   onConvertBlock: (
     block: PageBlockResponse,
-    currentToken: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) => Promise<void>
@@ -67,7 +65,6 @@ export default function LocationHomepageBlockRenderer({
   block,
   blockIndex: idx,
   homepageId: numericId,
-  token,
   canManage,
   locationGridChildLevel,
   convertTargets,
@@ -89,7 +86,6 @@ export default function LocationHomepageBlockRenderer({
       <CuratedHomepageBlockEditor
         block={block}
         blockIndex={idx}
-        token={token}
         canManage={canManage}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(block.id)}
@@ -98,11 +94,9 @@ export default function LocationHomepageBlockRenderer({
           'location-homepage-block',
           numericId,
           ...homepageBlockEditorIdentity(block),
-          token,
         ]}
-        saveSelection={async (currentToken, items, slotCount) => {
+        saveSelection={async (items, slotCount) => {
           const updated = await updateLocationHomepageBlock(
-            currentToken,
             numericId,
             block.id,
             items,
@@ -116,64 +110,63 @@ export default function LocationHomepageBlockRenderer({
           invalidateHomepage()
           return updatedBlock.selection
         }}
-        fetchCandidates={(currentToken, params) =>
+        fetchCandidates={(params) =>
           block.blockType === 'questurian-maps'
-            ? fetchLocationHomepageCandidates(currentToken, numericId, {
+            ? fetchLocationHomepageCandidates(numericId, {
                 ...params,
                 type: 'single-type-listicles',
               })
             : block.blockType === 'where-to-eat-drink'
-              ? fetchLocationHomepageWhereToEatDrinkCandidates(currentToken, numericId, params)
+              ? fetchLocationHomepageWhereToEatDrinkCandidates(numericId, params)
               : block.blockType === 'things-to-do-listicles'
-                ? fetchLocationHomepageThingsToDoListicleCandidates(currentToken, numericId, params)
+                ? fetchLocationHomepageThingsToDoListicleCandidates(numericId, params)
                 : fetchLocationHomepageCandidates(
-                  currentToken,
                   numericId,
-                  params as Parameters<typeof fetchLocationHomepageCandidates>[2],
+                  params as Parameters<typeof fetchLocationHomepageCandidates>[1],
                 )}
-        saveSectionHeading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionHeading(currentToken, numericId, block.id, value)
+        saveSectionHeading={async (value) => {
+          await updateLocationHomepageFeaturedSectionHeading(numericId, block.id, value)
           invalidateHomepage()
         }}
-        saveSectionSubheading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionSubheading(currentToken, numericId, block.id, value)
+        saveSectionSubheading={async (value) => {
+          await updateLocationHomepageFeaturedSectionSubheading(numericId, block.id, value)
           invalidateHomepage()
         }}
         saveSlot3Layout={
           block.blockType === 'featured-articles' && block.selection.totalSlots === 3
-            ? async (currentToken, value) => {
-                await updateLocationHomepageFeaturedSlot3Layout(currentToken, numericId, block.id, value)
+            ? async (value) => {
+                await updateLocationHomepageFeaturedSlot3Layout(numericId, block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         saveSlot4Layout={
           block.blockType === 'featured-articles' && block.selection.totalSlots === 4
-            ? async (currentToken, value) => {
-                await updateLocationHomepageFeaturedSlot4Layout(currentToken, numericId, block.id, value)
+            ? async (value) => {
+                await updateLocationHomepageFeaturedSlot4Layout(numericId, block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         saveSlot5Layout={
           block.blockType === 'featured-articles' && block.selection.totalSlots === 5
-            ? async (currentToken, value) => {
-                await updateLocationHomepageFeaturedSlot5Layout(currentToken, numericId, block.id, value)
+            ? async (value) => {
+                await updateLocationHomepageFeaturedSlot5Layout(numericId, block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         saveArticleGridFourLayout={
           block.blockType === 'article-grid' && block.selection.totalSlots === 4
-            ? async (currentToken, value) => {
-                await updateLocationHomepageArticleGridFourLayout(currentToken, numericId, block.id, value)
+            ? async (value) => {
+                await updateLocationHomepageArticleGridFourLayout(numericId, block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         convertEmptyFeaturedArticlesTargets={convertTargets}
-        onConvertEmptyFeaturedArticlesBlock={async (currentToken, blockType, slotCount) => {
-          await onConvertBlock(block, currentToken, blockType, slotCount)
+        onConvertEmptyFeaturedArticlesBlock={async (blockType, slotCount) => {
+          await onConvertBlock(block, blockType, slotCount)
         }}
         externalUsedKeys={externalUsedKeys}
         onSlotsChange={onSlotsChange}
@@ -186,7 +179,6 @@ export default function LocationHomepageBlockRenderer({
       <LocationGridBlockEditor
         block={block}
         blockIndex={idx}
-        token={token}
         canManage={canManage}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(block.id)}
@@ -196,10 +188,9 @@ export default function LocationHomepageBlockRenderer({
           'location-homepage-location-grid',
           numericId,
           ...homepageBlockEditorIdentity(block),
-          token,
         ]}
-        saveSelection={async (currentToken, items, slotCount) => {
-          const updated = await updateLocationHomepageBlock(currentToken, numericId, block.id, items, slotCount)
+        saveSelection={async (items, slotCount) => {
+          const updated = await updateLocationHomepageBlock(numericId, block.id, items, slotCount)
           const updatedBlock = updated.pageBlocks.find(
             (candidate): candidate is LocationGridBlockResponse =>
               candidate.id === block.id && candidate.blockType === block.blockType,
@@ -208,23 +199,23 @@ export default function LocationHomepageBlockRenderer({
           invalidateHomepage()
           return updatedBlock.selection
         }}
-        fetchCandidates={(currentToken, params) =>
-          fetchLocationHomepageLocationGridCandidates(currentToken, numericId, params)}
-        saveLocationGridSectionHeading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionHeading(currentToken, numericId, block.id, value)
+        fetchCandidates={(params) =>
+          fetchLocationHomepageLocationGridCandidates(numericId, params)}
+        saveLocationGridSectionHeading={async (value) => {
+          await updateLocationHomepageFeaturedSectionHeading(numericId, block.id, value)
           invalidateHomepage()
         }}
-        saveLocationGridSectionSubheading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionSubheading(currentToken, numericId, block.id, value)
+        saveLocationGridSectionSubheading={async (value) => {
+          await updateLocationHomepageFeaturedSectionSubheading(numericId, block.id, value)
           invalidateHomepage()
         }}
-        saveLocationGridMediaAspect={async (currentToken, value) => {
-          await updateLocationHomepageLocationGridMediaAspect(currentToken, numericId, block.id, value)
+        saveLocationGridMediaAspect={async (value) => {
+          await updateLocationHomepageLocationGridMediaAspect(numericId, block.id, value)
           invalidateHomepage()
         }}
         convertBlockTargets={convertTargets}
-        onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
-          await onConvertBlock(block, currentToken, blockType, slotCount)
+        onConvertEmptyBlock={async (blockType, slotCount) => {
+          await onConvertBlock(block, blockType, slotCount)
         }}
       />
     )
@@ -235,16 +226,15 @@ export default function LocationHomepageBlockRenderer({
       <NewsletterSignupBlockEditor
         block={block}
         blockIndex={idx}
-        token={token}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(block.id)}
         deleteError={deleteErrorFor(block.id)}
-        saveSectionHeading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionHeading(currentToken, numericId, block.id, value)
+        saveSectionHeading={async (value) => {
+          await updateLocationHomepageFeaturedSectionHeading(numericId, block.id, value)
           invalidateHomepage()
         }}
-        saveSectionSubheading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionSubheading(currentToken, numericId, block.id, value)
+        saveSectionSubheading={async (value) => {
+          await updateLocationHomepageFeaturedSectionSubheading(numericId, block.id, value)
           invalidateHomepage()
         }}
       />
@@ -257,7 +247,6 @@ export default function LocationHomepageBlockRenderer({
       <HotelGridBlockEditor
         block={gridBlock}
         blockIndex={idx}
-        token={token}
         canManage={canManage}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(gridBlock.id)}
@@ -266,10 +255,9 @@ export default function LocationHomepageBlockRenderer({
           'location-homepage-hotel-grid',
           numericId,
           ...homepageBlockEditorIdentity(gridBlock),
-          token,
         ]}
-        saveSelection={async (currentToken, items, slotCount) => {
-          const updated = await updateLocationHomepageBlock(currentToken, numericId, gridBlock.id, items, slotCount)
+        saveSelection={async (items, slotCount) => {
+          const updated = await updateLocationHomepageBlock(numericId, gridBlock.id, items, slotCount)
           const updatedBlock = updated.pageBlocks.find(
             (candidate): candidate is HotelOrAttractionGridBlockResponse =>
               candidate.id === gridBlock.id && candidate.blockType === gridBlock.blockType,
@@ -278,26 +266,25 @@ export default function LocationHomepageBlockRenderer({
           invalidateHomepage()
           return updatedBlock.selection
         }}
-        fetchCandidates={(currentToken, params) =>
+        fetchCandidates={(params) =>
           gridBlock.blockType === 'things-to-do-attractions'
             ? fetchLocationHomepageThingsToDoAttractionCandidates(
-              currentToken,
               numericId,
               params,
             )
             : gridBlock.blockType === 'tour-grid'
-              ? fetchLocationHomepageTourGridCandidates(currentToken, numericId, params)
-              : fetchLocationHomepageHotelGridCandidates(currentToken, numericId, params)}
+              ? fetchLocationHomepageTourGridCandidates(numericId, params)
+              : fetchLocationHomepageHotelGridCandidates(numericId, params)}
         convertBlockTargets={convertTargets}
-        onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
-          await onConvertBlock(gridBlock, currentToken, blockType, slotCount)
+        onConvertEmptyBlock={async (blockType, slotCount) => {
+          await onConvertBlock(gridBlock, blockType, slotCount)
         }}
-        saveHotelGridSectionHeading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionHeading(currentToken, numericId, gridBlock.id, value)
+        saveHotelGridSectionHeading={async (value) => {
+          await updateLocationHomepageFeaturedSectionHeading(numericId, gridBlock.id, value)
           invalidateHomepage()
         }}
-        saveHotelGridSectionSubheading={async (currentToken, value) => {
-          await updateLocationHomepageFeaturedSectionSubheading(currentToken, numericId, gridBlock.id, value)
+        saveHotelGridSectionSubheading={async (value) => {
+          await updateLocationHomepageFeaturedSectionSubheading(numericId, gridBlock.id, value)
           invalidateHomepage()
         }}
       />

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationHomepagePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationHomepagePage.tsx
@@ -19,7 +19,6 @@ import {
 export default function LocationHomepagePage() {
   const { id } = useParams<{ id: string }>()
   const numericId = Number(id)
-  const { token } = useAuth()
   const { canManagePublished: canManage } = usePermissions()
 
   const {
@@ -41,7 +40,7 @@ export default function LocationHomepagePage() {
     handleConfirmAddBlock,
     deleteError,
     invalidateHomepage,
-  } = useLocationHomepageEditor(numericId, token, canManage)
+  } = useLocationHomepageEditor(numericId, canManage)
 
   if (!canManage) {
     return (
@@ -203,7 +202,6 @@ export default function LocationHomepagePage() {
                 block={block}
                 blockIndex={idx}
                 homepageId={numericId}
-                token={token}
                 canManage={canManage}
                 locationGridChildLevel={locationGridChildLevel}
                 convertTargets={convertEmptyFeaturedArticlesTargets}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationPickerModal.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationPickerModal.test.tsx
@@ -16,7 +16,6 @@ function renderModal() {
   return render(
     <QueryClientProvider client={queryClient}>
       <LocationPickerModal
-        token="test-token"
         existingLocationIds={[]}
         onSelect={vi.fn().mockResolvedValue(undefined)}
         onClose={vi.fn()}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationPickerModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/LocationPickerModal.tsx
@@ -2,20 +2,17 @@ import { LocationPickerResults } from './location-picker/LocationPickerResults'
 import { useLocationPicker } from './location-picker/useLocationPicker'
 
 type LocationPickerModalProps = {
-  token: string
   existingLocationIds: number[]
   onSelect: (locationId: number) => Promise<void>
   onClose: () => void
 }
 
 export function LocationPickerModal({
-  token,
   existingLocationIds,
   onSelect,
   onClose,
 }: LocationPickerModalProps) {
   const picker = useLocationPicker({
-    token,
     existingLocationIds,
     onSelect,
     onClose,

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepageBlockRenderer.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepageBlockRenderer.tsx
@@ -39,7 +39,6 @@ import {
 type Props = {
   block: PageBlockResponse
   blockIndex: number
-  token: string | null
   canManage: boolean
   externalUsedKeys: Set<string>
   onSlotsChange: (blockId: string, keys: Set<string>) => void
@@ -49,7 +48,6 @@ type Props = {
   deleteError: string | null
   onConvertBlock: (
     block: PageBlockResponse,
-    currentToken: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) => Promise<void>
@@ -59,7 +57,6 @@ type Props = {
 export default function MainHomepageBlockRenderer({
   block,
   blockIndex,
-  token,
   canManage,
   externalUsedKeys,
   onSlotsChange,
@@ -80,7 +77,6 @@ export default function MainHomepageBlockRenderer({
       <CuratedHomepageBlockEditor
         block={block}
         blockIndex={blockIndex}
-        token={token}
         canManage={canManage}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(block.id)}
@@ -88,11 +84,9 @@ export default function MainHomepageBlockRenderer({
         selectionQueryKey={[
           'main-homepage-block',
           ...homepageBlockEditorIdentity(block),
-          token,
         ]}
-        saveSelection={async (currentToken, items, slotCount) => {
+        saveSelection={async (items, slotCount) => {
           const updated = await updateMainHomepageBlock(
-            currentToken,
             block.id,
             items,
             slotCount,
@@ -105,64 +99,63 @@ export default function MainHomepageBlockRenderer({
           invalidateHomepage()
           return updatedBlock.selection
         }}
-        fetchCandidates={(currentToken, params) =>
+        fetchCandidates={(params) =>
           block.blockType === 'questurian-maps'
-            ? fetchHomepageFeaturedCandidates(currentToken, {
+            ? fetchHomepageFeaturedCandidates({
                 ...params,
                 type: 'single-type-listicles',
               })
             : block.blockType === 'where-to-eat-drink'
-              ? fetchWhereToEatDrinkCandidates(currentToken, params)
+              ? fetchWhereToEatDrinkCandidates(params)
               : block.blockType === 'things-to-do-listicles'
-                ? fetchThingsToDoListicleCandidates(currentToken, params)
-                : fetchHomepageFeaturedCandidates(currentToken, params)}
-        saveSectionHeading={async (currentToken, value) => {
-          await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
+                ? fetchThingsToDoListicleCandidates(params)
+                : fetchHomepageFeaturedCandidates(params)}
+        saveSectionHeading={async (value) => {
+          await updateMainHomepageFeaturedSectionHeading(block.id, value)
           invalidateHomepage()
         }}
-        saveSectionSubheading={async (currentToken, value) => {
-          await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
+        saveSectionSubheading={async (value) => {
+          await updateMainHomepageFeaturedSectionSubheading(block.id, value)
           invalidateHomepage()
         }}
         saveSlot3Layout={
           block.blockType === 'featured-articles' && block.selection.totalSlots === 3
-            ? async (currentToken, value) => {
-                await updateMainHomepageFeaturedSlot3Layout(currentToken, block.id, value)
+            ? async (value) => {
+                await updateMainHomepageFeaturedSlot3Layout(block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         saveSlot4Layout={
           block.blockType === 'featured-articles' && block.selection.totalSlots === 4
-            ? async (currentToken, value) => {
-                await updateMainHomepageFeaturedSlot4Layout(currentToken, block.id, value)
+            ? async (value) => {
+                await updateMainHomepageFeaturedSlot4Layout(block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         saveSlot5Layout={
           block.blockType === 'featured-articles' && block.selection.totalSlots === 5
-            ? async (currentToken, value) => {
-                await updateMainHomepageFeaturedSlot5Layout(currentToken, block.id, value)
+            ? async (value) => {
+                await updateMainHomepageFeaturedSlot5Layout(block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         saveArticleGridFourLayout={
           block.blockType === 'article-grid' && block.selection.totalSlots === 4
-            ? async (currentToken, value) => {
-                await updateMainHomepageArticleGridFourLayout(currentToken, block.id, value)
+            ? async (value) => {
+                await updateMainHomepageArticleGridFourLayout(block.id, value)
                 invalidateHomepage()
               }
             : undefined
         }
         convertEmptyFeaturedArticlesTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
         onConvertEmptyFeaturedArticlesBlock={async (
-          currentToken,
           blockType,
           slotCount,
         ) => {
-          await onConvertBlock(block, currentToken, blockType, slotCount)
+          await onConvertBlock(block, blockType, slotCount)
         }}
         externalUsedKeys={externalUsedKeys}
         onSlotsChange={onSlotsChange}
@@ -175,7 +168,6 @@ export default function MainHomepageBlockRenderer({
       <LocationGridBlockEditor
         block={block}
         blockIndex={blockIndex}
-        token={token}
         canManage={canManage}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(block.id)}
@@ -184,11 +176,9 @@ export default function MainHomepageBlockRenderer({
         selectionQueryKey={[
           'main-homepage-location-grid',
           ...homepageBlockEditorIdentity(block),
-          token,
         ]}
-        saveSelection={async (currentToken, items, slotCount) => {
+        saveSelection={async (items, slotCount) => {
           const updated = await updateMainHomepageBlock(
-            currentToken,
             block.id,
             items,
             slotCount,
@@ -202,21 +192,21 @@ export default function MainHomepageBlockRenderer({
           return updatedBlock.selection
         }}
         fetchCandidates={fetchHomepageLocationGridCandidates}
-        saveLocationGridSectionHeading={async (currentToken, value) => {
-          await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
+        saveLocationGridSectionHeading={async (value) => {
+          await updateMainHomepageFeaturedSectionHeading(block.id, value)
           invalidateHomepage()
         }}
-        saveLocationGridSectionSubheading={async (currentToken, value) => {
-          await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
+        saveLocationGridSectionSubheading={async (value) => {
+          await updateMainHomepageFeaturedSectionSubheading(block.id, value)
           invalidateHomepage()
         }}
-        saveLocationGridMediaAspect={async (currentToken, value) => {
-          await updateMainHomepageLocationGridMediaAspect(currentToken, block.id, value)
+        saveLocationGridMediaAspect={async (value) => {
+          await updateMainHomepageLocationGridMediaAspect(block.id, value)
           invalidateHomepage()
         }}
         convertBlockTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
-        onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
-          await onConvertBlock(block, currentToken, blockType, slotCount)
+        onConvertEmptyBlock={async (blockType, slotCount) => {
+          await onConvertBlock(block, blockType, slotCount)
         }}
       />
     )
@@ -227,16 +217,15 @@ export default function MainHomepageBlockRenderer({
       <NewsletterSignupBlockEditor
         block={block}
         blockIndex={blockIndex}
-        token={token}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(block.id)}
         deleteError={deleteErrorFor(block.id)}
-        saveSectionHeading={async (currentToken, value) => {
-          await updateMainHomepageFeaturedSectionHeading(currentToken, block.id, value)
+        saveSectionHeading={async (value) => {
+          await updateMainHomepageFeaturedSectionHeading(block.id, value)
           invalidateHomepage()
         }}
-        saveSectionSubheading={async (currentToken, value) => {
-          await updateMainHomepageFeaturedSectionSubheading(currentToken, block.id, value)
+        saveSectionSubheading={async (value) => {
+          await updateMainHomepageFeaturedSectionSubheading(block.id, value)
           invalidateHomepage()
         }}
       />
@@ -253,7 +242,6 @@ export default function MainHomepageBlockRenderer({
       <HotelGridBlockEditor
         block={gridBlock}
         blockIndex={blockIndex}
-        token={token}
         canManage={canManage}
         onDeleteBlock={onDeleteBlock}
         isDeletingBlock={isDeletingBlockFor(gridBlock.id)}
@@ -261,11 +249,9 @@ export default function MainHomepageBlockRenderer({
         selectionQueryKey={[
           'main-homepage-hotel-grid',
           ...homepageBlockEditorIdentity(gridBlock),
-          token,
         ]}
-        saveSelection={async (currentToken, items, slotCount) => {
+        saveSelection={async (items, slotCount) => {
           const updated = await updateMainHomepageBlock(
-            currentToken,
             gridBlock.id,
             items,
             slotCount,
@@ -279,27 +265,25 @@ export default function MainHomepageBlockRenderer({
           invalidateHomepage()
           return updatedBlock.selection
         }}
-        fetchCandidates={(currentToken, params) =>
+        fetchCandidates={(params) =>
           gridBlock.blockType === 'things-to-do-attractions'
-            ? fetchThingsToDoAttractionCandidates(currentToken, params)
+            ? fetchThingsToDoAttractionCandidates(params)
             : gridBlock.blockType === 'tour-grid'
-              ? fetchTourGridCandidates(currentToken, params)
-              : fetchHomepageHotelGridCandidates(currentToken, params)}
+              ? fetchTourGridCandidates(params)
+              : fetchHomepageHotelGridCandidates(params)}
         convertBlockTargets={CONVERT_EMPTY_FEATURED_ARTICLES_TO_BLOCK_TYPES}
-        onConvertEmptyBlock={async (currentToken, blockType, slotCount) => {
-          await onConvertBlock(gridBlock, currentToken, blockType, slotCount)
+        onConvertEmptyBlock={async (blockType, slotCount) => {
+          await onConvertBlock(gridBlock, blockType, slotCount)
         }}
-        saveHotelGridSectionHeading={async (currentToken, value) => {
+        saveHotelGridSectionHeading={async (value) => {
           await updateMainHomepageFeaturedSectionHeading(
-            currentToken,
             gridBlock.id,
             value,
           )
           invalidateHomepage()
         }}
-        saveHotelGridSectionSubheading={async (currentToken, value) => {
+        saveHotelGridSectionSubheading={async (value) => {
           await updateMainHomepageFeaturedSectionSubheading(
-            currentToken,
             gridBlock.id,
             value,
           )

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.test.tsx
@@ -10,7 +10,6 @@ import type { MainHomepageResponse } from './api'
 
 function createAuthValue(): AuthContextValue {
   return {
-    token: 'test-token',
     expiresAt: Date.now() + 60_000,
     user: {
       id: 'user-1',

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.tsx
@@ -24,7 +24,6 @@ function usedKeysOutsideBlock(
 }
 
 export default function MainHomepagePage() {
-  const { token } = useAuth()
   const { canManagePublished: canManage } = usePermissions()
   const {
     homepageQuery,
@@ -43,7 +42,7 @@ export default function MainHomepagePage() {
     handleConfirmAddBlock,
     deleteError,
     invalidateHomepage,
-  } = useMainHomepageEditor(token, canManage)
+  } = useMainHomepageEditor(canManage)
 
   if (!canManage) {
     return (
@@ -192,7 +191,6 @@ export default function MainHomepagePage() {
                   key={homepageBlockEditorIdentity(block).join(':')}
                   block={block}
                   blockIndex={blockIndex}
-                  token={token}
                   canManage={canManage}
                   externalUsedKeys={usedKeysOutsideBlock(pageBlockSlotKeys, block.id)}
                   onSlotsChange={handleSlotsChange}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/NewsletterSignupBlockEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/NewsletterSignupBlockEditor.tsx
@@ -8,7 +8,6 @@ import { HOMEPAGE_PAGE_BLOCK_CONFIG, type NewsletterSignupBlockResponse } from '
 export default function NewsletterSignupBlockEditor({
   block,
   blockIndex,
-  token,
   onDeleteBlock,
   isDeletingBlock,
   deleteError,
@@ -17,12 +16,11 @@ export default function NewsletterSignupBlockEditor({
 }: {
   block: NewsletterSignupBlockResponse
   blockIndex: number
-  token: string | null
   onDeleteBlock: (blockId: string) => void
   isDeletingBlock: boolean
   deleteError: string | null
-  saveSectionHeading: (token: string, value: string | null) => Promise<void>
-  saveSectionSubheading: (token: string, value: string | null) => Promise<void>
+  saveSectionHeading: (value: string | null) => Promise<void>
+  saveSectionSubheading: (value: string | null) => Promise<void>
 }) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const blockConfig = HOMEPAGE_PAGE_BLOCK_CONFIG['newsletter-signup']
@@ -45,7 +43,6 @@ export default function NewsletterSignupBlockEditor({
             className="hf-btn-icon hf-block-settings-gear"
             title="Section title and subheading for this block"
             aria-label="Block settings"
-            disabled={!token}
             onClick={() => setSettingsOpen(true)}
           >
             ⚙
@@ -72,7 +69,6 @@ export default function NewsletterSignupBlockEditor({
         </p>
         <HomepageBlockSectionTextFields
           blockId={block.id}
-          token={token}
           sectionHeading={block.sectionHeading}
           sectionSubheading={block.sectionSubheading}
           settingsOpen={settingsOpen}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/apiCancellation.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/apiCancellation.test.ts
@@ -41,7 +41,7 @@ describe('homepage featured API cancellation', () => {
     const getRequestSignal = mockAbortableFetch()
     const queryAbortController = new AbortController()
 
-    const request = fetchMainHomepage('token', queryAbortController.signal)
+    const request = fetchMainHomepage(queryAbortController.signal)
 
     await vi.waitFor(() => expect(getRequestSignal()).toBeDefined())
     queryAbortController.abort()
@@ -54,7 +54,7 @@ describe('homepage featured API cancellation', () => {
     const getRequestSignal = mockAbortableFetch()
     const queryAbortController = new AbortController()
 
-    const request = fetchLocationHomepage('token', 1, queryAbortController.signal)
+    const request = fetchLocationHomepage(1, queryAbortController.signal)
 
     await vi.waitFor(() => expect(getRequestSignal()).toBeDefined())
     queryAbortController.abort()

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageFeaturedSlots.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageFeaturedSlots.types.ts
@@ -19,15 +19,13 @@ export type CandidateParams = {
 }
 
 export type UseHomepageFeaturedSlotsOptions = {
-  token: string | null
   canManage: boolean
   selection: HomepageFeaturedSelection
   saveSelection: (
-    token: string,
     items: HomepageFeaturedItemRef[],
     slotCount?: number,
   ) => Promise<HomepageFeaturedSelection>
-  fetchCandidates: (token: string, params: CandidateParams) => Promise<HomepageFeaturedCandidatesResponse>
+  fetchCandidates: (params: CandidateParams) => Promise<HomepageFeaturedCandidatesResponse>
   selectionQueryKey: unknown[]
   /** When set, candidate search stays on this collection (e.g. Questurian Maps → single-type listicles). */
   lockedCollectionFilter?: HomepageFeaturedCollection

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.types.ts
@@ -17,16 +17,13 @@ export type HotelGridCandidateParams = {
 }
 
 export type UseHomepageHotelGridSlotsOptions = {
-  token: string | null
   canManage: boolean
   selection: HomepageHotelGridSelection
   saveSelection: (
-    token: string,
     items: HomepageHotelGridItemRef[],
     slotCount?: number
   ) => Promise<HomepageHotelGridSelection>
   fetchCandidates: (
-    token: string,
     params: HotelGridCandidateParams
   ) => Promise<HomepageHotelGridCandidatesResponse>
   selectionQueryKey: unknown[]

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageLocationGridSlots.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageLocationGridSlots.types.ts
@@ -16,16 +16,13 @@ export type LocationGridCandidateParams = {
 }
 
 export type UseHomepageLocationGridSlotsOptions = {
-  token: string | null
   canManage: boolean
   selection: HomepageLocationGridSelection
   saveSelection: (
-    token: string,
     items: HomepageLocationGridItemRef[],
     slotCount?: number
   ) => Promise<HomepageLocationGridSelection>
   fetchCandidates: (
-    token: string,
     params: LocationGridCandidateParams
   ) => Promise<HomepageLocationGridCandidatesResponse>
   selectionQueryKey: unknown[]

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/useLocationPicker.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/location-picker/useLocationPicker.ts
@@ -7,14 +7,12 @@ import {
 } from './location-groups'
 
 type UseLocationPickerOptions = {
-  token: string
   existingLocationIds: number[]
   onSelect: (locationId: number) => Promise<void>
   onClose: () => void
 }
 
 export function useLocationPicker({
-  token,
   existingLocationIds,
   onSelect,
   onClose,
@@ -23,13 +21,13 @@ export function useLocationPicker({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const cityQuery = useQuery({
-    queryKey: ['locations-city', token],
-    queryFn: () => fetchLocationsIndex(token, { level: 'city' }),
+    queryKey: ['locations-city'],
+    queryFn: () => fetchLocationsIndex({ level: 'city' }),
     staleTime: 60_000,
   })
   const neighborhoodQuery = useQuery({
-    queryKey: ['locations-neighborhood', token],
-    queryFn: () => fetchLocationsIndex(token, { level: 'neighborhood' }),
+    queryKey: ['locations-neighborhood'],
+    queryFn: () => fetchLocationsIndex({ level: 'neighborhood' }),
     staleTime: 60_000,
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/blocks/blockSettings.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/blocks/blockSettings.api.ts
@@ -9,38 +9,34 @@ import { locationHomepageRequest } from '../request'
 import type { LocationHomepageResponse } from '../types'
 
 export async function updateLocationHomepageFeaturedSectionHeading(
-  token: string,
   id: number,
   blockId: string,
   sectionHeading: string | null
 ): Promise<LocationHomepageResponse> {
-  return locationHomepageRequest(`/api/location-homepages/${id}`, token, {
+  return locationHomepageRequest(`/api/location-homepages/${id}`, {
     method: 'PUT',
     body: JSON.stringify({ blockId, sectionHeading })
   })
 }
 
 export async function updateLocationHomepageFeaturedSectionSubheading(
-  token: string,
   id: number,
   blockId: string,
   sectionSubheading: string | null
 ): Promise<LocationHomepageResponse> {
-  return locationHomepageRequest(`/api/location-homepages/${id}`, token, {
+  return locationHomepageRequest(`/api/location-homepages/${id}`, {
     method: 'PUT',
     body: JSON.stringify({ blockId, sectionSubheading })
   })
 }
 
 export async function updateLocationHomepageFeaturedSlot3Layout(
-  token: string,
   homepageId: number,
   blockId: string,
   slot3Layout: FeaturedArticlesSlot3Layout
 ): Promise<LocationHomepageResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${homepageId}`,
-    token,
     {
       method: 'PUT',
       body: JSON.stringify({ blockId, slot3Layout })
@@ -49,14 +45,12 @@ export async function updateLocationHomepageFeaturedSlot3Layout(
 }
 
 export async function updateLocationHomepageFeaturedSlot4Layout(
-  token: string,
   homepageId: number,
   blockId: string,
   slot4Layout: FeaturedArticlesSlot4Layout
 ): Promise<LocationHomepageResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${homepageId}`,
-    token,
     {
       method: 'PUT',
       body: JSON.stringify({ blockId, slot4Layout })
@@ -65,14 +59,12 @@ export async function updateLocationHomepageFeaturedSlot4Layout(
 }
 
 export async function updateLocationHomepageFeaturedSlot5Layout(
-  token: string,
   homepageId: number,
   blockId: string,
   slot5Layout: FeaturedArticlesSlot5Layout
 ): Promise<LocationHomepageResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${homepageId}`,
-    token,
     {
       method: 'PUT',
       body: JSON.stringify({ blockId, slot5Layout })
@@ -81,14 +73,12 @@ export async function updateLocationHomepageFeaturedSlot5Layout(
 }
 
 export async function updateLocationHomepageLocationGridMediaAspect(
-  token: string,
   homepageId: number,
   blockId: string,
   mediaAspect: LocationGridMediaAspect
 ): Promise<LocationHomepageResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${homepageId}`,
-    token,
     {
       method: 'PUT',
       body: JSON.stringify({ blockId, mediaAspect })
@@ -97,14 +87,12 @@ export async function updateLocationHomepageLocationGridMediaAspect(
 }
 
 export async function updateLocationHomepageArticleGridFourLayout(
-  token: string,
   homepageId: number,
   blockId: string,
   articleGridFourLayout: ArticleGridFourLayout
 ): Promise<LocationHomepageResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${homepageId}`,
-    token,
     {
       method: 'PUT',
       body: JSON.stringify({ blockId, articleGridFourLayout })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/blocks/blocks.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/blocks/blocks.api.ts
@@ -8,7 +8,6 @@ import type {
 } from '../types'
 
 export async function updateLocationHomepageBlock(
-  token: string,
   id: number,
   blockId: string,
   items: HomepageBlockSaveItem[],
@@ -17,7 +16,7 @@ export async function updateLocationHomepageBlock(
   const body: Record<string, unknown> = { blockId, items }
   if (typeof slotCount === 'number') body.slotCount = slotCount
 
-  return locationHomepageRequest(`/api/location-homepages/${id}`, token, {
+  return locationHomepageRequest(`/api/location-homepages/${id}`, {
     method: 'PUT',
     body: JSON.stringify(body)
   })
@@ -25,7 +24,6 @@ export async function updateLocationHomepageBlock(
 
 /** When a Featured Articles block has no saved items, switch it to another block type; keeps section title. */
 export async function convertLocationHomepageFeaturedArticlesBlock(
-  token: string,
   homepageId: number,
   blockId: string,
   blockType: string,
@@ -33,7 +31,6 @@ export async function convertLocationHomepageFeaturedArticlesBlock(
 ): Promise<ConvertLocationHomepageBlockResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${homepageId}/blocks/convert?response=lean`,
-    token,
     {
       method: 'POST',
       body: JSON.stringify({ blockId, blockType, slotCount })
@@ -42,7 +39,6 @@ export async function convertLocationHomepageFeaturedArticlesBlock(
 }
 
 export async function addLocationHomepageBlock(
-  token: string,
   id: number,
   blockType: string,
   slotCount: number,
@@ -58,7 +54,6 @@ export async function addLocationHomepageBlock(
   }
   return locationHomepageRequest(
     `/api/location-homepages/${id}/blocks`,
-    token,
     {
       method: 'POST',
       body: JSON.stringify(body)
@@ -67,13 +62,11 @@ export async function addLocationHomepageBlock(
 }
 
 export async function deleteLocationHomepageBlock(
-  token: string,
   id: number,
   blockId: string
 ): Promise<DeleteLocationHomepageBlockResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/blocks?response=lean`,
-    token,
     {
       method: 'DELETE',
       body: JSON.stringify({ blockId })
@@ -82,13 +75,11 @@ export async function deleteLocationHomepageBlock(
 }
 
 export async function reorderLocationHomepageBlocks(
-  token: string,
   id: number,
   orderedBlockIds: string[]
 ): Promise<ReorderLocationHomepageBlocksResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/blocks?response=lean`,
-    token,
     {
       method: 'PATCH',
       body: JSON.stringify({ orderedBlockIds })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/candidates/candidates.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/candidates/candidates.api.ts
@@ -11,7 +11,6 @@ import {
 } from './candidateQuery'
 
 export async function fetchLocationHomepageCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams & {
     type?: HomepageFeaturedCollection | 'all'
@@ -26,72 +25,59 @@ export async function fetchLocationHomepageCandidates(
   const query = queryParams.toString()
   return locationHomepageRequest(
     `/api/location-homepages/${id}/candidates${query ? `?${query}` : ''}`,
-    token
   )
 }
 
 export async function fetchLocationHomepageLocationGridCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams = {}
 ): Promise<HomepageLocationGridCandidatesResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/location-candidates${buildCandidateQuery(params)}`,
-    token
   )
 }
 
 export async function fetchLocationHomepageHotelGridCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams = {}
 ): Promise<HomepageHotelGridCandidatesResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/hotel-candidates${buildCandidateQuery(params)}`,
-    token
   )
 }
 
 export async function fetchLocationHomepageTourGridCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams = {}
 ): Promise<HomepageHotelGridCandidatesResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/tour-candidates${buildCandidateQuery(params)}`,
-    token
   )
 }
 
 export async function fetchLocationHomepageWhereToEatDrinkCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams = {}
 ): Promise<HomepageFeaturedCandidatesResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/where-to-eat-drink-candidates${buildCandidateQuery(params)}`,
-    token
   )
 }
 
 export async function fetchLocationHomepageThingsToDoListicleCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams = {}
 ): Promise<HomepageFeaturedCandidatesResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/things-to-do-listicle-candidates${buildCandidateQuery(params)}`,
-    token
   )
 }
 
 export async function fetchLocationHomepageThingsToDoAttractionCandidates(
-  token: string,
   id: number,
   params: CandidateQueryParams = {}
 ): Promise<HomepageHotelGridCandidatesResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/things-to-do-attraction-candidates${buildCandidateQuery(params)}`,
-    token
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/homepageLifecycle.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/homepageLifecycle.api.ts
@@ -6,17 +6,14 @@ import type {
 } from './types'
 
 export async function fetchLocationHomepagesList(
-  token: string
 ): Promise<LocationHomepageListItem[]> {
-  return locationHomepageRequest('/api/location-homepages', token)
+  return locationHomepageRequest('/api/location-homepages')
 }
 
 export async function resetAllHomepageContent(
-  token: string
 ): Promise<ResetAllHomepageContentResponse> {
   return locationHomepageRequest(
     '/api/homepage-featured-content/reset',
-    token,
     {
       method: 'POST'
     }
@@ -24,41 +21,36 @@ export async function resetAllHomepageContent(
 }
 
 export async function createLocationHomepage(
-  token: string,
   locationId: number
 ): Promise<{ id: number }> {
-  return locationHomepageRequest('/api/location-homepages', token, {
+  return locationHomepageRequest('/api/location-homepages', {
     method: 'POST',
     body: JSON.stringify({ locationId })
   })
 }
 
 export async function fetchLocationHomepage(
-  token: string,
   id: number,
   signal?: AbortSignal
 ): Promise<LocationHomepageResponse> {
-  return locationHomepageRequest(`/api/location-homepages/${id}`, token, {
+  return locationHomepageRequest(`/api/location-homepages/${id}`, {
     signal
   })
 }
 
 export async function deleteLocationHomepage(
-  token: string,
   id: number
 ): Promise<void> {
-  await locationHomepageRequest(`/api/location-homepages/${id}`, token, {
+  await locationHomepageRequest(`/api/location-homepages/${id}`, {
     method: 'DELETE'
   })
 }
 
 export async function toggleLocationHomepage(
-  token: string,
   id: number
 ): Promise<{ id: number; isEnabled: boolean }> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/toggle`,
-    token,
     {
       method: 'PATCH'
     }
@@ -66,12 +58,10 @@ export async function toggleLocationHomepage(
 }
 
 export async function publishLocationHomepage(
-  token: string,
   id: number
 ): Promise<LocationHomepageResponse> {
   return locationHomepageRequest(
     `/api/location-homepages/${id}/publish`,
-    token,
     {
       method: 'POST'
     }

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/request.ts
@@ -5,7 +5,6 @@ const LOCATION_HOMEPAGE_REQUEST_TIMEOUT_MS = 12000
 
 export async function locationHomepageRequest<T>(
   endpoint: string,
-  token: string,
   init?: RequestInit
 ): Promise<T> {
   const controller = new AbortController()

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/locationHomepages/request.ts
@@ -34,7 +34,6 @@ export async function locationHomepageRequest<T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         ...(init?.headers || {})
       }
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/blocks/blockSettings.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/blocks/blockSettings.api.ts
@@ -9,77 +9,70 @@ import { mainHomepageRequest } from '../request'
 import type { MainHomepageResponse } from '../types'
 
 export async function updateMainHomepageFeaturedSectionHeading(
-  token: string,
   blockId: string,
   sectionHeading: string | null,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, sectionHeading }),
   })
 }
 
 export async function updateMainHomepageFeaturedSectionSubheading(
-  token: string,
   blockId: string,
   sectionSubheading: string | null,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, sectionSubheading }),
   })
 }
 
 export async function updateMainHomepageFeaturedSlot3Layout(
-  token: string,
   blockId: string,
   slot3Layout: FeaturedArticlesSlot3Layout,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, slot3Layout }),
   })
 }
 
 export async function updateMainHomepageFeaturedSlot4Layout(
-  token: string,
   blockId: string,
   slot4Layout: FeaturedArticlesSlot4Layout,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, slot4Layout }),
   })
 }
 
 export async function updateMainHomepageFeaturedSlot5Layout(
-  token: string,
   blockId: string,
   slot5Layout: FeaturedArticlesSlot5Layout,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, slot5Layout }),
   })
 }
 
 export async function updateMainHomepageLocationGridMediaAspect(
-  token: string,
   blockId: string,
   mediaAspect: LocationGridMediaAspect,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, mediaAspect }),
   })
 }
 
 export async function updateMainHomepageArticleGridFourLayout(
-  token: string,
   blockId: string,
   articleGridFourLayout: ArticleGridFourLayout,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify({ blockId, articleGridFourLayout }),
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/blocks/blocks.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/blocks/blocks.api.ts
@@ -8,7 +8,6 @@ import type {
 } from '../types'
 
 export async function updateMainHomepageBlock(
-  token: string,
   blockId: string,
   items: HomepageBlockSaveItem[],
   slotCount?: number,
@@ -16,7 +15,7 @@ export async function updateMainHomepageBlock(
   const body: Record<string, unknown> = { blockId, items }
   if (typeof slotCount === 'number') body.slotCount = slotCount
 
-  return mainHomepageRequest('/api/homepage-featured-content', token, {
+  return mainHomepageRequest('/api/homepage-featured-content', {
     method: 'PUT',
     body: JSON.stringify(body),
   })
@@ -24,19 +23,17 @@ export async function updateMainHomepageBlock(
 
 /** When a Featured Articles block has no saved items, switch it to another block type; keeps section title. */
 export async function convertMainHomepageFeaturedArticlesBlock(
-  token: string,
   blockId: string,
   blockType: string,
   slotCount: number,
 ): Promise<ConvertHomepageBlockResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content/blocks/convert?response=lean', token, {
+  return mainHomepageRequest('/api/homepage-featured-content/blocks/convert?response=lean', {
     method: 'POST',
     body: JSON.stringify({ blockId, blockType, slotCount }),
   })
 }
 
 export async function addMainHomepageBlock(
-  token: string,
   blockType: string,
   slotCount: number,
   sectionHeading?: string | null,
@@ -49,27 +46,25 @@ export async function addMainHomepageBlock(
   if (typeof sectionSubheading === 'string' && sectionSubheading.trim()) {
     body.sectionSubheading = sectionSubheading.trim()
   }
-  return mainHomepageRequest('/api/homepage-featured-content/blocks', token, {
+  return mainHomepageRequest('/api/homepage-featured-content/blocks', {
     method: 'POST',
     body: JSON.stringify(body),
   })
 }
 
 export async function deleteMainHomepageBlock(
-  token: string,
   blockId: string,
 ): Promise<DeleteHomepageBlockResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content/blocks?response=lean', token, {
+  return mainHomepageRequest('/api/homepage-featured-content/blocks?response=lean', {
     method: 'DELETE',
     body: JSON.stringify({ blockId }),
   })
 }
 
 export async function reorderMainHomepageBlocks(
-  token: string,
   orderedBlockIds: string[],
 ): Promise<ReorderHomepageBlocksResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content/blocks?response=lean', token, {
+  return mainHomepageRequest('/api/homepage-featured-content/blocks?response=lean', {
     method: 'PATCH',
     body: JSON.stringify({ orderedBlockIds }),
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/candidates/candidates.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/candidates/candidates.api.ts
@@ -8,7 +8,6 @@ import { mainHomepageRequest } from '../request'
 import { buildCandidateQuery, type CandidateQueryParams } from './candidateQuery'
 
 export async function fetchHomepageFeaturedCandidates(
-  token: string,
   params: CandidateQueryParams & {
     type?: HomepageFeaturedCollection | 'all'
   } = {},
@@ -22,66 +21,53 @@ export async function fetchHomepageFeaturedCandidates(
   const query = queryParams.toString()
   return mainHomepageRequest(
     `/api/homepage-featured-content/candidates${query ? `?${query}` : ''}`,
-    token,
   )
 }
 
 export async function fetchHomepageLocationGridCandidates(
-  token: string,
   params: CandidateQueryParams = {},
 ): Promise<HomepageLocationGridCandidatesResponse> {
   return mainHomepageRequest(
     `/api/homepage-featured-content/location-candidates${buildCandidateQuery(params)}`,
-    token,
   )
 }
 
 export async function fetchHomepageHotelGridCandidates(
-  token: string,
   params: CandidateQueryParams = {},
 ): Promise<HomepageHotelGridCandidatesResponse> {
   return mainHomepageRequest(
     `/api/homepage-featured-content/hotel-candidates${buildCandidateQuery(params)}`,
-    token,
   )
 }
 
 export async function fetchWhereToEatDrinkCandidates(
-  token: string,
   params: CandidateQueryParams = {},
 ): Promise<HomepageFeaturedCandidatesResponse> {
   return mainHomepageRequest(
     `/api/homepage-featured-content/where-to-eat-drink-candidates${buildCandidateQuery(params)}`,
-    token,
   )
 }
 
 export async function fetchThingsToDoListicleCandidates(
-  token: string,
   params: CandidateQueryParams = {},
 ): Promise<HomepageFeaturedCandidatesResponse> {
   return mainHomepageRequest(
     `/api/homepage-featured-content/things-to-do-listicle-candidates${buildCandidateQuery(params)}`,
-    token,
   )
 }
 
 export async function fetchTourGridCandidates(
-  token: string,
   params: CandidateQueryParams = {},
 ): Promise<HomepageHotelGridCandidatesResponse> {
   return mainHomepageRequest(
     `/api/homepage-featured-content/tour-candidates${buildCandidateQuery(params)}`,
-    token,
   )
 }
 
 export async function fetchThingsToDoAttractionCandidates(
-  token: string,
   params: CandidateQueryParams = {},
 ): Promise<HomepageHotelGridCandidatesResponse> {
   return mainHomepageRequest(
     `/api/homepage-featured-content/things-to-do-attraction-candidates${buildCandidateQuery(params)}`,
-    token,
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/homepageLifecycle.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/homepageLifecycle.api.ts
@@ -2,14 +2,13 @@ import { mainHomepageRequest } from './request'
 import type { MainHomepageResponse } from './types'
 
 export async function fetchMainHomepage(
-  token: string,
   signal?: AbortSignal,
 ): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content', token, { signal })
+  return mainHomepageRequest('/api/homepage-featured-content', { signal })
 }
 
-export async function publishMainHomepage(token: string): Promise<MainHomepageResponse> {
-  return mainHomepageRequest('/api/homepage-featured-content/publish', token, {
+export async function publishMainHomepage(): Promise<MainHomepageResponse> {
+  return mainHomepageRequest('/api/homepage-featured-content/publish', {
     method: 'POST',
   })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/request.ts
@@ -5,7 +5,6 @@ const HOMEPAGE_FEATURED_REQUEST_TIMEOUT_MS = 12000
 
 export async function mainHomepageRequest<T>(
   endpoint: string,
-  token: string,
   init?: RequestInit,
 ): Promise<T> {
   const controller = new AbortController()

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/request.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepage/request.ts
@@ -32,7 +32,6 @@ export async function mainHomepageRequest<T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         ...(init?.headers || {}),
       },
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useCuratedHomepageLayouts.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useCuratedHomepageLayouts.ts
@@ -16,8 +16,7 @@ import type {
 
 function usePersistedLayoutDraft<T extends string>(
   savedValue: T,
-  token: string | null,
-  save: ((token: string, value: T) => Promise<void>) | undefined,
+  save: ((value: T) => Promise<void>) | undefined,
 ) {
   const [draft, setDraft] = useState(savedValue)
 
@@ -27,8 +26,8 @@ function usePersistedLayoutDraft<T extends string>(
 
   const mutation = useMutation({
     mutationFn: async (value: T) => {
-      if (!token || !save) return
-      await save(token, value)
+      if (!save) return
+      await save(value)
     },
   })
 
@@ -43,27 +42,24 @@ function usePersistedLayoutDraft<T extends string>(
 
 type Params = {
   block: ArticleCuratedHomepageBlockResponse
-  token: string | null
-  saveSlot3Layout?: (token: string, value: FeaturedArticlesSlot3Layout) => Promise<void>
-  saveSlot4Layout?: (token: string, value: FeaturedArticlesSlot4Layout) => Promise<void>
-  saveSlot5Layout?: (token: string, value: FeaturedArticlesSlot5Layout) => Promise<void>
-  saveArticleGridFourLayout?: (token: string, value: ArticleGridFourLayout) => Promise<void>
+  saveSlot3Layout?: (value: FeaturedArticlesSlot3Layout) => Promise<void>
+  saveSlot4Layout?: (value: FeaturedArticlesSlot4Layout) => Promise<void>
+  saveSlot5Layout?: (value: FeaturedArticlesSlot5Layout) => Promise<void>
+  saveArticleGridFourLayout?: (value: ArticleGridFourLayout) => Promise<void>
 }
 
 export function useCuratedHomepageLayouts({
   block,
-  token,
   saveSlot3Layout,
   saveSlot4Layout,
   saveSlot5Layout,
   saveArticleGridFourLayout,
 }: Params) {
-  const slot3 = usePersistedLayoutDraft(slot3LayoutForBlock(block), token, saveSlot3Layout)
-  const slot4 = usePersistedLayoutDraft(slot4LayoutForBlock(block), token, saveSlot4Layout)
-  const slot5 = usePersistedLayoutDraft(slot5LayoutForBlock(block), token, saveSlot5Layout)
+  const slot3 = usePersistedLayoutDraft(slot3LayoutForBlock(block), saveSlot3Layout)
+  const slot4 = usePersistedLayoutDraft(slot4LayoutForBlock(block), saveSlot4Layout)
+  const slot5 = usePersistedLayoutDraft(slot5LayoutForBlock(block), saveSlot5Layout)
   const articleGridFour = usePersistedLayoutDraft(
     articleGridFourLayoutForBlock(block),
-    token,
     saveArticleGridFourLayout,
   )
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedCandidates.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedCandidates.ts
@@ -8,7 +8,6 @@ const CANDIDATE_PAGE_SIZE = 24
 
 type UseHomepageFeaturedCandidatesOptions = Pick<
   UseHomepageFeaturedSlotsOptions,
-  | 'token'
   | 'canManage'
   | 'fetchCandidates'
   | 'selectionQueryKey'
@@ -18,7 +17,6 @@ type UseHomepageFeaturedCandidatesOptions = Pick<
 }
 
 export function useHomepageFeaturedCandidates({
-  token,
   canManage,
   fetchCandidates,
   selectionQueryKey,
@@ -46,13 +44,13 @@ export function useHomepageFeaturedCandidates({
       candidatePage
     ],
     queryFn: () =>
-      fetchCandidates(token!, {
+      fetchCandidates({
         type: effectiveCollectionFilter,
         query: deferredSearchValue || undefined,
         page: candidatePage,
         limit: CANDIDATE_PAGE_SIZE
       }),
-    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
+    enabled: Boolean(canManage && pickerSlotIndex !== null),
     placeholderData: (previousData) => previousData
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSaveMutation.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSaveMutation.ts
@@ -13,7 +13,7 @@ import type {
 
 type UseHomepageFeaturedSaveMutationOptions = Pick<
   UseHomepageFeaturedSlotsOptions,
-  'token' | 'saveSelection'
+  'saveSelection'
 > & {
   slotCountRef: MutableRefObject<number>
   onSuccess: (selection: HomepageFeaturedSelection) => void
@@ -21,7 +21,6 @@ type UseHomepageFeaturedSaveMutationOptions = Pick<
 }
 
 export function useHomepageFeaturedSaveMutation({
-  token,
   saveSelection,
   slotCountRef,
   onSuccess,
@@ -32,7 +31,7 @@ export function useHomepageFeaturedSaveMutation({
 
   const saveMutation = useMutation({
     mutationFn: (items: HomepageFeaturedItemRef[]) =>
-      saveSelection(token!, items, slotCountRef.current),
+      saveSelection(items, slotCountRef.current),
     onSuccess: (selection) => {
       onSuccess(selection)
       onResultMessage('Homepage featured content saved.')

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSlots.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSlots.test.tsx
@@ -35,7 +35,6 @@ describe('useHomepageFeaturedSlots', () => {
     const { result, rerender } = renderHook(
       () =>
         useHomepageFeaturedSlots({
-          token: 'test-token',
           canManage: true,
           selection,
           saveSelection: vi.fn(),

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageFeaturedSlots.ts
@@ -35,7 +35,6 @@ export function useHomepageFeaturedSlots(
   options: UseHomepageFeaturedSlotsOptions
 ): UseHomepageFeaturedSlotsResult {
   const {
-    token,
     canManage,
     selection,
     saveSelection,
@@ -77,7 +76,6 @@ export function useHomepageFeaturedSlots(
     setCollectionFilter,
     setCandidatePage
   } = useHomepageFeaturedCandidates({
-    token,
     canManage,
     fetchCandidates,
     selectionQueryKey,
@@ -93,7 +91,6 @@ export function useHomepageFeaturedSlots(
   }, [repairSlotCount, slots.length])
 
   const { saveMutation, saveNotification } = useHomepageFeaturedSaveMutation({
-    token,
     saveSelection,
     slotCountRef: currentSaveSlotCountRef,
     onSuccess: applySelection,
@@ -118,7 +115,6 @@ export function useHomepageFeaturedSlots(
     savedInvalidItems.length > 0 &&
     saveItems.length === repairSlotCount
   const saveDisabled =
-    !token ||
     (!hasAllSlotsFilled && !hasRepairableStaleSlots) ||
     hasDuplicateSlots(slots) ||
     saveMutation.isPending ||

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridCandidates.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridCandidates.ts
@@ -7,13 +7,12 @@ const CANDIDATE_PAGE_SIZE = 24
 
 type UseHomepageHotelGridCandidatesOptions = Pick<
   UseHomepageHotelGridSlotsOptions,
-  'token' | 'canManage' | 'fetchCandidates' | 'selectionQueryKey'
+  'canManage' | 'fetchCandidates' | 'selectionQueryKey'
 > & {
   pickerSlotIndex: number | null
 }
 
 export function useHomepageHotelGridCandidates({
-  token,
   canManage,
   fetchCandidates,
   selectionQueryKey,
@@ -35,12 +34,12 @@ export function useHomepageHotelGridCandidates({
       candidatePage
     ],
     queryFn: () =>
-      fetchCandidates(token!, {
+      fetchCandidates({
         query: deferredSearchValue || undefined,
         page: candidatePage,
         limit: CANDIDATE_PAGE_SIZE
       }),
-    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
+    enabled: Boolean(canManage && pickerSlotIndex !== null),
     placeholderData: (previousData) => previousData
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSaveMutation.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSaveMutation.ts
@@ -9,7 +9,7 @@ import type { UseHomepageHotelGridSlotsOptions } from './homepageHotelGridSlots.
 
 type UseHomepageHotelGridSaveMutationOptions = Pick<
   UseHomepageHotelGridSlotsOptions,
-  'token' | 'saveSelection'
+  'saveSelection'
 > & {
   slotCountRef: MutableRefObject<number>
   onSuccess: (selection: HomepageHotelGridSelection) => void
@@ -17,7 +17,6 @@ type UseHomepageHotelGridSaveMutationOptions = Pick<
 }
 
 export function useHomepageHotelGridSaveMutation({
-  token,
   saveSelection,
   slotCountRef,
   onSuccess,
@@ -25,7 +24,7 @@ export function useHomepageHotelGridSaveMutation({
 }: UseHomepageHotelGridSaveMutationOptions) {
   return useMutation({
     mutationFn: (items: HomepageHotelGridItemRef[]) =>
-      saveSelection(token!, items, slotCountRef.current),
+      saveSelection(items, slotCountRef.current),
     onSuccess,
     onError
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageHotelGridSlots.ts
@@ -27,7 +27,6 @@ export function useHomepageHotelGridSlots(
   options: UseHomepageHotelGridSlotsOptions
 ): UseHomepageHotelGridSlotsResult {
   const {
-    token,
     canManage,
     selection,
     saveSelection,
@@ -60,7 +59,6 @@ export function useHomepageHotelGridSlots(
   } as ReturnType<typeof useQuery<HomepageHotelGridSelection>>
 
   const candidateState = useHomepageHotelGridCandidates({
-    token,
     canManage,
     fetchCandidates,
     selectionQueryKey,
@@ -75,7 +73,6 @@ export function useHomepageHotelGridSlots(
   }, [slots.length])
 
   const saveMutation = useHomepageHotelGridSaveMutation({
-    token,
     saveSelection,
     slotCountRef: currentSaveSlotCountRef,
     onSuccess: (nextSelection) => {
@@ -93,7 +90,6 @@ export function useHomepageHotelGridSlots(
 
   const hasUnsavedChanges = !areHotelSlotListsEqual(draftSlots, savedSlots)
   const saveDisabled =
-    !token ||
     slots.some((item) => item === null) ||
     saveMutation.isPending ||
     !hasUnsavedChanges

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageLocationGridCandidates.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageLocationGridCandidates.ts
@@ -7,13 +7,12 @@ const CANDIDATE_PAGE_SIZE = 24
 
 type UseHomepageLocationGridCandidatesOptions = Pick<
   UseHomepageLocationGridSlotsOptions,
-  'token' | 'canManage' | 'fetchCandidates' | 'selectionQueryKey'
+  'canManage' | 'fetchCandidates' | 'selectionQueryKey'
 > & {
   pickerSlotIndex: number | null
 }
 
 export function useHomepageLocationGridCandidates({
-  token,
   canManage,
   fetchCandidates,
   selectionQueryKey,
@@ -35,12 +34,12 @@ export function useHomepageLocationGridCandidates({
       candidatePage
     ],
     queryFn: () =>
-      fetchCandidates(token!, {
+      fetchCandidates({
         query: deferredSearchValue || undefined,
         page: candidatePage,
         limit: CANDIDATE_PAGE_SIZE
       }),
-    enabled: Boolean(token && canManage && pickerSlotIndex !== null),
+    enabled: Boolean(canManage && pickerSlotIndex !== null),
     placeholderData: (previousData) => previousData
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageLocationGridSaveMutation.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageLocationGridSaveMutation.ts
@@ -9,7 +9,7 @@ import type { UseHomepageLocationGridSlotsOptions } from './homepageLocationGrid
 
 type UseHomepageLocationGridSaveMutationOptions = Pick<
   UseHomepageLocationGridSlotsOptions,
-  'token' | 'saveSelection'
+  'saveSelection'
 > & {
   slotCountRef: MutableRefObject<number>
   onSuccess: (selection: HomepageLocationGridSelection) => void
@@ -17,7 +17,6 @@ type UseHomepageLocationGridSaveMutationOptions = Pick<
 }
 
 export function useHomepageLocationGridSaveMutation({
-  token,
   saveSelection,
   slotCountRef,
   onSuccess,
@@ -25,7 +24,7 @@ export function useHomepageLocationGridSaveMutation({
 }: UseHomepageLocationGridSaveMutationOptions) {
   return useMutation({
     mutationFn: (items: HomepageLocationGridItemRef[]) =>
-      saveSelection(token!, items, slotCountRef.current),
+      saveSelection(items, slotCountRef.current),
     onSuccess,
     onError
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageLocationGridSlots.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useHomepageLocationGridSlots.ts
@@ -32,7 +32,6 @@ export function useHomepageLocationGridSlots(
   options: UseHomepageLocationGridSlotsOptions
 ): UseHomepageLocationGridSlotsResult {
   const {
-    token,
     canManage,
     selection,
     saveSelection,
@@ -68,7 +67,6 @@ export function useHomepageLocationGridSlots(
     setSearchValue,
     setCandidatePage
   } = useHomepageLocationGridCandidates({
-    token,
     canManage,
     fetchCandidates,
     selectionQueryKey,
@@ -83,7 +81,6 @@ export function useHomepageLocationGridSlots(
   }, [slots.length])
 
   const saveMutation = useHomepageLocationGridSaveMutation({
-    token,
     saveSelection,
     slotCountRef: currentSaveSlotCountRef,
     onSuccess: (selection) => {
@@ -103,7 +100,6 @@ export function useHomepageLocationGridSlots(
   const hasAllSlotsFilled = slots.every((item) => item !== null)
   const hasUnsavedChanges = areSlotListsEqual(draftSlots, savedSlots) === false
   const saveDisabled =
-    !token ||
     !hasAllSlotsFilled ||
     hasDuplicateSlots(slots) ||
     saveMutation.isPending ||

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useLocationHomepageEditor.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useLocationHomepageEditor.ts
@@ -27,14 +27,14 @@ import type { CuratedHomepageBlockType, PageBlockResponse } from './pageBlocks'
  * refetch. `pageBlockSlotKeys` tracks which article slots each block has taken
  * so editors can exclude each other's picks.
  */
-export function useLocationHomepageEditor(numericId: number, token: string | null | undefined, canManage: boolean) {
+export function useLocationHomepageEditor(numericId: number, canManage: boolean) {
   const queryClient = useQueryClient()
-  const homepageQueryKey = ['location-homepage', numericId, token]
+  const homepageQueryKey = ['location-homepage', numericId]
 
   const homepageQuery = useQuery({
     queryKey: homepageQueryKey,
-    queryFn: ({ signal }) => fetchLocationHomepage(token!, numericId, signal),
-    enabled: Boolean(token && canManage && numericId),
+    queryFn: ({ signal }) => fetchLocationHomepage(numericId, signal),
+    enabled: Boolean(canManage && numericId),
   })
 
   const [isEnabled, setIsEnabled] = useState<boolean | null>(null)
@@ -46,7 +46,7 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
   }, [homepageQuery.data, isEnabled])
 
   const toggleMutation = useMutation({
-    mutationFn: () => toggleLocationHomepage(token!, numericId),
+    mutationFn: () => toggleLocationHomepage(numericId),
     onSuccess: (result) => {
       setIsEnabled(result.isEnabled)
       queryClient.invalidateQueries({ queryKey: ['location-homepages-list'] })
@@ -54,7 +54,7 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
   })
 
   const publishMutation = useMutation({
-    mutationFn: () => publishLocationHomepage(token!, numericId),
+    mutationFn: () => publishLocationHomepage(numericId),
     onSuccess: (result) => {
       queryClient.setQueryData<LocationHomepageResponse>(homepageQueryKey, result)
       queryClient.invalidateQueries({ queryKey: homepageQueryKey })
@@ -98,7 +98,7 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
       sectionHeading?: string | null
       sectionSubheading?: string | null
     }) =>
-      addLocationHomepageBlock(token!, numericId, blockType, slotCount, sectionHeading, sectionSubheading),
+      addLocationHomepageBlock(numericId, blockType, slotCount, sectionHeading, sectionSubheading),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: homepageQueryKey })
       setShowAddBlock(false)
@@ -107,7 +107,7 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
 
   const deleteBlockMutation = useMutation({
     mutationFn: ({ blockId }: { blockId: string }) =>
-      deleteLocationHomepageBlock(token!, numericId, blockId),
+      deleteLocationHomepageBlock(numericId, blockId),
     onMutate: async ({ blockId }) => {
       setDeletingBlockId(blockId)
       await queryClient.cancelQueries({ queryKey: homepageQueryKey })
@@ -130,7 +130,7 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
 
   const reorderBlocksMutation = useMutation({
     mutationFn: (orderedBlockIds: string[]) =>
-      reorderLocationHomepageBlocks(token!, numericId, orderedBlockIds),
+      reorderLocationHomepageBlocks(numericId, orderedBlockIds),
     onMutate: async (orderedBlockIds) => {
       await queryClient.cancelQueries({ queryKey: homepageQueryKey })
       const previousHomepage =
@@ -154,7 +154,6 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
 
   async function handleConvertBlock(
     block: PageBlockResponse,
-    currentToken: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) {
@@ -169,7 +168,6 @@ export function useLocationHomepageEditor(numericId: number, token: string | nul
 
     try {
       const result = await convertLocationHomepageFeaturedArticlesBlock(
-        currentToken,
         numericId,
         block.id,
         blockType,

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useMainHomepageEditor.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/useMainHomepageEditor.ts
@@ -19,16 +19,15 @@ import {
 import type { CuratedHomepageBlockType, PageBlockResponse } from './pageBlocks'
 
 export function useMainHomepageEditor(
-  token: string | null | undefined,
   canManage: boolean,
 ) {
   const queryClient = useQueryClient()
-  const homepageQueryKey = ['main-homepage', token]
+  const homepageQueryKey = ['main-homepage']
 
   const homepageQuery = useQuery({
     queryKey: homepageQueryKey,
-    queryFn: ({ signal }) => fetchMainHomepage(token!, signal),
-    enabled: Boolean(token && canManage),
+    queryFn: ({ signal }) => fetchMainHomepage(signal),
+    enabled: Boolean(canManage),
   })
 
   const [showAddBlock, setShowAddBlock] = useState(false)
@@ -69,7 +68,6 @@ export function useMainHomepageEditor(
       sectionHeading?: string | null
       sectionSubheading?: string | null
     }) => addMainHomepageBlock(
-      token!,
       blockType,
       slotCount,
       sectionHeading,
@@ -83,7 +81,7 @@ export function useMainHomepageEditor(
 
   const deleteBlockMutation = useMutation({
     mutationFn: ({ blockId }: { blockId: string }) =>
-      deleteMainHomepageBlock(token!, blockId),
+      deleteMainHomepageBlock(blockId),
     onMutate: async ({ blockId }) => {
       setDeletingBlockId(blockId)
       await queryClient.cancelQueries({ queryKey: homepageQueryKey })
@@ -106,7 +104,7 @@ export function useMainHomepageEditor(
 
   const reorderBlocksMutation = useMutation({
     mutationFn: (orderedBlockIds: string[]) =>
-      reorderMainHomepageBlocks(token!, orderedBlockIds),
+      reorderMainHomepageBlocks(orderedBlockIds),
     onMutate: async (orderedBlockIds) => {
       await queryClient.cancelQueries({ queryKey: homepageQueryKey })
       const previousHomepage =
@@ -129,7 +127,7 @@ export function useMainHomepageEditor(
   })
 
   const publishMutation = useMutation({
-    mutationFn: () => publishMainHomepage(token!),
+    mutationFn: () => publishMainHomepage(),
     onSuccess: (result) => {
       queryClient.setQueryData<MainHomepageResponse>(homepageQueryKey, result)
       queryClient.invalidateQueries({ queryKey: homepageQueryKey })
@@ -138,7 +136,6 @@ export function useMainHomepageEditor(
 
   async function handleConvertBlock(
     block: PageBlockResponse,
-    currentToken: string,
     blockType: CuratedHomepageBlockType,
     slotCount: number,
   ) {
@@ -157,7 +154,6 @@ export function useMainHomepageEditor(
 
     try {
       const result = await convertMainHomepageFeaturedArticlesBlock(
-        currentToken,
         block.id,
         blockType,
         slotCount,

--- a/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/components/ItineraryTitlePipelinePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/components/ItineraryTitlePipelinePanel.tsx
@@ -12,7 +12,6 @@ type Props = {
 
 export function ItineraryTitlePipelinePanel({ pipeline }: Props) {
   const {
-    token,
     locationId,
     setLocationId,
     dayCount,
@@ -112,7 +111,7 @@ export function ItineraryTitlePipelinePanel({ pipeline }: Props) {
               id="itineraries-pipeline-location"
               name="location"
               value={locationId ?? ''}
-              disabled={!token || locationsLoading || Boolean(locationsError)}
+              disabled={locationsLoading || Boolean(locationsError)}
               onChange={(event) => {
                 const raw = event.target.value
                 setLocationId(raw ? Number(raw) : null)

--- a/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/hooks/useItineraryTitlePipeline.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/hooks/useItineraryTitlePipeline.ts
@@ -19,7 +19,7 @@ import {
   locationRowIdsEqual
 } from '../locationSelectGroups'
 
-export function useItineraryTitlePipeline(token?: string | null) {
+export function useItineraryTitlePipeline() {
   const [locationId, setLocationId] = useState<number | null>(null)
   const [dayCount, setDayCount] = useState(1)
   const [itineraryType, setItineraryType] = useState<ItineraryPipelineTypeId>(
@@ -75,12 +75,11 @@ export function useItineraryTitlePipeline(token?: string | null) {
   }, [dayCount, selectedLocation, selectedTypeOption, typeMarkdown])
 
   useEffect(() => {
-    if (!token) return
 
     let cancelled = false
     setLocationsLoading(true)
     setLocationsError(null)
-    fetchLocations(token)
+    fetchLocations()
       .then((docs) => {
         if (!cancelled) setLocations(docs)
       })
@@ -98,7 +97,7 @@ export function useItineraryTitlePipeline(token?: string | null) {
     return () => {
       cancelled = true
     }
-  }, [token])
+  }, [])
 
   useEffect(() => {
     setPipelineResult(null)
@@ -141,7 +140,6 @@ export function useItineraryTitlePipeline(token?: string | null) {
   }
 
   return {
-    token,
     locationId,
     setLocationId,
     dayCount,

--- a/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/pages/ItinerariesPipelinePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/itinerariesPipeline/pages/ItinerariesPipelinePage.tsx
@@ -10,9 +10,8 @@ import '../../prompt2blog/styles.css'
 type ItinerariesPipelineTabId = 'pipeline' | 'main'
 
 export default function ItinerariesPipelinePage() {
-  const { token } = useAuth()
   const [activeTab, setActiveTab] = useState<ItinerariesPipelineTabId>('main')
-  const pipeline = useItineraryTitlePipeline(token)
+  const pipeline = useItineraryTitlePipeline()
 
   return (
     <div className="stl-page ip-pipeline">

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api.test.ts
@@ -12,7 +12,7 @@ describe('listicleItineraries api', () => {
 
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(fetchItineraries('token-123')).resolves.toEqual({
+    await expect(fetchItineraries()).resolves.toEqual({
       docs: [{ id: 7, title: 'One Day in Lima', location: 'peru|lima', status: 'draft' }],
     })
 
@@ -49,7 +49,7 @@ describe('listicleItineraries api', () => {
 
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(fetchLocations('token-123')).resolves.toEqual([
+    await expect(fetchLocations()).resolves.toEqual([
       { id: 1, locationKey: 'peru|lima' },
       { id: 2, locationKey: 'peru|cusco' },
     ])

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/itineraries.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/itineraries.ts
@@ -42,7 +42,6 @@ function relatedCollectionForBlockType(
 }
 
 export async function fetchItineraries(
-  token: string
 ): Promise<PayloadListResponse<PayloadItineraryDoc>> {
   const params = new URLSearchParams()
   params.set('depth', '0')
@@ -53,29 +52,25 @@ export async function fetchItineraries(
     params.set(`select[${field}]`, 'true')
   }
 
-  return payloadRequest(`/api/listicle-itineraries?${params.toString()}`, token)
+  return payloadRequest(`/api/listicle-itineraries?${params.toString()}`)
 }
 
 export async function fetchItineraryById(
   id: number,
-  token: string
 ): Promise<PayloadItineraryDoc> {
   return payloadRequest<PayloadItineraryDoc>(
     `/api/listicle-itineraries/${id}`,
-    token
   )
 }
 
 export async function createItinerary(
   body: Record<string, unknown>,
-  token: string
 ): Promise<PayloadItineraryDoc> {
   const safeBody = Object.fromEntries(
     Object.entries(body).filter(([key]) => key !== 'id')
   )
   const response = await payloadRequest<{ doc: PayloadItineraryDoc }>(
     `/api/listicle-itineraries`,
-    token,
     {
       method: 'POST',
       body: JSON.stringify(safeBody)
@@ -87,11 +82,9 @@ export async function createItinerary(
 export async function updateItinerary(
   id: number,
   body: Record<string, unknown>,
-  token: string
 ): Promise<PayloadItineraryDoc> {
   const response = await payloadRequest<{ doc: PayloadItineraryDoc }>(
     `/api/listicle-itineraries/${id}`,
-    token,
     {
       method: 'PATCH',
       body: JSON.stringify(body)
@@ -100,7 +93,7 @@ export async function updateItinerary(
   return response.doc
 }
 
-export async function fetchLocations(token: string): Promise<LocationOption[]> {
+export async function fetchLocations(): Promise<LocationOption[]> {
   const allDocs: LocationOption[] = []
   let page = 1
   let totalPages = 1
@@ -108,7 +101,6 @@ export async function fetchLocations(token: string): Promise<LocationOption[]> {
   while (page <= totalPages) {
     const response = await payloadRequest<PayloadListResponse<LocationOption>>(
       `/api/locations?limit=200&page=${page}&depth=0`,
-      token
     )
 
     allDocs.push(...(response.docs || []))
@@ -120,7 +112,6 @@ export async function fetchLocations(token: string): Promise<LocationOption[]> {
 }
 
 export async function fetchMediaAssets(
-  token: string,
   params?: { id?: number }
 ): Promise<MediaAssetOption[]> {
   const queryParams = new URLSearchParams()
@@ -132,13 +123,11 @@ export async function fetchMediaAssets(
 
   const response = await payloadRequest<PayloadListResponse<MediaAssetOption>>(
     `/api/media-assets?${queryParams.toString()}`,
-    token
   )
   return response.docs || []
 }
 
 export async function fetchInstagramPosts(
-  token: string,
   params?: { id?: number }
 ): Promise<InstagramPostOption[]> {
   const queryParams = new URLSearchParams()
@@ -151,7 +140,7 @@ export async function fetchInstagramPosts(
 
   const response = await payloadRequest<
     PayloadListResponse<InstagramPostOption>
-  >(`/api/instagram-posts?${queryParams.toString()}`, token)
+  >(`/api/instagram-posts?${queryParams.toString()}`)
 
   return response.docs || []
 }
@@ -159,7 +148,6 @@ export async function fetchInstagramPosts(
 export async function fetchRelatedItems(
   blockType: ItineraryBlockType,
   locationKey: string,
-  token: string,
   scope?: LocationScope
 ): Promise<RelatedItemOption[]> {
   const collection = relatedCollectionForBlockType(blockType)
@@ -173,13 +161,12 @@ export async function fetchRelatedItems(
 
   if (locationKey) {
     const resolvedScope =
-      scope || (await getArticleLocationScope({ locationKey, token }))
+      scope || (await getArticleLocationScope({ locationKey }))
     appendScopedLocationWhere(params, resolvedScope)
   }
 
   const response = await payloadRequest<PayloadListResponse<RelatedItemOption>>(
     `/api/${collection}?${params.toString()}`,
-    token
   )
 
   return normalizeRelatedItems(response.docs || [])

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
@@ -56,7 +56,6 @@ function formatPayloadHttpError(body: unknown, status: number): string {
 
 export async function payloadRequest<T>(
   endpoint: string,
-  token: string,
   init?: RequestInit
 ): Promise<T> {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/api/payloadClient.ts
@@ -65,7 +65,6 @@ export async function payloadRequest<T>(
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
       ...(init?.headers || {})
     }
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/BuilderHeaderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/BuilderHeaderPanel.tsx
@@ -6,7 +6,6 @@ import type { ListicleItineraryDraft, MediaAssetOption } from '../../types'
 
 type BuilderHeaderPanelProps = {
   draft: ListicleItineraryDraft
-  token: string | null
   locationRef: number | null
   mediaAssets: MediaAssetOption[]
   updateHeader: (next: Partial<ListicleItineraryDraft['header']>) => void
@@ -27,7 +26,6 @@ type BuilderHeaderPanelProps = {
 
 export function BuilderHeaderPanel({
   draft,
-  token,
   locationRef,
   mediaAssets,
   updateHeader,
@@ -49,7 +47,6 @@ export function BuilderHeaderPanel({
     <>
       <SharedBuilderHeaderPanel
         draft={draft}
-        token={token}
         locationRef={locationRef}
         mediaAssets={mediaAssets}
         updateHeader={updateHeader}
@@ -66,7 +63,6 @@ export function BuilderHeaderPanel({
             type="button"
             className="stl-btn stl-btn-secondary"
             onClick={() => setCompositeOpen(true)}
-            disabled={!token}
           >
             Create composite
           </button>
@@ -99,10 +95,9 @@ export function BuilderHeaderPanel({
           </>
         )}
       />
-      {token ? (
+      {(
         <CompositeImageModal
           isOpen={compositeOpen}
-          token={token}
           locationRef={locationRef}
           defaultTitle={`Composite: ${draft.title.trim() || 'Itinerary header'}`}
           onCreated={(response) => {
@@ -113,7 +108,7 @@ export function BuilderHeaderPanel({
           }}
           onClose={() => setCompositeOpen(false)}
         />
-      ) : null}
+      )}
     </>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/BuilderStopsPanel.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/BuilderStopsPanel.test.tsx
@@ -256,7 +256,6 @@ function Harness({
     <BuilderStopsPanel
       draft={draft}
       activeDayIndex={0}
-      token={null}
       locationRef={1}
       mediaAssets={[]}
       instagramPosts={[]}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/BuilderStopsPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/BuilderStopsPanel.tsx
@@ -23,7 +23,6 @@ type BuilderStopsPanelProps = {
   draft: ListicleItineraryDraft
   /** Index of the day tab being edited (0-based). */
   activeDayIndex: number
-  token: string | null
   locationRef: number | null
   mediaAssets: MediaAssetOption[]
   instagramPosts: InstagramPostOption[]
@@ -66,7 +65,6 @@ type BuilderStopsPanelProps = {
 export function BuilderStopsPanel({
   draft,
   activeDayIndex,
-  token,
   locationRef,
   mediaAssets,
   instagramPosts,
@@ -94,7 +92,6 @@ export function BuilderStopsPanel({
   onSaveStep3,
   onCancelStep3Update
 }: BuilderStopsPanelProps) {
-  const resolvedToken = token ?? ''
   const dayDraft = useMemo(() => {
     const day = draft.days[activeDayIndex] ?? draft.days[0]
     return (
@@ -138,7 +135,6 @@ export function BuilderStopsPanel({
     [dayDraft.whereStaying, dayDraft.items]
   )
   const fetchedManualImageAssets = useManualStopImageAssets({
-    token: resolvedToken,
     items: allStep3Items,
     mediaAssets
   })
@@ -338,7 +334,7 @@ export function BuilderStopsPanel({
               showHeading={
                 idx === 0 || step3Rows[idx - 1].section !== row.section
               }
-              token={resolvedToken}
+             
               locationRef={locationRef}
               mediaAssets={mediaAssets}
               instagramPosts={instagramPosts}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/stops/BuilderStopOverlays.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/stops/BuilderStopOverlays.tsx
@@ -27,7 +27,6 @@ type Props = {
   item: ItineraryItemBlock
   section: 'whereStaying' | 'stops'
   localIndex: number
-  token: string
   locationRef: number | null
   instagramPosts: InstagramPostOption[]
   relatedOptions: RelatedItemOption[]
@@ -57,7 +56,6 @@ export function BuilderStopOverlays(props: Props) {
     item,
     section,
     localIndex,
-    token: resolvedToken,
     locationRef,
     instagramPosts,
     relatedOptions,
@@ -215,7 +213,7 @@ export function BuilderStopOverlays(props: Props) {
       <FeaturedImagePicker
         isOpen={imagePickerItemId === item.id}
         selectedId={item.image}
-        token={resolvedToken}
+       
         locationRef={locationRef}
         payloadSourceMode="mediaSets"
         requireMediaSet={false}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/stops/BuilderStopRow.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/stops/BuilderStopRow.tsx
@@ -61,7 +61,6 @@ type Step3Row = {
 type BuilderStopRowProps = {
   row: Step3Row
   showHeading: boolean
-  token: string
   locationRef: number | null
   mediaAssets: MediaAssetOption[]
   instagramPosts: InstagramPostOption[]
@@ -94,7 +93,6 @@ type BuilderStopRowProps = {
 export function BuilderStopRow({
   row,
   showHeading,
-  token: resolvedToken,
   locationRef,
   mediaAssets,
   instagramPosts,
@@ -408,7 +406,7 @@ export function BuilderStopRow({
           item={item}
           section={section}
           localIndex={localIndex}
-          token={resolvedToken}
+         
           locationRef={locationRef}
           instagramPosts={instagramPosts}
           relatedOptions={relatedOptions}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/itineraryBuilderAiActions.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/itineraryBuilderAiActions.types.ts
@@ -15,7 +15,6 @@ export type StopComposeChoice = {
 }
 
 export type ItineraryBuilderAiActionsParams = {
-  token?: string | null
   draft: ListicleItineraryDraft | null
   setDraft: Dispatch<SetStateAction<ListicleItineraryDraft | null>>
   locations: LocationOption[]

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useBuilderBootstrap.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useBuilderBootstrap.ts
@@ -24,7 +24,6 @@ import {
 } from '../../../../shared/payloadSync/draftPayloadSync'
 
 type UseBuilderBootstrapParams = {
-  token?: string | null
   payloadIdParam: string | null
   draftIdParam: string | null
   setSearchParams: SetURLSearchParams
@@ -162,7 +161,6 @@ export function mergeLocalIntoPayloadDraft(
 }
 
 export function useBuilderBootstrap({
-  token,
   payloadIdParam,
   draftIdParam,
   setSearchParams,
@@ -173,7 +171,6 @@ export function useBuilderBootstrap({
     Awaited<ReturnType<typeof fetchItineraryById>>,
     AuxData
   >({
-    token,
     payloadIdParam,
     draftIdParam,
     setSearchParams,
@@ -184,11 +181,11 @@ export function useBuilderBootstrap({
       createEmptyDraft,
       saveDraft,
     },
-    loadAuxData: async (authToken) => {
+    loadAuxData: async () => {
       const [locationDocs, mediaDocs, instagramDocs] = await Promise.all([
-        fetchLocations(authToken),
-        fetchMediaAssets(authToken),
-        fetchInstagramPosts(authToken),
+        fetchLocations(),
+        fetchMediaAssets(),
+        fetchInstagramPosts(),
       ])
       return { locations: locationDocs, mediaAssets: mediaDocs, instagramPosts: instagramDocs }
     },
@@ -196,17 +193,17 @@ export function useBuilderBootstrap({
     payloadDocToDraft,
     mergeLocalIntoPayloadDraft,
     normalizeDraft: normalizeDraftModelName,
-    enrichAuxData: async (nextDraft, authToken, aux) => {
+    enrichAuxData: async (nextDraft, aux) => {
       const missingMediaIds = collectMissingMediaAssetIds(nextDraft, aux.mediaAssets)
       const missingInstagramIds = collectMissingInstagramPostIds(nextDraft, aux.instagramPosts)
 
       const [missingMediaDocs, missingInstagramDocs] = await Promise.all([
         Promise.all(missingMediaIds.map(async (id) => {
-          const docs = await fetchMediaAssets(authToken, { id })
+          const docs = await fetchMediaAssets({ id })
           return docs[0] || null
         })),
         Promise.all(missingInstagramIds.map(async (id) => {
-          const docs = await fetchInstagramPosts(authToken, { id })
+          const docs = await fetchInstagramPosts({ id })
           return docs[0] || null
         })),
       ])

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryAutobuildActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryAutobuildActions.ts
@@ -17,11 +17,10 @@ import type { ItineraryBuilderAiActionsParams } from './itineraryBuilderAiAction
 
 type Params = Pick<
   ItineraryBuilderAiActionsParams,
-  'token' | 'draft' | 'setDraft' | 'locations' | 'onError' | 'setResult'
+  'draft' | 'setDraft' | 'locations' | 'onError' | 'setResult'
 >
 
 export function useItineraryAutobuildActions({
-  token,
   draft,
   setDraft,
   locations,
@@ -125,10 +124,6 @@ export function useItineraryAutobuildActions({
     }
     const brief = (draft.generationBrief || '').trim()
     if (!brief) return
-    if (!token) {
-      onError('You must be signed in to generate an itinerary.')
-      return
-    }
     const hasExistingStops = draft.days.some(
       (day) => day.items.length > 0 || day.whereStaying.length > 0
     )
@@ -152,8 +147,7 @@ export function useItineraryAutobuildActions({
         title: draft.title.trim(),
         brief,
         dayCount: draft.dayCount,
-        payloadToken: token,
-        sharedNeighborhoods: draft.sharedNeighborhoods,
+                sharedNeighborhoods: draft.sharedNeighborhoods,
         dayShells: draft.days.map((day, dayIndex) => ({
           dayIndex,
           shell: getDayShellTemplate(
@@ -190,7 +184,7 @@ export function useItineraryAutobuildActions({
     } finally {
       setIsGeneratingItinerary(false)
     }
-  }, [draft, token, onError, setDraft, setResult])
+  }, [draft, onError, setDraft, setResult])
 
   const handleAutoFillOgUrl = useCallback(() => {
     if (!draft) return

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryDraftSyncState.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItineraryDraftSyncState.ts
@@ -10,7 +10,6 @@ import { payloadDocToDraft } from '../mappers/itinerary-draft.mapper'
 import { buildItineraryDraftComparableShape } from '../utils/itinerary-draft-sync-signature'
 
 type UseItineraryDraftSyncStateParams = {
-  token?: string | null
   draft: ListicleItineraryDraft | null
   setDraft: Dispatch<SetStateAction<ListicleItineraryDraft | null>>
   isLoading: boolean
@@ -21,7 +20,6 @@ type UseItineraryDraftSyncStateParams = {
 }
 
 export function useItineraryDraftSyncState({
-  token,
   draft,
   setDraft,
   isLoading,
@@ -60,10 +58,6 @@ export function useItineraryDraftSyncState({
 
   const revertToPayloadVersion = useCallback(async (): Promise<void> => {
     if (!draft?.payloadId) return
-    if (!token) {
-      onError('You must be logged in to reload from Payload.')
-      return
-    }
 
     const isPublishedPayload = draft.payloadStatus === 'published' || draft.status === 'published'
     const confirmed = window.confirm(
@@ -78,7 +72,7 @@ export function useItineraryDraftSyncState({
     setIsRevertingToPayload(true)
 
     try {
-      const doc = await fetchItineraryById(draft.payloadId, token)
+      const doc = await fetchItineraryById(draft.payloadId)
       const nextDraft = payloadDocToDraft(doc, draft.draftId)
       nextDraft.editorModelName = draft.editorModelName
       // Reverting reloads the doc but doesn't resync Payload, so the media
@@ -93,7 +87,7 @@ export function useItineraryDraftSyncState({
     } finally {
       setIsRevertingToPayload(false)
     }
-  }, [draft, onError, setDraft, setResult, token])
+  }, [draft, onError, setDraft, setResult])
 
   return {
     hasUnsyncedPayloadChanges,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItinerarySeoAiActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItinerarySeoAiActions.ts
@@ -19,7 +19,6 @@ import type { ItineraryBuilderAiActionsParams } from './itineraryBuilderAiAction
 
 type Params = Pick<
   ItineraryBuilderAiActionsParams,
-  | 'token'
   | 'draft'
   | 'setDraft'
   | 'canonicalStructuredData'
@@ -28,7 +27,6 @@ type Params = Pick<
 >
 
 export function useItinerarySeoAiActions({
-  token,
   draft,
   setDraft,
   canonicalStructuredData,
@@ -157,10 +155,6 @@ export function useItinerarySeoAiActions({
       return
     }
 
-    if (!token) {
-      onError('You must be logged in to generate social image URLs.')
-      return
-    }
 
     onError('')
     setResult(null)
@@ -171,7 +165,6 @@ export function useItinerarySeoAiActions({
         featuredMediaSetId
           ? { featuredMediaSetId }
           : { featuredAssetId: featuredAssetId as number },
-        token
       )
       const bunnyUrl = response.generatedImageUrl.trim()
       if (!bunnyUrl) {
@@ -208,7 +201,7 @@ export function useItinerarySeoAiActions({
     } finally {
       setIsGeneratingSeoImage(false)
     }
-  }, [draft, onError, setDraft, setResult, token])
+  }, [draft, onError, setDraft, setResult])
 
   return {
     isGeneratingSeoTarget,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItinerarySubmit.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItinerarySubmit.test.tsx
@@ -135,7 +135,6 @@ describe('useItinerarySubmit', () => {
       )
 
       return useItinerarySubmit({
-        token: 'test-token',
         draft,
         setDraft,
         selectedLocationRefId: 1,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItinerarySubmit.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useItinerarySubmit.ts
@@ -42,7 +42,6 @@ import {
 } from '../validators/step.validators'
 
 type UseItinerarySubmitParams = {
-  token?: string | null
   draft: ListicleItineraryDraft | null
   setDraft: Dispatch<SetStateAction<ListicleItineraryDraft | null>>
   selectedLocationRefId: number | null
@@ -177,7 +176,6 @@ async function itineraryItemToPayloadBlock(params: {
 }
 
 export function useItinerarySubmit({
-  token,
   draft,
   setDraft,
   selectedLocationRefId,
@@ -191,8 +189,8 @@ export function useItinerarySubmit({
   const [isSaving, setIsSaving] = useState(false)
 
   async function submit(targetStatus: 'draft' | 'published') {
-    if (!token || !draft) return
-    const authToken = token
+    if (!draft) return
+    const authToken = undefined
 
     onError('')
     setResult(null)
@@ -351,8 +349,8 @@ export function useItinerarySubmit({
       stripNestedRowIdsFromItineraryDays(body.itineraryDays)
 
       let doc = draft.payloadId
-        ? await updateItinerary(draft.payloadId, body, authToken)
-        : await createItinerary(body, authToken)
+        ? await updateItinerary(draft.payloadId, body)
+        : await createItinerary(body)
 
       if (targetStatus === 'published') {
         const publishedStructuredData = serializeStructuredDataTemplate(
@@ -385,7 +383,6 @@ export function useItinerarySubmit({
                 structuredData: publishedStructuredData
               })
             },
-            authToken
           )
         }
       }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useManualStopImageAssets.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useManualStopImageAssets.ts
@@ -5,18 +5,15 @@ import type { ItineraryItemBlock, MediaAssetOption } from '../../types'
 import { isManualItineraryBlockType } from '../../types'
 
 export function useManualStopImageAssets({
-  token,
   items,
   mediaAssets,
 }: {
-  token: string
   items: ItineraryItemBlock[]
   mediaAssets: MediaAssetOption[]
 }): Record<number, MediaAssetOption> {
   const [fetchedManualImageAssets, setFetchedManualImageAssets] = useState<Record<number, MediaAssetOption>>({})
 
   const missingManualImageIds = useMemo(() => {
-    if (!token) return []
 
     const loadedIds = new Set<number>([
       ...mediaAssets.map((asset) => asset.id),
@@ -29,10 +26,10 @@ export function useManualStopImageAssets({
         .map((item) => item.image)
         .filter((imageId): imageId is number => typeof imageId === 'number' && !loadedIds.has(imageId)),
     ))
-  }, [fetchedManualImageAssets, items, mediaAssets, token])
+  }, [fetchedManualImageAssets, items, mediaAssets])
 
   useEffect(() => {
-    if (!token || missingManualImageIds.length === 0) return
+    if (missingManualImageIds.length === 0) return
 
     let cancelled = false
 
@@ -40,7 +37,7 @@ export function useManualStopImageAssets({
       const responses = await Promise.all(
         missingManualImageIds.map(async (imageId) => {
           try {
-            const response = await fetchPayloadMediaAssets(token, {
+            const response = await fetchPayloadMediaAssets({
               id: imageId,
               limit: 1,
             })
@@ -81,7 +78,7 @@ export function useManualStopImageAssets({
     return () => {
       cancelled = true
     }
-  }, [missingManualImageIds, token])
+  }, [missingManualImageIds])
 
   return fetchedManualImageAssets
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useRelatedItems.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/hooks/useRelatedItems.ts
@@ -5,7 +5,6 @@ import type { ItineraryBlockType, LocationOption, RelatedItemOption } from '../.
 import { BLOCK_TYPE_OPTIONS, EMPTY_RELATED_BY_BLOCK_TYPE } from '../constants/builder-options.constants'
 
 type UseRelatedItemsParams = {
-  token?: string | null
   location?: string
   sharedNeighborhoods?: number[]
   locations: LocationOption[]
@@ -18,7 +17,6 @@ type UseRelatedItemsResult = {
 }
 
 export function useRelatedItems({
-  token,
   location,
   sharedNeighborhoods,
   locations,
@@ -28,12 +26,12 @@ export function useRelatedItems({
   const [relatedByBlockType, setRelatedByBlockType] = useState<Record<ItineraryBlockType, RelatedItemOption[]>>(EMPTY_RELATED_BY_BLOCK_TYPE)
 
   useEffect(() => {
-    if (!token || !location) {
+    if (!location) {
       setRelatedByBlockType(EMPTY_RELATED_BY_BLOCK_TYPE)
       return
     }
 
-    const authToken = token
+    const authToken = undefined
     const primaryLocation = location
     const exactNeighborhoods = sharedNeighborhoods
 
@@ -44,12 +42,11 @@ export function useRelatedItems({
       locationKey: primaryLocation,
       sharedNeighborhoods: exactNeighborhoods,
       locations,
-      token: authToken,
     })
       .then((scope) => {
         if (cancelled) return []
         return Promise.all(BLOCK_TYPE_OPTIONS.map(async (option) => (
-          [option.value, await fetchRelatedItems(option.value, primaryLocation, authToken, scope)] as const
+          [option.value, await fetchRelatedItems(option.value, primaryLocation, scope)] as const
         )))
       })
       .then((docsByType) => {
@@ -72,7 +69,7 @@ export function useRelatedItems({
     return () => {
       cancelled = true
     }
-  }, [token, location, sharedNeighborhoods, locations, onError])
+  }, [location, sharedNeighborhoods, locations, onError])
 
   return {
     isLoadingRelated,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/autobuild.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/autobuild.api.test.ts
@@ -20,7 +20,6 @@ describe('generateItinerary', () => {
       title: 'One Perfect Day in Lima',
       brief: 'coffee, culture, tasting night',
       dayCount: 1,
-      payloadToken: 'token',
       dayShells: [
         {
           dayIndex: 0,
@@ -86,7 +85,6 @@ describe('generateItinerary', () => {
       title: 'One Perfect Day in Lima',
       brief: 'coffee, culture, tasting night',
       dayCount: 1,
-      payloadToken: 'token',
       includeLodging: false,
       dayShells: [
         {

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/autobuild.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/services/autobuild.api.ts
@@ -69,8 +69,6 @@ export type GenerateItineraryParams = {
   title: string
   brief: string
   dayCount: number
-  /** Operator JWT — the backend reads Payload with it (never writes). */
-  payloadToken: string
   sharedNeighborhoods?: number[]
   dayShells: Array<{ dayIndex: number; shell: DayShellTemplate }>
   modelName?: string | null
@@ -88,7 +86,6 @@ export async function generateItinerary(params: GenerateItineraryParams): Promis
       title: params.title,
       brief: params.brief,
       day_count: params.dayCount,
-      payload_jwt: params.payloadToken,
       shared_neighborhoods: params.sharedNeighborhoods ?? [],
       day_shells: params.dayShells.map(({ dayIndex, shell }) => ({
         day_index: dayIndex,

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/pages/ListicleItinerariesPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/pages/ListicleItinerariesPage.tsx
@@ -20,7 +20,6 @@ function formatDate(value?: string): string {
 }
 
 export default function ListicleItinerariesPage() {
-  const { token } = useAuth()
   const [itineraries, setItineraries] = useState<PayloadItineraryDoc[]>([])
   const [localDrafts, setLocalDrafts] = useState(() => listDrafts())
   const [isLoading, setIsLoading] = useState(true)
@@ -48,13 +47,12 @@ export default function ListicleItinerariesPage() {
   }, [])
 
   useEffect(() => {
-    if (!token) return
 
     let cancelled = false
     setIsLoading(true)
     setError(null)
 
-    fetchItineraries(token)
+    fetchItineraries()
       .then((response) => {
         if (cancelled) return
         setItineraries(response.docs || [])
@@ -71,7 +69,7 @@ export default function ListicleItinerariesPage() {
     return () => {
       cancelled = true
     }
-  }, [token])
+  }, [])
 
   const rows = useMemo(() => {
     const localChangesByPayloadId = new Map(

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/pages/ListicleItineraryBuilderPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/pages/ListicleItineraryBuilderPage.tsx
@@ -41,7 +41,6 @@ import { StopBlurbComposeChoiceModal } from '../builder/components/StopBlurbComp
 import '../styles.css'
 const schemaPublisherConfig = getItinerarySchemaPublisherConfig()
 export default function ListicleItineraryBuilderPage() {
-  const { token } = useAuth()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -70,7 +69,6 @@ export default function ListicleItineraryBuilderPage() {
     mediaAssets,
     instagramPosts,
   } = useBuilderBootstrap({
-    token,
     payloadIdParam,
     draftIdParam,
     setSearchParams,
@@ -85,7 +83,6 @@ export default function ListicleItineraryBuilderPage() {
     saveLocalDraft,
     revertToPayloadVersion,
   } = useItineraryDraftSyncState({
-    token,
     draft,
     setDraft,
     isLoading,
@@ -103,7 +100,6 @@ export default function ListicleItineraryBuilderPage() {
   }, [draft, activeDayIndex])
 
   const { isLoadingRelated, relatedByBlockType } = useRelatedItems({
-    token,
     location: draft?.location,
     sharedNeighborhoods: draft?.sharedNeighborhoods,
     locations,
@@ -127,7 +123,6 @@ export default function ListicleItineraryBuilderPage() {
   })
 
   const { isSaving, submit } = useItinerarySubmit({
-    token,
     draft,
     setDraft,
     selectedLocationRefId: actions.selectedLocationRefId,
@@ -182,7 +177,6 @@ export default function ListicleItineraryBuilderPage() {
   }, [canonicalStructuredData, draft, isStep4Ready, isSynced, setDraft])
 
   const aiActions = useItineraryBuilderAiActions({
-    token,
     draft,
     setDraft,
     locations,
@@ -271,7 +265,7 @@ export default function ListicleItineraryBuilderPage() {
           {(isStep1LockedView || isSynced) ? (
             <BuilderHeaderPanel
               draft={draft}
-              token={token ?? null}
+             
               locationRef={actions.selectedLocationRefId}
               mediaAssets={mediaAssets}
               updateHeader={actions.updateHeader}
@@ -306,7 +300,7 @@ export default function ListicleItineraryBuilderPage() {
               <BuilderStopsPanel
                 draft={draft}
                 activeDayIndex={activeDayIndex}
-                token={token ?? null}
+               
                 locationRef={actions.selectedLocationRefId}
                 mediaAssets={mediaAssets}
                 instagramPosts={instagramPosts}

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
@@ -19,7 +19,6 @@ const PAYLOAD_REQUEST_TIMEOUT_MS = 12000
 
 async function payloadRequest<T>(
   endpoint: string,
-  token: string,
   init?: RequestInit,
 ): Promise<T> {
   const controller = new AbortController()
@@ -111,7 +110,6 @@ function appendIndexFilters(params: URLSearchParams, filters: LocationIndexFilte
 }
 
 export async function fetchLocationsIndex(
-  token: string,
   filters: LocationIndexFilters = {},
 ): Promise<LocationIndexRow[]> {
   const docs: LocationIndexRow[] = []
@@ -142,7 +140,6 @@ export async function fetchLocationsIndex(
 
     const response = await payloadRequest<PayloadListResponse<LocationIndexRow>>(
       `/api/locations?${params.toString()}`,
-      token,
     )
     docs.push(...(response.docs || []))
     totalPages = response.totalPages || 1
@@ -154,25 +151,23 @@ export async function fetchLocationsIndex(
 
 export async function fetchLocationById(
   id: number,
-  token: string,
 ): Promise<PayloadLocationDoc> {
-  const response = await payloadRequest<unknown>(`/api/locations/${id}?depth=0`, token)
+  const response = await payloadRequest<unknown>(`/api/locations/${id}?depth=0`)
   return parsePayloadLocationDocResponse(response, 'Fetch location')
 }
 
 export async function updateLocation(
   id: number,
   body: PayloadLocationBody,
-  token: string,
 ): Promise<PayloadLocationDoc> {
-  const response = await payloadRequest<unknown>(`/api/locations/${id}`, token, {
+  const response = await payloadRequest<unknown>(`/api/locations/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(body),
   })
   return parsePayloadLocationDocResponse(response, 'Update location')
 }
 
-export async function fetchMediaSetOptions(token: string): Promise<MediaSetOption[]> {
+export async function fetchMediaSetOptions(): Promise<MediaSetOption[]> {
   const docs: MediaSetOption[] = []
   let page = 1
   let totalPages = 1
@@ -187,7 +182,6 @@ export async function fetchMediaSetOptions(token: string): Promise<MediaSetOptio
 
     const response = await payloadRequest<PayloadListResponse<MediaSetOption>>(
       `/api/media-sets?${params.toString()}`,
-      token,
     )
     docs.push(...(response.docs || []))
     totalPages = response.totalPages || 1
@@ -198,7 +192,6 @@ export async function fetchMediaSetOptions(token: string): Promise<MediaSetOptio
 }
 
 export async function fetchMediaSetLibrary(
-  token: string,
   params: {
     /** Page size when listing all sets (default 200). Ignored when `id` is set. */
     limit?: number
@@ -213,7 +206,6 @@ export async function fetchMediaSetLibrary(
     query.set('where[id][equals]', String(params.id))
     const response = await payloadRequest<PayloadListResponse<MediaSetOption>>(
       `/api/media-sets?${query.toString()}`,
-      token,
     )
     return response.docs || []
   }
@@ -232,7 +224,6 @@ export async function fetchMediaSetLibrary(
 
     const response = await payloadRequest<PayloadListResponse<MediaSetOption>>(
       `/api/media-sets?${query.toString()}`,
-      token,
     )
     docs.push(...(response.docs || []))
     totalPages = response.totalPages || 1

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/api.ts
@@ -33,7 +33,6 @@ async function payloadRequest<T>(
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
         ...(init?.headers || {}),
       },
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/components/CoverImagePickerField.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/components/CoverImagePickerField.tsx
@@ -7,7 +7,6 @@ import { formatMediaSetLabel, resolveMediaSetPreviewUrl } from '../utils'
 type CoverImagePickerFieldProps = {
   field: RelationshipFieldDefinition
   value: number | null
-  token: string | null
   locationRef: number | null
   mediaSets: MediaSetOption[]
   onValueChange: (value: number | null) => void
@@ -21,7 +20,6 @@ type CoverImagePickerFieldProps = {
 export function CoverImagePickerField({
   field,
   value,
-  token,
   locationRef,
   mediaSets,
   onValueChange,
@@ -36,7 +34,7 @@ export function CoverImagePickerField({
   )
 
   useEffect(() => {
-    if (!value || !token) {
+    if (!value) {
       setSelectedMediaSet(null)
       setIsLoadingSelected(false)
       return
@@ -47,7 +45,7 @@ export function CoverImagePickerField({
 
     const loadSelectedMediaSet = async () => {
       try {
-        const docs = await fetchMediaSetLibrary(token, { id: value })
+        const docs = await fetchMediaSetLibrary({ id: value })
         if (!cancelled) {
           setSelectedMediaSet(docs[0] || null)
         }
@@ -67,7 +65,7 @@ export function CoverImagePickerField({
     return () => {
       cancelled = true
     }
-  }, [token, value])
+  }, [value])
 
   const handlePickerSelect = (result: ImagePickerResult) => {
     const rawId =
@@ -100,7 +98,6 @@ export function CoverImagePickerField({
             type="button"
             className="ldb-cover-image-preview__button"
             onClick={() => setIsPickerOpen(true)}
-            disabled={!token}
           >
             {selectedPreviewUrl ? (
               <img
@@ -120,7 +117,7 @@ export function CoverImagePickerField({
           </button>
 
           <div className="ldb-cover-image-actions">
-            <button type="button" className="ldb-ghost-btn" onClick={() => setIsPickerOpen(true)} disabled={!token}>
+            <button type="button" className="ldb-ghost-btn" onClick={() => setIsPickerOpen(true)}>
               Change Cover Image
             </button>
             <button type="button" className="ldb-danger-link" onClick={() => onValueChange(null)}>
@@ -133,7 +130,6 @@ export function CoverImagePickerField({
           type="button"
           className="ldb-picker-trigger"
           onClick={() => setIsPickerOpen(true)}
-          disabled={!token}
         >
           <span className="ldb-picker-trigger__preview">
             <span className="ldb-picker-trigger__label ldb-picker-trigger__label--placeholder">
@@ -144,10 +140,9 @@ export function CoverImagePickerField({
         </button>
       )}
 
-      {token ? (
+      {(
         <ImagePicker
           isOpen={isPickerOpen}
-          token={token}
           locationRef={locationRef}
           selectedId={value}
           query={{ browseUnit: 'mediaSets', requirementLabel: field.label }}
@@ -159,7 +154,7 @@ export function CoverImagePickerField({
           onSelect={handlePickerSelect}
           onClose={() => setIsPickerOpen(false)}
         />
-      ) : null}
+      )}
     </div>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/pages/LocationDocumentBuilderPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/pages/LocationDocumentBuilderPage.tsx
@@ -53,7 +53,6 @@ function normalizeDraftForEdit(draft: LocationDocumentDraft): LocationDocumentDr
 }
 
 export default function LocationDocumentBuilderPage() {
-  const { token } = useAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const [draft, setDraft] = useState<LocationDocumentDraft | null>(null)
   const [mediaSets, setMediaSets] = useState<Awaited<ReturnType<typeof fetchMediaSetOptions>>>([])
@@ -69,10 +68,6 @@ export default function LocationDocumentBuilderPage() {
   const payloadId = payloadIdParam ? Number(payloadIdParam) : NaN
 
   useEffect(() => {
-    if (!token) {
-      setIsLoading(false)
-      return
-    }
 
     let cancelled = false
     setIsLoading(true)
@@ -107,7 +102,7 @@ export default function LocationDocumentBuilderPage() {
             return
           }
 
-          const payloadDoc = await fetchLocationById(payloadId, token)
+          const payloadDoc = await fetchLocationById(payloadId)
           if (cancelled) return
           setDraft(normalizeDraftForEdit(buildDraftFromPayloadDoc(payloadDoc)))
           return
@@ -131,15 +126,14 @@ export default function LocationDocumentBuilderPage() {
     return () => {
       cancelled = true
     }
-  }, [draftIdParam, payloadId, setSearchParams, token])
+  }, [draftIdParam, payloadId, setSearchParams])
 
   useEffect(() => {
-    if (!token) return
 
     let cancelled = false
     setOptionsError(null)
 
-    fetchMediaSetOptions(token)
+    fetchMediaSetOptions()
       .then((options) => {
         if (!cancelled) setMediaSets(options)
       })
@@ -153,7 +147,7 @@ export default function LocationDocumentBuilderPage() {
     return () => {
       cancelled = true
     }
-  }, [token])
+  }, [])
 
   useBuilderAutosave(draft, saveDraft, 1200)
 
@@ -201,7 +195,7 @@ export default function LocationDocumentBuilderPage() {
   }, [draft])
 
   const handleSubmit = useCallback(async () => {
-    if (!token || !draft) return
+    if (!draft) return
 
     setIsSaving(true)
     setError(null)
@@ -215,7 +209,7 @@ export default function LocationDocumentBuilderPage() {
       }
 
       const payloadBody = buildPayloadLocationBody(draft)
-      const savedDoc = await updateLocation(draft.payloadId, payloadBody, token)
+      const savedDoc = await updateLocation(draft.payloadId, payloadBody)
       const syncedDraft = markDraftAsPayloadSynced(
         {
           ...buildDraftFromPayloadDoc(savedDoc),
@@ -236,17 +230,8 @@ export default function LocationDocumentBuilderPage() {
     } finally {
       setIsSaving(false)
     }
-  }, [draft, setSearchParams, token])
+  }, [draft, setSearchParams])
 
-  if (!token) {
-    return (
-      <div className="ldb-page">
-        <section className="ldb-panel">
-          <p className="ldb-placeholder">Sign in to edit Payload location images.</p>
-        </section>
-      </div>
-    )
-  }
 
   if (isLoading) {
     return (
@@ -381,7 +366,6 @@ export default function LocationDocumentBuilderPage() {
         <CoverImagePickerField
           field={COVER_IMAGE_FIELD}
           value={draft.coverImage}
-          token={token}
           locationRef={draft.payloadId ?? null}
           mediaSets={mediaSets}
           onValueChange={updateCoverImage}

--- a/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/pages/LocationDocumentsPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/locationDocuments/pages/LocationDocumentsPage.tsx
@@ -61,7 +61,6 @@ function getLinkedDraftStatus(draft: LocationDocumentDraft): {
 }
 
 export default function LocationDocumentsPage() {
-  const { token } = useAuth()
   const [payloadRows, setPayloadRows] = useState<LocationIndexRow[]>([])
   const [localDrafts, setLocalDrafts] = useState<LocationDocumentDraft[]>(() => listDrafts())
   const [searchQuery, setSearchQuery] = useState('')
@@ -88,13 +87,12 @@ export default function LocationDocumentsPage() {
   }, [])
 
   useEffect(() => {
-    if (!token) return
 
     let cancelled = false
     setIsLoading(true)
     setError(null)
 
-    fetchLocationsIndex(token)
+    fetchLocationsIndex()
       .then((rows) => {
         if (cancelled) return
         setPayloadRows(rows)
@@ -111,7 +109,7 @@ export default function LocationDocumentsPage() {
     return () => {
       cancelled = true
     }
-  }, [token])
+  }, [])
 
   const sortedDrafts = useMemo(() => {
     return [...localDrafts].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/MediaLibraryPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/MediaLibraryPage.tsx
@@ -19,9 +19,7 @@ const TABS: { id: Tab; label: string }[] = [
 
 export function MediaLibraryPage() {
   const [activeTab, setActiveTab] = useState<Tab>('browse')
-  const { token } = useAuth()
 
-  if (!token) return <div className="ml-error-full">Not authenticated</div>
 
   return (
     <div className="ml-page">
@@ -44,11 +42,11 @@ export function MediaLibraryPage() {
       </div>
 
       <div className="ml-tab-content">
-        {activeTab === 'browse' && <BrowseTab token={token} />}
-        {activeTab === 'audit' && <AuditTab token={token} />}
-        {activeTab === 'orphans' && <OrphansTab token={token} />}
-        {activeTab === 'upload' && <UploadTab token={token} />}
-        {activeTab === 'composite' && <CompositeTab token={token} />}
+        {activeTab === 'browse' && <BrowseTab />}
+        {activeTab === 'audit' && <AuditTab />}
+        {activeTab === 'orphans' && <OrphansTab />}
+        {activeTab === 'upload' && <UploadTab />}
+        {activeTab === 'composite' && <CompositeTab />}
       </div>
     </div>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/AuditTab.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/AuditTab.tsx
@@ -7,7 +7,6 @@ import { HealthScore } from './HealthScore'
 import { MediaSetSidePanel } from './MediaSetSidePanel'
 import { generateAltTextFromUrl } from '../api/mediaLibraryApi'
 
-type Props = { token: string }
 
 function getSourceUrl(ms: MediaSet): string | null {
   if (ms.source && typeof ms.source === 'object' && ms.source.url) return ms.source.url
@@ -20,15 +19,15 @@ function getSourceUrl(ms: MediaSet): string | null {
   return null
 }
 
-export function AuditTab({ token }: Props) {
+export function AuditTab() {
   const [page, setPage] = useState(1)
   const [selected, setSelected] = useState<MediaSet | null>(null)
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set())
   const [bulkGenerating, setBulkGenerating] = useState(false)
   const [bulkProgress, setBulkProgress] = useState('')
 
-  const { data, isLoading, isError, refetch } = useAuditMediaSets(token, page)
-  const updateMutation = useUpdateMediaSet(token)
+  const { data, isLoading, isError, refetch } = useAuditMediaSets(page)
+  const updateMutation = useUpdateMediaSet()
 
   const mediaSets = data?.docs ?? []
   const totalPages = data?.totalPages ?? 1
@@ -75,7 +74,7 @@ export function AuditTab({ token }: Props) {
       if (!url) { done++; continue }
       try {
         setBulkProgress(`Generating ${done + 1} of ${targets.length}…`)
-        const text = await generateAltTextFromUrl(url, token)
+        const text = await generateAltTextFromUrl(url)
         await updateMutation.mutateAsync({ id: ms.id, patch: { alt_text: text } })
       } catch {
         // skip failures silently; they'll remain in audit
@@ -203,7 +202,6 @@ export function AuditTab({ token }: Props) {
         <MediaSetSidePanel
           mediaSet={selected}
           health={computeHealth(selected)}
-          token={token}
           onSave={handleSave}
           onClose={() => setSelected(null)}
         />

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/BrowseTab.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/BrowseTab.tsx
@@ -17,20 +17,18 @@ const EMPTY_FILTERS: BrowseFilters = {
   missingField: '',
 }
 
-type Props = { token: string }
 
-export function BrowseTab({ token }: Props) {
+export function BrowseTab() {
   const [filters, setFilters] = useState<BrowseFilters>(EMPTY_FILTERS)
   const [page, setPage] = useState(1)
   const [selected, setSelected] = useState<MediaSet | null>(null)
 
-  const { data, isLoading, isError } = useBrowseMediaSets(token, filters, page)
-  const updateMutation = useUpdateMediaSet(token)
+  const { data, isLoading, isError } = useBrowseMediaSets(filters, page)
+  const updateMutation = useUpdateMediaSet()
 
   const { data: locationsData } = useQuery({
     queryKey: ['locations'],
-    queryFn: () => fetchLocations(token),
-    enabled: !!token,
+    queryFn: () => fetchLocations(),
   })
   const locations = locationsData?.docs ?? []
 
@@ -116,7 +114,6 @@ export function BrowseTab({ token }: Props) {
         <MediaSetSidePanel
           mediaSet={selected}
           health={computeHealth(selected)}
-          token={token}
           onSave={handleSave}
           onClose={() => setSelected(null)}
         />

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/CompositeTab.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/CompositeTab.tsx
@@ -7,14 +7,12 @@ import {
   fetchHangingComposites,
 } from '../../../shared/images/api/composites/composite-image.api'
 
-type Props = { token: string }
 
-function HangingCompositesPanel({ token }: Props) {
+function HangingCompositesPanel() {
   const queryClient = useQueryClient()
   const { data, isLoading, isError, refetch, isFetching } = useQuery({
     queryKey: ['hanging-composites'],
     queryFn: () => fetchHangingComposites(),
-    enabled: !!token,
   })
 
   const cleanup = useMutation({
@@ -111,15 +109,14 @@ function HangingCompositesPanel({ token }: Props) {
   )
 }
 
-export function CompositeTab({ token }: Props) {
+export function CompositeTab() {
   const [locationRef, setLocationRef] = useState<number | null>(null)
   const [open, setOpen] = useState(false)
   const [result, setResult] = useState<string | null>(null)
 
   const { data: locationsData } = useQuery({
     queryKey: ['locations'],
-    queryFn: () => fetchLocations(token),
-    enabled: !!token,
+    queryFn: () => fetchLocations(),
   })
   const locations = locationsData?.docs ?? []
 
@@ -152,12 +149,11 @@ export function CompositeTab({ token }: Props) {
 
         {result && <p className="ml-upload-success">{result}</p>}
 
-        <HangingCompositesPanel token={token} />
+        <HangingCompositesPanel />
       </div>
 
       <CompositeImageModal
         isOpen={open}
-        token={token}
         locationRef={locationRef}
         defaultTitle="Composite image"
         onCreated={(response) => setResult(`MediaSet #${response.mediaSetId} created.`)}

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/MediaSetSidePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/MediaSetSidePanel.tsx
@@ -10,7 +10,6 @@ import { generateAltTextFromUrl } from '../api/mediaLibraryApi'
 type Props = {
   mediaSet: MediaSet
   health: MediaSetHealth
-  token: string
   onSave: (patch: MediaSetPatch) => Promise<void>
   onClose: () => void
 }
@@ -28,7 +27,7 @@ function getSourceUrl(ms: MediaSet): string | null {
   return null
 }
 
-export function MediaSetSidePanel({ mediaSet, health, token, onSave, onClose }: Props) {
+export function MediaSetSidePanel({ mediaSet, health, onSave, onClose }: Props) {
   const [form, setForm] = useState<MediaSetPatch>({
     title: mediaSet.title ?? '',
     alt_text: mediaSet.alt_text ?? '',
@@ -45,14 +44,12 @@ export function MediaSetSidePanel({ mediaSet, health, token, onSave, onClose }: 
 
   const { data: tagsData } = useQuery({
     queryKey: ['article-tags'],
-    queryFn: () => fetchArticleTags(token, { limit: 200 }),
-    enabled: !!token,
+    queryFn: () => fetchArticleTags({ limit: 200 }),
   })
 
   const { data: locationsData } = useQuery({
     queryKey: ['locations'],
-    queryFn: () => fetchLocations(token),
-    enabled: !!token,
+    queryFn: () => fetchLocations(),
   })
 
   const tags: ArticleTag[] = tagsData?.docs ?? []
@@ -100,7 +97,7 @@ export function MediaSetSidePanel({ mediaSet, health, token, onSave, onClose }: 
     if (!url) return
     setAltGen({ status: 'generating', text: '' })
     try {
-      const text = await generateAltTextFromUrl(url, token)
+      const text = await generateAltTextFromUrl(url)
       setForm((f) => ({ ...f, alt_text: text }))
       setAltGen({ status: 'done', text })
     } catch (err) {

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/OrphansTab.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/OrphansTab.tsx
@@ -2,11 +2,10 @@ import { useState } from 'react'
 import type { MediaAsset } from '../../../shared/api/payload/payload.types'
 import { useOrphanMediaAssets } from '../hooks/useMediaSets'
 
-type Props = { token: string }
 
-export function OrphansTab({ token }: Props) {
+export function OrphansTab() {
   const [page, setPage] = useState(1)
-  const { data, isLoading, isError } = useOrphanMediaAssets(token, page)
+  const { data, isLoading, isError } = useOrphanMediaAssets(page)
 
   const assets: MediaAsset[] = data?.docs ?? []
   const totalPages = data?.totalPages ?? 1

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/UploadTab.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/components/UploadTab.tsx
@@ -11,7 +11,6 @@ import {
 import { useImageUploadFlow } from '../../../shared/images/hooks/useImageUploadFlow'
 import '../../../shared/images/components/upload-primitives/upload-primitives.css'
 
-type Props = { token: string }
 
 function buildExternalRef(filename: string): string {
   return filename
@@ -20,13 +19,12 @@ function buildExternalRef(filename: string): string {
     .toLowerCase()
 }
 
-export function UploadTab({ token }: Props) {
+export function UploadTab() {
   const [locationRef, setLocationRef] = useState<number | null>(null)
 
   const { data: locationsData } = useQuery({
     queryKey: ['locations'],
-    queryFn: () => fetchLocations(token),
-    enabled: !!token,
+    queryFn: () => fetchLocations(),
   })
   const locations = locationsData?.docs ?? []
 
@@ -63,7 +61,6 @@ export function UploadTab({ token }: Props) {
   } = useImageUploadFlow({
     externalRef,
     locationRef: locationRef ?? 0,
-    token,
     onComplete: () => {
       setLocationRef(null)
     },

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/hooks/useMediaSets.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/hooks/useMediaSets.ts
@@ -7,39 +7,35 @@ import {
 import type { BrowseFilters } from '../types'
 
 export function useBrowseMediaSets(
-  token: string | undefined,
   filters: BrowseFilters,
   page: number,
 ) {
   return useQuery({
     queryKey: ['media-library', 'browse', filters, page],
     queryFn: () =>
-      fetchMediaSets(token, {
+      fetchMediaSets({
         limit: 24,
         page,
         search: filters.search || undefined,
         status: filters.status || undefined,
         locationId: filters.locationId ?? undefined,
       }),
-    enabled: !!token,
     placeholderData: (prev) => prev,
   })
 }
 
-export function useAuditMediaSets(token: string | undefined, page: number) {
+export function useAuditMediaSets(page: number) {
   return useQuery({
     queryKey: ['media-library', 'audit', page],
-    queryFn: () => fetchAuditMediaSets(token, { limit: 50, page }),
-    enabled: !!token,
+    queryFn: () => fetchAuditMediaSets({ limit: 50, page }),
     placeholderData: (prev) => prev,
   })
 }
 
-export function useOrphanMediaAssets(token: string | undefined, page: number) {
+export function useOrphanMediaAssets(page: number) {
   return useQuery({
     queryKey: ['media-library', 'orphans', page],
-    queryFn: () => fetchOrphanMediaAssets(token, { limit: 50, page }),
-    enabled: !!token,
+    queryFn: () => fetchOrphanMediaAssets({ limit: 50, page }),
     placeholderData: (prev) => prev,
   })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/hooks/useUpdateMediaSet.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/mediaLibrary/hooks/useUpdateMediaSet.ts
@@ -2,12 +2,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { updateMediaSet } from '../../../shared/api/payload/payload.api'
 import type { MediaSetPatch } from '../../../shared/api/payload/payload.types'
 
-export function useUpdateMediaSet(token: string | undefined) {
+export function useUpdateMediaSet() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: ({ id, patch }: { id: number; patch: MediaSetPatch }) =>
-      updateMediaSet(id, patch, token),
+      updateMediaSet(id, patch),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['media-library'] })
     },

--- a/apps/ai-blog-writer/apps/frontend/src/features/payloadArticles/pages/PayloadArticleStagePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/payloadArticles/pages/PayloadArticleStagePage.tsx
@@ -61,12 +61,11 @@ const rewriteBlockWithAssistModel: Parameters<typeof StandardArticleStageBuilder
     })
 
 function PayloadArticleImport({ payloadId }: { payloadId: number }) {
-  const { token } = useAuth()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!token || !Number.isFinite(payloadId) || payloadId <= 0) return
+    if (!Number.isFinite(payloadId) || payloadId <= 0) return
     let isCancelled = false
 
     const importArticle = async () => {
@@ -80,7 +79,7 @@ function PayloadArticleImport({ payloadId }: { payloadId: number }) {
           return
         }
 
-        const doc = await getArticleById(payloadId, token) as PayloadArticleDetail
+        const doc = await getArticleById(payloadId) as PayloadArticleDetail
         const stagedArticle = await buildStagedArticleFromPayloadDoc({
           doc,
           convertLexicalToMarkdown,
@@ -98,14 +97,12 @@ function PayloadArticleImport({ payloadId }: { payloadId: number }) {
     return () => {
       isCancelled = true
     }
-  }, [token, payloadId, navigate])
+  }, [payloadId, navigate])
 
   return (
     <div className="stl-page">
       <section className="stl-panel">
-        {!token ? (
-          <p className="stl-placeholder">Sign in to edit Payload articles.</p>
-        ) : error ? (
+        {error ? (
           <>
             <p className="stl-error">Failed to load article #{payloadId} from Payload: {error}</p>
             <Link to={PAYLOAD_ARTICLES_PATH} className="stl-link">Back to Payload Articles</Link>

--- a/apps/ai-blog-writer/apps/frontend/src/features/payloadArticles/pages/PayloadArticlesPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/payloadArticles/pages/PayloadArticlesPage.tsx
@@ -10,15 +10,14 @@ import {
 import { PAYLOAD_ARTICLES_STORAGE_KEY } from '../constants'
 
 export default function PayloadArticlesPage() {
-  const { token } = useAuth()
+  const { user } = useAuth()
   const { localDrafts, discardLocalDraft, clearAllLocalDrafts } = useLocalStagedDrafts(
     PAYLOAD_ARTICLES_STORAGE_KEY,
   )
 
   const payloadDocsQuery = useQuery({
-    queryKey: ['payload-articles', token || 'no-token'],
-    enabled: Boolean(token),
-    queryFn: () => fetchPayloadArticles(token as string),
+    queryKey: ['payload-articles', user?.id ?? 'anonymous'],
+    queryFn: () => fetchPayloadArticles(),
   })
   const payloadDocs = payloadDocsQuery.data ?? []
 
@@ -61,7 +60,7 @@ export default function PayloadArticlesPage() {
               ? (payloadDocsQuery.error instanceof Error ? payloadDocsQuery.error.message : 'Unknown error')
               : null
           }
-          hasToken={Boolean(token)}
+          isSignedIn={Boolean()}
         />
       </main>
     </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
@@ -13,7 +13,7 @@ import type {
 
 const PAYLOAD_API_URL = import.meta.env.VITE_PAYLOAD_API_URL || 'http://localhost:4000'
 
-async function payloadRequest<T>(endpoint: string, token: string, init?: RequestInit): Promise<T> {
+async function payloadRequest<T>(endpoint: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     ...init,
     credentials: 'include',
@@ -58,16 +58,16 @@ export function getBlockTypeForListicleType(type: ListicleType) {
   }
 }
 
-export async function fetchListicles(token: string): Promise<PayloadListResponse<PayloadListicleDoc>> {
-  return payloadRequest(`/api/single-type-listicles?limit=100&sort=-updatedAt`, token)
+export async function fetchListicles(): Promise<PayloadListResponse<PayloadListicleDoc>> {
+  return payloadRequest(`/api/single-type-listicles?limit=100&sort=-updatedAt`)
 }
 
-export async function fetchListicleById(id: number, token: string): Promise<PayloadListicleDoc> {
-  return payloadRequest<PayloadListicleDoc>(`/api/single-type-listicles/${id}`, token)
+export async function fetchListicleById(id: number): Promise<PayloadListicleDoc> {
+  return payloadRequest<PayloadListicleDoc>(`/api/single-type-listicles/${id}`)
 }
 
-export async function createListicle(body: Record<string, unknown>, token: string): Promise<PayloadListicleDoc> {
-  const response = await payloadRequest<{ doc: PayloadListicleDoc }>(`/api/single-type-listicles`, token, {
+export async function createListicle(body: Record<string, unknown>): Promise<PayloadListicleDoc> {
+  const response = await payloadRequest<{ doc: PayloadListicleDoc }>(`/api/single-type-listicles`, {
     method: 'POST',
     body: JSON.stringify(body),
   })
@@ -77,16 +77,15 @@ export async function createListicle(body: Record<string, unknown>, token: strin
 export async function updateListicle(
   id: number,
   body: Record<string, unknown>,
-  token: string,
 ): Promise<PayloadListicleDoc> {
-  const response = await payloadRequest<{ doc: PayloadListicleDoc }>(`/api/single-type-listicles/${id}`, token, {
+  const response = await payloadRequest<{ doc: PayloadListicleDoc }>(`/api/single-type-listicles/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(body),
   })
   return response.doc
 }
 
-export async function fetchLocations(token: string): Promise<LocationOption[]> {
+export async function fetchLocations(): Promise<LocationOption[]> {
   const allDocs: LocationOption[] = []
   let page = 1
   let totalPages = 1
@@ -94,7 +93,6 @@ export async function fetchLocations(token: string): Promise<LocationOption[]> {
   while (page <= totalPages) {
     const response = await payloadRequest<PayloadListResponse<LocationOption>>(
       `/api/locations?limit=200&page=${page}&depth=0`,
-      token,
     )
     allDocs.push(...(response.docs || []))
     totalPages = response.totalPages || 1
@@ -104,10 +102,9 @@ export async function fetchLocations(token: string): Promise<LocationOption[]> {
   return allDocs
 }
 
-export async function fetchMediaAssets(token: string): Promise<MediaAssetOption[]> {
+export async function fetchMediaAssets(): Promise<MediaAssetOption[]> {
   const response = await payloadRequest<PayloadListResponse<MediaAssetOption>>(
     `/api/media-assets?limit=200&where[mimeType][like]=image/`,
-    token,
   )
   return response.docs || []
 }
@@ -115,7 +112,6 @@ export async function fetchMediaAssets(token: string): Promise<MediaAssetOption[
 export async function fetchRelatedItems(
   listicleType: ListicleType,
   locationKey: string,
-  token: string,
   scope?: LocationScope,
 ): Promise<RelatedItemOption[]> {
   const collection = relatedCollectionForType(listicleType)
@@ -124,13 +120,12 @@ export async function fetchRelatedItems(
   params.set('limit', '200')
   params.set('where[status][equals]', 'published')
   if (locationKey) {
-    const resolvedScope = scope || (await getArticleLocationScope({ locationKey, token }))
+    const resolvedScope = scope || (await getArticleLocationScope({ locationKey }))
     appendScopedLocationWhere(params, resolvedScope)
   }
 
   const response = await payloadRequest<PayloadListResponse<RelatedItemOption>>(
     `/api/${collection}?${params.toString()}`,
-    token,
   )
 
   return normalizeRelatedItems(response.docs || [])

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/api.ts
@@ -20,7 +20,6 @@ async function payloadRequest<T>(endpoint: string, token: string, init?: Request
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
       ...(init?.headers || {}),
     },
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/components/BuilderHeaderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/components/BuilderHeaderPanel.tsx
@@ -4,7 +4,6 @@ import { AiJobButtonContent } from './AiJobButtonContent'
 
 type BuilderHeaderPanelProps = {
   draft: SingleTypeListicleDraft
-  token: string | null
   locationRef: number | null
   mediaAssets: MediaAssetOption[]
   updateHeader: (next: Partial<SingleTypeListicleDraft['header']>) => void
@@ -25,7 +24,6 @@ type BuilderHeaderPanelProps = {
 
 export function BuilderHeaderPanel({
   draft,
-  token,
   locationRef,
   mediaAssets,
   updateHeader,
@@ -56,7 +54,6 @@ export function BuilderHeaderPanel({
   return (
     <SharedBuilderHeaderPanel
       draft={draft}
-      token={token}
       locationRef={locationRef}
       mediaAssets={mediaAssets}
       updateHeader={updateHeader}

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useBuilderBootstrap.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useBuilderBootstrap.ts
@@ -18,7 +18,6 @@ import {
 } from '../../../../shared/payloadSync/draftPayloadSync'
 
 type UseBuilderBootstrapParams = {
-  token?: string | null
   payloadIdParam: string | null
   draftIdParam: string | null
   setSearchParams: SetURLSearchParams
@@ -102,7 +101,6 @@ function mergeLocalIntoPayloadDraft(
 }
 
 export function useBuilderBootstrap({
-  token,
   payloadIdParam,
   draftIdParam,
   setSearchParams,
@@ -113,7 +111,6 @@ export function useBuilderBootstrap({
     Awaited<ReturnType<typeof fetchListicleById>>,
     AuxData
   >({
-    token,
     payloadIdParam,
     draftIdParam,
     setSearchParams,
@@ -128,10 +125,10 @@ export function useBuilderBootstrap({
       },
       saveDraft,
     },
-    loadAuxData: async (authToken) => {
+    loadAuxData: async () => {
       const [locationDocs, mediaDocs] = await Promise.all([
-        fetchLocations(authToken),
-        fetchMediaAssets(authToken),
+        fetchLocations(),
+        fetchMediaAssets(),
       ])
       return { locations: locationDocs, mediaAssets: mediaDocs }
     },

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useListicleSubmit.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useListicleSubmit.ts
@@ -6,7 +6,6 @@ import type { RelatedItemOption, SingleTypeListicleDraft } from '../../types'
 import { submitListicle } from '../services/listicle-submit.service'
 
 type UseListicleSubmitParams = {
-  token?: string | null
   draft: SingleTypeListicleDraft | null
   relatedItems: RelatedItemOption[]
   selectedLocationRefId: number | null
@@ -22,7 +21,6 @@ type UseListicleSubmitResult = {
 }
 
 export function useListicleSubmit({
-  token,
   draft,
   relatedItems,
   selectedLocationRefId,
@@ -34,8 +32,8 @@ export function useListicleSubmit({
   const [isSaving, setIsSaving] = useState(false)
 
   async function submit(targetStatus: 'draft' | 'published') {
-    if (!token || !draft) return
-    const authToken = token
+    if (!draft) return
+    const authToken = undefined
 
     onError('')
     onResult(null)
@@ -47,7 +45,6 @@ export function useListicleSubmit({
         selectedLocationRefId,
         targetStatus,
         relatedItems,
-        token: authToken,
       })
 
       setDraft(nextDraft)

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useRelatedItems.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useRelatedItems.ts
@@ -4,7 +4,6 @@ import { getArticleLocationScope } from '../../../../shared/locationScope/scope'
 import type { LocationOption, RelatedItemOption, SingleTypeListicleDraft } from '../../types'
 
 type UseRelatedItemsParams = {
-  token?: string | null
   draft: SingleTypeListicleDraft | null
   locations: LocationOption[]
   onError: (message: string) => void
@@ -15,17 +14,17 @@ type UseRelatedItemsResult = {
   isLoadingRelated: boolean
 }
 
-export function useRelatedItems({ token, draft, locations, onError }: UseRelatedItemsParams): UseRelatedItemsResult {
+export function useRelatedItems({ draft, locations, onError }: UseRelatedItemsParams): UseRelatedItemsResult {
   const [relatedItems, setRelatedItems] = useState<RelatedItemOption[]>([])
   const [isLoadingRelated, setIsLoadingRelated] = useState(false)
 
   useEffect(() => {
-    if (!token || !draft?.listicleType || !draft.location) {
+    if (!draft?.listicleType || !draft.location) {
       setRelatedItems([])
       return
     }
 
-    const authToken = token
+    const authToken = undefined
     const listicleType = draft.listicleType
     const locationKey = draft.location
     const sharedNeighborhoods = draft.sharedNeighborhoods
@@ -37,11 +36,10 @@ export function useRelatedItems({ token, draft, locations, onError }: UseRelated
       locationKey,
       sharedNeighborhoods,
       locations,
-      token: authToken,
     })
       .then((scope) => {
         if (cancelled) return []
-        return fetchRelatedItems(listicleType, locationKey, authToken, scope)
+        return fetchRelatedItems(listicleType, locationKey, scope)
       })
       .then((docs) => {
         if (cancelled) return
@@ -59,7 +57,7 @@ export function useRelatedItems({ token, draft, locations, onError }: UseRelated
     return () => {
       cancelled = true
     }
-  }, [token, draft?.listicleType, draft?.location, draft?.sharedNeighborhoods, locations, onError])
+  }, [draft?.listicleType, draft?.location, draft?.sharedNeighborhoods, locations, onError])
 
   return { relatedItems, isLoadingRelated }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useSingleTypeListicleSeo.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/hooks/useSingleTypeListicleSeo.ts
@@ -27,7 +27,6 @@ import {
 } from '../services/structured-data-template.service'
 
 type UseSingleTypeListicleSeoParams = {
-  token?: string | null
   draft: SingleTypeListicleDraft | null
   relatedItems: RelatedItemOption[]
   selectedLocationRefId: number | null
@@ -37,7 +36,6 @@ type UseSingleTypeListicleSeoParams = {
 }
 
 export function useSingleTypeListicleSeo({
-  token,
   draft,
   relatedItems,
   selectedLocationRefId,
@@ -123,10 +121,6 @@ export function useSingleTypeListicleSeo({
       onError('Select a featured image in Step 2 before generating social image URLs.')
       return
     }
-    if (!token) {
-      onError('You must be logged in to generate social image URLs.')
-      return
-    }
 
     onError('')
     setResult(null)
@@ -137,7 +131,6 @@ export function useSingleTypeListicleSeo({
         featuredMediaSetId
           ? { featuredMediaSetId }
           : { featuredAssetId: featuredAssetId as number },
-        token,
       )
       const bunnyUrl = response.generatedImageUrl.trim()
       if (!bunnyUrl) {
@@ -161,7 +154,7 @@ export function useSingleTypeListicleSeo({
     } finally {
       setIsGeneratingSeoImage(false)
     }
-  }, [draft, onError, setDraft, setResult, token])
+  }, [draft, onError, setDraft, setResult])
 
   const uploadOgImageFile = useCallback(async (file: File): Promise<void> => {
     if (!draft) return
@@ -170,11 +163,6 @@ export function useSingleTypeListicleSeo({
     if (fileIssue) {
       onError(fileIssue)
       throw new Error(fileIssue)
-    }
-    if (!token) {
-      const message = 'You must be logged in to upload social image URLs.'
-      onError(message)
-      throw new Error(message)
     }
 
     const locationRef = selectedLocationRefId ?? draft.locationRef
@@ -194,7 +182,6 @@ export function useSingleTypeListicleSeo({
         file,
         `Social share image for ${articleTitle}`,
         locationRef,
-        token,
         'Questurian Creative',
       )
       const bunnyUrl = response.generatedImageUrl.trim()
@@ -221,7 +208,7 @@ export function useSingleTypeListicleSeo({
     } finally {
       setIsUploadingOgImage(false)
     }
-  }, [draft, onError, selectedLocationRefId, setDraft, setResult, token])
+  }, [draft, onError, selectedLocationRefId, setDraft, setResult])
 
   return {
     generateSeo,

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/listicle-submit.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/builder/services/listicle-submit.service.ts
@@ -19,7 +19,6 @@ export type SubmitListicleParams = {
   selectedLocationRefId: number | null
   targetStatus: 'draft' | 'published'
   relatedItems: RelatedItemOption[]
-  token: string
 }
 
 export async function submitListicle({
@@ -27,7 +26,6 @@ export async function submitListicle({
   selectedLocationRefId,
   targetStatus,
   relatedItems,
-  token,
 }: SubmitListicleParams): Promise<{ doc: PayloadListicleDoc; nextDraft: SingleTypeListicleDraft; resultMessage: string }> {
   const submitIssue = validateSubmit(draft, selectedLocationRefId, targetStatus, relatedItems)
   if (submitIssue) throw new Error(submitIssue)
@@ -118,8 +116,8 @@ export async function submitListicle({
   }
 
   let doc = draft.payloadId
-    ? await updateListicle(draft.payloadId, body, token)
-    : await createListicle(body, token)
+    ? await updateListicle(draft.payloadId, body)
+    : await createListicle(body)
 
   if (targetStatus === 'published') {
     const publishedStructuredData = serializeStructuredDataTemplate(
@@ -145,7 +143,7 @@ export async function submitListicle({
           ...seoSectionForSubmit,
           structuredData: publishedStructuredData,
         }),
-      }, token)
+      })
     }
   }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx
@@ -25,7 +25,6 @@ import { saveDraft } from '../storage'
 import '../styles.css'
 
 export default function SingleTypeListicleBuilderPage() {
-  const { token } = useAuth()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const [error, setError] = useState<string | null>(null)
@@ -44,7 +43,6 @@ export default function SingleTypeListicleBuilderPage() {
     locations,
     mediaAssets,
   } = useBuilderBootstrap({
-    token,
     payloadIdParam,
     draftIdParam,
     setSearchParams,
@@ -63,7 +61,6 @@ export default function SingleTypeListicleBuilderPage() {
     initializeMissingBaselineAsSynced: true,
   })
   const { relatedItems, isLoadingRelated } = useRelatedItems({
-    token,
     draft,
     locations,
     onError,
@@ -94,7 +91,6 @@ export default function SingleTypeListicleBuilderPage() {
     onError,
   })
   const seo = useSingleTypeListicleSeo({
-    token,
     draft,
     relatedItems,
     selectedLocationRefId: actions.selectedLocationRefId,
@@ -103,7 +99,6 @@ export default function SingleTypeListicleBuilderPage() {
     setResult,
   })
   const { isSaving, submit } = useListicleSubmit({
-    token,
     draft,
     relatedItems,
     selectedLocationRefId: actions.selectedLocationRefId,
@@ -194,7 +189,6 @@ export default function SingleTypeListicleBuilderPage() {
           {(isStep1Locked || isSynced) ? (
             <BuilderHeaderPanel
               draft={draft}
-              token={token}
               locationRef={actions.selectedLocationRefId ?? draft.locationRef}
               mediaAssets={mediaAssets}
               updateHeader={actions.updateHeader}

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListiclesPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListiclesPage.tsx
@@ -25,7 +25,6 @@ function isGenericPayloadError(value: string): boolean {
 }
 
 export default function SingleTypeListiclesPage() {
-  const { token } = useAuth()
   const [listicles, setListicles] = useState<PayloadListicleDoc[]>([])
   const [localDrafts, setLocalDrafts] = useState(() => listDrafts())
   const [isLoading, setIsLoading] = useState(true)
@@ -53,13 +52,12 @@ export default function SingleTypeListiclesPage() {
   }, [])
 
   useEffect(() => {
-    if (!token) return
 
     let cancelled = false
     setIsLoading(true)
     setError(null)
 
-    fetchListicles(token)
+    fetchListicles()
       .then((response) => {
         if (cancelled) return
         setListicles(response.docs || [])
@@ -76,7 +74,7 @@ export default function SingleTypeListiclesPage() {
     return () => {
       cancelled = true
     }
-  }, [token])
+  }, [])
 
   const rows = useMemo(() => {
     return listicles.map((doc) => ({

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
@@ -39,7 +39,7 @@ function jsonResponse(body: unknown, ok = true, status = 200) {
 describe('staff.api', () => {
   // depth=0: the account carries no relationships worth populating now that
   // authorship (and its avatar) live on the author record.
-  it('fetches the staff user with auth header', async () => {
+  it('fetches the staff user with the session cookie, not a header', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ id: 3, email: 'w@questurian.com', role: 'writer' }))
 
     const user = await fetchStaffUser(3, 'token-1')
@@ -47,7 +47,8 @@ describe('staff.api', () => {
     expect(user.id).toBe(3)
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/api/users/3?depth=0')
-    expect(init.headers.Authorization).toBe('Bearer token-1')
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
+    expect(init.credentials).toBe('include')
   })
 
   it('updates the staff user and unwraps the doc', async () => {
@@ -122,7 +123,8 @@ describe('staff.api', () => {
     expect(String(url)).toContain('/api/media-assets')
     expect(init.method).toBe('POST')
     expect(init.body).toBeInstanceOf(FormData)
-    expect(init.headers.Authorization).toBe('Bearer token-1')
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
+    expect(init.credentials).toBe('include')
   })
 
   it('surfaces upload failures with status and body', async () => {
@@ -173,10 +175,10 @@ describe('staff.api', () => {
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/api/users/forgot-password')
     expect(JSON.parse(init.body)).toEqual({ email: 'new@questurian.com' })
-    expect(init.headers.Authorization).toBeUndefined()
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
   })
 
-  it('fetches recent email logs newest-first with auth', async () => {
+  it('fetches recent email logs newest-first on the session cookie', async () => {
     fetchMock.mockResolvedValue(
       jsonResponse({
         docs: [
@@ -197,7 +199,8 @@ describe('staff.api', () => {
     expect(logs[0].emailType).toBe('password-set-link')
     const [url, init] = fetchMock.mock.calls[0]
     expect(String(url)).toContain('/api/email-logs?limit=50&sort=-createdAt')
-    expect(init.headers.Authorization).toBe('Bearer token-1')
+    expect(new Headers(init.headers).get('Authorization')).toBeNull()
+    expect(init.credentials).toBe('include')
   })
 
   it('returns an empty log list when the collection has no docs', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.test.ts
@@ -42,7 +42,7 @@ describe('staff.api', () => {
   it('fetches the staff user with the session cookie, not a header', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ id: 3, email: 'w@questurian.com', role: 'writer' }))
 
-    const user = await fetchStaffUser(3, 'token-1')
+    const user = await fetchStaffUser(3)
 
     expect(user.id).toBe(3)
     const [url, init] = fetchMock.mock.calls[0]
@@ -54,7 +54,7 @@ describe('staff.api', () => {
   it('updates the staff user and unwraps the doc', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ doc: { id: 3, email: 'w@questurian.com', role: 'writer', firstName: 'Ana' } }))
 
-    const user = await updateStaffUser(3, { firstName: 'Ana' }, 'token-1')
+    const user = await updateStaffUser(3, { firstName: 'Ana' })
 
     expect(user.firstName).toBe('Ana')
     const [url, init] = fetchMock.mock.calls[0]
@@ -70,7 +70,7 @@ describe('staff.api', () => {
       jsonResponse({ doc: { id: 9, displayName: 'Ana Writes', slug: 'ana-writes' } }),
     )
 
-    const author = await updateAuthor(9, { slug: 'ana-writes' }, 'token-1')
+    const author = await updateAuthor(9, { slug: 'ana-writes' })
 
     expect(author.slug).toBe('ana-writes')
     const [url, init] = fetchMock.mock.calls[0]
@@ -81,7 +81,7 @@ describe('staff.api', () => {
   it('looks an author up by the account it is linked to', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [{ id: 9, displayName: 'Ana Writes' }] }))
 
-    const author = await fetchAuthorForUser(3, 'token-1')
+    const author = await fetchAuthorForUser(3)
 
     expect(author?.id).toBe(9)
     expect(String(fetchMock.mock.calls[0][0])).toContain('/api/authors?where[user][equals]=3')
@@ -90,7 +90,7 @@ describe('staff.api', () => {
   it('reports no author rather than failing when an account has none yet', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
 
-    await expect(fetchAuthorForUser(3, 'token-1')).resolves.toBeNull()
+    await expect(fetchAuthorForUser(3)).resolves.toBeNull()
   })
 
   it('creates an author linked to the account on first save', async () => {
@@ -98,7 +98,7 @@ describe('staff.api', () => {
       jsonResponse({ doc: { id: 9, displayName: 'Ana Writes', user: 3 } }),
     )
 
-    const author = await createAuthorForUser(3, { displayName: 'Ana Writes' }, 'token-1')
+    const author = await createAuthorForUser(3, { displayName: 'Ana Writes' })
 
     expect(author.id).toBe(9)
     const [url, init] = fetchMock.mock.calls[0]
@@ -110,13 +110,13 @@ describe('staff.api', () => {
   it('throws when update returns no doc', async () => {
     fetchMock.mockResolvedValue(jsonResponse({}))
 
-    await expect(updateStaffUser(3, {}, 'token-1')).rejects.toThrow('no updated user document')
+    await expect(updateStaffUser(3, {})).rejects.toThrow('no updated user document')
   })
 
   it('uploads an avatar as multipart form data', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ doc: { id: 9, url: 'https://cdn/avatar.jpg' } }))
 
-    const asset = await uploadAvatarAsset(new File(['x'], 'a.jpg', { type: 'image/jpeg' }), 'token-1')
+    const asset = await uploadAvatarAsset(new File(['x'], 'a.jpg', { type: 'image/jpeg' }))
 
     expect(asset.id).toBe(9)
     const [url, init] = fetchMock.mock.calls[0]
@@ -131,7 +131,7 @@ describe('staff.api', () => {
     fetchMock.mockResolvedValue(jsonResponse({ errors: [{ message: 'nope' }] }, false, 403))
 
     await expect(
-      uploadAvatarAsset(new File(['x'], 'a.jpg', { type: 'image/jpeg' }), 'token-1'),
+      uploadAvatarAsset(new File(['x'], 'a.jpg', { type: 'image/jpeg' })),
     ).rejects.toThrow('Avatar upload failed: 403')
   })
 
@@ -140,7 +140,7 @@ describe('staff.api', () => {
       jsonResponse({ docs: [{ id: 1, email: 'a@questurian.com', role: 'admin' }] }),
     )
 
-    const users = await fetchStaffUsers('token-1')
+    const users = await fetchStaffUsers()
 
     expect(users).toHaveLength(1)
     const [url] = fetchMock.mock.calls[0]
@@ -154,7 +154,6 @@ describe('staff.api', () => {
 
     const created = await createStaffUser(
       { email: 'new@questurian.com', firstName: 'New', lastName: 'Writer', role: 'writer' },
-      'token-1',
     )
 
     expect(created.id).toBe(5)
@@ -193,7 +192,7 @@ describe('staff.api', () => {
       }),
     )
 
-    const logs = await fetchEmailLogs('token-1')
+    const logs = await fetchEmailLogs()
 
     expect(logs).toHaveLength(1)
     expect(logs[0].emailType).toBe('password-set-link')
@@ -206,7 +205,7 @@ describe('staff.api', () => {
   it('returns an empty log list when the collection has no docs', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
 
-    expect(await fetchEmailLogs('token-1')).toEqual([])
+    expect(await fetchEmailLogs()).toEqual([])
   })
 
   it('promotes a writer to editor via role patch', async () => {
@@ -214,7 +213,7 @@ describe('staff.api', () => {
       jsonResponse({ doc: { id: 5, email: 'new@questurian.com', role: 'editor' } }),
     )
 
-    const updated = await changeStaffRole(5, 'editor', 'token-1')
+    const updated = await changeStaffRole(5, 'editor')
 
     expect(updated.role).toBe('editor')
     const [url, init] = fetchMock.mock.calls[0]
@@ -228,7 +227,7 @@ describe('staff.api', () => {
       jsonResponse({ doc: { id: 5, email: 'new@questurian.com', role: 'writer' } }),
     )
 
-    const updated = await changeStaffRole(5, 'writer', 'token-1')
+    const updated = await changeStaffRole(5, 'writer')
 
     expect(updated.role).toBe('writer')
     expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ role: 'writer' })
@@ -239,7 +238,7 @@ describe('staff.api', () => {
       jsonResponse({ doc: { id: 5, email: 'new@questurian.com', role: 'writer', status: 'disabled' } }),
     )
 
-    const disabled = await setStaffStatus(5, 'disabled', 'token-1')
+    const disabled = await setStaffStatus(5, 'disabled')
 
     expect(disabled.status).toBe('disabled')
     const [url, init] = fetchMock.mock.calls[0]
@@ -251,7 +250,7 @@ describe('staff.api', () => {
       jsonResponse({ doc: { id: 5, email: 'new@questurian.com', role: 'writer', status: 'active' } }),
     )
 
-    const reenabled = await setStaffStatus(5, 'active', 'token-1')
+    const reenabled = await setStaffStatus(5, 'active')
 
     expect(reenabled.status).toBe('active')
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ status: 'active' })
@@ -260,7 +259,7 @@ describe('staff.api', () => {
   it('throws when a status patch comes back without a document', async () => {
     fetchMock.mockResolvedValue(jsonResponse({}))
 
-    await expect(setStaffStatus(5, 'disabled', 'token-1')).rejects.toThrow(
+    await expect(setStaffStatus(5, 'disabled')).rejects.toThrow(
       'Payload returned no updated user document.',
     )
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types'
 
 export async function fetchStaffUser(id: number | string, token: string): Promise<StaffUser> {
-  return payloadRequest(`/api/users/${id}?depth=0`, token)
+  return payloadRequest(`/api/users/${id}?depth=0`)
 }
 
 /**
@@ -28,7 +28,6 @@ export async function fetchAuthorForUser(
   // depth=1 populates the avatar upload relationship for preview
   const response = (await payloadRequest(
     `/api/authors?where[user][equals]=${userId}&limit=1&depth=1`,
-    token,
   )) as { docs?: Author[] }
   return response.docs?.[0] ?? null
 }
@@ -37,7 +36,6 @@ export async function fetchAuthorForUser(
 export async function fetchAuthors(token: string): Promise<Author[]> {
   const response = (await payloadRequest(
     '/api/authors?limit=200&sort=displayName&depth=0',
-    token,
   )) as { docs?: Author[] }
   return response.docs ?? []
 }
@@ -51,7 +49,6 @@ export async function createAuthorForUser(
     '/api/authors',
     'POST',
     { ...patch, user: Number(userId) },
-    token,
   )) as { doc?: Author }
   if (!response.doc) {
     throw new Error('Payload returned no created author document.')
@@ -64,7 +61,7 @@ export async function updateAuthor(
   patch: AuthorPatch,
   token: string,
 ): Promise<Author> {
-  const response = (await payloadMutation(`/api/authors/${id}`, 'PATCH', patch, token)) as {
+  const response = (await payloadMutation(`/api/authors/${id}`, 'PATCH', patch)) as {
     doc?: Author
   }
   if (!response.doc) {
@@ -78,7 +75,7 @@ export async function updateStaffUser(
   patch: StaffUserPatch,
   token: string,
 ): Promise<StaffUser> {
-  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', patch, token)) as {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', patch)) as {
     doc?: StaffUser
   }
   if (!response.doc) {
@@ -101,7 +98,7 @@ export async function uploadAvatarAsset(file: File, token: string): Promise<Avat
     method: 'POST',
     mode: 'cors',
     credentials: 'include',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { },
     body: formData,
   })
 
@@ -118,7 +115,7 @@ export async function uploadAvatarAsset(file: File, token: string): Promise<Avat
 }
 
 export async function fetchStaffUsers(token: string): Promise<StaffUser[]> {
-  const response = (await payloadRequest('/api/users?limit=200&sort=email&depth=0', token)) as {
+  const response = (await payloadRequest('/api/users?limit=200&sort=email&depth=0')) as {
     docs?: StaffUser[]
   }
   return response.docs ?? []
@@ -137,7 +134,6 @@ export async function createStaffUser(
     '/api/users',
     'POST',
     { ...input, password: generateDiscardedPassword() },
-    token,
   )) as { doc?: StaffUser }
   if (!response.doc) {
     throw new Error('Payload returned no created user document.')
@@ -167,7 +163,6 @@ export async function requestPasswordSetEmail(email: string): Promise<void> {
 export async function fetchEmailLogs(token: string, limit = 50): Promise<EmailLog[]> {
   const response = (await payloadRequest(
     `/api/email-logs?limit=${limit}&sort=-createdAt&depth=0`,
-    token,
   )) as { docs?: EmailLog[] }
   return response.docs ?? []
 }
@@ -182,7 +177,7 @@ export async function changeStaffRole(
   role: AssignableStaffRole,
   token: string,
 ): Promise<StaffUser> {
-  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { role }, token)) as {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { role })) as {
     doc?: StaffUser
   }
   if (!response.doc) {
@@ -201,7 +196,7 @@ export async function setStaffStatus(
   status: StaffStatus,
   token: string,
 ): Promise<StaffUser> {
-  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { status }, token)) as {
+  const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { status })) as {
     doc?: StaffUser
   }
   if (!response.doc) {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/api/staff.api.ts
@@ -11,7 +11,7 @@ import type {
   StaffUserPatch,
 } from '../types'
 
-export async function fetchStaffUser(id: number | string, token: string): Promise<StaffUser> {
+export async function fetchStaffUser(id: number | string): Promise<StaffUser> {
   return payloadRequest(`/api/users/${id}?depth=0`)
 }
 
@@ -23,7 +23,6 @@ export async function fetchStaffUser(id: number | string, token: string): Promis
  */
 export async function fetchAuthorForUser(
   userId: number | string,
-  token: string,
 ): Promise<Author | null> {
   // depth=1 populates the avatar upload relationship for preview
   const response = (await payloadRequest(
@@ -33,7 +32,7 @@ export async function fetchAuthorForUser(
 }
 
 /** Every author, for joining onto the staff table by linked account. */
-export async function fetchAuthors(token: string): Promise<Author[]> {
+export async function fetchAuthors(): Promise<Author[]> {
   const response = (await payloadRequest(
     '/api/authors?limit=200&sort=displayName&depth=0',
   )) as { docs?: Author[] }
@@ -43,7 +42,6 @@ export async function fetchAuthors(token: string): Promise<Author[]> {
 export async function createAuthorForUser(
   userId: number | string,
   patch: AuthorPatch,
-  token: string,
 ): Promise<Author> {
   const response = (await payloadMutation(
     '/api/authors',
@@ -59,7 +57,6 @@ export async function createAuthorForUser(
 export async function updateAuthor(
   id: number | string,
   patch: AuthorPatch,
-  token: string,
 ): Promise<Author> {
   const response = (await payloadMutation(`/api/authors/${id}`, 'PATCH', patch)) as {
     doc?: Author
@@ -73,7 +70,6 @@ export async function updateAuthor(
 export async function updateStaffUser(
   id: number | string,
   patch: StaffUserPatch,
-  token: string,
 ): Promise<StaffUser> {
   const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', patch)) as {
     doc?: StaffUser
@@ -89,7 +85,7 @@ export async function updateStaffUser(
  * explicitly reserve direct media-asset uploads for internal profile images,
  * so this does not go through the MediaSet workflow.
  */
-export async function uploadAvatarAsset(file: File, token: string): Promise<AvatarAsset> {
+export async function uploadAvatarAsset(file: File): Promise<AvatarAsset> {
   const formData = new FormData()
   formData.append('file', file)
   formData.append('_payload', JSON.stringify({ alt_text: 'Author profile avatar' }))
@@ -114,7 +110,7 @@ export async function uploadAvatarAsset(file: File, token: string): Promise<Avat
   return data.doc
 }
 
-export async function fetchStaffUsers(token: string): Promise<StaffUser[]> {
+export async function fetchStaffUsers(): Promise<StaffUser[]> {
   const response = (await payloadRequest('/api/users?limit=200&sort=email&depth=0')) as {
     docs?: StaffUser[]
   }
@@ -128,7 +124,6 @@ export async function fetchStaffUsers(token: string): Promise<StaffUser[]> {
  */
 export async function createStaffUser(
   input: { email: string; firstName: string; lastName: string; role: 'writer' | 'editor' },
-  token: string,
 ): Promise<StaffUser> {
   const response = (await payloadMutation(
     '/api/users',
@@ -160,7 +155,7 @@ export async function requestPasswordSetEmail(email: string): Promise<void> {
  * written by questura's email tracking; an empty result may just mean tracking
  * is disabled (EMAIL_TRACKING=false).
  */
-export async function fetchEmailLogs(token: string, limit = 50): Promise<EmailLog[]> {
+export async function fetchEmailLogs(limit = 50): Promise<EmailLog[]> {
   const response = (await payloadRequest(
     `/api/email-logs?limit=${limit}&sort=-createdAt&depth=0`,
   )) as { docs?: EmailLog[] }
@@ -175,7 +170,6 @@ export async function fetchEmailLogs(token: string, limit = 50): Promise<EmailLo
 export async function changeStaffRole(
   id: number | string,
   role: AssignableStaffRole,
-  token: string,
 ): Promise<StaffUser> {
   const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { role })) as {
     doc?: StaffUser
@@ -194,7 +188,6 @@ export async function changeStaffRole(
 export async function setStaffStatus(
   id: number | string,
   status: StaffStatus,
-  token: string,
 ): Promise<StaffUser> {
   const response = (await payloadMutation(`/api/users/${id}`, 'PATCH', { status })) as {
     doc?: StaffUser

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/components/ProfileEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/components/ProfileEditor.tsx
@@ -66,7 +66,6 @@ function formStateFromRecords(
 }
 
 export default function ProfileEditor({ userId, variant }: ProfileEditorProps) {
-  const { token } = useAuth()
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -81,12 +80,12 @@ export default function ProfileEditor({ userId, variant }: ProfileEditorProps) {
     queryKey: ['staff', 'profile', String(userId)],
     queryFn: async () => {
       const [user, author] = await Promise.all([
-        fetchStaffUser(userId, token as string),
-        fetchAuthorForUser(userId, token as string),
+        fetchStaffUser(userId),
+        fetchAuthorForUser(userId),
       ])
       return { user, author }
     },
-    enabled: Boolean(token),
+    enabled: Boolean(),
   })
 
   useEffect(() => {
@@ -105,7 +104,7 @@ export default function ProfileEditor({ userId, variant }: ProfileEditorProps) {
   }, [userId])
 
   const avatarUpload = useMutation({
-    mutationFn: (file: File) => uploadAvatarAsset(file, token as string),
+    mutationFn: (file: File) => uploadAvatarAsset(file),
     onSuccess: (asset) => {
       setPendingAvatarId(asset.id)
       setPendingAvatarPreview(avatarUrl(asset))
@@ -146,10 +145,10 @@ export default function ProfileEditor({ userId, variant }: ProfileEditorProps) {
       // account goes first: it is the one that must not be lost if the second
       // fails, and an author record can always be re-saved.
       const [user, author] = [
-        await updateStaffUser(userId, userPatch, token as string),
+        await updateStaffUser(userId, userPatch),
         existingAuthor
-          ? await updateAuthor(existingAuthor.id, authorPatch, token as string)
-          : await createAuthorForUser(userId, authorPatch, token as string),
+          ? await updateAuthor(existingAuthor.id, authorPatch)
+          : await createAuthorForUser(userId, authorPatch),
       ]
 
       return { user, author }

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/pages/MyProfilePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/pages/MyProfilePage.tsx
@@ -2,9 +2,9 @@ import { useAuth } from '../../auth'
 import ProfileEditor from '../components/ProfileEditor'
 
 export default function MyProfilePage() {
-  const { user: authUser, token } = useAuth()
+  const { user: authUser } = useAuth()
 
-  if (!authUser?.id || !token) return null
+  if (!authUser?.id) return null
 
   return (
     <div className="staff-page">

--- a/apps/ai-blog-writer/apps/frontend/src/features/staff/pages/StaffPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staff/pages/StaffPage.tsx
@@ -81,7 +81,7 @@ function latestInviteByRecipient(logs: EmailLog[]): Map<string, EmailLog> {
 }
 
 export default function StaffPage() {
-  const { token, user: currentUser } = useAuth()
+  const { user: currentUser } = useAuth()
   const { canManageUsers, isLoading: permissionsLoading } = usePermissions()
   const queryClient = useQueryClient()
 
@@ -91,20 +91,20 @@ export default function StaffPage() {
 
   const staffQuery = useQuery({
     queryKey: ['staff', 'list'],
-    queryFn: () => fetchStaffUsers(token as string),
-    enabled: Boolean(token) && canManageUsers,
+    queryFn: () => fetchStaffUsers(),
+    enabled: Boolean() && canManageUsers,
   })
 
   const authorsQuery = useQuery({
     queryKey: ['staff', 'authors'],
-    queryFn: () => fetchAuthors(token as string),
-    enabled: Boolean(token) && canManageUsers,
+    queryFn: () => fetchAuthors(),
+    enabled: Boolean() && canManageUsers,
   })
 
   const emailLogsQuery = useQuery({
     queryKey: ['staff', 'email-logs'],
-    queryFn: () => fetchEmailLogs(token as string),
-    enabled: Boolean(token) && canManageUsers,
+    queryFn: () => fetchEmailLogs(),
+    enabled: Boolean() && canManageUsers,
   })
 
   const inviteStaff = useMutation({
@@ -116,7 +116,6 @@ export default function StaffPage() {
           lastName: input.lastName.trim(),
           role: input.role,
         },
-        token as string,
       )
       // Invite-style onboarding: the random creation password is discarded;
       // the hire sets their own through this email.
@@ -154,7 +153,7 @@ export default function StaffPage() {
 
   const changeRole = useMutation({
     mutationFn: ({ user, role }: { user: StaffUser; role: AssignableStaffRole }) =>
-      changeStaffRole(user.id, role, token as string),
+      changeStaffRole(user.id, role),
     onSuccess: (updated) => {
       void queryClient.invalidateQueries({ queryKey: ['staff', 'list'] })
       setErrorMessage(null)
@@ -168,7 +167,7 @@ export default function StaffPage() {
 
   const changeStatus = useMutation({
     mutationFn: ({ user, status }: { user: StaffUser; status: StaffStatus }) =>
-      setStaffStatus(user.id, status, token as string),
+      setStaffStatus(user.id, status),
     onSuccess: (updated) => {
       void queryClient.invalidateQueries({ queryKey: ['staff', 'list'] })
       setErrorMessage(null)

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.test.ts
@@ -20,7 +20,7 @@ describe('articles api', () => {
       }),
     })
 
-    await expect(getArticleById(39, 'token-1')).resolves.toMatchObject({
+    await expect(getArticleById(39)).resolves.toMatchObject({
       id: 39,
       title: 'Payload Article',
     })
@@ -37,7 +37,7 @@ describe('articles api', () => {
       }),
     })
 
-    await expect(getArticleById(40, 'token-1')).resolves.toMatchObject({
+    await expect(getArticleById(40)).resolves.toMatchObject({
       id: 40,
       title: 'Wrapped Article',
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
@@ -21,7 +21,6 @@ export async function createArticle(
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(article),
   })
@@ -47,7 +46,6 @@ export async function updateArticle(
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(article),
   })
@@ -71,7 +69,6 @@ export async function getArticleById(
     credentials: 'include',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
 
@@ -96,7 +93,6 @@ export async function fetchPayloadArticles(token: string): Promise<PayloadArticl
     credentials: 'include',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/api/articles/articles.api.ts
@@ -12,7 +12,6 @@ function unwrapPayloadDoc<T>(result: T | { doc?: T }): T {
 
 export async function createArticle(
   article: CreateArticlePayload,
-  token: string,
 ): Promise<PayloadArticleDoc> {
   const response = await fetch(`${PAYLOAD_API_URL}/api/articles`, {
     method: 'POST',
@@ -37,7 +36,6 @@ export async function createArticle(
 export async function updateArticle(
   id: number,
   article: CreateArticlePayload,
-  token: string,
 ): Promise<PayloadArticleDoc> {
   const response = await fetch(`${PAYLOAD_API_URL}/api/articles/${id}`, {
     method: 'PATCH',
@@ -61,7 +59,6 @@ export async function updateArticle(
 
 export async function getArticleById(
   id: number,
-  token: string,
 ): Promise<PayloadArticleDoc> {
   const response = await fetch(`${PAYLOAD_API_URL}/api/articles/${id}?depth=1`, {
     method: 'GET',
@@ -81,7 +78,7 @@ export async function getArticleById(
   return unwrapPayloadDoc<PayloadArticleDoc>(result)
 }
 
-export async function fetchPayloadArticles(token: string): Promise<PayloadArticleDoc[]> {
+export async function fetchPayloadArticles(): Promise<PayloadArticleDoc[]> {
   const query = new URLSearchParams({
     limit: '200',
     depth: '0',

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/StandardArticleStageBuilder.tsx
@@ -44,7 +44,6 @@ export function StandardArticleStageBuilder({
   syncBehavior = 'draft-sync',
   backToStageLabel = 'Back to Stage List',
 }: StandardArticleStageBuilderProps) {
-  const { token } = useAuth()
   const { canManagePublished, role } = usePermissions()
   const [localError, setLocalError] = useState<string | null>(null)
   const [localResult, setLocalResult] = useState<string | null>(null)
@@ -54,7 +53,6 @@ export function StandardArticleStageBuilder({
     routes,
     syncBehavior,
     api,
-    token,
   })
   const {
     status,
@@ -95,7 +93,6 @@ export function StandardArticleStageBuilder({
   })
   const seo = useStandardArticleSeoActions({
     api,
-    token,
     stagedArticle,
     featureLabel,
     selectedLocationLabel: derived.selectedLocationLabel,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/BlockImageModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/BlockImageModal.tsx
@@ -27,7 +27,6 @@ type BlockImageModalProps = {
   blockImageModal: BlockImageModalState | null
   publishedToPayload: boolean
   onClose: () => void
-  token?: string
   locationRef: number | null
   singleImageRequirementLabel: string
   imgPairRequirementLabel: string
@@ -62,7 +61,6 @@ export function BlockImageModal({
   blockImageModal,
   publishedToPayload,
   onClose,
-  token,
   locationRef,
   singleImageRequirementLabel,
   imgPairRequirementLabel,
@@ -167,7 +165,6 @@ export function BlockImageModal({
   return (
     <ImagePicker
       isOpen={Boolean(blockImageModal.show) && !publishedToPayload}
-      token={token}
       locationRef={locationRef}
       query={query}
       selection={selection}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialStageArticleScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/EditorialStageArticleScreen.tsx
@@ -12,14 +12,12 @@ import { EditorialTimelineList } from './EditorialTimelineList'
 import { FeaturedImageModal } from './FeaturedImageModal'
 
 type EditorialStageArticleScreenProps = EditorialStageArticlePageProps & {
-  token: string | null | undefined
 }
 
 export function EditorialStageArticleScreen({
   storageKey,
   routes,
   api,
-  token,
 }: EditorialStageArticleScreenProps) {
   const {
     status,
@@ -32,7 +30,6 @@ export function EditorialStageArticleScreen({
     storageKey,
     routes,
     api,
-    token,
   })
 
   const [isExpansionModalOpen, setIsExpansionModalOpen] = useState(false)

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/FeaturedImageModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/editorial-stage/FeaturedImageModal.tsx
@@ -9,7 +9,6 @@ type FeaturedImageModalProps = {
   show: boolean
   publishedToPayload: boolean
   onClose: () => void
-  token?: string
   locationRef: number | null
   selectedFeaturedImageId: number | null
   requirementLabel: string
@@ -25,7 +24,6 @@ export function FeaturedImageModal({
   show,
   publishedToPayload,
   onClose,
-  token,
   locationRef,
   selectedFeaturedImageId,
   requirementLabel,
@@ -46,7 +44,6 @@ export function FeaturedImageModal({
   return (
     <ImagePicker
       isOpen={show && !publishedToPayload}
-      token={token}
       locationRef={locationRef}
       selectedId={selectedFeaturedImageId}
       query={{

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleMediaController.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleMediaController.ts
@@ -10,18 +10,15 @@ import type { EditorialStageArticleWorkspace } from './useEditorialStageArticleW
 import { useEditorialStageMedia } from './useEditorialStageMedia'
 
 type UseEditorialStageArticleMediaControllerParams = {
-  token: string | null | undefined
   api: EditorialStageArticleApi
   workspace: EditorialStageArticleWorkspace
 }
 
 export function useEditorialStageArticleMediaController({
-  token,
   api,
   workspace,
 }: UseEditorialStageArticleMediaControllerParams) {
   const media = useEditorialStageMedia({
-    token,
     stagedArticle: workspace.page.stagedArticle,
     locations: workspace.page.locations,
     mediaAssets: workspace.page.mediaAssets,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticlePublishing.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticlePublishing.ts
@@ -5,7 +5,6 @@ import type { EditorialStageArticleWorkspace } from './useEditorialStageArticleW
 import { useEditorialStagePublishWorkflow } from './useEditorialStagePublishWorkflow'
 
 type UseEditorialStageArticlePublishingParams = {
-  token: string | null | undefined
   routes: EditorialStageRoutes
   api: EditorialStageArticleApi
   workspace: EditorialStageArticleWorkspace
@@ -13,14 +12,12 @@ type UseEditorialStageArticlePublishingParams = {
 }
 
 export function useEditorialStageArticlePublishing({
-  token,
   routes,
   api,
   workspace,
   media,
 }: UseEditorialStageArticlePublishingParams) {
   const publishWorkflow = useEditorialStagePublishWorkflow({
-    token,
     // Route prefixes double as feature keys ('/url2blog/stage-article' -> 'url2blog'),
     // matching the backend API prefixes for each blog-writer pipeline.
     sourceFeature: routes.stageArticlePath.split('/')[1] ?? '',

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleScreenViewModel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleScreenViewModel.tsx
@@ -11,26 +11,22 @@ import { useEditorialStageArticleWorkspace } from './useEditorialStageArticleWor
 import { useEditorialStageLoadedArticleViews } from './useEditorialStageLoadedArticleViews'
 
 type UseEditorialStageArticleScreenViewModelParams = EditorialStageArticlePageProps & {
-  token: string | null | undefined
 }
 
 export function useEditorialStageArticleScreenViewModel({
   storageKey,
   routes,
   api,
-  token,
   syncBehavior,
 }: UseEditorialStageArticleScreenViewModelParams): EditorialStageArticleScreenViewModel {
   const workspace = useEditorialStageArticleWorkspace({
     storageKey,
     routes,
     api,
-    token,
     syncBehavior,
   })
-  const media = useEditorialStageArticleMediaController({ token, api, workspace })
+  const media = useEditorialStageArticleMediaController({ api, workspace })
   const publishing = useEditorialStageArticlePublishing({
-    token,
     routes,
     api,
     workspace,
@@ -54,7 +50,6 @@ export function useEditorialStageArticleScreenViewModel({
   const loadedViews = useEditorialStageLoadedArticleViews({
     stagedArticle: workspace.page.stagedArticle ?? EMPTY_STAGED_ARTICLE,
     stagePath: routes.stagePath,
-    token,
     workspace,
     media,
     publishing,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleWorkspace.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageArticleWorkspace.ts
@@ -17,7 +17,6 @@ import { useEditorialStagePageData } from './useEditorialStagePageData'
 import { useEditorialStageTimeline } from './useEditorialStageTimeline'
 
 type UseEditorialStageArticleWorkspaceParams = EditorialStageArticlePageProps & {
-  token: string | null | undefined
 }
 
 function useSetPublishResult(
@@ -34,7 +33,6 @@ export function useEditorialStageArticleWorkspace({
   storageKey,
   routes,
   api,
-  token,
   syncBehavior,
 }: UseEditorialStageArticleWorkspaceParams) {
   const [uiState, dispatchUi] = useReducer(
@@ -48,7 +46,6 @@ export function useEditorialStageArticleWorkspace({
     storageKey,
     stageArticlePath: routes.stageArticlePath,
     stagePath: routes.stagePath,
-    token,
     syncBehavior,
     api: {
       fetchResult: api.fetchResult,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageBlockMedia.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageBlockMedia.ts
@@ -30,10 +30,8 @@ import { searchExternalPhotos } from '../services/editorial-stage-image-search.s
 const BLOCK_PAYLOAD_PAGE_LIMIT = 60
 
 type UseEditorialStageBlockMediaParams = {
-  token: string | null | undefined
   mediaAssets: MediaAsset[]
   fetchMediaAssets: (
-    token?: string,
     params?: {
       limit?: number
       page?: number
@@ -66,7 +64,6 @@ type UseEditorialStageBlockMediaParams = {
 }
 
 export function useEditorialStageBlockMedia({
-  token,
   mediaAssets,
   fetchMediaAssets,
   searchPexelsImages,
@@ -172,13 +169,13 @@ export function useEditorialStageBlockMedia({
     }
   ) => {
     const request = buildPayloadRequestParams()
-    if (!token || !blockImageModal || !request) return
+    if (!blockImageModal || !request) return
 
     setIsLoadingImgBlockAssets(true)
     setImgBlockAssetsError(null)
 
     try {
-      const response = await fetchMediaAssets(token, {
+      const response = await fetchMediaAssets({
         ...request,
         page,
       })
@@ -231,11 +228,10 @@ export function useEditorialStageBlockMedia({
     buildPayloadRequestParams,
     fetchMediaAssets,
     replaceImgBlockAssets,
-    token,
   ])
 
   const reloadImgBlockAssets = useCallback(async () => {
-    if (!blockImageModal || !token) return
+    if (!blockImageModal) return
 
     const selectedSeedAssets = mediaAssetsRef.current.filter((asset) =>
       selectedImgBlockAssetIdsRef.current.includes(asset.id)
@@ -245,10 +241,10 @@ export function useEditorialStageBlockMedia({
       totalPages: 1,
     })
     await fetchImgBlockPayloadPage(1, { reset: true })
-  }, [blockImageModal, fetchImgBlockPayloadPage, replaceImgBlockAssets, token])
+  }, [blockImageModal, fetchImgBlockPayloadPage, replaceImgBlockAssets])
 
   const loadMoreImgBlockAssets = useCallback(async () => {
-    if (!blockImageModal || !token) return
+    if (!blockImageModal) return
     if (isLoadingImgBlockAssets) return
     if (imgBlockPayloadPage >= imgBlockPayloadTotalPages && imgBlockPayloadPage > 0) return
 
@@ -260,7 +256,6 @@ export function useEditorialStageBlockMedia({
     imgBlockPayloadPage,
     imgBlockPayloadTotalPages,
     isLoadingImgBlockAssets,
-    token,
   ])
 
   const closeBlockImageModal = useCallback(() => {
@@ -337,17 +332,9 @@ export function useEditorialStageBlockMedia({
     if (!blockImageModal) return
     if (blockImageSource !== 'payload') return
 
-    if (!token) {
-      replaceImgBlockAssets([], {
-        page: 0,
-        totalPages: 1,
-      })
-      setSelectedImgBlockAssetIds([])
-      return
-    }
 
     void reloadImgBlockAssets()
-  }, [blockImageSource, blockPayloadRequestKey, reloadImgBlockAssets, replaceImgBlockAssets, token, blockImageModal])
+  }, [blockImageSource, blockPayloadRequestKey, reloadImgBlockAssets, replaceImgBlockAssets, blockImageModal])
 
   useEffect(() => {
     if (blockImageSource === 'payload') return

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageLoadedArticleViews.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageLoadedArticleViews.tsx
@@ -23,7 +23,6 @@ import type { EditorialStageArticlePublishing } from './useEditorialStageArticle
 type UseEditorialStageLoadedArticleViewsParams = {
   stagedArticle: StagedArticle
   stagePath: string
-  token: string | null | undefined
   workspace: EditorialStageArticleWorkspace
   media: EditorialStageArticleMediaController
   publishing: EditorialStageArticlePublishing
@@ -43,7 +42,6 @@ export function useEditorialStageLoadedArticleViews(
   const {
     stagedArticle,
     stagePath,
-    token,
     workspace,
     media,
     publishing,
@@ -58,7 +56,6 @@ export function useEditorialStageLoadedArticleViews(
     ...publishing,
     stagedArticle,
     stagePath,
-    token,
     editorialPublishAnalysis: workspace.editorialPublishAnalysis,
     setPublishResult: workspace.setPublishResult,
     openImagePickerTarget: workspace.uiState.pickers.openImageTarget,
@@ -191,7 +188,6 @@ export function useEditorialStageLoadedArticleViews(
     stagedArticle: params.stagedArticle,
     featuredImageRequirementLabel,
     selectedLocation,
-    token: params.token || undefined,
     updateStagedArticle: params.updateStagedArticle,
     setShowImageModal: params.setShowImageModalTracked,
   })
@@ -200,7 +196,6 @@ export function useEditorialStageLoadedArticleViews(
     stagedArticle: params.stagedArticle,
     blockImageModal: params.blockImageModal,
     closeBlockImageModal: params.closeBlockImageModalTracked,
-    token: params.token || undefined,
     selectedLocation,
     singleImageRequirementLabel,
     imgPairRequirementLabel,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageMedia.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageMedia.test.ts
@@ -66,7 +66,7 @@ function buildStagedArticle(): StagedArticle {
 
 describe('useEditorialStageMedia', () => {
   it('hydrates referenced block image assets that are missing from the initial media page', async () => {
-    const fetchMediaAssets = vi.fn(async (_token?: string, params?: { id?: number }) => {
+    const fetchMediaAssets = vi.fn(async (params?: { id?: number }) => {
       const assetId = params?.id
 
       return {
@@ -92,7 +92,6 @@ describe('useEditorialStageMedia', () => {
       }, [])
 
       return useEditorialStageMedia({
-        token: 'token',
         stagedArticle: buildStagedArticle(),
         locations: [],
         mediaAssets,
@@ -115,7 +114,7 @@ describe('useEditorialStageMedia', () => {
     await waitFor(() => {
       const requestedIds = Array.from(new Set(
         fetchMediaAssets.mock.calls
-          .map(([, params]) => params?.id)
+          .map(([params]) => params?.id)
           .filter((assetId): assetId is number => typeof assetId === 'number')
       )).sort((left, right) => left - right)
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageMedia.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStageMedia.tsx
@@ -42,13 +42,11 @@ function getReferencedBlockAssetIds(blocks: StagedArticle['blocks'] | undefined)
 }
 
 type UseEditorialStageMediaParams = {
-  token: string | null | undefined
   stagedArticle: StagedArticle | null
   locations: Location[]
   mediaAssets: MediaAsset[]
   mergeMediaAssetsIntoState: (assets: MediaAsset[]) => void
   fetchMediaAssets: (
-    token?: string,
     params?: {
       limit?: number
       page?: number
@@ -66,7 +64,6 @@ type UseEditorialStageMediaParams = {
       provider: ExternalImageProvider
       photoId?: string | number
     },
-    token: string
   ) => Promise<{
     blob: Blob
     fileName: string
@@ -109,7 +106,6 @@ type UseEditorialStageMediaParams = {
  * loaded yet. The params keep the full shape the sub-hooks consume.
  */
 export function useEditorialStageMedia({
-  token,
   stagedArticle,
   mediaAssets,
   mergeMediaAssetsIntoState,
@@ -121,7 +117,6 @@ export function useEditorialStageMedia({
   const resetExternalImportState = useCallback(() => {}, [])
 
   const block = useEditorialStageBlockMedia({
-    token,
     mediaAssets,
     fetchMediaAssets,
     searchPexelsImages,
@@ -133,7 +128,7 @@ export function useEditorialStageMedia({
 
   // Backfill assets referenced by blocks but missing from the loaded media page.
   useEffect(() => {
-    if (!token || !stagedArticle?.blocks.length) return
+    if (!stagedArticle?.blocks.length) return
 
     const loadedAssetIds = new Set(mediaAssets.map((asset) => asset.id))
     const missingBlockAssetIds = getReferencedBlockAssetIds(stagedArticle.blocks).filter(
@@ -148,7 +143,7 @@ export function useEditorialStageMedia({
       const responses = await Promise.all(
         missingBlockAssetIds.map(async (assetId) => {
           try {
-            return await fetchMediaAssets(token, {
+            return await fetchMediaAssets({
               limit: 1,
               id: assetId,
             })
@@ -173,7 +168,6 @@ export function useEditorialStageMedia({
       isCancelled = true
     }
   }, [
-    token,
     stagedArticle?.blocks,
     mediaAssets,
     fetchMediaAssets,
@@ -183,7 +177,7 @@ export function useEditorialStageMedia({
 
   // Backfill the featured asset if it isn't already loaded.
   useEffect(() => {
-    if (!token || !stagedArticle?.featuredImageId) return
+    if (!stagedArticle?.featuredImageId) return
 
     const featuredAssetId = Number(stagedArticle.featuredImageId)
     if (!Number.isFinite(featuredAssetId) || featuredAssetId <= 0) return
@@ -193,7 +187,7 @@ export function useEditorialStageMedia({
 
     const hydrateFeaturedAsset = async () => {
       try {
-        const response = await fetchMediaAssets(token, {
+        const response = await fetchMediaAssets({
           limit: 1,
           id: featuredAssetId,
         })
@@ -211,7 +205,6 @@ export function useEditorialStageMedia({
       isCancelled = true
     }
   }, [
-    token,
     stagedArticle?.featuredImageId,
     mediaAssets,
     fetchMediaAssets,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePageData.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePageData.ts
@@ -44,7 +44,6 @@ type UseEditorialStagePageDataParams = {
   storageKey: string
   stageArticlePath: string
   stagePath: string
-  token: string | null | undefined
   syncBehavior?: 'finalize' | 'draft-sync'
   api: Pick<EditorialStageArticleApi, 'fetchResult' | 'fetchLocations' | 'fetchMediaAssets' | 'getArticleSyncStatus' | 'getArticleById'>
 }
@@ -53,7 +52,6 @@ export function useEditorialStagePageData({
   storageKey,
   stageArticlePath,
   stagePath,
-  token,
   syncBehavior = 'finalize',
   api,
 }: UseEditorialStagePageDataParams) {
@@ -149,9 +147,9 @@ export function useEditorialStagePageData({
 
     let payloadMetadataPatch: Partial<StagedArticle> = {}
 
-    if (existing.payloadArticleId && token && getArticleById) {
+    if (existing.payloadArticleId && getArticleById) {
       try {
-        const payloadDoc = await getArticleById(existing.payloadArticleId, token)
+        const payloadDoc = await getArticleById(existing.payloadArticleId)
         payloadMetadataPatch = buildPayloadArticleMetadataPatch({
           doc: payloadDoc,
           fallbackAuthorName: schemaPublisherConfig.defaultAuthorName,
@@ -180,7 +178,7 @@ export function useEditorialStagePageData({
         missingBaselineIsUnsynced: true,
       },
     )
-  }, [fetchResult, getArticleById, schemaPublisherConfig.defaultAuthorName, syncBehavior, token])
+  }, [fetchResult, getArticleById, schemaPublisherConfig.defaultAuthorName, syncBehavior])
 
   useEffect(() => {
     if (!urlRunId && !stagedId) return
@@ -345,8 +343,8 @@ export function useEditorialStagePageData({
         if (isCancelled || !syncStatus.synced_to_payload || !syncStatus.payload_article_id) return
 
         const payloadMetadataPatch: Partial<StagedArticle> = (
-          token && getArticleById
-            ? await getArticleById(syncStatus.payload_article_id, token)
+          getArticleById
+            ? await getArticleById(syncStatus.payload_article_id)
               .then((payloadDoc) => buildPayloadArticleMetadataPatch({
                 doc: payloadDoc,
                 fallbackAuthorName: schemaPublisherConfig.defaultAuthorName,
@@ -396,22 +394,17 @@ export function useEditorialStagePageData({
     return () => {
       isCancelled = true
     }
-  }, [getArticleById, getArticleSyncStatus, schemaPublisherConfig.defaultAuthorName, stagedArticle?.runId, storageKey, token])
+  }, [getArticleById, getArticleSyncStatus, schemaPublisherConfig.defaultAuthorName, stagedArticle?.runId, storageKey])
 
   useEffect(() => {
-    if (!token) {
-      setIsLoading(false)
-      setError('Authentication required to load locations and media assets. Please sign in again.')
-      return
-    }
 
     const loadData = async () => {
       try {
         setIsLoading(true)
         setError(null)
         const [locationsRes, mediaRes] = await Promise.all([
-          fetchLocations(token, { limit: 200 }),
-          fetchMediaAssets(token, { limit: MEDIA_ASSET_PAGE_LIMIT, page: 1, mimeType: 'image/' }),
+          fetchLocations({ limit: 200 }),
+          fetchMediaAssets({ limit: MEDIA_ASSET_PAGE_LIMIT, page: 1, mimeType: 'image/' }),
         ])
 
         setLocations(locationsRes.docs || [])
@@ -424,7 +417,7 @@ export function useEditorialStagePageData({
     }
 
     void loadData()
-  }, [token, fetchLocations, fetchMediaAssets])
+  }, [fetchLocations, fetchMediaAssets])
 
   const updateStagedArticle = useCallback((updates: Partial<StagedArticle>) => {
     setStagedArticle((previous) => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishWorkflow.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useEditorialStagePublishWorkflow.ts
@@ -16,7 +16,6 @@ import type { TimelineItem } from '../workflow.service'
 import { useEditorialStagePublishUi } from './useEditorialStagePublishUi'
 
 type UseEditorialStagePublishWorkflowParams = {
-  token: string | null | undefined
   sourceFeature: string
   stagedArticle: StagedArticle | null
   locations: Location[]
@@ -30,12 +29,10 @@ type UseEditorialStagePublishWorkflowParams = {
   }>
   createArticle: (
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   updateArticle?: (
     id: number,
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   markArticleSynced: (
     runId: string,
@@ -52,7 +49,6 @@ type UseEditorialStagePublishWorkflowParams = {
 }
 
 export function useEditorialStagePublishWorkflow({
-  token,
   sourceFeature,
   stagedArticle,
   locations,
@@ -108,18 +104,17 @@ export function useEditorialStagePublishWorkflow({
 
   const handlePublish = useCallback(
     async (targetStatus: EditorialPublishTargetStatus) => {
-      if (!token || !stagedArticle) return
+      if (!stagedArticle) return
 
       await runEditorialStagePublishWorkflow({
         ...workflow,
-        token,
         targetStatus,
         stagedArticle,
         publisherConfig,
         lifecycle: publishUi.lifecycle
       })
     },
-    [publisherConfig, publishUi.lifecycle, stagedArticle, token, workflow]
+    [publisherConfig, publishUi.lifecycle, stagedArticle, workflow]
   )
 
   return {

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleSeoActions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/hooks/useStandardArticleSeoActions.ts
@@ -23,7 +23,6 @@ import type { EditorialStageArticleApi } from '../types'
 
 type UseStandardArticleSeoActionsParams = {
   api: EditorialStageArticleApi
-  token?: string | null
   stagedArticle?: StagedArticle
   featureLabel: string
   selectedLocationLabel: string
@@ -37,7 +36,6 @@ type UseStandardArticleSeoActionsParams = {
 
 export function useStandardArticleSeoActions({
   api,
-  token,
   stagedArticle,
   featureLabel,
   selectedLocationLabel,
@@ -104,7 +102,7 @@ export function useStandardArticleSeoActions({
   ])
 
   const generateImageFromFeatured = useCallback(async () => {
-    if (!token || !stagedArticle?.featuredImageId) {
+    if (!stagedArticle?.featuredImageId) {
       setLocalError('Select a featured image before generating an OG image.')
       return
     }
@@ -115,7 +113,6 @@ export function useStandardArticleSeoActions({
     try {
       const response = await generateSocialImageFromFeatured(
         { featuredAssetId: stagedArticle.featuredImageId },
-        token,
       )
       const socialImageUrl = response.generatedImageUrl.trim()
       if (!socialImageUrl) {
@@ -132,10 +129,10 @@ export function useStandardArticleSeoActions({
     } finally {
       setIsGeneratingSeoImage(false)
     }
-  }, [setLocalError, setLocalResult, stagedArticle?.featuredImageId, token, updateSeoSection])
+  }, [setLocalError, setLocalResult, stagedArticle?.featuredImageId, updateSeoSection])
 
   const uploadOgImageFile = useCallback(async (file: File) => {
-    if (!token || !stagedArticle?.locationId) {
+    if (!stagedArticle?.locationId) {
       throw new Error('Select a location before uploading an OG image.')
     }
 
@@ -147,7 +144,6 @@ export function useStandardArticleSeoActions({
         file,
         stagedArticle.title.trim() || `${featureLabel} social image`,
         stagedArticle.locationId,
-        token,
         '',
       )
       const socialImageUrl = response.generatedImageUrl.trim()
@@ -173,7 +169,6 @@ export function useStandardArticleSeoActions({
     setLocalResult,
     stagedArticle?.locationId,
     stagedArticle?.title,
-    token,
     updateSeoSection,
   ])
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/selectors/buildBlockModalView.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/selectors/buildBlockModalView.ts
@@ -11,7 +11,6 @@ type BuildBlockModalViewInput = {
   }
   blockImageModal: BlockImageModalState | null
   closeBlockImageModal: () => void
-  token?: string
   selectedLocation?: Location
   singleImageRequirementLabel: string
   imgPairRequirementLabel: string
@@ -38,8 +37,7 @@ export function buildBlockModalView(input: BuildBlockModalViewInput): BlockModal
     blockImageModal: input.blockImageModal,
     publishedToPayload: isStagedArticleEditingLocked(input.stagedArticle),
     onClose: input.closeBlockImageModal,
-    token: input.token,
-    locationRef: input.selectedLocation?.id ?? null,
+        locationRef: input.selectedLocation?.id ?? null,
     singleImageRequirementLabel: input.singleImageRequirementLabel,
     imgPairRequirementLabel: input.imgPairRequirementLabel,
     imgTrioRequirementLabel: input.imgTrioRequirementLabel,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/selectors/buildFeaturedModalView.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/selectors/buildFeaturedModalView.ts
@@ -9,7 +9,6 @@ type BuildFeaturedModalViewInput = {
   stagedArticle: StagedArticle
   featuredImageRequirementLabel: string
   selectedLocation?: Location
-  token?: string
   updateStagedArticle: (updates: Partial<StagedArticle>) => void
   setShowImageModal: Dispatch<SetStateAction<boolean>>
 }
@@ -19,8 +18,7 @@ export function buildFeaturedModalView(input: BuildFeaturedModalViewInput): Feat
     show: input.showImageModal,
     publishedToPayload: isStagedArticleEditingLocked(input.stagedArticle),
     onClose: () => input.setShowImageModal(false),
-    token: input.token,
-    locationRef: input.selectedLocation?.id ?? null,
+        locationRef: input.selectedLocation?.id ?? null,
     selectedFeaturedImageId: input.stagedArticle.featuredImageId ?? null,
     requirementLabel: input.featuredImageRequirementLabel,
     onSelectAssetId: (assetId: number) => input.updateStagedArticle({ featuredImageId: assetId }),

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-persistence.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-persistence.service.ts
@@ -18,7 +18,6 @@ import type {
 } from './editorial-stage-publish-validation.service'
 
 type PersistEditorialStageArticleParams = {
-  token: string
   sourceFeature: string
   targetStatus: EditorialPublishTargetStatus
   stagedArticle: StagedArticle
@@ -28,12 +27,10 @@ type PersistEditorialStageArticleParams = {
   publisherConfig: SchemaPublisherConfig
   createArticle: (
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   updateArticle?: (
     id: number,
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   markArticleSynced: (
     runId: string,
@@ -96,9 +93,8 @@ async function persistPayloadArticle(
       ? await input.updateArticle(
           input.stagedArticle.payloadArticleId,
           payload,
-          input.token
         )
-      : await input.createArticle(payload, input.token)
+      : await input.createArticle(payload)
   let seoSection = input.seoSection
 
   if (input.targetStatus !== 'published' || !input.updateArticle) {
@@ -120,7 +116,6 @@ async function persistPayloadArticle(
         ...payload,
         seoSection: buildSeoPayload(publishedSeoSection)
       },
-      input.token
     )
   }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.test.ts
@@ -101,7 +101,6 @@ function buildWorkflowParams(
   const events: string[] = []
 
   return {
-    token: 'token',
     sourceFeature: 'url2blog',
     targetStatus: 'draft',
     stagedArticle: buildStagedArticle(),
@@ -184,7 +183,6 @@ describe('runEditorialStagePublishWorkflow', () => {
         sourceRunId: 'run-1',
         headerSection: { featuredImage: 99 }
       }),
-      'token'
     )
     expect(params.markArticleSynced).toHaveBeenCalledWith('run-1', 42)
     expect(params.updateStagedArticle).toHaveBeenCalledWith(

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.ts
@@ -24,7 +24,6 @@ export type EditorialPublishLifecycle = {
 }
 
 export type EditorialStagePublishWorkflowParams = {
-  token: string
   sourceFeature: string
   targetStatus: EditorialPublishTargetStatus
   stagedArticle: StagedArticle
@@ -40,12 +39,10 @@ export type EditorialStagePublishWorkflowParams = {
   }>
   createArticle: (
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   updateArticle?: (
     id: number,
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   markArticleSynced: (
     runId: string,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/types.ts
@@ -31,11 +31,9 @@ export type EditorModelName = EditorBlockRewriteModelName
 
 export type EditorialStageArticleApi = {
   fetchLocations: (
-    token?: string,
     params?: { limit?: number; page?: number }
   ) => Promise<{ docs: Location[]; totalDocs: number; totalPages: number }>
   fetchMediaAssets: (
-    token?: string,
     params?: {
       limit?: number
       page?: number
@@ -49,7 +47,6 @@ export type EditorialStageArticleApi = {
   ) => Promise<{ docs: MediaAsset[]; totalDocs: number; totalPages: number }>
   createArticle: (
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   convertMarkdownToLexical: (markdown: string) => Promise<{
     success: boolean
@@ -64,11 +61,9 @@ export type EditorialStageArticleApi = {
   updateArticle?: (
     id: number,
     payload: CreateArticlePayload,
-    token: string
   ) => Promise<PayloadArticleDoc>
   getArticleById?: (
     id: number,
-    token: string
   ) => Promise<PayloadArticleDoc>
   getArticleSyncStatus?: (runId: string) => Promise<{
     synced_to_payload: boolean
@@ -105,7 +100,6 @@ export type EditorialStageArticleApi = {
       locationRef: number
       photoId?: string | number
     },
-    token: string
   ) => Promise<UploadImageResponse>
   fetchExternalImageSource: (
     input: {
@@ -113,7 +107,6 @@ export type EditorialStageArticleApi = {
       provider: ExternalImageProvider
       photoId?: string | number
     },
-    token: string
   ) => Promise<{
     blob: Blob
     fileName: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/pages/ArticlesPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/youtube2blog/pages/ArticlesPage.test.tsx
@@ -104,7 +104,7 @@ describe('YouTube2Blog ArticlesPage', () => {
   })
 
   it('shows local drafts and payload statuses with local overlay', async () => {
-    mockUseAuth.mockReturnValue({ token: 'token-1' })
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: '1', email: 'w@questurian.com' } })
     mockGetAllStagedArticles.mockReturnValue([
       makeDraft({ id: 'local-only', runId: 'run-local', title: 'Only Local' }),
       makeDraft({ id: 'local-linked', runId: 'run-1', payloadArticleId: 101, title: 'Linked Local Draft' }),
@@ -156,7 +156,7 @@ describe('YouTube2Blog ArticlesPage', () => {
   })
 
   it('shows empty states when no data exists', async () => {
-    mockUseAuth.mockReturnValue({ token: 'token-1' })
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: '1', email: 'w@questurian.com' } })
     mockGetAllStagedArticles.mockReturnValue([])
     mockFetchArticles.mockResolvedValue([])
     mockFetchPayloadArticles.mockResolvedValue([])

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/client/http.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/client/http.ts
@@ -1,20 +1,31 @@
 import { PAYLOAD_API_URL } from './config'
 
-export async function payloadRequest(endpoint: string, token?: string) {
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-  }
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`
-  }
-
+/**
+ * Requests to Payload.
+ *
+ * The caller is identified by the httpOnly `payload-token` cookie, which
+ * `credentials: 'include'` sends and which no script can read. These used to
+ * take a `token` and set `Authorization: Bearer`, which meant a privileged
+ * Staff JWT had to be readable by JavaScript to reach Payload at all.
+ *
+ * Passing a token here would be worse than redundant: `extractJWT` returns the
+ * *first* credential it finds in `jwtOrder` (JWT, Bearer, cookie) and verifies
+ * only that one, so a stale header shadows a perfectly good cookie and fails
+ * the request.
+ *
+ * Payload gates *cookie* auth on its `csrf` allowlist, not its `cors` list —
+ * this app's origin has to appear in `CORS_ALLOWED_ORIGINS` on the server, or
+ * these come back 401 with nothing else to explain it.
+ */
+export async function payloadRequest(endpoint: string) {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     method: 'GET',
     mode: 'cors',
     cache: 'no-store',
     credentials: 'include',
-    headers,
+    headers: {
+      Accept: 'application/json',
+    },
   })
 
   if (!response.ok) {
@@ -28,22 +39,15 @@ export async function payloadMutation(
   endpoint: string,
   method: 'POST' | 'PATCH' | 'DELETE',
   body?: unknown,
-  token?: string,
 ) {
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  }
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`
-  }
-
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     method,
     mode: 'cors',
     credentials: 'include',
-    headers,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
@@ -8,25 +8,27 @@ import { payloadRequest as itineraryPayloadRequest } from '../../features/listic
 import { getArticleLocationScope } from '../locationScope/scope'
 
 /**
- * Every authenticated call to Payload must send the session cookie.
+ * Every authenticated call to Payload sends the session cookie, and nothing
+ * else.
  *
- * These clients grew independently and disagreed: some passed
- * `credentials: 'include'`, some passed `'omit'`, and some named no option at
- * all — which means `'same-origin'`, and Payload is never the same origin as
- * this app. None of it showed, because each one also carries an
- * `Authorization: Bearer` header.
+ * These clients grew independently and disagreed about `credentials`; that was
+ * unified first, while each one still carried an `Authorization: Bearer`
+ * header. The header is now gone, which is what makes the cookie the actual
+ * credential rather than a redundant second one.
  *
- * The cookie is *not* a fallback today, and that is worth being exact about:
- * Payload's `extractJWT` returns the first token it finds in `jwtOrder`
- * (`JWT`, `Bearer`, `cookie`) and `JWTAuthentication` verifies only that one.
- * A present-but-invalid Bearer fails outright rather than falling through to
- * the cookie. So while the header is sent these calls behave exactly as
- * before — the change is consistency, and it is what makes eventually dropping
- * the header a one-line change rather than an eight-file one.
+ * Both halves are asserted per client, because dropping the header is only
+ * safe where the cookie is genuinely being sent. A client that lost the header
+ * but kept `credentials: 'same-origin'` would authenticate as nobody.
  *
- * Every Payload client in the app is listed below, including the four that
- * were already correct, so the set is checkable by reading rather than by
- * remembering.
+ * Sending both would be worse than redundant. Payload's `extractJWT` returns
+ * the *first* credential it finds in `jwtOrder` (`JWT`, `Bearer`, `cookie`)
+ * and `JWTAuthentication` verifies only that one — so a stale header shadows a
+ * valid cookie and fails the request outright rather than falling through.
+ * That is not hypothetical: it is exactly the bug `logoutPayloadUser` already
+ * had to work around, and the one `requestSession` had until this change.
+ *
+ * Every Payload client in the app is listed below, so the set is checkable by
+ * reading rather than by remembering.
  */
 
 const fetchMock = vi.fn()
@@ -40,10 +42,23 @@ function jsonResponse(body: unknown = { docs: [] }): Response {
   } as Response
 }
 
-function lastCredentials(): RequestCredentials | undefined {
+function lastInit(): RequestInit | undefined {
   const calls = fetchMock.mock.calls
-  const init = calls[calls.length - 1]?.[1] as RequestInit | undefined
-  return init?.credentials
+  return calls[calls.length - 1]?.[1] as RequestInit | undefined
+}
+
+function lastCredentials(): RequestCredentials | undefined {
+  return lastInit()?.credentials
+}
+
+function lastAuthorization(): string | null {
+  return new Headers(lastInit()?.headers).get('Authorization')
+}
+
+/** The cookie is sent, and no header is there to shadow it. */
+function expectCookieIsTheOnlyCredential(): void {
+  expect(lastCredentials()).toBe('include')
+  expect(lastAuthorization()).toBeNull()
 }
 
 describe('Payload clients send the session cookie', () => {
@@ -58,15 +73,15 @@ describe('Payload clients send the session cookie', () => {
   })
 
   it('shared payloadRequest', async () => {
-    await payloadRequest('/api/articles', 'token')
+    await payloadRequest('/api/articles')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('shared payloadMutation', async () => {
-    await payloadMutation('/api/articles/1', 'PATCH', { title: 'x' }, 'token')
+    await payloadMutation('/api/articles/1', 'PATCH', { title: 'x' })
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('staff avatar upload', async () => {
@@ -74,7 +89,7 @@ describe('Payload clients send the session cookie', () => {
 
     await uploadAvatarAsset(new File(['x'], 'a.png'), 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('staff list', async () => {
@@ -82,7 +97,7 @@ describe('Payload clients send the session cookie', () => {
 
     await fetchStaffUsers('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('location documents', async () => {
@@ -90,19 +105,19 @@ describe('Payload clients send the session cookie', () => {
 
     await fetchMediaSetOptions('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('single-type listicles', async () => {
     await fetchListicles('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('listicle itineraries', async () => {
     await itineraryPayloadRequest('/api/itineraries', 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('location scope', async () => {
@@ -110,7 +125,7 @@ describe('Payload clients send the session cookie', () => {
 
     await getArticleLocationScope({ locationKey: 'lima', token: 'token' })
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('staging articles', async () => {
@@ -119,7 +134,7 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await fetchPayloadArticles('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('access permissions', async () => {
@@ -128,7 +143,7 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({}))
     await fetchAccessPermissions('token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('homepage featured content', async () => {
@@ -138,7 +153,7 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await mainHomepageRequest('/api/pages', 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
   })
 
   it('location homepages', async () => {
@@ -148,7 +163,22 @@ describe('Payload clients send the session cookie', () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await locationHomepageRequest('/api/pages', 'token')
 
-    expect(lastCredentials()).toBe('include')
+    expectCookieIsTheOnlyCredential()
+  })
+
+  it('session hydrate and renew', async () => {
+    const { hydratePayloadSession } = await import('../../features/auth/payload-auth-client')
+
+    fetchMock.mockResolvedValue(jsonResponse({ user: { id: 1, email: 'a@b.c' }, exp: 9e12 }))
+    await hydratePayloadSession({
+      token: 'stale-token',
+      expiresAt: Date.now() + 60_000,
+      user: { id: '1', email: 'a@b.c' },
+    })
+
+    // The stale in-memory token must not be offered even when one exists:
+    // `extractJWT` would take it in preference to the live cookie.
+    expectCookieIsTheOnlyCredential()
   })
 
   it('leaves the unauthenticated health check uncredentialed', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
@@ -87,7 +87,7 @@ describe('Payload clients send the session cookie', () => {
   it('staff avatar upload', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ doc: { id: 1, filename: 'a.png' } }))
 
-    await uploadAvatarAsset(new File(['x'], 'a.png'), 'token')
+    await uploadAvatarAsset(new File(['x'], 'a.png'))
 
     expectCookieIsTheOnlyCredential()
   })
@@ -95,7 +95,7 @@ describe('Payload clients send the session cookie', () => {
   it('staff list', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
 
-    await fetchStaffUsers('token')
+    await fetchStaffUsers()
 
     expectCookieIsTheOnlyCredential()
   })
@@ -103,19 +103,19 @@ describe('Payload clients send the session cookie', () => {
   it('location documents', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
 
-    await fetchMediaSetOptions('token')
+    await fetchMediaSetOptions()
 
     expectCookieIsTheOnlyCredential()
   })
 
   it('single-type listicles', async () => {
-    await fetchListicles('token')
+    await fetchListicles()
 
     expectCookieIsTheOnlyCredential()
   })
 
   it('listicle itineraries', async () => {
-    await itineraryPayloadRequest('/api/itineraries', 'token')
+    await itineraryPayloadRequest('/api/itineraries')
 
     expectCookieIsTheOnlyCredential()
   })
@@ -123,7 +123,7 @@ describe('Payload clients send the session cookie', () => {
   it('location scope', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ docs: [{ id: 1 }] }))
 
-    await getArticleLocationScope({ locationKey: 'lima', token: 'token' })
+    await getArticleLocationScope({ locationKey: 'lima' })
 
     expectCookieIsTheOnlyCredential()
   })
@@ -132,7 +132,7 @@ describe('Payload clients send the session cookie', () => {
     const { fetchPayloadArticles } = await import('../../features/staging/api/articles/articles.api')
 
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
-    await fetchPayloadArticles('token')
+    await fetchPayloadArticles()
 
     expectCookieIsTheOnlyCredential()
   })
@@ -141,7 +141,7 @@ describe('Payload clients send the session cookie', () => {
     const { fetchAccessPermissions } = await import('../../features/auth/permissions-client')
 
     fetchMock.mockResolvedValue(jsonResponse({}))
-    await fetchAccessPermissions('token')
+    await fetchAccessPermissions()
 
     expectCookieIsTheOnlyCredential()
   })
@@ -151,7 +151,7 @@ describe('Payload clients send the session cookie', () => {
       '../../features/homepageFeaturedContent/mainHomepage/request')
 
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
-    await mainHomepageRequest('/api/pages', 'token')
+    await mainHomepageRequest('/api/pages')
 
     expectCookieIsTheOnlyCredential()
   })
@@ -161,7 +161,7 @@ describe('Payload clients send the session cookie', () => {
       '../../features/homepageFeaturedContent/locationHomepages/request')
 
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
-    await locationHomepageRequest('/api/pages', 'token')
+    await locationHomepageRequest('/api/pages')
 
     expectCookieIsTheOnlyCredential()
   })
@@ -171,13 +171,12 @@ describe('Payload clients send the session cookie', () => {
 
     fetchMock.mockResolvedValue(jsonResponse({ user: { id: 1, email: 'a@b.c' }, exp: 9e12 }))
     await hydratePayloadSession({
-      token: 'stale-token',
       expiresAt: Date.now() + 60_000,
       user: { id: '1', email: 'a@b.c' },
     })
 
-    // The stale in-memory token must not be offered even when one exists:
-    // `extractJWT` would take it in preference to the live cookie.
+    // Nothing in memory can shadow the cookie any more — there is no token to
+    // offer. `extractJWT` would have taken a stale one in preference to it.
     expectCookieIsTheOnlyCredential()
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload/payload.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload/payload.api.ts
@@ -21,7 +21,7 @@ export async function fetchLocations(
     const queryParams = new URLSearchParams()
     queryParams.append('limit', String(limit))
     queryParams.append('page', String(params.page))
-    return payloadRequest(`/api/locations?${queryParams.toString()}`, token)
+    return payloadRequest(`/api/locations?${queryParams.toString()}`)
   }
 
   const allDocs: Location[] = []
@@ -36,7 +36,6 @@ export async function fetchLocations(
 
     const response = (await payloadRequest(
       `/api/locations?${queryParams.toString()}`,
-      token,
     )) as { docs: Location[]; totalDocs: number; totalPages: number }
 
     allDocs.push(...(response.docs || []))
@@ -55,7 +54,7 @@ export async function fetchArticleCategories(
   const queryParams = new URLSearchParams()
   queryParams.append('limit', String(params?.limit || 100))
   if (params?.status) queryParams.append('where[status][equals]', params.status)
-  return payloadRequest(`/api/article-categories?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/article-categories?${queryParams.toString()}`)
 }
 
 export async function fetchArticleTags(
@@ -65,7 +64,7 @@ export async function fetchArticleTags(
   const queryParams = new URLSearchParams()
   queryParams.append('limit', String(params?.limit || 100))
   if (params?.status) queryParams.append('where[status][equals]', params.status)
-  return payloadRequest(`/api/article-tags?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/article-tags?${queryParams.toString()}`)
 }
 
 export async function fetchMediaAssets(
@@ -105,7 +104,7 @@ export async function fetchMediaAssets(
     }
     return queryParams.toString()
   }
-  return payloadRequest(`/api/media-assets?${buildQuery(params?.page || 1)}`, token)
+  return payloadRequest(`/api/media-assets?${buildQuery(params?.page || 1)}`)
 }
 
 export async function fetchMediaSets(
@@ -138,7 +137,7 @@ export async function fetchMediaSets(
     queryParams.append('where[title][like]', params.search)
   }
 
-  return payloadRequest(`/api/media-sets?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/media-sets?${queryParams.toString()}`)
 }
 
 export async function fetchAuditMediaSets(
@@ -156,7 +155,7 @@ export async function fetchAuditMediaSets(
   queryParams.append('where[or][2][location][exists]', 'false')
   queryParams.append('where[or][3][title][exists]', 'false')
 
-  return payloadRequest(`/api/media-sets?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/media-sets?${queryParams.toString()}`)
 }
 
 export async function fetchOrphanMediaAssets(
@@ -170,7 +169,7 @@ export async function fetchOrphanMediaAssets(
   queryParams.append('sort', '-createdAt')
   queryParams.append('where[mediaSet][exists]', 'false')
 
-  return payloadRequest(`/api/media-assets?${queryParams.toString()}`, token)
+  return payloadRequest(`/api/media-assets?${queryParams.toString()}`)
 }
 
 export async function updateMediaSet(
@@ -178,7 +177,7 @@ export async function updateMediaSet(
   patch: MediaSetPatch,
   token?: string,
 ): Promise<{ doc: MediaSet }> {
-  return payloadMutation(`/api/media-sets/${id}`, 'PATCH', patch, token)
+  return payloadMutation(`/api/media-sets/${id}`, 'PATCH', patch)
 }
 
 export async function updateMediaAsset(
@@ -186,5 +185,5 @@ export async function updateMediaAsset(
   patch: Partial<Pick<MediaAsset, 'alt_text' | 'photographer_credit' | 'location' | 'location_finalized' | 'tags'>>,
   token?: string,
 ): Promise<{ doc: MediaAsset }> {
-  return payloadMutation(`/api/media-assets/${id}`, 'PATCH', patch, token)
+  return payloadMutation(`/api/media-assets/${id}`, 'PATCH', patch)
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload/payload.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload/payload.api.ts
@@ -9,7 +9,6 @@ import type {
 } from './payload.types'
 
 export async function fetchLocations(
-  token?: string,
   params?: {
     limit?: number
     page?: number
@@ -48,7 +47,6 @@ export async function fetchLocations(
 }
 
 export async function fetchArticleCategories(
-  token?: string,
   params?: { limit?: number; status?: string },
 ): Promise<{ docs: ArticleCategory[]; totalDocs: number }> {
   const queryParams = new URLSearchParams()
@@ -58,7 +56,6 @@ export async function fetchArticleCategories(
 }
 
 export async function fetchArticleTags(
-  token?: string,
   params?: { limit?: number; status?: string },
 ): Promise<{ docs: ArticleTag[]; totalDocs: number }> {
   const queryParams = new URLSearchParams()
@@ -68,7 +65,6 @@ export async function fetchArticleTags(
 }
 
 export async function fetchMediaAssets(
-  token?: string,
   params?: {
     limit?: number
     page?: number
@@ -108,7 +104,6 @@ export async function fetchMediaAssets(
 }
 
 export async function fetchMediaSets(
-  token?: string,
   params?: {
     limit?: number
     page?: number
@@ -141,7 +136,6 @@ export async function fetchMediaSets(
 }
 
 export async function fetchAuditMediaSets(
-  token?: string,
   params?: { limit?: number; page?: number },
 ): Promise<{ docs: MediaSet[]; totalDocs: number; totalPages: number }> {
   const queryParams = new URLSearchParams()
@@ -159,7 +153,6 @@ export async function fetchAuditMediaSets(
 }
 
 export async function fetchOrphanMediaAssets(
-  token?: string,
   params?: { limit?: number; page?: number },
 ): Promise<{ docs: MediaAsset[]; totalDocs: number; totalPages: number }> {
   const queryParams = new URLSearchParams()
@@ -175,7 +168,6 @@ export async function fetchOrphanMediaAssets(
 export async function updateMediaSet(
   id: number,
   patch: MediaSetPatch,
-  token?: string,
 ): Promise<{ doc: MediaSet }> {
   return payloadMutation(`/api/media-sets/${id}`, 'PATCH', patch)
 }
@@ -183,7 +175,6 @@ export async function updateMediaSet(
 export async function updateMediaAsset(
   id: number,
   patch: Partial<Pick<MediaAsset, 'alt_text' | 'photographer_credit' | 'location' | 'location_finalized' | 'tags'>>,
-  token?: string,
 ): Promise<{ doc: MediaAsset }> {
   return payloadMutation(`/api/media-assets/${id}`, 'PATCH', patch)
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/builder/components/BuilderHeaderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/builder/components/BuilderHeaderPanel.tsx
@@ -25,7 +25,6 @@ type DraftLike = {
 
 export type BuilderHeaderPanelProps<TDraft extends DraftLike> = {
   draft: TDraft
-  token: string | null
   locationRef: number | null
   mediaAssets: MediaAssetOption[]
   updateHeader: (next: Partial<HeaderShape>) => void
@@ -53,7 +52,6 @@ export type BuilderHeaderPanelProps<TDraft extends DraftLike> = {
 
 export function BuilderHeaderPanel<TDraft extends DraftLike>({
   draft,
-  token,
   locationRef,
   mediaAssets,
   updateHeader,
@@ -73,7 +71,6 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
   introLabelRowExtraClassName,
   introActionsExtraClassName,
 }: BuilderHeaderPanelProps<TDraft>) {
-  const resolvedToken = token ?? ''
   const [pickerOpen, setPickerOpen] = useState(false)
   const [fetchedFeaturedAsset, setFetchedFeaturedAsset] = useState<MediaAssetOption | null>(null)
   const [fetchedFeaturedMediaSet, setFetchedFeaturedMediaSet] = useState<MediaSet | null>(null)
@@ -99,7 +96,7 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
   )
 
   useEffect(() => {
-    if (!featuredImageId || selectedFeaturedAsset || !resolvedToken) {
+    if (!featuredImageId || selectedFeaturedAsset) {
       setFetchedFeaturedAsset(null)
       return
     }
@@ -108,7 +105,7 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
 
     const loadSelectedAsset = async () => {
       try {
-        const response = await fetchPayloadMediaAssets(resolvedToken, {
+        const response = await fetchPayloadMediaAssets({
           id: featuredImageId,
           limit: 1,
         })
@@ -138,10 +135,10 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
     return () => {
       cancelled = true
     }
-  }, [featuredImageId, selectedFeaturedAsset, resolvedToken])
+  }, [featuredImageId, selectedFeaturedAsset])
 
   useEffect(() => {
-    if (!featuredMediaSetId || !resolvedToken) {
+    if (!featuredMediaSetId) {
       setFetchedFeaturedMediaSet(null)
       return
     }
@@ -150,7 +147,7 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
 
     const loadSelectedMediaSet = async () => {
       try {
-        const response = await fetchMediaSets(resolvedToken, {
+        const response = await fetchMediaSets({
           id: featuredMediaSetId,
           limit: 1,
         })
@@ -166,7 +163,7 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
     return () => {
       cancelled = true
     }
-  }, [featuredMediaSetId, resolvedToken])
+  }, [featuredMediaSetId])
 
   const featuredAsset = selectedFeaturedAsset || fetchedFeaturedAsset
   const featuredMediaSetPreviewUrl = fetchedFeaturedMediaSet ? resolveMediaSetPreviewUrl(fetchedFeaturedMediaSet) : undefined
@@ -275,7 +272,7 @@ export function BuilderHeaderPanel<TDraft extends DraftLike>({
       <FeaturedImagePicker
         isOpen={pickerOpen}
         selectedId={featuredMediaSetId}
-        token={resolvedToken}
+       
         locationRef={locationRef}
         payloadSourceMode="mediaSets"
         payloadVariant="wide"

--- a/apps/ai-blog-writer/apps/frontend/src/shared/builder/hooks/useBuilderBootstrap.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/builder/hooks/useBuilderBootstrap.test.tsx
@@ -43,14 +43,13 @@ function renderBootstrap(options: {
   draftIdParam?: string | null
   payloadIdParam?: string | null
   setSearchParams?: ReturnType<typeof vi.fn>
-  fetchPayloadDoc?: (id: number, token: string) => Promise<{ id: number; title: string }>
+  fetchPayloadDoc?: (id: number) => Promise<{ id: number; title: string }>
   strict?: boolean
 }) {
   const setSearchParams = options.setSearchParams ?? vi.fn()
   const result = renderHook(
     () =>
       useBuilderBootstrap<TestDraft, { id: number; title: string }, TestAux>({
-        token: 'test-token',
         payloadIdParam: options.payloadIdParam ?? null,
         draftIdParam: options.draftIdParam ?? null,
         setSearchParams: setSearchParams as never,

--- a/apps/ai-blog-writer/apps/frontend/src/shared/builder/hooks/useBuilderBootstrap.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/builder/hooks/useBuilderBootstrap.ts
@@ -9,21 +9,20 @@ export type BuilderBootstrapStorage<TDraft extends { draftId: string }> = {
 }
 
 export type BuilderBootstrapParams<TDraft extends { draftId: string }, TPayloadDoc, TAuxData> = {
-  token: string | null | undefined
   payloadIdParam: string | null
   draftIdParam: string | null
   setSearchParams: SetURLSearchParams
   onError: (message: string) => void
   storage: BuilderBootstrapStorage<TDraft>
-  loadAuxData: (token: string) => Promise<TAuxData>
-  fetchPayloadDoc: (id: number, token: string) => Promise<TPayloadDoc>
+  loadAuxData: () => Promise<TAuxData>
+  fetchPayloadDoc: (id: number) => Promise<TPayloadDoc>
   payloadDocToDraft: (doc: TPayloadDoc, existingDraftId?: string) => TDraft
   /** Optional. Apply local-draft preserved fields (e.g. markdown) onto a payload-loaded draft. */
   mergeLocalIntoPayloadDraft?: (payloadDraft: TDraft, localDraft: TDraft) => TDraft
   /** Optional. Normalize/repair a draft right before it is set. */
   normalizeDraft?: (draft: TDraft) => TDraft
   /** Optional. Refine aux data after the draft is known (e.g. backfill missing related IDs). */
-  enrichAuxData?: (draft: TDraft, token: string, aux: TAuxData) => Promise<TAuxData>
+  enrichAuxData?: (draft: TDraft, aux: TAuxData) => Promise<TAuxData>
   initialAuxData: TAuxData
 }
 
@@ -39,7 +38,6 @@ export function useBuilderBootstrap<
   TPayloadDoc,
   TAuxData,
 >({
-  token,
   payloadIdParam,
   draftIdParam,
   setSearchParams,
@@ -58,8 +56,7 @@ export function useBuilderBootstrap<
   const [auxData, setAuxData] = useState<TAuxData>(initialAuxData)
 
   useEffect(() => {
-    if (!token) return
-    const authToken = token
+    const authToken = undefined
     let cancelled = false
 
     async function load() {
@@ -67,14 +64,14 @@ export function useBuilderBootstrap<
       onError('')
 
       try {
-        const baseAux = await loadAuxData(authToken)
+        const baseAux = await loadAuxData()
         if (cancelled) return
 
         let nextDraft: TDraft
 
         const payloadId = payloadIdParam ? Number(payloadIdParam) : null
         if (payloadId && Number.isFinite(payloadId)) {
-          const doc = await fetchPayloadDoc(payloadId, authToken)
+          const doc = await fetchPayloadDoc(payloadId)
           if (cancelled) return
           const localDraft = storage.findDraftByPayloadId(payloadId)
           let payloadDraft = payloadDocToDraft(doc, localDraft?.draftId)
@@ -120,7 +117,7 @@ export function useBuilderBootstrap<
         }
 
         const finalAux = enrichAuxData
-          ? await enrichAuxData(nextDraft, authToken, baseAux)
+          ? await enrichAuxData(nextDraft, baseAux)
           : baseAux
 
         if (cancelled) return
@@ -141,7 +138,7 @@ export function useBuilderBootstrap<
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, payloadIdParam, draftIdParam])
+  }, [payloadIdParam, draftIdParam])
 
   return { draft, setDraft, isLoading, auxData }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux-edit.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux-edit.api.ts
@@ -6,7 +6,6 @@ type FluxEditParams = {
   prompt: string;
   referenceImage: File;
   additionalReferenceImages?: File[];
-  token: string;
   modelId?: string;
   width?: number;
   height?: number;
@@ -34,7 +33,6 @@ export async function fluxEditApi({
   prompt,
   referenceImage,
   additionalReferenceImages = [],
-  token,
   modelId,
   width,
   height,

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux/flux-editing.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux/flux-editing.api.test.ts
@@ -29,7 +29,7 @@ describe('Flux editing public API', () => {
     vi.mocked(fluxEditApi).mockResolvedValue(response)
 
     await expect(
-      generateFluxEditedImage('Recreate this scene', referenceImage, 'token', {
+      generateFluxEditedImage('Recreate this scene', referenceImage, {
         additionalReferenceImages: [additionalReferenceImage],
         modelId: 'flux-2-pro',
         width: 1200,
@@ -43,7 +43,6 @@ describe('Flux editing public API', () => {
     expect(fluxEditApi).toHaveBeenCalledWith({
       prompt: 'Recreate this scene',
       referenceImage,
-      token: 'token',
       additionalReferenceImages: [additionalReferenceImage],
       modelId: 'flux-2-pro',
       width: 1200,

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux/flux-editing.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/flux/flux-editing.api.ts
@@ -16,13 +16,11 @@ export type FluxEditOptions = {
 export async function generateFluxEditedImage(
   prompt: string,
   referenceImage: File,
-  token: string,
   options?: FluxEditOptions
 ): Promise<FluxEditImageResponse> {
   return fluxEditApi({
     prompt,
     referenceImage,
-    token,
     ...options
   })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/generate-social-image.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/generate-social-image.api.ts
@@ -5,13 +5,11 @@ import { normalizeRequestError, parseErrorMessage } from './errors/image-api-err
 type GenerateSocialImageParams = {
   featuredAssetId?: number;
   featuredMediaSetId?: number;
-  token: string;
 };
 
 export async function generateSocialImageApi({
   featuredAssetId,
   featuredMediaSetId,
-  token,
 }: GenerateSocialImageParams): Promise<GenerateSocialImageResponse> {
   try {
     const response = await postJson(

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/social/social-images.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/social/social-images.api.test.ts
@@ -33,11 +33,10 @@ describe('social image public API', () => {
     vi.mocked(generateSocialImageApi).mockResolvedValue(response)
 
     await expect(
-      generateSocialImageFromFeatured({ featuredMediaSetId: 17 }, 'token')
+      generateSocialImageFromFeatured({ featuredMediaSetId: 17 })
     ).resolves.toBe(response)
     expect(generateSocialImageApi).toHaveBeenCalledWith({
       featuredMediaSetId: 17,
-      token: 'token'
     })
   })
 
@@ -55,13 +54,12 @@ describe('social image public API', () => {
     vi.mocked(uploadSocialImageApi).mockResolvedValue(response)
 
     await expect(
-      uploadSocialImage(file, 'Social preview', 3, 'token', 'Photographer')
+      uploadSocialImage(file, 'Social preview', 3, 'Photographer')
     ).resolves.toBe(response)
     expect(uploadSocialImageApi).toHaveBeenCalledWith({
       file,
       altText: 'Social preview',
       locationRef: 3,
-      token: 'token',
       photographerCredit: 'Photographer'
     })
   })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/social/social-images.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/social/social-images.api.ts
@@ -13,23 +13,20 @@ export type FeaturedSocialImageRef =
 
 export async function generateSocialImageFromFeatured(
   ref: FeaturedSocialImageRef,
-  token: string
 ): Promise<GenerateSocialImageResponse> {
-  return generateSocialImageApi({ ...ref, token })
+  return generateSocialImageApi({ ...ref })
 }
 
 export async function uploadSocialImage(
   file: File,
   altText: string,
   locationRef: number,
-  token: string,
   photographerCredit: string
 ): Promise<UploadSocialImageResponse> {
   return uploadSocialImageApi({
     file,
     altText,
     locationRef,
-    token,
     photographerCredit
   })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/upload-social-image.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/upload-social-image.api.ts
@@ -7,7 +7,6 @@ type UploadSocialImageParams = {
   altText: string;
   photographerCredit: string;
   locationRef: number;
-  token: string;
 };
 
 export async function uploadSocialImageApi({
@@ -15,7 +14,6 @@ export async function uploadSocialImageApi({
   altText,
   photographerCredit,
   locationRef,
-  token,
 }: UploadSocialImageParams): Promise<UploadSocialImageResponse> {
   try {
     const formData = new FormData();

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/image-uploads.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/image-uploads.api.test.ts
@@ -38,7 +38,6 @@ describe('image upload public API', () => {
         'featured-upload',
         'A waterfront skyline',
         undefined,
-        'token',
         'Photographer',
         onProgress,
         [3, 5]
@@ -50,7 +49,6 @@ describe('image upload public API', () => {
       externalRef: 'featured-upload',
       altText: 'A waterfront skyline',
       locationRef: undefined,
-      token: 'token',
       photographerCredit: 'Photographer',
       onProgress,
       tags: [3, 5]
@@ -74,7 +72,6 @@ describe('image upload public API', () => {
         'original-upload',
         'A mountain trail',
         12,
-        'token',
         'Photographer',
         onProgress
       )
@@ -85,7 +82,6 @@ describe('image upload public API', () => {
       externalRef: 'original-upload',
       altText: 'A mountain trail',
       locationRef: 12,
-      token: 'token',
       photographerCredit: 'Photographer',
       onProgress
     })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/image-uploads.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/image-uploads.api.ts
@@ -13,7 +13,6 @@ export async function uploadImageVariants(
   externalRef: string,
   altText: string,
   locationRef: number | undefined,
-  token: string,
   photographerCredit: string,
   onProgress?: (progress: UploadProgress) => void,
   tags?: number[]
@@ -23,7 +22,6 @@ export async function uploadImageVariants(
     externalRef,
     altText,
     locationRef,
-    token,
     photographerCredit,
     onProgress,
     tags
@@ -35,7 +33,6 @@ export async function uploadImage(
   externalRef: string,
   altText: string,
   locationRef: number,
-  token: string,
   photographerCredit: string,
   onProgress?: (progress: UploadProgress) => void
 ): Promise<UploadImageResponse> {
@@ -44,7 +41,6 @@ export async function uploadImage(
     externalRef,
     altText,
     locationRef,
-    token,
     photographerCredit,
     onProgress
   })

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-single.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-single.api.ts
@@ -7,7 +7,6 @@ type UploadSingleParams = {
   externalRef: string;
   altText: string;
   locationRef: number;
-  token: string;
   photographerCredit: string;
   onProgress?: (progress: UploadProgress) => void;
 };
@@ -17,7 +16,6 @@ export async function uploadSingleApi({
   externalRef,
   altText,
   locationRef,
-  token,
   photographerCredit,
   onProgress,
 }: UploadSingleParams): Promise<UploadImageResponse> {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-variants.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-variants.api.test.ts
@@ -37,7 +37,6 @@ describe('uploadVariantsApi validation', () => {
         externalRef: 'featured-upload',
         altText: 'Alt text',
         locationRef: 1,
-        token: 'token',
         photographerCredit: 'Credit',
       })
     ).rejects.toThrow('Exactly 7 crop variants are required before upload.');
@@ -57,7 +56,6 @@ describe('uploadVariantsApi validation', () => {
         externalRef: 'featured-upload',
         altText: 'Alt text',
         locationRef: 1,
-        token: 'token',
         photographerCredit: 'Credit',
       })
     ).rejects.toThrow('Duplicate: wide.');

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-variants.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/api/uploads/upload-variants.api.ts
@@ -8,7 +8,6 @@ type UploadVariantsParams = {
   externalRef: string;
   altText: string;
   locationRef?: number;
-  token: string;
   photographerCredit: string;
   onProgress?: (progress: UploadProgress) => void;
   tags?: number[];
@@ -52,7 +51,6 @@ export async function uploadVariantsApi({
   externalRef,
   altText,
   locationRef,
-  token,
   photographerCredit,
   onProgress,
   tags,

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/components/CompositeImageModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/components/CompositeImageModal.tsx
@@ -12,7 +12,6 @@ import './composite-image.css'
 
 type CompositeImageModalProps = {
   isOpen: boolean
-  token: string
   locationRef: number | null
   defaultTitle?: string
   onCreated?: (response: CompositeImageCreateResponse) => void
@@ -33,7 +32,6 @@ function slotLabels(layout: CompositeImageLayout): string[] {
 
 export function CompositeImageModal({
   isOpen,
-  token,
   locationRef,
   defaultTitle = 'Composite image',
   onCreated,
@@ -226,7 +224,6 @@ export function CompositeImageModal({
 
         <ImagePicker
           isOpen={pickerOpen}
-          token={token}
           locationRef={locationRef}
           query={{
             browseUnit: 'mediaSets',

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/hooks/useImageUploadFlow.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/hooks/useImageUploadFlow.ts
@@ -36,7 +36,6 @@ export type UseImageUploadFlowResult = {
 export function useImageUploadFlow({
   externalRef,
   locationRef,
-  token,
   initialAltText = '',
   initialPhotographerCredit = '',
   onComplete,
@@ -98,7 +97,6 @@ export function useImageUploadFlow({
         externalRef,
         altText,
         locationRef,
-        token,
         photographerCredit,
         onProgress: setProgress,
       })
@@ -111,7 +109,7 @@ export function useImageUploadFlow({
       })
       setStage(selectedFile ? 'metadata' : 'select')
     }
-  }, [altText, externalRef, locationRef, onComplete, photographerCredit, selectedFile, token])
+  }, [altText, externalRef, locationRef, onComplete, photographerCredit, selectedFile])
 
   const handleDrop = useCallback((event: DragEvent) => {
     event.preventDefault()

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/ImagePicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/ImagePicker.tsx
@@ -18,7 +18,6 @@ export type { ImagePickerProps } from './imagePicker.types'
 export function ImagePicker(props: ImagePickerProps) {
   const {
     isOpen,
-    token,
     locationRef,
     query,
     selection = { mode: 'single' },
@@ -77,7 +76,6 @@ export function ImagePicker(props: ImagePickerProps) {
         {controller.activeTab === 'upload' && (
           <UploadImagePanel
             locationRef={locationRef}
-            token={token}
             uploadIdentity={controller.uploadIdentity}
             onComplete={controller.handleUploadComplete}
             onCancel={() => controller.switchTab('payload')}

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/UploadImagePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/UploadImagePanel.tsx
@@ -3,7 +3,6 @@ import type { UploadImageResponse } from '../api/contracts/image-api.contracts'
 
 type UploadImagePanelProps = {
   locationRef: number | null
-  token?: string
   uploadIdentity: { externalRef: string; fileNamePrefix: string }
   onComplete: (response: UploadImageResponse) => void
   onCancel: () => void
@@ -11,7 +10,6 @@ type UploadImagePanelProps = {
 
 export function UploadImagePanel({
   locationRef,
-  token,
   uploadIdentity,
   onComplete,
   onCancel,
@@ -28,7 +26,7 @@ export function UploadImagePanel({
           externalRef={uploadIdentity.externalRef}
           fileNamePrefix={uploadIdentity.fileNamePrefix}
           locationRef={locationRef}
-          token={token ?? ''}
+         
           onComplete={onComplete}
           onCancel={onCancel}
         />

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/imagePicker.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/imagePicker.types.ts
@@ -48,7 +48,6 @@ export type ImagePickerResult =
 
 export type ImagePickerProps = {
   isOpen: boolean
-  token?: string
   /** Required for uploads/imports; when null those tabs show a notice. */
   locationRef: number | null
   /** Reactive filter that drives the Payload fetch. */

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useExternalImageImport.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useExternalImageImport.ts
@@ -34,7 +34,6 @@ export type ExternalCropDraft = {
 }
 
 type UseExternalImageImportParams = {
-  token?: string
   /** Required to upload into Payload; when null, prepare/confirm refuse with a notice. */
   locationRef: number | null
   /** Stable prefix for the generated external ref, e.g. 'featured-image-picker'. */
@@ -71,7 +70,6 @@ const DEFAULT_LOCATION_REQUIRED = 'Set a location before importing images into P
  * single selection or push it into the multi-select buffer (ADR 0020).
  */
 export function useExternalImageImport({
-  token,
   locationRef,
   externalRefBase,
   fileNameTitle,
@@ -96,10 +94,6 @@ export function useExternalImageImport({
     async (photo: ExternalImagePhoto, provider: ExternalImageProvider) => {
       if (locationRef === null) {
         setError(locationRequiredMessage)
-        return
-      }
-      if (!token) {
-        setError('Please sign in again before importing images.')
         return
       }
 
@@ -137,7 +131,7 @@ export function useExternalImageImport({
         setImportingId(null)
       }
     },
-    [locationRef, token, externalRefBase, fileNameTitle, altContextLabel, locationRequiredMessage],
+    [locationRef, externalRefBase, fileNameTitle, altContextLabel, locationRequiredMessage],
   )
 
   const updateDraft = useCallback(
@@ -154,10 +148,6 @@ export function useExternalImageImport({
         setError(locationRequiredMessage)
         return null
       }
-      if (!token) {
-        setError('Please sign in again before importing images.')
-        return null
-      }
       if (!cropDraft.photographerCredit.trim()) {
         setError('Photographer credit is required before importing.')
         return null
@@ -171,7 +161,6 @@ export function useExternalImageImport({
           cropDraft.externalRef,
           cropDraft.altText,
           locationRef,
-          token,
           cropDraft.photographerCredit,
           (progress) => setUploadProgress(progress),
         )
@@ -185,7 +174,7 @@ export function useExternalImageImport({
         setIsUploading(false)
       }
     },
-    [cropDraft, locationRef, token, locationRequiredMessage, reset],
+    [cropDraft, locationRef, locationRequiredMessage, reset],
   )
 
   return {

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerController.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerController.ts
@@ -18,7 +18,6 @@ import { useProviderImageSearch } from './useProviderImageSearch'
 
 export function useImagePickerController({
   isOpen,
-  token,
   locationRef,
   query,
   selection = { mode: 'single' },
@@ -40,11 +39,10 @@ export function useImagePickerController({
     buildUploadIdentity(uploadExternalRefBase, uploadFileNameTitle),
   )
   const buffer = useImagePickerSelectionBuffer(requiredCount)
-  const data = useImagePickerData({ isOpen, token, query, search, selectedId })
+  const data = useImagePickerData({ isOpen, query, search, selectedId })
   const unsplash = useProviderImageSearch<UnsplashPhoto>(searchUnsplashImages)
   const pexels = useProviderImageSearch<PexelsPhoto>(searchPexelsImages)
   const importer = useExternalImageImport({
-    token,
     locationRef,
     externalRefBase: importExternalRefBase ?? uploadExternalRefBase,
     fileNameTitle: importFileNameTitle ?? uploadFileNameTitle,
@@ -132,9 +130,9 @@ export function useImagePickerController({
     }
 
     const assetId = pickUploadedAssetId(response, query.variant ?? undefined)
-    if (assetId === null || !token) return
+    if (assetId === null) return
     try {
-      const result = await fetchMediaAssets(token, { limit: 1, id: assetId })
+      const result = await fetchMediaAssets({ limit: 1, id: assetId })
       buffer.addToBuffer(assetId, result.docs[0] ?? null, 'rolling')
     } catch {
       // Import succeeded but resolution failed; the asset remains in Payload.

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerData.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerData.test.ts
@@ -43,45 +43,43 @@ describe('useImagePickerData', () => {
     mockFetchAssets.mockResolvedValue(page([asset(1), asset(2)]))
 
     const { result } = renderHook(() =>
-      useImagePickerData({ isOpen: true, token: 't', query: baseQuery, search: '', selectedId: null }),
+      useImagePickerData({ isOpen: true, query: baseQuery, search: '', selectedId: null }),
     )
 
     await waitFor(() => expect(result.current.assets).toHaveLength(2))
-    expect(mockFetchAssets).toHaveBeenCalledWith(
-      't',
-      expect.objectContaining({ page: 1, mimeType: 'image/' }),
+    expect(mockFetchAssets).toHaveBeenCalledWith(expect.objectContaining({ page: 1, mimeType: 'image/' }),
     )
   })
 
   it('does not fetch while closed', () => {
     renderHook(() =>
-      useImagePickerData({ isOpen: false, token: 't', query: baseQuery, search: '', selectedId: null }),
+      useImagePickerData({ isOpen: false, query: baseQuery, search: '', selectedId: null }),
     )
     expect(mockFetchAssets).not.toHaveBeenCalled()
   })
 
   it('hydrates the selected asset when it is off the current page', async () => {
-    mockFetchAssets.mockImplementation(async (_token, params) => {
+    mockFetchAssets.mockImplementation(async (params) => {
       if (params?.id === 99) return page([asset(99)])
       return page([asset(1), asset(2)])
     })
 
     const { result } = renderHook(() =>
-      useImagePickerData({ isOpen: true, token: 't', query: baseQuery, search: '', selectedId: 99 }),
+      useImagePickerData({ isOpen: true, query: baseQuery, search: '', selectedId: 99 }),
     )
 
     await waitFor(() => expect(result.current.assets.some((a) => a.id === 99)).toBe(true))
-    expect(mockFetchAssets).toHaveBeenCalledWith('t', expect.objectContaining({ limit: 1, id: 99 }))
+    expect(mockFetchAssets).toHaveBeenCalledWith(expect.objectContaining({ limit: 1, id: 99 }))
   })
 
   it('dedups assets across load-more pages', async () => {
-    mockFetchAssets.mockImplementation(async (_token, params) => {
+    mockFetchAssets.mockImplementation(async (params) => {
       if (params?.page === 2) return page([asset(2), asset(3)], 2)
       return page([asset(1), asset(2)], 2)
     })
 
     const { result } = renderHook(() =>
-      useImagePickerData({ isOpen: true, token: 't', query: baseQuery, search: '', selectedId: null }),
+      useImagePickerData({ isOpen: true, query: baseQuery, search: '', selectedId: null }),
     )
 
     await waitFor(() => expect(result.current.assets).toHaveLength(2))
@@ -98,7 +96,6 @@ describe('useImagePickerData', () => {
     const { result } = renderHook(() =>
       useImagePickerData({
         isOpen: true,
-        token: 't',
         query: { browseUnit: 'assets', requireMediaSet: true },
         search: '',
         selectedId: null,
@@ -109,13 +106,13 @@ describe('useImagePickerData', () => {
   })
 
   it('resets and refetches when the query variant changes', async () => {
-    mockFetchAssets.mockImplementation(async (_token, params) =>
+    mockFetchAssets.mockImplementation(async (params) =>
       page([params?.variant === 'wide' ? asset(10, { variant: 'wide' }) : asset(1)]),
     )
 
     const { result, rerender } = renderHook(
       ({ query }: { query: ImagePickerQuery }) =>
-        useImagePickerData({ isOpen: true, token: 't', query, search: '', selectedId: null }),
+        useImagePickerData({ isOpen: true, query, search: '', selectedId: null }),
       { initialProps: { query: { browseUnit: 'assets', variant: 'editorial' } as ImagePickerQuery } },
     )
 
@@ -130,11 +127,11 @@ describe('useImagePickerData', () => {
     mockFetchAssets.mockResolvedValue(page([asset(1)]))
 
     renderHook(() =>
-      useImagePickerData({ isOpen: true, token: 't', query: baseQuery, search: '  cafe  ', selectedId: null }),
+      useImagePickerData({ isOpen: true, query: baseQuery, search: '  cafe  ', selectedId: null }),
     )
 
     await waitFor(() =>
-      expect(mockFetchAssets).toHaveBeenCalledWith('t', expect.objectContaining({ search: 'cafe' })),
+      expect(mockFetchAssets).toHaveBeenCalledWith(expect.objectContaining({ search: 'cafe' })),
     )
   })
 
@@ -148,7 +145,6 @@ describe('useImagePickerData', () => {
     const { result } = renderHook(() =>
       useImagePickerData({
         isOpen: true,
-        token: 't',
         query: { browseUnit: 'mediaSets' },
         search: '',
         selectedId: null,

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerData.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/picker/useImagePickerData.ts
@@ -8,7 +8,6 @@ const PAGE_SIZE = 48
 
 type UseImagePickerDataParams = {
   isOpen: boolean
-  token?: string
   query: ImagePickerQuery
   /** Trimmed by the hook; drives server-side whole-library search. */
   search: string
@@ -50,7 +49,6 @@ function dedupMediaSets(prev: MediaSet[], next: MediaSet[]): MediaSet[] {
  */
 export function useImagePickerData({
   isOpen,
-  token,
   query,
   search,
   selectedId,
@@ -84,7 +82,7 @@ export function useImagePickerData({
 
       try {
         if (browseUnit === 'mediaSets') {
-          const res = await fetchMediaSets(token, {
+          const res = await fetchMediaSets({
             limit: PAGE_SIZE,
             page: targetPage,
             search: trimmedSearch || undefined,
@@ -94,7 +92,7 @@ export function useImagePickerData({
           setRawAssets([])
           setTotalPages(Math.max(res.totalPages || 1, 1))
         } else {
-          const res = await fetchMediaAssets(token, {
+          const res = await fetchMediaAssets({
             limit: PAGE_SIZE,
             page: targetPage,
             mimeType: 'image/',
@@ -117,7 +115,7 @@ export function useImagePickerData({
         if (seq === requestSeq.current) setIsLoading(false)
       }
     },
-    [isOpen, token, browseUnit, variant, exactWidth, exactHeight, minWidth, minHeight, trimmedSearch],
+    [isOpen, browseUnit, variant, exactWidth, exactHeight, minWidth, minHeight, trimmedSearch],
   )
 
   // Reset + load page 1 whenever the picker opens or the query/search changes.
@@ -136,7 +134,7 @@ export function useImagePickerData({
     void loadPage(1, 'replace')
     // loadPage already depends on every reset input; resetKey keeps the intent explicit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resetKey, isOpen, token])
+  }, [resetKey, isOpen])
 
   const hasMore = page < totalPages
 
@@ -153,7 +151,7 @@ export function useImagePickerData({
 
   // Hydrate the selected entity if it isn't on a loaded page, so it stays visible/selected.
   useEffect(() => {
-    if (!isOpen || selectedId === null || !token) return
+    if (!isOpen || selectedId === null) return
 
     const present =
       browseUnit === 'mediaSets'
@@ -165,7 +163,7 @@ export function useImagePickerData({
     const hydrate = async () => {
       try {
         if (browseUnit === 'mediaSets') {
-          const res = await fetchMediaSets(token, { limit: 1, id: selectedId })
+          const res = await fetchMediaSets({ limit: 1, id: selectedId })
           const doc = res.docs[0]
           if (!cancelled && doc) {
             setMediaSets((prev) =>
@@ -173,7 +171,7 @@ export function useImagePickerData({
             )
           }
         } else {
-          const res = await fetchMediaAssets(token, { limit: 1, id: selectedId })
+          const res = await fetchMediaAssets({ limit: 1, id: selectedId })
           const doc = res.docs[0]
           if (!cancelled && doc) {
             setRawAssets((prev) => (prev.some((a) => a.id === doc.id) ? prev : [doc, ...prev]))
@@ -188,7 +186,7 @@ export function useImagePickerData({
     return () => {
       cancelled = true
     }
-  }, [isOpen, selectedId, browseUnit, token, rawAssets, mediaSets])
+  }, [isOpen, selectedId, browseUnit, rawAssets, mediaSets])
 
   const assets = useMemo(
     () => (requireMediaSet ? filterAssetsWithMediaSet(rawAssets) : rawAssets),

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/services/image-upload-flow.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/services/image-upload-flow.service.ts
@@ -11,7 +11,6 @@ type UploadPreparedVariantsParams = {
   externalRef: string;
   altText: string;
   locationRef: number;
-  token: string;
   photographerCredit: string;
   onProgress: (progress: UploadProgress) => void;
 };
@@ -34,7 +33,6 @@ export async function uploadPreparedVariants({
   externalRef,
   altText,
   locationRef,
-  token,
   photographerCredit,
   onProgress,
 }: UploadPreparedVariantsParams): Promise<UploadImageResponse> {
@@ -43,7 +41,6 @@ export async function uploadPreparedVariants({
     externalRef,
     altText,
     locationRef,
-    token,
     photographerCredit,
     onProgress,
   );

--- a/apps/ai-blog-writer/apps/frontend/src/shared/images/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/images/types.ts
@@ -5,7 +5,6 @@ export interface ImageUploadProps {
   externalRef: string
   fileNamePrefix?: string
   locationRef: number
-  token: string
   initialAltText?: string
   initialPhotographerCredit?: string
   onComplete: (result: UploadImageResponse) => void

--- a/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
@@ -69,7 +69,6 @@ async function payloadRequest<T>(endpoint: string, token: string): Promise<T> {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
     },
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/locationScope/scope.ts
@@ -63,7 +63,7 @@ function buildScopeWhere(parts: string[]): URLSearchParams {
   return params
 }
 
-async function payloadRequest<T>(endpoint: string, token: string): Promise<T> {
+async function payloadRequest<T>(endpoint: string): Promise<T> {
   const response = await fetch(`${PAYLOAD_API_URL}${endpoint}`, {
     credentials: 'include',
     headers: {
@@ -80,7 +80,7 @@ async function payloadRequest<T>(endpoint: string, token: string): Promise<T> {
   return response.json()
 }
 
-async function getLocationScopeForKey(locationKey: string, token: string): Promise<LocationScope> {
+async function getLocationScopeForKey(locationKey: string): Promise<LocationScope> {
   const normalized = normalizeLocationKey(locationKey)
   const parts = getEffectiveScopeParts(normalized)
   const effectiveLocation = parts.join('|')
@@ -112,7 +112,7 @@ async function getLocationScopeForKey(locationKey: string, token: string): Promi
     params.set('page', String(page))
     params.set('depth', '0')
 
-    const response = await payloadRequest<LocationListResponse>(`/api/locations?${params.toString()}`, token)
+    const response = await payloadRequest<LocationListResponse>(`/api/locations?${params.toString()}`)
 
     for (const doc of response.docs || []) {
       const normalizedLocationKey = normalizeLocationKey(doc.locationKey || '')
@@ -158,14 +158,13 @@ export async function getArticleLocationScope(input: {
   locationKey: string
   sharedNeighborhoods?: number[]
   locations?: Array<Pick<LocationDoc, 'id' | 'locationKey'>>
-  token: string
 }): Promise<LocationScope> {
   const exactNeighborhoodScope = buildExactNeighborhoodScope(input.sharedNeighborhoods, input.locations)
   if (exactNeighborhoodScope) {
     return exactNeighborhoodScope
   }
 
-  return getLocationScopeForKey(input.locationKey, input.token)
+  return getLocationScopeForKey(input.locationKey)
 }
 
 export function isLocationWithinArticleScope(input: {

--- a/apps/ai-blog-writer/docs/adr/0028-staff-session-is-held-in-memory-not-localstorage.md
+++ b/apps/ai-blog-writer/docs/adr/0028-staff-session-is-held-in-memory-not-localstorage.md
@@ -8,8 +8,8 @@ window and the browser restart.
 The token is no longer written to disk. It lives in a module-scoped store for
 the lifetime of the page (`features/auth/auth-session-store.ts`), and a reload
 restores the session from the httpOnly `payload-token` cookie Payload already
-sets on `POST /api/users/login`. `GET /api/users/me` returns the user *and* the
-current token, so the cookie alone is sufficient to rebuild the session.
+sets on `POST /api/users/login`. `GET /api/users/me` returns the user and an
+`exp`, so the cookie alone is sufficient to rebuild the session.
 
 Bootstrap deletes anything an earlier build left under the old key, because the
 code that would have cleared it on logout is the code being removed.
@@ -25,21 +25,16 @@ Every authenticated Payload client sends `credentials: 'include'`. They
 previously disagreed — some `'include'`, some `'omit'`, some unset (meaning
 `'same-origin'`, and Payload is never same-origin with this app). That is
 consistency, **not** a fallback: while a Bearer header is present the cookie is
-never consulted, for the reason above. Its value is that dropping the header
-later is a one-line change rather than an eight-file one.
+never consulted, for the reason above. Its value was that dropping the header
+later became a small change rather than an eight-file one — which is what
+happened next.
 
 ## What this does and does not achieve
 
-It removes the credential *at rest*. A generic XSS payload can no longer read a
-Staff token out of a well-known storage key, and a token cannot outlive the
-page.
-
-It does not yet make the token unreadable by JavaScript. The FastAPI backend
-identifies callers from an `Authorization: Bearer` header
-(`apps/backend/app/core/staff_auth.py`), and the image routes forward that same
-JWT to Payload to create media as the acting Staff user
-(`apps/backend/app/features/images/payload_client.py`). While that is the
-contract, the frontend has to hold a token in memory to send it.
+It removed the credential *at rest*: a generic XSS payload could no longer read
+a Staff token out of a well-known storage key, and a token could not outlive the
+page. It did not remove it from memory — the section below records how that was
+finished.
 
 ## Consequences
 
@@ -57,22 +52,65 @@ contract, the frontend has to hold a token in memory to send it.
 - If Payload is unreachable at load, the operator is treated as logged out
   rather than resuming on a stale stored token. That is the correct reading of
   "we cannot confirm this session".
-- `payload-token` lives 2 hours while `SESSION_DURATION_FALLBACK_MS` assumes 7
-  days. The fallback only applies when the response carries no usable expiry;
-  `/api/users/me` returns `exp`, and the JWT is still decodable in memory, so
-  the honest expiry is still available.
+- `payload-token` lived 2 hours while `SESSION_DURATION_FALLBACK_MS` assumed 7
+  days. That mismatch is resolved below: the constant is gone and an unknown
+  expiry now means "no session".
 
-## Not done here
+## Finished: the token is gone from JavaScript
 
-Making the token unreadable by JavaScript entirely requires FastAPI to accept
-the `payload-token` cookie as caller identity — including for the delegated
-writes to Payload, where the cookie value *is* the JWT the backend needs. That
-change depends on a production origin decision this repo has not made:
-`VITE_PAYLOAD_API_URL` is configured nowhere, Payload's `Users.auth` sets no
-`cookies` block (so `SameSite=Lax`, `Secure=false`, host-only `Domain`), and a
-cross-site or cross-host deployment would need `sameSite: 'None'`,
-`secure: true` and an explicit `domain`. Accepting a cookie on the backend also
-introduces a CSRF surface that must be closed deliberately rather than by
-relying on the public `X-API-Key` header forcing a preflight.
+Settled 2026-08-12 and completed in PRs #222-227. The deployment topology that
+had blocked this is: every service is a sibling subdomain of one registrable
+domain — `www` and `cms` deployed, `abw` and `abw-api` behind a Cloudflare
+Tunnel. Siblings of one registrable domain are *same-site*, so `SameSite=Lax`
+holds and no third-party cookie is involved; only the cookie's `Domain` had to
+widen. Cross-site hosting was rejected because it forces `SameSite=None`, which
+Safari and Brave block outright.
 
-Deferred until the deployment topology is settled.
+What that unlocked, in order:
+
+1. `Users.auth.cookies` scopes `payload-token` to the registrable domain, with
+   `PAYLOAD_COOKIE_DOMAIN` a hard production boot requirement (`host-only` is
+   the explicit opt-out).
+2. FastAPI reads the cookie as caller identity. The CSRF surface that opens is
+   closed with an `Origin` check against the pinned CORS allowlist — **not**
+   with `X-API-Key`, which is Vite-inlined and public. A wildcard allowlist
+   refuses cookie auth outright.
+3. Every client — `apiFetch`, the Payload clients, and the image clients —
+   sends `credentials: 'include'` and no `Authorization` header.
+4. `AuthState` carries no token. Session expiry comes from the `exp` that
+   `loginOperation`, `refreshOperation` and `meOperation` all return, so
+   nothing needs to decode a JWT.
+
+The delegated writes still work unchanged: the cookie's value *is* the JWT the
+backend forwards to Payload, so uploads are still created as the acting Staff
+user rather than a service account.
+
+### Consequences worth knowing
+
+- **Never send a Bearer header alongside the cookie.** `extractJWT` returns the
+  *first* credential in `jwtOrder` (JWT, Bearer, cookie) and verifies only that
+  one, so a stale header shadows a valid cookie and fails the request. This bit
+  `logoutPayloadUser` before, and `requestSession` latently: it attached the
+  in-memory token whenever one existed, so a token expiring slightly before its
+  cookie turned a renewable session into a forced logout.
+- **An unknown expiry now means "no session"**, rather than the invented 7 days
+  the old fallback used. That also removes the 2h-cookie-vs-7d-fallback
+  mismatch this ADR previously flagged.
+- **The `!token` guards were dead, not translated.** Every component holding
+  one renders only inside `RequireAuth`, which returns `<Navigate>` when
+  `!isAuthenticated` — and `isAuthenticated` used to require a truthy token. All
+  74 were unreachable and were deleted.
+- **The permissions access cache is keyed by Staff id**, not by token. It used
+  to re-fetch on every renewal because renewal minted a new key. It is now
+  cleared on logout, which it never was.
+- `payload_jwt` on `POST /itineraries-pipeline/generate` was a **required** body
+  field. It is now optional and cookie-sourced, with a body value still winning
+  so non-browser callers keep working. Any future route taking a JWT in its body
+  has the same latent break.
+
+### What this does and does not achieve
+
+An XSS payload can no longer read a Staff credential — there is nothing to
+read, at rest or in memory. It can still *act* as the operator while the page is
+open, because the browser attaches the cookie to any request it makes. The gain
+is that a credential cannot be extracted and replayed elsewhere, later.


### PR DESCRIPTION
`AuthState` no longer carries a token. This is the last step of the
roadmap item ADR-0028 deferred: the Staff JWT is now unreadable by
JavaScript, not merely absent from disk.

## Session expiry no longer needs the token

Expiry comes from the `exp` that every Payload session endpoint returns —
`loginOperation` (login.js:306), `refreshOperation` (refresh.js:100) and
`meOperation` (me.js:41,57). `decodeTokenExpiry` and the 7-day
`SESSION_DURATION_FALLBACK_MS` are deleted, and an unknown expiry now
means "no session" rather than a guessed week. That also resolves the
2h-cookie-vs-7d-fallback mismatch ADR-0028 flagged as a consequence:
guessing long only delays discovering that the cookie is already gone.

## The `!token` guards were dead code, not something to translate

All 74 of them were deleted rather than rewritten as `!isAuthenticated`,
because they were unreachable. Every component holding one renders only
inside `RequireAuth`, which returns `<Navigate>` when `!isAuthenticated`
(RequireAuth.tsx:30) — and `isAuthenticated` was
`hasActiveSession(token, expiresAt)`, which required a truthy token. Only
`/login` sits outside that tree, and it had no such guard. `!token` was
therefore always false wherever it appeared.

One consumer prop (`HomepageBlockLayoutSection.disabled`) became optional
rather than being handed a permanently-`false` value.

## Three pre-existing defects fixed, all in code this had to rewrite

Flagged as pre-existing on PR #221 and left there to keep it reviewable:

- The renewal effect in `useAuthSessionState` had no cancellation guard,
  unlike the hydrate effect. Logging out while
  `/api/users/refresh-token` was in flight applied the renewed session on
  top of the logout and signed the operator back in, in both the UI and
  the module store.
- `clearPermissionsCache` was exported and never called. It is now called
  on logout, and it matters more than before: the cache is keyed by Staff
  id rather than by token, so it no longer turns over on renewal. Keying
  on identity is also the fix for a silent inefficiency — renewal minted
  a new token and therefore a new cache key, re-fetching `/api/access`
  every time.
- `requestSession` attached the in-memory token whenever one existed.
  Because `extractJWT` returns the *first* credential in `jwtOrder` and
  verifies only that one, a token expiring slightly before its cookie
  turned a renewable session into a forced logout. (Fixed in the parent
  commit; called out here because it is the same class as the above.)

## A real cross-service contract break

`payload_jwt` on `POST /itineraries-pipeline/generate` was a **required**
body field (`min_length=1`) that the backend uses to read Payload
candidates. The frontend can no longer supply it. It is now optional and
filled from the session cookie via `app.core.staff_token`, with a
body-supplied value still winning so non-browser callers and older
frontend builds keep working. Absent both, the route answers 401 rather
than failing deep inside the retrieval stage.

Any other route taking a JWT in its request body has the same latent
break. This was the only one.

## Verification

- abw frontend: 136 files / 644 tests pass. `tsc --noEmit`: exactly 7
  errors, the unchanged pre-existing baseline, at the same 7 sites.
- abw backend: 632 passed (629 before; +3 for the cookie-sourced
  `payload_jwt`). flake8 clean on changed files.
- Audited: zero Staff-token references remain in frontend source. The
  surviving matches are the cookie name, the `refresh-token` endpoint
  path, and three unrelated `token` locals — a JSON lexer in
  `seo-ai-json-repair.ts` and two filename-slug builders — which were
  explicitly excluded and left untouched.

Depends on #222 (cookie domain), #223 (backend reads the cookie), #224
(apiFetch credentials), #225 (Payload clients), #226 (image clients).

---

**Last of the series.** Closes the roadmap item ADR-0028 deferred. Merge after #222, #223, #224, #225, #226 — this branch is based on #226 and merges in #223 and #225, so the diff shown against those is D3 only.

ADR-0028's "Not done here" section is replaced with what was decided and done, and its now-stale consequences (the 7-day fallback, the token in `/me`) are reconciled.

**Not deployed.**