### PR TITLE
ops(questura): run migrations during softprod deploy

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -30,8 +30,9 @@
     "sync:exchange-rates": "cross-env NODE_OPTIONS=--no-deprecation bun src/scripts/sync-exchange-rates.ts",
     "clear:test": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/clear-test-collections.ts",
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
-    "test": "pnpm run test:int",
+    "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts"
   },
   "dependencies": {

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -1,0 +1,71 @@
+# Questura soft-production deployment
+
+`host-deploy-wrapper.sh` is installed as `~/questura/deploy.sh` on the Linux
+laptop. It serializes deploys, resets the dedicated deployment checkout to
+`origin/main`, then executes the freshly fetched `deploy.sh` from this folder.
+
+Normal deploy:
+
+```bash
+ssh linux-laptop '~/questura/deploy.sh'
+```
+
+Deployment order is intentional:
+
+1. Install dependencies from the committed lockfile.
+2. Build, test, and lint the server.
+3. Inspect pending migration `up()` bodies and block risky SQL by default.
+4. Run migrations and prove none remain pending.
+5. Restart the server and verify its DB-backed health endpoint locally and
+   through Cloudflare.
+6. Build the client while the server is publicly reachable, restart it, and
+   verify the public site.
+
+## Reviewed migrations
+
+The preflight blocks destructive SQL, data rewrites, column/table rewrites,
+and visitor-auth schema changes. It deliberately ignores `down()` rollback SQL.
+
+Before manually running blocked migrations:
+
+1. Back up the soft-production Postgres database.
+2. Record row counts for `locations`, `articles`, `media_assets`, `media_sets`,
+   `users`, `visitor_profiles`, and every `visitor_auth_*` table.
+3. Review every pending migration's `up()` body for destructive or unrelated
+   SQL and unexpected BetterAuth/visitor-auth changes. `pnpm db:migrate` applies
+   the entire pending batch, not one named file.
+4. Stop for explicit approval of that complete pending batch.
+5. Run the batch manually during the approved maintenance window.
+6. Rerun deployment; preflight will see the migrations already recorded.
+
+```bash
+cd ~/questura/app/apps/questura/apps/server
+source ~/.nvm/nvm.sh
+nvm use 22
+pnpm db:migrate
+~/questura/deploy.sh
+```
+
+There is no bypass or `--force` switch in automated deployment.
+
+## First install
+
+Install the wrapper. Installer preserves any existing copy under
+`~/questura/backups/deploy/`:
+
+```bash
+~/questura/app/apps/questura/infra/softprod/install-deploy-wrapper.sh
+```
+
+This baseline still builds inside deployment checkout. Do not install it alone
+on soft production; adopt it together with atomic-release units from follow-up
+PR so a failed build cannot damage live `.next` files.
+
+## Validation
+
+Migration-preflight and deploy-runner regression tests are part of the server
+test command. Run the shell suite alone with:
+
+```bash
+pnpm --dir apps/questura/apps/server test:softprod
+```

--- a/apps/questura/infra/softprod/deploy.sh
+++ b/apps/questura/infra/softprod/deploy.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Build and restart Questura soft production from an already-synced checkout.
+# Use host-deploy-wrapper.sh as the host entry point so code sync happens first.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+QUESTURA_APPS="$REPO_ROOT/apps/questura/apps"
+SERVER="$QUESTURA_APPS/server"
+CLIENT="$QUESTURA_APPS/client"
+stage=initialization
+
+report_failure() {
+  local exit_code=$?
+  echo "ERROR: deploy failed during $stage (exit $exit_code)" >&2
+  exit "$exit_code"
+}
+trap report_failure ERR
+
+if (($# > 0)); then
+  echo "ERROR: deploy.sh takes no arguments" >&2
+  exit 2
+fi
+
+if [[ ${QUESTURA_DEPLOY_LOCK_HELD:-0} != 1 ]]; then
+  exec 9>"$DEPLOY_ROOT/deploy.lock"
+  if ! flock -n 9; then
+    echo "ERROR: another Questura deploy is running" >&2
+    exit 1
+  fi
+fi
+
+if ! git -C "$REPO_ROOT" diff --quiet || ! git -C "$REPO_ROOT" diff --cached --quiet; then
+  echo "ERROR: deployment checkout has tracked changes" >&2
+  exit 1
+fi
+
+export NVM_DIR=${NVM_DIR:-"$HOME/.nvm"}
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+  nvm use "${QUESTURA_NODE_VERSION:-22}" >/dev/null
+fi
+
+wait_for_healthy_server() {
+  local label=$1
+  local url=$2
+  local attempt body
+
+  for attempt in $(seq 1 30); do
+    body=$(curl --fail --silent --show-error --max-time 10 "$url" 2>/dev/null || true)
+    if [[ $body =~ \"status\"[[:space:]]*:[[:space:]]*\"healthy\" ]]; then
+      echo "    $label healthy"
+      return 0
+    fi
+    sleep 3
+  done
+
+  echo "ERROR: $label never became healthy: $url" >&2
+  return 1
+}
+
+wait_for_http_200() {
+  local label=$1
+  local url=$2
+  local attempt code
+
+  for attempt in $(seq 1 30); do
+    code=$(curl --location --silent --output /dev/null --write-out '%{http_code}' --max-time 10 "$url" || true)
+    if [[ $code == 200 ]]; then
+      echo "    $label reachable"
+      return 0
+    fi
+    sleep 3
+  done
+
+  echo "ERROR: $label never returned HTTP 200: $url" >&2
+  return 1
+}
+
+stage="dependency installation"
+echo "==> Installing locked dependencies (Questura workspaces only)"
+cd "$REPO_ROOT"
+pnpm install --frozen-lockfile --prod=false \
+  --filter "@questura/server..." \
+  --filter "@questura/client..."
+
+stage="server build"
+echo "==> Building server"
+cd "$SERVER"
+pnpm build
+
+stage="server tests"
+echo "==> Testing server"
+pnpm test
+
+stage="server lint"
+echo "==> Linting server"
+pnpm lint
+
+stage="migration preflight"
+echo "==> Checking pending database migrations"
+node scripts/deploy/check-pending-migrations.mjs
+
+stage="database migration"
+echo "==> Running database migrations"
+pnpm db:migrate
+node scripts/deploy/check-pending-migrations.mjs --require-clean
+
+stage="server restart"
+echo "==> Restarting server"
+systemctl --user restart questura-server
+stage="server health checks"
+wait_for_healthy_server "local server" "http://127.0.0.1:4000/api/health"
+wait_for_healthy_server "public server" "https://cms.questurian.com/api/health"
+
+# Client statically prerenders /articles from its public backend URL. Build only
+# after the new server is reachable through the Cloudflare tunnel.
+stage="client build"
+echo "==> Building client"
+cd "$CLIENT"
+pnpm build
+
+stage="client restart"
+echo "==> Restarting client"
+systemctl --user restart questura-client
+stage="client health checks"
+wait_for_http_200 "local client" "http://127.0.0.1:3000/"
+wait_for_http_200 "public client" "https://www.questurian.com/"
+
+stage="unit status check"
+echo "==> Unit status"
+systemctl --user is-active questura-server questura-client questura-tunnel
+echo "Deployed $(git -C "$REPO_ROOT" rev-parse --short HEAD)."

--- a/apps/questura/infra/softprod/deploy.test.sh
+++ b/apps/questura/infra/softprod/deploy.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+REPO="$TEST_ROOT/repo"
+FAKE_BIN="$TEST_ROOT/bin"
+DEPLOY_ROOT="$TEST_ROOT/host"
+LOG="$TEST_ROOT/commands.log"
+mkdir -p \
+  "$REPO/apps/questura/infra/softprod" \
+  "$REPO/apps/questura/apps/server/scripts/deploy" \
+  "$REPO/apps/questura/apps/client" \
+  "$FAKE_BIN" \
+  "$DEPLOY_ROOT"
+cp "$SCRIPT_DIR/deploy.sh" "$REPO/apps/questura/infra/softprod/deploy.sh"
+
+git -C "$REPO" init --quiet
+git -C "$REPO" config user.email deploy-test@example.invalid
+git -C "$REPO" config user.name deploy-test
+git -C "$REPO" add .
+git -C "$REPO" commit --quiet -m fixture
+git -C "$TEST_ROOT" init --quiet --bare --initial-branch=main origin.git
+git -C "$REPO" branch -M main
+git -C "$REPO" remote add origin "$TEST_ROOT/origin.git"
+git -C "$REPO" push --quiet -u origin main
+
+create_fake() {
+  local command=$1
+  local target="$FAKE_BIN/$command"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -eu' \
+    'printf "%s|%s|%s\\n" "$PWD" "$(basename "$0")" "$*" >> "$DEPLOY_TEST_LOG"' \
+    'if [[ $(basename "$0") == pnpm && $* == db:migrate && ${FAIL_MIGRATE:-0} == 1 ]]; then exit 42; fi' \
+    'if [[ $(basename "$0") == flock && ${FAIL_FLOCK:-0} == 1 ]]; then exit 73; fi' \
+    'if [[ $(basename "$0") == curl ]]; then' \
+    '  if [[ " $* " == *" --write-out "* ]]; then printf 200; else printf '\''{"status":"healthy"}'\''; fi' \
+    'fi' > "$target"
+  chmod +x "$target"
+}
+
+for command in pnpm node systemctl curl flock; do
+  create_fake "$command"
+done
+
+run_deploy() {
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    NVM_DIR="$TEST_ROOT/no-nvm" \
+    QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_DEPLOY_LOCK_HELD="${DEPLOY_LOCK_HELD:-0}" \
+    DEPLOY_TEST_LOG="$LOG" \
+    FAIL_MIGRATE="${FAIL_MIGRATE:-0}" \
+    FAIL_FLOCK="${FAIL_FLOCK:-0}" \
+    "$REPO/apps/questura/infra/softprod/deploy.sh"
+}
+
+line_number() {
+  local pattern=$1
+  grep -n -m1 "$pattern" "$LOG" | cut -d: -f1
+}
+
+run_deploy > "$TEST_ROOT/success.out" 2> "$TEST_ROOT/success.err"
+
+preflight=$(line_number 'node|scripts/deploy/check-pending-migrations.mjs$')
+server_build=$(grep -n '/server|pnpm|build$' "$LOG" | cut -d: -f1)
+server_test=$(line_number 'pnpm|test$')
+server_lint=$(line_number 'pnpm|lint$')
+migrate=$(line_number 'pnpm|db:migrate$')
+clean=$(line_number 'node|scripts/deploy/check-pending-migrations.mjs --require-clean$')
+restart=$(line_number 'systemctl|--user restart questura-server$')
+server_public=$(line_number 'curl|.*https://cms.questurian.com/api/health')
+client_build=$(grep -n '/client|pnpm|build$' "$LOG" | cut -d: -f1)
+client_restart=$(line_number 'systemctl|--user restart questura-client$')
+client_public=$(line_number 'curl|.*https://www.questurian.com/')
+
+((server_build < server_test && server_test < server_lint && server_lint < preflight))
+((preflight < migrate && migrate < clean && clean < restart))
+((restart < server_public && server_public < client_build))
+((client_build < client_restart && client_restart < client_public))
+grep -q -- '--frozen-lockfile --prod=false' "$LOG"
+grep -q 'Deployed ' "$TEST_ROOT/success.out"
+
+: > "$LOG"
+set +e
+FAIL_MIGRATE=1 run_deploy > "$TEST_ROOT/failure.out" 2> "$TEST_ROOT/failure.err"
+failure_code=$?
+set -e
+
+[[ $failure_code == 42 ]]
+grep -q 'deploy failed during database migration' "$TEST_ROOT/failure.err"
+if grep -q 'systemctl|--user restart' "$LOG"; then
+  echo 'service restarted after failed migration' >&2
+  exit 1
+fi
+
+: > "$LOG"
+set +e
+FAIL_FLOCK=1 run_deploy > "$TEST_ROOT/lock.out" 2> "$TEST_ROOT/lock.err"
+lock_code=$?
+set -e
+
+[[ $lock_code == 1 ]]
+grep -q 'another Questura deploy is running' "$TEST_ROOT/lock.err"
+if grep -q 'pnpm|' "$LOG"; then
+  echo 'deployment started without acquiring lock' >&2
+  exit 1
+fi
+
+: > "$LOG"
+env \
+  PATH="$FAKE_BIN:$PATH" \
+  NVM_DIR="$TEST_ROOT/no-nvm" \
+  QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+  QUESTURA_APP_ROOT="$REPO" \
+  DEPLOY_TEST_LOG="$LOG" \
+  "$SCRIPT_DIR/host-deploy-wrapper.sh" > "$TEST_ROOT/wrapper.out" 2> "$TEST_ROOT/wrapper.err"
+grep -q '|flock|-n 9$' "$LOG"
+grep -q 'Deployed ' "$TEST_ROOT/wrapper.out"
+
+INSTALL_ROOT="$TEST_ROOT/install-host"
+mkdir -p "$INSTALL_ROOT"
+printf '%s\n' '#!/bin/sh' 'echo old' > "$INSTALL_ROOT/deploy.sh"
+chmod 0700 "$INSTALL_ROOT/deploy.sh"
+QUESTURA_DEPLOY_ROOT="$INSTALL_ROOT" \
+  "$SCRIPT_DIR/install-deploy-wrapper.sh" > "$TEST_ROOT/install.out"
+cmp "$SCRIPT_DIR/host-deploy-wrapper.sh" "$INSTALL_ROOT/deploy.sh"
+[[ $(find "$INSTALL_ROOT/backups/deploy" -type f | wc -l | tr -d ' ') == 1 ]]
+[[ $(stat -f '%Lp' "$INSTALL_ROOT/deploy.sh" 2>/dev/null || stat -c '%a' "$INSTALL_ROOT/deploy.sh") == 755 ]]
+
+echo 'deploy sequencing tests passed'

--- a/apps/questura/infra/softprod/host-deploy-wrapper.sh
+++ b/apps/questura/infra/softprod/host-deploy-wrapper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Stable host entry point. Install as ~/questura/deploy.sh.
+set -Eeuo pipefail
+
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+APP=${QUESTURA_APP_ROOT:-"$DEPLOY_ROOT/app"}
+
+exec 9>"$DEPLOY_ROOT/deploy.lock"
+if ! flock -n 9; then
+  echo "ERROR: another Questura deploy is running" >&2
+  exit 1
+fi
+
+echo "==> Fetching origin/main"
+git -C "$APP" fetch --prune origin main --quiet
+git -C "$APP" reset --hard origin/main
+
+# Dispatch through the freshly fetched copy. This keeps host bootstrap small
+# while allowing deploy behaviour to evolve through reviewed repository PRs.
+export QUESTURA_DEPLOY_LOCK_HELD=1
+exec "$APP/apps/questura/infra/softprod/deploy.sh" "$@"

--- a/apps/questura/infra/softprod/install-deploy-wrapper.sh
+++ b/apps/questura/infra/softprod/install-deploy-wrapper.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Install repository-controlled deployment wrapper without losing host copy.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+TARGET="$DEPLOY_ROOT/deploy.sh"
+BACKUP_ROOT="$DEPLOY_ROOT/backups/deploy"
+temporary=''
+
+cleanup() {
+  if [[ -n $temporary && -e $temporary ]]; then
+    rm -f -- "$temporary"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$BACKUP_ROOT"
+if [[ -e "$TARGET" ]]; then
+  backup=$(mktemp "$BACKUP_ROOT/deploy.sh.XXXXXX")
+  cp -p "$TARGET" "$backup"
+  echo "Preserved previous wrapper at $backup"
+fi
+
+temporary=$(mktemp "$DEPLOY_ROOT/.deploy.sh.XXXXXX")
+install -m 0755 "$SCRIPT_DIR/host-deploy-wrapper.sh" "$temporary"
+mv -f "$temporary" "$TARGET"
+temporary=''
+echo "Installed $TARGET"


### PR DESCRIPTION
## What changed

- versions soft-production deploy runner and stable host wrapper
- serializes deploys and installs from the committed lockfile
- builds, tests, and lints before migration
- runs migration preflight, applies safe pending migrations, and proves none remain
- restarts only after migration success; checks local/public DB health before client build
- atomically installs wrapper while preserving existing host copy
- adds regression coverage for order, migration failure, overlap, wrapper dispatch, and installer

## Why

The host-only deploy script never ran Payload migrations, leaving code and DB schema silently out of sync.

## Validation

- server Vitest: 89 files / 576 tests
- migration preflight: 8 tests
- softprod shell suite: passing
- server lint: 0 errors, 5 existing warnings
- production server build completed with local runtime env
- `git diff --check`

## Rollout note

README intentionally blocks installing this in-place baseline alone. Host adoption happens after the atomic-release follow-up merges.
