### PR TITLE
ops(questura): add atomic release switching and rollback

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -32,7 +32,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
-    "test:softprod": "bash ../../infra/softprod/deploy.test.sh",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts"
   },
   "dependencies": {

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -69,3 +69,23 @@ test command. Run the shell suite alone with:
 ```bash
 pnpm --dir apps/questura/apps/server test:softprod
 ```
+
+## Code rollback
+
+`release-lib.sh` activates server and client releases by atomically replacing
+their `current-*` symlinks. A component restart must report both `healthy` and
+the exact target commit from its local and public `/api/health` endpoints. On
+failure, activation restores the prior symlink, restarts it, and checks it too.
+
+After release-based host units are installed, swap current and previous code:
+
+```bash
+~/questura/app/apps/questura/infra/softprod/rollback.sh all
+```
+
+`all` rolls back client first, then server. If client rollback fails, server
+stays untouched while restoration of the original client is attempted. If
+server rollback fails, client is reconciled with whichever release the server
+actually retained. Rollback first requires both current pointers and both
+`previous-*` pointers to identify matching commits, and never runs a Payload
+`down()` migration; database schema stays forward-only.

--- a/apps/questura/infra/softprod/release-lib.sh
+++ b/apps/questura/infra/softprod/release-lib.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Shared atomic release activation helpers. Source from deploy/rollback scripts.
+
+SOFTPROD_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+SOFTPROD_RELEASES=${QUESTURA_RELEASES_ROOT:-"$SOFTPROD_ROOT/releases"}
+SOFTPROD_HEALTH_ATTEMPTS=${QUESTURA_HEALTH_ATTEMPTS:-30}
+SOFTPROD_HEALTH_SLEEP_SECONDS=${QUESTURA_HEALTH_SLEEP_SECONDS:-3}
+
+canonical_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+require_release_directory() {
+  local candidate root
+  candidate=$(canonical_path "$1") || return
+  root=$(canonical_path "$SOFTPROD_RELEASES") || return
+
+  if [[ ! -d $candidate || $candidate != "$root/"* ]]; then
+    echo "ERROR: release target is outside $root: $candidate" >&2
+    return 1
+  fi
+}
+
+require_component_release_directory() {
+  local component=$1
+  local candidate=$2
+  local canonical root release_directory release_name expected_suffix
+
+  canonical=$(canonical_path "$candidate") || return
+  root=$(canonical_path "$SOFTPROD_RELEASES") || return
+  expected_suffix="/apps/questura/apps/$component"
+
+  if [[ $canonical != *"$expected_suffix" ]]; then
+    echo "ERROR: target is not a $component release directory: $canonical" >&2
+    return 1
+  fi
+  release_directory=${canonical%"$expected_suffix"}
+  if [[ $release_directory != "$root/"* ]]; then
+    echo "ERROR: target is outside release root: $canonical" >&2
+    return 1
+  fi
+  release_name=${release_directory#"$root/"}
+  if [[ $release_name == */* || ! $release_name =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: release directory must be named by full commit SHA: $canonical" >&2
+    return 1
+  fi
+}
+
+release_sha() {
+  local release_directory=$1
+  local metadata="$release_directory/.env.release"
+  local matches count canonical root relative directory_sha
+
+  require_release_directory "$release_directory" || return
+  canonical=$(canonical_path "$release_directory") || return
+  root=$(canonical_path "$SOFTPROD_RELEASES") || return
+  relative=${canonical#"$root/"}
+  directory_sha=${relative%%/*}
+  if [[ ! -f $metadata ]]; then
+    echo "ERROR: release metadata is missing: $metadata" >&2
+    return 1
+  fi
+
+  matches=$(grep -E '^QUESTURA_RELEASE_SHA=[0-9a-f]{40}$' "$metadata" || true)
+  count=$(grep -c . <<< "$matches" || true)
+  if [[ $count != 1 ]]; then
+    echo "ERROR: release metadata must contain exactly one full commit SHA: $metadata" >&2
+    return 1
+  fi
+  matches=${matches#QUESTURA_RELEASE_SHA=}
+  if [[ $matches != "$directory_sha" ]]; then
+    echo "ERROR: release metadata SHA does not match directory SHA: $metadata" >&2
+    return 1
+  fi
+  printf '%s\n' "$matches"
+}
+
+atomic_symlink() {
+  local target=$1
+  local link=$2
+
+  python3 - "$target" "$link" <<'PY'
+import os
+import pathlib
+import sys
+import uuid
+
+target, link = sys.argv[1:]
+destination = pathlib.Path(link)
+destination.parent.mkdir(parents=True, exist_ok=True)
+temporary = destination.parent / f'.{destination.name}.swap.{uuid.uuid4().hex}'
+
+try:
+    os.symlink(target, temporary)
+    os.replace(temporary, destination)
+finally:
+    try:
+        temporary.unlink()
+    except FileNotFoundError:
+        pass
+PY
+}
+
+health_response_matches() {
+  local expected_sha=$1
+  python3 -c '
+import json
+import sys
+try:
+    body = json.load(sys.stdin)
+except (json.JSONDecodeError, UnicodeDecodeError):
+    raise SystemExit(1)
+valid = isinstance(body, dict) and body.get("status") == "healthy" and body.get("releaseSha") == sys.argv[1]
+raise SystemExit(0 if valid else 1)
+' "$expected_sha"
+}
+
+wait_for_release_health() {
+  local label=$1
+  local url=$2
+  local expected_sha=$3
+  local attempt body
+
+  for attempt in $(seq 1 "$SOFTPROD_HEALTH_ATTEMPTS"); do
+    body=$(curl --fail --silent --show-error --max-time 10 "$url" 2>/dev/null || true)
+    if health_response_matches "$expected_sha" <<< "$body"; then
+      echo "    $label healthy at ${expected_sha:0:12}"
+      return 0
+    fi
+    sleep "$SOFTPROD_HEALTH_SLEEP_SECONDS"
+  done
+
+  echo "ERROR: $label did not report release ${expected_sha:0:12}: $url" >&2
+  return 1
+}
+
+component_unit() {
+  case "$1" in
+    server) printf '%s\n' questura-server ;;
+    client) printf '%s\n' questura-client ;;
+    *) echo "ERROR: unknown component: $1" >&2; return 1 ;;
+  esac
+}
+
+verify_component() {
+  local component=$1
+  local expected_sha=$2
+
+  case "$component" in
+    server)
+      wait_for_release_health "local server" "http://127.0.0.1:4000/api/health" "$expected_sha" &&
+        wait_for_release_health "public server" "https://cms.questurian.com/api/health" "$expected_sha"
+      ;;
+    client)
+      wait_for_release_health "local client" "http://127.0.0.1:3000/api/health" "$expected_sha" &&
+        wait_for_release_health "public client" "https://www.questurian.com/api/health" "$expected_sha"
+      ;;
+    *) echo "ERROR: unknown component: $component" >&2; return 1 ;;
+  esac
+}
+
+restore_component() {
+  local component=$1
+  local directory=$2
+  local expected_sha=$3
+  local current_link="$SOFTPROD_ROOT/current-$component"
+  local unit
+
+  unit=$(component_unit "$component") || return
+  if ! atomic_symlink "$directory" "$current_link"; then
+    echo "CRITICAL: failed to restore $component release link to ${expected_sha:0:12}." >&2
+    return 1
+  fi
+  if ! systemctl --user restart "$unit"; then
+    echo "CRITICAL: failed to restart restored $component release ${expected_sha:0:12}." >&2
+    return 1
+  fi
+  if ! verify_component "$component" "$expected_sha"; then
+    echo "CRITICAL: restored $component release is unhealthy." >&2
+    return 1
+  fi
+}
+
+activate_release() {
+  local component=$1
+  local target=$2
+  local current_link="$SOFTPROD_ROOT/current-$component"
+  local previous_link="$SOFTPROD_ROOT/previous-$component"
+  local current target_sha current_sha unit
+
+  require_component_release_directory "$component" "$target" || return
+  target=$(canonical_path "$target") || return
+  target_sha=$(release_sha "$target") || return
+  unit=$(component_unit "$component") || return
+
+  if [[ ! -L $current_link ]]; then
+    echo "ERROR: current release link is missing: $current_link" >&2
+    return 1
+  fi
+  current=$(canonical_path "$current_link") || return
+  require_component_release_directory "$component" "$current" || return
+  current_sha=$(release_sha "$current") || return
+
+  if [[ $current == "$target" ]]; then
+    if ! systemctl --user restart "$unit"; then
+      echo "ERROR: failed to restart current $component release ${target_sha:0:12}." >&2
+      return 1
+    fi
+    verify_component "$component" "$target_sha" || return
+    return 0
+  fi
+
+  atomic_symlink "$target" "$current_link" || return
+  if ! systemctl --user restart "$unit" || ! verify_component "$component" "$target_sha"; then
+    echo "Activation failed; restoring $component release ${current_sha:0:12}." >&2
+    restore_component "$component" "$current" "$current_sha" || true
+    return 1
+  fi
+
+  if ! atomic_symlink "$current" "$previous_link"; then
+    echo "Activation bookkeeping failed; restoring $component release ${current_sha:0:12}." >&2
+    restore_component "$component" "$current" "$current_sha" || true
+    return 1
+  fi
+}

--- a/apps/questura/infra/softprod/release-lib.test.sh
+++ b/apps/questura/infra/softprod/release-lib.test.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+export QUESTURA_DEPLOY_ROOT="$TEST_ROOT/host"
+export QUESTURA_RELEASES_ROOT="$QUESTURA_DEPLOY_ROOT/releases"
+export QUESTURA_HEALTH_ATTEMPTS=1
+export QUESTURA_HEALTH_SLEEP_SECONDS=0
+export TEST_COMMAND_LOG="$TEST_ROOT/commands.log"
+FAKE_BIN="$TEST_ROOT/bin"
+mkdir -p "$QUESTURA_RELEASES_ROOT" "$FAKE_BIN"
+
+make_release() {
+  local sha=$1
+  local component=$2
+  local directory="$QUESTURA_RELEASES_ROOT/$sha/apps/questura/apps/$component"
+  mkdir -p "$directory"
+  printf 'QUESTURA_RELEASE_SHA=%s\n' "$sha" > "$directory/.env.release"
+  printf '%s\n' "$directory"
+}
+
+OLD_SHA=1111111111111111111111111111111111111111
+NEW_SHA=2222222222222222222222222222222222222222
+OLD_SERVER=$(make_release "$OLD_SHA" server)
+NEW_SERVER=$(make_release "$NEW_SHA" server)
+OLD_CLIENT=$(make_release "$OLD_SHA" client)
+NEW_CLIENT=$(make_release "$NEW_SHA" client)
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s|%s\\n" "$(basename "$0")" "$*" >> "$TEST_COMMAND_LOG"' \
+  'if [[ -n ${SABOTAGE_CLIENT_LINK_MARKER:-} && $* == *questura-client* && ! -e $SABOTAGE_CLIENT_LINK_MARKER ]]; then touch "$SABOTAGE_CLIENT_LINK_MARKER"; unlink "$QUESTURA_DEPLOY_ROOT/current-client"; mkdir "$QUESTURA_DEPLOY_ROOT/current-client"; exit 75; fi' \
+  'if [[ -n ${FAIL_RESTART_MARKER:-} && ! -e $FAIL_RESTART_MARKER ]]; then touch "$FAIL_RESTART_MARKER"; exit 74; fi' > "$FAKE_BIN/systemctl"
+chmod +x "$FAKE_BIN/systemctl"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [[ -n ${FAKE_HEALTH_SHA:-} ]]; then sha=$FAKE_HEALTH_SHA' \
+  'elif [[ $* == *cms.questurian.com* || $* == *127.0.0.1:4000* ]]; then . "$QUESTURA_DEPLOY_ROOT/current-server/.env.release"; sha=$QUESTURA_RELEASE_SHA' \
+  'else . "$QUESTURA_DEPLOY_ROOT/current-client/.env.release"; sha=$QUESTURA_RELEASE_SHA; fi' \
+  'if [[ ${FAIL_PUBLIC_SERVER_HEALTH:-0} == 1 && $* == *cms.questurian.com* ]]; then sha=ffffffffffffffffffffffffffffffffffffffff; fi' \
+  'if [[ -n ${FAIL_SERVER_SHA:-} && ($* == *cms.questurian.com* || $* == *127.0.0.1:4000*) && $sha == "$FAIL_SERVER_SHA" ]]; then sha=ffffffffffffffffffffffffffffffffffffffff; fi' \
+  'if [[ -n ${FAIL_CLIENT_SHA:-} && ($* == *www.questurian.com* || $* == *127.0.0.1:3000*) && $sha == "$FAIL_CLIENT_SHA" ]]; then sha=ffffffffffffffffffffffffffffffffffffffff; fi' \
+  'printf '\''{"status":"healthy","releaseSha":"%s"}'\'' "$sha"' > "$FAKE_BIN/curl"
+chmod +x "$FAKE_BIN/curl"
+
+printf '%s\n' '#!/usr/bin/env bash' 'exit "${FAKE_FLOCK_EXIT:-0}"' > "$FAKE_BIN/flock"
+chmod +x "$FAKE_BIN/flock"
+export PATH="$FAKE_BIN:$PATH"
+
+# shellcheck source=release-lib.sh
+. "$SCRIPT_DIR/release-lib.sh"
+
+printf '{"status":"healthy","releaseSha":"%s"}\n' "$NEW_SHA" |
+  health_response_matches "$NEW_SHA"
+if printf '{"status":"healthy","releaseSha":"wrong"}\n' |
+    health_response_matches "$NEW_SHA"; then
+  echo 'health matcher accepted wrong SHA' >&2
+  exit 1
+fi
+
+atomic_symlink "$OLD_SERVER" "$SOFTPROD_ROOT/current-server"
+export FAKE_HEALTH_SHA="$NEW_SHA"
+activate_release server "$NEW_SERVER"
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$NEW_SERVER" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/previous-server") == "$OLD_SERVER" ]]
+grep -q 'systemctl|--user restart questura-server' "$TEST_COMMAND_LOG"
+
+# Same-target activation must preserve previous rollback target.
+activate_release server "$NEW_SERVER"
+[[ $(canonical_path "$SOFTPROD_ROOT/previous-server") == "$OLD_SERVER" ]]
+
+# Failed activation restores current link and does not overwrite previous.
+export FAKE_HEALTH_SHA=ffffffffffffffffffffffffffffffffffffffff
+if activate_release server "$OLD_SERVER" > "$TEST_ROOT/failure.out" 2> "$TEST_ROOT/failure.err"; then
+  echo 'activation unexpectedly succeeded with wrong health SHA' >&2
+  exit 1
+fi
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$NEW_SERVER" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/previous-server") == "$OLD_SERVER" ]]
+grep -q 'Activation failed; restoring server release' "$TEST_ROOT/failure.err"
+unset FAKE_HEALTH_SHA
+
+# Restart failure after symlink switch restores old release before returning.
+atomic_symlink "$OLD_SERVER" "$SOFTPROD_ROOT/current-server"
+atomic_symlink "$NEW_SERVER" "$SOFTPROD_ROOT/previous-server"
+export FAIL_RESTART_MARKER="$TEST_ROOT/restart-failed"
+if activate_release server "$NEW_SERVER" > "$TEST_ROOT/restart.out" 2> "$TEST_ROOT/restart.err"; then
+  echo 'activation unexpectedly succeeded after restart failure' >&2
+  exit 1
+fi
+unset FAIL_RESTART_MARKER
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$OLD_SERVER" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/previous-server") == "$NEW_SERVER" ]]
+grep -q 'Activation failed; restoring server release' "$TEST_ROOT/restart.err"
+
+# Public mismatch fails activation even when local health matches target.
+export FAIL_PUBLIC_SERVER_HEALTH=1
+if activate_release server "$NEW_SERVER" > "$TEST_ROOT/public.out" 2> "$TEST_ROOT/public.err"; then
+  echo 'activation ignored public health mismatch' >&2
+  exit 1
+fi
+unset FAIL_PUBLIC_SERVER_HEALTH
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$OLD_SERVER" ]]
+grep -q 'public server did not report release' "$TEST_ROOT/public.err"
+
+# Bookkeeping failure restores component instead of reporting ambiguous state.
+unlink "$SOFTPROD_ROOT/previous-server"
+mkdir "$SOFTPROD_ROOT/previous-server"
+if activate_release server "$NEW_SERVER" > "$TEST_ROOT/bookkeeping.out" 2> "$TEST_ROOT/bookkeeping.err"; then
+  echo 'activation ignored previous-link bookkeeping failure' >&2
+  exit 1
+fi
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$OLD_SERVER" ]]
+grep -q 'Activation bookkeeping failed' "$TEST_ROOT/bookkeeping.err"
+rmdir "$SOFTPROD_ROOT/previous-server"
+
+OUTSIDE="$TEST_ROOT/outside"
+mkdir -p "$OUTSIDE"
+if require_release_directory "$OUTSIDE" 2> "$TEST_ROOT/outside.err"; then
+  echo 'outside release target accepted' >&2
+  exit 1
+fi
+grep -q 'outside' "$TEST_ROOT/outside.err"
+
+MALFORMED_SHA=3333333333333333333333333333333333333333
+MALFORMED=$(make_release "$MALFORMED_SHA" server)
+printf '%s\n' 'QUESTURA_RELEASE_SHA=short' > "$MALFORMED/.env.release"
+if release_sha "$MALFORMED" 2> "$TEST_ROOT/metadata.err"; then
+  echo 'malformed release metadata accepted' >&2
+  exit 1
+fi
+grep -q 'exactly one full commit SHA' "$TEST_ROOT/metadata.err"
+
+MISSING_SHA=5555555555555555555555555555555555555555
+MISSING=$(make_release "$MISSING_SHA" server)
+unlink "$MISSING/.env.release"
+if release_sha "$MISSING" 2> "$TEST_ROOT/missing-metadata.err"; then
+  echo 'release without metadata accepted' >&2
+  exit 1
+fi
+grep -q 'release metadata is missing' "$TEST_ROOT/missing-metadata.err"
+
+MISMATCH_SHA=4444444444444444444444444444444444444444
+MISMATCH=$(make_release "$MISMATCH_SHA" server)
+printf 'QUESTURA_RELEASE_SHA=%s\n' "$NEW_SHA" > "$MISMATCH/.env.release"
+if release_sha "$MISMATCH" 2> "$TEST_ROOT/mismatch.err"; then
+  echo 'mismatched release directory and metadata accepted' >&2
+  exit 1
+fi
+grep -q 'does not match directory SHA' "$TEST_ROOT/mismatch.err"
+
+if require_component_release_directory server "$NEW_CLIENT" 2> "$TEST_ROOT/component.err"; then
+  echo 'client release accepted as server release' >&2
+  exit 1
+fi
+grep -q 'not a server release directory' "$TEST_ROOT/component.err"
+
+# Manual rollback swaps current and previous through the same checked activator.
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$OLD_CLIENT" "$SOFTPROD_ROOT/previous-client"
+"$SCRIPT_DIR/rollback.sh" client > "$TEST_ROOT/rollback.out"
+[[ $(canonical_path "$SOFTPROD_ROOT/current-client") == "$OLD_CLIENT" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/previous-client") == "$NEW_CLIENT" ]]
+grep -q 'Database remains on its current forward-migrated schema' "$TEST_ROOT/rollback.out"
+
+# All-component rollback is client-first and leaves both on previous SHA.
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$OLD_CLIENT" "$SOFTPROD_ROOT/previous-client"
+atomic_symlink "$NEW_SERVER" "$SOFTPROD_ROOT/current-server"
+atomic_symlink "$OLD_SERVER" "$SOFTPROD_ROOT/previous-server"
+: > "$TEST_COMMAND_LOG"
+"$SCRIPT_DIR/rollback.sh" all > "$TEST_ROOT/rollback-all.out"
+[[ $(canonical_path "$SOFTPROD_ROOT/current-client") == "$OLD_CLIENT" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$OLD_SERVER" ]]
+client_restart=$(grep -n 'restart questura-client' "$TEST_COMMAND_LOG" | head -1 | cut -d: -f1)
+server_restart=$(grep -n 'restart questura-server' "$TEST_COMMAND_LOG" | head -1 | cut -d: -f1)
+((client_restart < server_restart))
+
+# Mixed previous pointers abort before either component changes.
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$OLD_CLIENT" "$SOFTPROD_ROOT/previous-client"
+atomic_symlink "$NEW_SERVER" "$SOFTPROD_ROOT/current-server"
+atomic_symlink "$NEW_SERVER" "$SOFTPROD_ROOT/previous-server"
+: > "$TEST_COMMAND_LOG"
+if "$SCRIPT_DIR/rollback.sh" all > "$TEST_ROOT/mixed.out" 2> "$TEST_ROOT/mixed.err"; then
+  echo 'all rollback accepted mismatched previous release SHAs' >&2
+  exit 1
+fi
+[[ $(canonical_path "$SOFTPROD_ROOT/current-client") == "$NEW_CLIENT" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$NEW_SERVER" ]]
+[[ ! -s $TEST_COMMAND_LOG ]]
+grep -q 'do not form one deploy' "$TEST_ROOT/mixed.err"
+
+# Failed server rollback moves client forward again; pair stays aligned.
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$OLD_CLIENT" "$SOFTPROD_ROOT/previous-client"
+atomic_symlink "$NEW_SERVER" "$SOFTPROD_ROOT/current-server"
+atomic_symlink "$OLD_SERVER" "$SOFTPROD_ROOT/previous-server"
+export FAIL_SERVER_SHA="$OLD_SHA"
+if "$SCRIPT_DIR/rollback.sh" all > "$TEST_ROOT/compensate.out" 2> "$TEST_ROOT/compensate.err"; then
+  echo 'all rollback unexpectedly succeeded with failed server health' >&2
+  exit 1
+fi
+unset FAIL_SERVER_SHA
+[[ $(canonical_path "$SOFTPROD_ROOT/current-client") == "$NEW_CLIENT" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$NEW_SERVER" ]]
+grep -q 'restoring client to match' "$TEST_ROOT/compensate.err"
+
+# Failed client rollback restores original client and never touches server.
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$OLD_CLIENT" "$SOFTPROD_ROOT/previous-client"
+atomic_symlink "$NEW_SERVER" "$SOFTPROD_ROOT/current-server"
+atomic_symlink "$OLD_SERVER" "$SOFTPROD_ROOT/previous-server"
+: > "$TEST_COMMAND_LOG"
+export FAIL_CLIENT_SHA="$OLD_SHA"
+if "$SCRIPT_DIR/rollback.sh" all > "$TEST_ROOT/client-failure.out" 2> "$TEST_ROOT/client-failure.err"; then
+  echo 'all rollback unexpectedly succeeded with failed client health' >&2
+  exit 1
+fi
+unset FAIL_CLIENT_SHA
+[[ $(canonical_path "$SOFTPROD_ROOT/current-client") == "$NEW_CLIENT" ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$NEW_SERVER" ]]
+! grep -q 'restart questura-server' "$TEST_COMMAND_LOG"
+grep -q 'Server was not changed' "$TEST_ROOT/client-failure.err"
+
+# Corrupted client link makes restoration fail loudly; server stays untouched.
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$OLD_CLIENT" "$SOFTPROD_ROOT/previous-client"
+: > "$TEST_COMMAND_LOG"
+export SABOTAGE_CLIENT_LINK_MARKER="$TEST_ROOT/client-link-sabotaged"
+if "$SCRIPT_DIR/rollback.sh" all > "$TEST_ROOT/client-restore.out" 2> "$TEST_ROOT/client-restore.err"; then
+  echo 'all rollback ignored client restoration failure' >&2
+  exit 1
+fi
+unset SABOTAGE_CLIENT_LINK_MARKER
+[[ -d $SOFTPROD_ROOT/current-client && ! -L $SOFTPROD_ROOT/current-client ]]
+[[ $(canonical_path "$SOFTPROD_ROOT/current-server") == "$NEW_SERVER" ]]
+! grep -q 'restart questura-server' "$TEST_COMMAND_LOG"
+grep -q 'original client restoration failed; server remains untouched' "$TEST_ROOT/client-restore.err"
+rmdir "$SOFTPROD_ROOT/current-client"
+atomic_symlink "$NEW_CLIENT" "$SOFTPROD_ROOT/current-client"
+
+export FAKE_FLOCK_EXIT=73
+if "$SCRIPT_DIR/rollback.sh" client > "$TEST_ROOT/lock.out" 2> "$TEST_ROOT/lock.err"; then
+  echo 'rollback ignored lock contention' >&2
+  exit 1
+fi
+unset FAKE_FLOCK_EXIT
+grep -q 'already running' "$TEST_ROOT/lock.err"
+
+echo 'release switching tests passed'

--- a/apps/questura/infra/softprod/rollback.sh
+++ b/apps/questura/infra/softprod/rollback.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Swap current and previous code releases. Database migrations are never reversed.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=release-lib.sh
+. "$SCRIPT_DIR/release-lib.sh"
+
+usage() {
+  echo "Usage: $0 server|client|all" >&2
+  exit 2
+}
+
+previous_target() {
+  local component=$1
+  local previous_link="$SOFTPROD_ROOT/previous-$component"
+  local target
+
+  if [[ ! -L $previous_link ]]; then
+    echo "ERROR: previous release link is missing: $previous_link" >&2
+    return 1
+  fi
+  target=$(canonical_path "$previous_link") || return
+  require_component_release_directory "$component" "$target" || return
+  printf '%s\n' "$target"
+}
+
+current_target() {
+  local component=$1
+  local current_link="$SOFTPROD_ROOT/current-$component"
+  local target
+
+  if [[ ! -L $current_link ]]; then
+    echo "ERROR: current release link is missing: $current_link" >&2
+    return 1
+  fi
+  target=$(canonical_path "$current_link") || return
+  require_component_release_directory "$component" "$target" || return
+  printf '%s\n' "$target"
+}
+
+rollback_component_to() {
+  local component=$1
+  local target=$2
+  local target_sha
+
+  target_sha=$(release_sha "$target") || return
+  echo "==> Rolling back $component to ${target_sha:0:12}"
+  activate_release "$component" "$target" || return
+}
+
+rollback_component() {
+  local component=$1
+  local target
+  target=$(previous_target "$component") || return
+  rollback_component_to "$component" "$target"
+}
+
+if (($# != 1)); then usage; fi
+
+exec 9>"$SOFTPROD_ROOT/deploy.lock"
+if ! flock -n 9; then
+  echo "ERROR: a Questura deploy or rollback is already running" >&2
+  exit 1
+fi
+
+case "$1" in
+  server) rollback_component server ;;
+  client) rollback_component client ;;
+  all)
+    original_client_target=$(current_target client) || exit 1
+    original_server_target=$(current_target server) || exit 1
+    original_client_sha=$(release_sha "$original_client_target") || exit 1
+    original_server_sha=$(release_sha "$original_server_target") || exit 1
+    if [[ $original_client_sha != "$original_server_sha" ]]; then
+      echo "ERROR: current client/server releases are already mismatched: ${original_client_sha:0:12} != ${original_server_sha:0:12}" >&2
+      exit 1
+    fi
+
+    client_target=$(previous_target client) || exit 1
+    server_target=$(previous_target server) || exit 1
+    client_sha=$(release_sha "$client_target") || exit 1
+    server_sha=$(release_sha "$server_target") || exit 1
+    if [[ $client_sha != "$server_sha" ]]; then
+      echo "ERROR: client/server previous releases do not form one deploy: ${client_sha:0:12} != ${server_sha:0:12}" >&2
+      exit 1
+    fi
+
+    if ! rollback_component_to client "$client_target"; then
+      echo "Client rollback failed; restoring original client before aborting. Server was not changed." >&2
+      if client_now_target=$(current_target client 2>/dev/null); then
+        client_now_sha=$(release_sha "$client_now_target" 2>/dev/null || true)
+        if [[ -n $client_now_sha ]]; then
+          echo "Client link currently identifies ${client_now_sha:0:12}." >&2
+        fi
+      else
+        echo "CRITICAL: cannot identify client release after failed rollback." >&2
+      fi
+      if ! restore_component client "$original_client_target" "$original_client_sha"; then
+        echo "CRITICAL: original client restoration failed; server remains untouched." >&2
+      fi
+      exit 1
+    fi
+    if ! rollback_component_to server "$server_target"; then
+      server_now_target=$(current_target server) || {
+        echo "CRITICAL: cannot identify server release after failed rollback." >&2
+        exit 1
+      }
+      server_now_sha=$(release_sha "$server_now_target") || {
+        echo "CRITICAL: cannot identify server SHA after failed rollback." >&2
+        exit 1
+      }
+
+      if [[ $server_now_sha == "$server_sha" ]]; then
+        echo "Server rollback failed but its link remains on target; leaving client on matching target." >&2
+      elif [[ $server_now_sha == "$original_server_sha" ]]; then
+        echo "Server rollback failed and restored original link; restoring client to match." >&2
+        client_forward_target=$(previous_target client) || exit 1
+        client_forward_sha=$(release_sha "$client_forward_target") || exit 1
+        if [[ $client_forward_sha != "$original_server_sha" ]]; then
+          echo "CRITICAL: client forward target does not match restored server." >&2
+          exit 1
+        fi
+        if ! rollback_component_to client "$client_forward_target"; then
+          echo "CRITICAL: client restoration also failed; components may be on mismatched releases." >&2
+        fi
+      else
+        echo "CRITICAL: server now points at unexpected release ${server_now_sha:0:12}; client was not changed again." >&2
+      fi
+      exit 1
+    fi
+    ;;
+  *) usage ;;
+esac
+
+echo "Rollback complete. Database remains on its current forward-migrated schema."


### PR DESCRIPTION
## Summary
- add validated commit-addressed release activation helpers
- require exact local/public release identity before activation succeeds
- add paired, forward-schema-only rollback with failure compensation
- wire focused regression suite into `test:softprod`

## Validation
- `bash -n apps/questura/infra/softprod/release-lib.sh apps/questura/infra/softprod/rollback.sh apps/questura/infra/softprod/release-lib.test.sh`
- `apps/questura/infra/softprod/release-lib.test.sh`
- `pnpm --dir apps/questura/apps/server test:softprod`
- `git diff --check origin/main...HEAD`
- independent spec review: no findings
- independent standards review: no findings

ShellCheck unavailable locally.