### PR TITLE
fix(questura): remove stale Next lint suppression

### DIFF
--- a/apps/questura/apps/server/src/features/media/components/FocalPointPickerField.tsx
+++ b/apps/questura/apps/server/src/features/media/components/FocalPointPickerField.tsx
@@ -181,7 +181,6 @@ const FocalPointPickerField = (_props: FocalPointFieldProps) => {
             overflow: 'hidden',
           }}
         >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             id="focal-point-picker-image"
             ref={imageRef}


### PR DESCRIPTION
## What changed

- removes one stale `@next/next/no-img-element` suppression

## Why

Questura server ESLint config does not load the Next plugin, so the suppression itself was the only lint error. Restoring a green lint baseline lets soft-production deploys enforce the documented lint gate.

## Validation

- `pnpm --dir apps/questura/apps/server lint` (0 errors, 5 existing warnings)
- `git diff --check`
