### PR TITLE
ops(questura): deploy immutable commit releases

### DIFF
--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -10,16 +10,30 @@ Normal deploy:
 ssh linux-laptop '~/questura/deploy.sh'
 ```
 
+Deployment publishes an immutable snapshot at `~/questura/releases/<full-sha>`.
+Only tracked files from that exact commit enter the snapshot; host secrets stay
+in `~/questura/config/{server,client}.env` and are linked into the release.
 Deployment order is intentional:
 
-1. Install dependencies from the committed lockfile.
-2. Build, test, and lint the server.
-3. Inspect pending migration `up()` bodies and block risky SQL by default.
-4. Run migrations and prove none remain pending.
-5. Restart the server and verify its DB-backed health endpoint locally and
-   through Cloudflare.
-6. Build the client while the server is publicly reachable, restart it, and
-   verify the public site.
+1. Require aligned `current-server` and `current-client` release pointers.
+2. Extract the exact Git commit into private staging; link explicit config.
+3. Install locked dependencies; build, test, and lint the server off-line.
+4. Atomically publish the server-ready release.
+5. Inspect migration `up()` bodies, migrate forward, and prove none remain.
+6. Activate server; require its exact commit locally and through Cloudflare.
+7. Build client against that server, activate it, then require the same exact
+   commit from both client endpoints.
+
+Failure before publication removes staging without touching live links. Any
+failure after server activation but before client activation restores original
+client/server links and their paired rollback history. `SIGINT` and `SIGTERM`
+use the same cleanup path. Published partial releases remain for safe retry.
+Config and artifact fingerprints reject drift, corruption, or build-time config
+races when a commit is reused; runtime dependencies are certified too. Next ISR
+disk writes are disabled so regenerated pages cannot mutate certified release
+artifacts; image/fetch caches under `.next/cache` remain runtime-owned. Make a
+new commit for intentional config changes. Database schema is never migrated
+backward.
 
 ## Reviewed migrations
 
@@ -57,9 +71,9 @@ Install the wrapper. Installer preserves any existing copy under
 ~/questura/app/apps/questura/infra/softprod/install-deploy-wrapper.sh
 ```
 
-This baseline still builds inside deployment checkout. Do not install it alone
-on soft production; adopt it together with atomic-release units from follow-up
-PR so a failed build cannot damage live `.next` files.
+Deploy requires release-based host units and aligned `current-*` pointers.
+Install/adopt those through host-bootstrap tooling before replacing current
+wrapper. Until then, existing host deploy path remains unchanged.
 
 ## Validation
 

--- a/apps/questura/infra/softprod/deploy.sh
+++ b/apps/questura/infra/softprod/deploy.sh
@@ -1,26 +1,103 @@
 #!/usr/bin/env bash
-# Build and restart Questura soft production from an already-synced checkout.
+# Build one commit-addressed release, migrate forward, then activate both parts.
 # Use host-deploy-wrapper.sh as the host entry point so code sync happens first.
 set -Eeuo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
+SOURCE_REPO=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
 DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
-QUESTURA_APPS="$REPO_ROOT/apps/questura/apps"
-SERVER="$QUESTURA_APPS/server"
-CLIENT="$QUESTURA_APPS/client"
+RELEASES_ROOT=${QUESTURA_RELEASES_ROOT:-"$DEPLOY_ROOT/releases"}
+CONFIG_ROOT=${QUESTURA_CONFIG_ROOT:-"$DEPLOY_ROOT/config"}
+TARGET_SHA=$(git -C "$SOURCE_REPO" rev-parse HEAD)
 stage=initialization
+reconcile_original_pair=0
+original_server_target=''
+original_client_target=''
+original_previous_server=''
+original_previous_client=''
+
+export QUESTURA_RELEASES_ROOT="$RELEASES_ROOT"
+# shellcheck source=release-lib.sh
+. "$SCRIPT_DIR/release-lib.sh"
+# shellcheck source=release-builder.sh
+. "$SCRIPT_DIR/release-builder.sh"
+
+previous_component_target() {
+  local component=$1
+  local link="$DEPLOY_ROOT/previous-$component"
+  local target
+
+  if [[ ! -e $link && ! -L $link ]]; then return 0; fi
+  if [[ ! -L $link ]]; then
+    echo "ERROR: previous release path is not a symlink: $link" >&2
+    return 1
+  fi
+  target=$(canonical_path "$link") || return
+  require_component_release_directory "$component" "$target" || return
+  printf '%s\n' "$target"
+}
+
+restore_previous_target() {
+  local component=$1
+  local target=$2
+  local link="$DEPLOY_ROOT/previous-$component"
+
+  if [[ -n $target ]]; then
+    atomic_symlink "$target" "$link" || return
+  elif [[ -L $link ]]; then
+    unlink "$link" || return
+  elif [[ -e $link ]]; then
+    echo "CRITICAL: previous release path cannot be restored: $link" >&2
+    return 1
+  fi
+}
+
+restore_original_pair() {
+  local failed=0 current_client current_server
+
+  echo "Target release did not commit; reconciling original client/server pair." >&2
+  if ! restore_component client "$original_client_target" "$original_client_sha"; then
+    echo "CRITICAL: original client restoration failed." >&2
+    failed=1
+  fi
+  if ! restore_component server "$original_server_target" "$original_server_sha"; then
+    echo "CRITICAL: original server restoration failed." >&2
+    failed=1
+  fi
+  if ! restore_previous_target client "$original_previous_client"; then failed=1; fi
+  if ! restore_previous_target server "$original_previous_server"; then failed=1; fi
+
+  current_client=$(canonical_path "$DEPLOY_ROOT/current-client" 2>/dev/null || true)
+  current_server=$(canonical_path "$DEPLOY_ROOT/current-server" 2>/dev/null || true)
+  echo "Current links after reconciliation: client=${current_client:-unknown} server=${current_server:-unknown}" >&2
+  ((failed == 0))
+}
 
 report_failure() {
-  local exit_code=$?
+  local exit_code=${1:-1}
+  trap - ERR INT TERM
+  if ! cleanup_release_staging; then
+    echo "CRITICAL: failed to clean release staging directory." >&2
+  fi
   echo "ERROR: deploy failed during $stage (exit $exit_code)" >&2
+
+  if ((reconcile_original_pair == 1)); then
+    restore_original_pair || true
+  fi
   exit "$exit_code"
 }
