### PR TITLE
ops(questura): version softprod host templates

### DIFF
--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -75,6 +75,24 @@ Deploy requires release-based host units and aligned `current-*` pointers.
 Install/adopt those through host-bootstrap tooling before replacing current
 wrapper. Until then, existing host deploy path remains unchanged.
 
+## Versioned host configuration
+
+`host/` is canonical source for soft-production Compose, Cloudflare Tunnel,
+and user-systemd configuration. Unit templates deliberately use
+`current-server`/`current-client`, exact release metadata, and journald; they do
+not append unbounded files under `~/questura/logs`. Both Next services bind
+only to `127.0.0.1`; Cloudflare Tunnel remains their sole public path.
+
+Compose must be installed at `~/questura/infra/compose.yml` with a mode-0600
+adjacent `.env`. Its project name and explicit volumes preserve existing
+`infra_questura-pgdata` and `infra_questura-redisdata`; do not run a renamed
+copy with a different project name. Tunnel credentials remain outside Git at
+`~/.cloudflared/c8f86728-8dcd-4d3e-9d2e-e84d06661416.json`.
+
+Files in this PR are inert templates. Host-bootstrap tooling renders binary
+paths, validates release/config prerequisites, backs up live files, then
+installs them in a later reviewed change.
+
 ## Validation
 
 Migration-preflight and deploy-runner regression tests are part of the server

--- a/apps/questura/infra/softprod/host/compose.env.example
+++ b/apps/questura/infra/softprod/host/compose.env.example
@@ -1,0 +1,2 @@
+# Copy to ~/questura/infra/.env, set mode 0600, then replace this value.
+POSTGRES_PASSWORD=replace-with-existing-softprod-password

--- a/apps/questura/infra/softprod/host/compose.yml
+++ b/apps/questura/infra/softprod/host/compose.yml
@@ -1,0 +1,44 @@
+# Questura soft-production data services. Install at ~/questura/infra/compose.yml.
+# Keep project name and explicit volume names stable: existing production data
+# lives in infra_questura-{pgdata,redisdata}.
+name: infra
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: questura-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: questura
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in the adjacent .env file}
+      POSTGRES_DB: questura
+    ports:
+      - "127.0.0.1:5433:5432"
+    volumes:
+      - questura-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U questura -d questura"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: questura-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - questura-redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  questura-pgdata:
+    name: infra_questura-pgdata
+  questura-redisdata:
+    name: infra_questura-redisdata

--- a/apps/questura/infra/softprod/host/systemd/questura-client.service.in
+++ b/apps/questura/infra/softprod/host/systemd/questura-client.service.in
@@ -1,0 +1,22 @@
+[Unit]
+Description=Questura client frontend (soft production)
+Documentation=https://github.com/Questurian/questurian
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/questura/current-client
+Environment=PATH=@NODE_BIN_DIR@:/usr/local/bin:/usr/bin:/bin
+Environment=NODE_ENV=production
+Environment=NODE_OPTIONS=--no-deprecation
+EnvironmentFile=%h/questura/config/client.env
+EnvironmentFile=%h/questura/current-client/.env.release
+ExecStart=@PNPM_BIN@ exec next start -H 127.0.0.1 -p 3000
+Restart=always
+RestartSec=5
+TimeoutStartSec=180
+SyslogIdentifier=questura-client
+
+[Install]
+WantedBy=default.target

--- a/apps/questura/infra/softprod/host/systemd/questura-server.service.in
+++ b/apps/questura/infra/softprod/host/systemd/questura-server.service.in
@@ -1,0 +1,22 @@
+[Unit]
+Description=Questura Payload CMS (soft production)
+Documentation=https://github.com/Questurian/questurian
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/questura/current-server
+Environment=PATH=@NODE_BIN_DIR@:/usr/local/bin:/usr/bin:/bin
+Environment=NODE_ENV=production
+Environment=NODE_OPTIONS=--no-deprecation
+EnvironmentFile=%h/questura/config/server.env
+EnvironmentFile=%h/questura/current-server/.env.release
+ExecStart=@PNPM_BIN@ exec next start -H 127.0.0.1 -p 4000
+Restart=always
+RestartSec=5
+TimeoutStartSec=180
+SyslogIdentifier=questura-server
+
+[Install]
+WantedBy=default.target

--- a/apps/questura/infra/softprod/host/systemd/questura-tunnel.service.in
+++ b/apps/questura/infra/softprod/host/systemd/questura-tunnel.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Cloudflare Tunnel for Questura (cms + www)
+Documentation=https://github.com/Questurian/questurian
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=@CLOUDFLARED_BIN@ --no-autoupdate --config %h/questura/infra/tunnel-config.yml tunnel run
+Restart=always
+RestartSec=5
+SyslogIdentifier=questura-tunnel
+
+[Install]
+WantedBy=default.target

--- a/apps/questura/infra/softprod/host/tunnel-config.yml
+++ b/apps/questura/infra/softprod/host/tunnel-config.yml
@@ -1,0 +1,15 @@
+# Questura soft-production tunnel. Keep separate from other host tunnels.
+tunnel: c8f86728-8dcd-4d3e-9d2e-e84d06661416
+credentials-file: /home/webdev/.cloudflared/c8f86728-8dcd-4d3e-9d2e-e84d06661416.json
+
+originRequest:
+  connectTimeout: 30s
+
+ingress:
+  - hostname: cms.questurian.com
+    service: http://localhost:4000
+  - hostname: www.questurian.com
+    service: http://localhost:3000
+  - hostname: questurian.com
+    service: http://localhost:3000
+  - service: http_status:404


### PR DESCRIPTION
## Summary
- version sanitized Compose and Cloudflare Tunnel config
- preserve existing `infra` project and production volume identities
- add release-pointer user-unit templates using journald
- bind Next services to loopback so Tunnel remains sole public ingress

## Validation
- `docker compose config --quiet` on target host using fixture password
- `cloudflared tunnel ingress validate` on target host
- `systemd-analyze --user verify` for all rendered units on target host
- `git diff --check origin/main...HEAD`
- independent spec review: no findings
- independent standards review: no findings

Validation used ephemeral temp files only; live host state unchanged.