### PR TITLE
ops(questura): expose release identity in health checks

### DIFF
--- a/apps/questura/apps/client/src/app/api/health/route.ts
+++ b/apps/questura/apps/client/src/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+  return NextResponse.json({
+    status: 'healthy',
+    releaseSha: process.env.QUESTURA_RELEASE_SHA || 'unknown',
+  })
+}

--- a/apps/questura/apps/server/src/app/api/health/route.test.ts
+++ b/apps/questura/apps/server/src/app/api/health/route.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NextRequest } from 'next/server'
+
+const { find } = vi.hoisted(() => ({ find: vi.fn() }))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn(async () => ({ find })),
+}))
+
+vi.mock('@/payload.config', () => ({ default: {} }))
+vi.mock('@/shared/utils/cors', () => ({
+  getCorsHeaders: () => new Headers(),
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}))
+
+const { GET } = await import('./route')
+const request = { headers: new Headers() } as NextRequest
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    vi.stubEnv('QUESTURA_RELEASE_SHA', '')
+    find.mockReset()
+    find.mockResolvedValue({ docs: [] })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('reports runtime release identity after checking the database', async () => {
+    vi.stubEnv('QUESTURA_RELEASE_SHA', 'abc123')
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'healthy',
+      releaseSha: 'abc123',
+      database: { status: 'connected' },
+    })
+    expect(find).toHaveBeenCalledWith({ collection: 'users', limit: 1, depth: 0 })
+  })
+
+  it('retains release identity when the database is unhealthy', async () => {
+    vi.stubEnv('QUESTURA_RELEASE_SHA', 'broken-release')
+    find.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'unhealthy',
+      releaseSha: 'broken-release',
+      database: { status: 'disconnected' },
+    })
+  })
+
+  it('uses an explicit unknown sentinel outside release deployments', async () => {
+    const response = await GET(request)
+    await expect(response.json()).resolves.toMatchObject({ releaseSha: 'unknown' })
+  })
+})

--- a/apps/questura/apps/server/src/app/api/health/route.ts
+++ b/apps/questura/apps/server/src/app/api/health/route.ts
@@ -32,6 +32,7 @@ export async function GET(req: NextRequest) {
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
       environment: process.env.NODE_ENV || 'development',
+      releaseSha: process.env.QUESTURA_RELEASE_SHA || 'unknown',
       version: process.env.npm_package_version || 'unknown',
       database: {
         status: 'connected',
@@ -54,6 +55,7 @@ export async function GET(req: NextRequest) {
         status: 'unhealthy',
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV || 'development',
+        releaseSha: process.env.QUESTURA_RELEASE_SHA || 'unknown',
         error: error instanceof Error ? error.message : 'Unknown error',
         database: {
           status: 'disconnected',


### PR DESCRIPTION
## What changed

- adds runtime release SHA to Payload health responses, including unhealthy DB responses
- adds a dynamic client health endpoint with the same release identity
- tests DB health + release identity behavior and ambient-env isolation

## Why

Atomic deployment must verify that each restarted process is serving the exact target commit, not merely that some old process still returns 200.

## Validation

- server health tests: 3 passing, including ambient `QUESTURA_RELEASE_SHA` isolation
- server full suite: 90 files / 579 tests
- server and client production builds
- live local client process returned `{"status":"healthy","releaseSha":"release-test"}`
- server lint: 0 errors, 5 existing warnings
- `git diff --check`