-trap report_failure ERR
+trap 'report_failure "$?"' ERR
+trap 'report_failure 130' INT
+trap 'report_failure 143' TERM
 
 if (($# > 0)); then
   echo "ERROR: deploy.sh takes no arguments" >&2
   exit 2
+fi
+
+if [[ ! $TARGET_SHA =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: deployment target is not a full commit SHA: $TARGET_SHA" >&2
+  exit 1
 fi
 
 if [[ ${QUESTURA_DEPLOY_LOCK_HELD:-0} != 1 ]]; then
@@ -31,7 +108,7 @@ if [[ ${QUESTURA_DEPLOY_LOCK_HELD:-0} != 1 ]]; then
   fi
 fi
 
-if ! git -C "$REPO_ROOT" diff --quiet || ! git -C "$REPO_ROOT" diff --cached --quiet; then
+if ! git -C "$SOURCE_REPO" diff --quiet || ! git -C "$SOURCE_REPO" diff --cached --quiet; then
   echo "ERROR: deployment checkout has tracked changes" >&2
   exit 1
 fi
@@ -43,64 +120,54 @@ if [[ -s "$NVM_DIR/nvm.sh" ]]; then
   nvm use "${QUESTURA_NODE_VERSION:-22}" >/dev/null
 fi
 
-wait_for_healthy_server() {
-  local label=$1
-  local url=$2
-  local attempt body
+current_component_target() {
+  local component=$1
+  local link="$DEPLOY_ROOT/current-$component"
+  local target
 
-  for attempt in $(seq 1 30); do
-    body=$(curl --fail --silent --show-error --max-time 10 "$url" 2>/dev/null || true)
-    if [[ $body =~ \"status\"[[:space:]]*:[[:space:]]*\"healthy\" ]]; then
-      echo "    $label healthy"
-      return 0
-    fi
-    sleep 3
-  done
-
-  echo "ERROR: $label never became healthy: $url" >&2
-  return 1
+  if [[ ! -L $link ]]; then
+    echo "ERROR: release-based host units are not initialized: $link is missing" >&2
+    return 1
+  fi
+  target=$(canonical_path "$link") || return
+  require_component_release_directory "$component" "$target" || return
+  printf '%s\n' "$target"
 }
 
-wait_for_http_200() {
-  local label=$1
-  local url=$2
-  local attempt code
+stage="current release preflight"
+original_server_target=$(current_component_target server)
+original_client_target=$(current_component_target client)
+original_server_sha=$(release_sha "$original_server_target")
+original_client_sha=$(release_sha "$original_client_target")
+if [[ $original_server_sha != "$original_client_sha" ]]; then
+  echo "ERROR: current client/server releases are mismatched: ${original_client_sha:0:12} != ${original_server_sha:0:12}" >&2
+  exit 1
+fi
+original_previous_server=$(previous_component_target server)
+original_previous_client=$(previous_component_target client)
 
-  for attempt in $(seq 1 30); do
-    code=$(curl --location --silent --output /dev/null --write-out '%{http_code}' --max-time 10 "$url" || true)
-    if [[ $code == 200 ]]; then
-      echo "    $label reachable"
-      return 0
-    fi
-    sleep 3
-  done
+stage="server release preparation"
+echo "==> Preparing release ${TARGET_SHA:0:12}"
+prepare_server_release "$TARGET_SHA"
+RELEASE=$(canonical_path "$RELEASES_ROOT/$TARGET_SHA")
+SERVER="$RELEASE/apps/questura/apps/server"
+CLIENT="$RELEASE/apps/questura/apps/client"
+export QUESTURA_RELEASE_SHA="$TARGET_SHA"
 
-  echo "ERROR: $label never returned HTTP 200: $url" >&2
-  return 1
-}
-
-stage="dependency installation"
-echo "==> Installing locked dependencies (Questura workspaces only)"
-cd "$REPO_ROOT"
-pnpm install --frozen-lockfile --prod=false \
-  --filter "@questura/server..." \
-  --filter "@questura/client..."
-
-stage="server build"
-echo "==> Building server"
-cd "$SERVER"
-pnpm build
-
-stage="server tests"
-echo "==> Testing server"
-pnpm test
-
-stage="server lint"
-echo "==> Linting server"
-pnpm lint
+if [[ $original_server_target == "$SERVER" && $original_client_target == "$CLIENT" ]]; then
+  require_complete_release "$TARGET_SHA"
+  stage="existing release verification"
+  echo "==> Release already active; verifying exact identity"
+  verify_component server "$TARGET_SHA"
+  verify_component client "$TARGET_SHA"
+  systemctl --user is-active questura-server questura-client questura-tunnel
+  echo "Already deployed $TARGET_SHA."
+  exit 0
+fi
 
 stage="migration preflight"
 echo "==> Checking pending database migrations"
+cd "$SERVER"
 node scripts/deploy/check-pending-migrations.mjs
 
 stage="database migration"
@@ -108,28 +175,26 @@ echo "==> Running database migrations"
 pnpm db:migrate
 node scripts/deploy/check-pending-migrations.mjs --require-clean
 
-stage="server restart"
-echo "==> Restarting server"
-systemctl --user restart questura-server
-stage="server health checks"
-wait_for_healthy_server "local server" "http://127.0.0.1:4000/api/health"
-wait_for_healthy_server "public server" "https://cms.questurian.com/api/health"
+stage="server activation"
+echo "==> Activating server"
+validate_server_release "$TARGET_SHA"
+reconcile_original_pair=1
+activate_release server "$SERVER"
 
-# Client statically prerenders /articles from its public backend URL. Build only
-# after the new server is reachable through the Cloudflare tunnel.
-stage="client build"
-echo "==> Building client"
-cd "$CLIENT"
-pnpm build
+# Client may statically prerender backend data. Build only after target server
+# is reachable through public Cloudflare path and reports exact target SHA.
+stage="client release completion"
+echo "==> Completing client release"
+complete_client_release "$TARGET_SHA"
 
-stage="client restart"
-echo "==> Restarting client"
-systemctl --user restart questura-client
-stage="client health checks"
-wait_for_http_200 "local client" "http://127.0.0.1:3000/"
-wait_for_http_200 "public client" "https://www.questurian.com/"
+stage="client activation"
+echo "==> Activating client"
+require_complete_release "$TARGET_SHA"
+activate_release client "$CLIENT"
+reconcile_original_pair=0
 
-stage="unit status check"
-echo "==> Unit status"
+stage="final release verification"
+verify_component server "$TARGET_SHA"
+verify_component client "$TARGET_SHA"
 systemctl --user is-active questura-server questura-client questura-tunnel
-echo "Deployed $(git -C "$REPO_ROOT" rev-parse --short HEAD)."
+echo "Deployed $TARGET_SHA."

--- a/apps/questura/infra/softprod/deploy.test.sh
+++ b/apps/questura/infra/softprod/deploy.test.sh
@@ -2,20 +2,29 @@
 set -Eeuo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+CLIENT_CONFIG="$SCRIPT_DIR/../../apps/client/next.config.ts"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf -- "$TEST_ROOT"' EXIT
 
 REPO="$TEST_ROOT/repo"
 FAKE_BIN="$TEST_ROOT/bin"
 DEPLOY_ROOT="$TEST_ROOT/host"
+CONFIG_ROOT="$DEPLOY_ROOT/config"
 LOG="$TEST_ROOT/commands.log"
 mkdir -p \
   "$REPO/apps/questura/infra/softprod" \
   "$REPO/apps/questura/apps/server/scripts/deploy" \
   "$REPO/apps/questura/apps/client" \
   "$FAKE_BIN" \
-  "$DEPLOY_ROOT"
-cp "$SCRIPT_DIR/deploy.sh" "$REPO/apps/questura/infra/softprod/deploy.sh"
+  "$CONFIG_ROOT"
+cp \
+  "$SCRIPT_DIR/deploy.sh" \
+  "$SCRIPT_DIR/release-builder.sh" \
+  "$SCRIPT_DIR/release-lib.sh" \
+  "$REPO/apps/questura/infra/softprod/"
+printf '%s\n' '{"name":"@questura/server"}' > "$REPO/apps/questura/apps/server/package.json"
+printf '%s\n' 'export {}' > "$REPO/apps/questura/apps/server/scripts/deploy/check-pending-migrations.mjs"
+printf '%s\n' '{"name":"@questura/client"}' > "$REPO/apps/questura/apps/client/package.json"
 
 git -C "$REPO" init --quiet
 git -C "$REPO" config user.email deploy-test@example.invalid
@@ -27,6 +36,9 @@ git -C "$REPO" branch -M main
 git -C "$REPO" remote add origin "$TEST_ROOT/origin.git"
 git -C "$REPO" push --quiet -u origin main
 
+printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$CONFIG_ROOT/server.env"
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$CONFIG_ROOT/client.env"
+
 create_fake() {
   local command=$1
   local target="$FAKE_BIN/$command"
@@ -34,10 +46,26 @@ create_fake() {
     '#!/usr/bin/env bash' \
     'set -eu' \
     'printf "%s|%s|%s\\n" "$PWD" "$(basename "$0")" "$*" >> "$DEPLOY_TEST_LOG"' \
-    'if [[ $(basename "$0") == pnpm && $* == db:migrate && ${FAIL_MIGRATE:-0} == 1 ]]; then exit 42; fi' \
-    'if [[ $(basename "$0") == flock && ${FAIL_FLOCK:-0} == 1 ]]; then exit 73; fi' \
-    'if [[ $(basename "$0") == curl ]]; then' \
-    '  if [[ " $* " == *" --write-out "* ]]; then printf 200; else printf '\''{"status":"healthy"}'\''; fi' \
+    'name=$(basename "$0")' \
+    'if [[ $name == pnpm && $* == install* ]]; then mkdir -p "$PWD/node_modules/.pnpm/fake"; printf "certified dependency\\n" > "$PWD/node_modules/.pnpm/fake/runtime.js"; fi' \
+    'if [[ $name == pnpm && $PWD == */server && $* == build && ${FAIL_SERVER_BUILD:-0} == 1 ]]; then exit 41; fi' \
+    'if [[ $name == pnpm && $PWD == */server && $* == build && ${CHANGE_SERVER_CONFIG:-0} == 1 ]]; then printf "RACE=changed\\n" >> "$QUESTURA_CONFIG_ROOT/server.env"; fi' \
+    'if [[ $name == pnpm && $PWD == */server && $* == build && ${CHANGE_CLIENT_CONFIG_DURING_SERVER_BUILD:-0} == 1 ]]; then printf "CROSS_RACE=changed\\n" >> "$QUESTURA_CONFIG_ROOT/client.env"; fi' \
+    'if [[ $name == pnpm && $* == db:migrate && ${FAIL_MIGRATE:-0} == 1 ]]; then exit 42; fi' \
+    'if [[ $name == node && $* == *--require-clean* && ${CHANGE_SERVER_CONFIG_AFTER_MIGRATION:-0} == 1 ]]; then printf "POST_MIGRATION_RACE=changed\\n" >> "$QUESTURA_CONFIG_ROOT/server.env"; fi' \
+    'if [[ $name == pnpm && $PWD == */client && $* == build && ${FAIL_CLIENT_BUILD:-0} == 1 ]]; then exit 43; fi' \
+    'if [[ $name == pnpm && $PWD == */client && $* == build && ${CHANGE_SERVER_CONFIG_DURING_CLIENT_BUILD:-0} == 1 ]]; then printf "CROSS_RACE=changed\\n" >> "$QUESTURA_CONFIG_ROOT/server.env"; fi' \
+    'if [[ $name == pnpm && $PWD == */client && $* == build && ${SIGNAL_CLIENT_BUILD:-0} == 1 ]]; then kill -TERM "$PPID"; fi' \
+    'if [[ $name == flock && ${FAIL_FLOCK:-0} == 1 ]]; then exit 73; fi' \
+    'if [[ $name == systemctl && $* == *questura-client* && -n ${FAIL_CLIENT_ACTIVATION_SHA:-} ]]; then . "$QUESTURA_DEPLOY_ROOT/current-client/.env.release"; if [[ $QUESTURA_RELEASE_SHA == "$FAIL_CLIENT_ACTIVATION_SHA" && ! -e $QUESTURA_DEPLOY_ROOT/client-activation-failed ]]; then touch "$QUESTURA_DEPLOY_ROOT/client-activation-failed"; exit 75; fi; fi' \
+    'if [[ $name == systemctl && $* == *questura-server* && -n ${FAIL_SERVER_RESTORE_SHA:-} ]]; then . "$QUESTURA_DEPLOY_ROOT/current-server/.env.release"; if [[ $QUESTURA_RELEASE_SHA == "$FAIL_SERVER_RESTORE_SHA" ]]; then exit 76; fi; fi' \
+    'if [[ $name == curl ]]; then' \
+    '  if [[ $* == *127.0.0.1:4000* || $* == *cms.questurian.com* ]]; then' \
+    '    . "$QUESTURA_DEPLOY_ROOT/current-server/.env.release"' \
+    '  else' \
+    '    . "$QUESTURA_DEPLOY_ROOT/current-client/.env.release"' \
+    '  fi' \
+    '  printf '\''{"status":"healthy","releaseSha":"%s"}'\'' "$QUESTURA_RELEASE_SHA"' \
     'fi' > "$target"
   chmod +x "$target"
 }
@@ -46,15 +74,37 @@ for command in pnpm node systemctl curl flock; do
   create_fake "$command"
 done
 
+grep -q 'isrFlushToDisk: false' "$CLIENT_CONFIG"
+
+OLD_SHA=1111111111111111111111111111111111111111
+OLD_RELEASE="$DEPLOY_ROOT/releases/$OLD_SHA/apps/questura/apps"
+mkdir -p "$OLD_RELEASE/server" "$OLD_RELEASE/client"
+printf 'QUESTURA_RELEASE_SHA=%s\n' "$OLD_SHA" > "$OLD_RELEASE/server/.env.release"
+printf 'QUESTURA_RELEASE_SHA=%s\n' "$OLD_SHA" > "$OLD_RELEASE/client/.env.release"
+ln -s "$OLD_RELEASE/server" "$DEPLOY_ROOT/current-server"
+ln -s "$OLD_RELEASE/client" "$DEPLOY_ROOT/current-client"
+
 run_deploy() {
   env \
     PATH="$FAKE_BIN:$PATH" \
     NVM_DIR="$TEST_ROOT/no-nvm" \
     QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_CONFIG_ROOT="$CONFIG_ROOT" \
+    QUESTURA_HEALTH_ATTEMPTS=1 \
+    QUESTURA_HEALTH_SLEEP_SECONDS=0 \
     QUESTURA_DEPLOY_LOCK_HELD="${DEPLOY_LOCK_HELD:-0}" \
     DEPLOY_TEST_LOG="$LOG" \
+    FAIL_SERVER_BUILD="${FAIL_SERVER_BUILD:-0}" \
+    CHANGE_SERVER_CONFIG="${CHANGE_SERVER_CONFIG:-0}" \
+    CHANGE_CLIENT_CONFIG_DURING_SERVER_BUILD="${CHANGE_CLIENT_CONFIG_DURING_SERVER_BUILD:-0}" \
     FAIL_MIGRATE="${FAIL_MIGRATE:-0}" \
+    CHANGE_SERVER_CONFIG_AFTER_MIGRATION="${CHANGE_SERVER_CONFIG_AFTER_MIGRATION:-0}" \
+    FAIL_CLIENT_BUILD="${FAIL_CLIENT_BUILD:-0}" \
+    CHANGE_SERVER_CONFIG_DURING_CLIENT_BUILD="${CHANGE_SERVER_CONFIG_DURING_CLIENT_BUILD:-0}" \
+    SIGNAL_CLIENT_BUILD="${SIGNAL_CLIENT_BUILD:-0}" \
     FAIL_FLOCK="${FAIL_FLOCK:-0}" \
+    FAIL_CLIENT_ACTIVATION_SHA="${FAIL_CLIENT_ACTIVATION_SHA:-}" \
+    FAIL_SERVER_RESTORE_SHA="${FAIL_SERVER_RESTORE_SHA:-}" \
     "$REPO/apps/questura/infra/softprod/deploy.sh"
 }
 
@@ -63,39 +113,286 @@ line_number() {
   grep -n -m1 "$pattern" "$LOG" | cut -d: -f1
 }
 
-run_deploy > "$TEST_ROOT/success.out" 2> "$TEST_ROOT/success.err"
+FIRST_SHA=$(git -C "$REPO" rev-parse HEAD)
+FIRST_RELEASE="$DEPLOY_ROOT/releases/$FIRST_SHA"
 
-preflight=$(line_number 'node|scripts/deploy/check-pending-migrations.mjs$')
-server_build=$(grep -n '/server|pnpm|build$' "$LOG" | cut -d: -f1)
-server_test=$(line_number 'pnpm|test$')
-server_lint=$(line_number 'pnpm|lint$')
-migrate=$(line_number 'pnpm|db:migrate$')
-clean=$(line_number 'node|scripts/deploy/check-pending-migrations.mjs --require-clean$')
-restart=$(line_number 'systemctl|--user restart questura-server$')
-server_public=$(line_number 'curl|.*https://cms.questurian.com/api/health')
-client_build=$(grep -n '/client|pnpm|build$' "$LOG" | cut -d: -f1)
-client_restart=$(line_number 'systemctl|--user restart questura-client$')
-client_public=$(line_number 'curl|.*https://www.questurian.com/')
-
-((server_build < server_test && server_test < server_lint && server_lint < preflight))
-((preflight < migrate && migrate < clean && clean < restart))
-((restart < server_public && server_public < client_build))
-((client_build < client_restart && client_restart < client_public))
-grep -q -- '--frozen-lockfile --prod=false' "$LOG"
-grep -q 'Deployed ' "$TEST_ROOT/success.out"
-
+# Mismatched current pair aborts before release preparation or migration.
+MISMATCH_SHA=3333333333333333333333333333333333333333
+MISMATCH_CLIENT="$DEPLOY_ROOT/releases/$MISMATCH_SHA/apps/questura/apps/client"
+mkdir -p "$MISMATCH_CLIENT"
+printf 'QUESTURA_RELEASE_SHA=%s\n' "$MISMATCH_SHA" > "$MISMATCH_CLIENT/.env.release"
+ln -sfn "$MISMATCH_CLIENT" "$DEPLOY_ROOT/current-client"
 : > "$LOG"
 set +e
-FAIL_MIGRATE=1 run_deploy > "$TEST_ROOT/failure.out" 2> "$TEST_ROOT/failure.err"
-failure_code=$?
+run_deploy > "$TEST_ROOT/mismatch.out" 2> "$TEST_ROOT/mismatch.err"
+mismatch_code=$?
+set -e
+[[ $mismatch_code == 1 ]]
+grep -q 'current client/server releases are mismatched' "$TEST_ROOT/mismatch.err"
+if grep -Eq '\|(pnpm|node)\|' "$LOG"; then
+  echo 'mismatched current pair reached build or migration' >&2
+  exit 1
+fi
+ln -sfn "$OLD_RELEASE/client" "$DEPLOY_ROOT/current-client"
+: > "$LOG"
+
+mkdir -p "$REPO/apps/questura/apps/server/.next"
+printf '%s\n' secret-sentinel > "$REPO/apps/questura/apps/server/.env.untracked"
+printf '%s\n' stale-build > "$REPO/apps/questura/apps/server/.next/stale"
+if ! run_deploy > "$TEST_ROOT/success.out" 2> "$TEST_ROOT/success.err"; then
+  echo 'initial release deployment failed:' >&2
+  tail -40 "$TEST_ROOT/success.err" >&2
+  exit 1
+fi
+
+install_line=$(line_number 'releases/.staging-.*|pnpm|install ')
+server_build=$(line_number 'releases/.staging-.*/apps/questura/apps/server|pnpm|build$')
+server_test=$(line_number '|pnpm|test$')
+server_lint=$(line_number '|pnpm|lint$')
+preflight=$(line_number 'node|scripts/deploy/check-pending-migrations.mjs$')
+migrate=$(line_number 'pnpm|db:migrate$')
+clean=$(line_number 'node|scripts/deploy/check-pending-migrations.mjs --require-clean$')
+server_restart=$(line_number 'systemctl|--user restart questura-server$')
+server_public=$(line_number 'curl|.*https://cms.questurian.com/api/health')
+client_build=$(line_number "$FIRST_RELEASE/apps/questura/apps/client|pnpm|build$")
+client_restart=$(line_number 'systemctl|--user restart questura-client$')
+client_public=$(line_number 'curl|.*https://www.questurian.com/api/health')
+
+((install_line < server_build && server_build < server_test && server_test < server_lint))
+((server_lint < preflight && preflight < migrate && migrate < clean))
+((clean < server_restart && server_restart < server_public && server_public < client_build))
+((client_build < client_restart && client_restart < client_public))
+grep -q -- '--frozen-lockfile --prod=false' "$LOG"
+grep -q "QUESTURA_RELEASE_SHA=$FIRST_SHA" "$FIRST_RELEASE/.questura/server-ready"
+grep -q "QUESTURA_RELEASE_SHA=$FIRST_SHA" "$FIRST_RELEASE/.questura/release-ready"
+[[ ! -e $FIRST_RELEASE/apps/questura/apps/server/.env.untracked ]]
+[[ ! -e $FIRST_RELEASE/apps/questura/apps/server/.next/stale ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$FIRST_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$FIRST_RELEASE/apps/questura/apps/client" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$FIRST_RELEASE/apps/questura/apps/server/.env") == "$CONFIG_ROOT/server.env" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$FIRST_RELEASE/apps/questura/apps/client/.env.production.local") == "$CONFIG_ROOT/client.env" ]]
+grep -q "Deployed $FIRST_SHA" "$TEST_ROOT/success.out"
+
+# Same commit is immutable: verify exact health without rebuilding or restarting.
+: > "$LOG"
+run_deploy > "$TEST_ROOT/repeat.out" 2> "$TEST_ROOT/repeat.err"
+if grep -Eq '\|(pnpm|node)\||restart questura-' "$LOG"; then
+  echo 'same-SHA deploy mutated active release' >&2
+  tail -40 "$LOG" >&2
+  exit 1
+fi
+grep -q "Already deployed $FIRST_SHA" "$TEST_ROOT/repeat.out"
+
+# Normal Next runtime cache writes do not invalidate immutable code/artifacts.
+mkdir -p "$FIRST_RELEASE/apps/questura/apps/server/.next/cache/runtime"
+printf '%s\n' mutable-cache > "$FIRST_RELEASE/apps/questura/apps/server/.next/cache/runtime/value"
+mkdir -p "$FIRST_RELEASE/apps/questura/apps/client/.next/cache/images"
+printf '%s\n' mutable-cache > "$FIRST_RELEASE/apps/questura/apps/client/.next/cache/images/value"
+: > "$LOG"
+run_deploy > "$TEST_ROOT/cache-repeat.out" 2> "$TEST_ROOT/cache-repeat.err"
+grep -q "Already deployed $FIRST_SHA" "$TEST_ROOT/cache-repeat.out"
+
+# Runtime dependency mutation invalidates release certification.
+printf '%s\n' corrupted > "$FIRST_RELEASE/node_modules/.pnpm/fake/runtime.js"
+set +e
+run_deploy > "$TEST_ROOT/dependency-corrupt.out" 2> "$TEST_ROOT/dependency-corrupt.err"
+dependency_corrupt_code=$?
+set -e
+[[ $dependency_corrupt_code == 1 ]]
+grep -q 'state does not match commit/config/artifacts/dependencies' "$TEST_ROOT/dependency-corrupt.err"
+printf '%s\n' 'certified dependency' > "$FIRST_RELEASE/node_modules/.pnpm/fake/runtime.js"
+
+# Published artifact mutation invalidates marker and prevents reuse.
+printf '%s\n' corrupted >> "$FIRST_RELEASE/apps/questura/apps/server/package.json"
+set +e
+run_deploy > "$TEST_ROOT/corrupt.out" 2> "$TEST_ROOT/corrupt.err"
+corrupt_code=$?
+set -e
+[[ $corrupt_code == 1 ]]
+grep -q 'state does not match commit/config/artifacts/dependencies' "$TEST_ROOT/corrupt.err"
+cp "$REPO/apps/questura/apps/server/package.json" "$FIRST_RELEASE/apps/questura/apps/server/package.json"
+
+# A reused commit cannot silently embed changed build-time env.
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://changed.example' > "$CONFIG_ROOT/client.env"
+set +e
+run_deploy > "$TEST_ROOT/env-drift.out" 2> "$TEST_ROOT/env-drift.err"
+env_drift_code=$?
+set -e
+[[ $env_drift_code == 1 ]]
+grep -q 'new commit before deploying config changes' "$TEST_ROOT/env-drift.err"
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$CONFIG_ROOT/client.env"
+
+# Failed staged build is removed without publishing or touching live links.
+printf '%s\n' failed-build > "$REPO/release-fixture.txt"
+git -C "$REPO" add release-fixture.txt
+git -C "$REPO" commit --quiet -m failed-build
+FAILED_BUILD_SHA=$(git -C "$REPO" rev-parse HEAD)
+: > "$LOG"
+set +e
+FAIL_SERVER_BUILD=1 run_deploy > "$TEST_ROOT/server-build-failure.out" 2> "$TEST_ROOT/server-build-failure.err"
+server_build_code=$?
+set -e
+[[ $server_build_code == 41 ]]
+[[ ! -e $DEPLOY_ROOT/releases/$FAILED_BUILD_SHA ]]
+[[ -z $(find "$DEPLOY_ROOT/releases" -maxdepth 1 -name '.staging-*' -print -quit) ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$FIRST_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$FIRST_RELEASE/apps/questura/apps/client" ]]
+
+# Config drift during build prevents release certification/publication.
+printf '%s\n' config-race > "$REPO/release-fixture.txt"
+git -C "$REPO" add release-fixture.txt
+git -C "$REPO" commit --quiet -m config-race
+CONFIG_RACE_SHA=$(git -C "$REPO" rev-parse HEAD)
+: > "$LOG"
+set +e
+CHANGE_SERVER_CONFIG=1 run_deploy > "$TEST_ROOT/config-race.out" 2> "$TEST_ROOT/config-race.err"
+config_race_code=$?
+set -e
+[[ $config_race_code == 1 ]]
+grep -q 'release inputs changed' "$TEST_ROOT/config-race.err"
+[[ ! -e $DEPLOY_ROOT/releases/$CONFIG_RACE_SHA ]]
+[[ -z $(find "$DEPLOY_ROOT/releases" -maxdepth 1 -name '.staging-*' -print -quit) ]]
+printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$CONFIG_ROOT/server.env"
+
+# Reciprocal client-config drift during server build also blocks publication.
+printf '%s\n' cross-config-race > "$REPO/release-fixture.txt"
+git -C "$REPO" add release-fixture.txt
+git -C "$REPO" commit --quiet -m cross-config-race
+CROSS_CONFIG_RACE_SHA=$(git -C "$REPO" rev-parse HEAD)
+set +e
+CHANGE_CLIENT_CONFIG_DURING_SERVER_BUILD=1 run_deploy > "$TEST_ROOT/cross-config-race.out" 2> "$TEST_ROOT/cross-config-race.err"
+cross_config_code=$?
+set -e
+[[ $cross_config_code == 1 ]]
+grep -q 'release inputs changed' "$TEST_ROOT/cross-config-race.err"
+[[ ! -e $DEPLOY_ROOT/releases/$CROSS_CONFIG_RACE_SHA ]]
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$CONFIG_ROOT/client.env"
+
+# New target migration failure leaves both components on previous release.
+printf '%s\n' second > "$REPO/release-fixture.txt"
+git -C "$REPO" add release-fixture.txt
+git -C "$REPO" commit --quiet -m second
+SECOND_SHA=$(git -C "$REPO" rev-parse HEAD)
+SECOND_RELEASE="$DEPLOY_ROOT/releases/$SECOND_SHA"
+: > "$LOG"
+set +e
+FAIL_MIGRATE=1 run_deploy > "$TEST_ROOT/migrate-failure.out" 2> "$TEST_ROOT/migrate-failure.err"
+migrate_code=$?
 set -e
 
-[[ $failure_code == 42 ]]
-grep -q 'deploy failed during database migration' "$TEST_ROOT/failure.err"
+[[ $migrate_code == 42 ]]
+grep -q 'deploy failed during database migration' "$TEST_ROOT/migrate-failure.err"
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$FIRST_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$FIRST_RELEASE/apps/questura/apps/client" ]]
 if grep -q 'systemctl|--user restart' "$LOG"; then
   echo 'service restarted after failed migration' >&2
   exit 1
 fi
+
+# Config drift after migration is rechecked immediately before activation.
+: > "$LOG"
+set +e
+CHANGE_SERVER_CONFIG_AFTER_MIGRATION=1 run_deploy > "$TEST_ROOT/post-migration-race.out" 2> "$TEST_ROOT/post-migration-race.err"
+post_migration_code=$?
+set -e
+[[ $post_migration_code == 1 ]]
+grep -q 'release inputs changed' "$TEST_ROOT/post-migration-race.err"
+if grep -q 'restart questura-server' "$LOG"; then
+  echo 'server activated after post-migration config drift' >&2
+  exit 1
+fi
+printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$CONFIG_ROOT/server.env"
+
+# Client build failure compensates target server; old pair remains aligned.
+: > "$LOG"
+set +e
+FAIL_CLIENT_BUILD=1 run_deploy > "$TEST_ROOT/client-failure.out" 2> "$TEST_ROOT/client-failure.err"
+client_code=$?
+set -e
+
+[[ $client_code == 43 ]]
+grep -q 'deploy failed during client build' "$TEST_ROOT/client-failure.err"
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$FIRST_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$FIRST_RELEASE/apps/questura/apps/client" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/previous-server") == "$OLD_RELEASE/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/previous-client") == "$OLD_RELEASE/client" ]]
+grep -q 'Current links after reconciliation' "$TEST_ROOT/client-failure.err"
+
+# Partial release remains bound to original build-time config on retry.
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://changed.example' > "$CONFIG_ROOT/client.env"
+set +e
+run_deploy > "$TEST_ROOT/partial-env-drift.out" 2> "$TEST_ROOT/partial-env-drift.err"
+partial_env_code=$?
+set -e
+[[ $partial_env_code == 1 ]]
+grep -q 'release inputs changed' "$TEST_ROOT/partial-env-drift.err"
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$CONFIG_ROOT/client.env"
+
+# Retry reuses published server artifact, migrates, then completes client.
+: > "$LOG"
+run_deploy > "$TEST_ROOT/resume.out" 2> "$TEST_ROOT/resume.err"
+if grep -Eq '\|pnpm\|install |/server\|pnpm\|(build|test|lint)' "$LOG"; then
+  echo 'partial deploy retry rebuilt published server release' >&2
+  exit 1
+fi
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$SECOND_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$SECOND_RELEASE/apps/questura/apps/client" ]]
+
+# Client activation failure restores pair and preserves paired rollback history.
+printf '%s\n' third > "$REPO/release-fixture.txt"
+git -C "$REPO" add release-fixture.txt
+git -C "$REPO" commit --quiet -m third
+THIRD_SHA=$(git -C "$REPO" rev-parse HEAD)
+
+# Reciprocal server-config drift during client build blocks client activation.
+: > "$LOG"
+set +e
+CHANGE_SERVER_CONFIG_DURING_CLIENT_BUILD=1 run_deploy > "$TEST_ROOT/client-cross-race.out" 2> "$TEST_ROOT/client-cross-race.err"
+client_cross_code=$?
+set -e
+[[ $client_cross_code == 1 ]]
+grep -q 'release inputs changed' "$TEST_ROOT/client-cross-race.err"
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$SECOND_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$SECOND_RELEASE/apps/questura/apps/client" ]]
+printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$CONFIG_ROOT/server.env"
+
+# TERM during post-activation client build restores original pair and history.
+: > "$LOG"
+set +e
+SIGNAL_CLIENT_BUILD=1 run_deploy > "$TEST_ROOT/client-signal.out" 2> "$TEST_ROOT/client-signal.err"
+client_signal_code=$?
+set -e
+[[ $client_signal_code == 143 ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$SECOND_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$SECOND_RELEASE/apps/questura/apps/client" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/previous-server") == "$FIRST_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/previous-client") == "$FIRST_RELEASE/apps/questura/apps/client" ]]
+
+: > "$LOG"
+set +e
+FAIL_CLIENT_ACTIVATION_SHA="$THIRD_SHA" run_deploy > "$TEST_ROOT/client-activation.out" 2> "$TEST_ROOT/client-activation.err"
+client_activation_code=$?
+set -e
+[[ $client_activation_code == 1 ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$SECOND_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$SECOND_RELEASE/apps/questura/apps/client" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/previous-server") == "$FIRST_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/previous-client") == "$FIRST_RELEASE/apps/questura/apps/client" ]]
+
+# Compensation failure is loud, nonzero, and reports actual current links.
+printf '%s\n' fourth > "$REPO/release-fixture.txt"
+git -C "$REPO" add release-fixture.txt
+git -C "$REPO" commit --quiet -m fourth
+: > "$LOG"
+set +e
+FAIL_CLIENT_BUILD=1 FAIL_SERVER_RESTORE_SHA="$SECOND_SHA" run_deploy > "$TEST_ROOT/compensation.out" 2> "$TEST_ROOT/compensation.err"
+compensation_code=$?
+set -e
+[[ $compensation_code == 43 ]]
+grep -q 'CRITICAL: original server restoration failed' "$TEST_ROOT/compensation.err"
+grep -q 'Current links after reconciliation' "$TEST_ROOT/compensation.err"
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-server") == "$SECOND_RELEASE/apps/questura/apps/server" ]]
+[[ $(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DEPLOY_ROOT/current-client") == "$SECOND_RELEASE/apps/questura/apps/client" ]]
 
 : > "$LOG"
 set +e
@@ -110,11 +407,15 @@ if grep -q 'pnpm|' "$LOG"; then
   exit 1
 fi
 
+# Stable wrapper holds lock, syncs main, and dispatches reviewed deploy script.
 : > "$LOG"
 env \
   PATH="$FAKE_BIN:$PATH" \
   NVM_DIR="$TEST_ROOT/no-nvm" \
   QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+  QUESTURA_CONFIG_ROOT="$CONFIG_ROOT" \
+  QUESTURA_HEALTH_ATTEMPTS=1 \
+  QUESTURA_HEALTH_SLEEP_SECONDS=0 \
   QUESTURA_APP_ROOT="$REPO" \
   DEPLOY_TEST_LOG="$LOG" \
   "$SCRIPT_DIR/host-deploy-wrapper.sh" > "$TEST_ROOT/wrapper.out" 2> "$TEST_ROOT/wrapper.err"

--- a/apps/questura/infra/softprod/release-builder.sh
+++ b/apps/questura/infra/softprod/release-builder.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# Build and publish immutable, commit-addressed Questura release snapshots.
+# shellcheck shell=bash
+
+SOFTPROD_SOURCE_REPO=${SOURCE_REPO:?SOURCE_REPO must be set before sourcing release-builder.sh}
+SOFTPROD_CONFIG_ROOT=${CONFIG_ROOT:?CONFIG_ROOT must be set before sourcing release-builder.sh}
+SOFTPROD_STAGING=''
+
+config_path() {
+  case "$1" in
+    server) printf '%s\n' "$SOFTPROD_CONFIG_ROOT/server.env" ;;
+    client) printf '%s\n' "$SOFTPROD_CONFIG_ROOT/client.env" ;;
+    *) echo "ERROR: unknown component: $1" >&2; return 1 ;;
+  esac
+}
+
+config_destination() {
+  local release=$1
+  case "$2" in
+    server) printf '%s\n' "$release/apps/questura/apps/server/.env" ;;
+    client) printf '%s\n' "$release/apps/questura/apps/client/.env.production.local" ;;
+    *) echo "ERROR: unknown component: $2" >&2; return 1 ;;
+  esac
+}
+
+config_fingerprint() {
+  local source
+  source=$(config_path "$1") || return
+  if [[ ! -r $source || ! -f $source ]]; then
+    echo "ERROR: release config is missing or unreadable: $source" >&2
+    return 1
+  fi
+  python3 - "$source" <<'PY'
+import hashlib
+import pathlib
+import sys
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+}
+
+tree_fingerprint() {
+  local root=$1
+  local mode=$2
+
+  python3 - "$root" "$mode" <<'PY'
+import hashlib
+import os
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+mode = sys.argv[2]
+if mode == "server":
+    excluded_prefix = pathlib.PurePosixPath("apps/questura/apps/client")
+    excluded_names = {".questura", "node_modules"}
+    excluded_files = {".env", ".env.production.local", ".env.release"}
+elif mode == "client":
+    excluded_prefix = None
+    excluded_names = {".questura", "node_modules"}
+    excluded_files = {".env", ".env.production.local", ".env.release"}
+elif mode == "dependencies":
+    excluded_prefix = None
+    excluded_names = set()
+    excluded_files = set()
+else:
+    raise SystemExit(f"unknown fingerprint mode: {mode}")
+
+digest = hashlib.sha256()
+
+for current, directories, files in os.walk(root, followlinks=False):
+    current_path = pathlib.Path(current)
+    relative_current = current_path.relative_to(root)
+    directories[:] = sorted(name for name in directories if name not in excluded_names)
+    if mode != "dependencies" and relative_current.name == ".next":
+        directories[:] = [name for name in directories if name != "cache"]
+    if excluded_prefix is not None:
+        directories[:] = [
+            name
+            for name in directories
+            if not (relative_current / name).as_posix().startswith(excluded_prefix.as_posix())
+        ]
+
+    for name in list(directories):
+        path = current_path / name
+        if path.is_symlink():
+            relative = path.relative_to(root).as_posix()
+            digest.update(f"L\0{relative}\0{os.readlink(path)}\0".encode())
+            directories.remove(name)
+
+    for name in sorted(files):
+        if name in excluded_files:
+            continue
+        path = current_path / name
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            digest.update(f"L\0{relative}\0{os.readlink(path)}\0".encode())
+        else:
+            digest.update(f"F\0{relative}\0".encode())
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            digest.update(b"\0")
+
+print(digest.hexdigest())
+PY
+}
+
+artifact_fingerprint() {
+  local release=$1
+  local component=$2
+  local root
+
+  case "$component" in
+    server) root=$release ;;
+    client) root="$release/apps/questura/apps/client" ;;
+    *) echo "ERROR: unknown component: $component" >&2; return 1 ;;
+  esac
+  tree_fingerprint "$root" "$component"
+}
+
+dependency_fingerprint() {
+  local release=$1
+  local directory="$release/node_modules"
+
+  if [[ ! -d $directory ]]; then
+    echo "ERROR: release dependencies are missing: $directory" >&2
+    return 1
+  fi
+  tree_fingerprint "$directory" dependencies
+}
+
+ensure_config_link() {
+  local release=$1
+  local component=$2
+  local source destination actual_source actual_destination
+
+  source=$(config_path "$component") || return
+  config_fingerprint "$component" >/dev/null || return
+  destination=$(config_destination "$release" "$component") || return
+  actual_source=$(canonical_path "$source") || return
+
+  if [[ -L $destination ]]; then
+    actual_destination=$(canonical_path "$destination") || return
+    if [[ $actual_destination != "$actual_source" ]]; then
+      echo "ERROR: release config link points at unexpected file: $destination" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if [[ -e $destination ]]; then
+    echo "ERROR: release config path exists and is not a symlink: $destination" >&2
+    return 1
+  fi
+  atomic_symlink "$source" "$destination"
+}
+
+validate_config_link() {
+  local release=$1
+  local component=$2
+  local source destination actual_source actual_destination
+
+  source=$(config_path "$component") || return
+  config_fingerprint "$component" >/dev/null || return
+  destination=$(config_destination "$release" "$component") || return
+  if [[ ! -L $destination ]]; then
+    echo "ERROR: published release config link is missing: $destination" >&2
+    return 1
+  fi
+  actual_source=$(canonical_path "$source") || return
+  actual_destination=$(canonical_path "$destination") || return
+  if [[ $actual_destination != "$actual_source" ]]; then
+    echo "ERROR: published release config link points at unexpected file: $destination" >&2
+    return 1
+  fi
+}
+
+write_release_metadata() {
+  local release=$1
+  local sha=$2
+  local component directory
+
+  for component in server client; do
+    directory="$release/apps/questura/apps/$component"
+    printf 'QUESTURA_RELEASE_SHA=%s\n' "$sha" > "$directory/.env.release"
+  done
+}
+
+marker_path() {
+  local release=$1
+  local marker=$2
+  printf '%s\n' "$release/.questura/$marker"
+}
+
+write_release_inputs() {
+  local release=$1
+  local sha=$2
+  local server_fingerprint=$3
+  local client_fingerprint=$4
+  local path="$release/.questura/release-inputs"
+  local temporary
+
+  mkdir -p "$(dirname -- "$path")"
+  temporary=$(mktemp "$(dirname -- "$path")/.release-inputs.XXXXXX") || return
+  printf 'QUESTURA_RELEASE_SHA=%s\nQUESTURA_SERVER_CONFIG_SHA256=%s\nQUESTURA_CLIENT_CONFIG_SHA256=%s\n' \
+    "$sha" "$server_fingerprint" "$client_fingerprint" > "$temporary"
+  chmod 0600 "$temporary"
+  mv -f "$temporary" "$path"
+}
+
+validate_release_inputs() {
+  local release=$1
+  local sha=$2
+  local server_fingerprint client_fingerprint expected actual
+  local path="$release/.questura/release-inputs"
+
+  server_fingerprint=$(config_fingerprint server) || return
+  client_fingerprint=$(config_fingerprint client) || return
+  if [[ ! -f $path ]]; then
+    echo "ERROR: release input fingerprint is missing: $path" >&2
+    return 1
+  fi
+  expected=$(printf 'QUESTURA_RELEASE_SHA=%s\nQUESTURA_SERVER_CONFIG_SHA256=%s\nQUESTURA_CLIENT_CONFIG_SHA256=%s' \
+    "$sha" "$server_fingerprint" "$client_fingerprint")
+  actual=$(cat "$path") || return
+  if [[ $actual != "$expected" ]]; then
+    echo "ERROR: release inputs changed; create a new commit before deploying config changes: $path" >&2
+    return 1
+  fi
+}
+
+write_marker() {
+  local release=$1
+  local marker=$2
+  local component=$3
+  local sha=$4
+  local expected_config_fingerprint=$5
+  local fingerprint artifact dependencies temporary path
+
+  fingerprint=$(config_fingerprint "$component") || return
+  if [[ $fingerprint != "$expected_config_fingerprint" ]]; then
+    echo "ERROR: $component config changed during build; release was not certified" >&2
+    return 1
+  fi
+  artifact=$(artifact_fingerprint "$release" "$component") || return
+  dependencies=$(dependency_fingerprint "$release") || return
+  path=$(marker_path "$release" "$marker") || return
+  mkdir -p "$(dirname -- "$path")"
+  temporary=$(mktemp "$(dirname -- "$path")/.$marker.XXXXXX") || return
+  printf 'QUESTURA_RELEASE_SHA=%s\nQUESTURA_CONFIG_SHA256=%s\nQUESTURA_ARTIFACT_SHA256=%s\nQUESTURA_DEPENDENCY_SHA256=%s\n' \
+    "$sha" "$fingerprint" "$artifact" "$dependencies" > "$temporary"
+  chmod 0600 "$temporary"
+  mv -f "$temporary" "$path"
+}
+
+validate_marker() {
+  local release=$1
+  local marker=$2
+  local component=$3
+  local sha=$4
+  local fingerprint artifact dependencies path expected actual
+
+  fingerprint=$(config_fingerprint "$component") || return
+  artifact=$(artifact_fingerprint "$release" "$component") || return
+  dependencies=$(dependency_fingerprint "$release") || return
+  path=$(marker_path "$release" "$marker") || return
+  if [[ ! -f $path ]]; then
+    return 2
+  fi
+  expected=$(printf 'QUESTURA_RELEASE_SHA=%s\nQUESTURA_CONFIG_SHA256=%s\nQUESTURA_ARTIFACT_SHA256=%s\nQUESTURA_DEPENDENCY_SHA256=%s' \
+    "$sha" "$fingerprint" "$artifact" "$dependencies")
+  actual=$(cat "$path") || return
+  if [[ $actual != "$expected" ]]; then
+    echo "ERROR: $marker state does not match commit/config/artifacts/dependencies; create a new commit before deploying config changes: $path" >&2
+    return 1
+  fi
+}
+
+validate_server_release() {
+  local sha=$1
+  local release="$SOFTPROD_RELEASES/$sha"
+
+  require_component_release_directory server "$release/apps/questura/apps/server" || return
+  require_component_release_directory client "$release/apps/questura/apps/client" || return
+  [[ $(release_sha "$release/apps/questura/apps/server") == "$sha" ]] || return
+  [[ $(release_sha "$release/apps/questura/apps/client") == "$sha" ]] || return
+  validate_config_link "$release" server || return
+  validate_config_link "$release" client || return
+  validate_release_inputs "$release" "$sha" || return
+  validate_marker "$release" server-ready server "$sha"
+}
+
+require_complete_release() {
+  local sha=$1
+  local release="$SOFTPROD_RELEASES/$sha"
+
+  validate_server_release "$sha" || return
+  validate_marker "$release" release-ready client "$sha" || {
+    echo "ERROR: release is not complete: $release" >&2
+    return 1
+  }
+}
+
+cleanup_release_staging() {
+  local root staging
+  if [[ -z $SOFTPROD_STAGING || ! -e $SOFTPROD_STAGING ]]; then return 0; fi
+  root=$(canonical_path "$SOFTPROD_RELEASES") || return
+  staging=$(canonical_path "$SOFTPROD_STAGING") || return
+  if [[ $staging != "$root/".staging-* ]]; then
+    echo "CRITICAL: refusing to clean unexpected staging path: $SOFTPROD_STAGING" >&2
+    return 1
+  fi
+  rm -rf -- "$staging" || return
+  SOFTPROD_STAGING=''
+}
+
+prepare_server_release() {
+  local sha=$1
+  local release="$SOFTPROD_RELEASES/$sha"
+  local server_config_before client_config_before
+
+  if [[ ! $sha =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: release SHA must be 40 lowercase hex characters: $sha" >&2
+    return 1
+  fi
+  config_fingerprint server >/dev/null || return
+  config_fingerprint client >/dev/null || return
+  server_config_before=$(config_fingerprint server) || return
+  client_config_before=$(config_fingerprint client) || return
+  mkdir -p "$SOFTPROD_RELEASES"
+
+  if [[ -L $release ]]; then
+    echo "ERROR: release path must not be a symlink: $release" >&2
+    return 1
+  fi
+  if [[ -e $release ]]; then
+    if [[ ! -d $release ]]; then
+      echo "ERROR: release path is not a directory: $release" >&2
+      return 1
+    fi
+    validate_server_release "$sha" || return
+    return 0
+  fi
+
+  git -C "$SOFTPROD_SOURCE_REPO" cat-file -e "$sha^{commit}" || return
+  SOFTPROD_STAGING=$(mktemp -d "$SOFTPROD_RELEASES/.staging-$sha.XXXXXX") || return
+  git -C "$SOFTPROD_SOURCE_REPO" archive "$sha" | tar -x -C "$SOFTPROD_STAGING"
+  write_release_metadata "$SOFTPROD_STAGING" "$sha"
+  ensure_config_link "$SOFTPROD_STAGING" server
+  ensure_config_link "$SOFTPROD_STAGING" client
+  write_release_inputs "$SOFTPROD_STAGING" "$sha" "$server_config_before" "$client_config_before"
+
+  stage="dependency installation"
+  echo "==> Installing locked dependencies (Questura workspaces only)"
+  cd "$SOFTPROD_STAGING"
+  pnpm install --frozen-lockfile --prod=false \
+    --filter "@questura/server..." \
+    --filter "@questura/client..."
+
+  stage="server build"
+  echo "==> Building server"
+  cd "$SOFTPROD_STAGING/apps/questura/apps/server"
+  pnpm build
+
+  stage="server tests"
+  echo "==> Testing server"
+  pnpm test
+
+  stage="server lint"
+  echo "==> Linting server"
+  pnpm lint
+  validate_release_inputs "$SOFTPROD_STAGING" "$sha"
+  write_marker "$SOFTPROD_STAGING" server-ready server "$sha" "$server_config_before"
+
+  stage="server release publication"
+  if [[ -e $release ]]; then
+    echo "ERROR: release appeared while staging: $release" >&2
+    return 1
+  fi
+  mv "$SOFTPROD_STAGING" "$release"
+  SOFTPROD_STAGING=''
+
+  validate_marker "$release" server-ready server "$sha"
+}
+
+complete_client_release() {
+  local sha=$1
+  local release="$SOFTPROD_RELEASES/$sha"
+  local marker_status=0
+  local client_config_before
+
+  validate_server_release "$sha" || return
+  validate_marker "$release" release-ready client "$sha" || marker_status=$?
+  if ((marker_status == 0)); then return 0; fi
+  if ((marker_status != 2)); then return "$marker_status"; fi
+  client_config_before=$(config_fingerprint client) || return
+
+  stage="client build"
+  echo "==> Building client"
+  cd "$release/apps/questura/apps/client"
+  pnpm build
+  validate_release_inputs "$release" "$sha"
+  write_marker "$release" release-ready client "$sha" "$client_config_before"
+  validate_marker "$release" release-ready client "$sha"
+}


### PR DESCRIPTION
## Summary
- build exact Git commits in private staging; atomically publish SHA-addressed releases
- link external host config; certify config, artifacts, dependencies, metadata
- migrate forward before exact-SHA server activation; build client only after server health
- reconcile original current/previous pair on failures and signals
- safely resume partial releases and reject drift/corruption

## Validation
- `pnpm --dir apps/questura/apps/server test` (90 files / 579 tests, 8 deploy tests, softprod suites)
- `pnpm --dir apps/questura/apps/server lint` (0 errors; 5 known warnings)
- `pnpm --dir apps/questura/apps/client build`
- `git diff --check origin/main...HEAD`
- independent spec review: no findings
- independent standards/Fowler review: no findings

ShellCheck unavailable locally.