### PR TITLE
ops(questura): keep ISR cache memory-only

### DIFF
--- a/apps/questura/apps/client/next.config.ts
+++ b/apps/questura/apps/client/next.config.ts
@@ -6,6 +6,11 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 const nextConfig: NextConfig = {
   // Frontend calls backend directly at NEXT_PUBLIC_BACKEND_URL
   // No API proxy needed - cookies work natively on same domain (localhost or questurian.com)
+  // Keep ISR output in memory so production traffic cannot mutate immutable
+  // commit-addressed release artifacts under .next/server/{app,pages}.
+  experimental: {
+    isrFlushToDisk: false,
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
- disable Next ISR disk flushes
- keep commit-addressed release artifacts immutable during on-demand revalidation
- image/fetch cache remains under `.next/cache` for runtime ownership

## Validation
- `pnpm --dir apps/questura/apps/client build`
- `git diff --check origin/main...HEAD`