### PR TITLE
ops(questura): stage canonical host config safely

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -32,7 +32,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
-    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts"
   },
   "dependencies": {

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -93,6 +93,18 @@ Files in this PR are inert templates. Host-bootstrap tooling renders binary
 paths, validates release/config prerequisites, backs up live files, then
 installs them in a later reviewed change.
 
+Stage host config before release adoption:
+
+```bash
+~/questura/app/apps/questura/infra/softprod/stage-host-config.sh
+```
+
+This migrates existing app env files into mode-0600 canonical config, extracts
+the existing Compose password into a mode-0600 `.env` without printing it,
+installs sanitized Compose/Tunnel config, and renders validated units under
+`~/questura/infra/systemd`. It backs up prior files and never changes active
+unit files or service state. Any differing canonical app config fails closed.
+
 ## Validation
 
 Migration-preflight and deploy-runner regression tests are part of the server

--- a/apps/questura/infra/softprod/stage-host-config.sh
+++ b/apps/questura/infra/softprod/stage-host-config.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Stage canonical host config and rendered units without changing live services.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+HOST_SOURCE="$SCRIPT_DIR/host"
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+APP_ROOT=${QUESTURA_APP_ROOT:-"$DEPLOY_ROOT/app"}
+INFRA_ROOT=${QUESTURA_INFRA_ROOT:-"$DEPLOY_ROOT/infra"}
+CONFIG_ROOT=${QUESTURA_CONFIG_ROOT:-"$DEPLOY_ROOT/config"}
+RENDERED_ROOT=${QUESTURA_RENDERED_UNITS_ROOT:-"$INFRA_ROOT/systemd"}
+SERVER_ENV_SOURCE=${QUESTURA_SERVER_ENV_SOURCE:-"$APP_ROOT/apps/questura/apps/server/.env"}
+CLIENT_ENV_SOURCE=${QUESTURA_CLIENT_ENV_SOURCE:-"$APP_ROOT/apps/questura/apps/client/.env.production.local"}
+EXISTING_COMPOSE=${QUESTURA_EXISTING_COMPOSE:-"$INFRA_ROOT/compose.yml"}
+stage_directory=''
+
+cleanup() {
+  if [[ -n $stage_directory && -d $stage_directory && $stage_directory == "$DEPLOY_ROOT/".host-config.* ]]; then
+    rm -rf -- "$stage_directory"
+  fi
+}
+trap cleanup EXIT
+
+if (($# > 0)); then
+  echo "ERROR: stage-host-config.sh takes no arguments" >&2
+  exit 2
+fi
+
+mkdir -p "$DEPLOY_ROOT"
+exec 9>"$DEPLOY_ROOT/deploy.lock"
+if ! flock -n 9; then
+  echo "ERROR: another Questura deploy or host-config operation is running" >&2
+  exit 1
+fi
+
+require_regular_file() {
+  local path=$1
+  if [[ ! -f $path || ! -r $path ]]; then
+    echo "ERROR: required readable file is missing: $path" >&2
+    return 1
+  fi
+}
+
+require_regular_file "$SERVER_ENV_SOURCE"
+require_regular_file "$CLIENT_ENV_SOURCE"
+require_regular_file "$HOST_SOURCE/compose.yml"
+require_regular_file "$HOST_SOURCE/tunnel-config.yml"
+
+PNPM_BIN=${QUESTURA_PNPM_BIN:-}
+if [[ -z $PNPM_BIN ]]; then
+  export NVM_DIR=${NVM_DIR:-"$HOME/.nvm"}
+  if [[ -s $NVM_DIR/nvm.sh ]]; then
+    # shellcheck source=/dev/null
+    . "$NVM_DIR/nvm.sh"
+    nvm use "${QUESTURA_NODE_VERSION:-22}" >/dev/null
+  fi
+  PNPM_BIN=$(command -v pnpm || true)
+fi
+CLOUDFLARED_BIN=${QUESTURA_CLOUDFLARED_BIN:-$(command -v cloudflared || true)}
+NODE_BIN_DIR=${QUESTURA_NODE_BIN_DIR:-$(dirname -- "$PNPM_BIN")}
+
+for binary in "$PNPM_BIN" "$CLOUDFLARED_BIN"; do
+  if [[ $binary != /* || ! -x $binary ]]; then
+    echo "ERROR: required executable has no absolute executable path: ${binary:-missing}" >&2
+    exit 1
+  fi
+done
+
+stage_directory=$(mktemp -d "$DEPLOY_ROOT/.host-config.XXXXXX")
+mkdir -p "$stage_directory/config" "$stage_directory/infra/systemd"
+install -m 0600 "$SERVER_ENV_SOURCE" "$stage_directory/config/server.env"
+install -m 0600 "$CLIENT_ENV_SOURCE" "$stage_directory/config/client.env"
+install -m 0644 "$HOST_SOURCE/compose.yml" "$stage_directory/infra/compose.yml"
+install -m 0644 "$HOST_SOURCE/tunnel-config.yml" "$stage_directory/infra/tunnel-config.yml"
+
+expected_compose_json="$stage_directory/expected-compose.json"
+if [[ -f $INFRA_ROOT/.env ]]; then
+  docker compose \
+    --env-file "$INFRA_ROOT/.env" \
+    -f "$EXISTING_COMPOSE" \
+    config --format json > "$expected_compose_json"
+  install -m 0600 "$INFRA_ROOT/.env" "$stage_directory/infra/.env"
+else
+  require_regular_file "$EXISTING_COMPOSE"
+  docker compose -f "$EXISTING_COMPOSE" config --format json > "$expected_compose_json"
+  python3 - "$expected_compose_json" "$stage_directory/infra/.env" <<'PY'
+import json
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+document = json.loads(source.read_text(encoding="utf-8"))
+environment = document["services"]["postgres"]["environment"]
+if isinstance(environment, list):
+    values = dict(item.split("=", 1) for item in environment)
+else:
+    values = environment
+password = values.get("POSTGRES_PASSWORD")
+if not isinstance(password, str) or not password:
+    raise SystemExit("Postgres password was not found in existing Compose config")
+if "\0" in password:
+    raise SystemExit("Postgres password contains an unsupported NUL byte")
+# JSON quoting matches Compose double-quoted dotenv escapes. Double dollar signs
+# suppress Compose interpolation while preserving one literal dollar at runtime.
+encoded = json.dumps(password).replace("$", "$$")
+output.write_text(f"POSTGRES_PASSWORD={encoded}\n", encoding="utf-8")
+PY
+  chmod 0600 "$stage_directory/infra/.env"
+fi
+
+render_unit() {
+  local source=$1
+  local destination=$2
+  python3 - "$source" "$destination" "$NODE_BIN_DIR" "$PNPM_BIN" "$CLOUDFLARED_BIN" <<'PY'
+import pathlib
+import sys
+
+source, destination, node_bin_dir, pnpm_bin, cloudflared_bin = sys.argv[1:]
+text = pathlib.Path(source).read_text(encoding="utf-8")
+replacements = {
+    "@NODE_BIN_DIR@": node_bin_dir,
+    "@PNPM_BIN@": pnpm_bin,
+    "@CLOUDFLARED_BIN@": cloudflared_bin,
+}
+for marker, value in replacements.items():
+    text = text.replace(marker, value)
+if "@" in "\n".join(line for line in text.splitlines() if line.startswith(("Environment=PATH=", "ExecStart="))):
+    raise SystemExit(f"unrendered unit placeholder in {source}")
+pathlib.Path(destination).write_text(text, encoding="utf-8")
+PY
+  chmod 0644 "$destination"
+}
+
+for template in "$HOST_SOURCE/systemd"/*.service.in; do
+  unit_name=$(basename -- "$template" .in)
+  render_unit "$template" "$stage_directory/infra/systemd/$unit_name"
+done
+
+docker compose \
+  --env-file "$stage_directory/infra/.env" \
+  -f "$stage_directory/infra/compose.yml" \
+  config --quiet
+rendered_compose_json="$stage_directory/rendered-compose.json"
+docker compose \
+  --env-file "$stage_directory/infra/.env" \
+  -f "$stage_directory/infra/compose.yml" \
+  config --format json > "$rendered_compose_json"
+python3 - "$expected_compose_json" "$rendered_compose_json" <<'PY'
+import json
+import pathlib
+import sys
+
+def password(path: str) -> str:
+    document = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    environment = document["services"]["postgres"]["environment"]
+    if isinstance(environment, list):
+        values = dict(item.split("=", 1) for item in environment)
+    else:
+        values = environment
+    value = values.get("POSTGRES_PASSWORD")
+    if not isinstance(value, str):
+        raise SystemExit("Postgres password is absent from rendered Compose config")
+    return value
+
+if password(sys.argv[1]) != password(sys.argv[2]):
+    raise SystemExit("Postgres password changed during Compose config migration")
+PY
+"$CLOUDFLARED_BIN" \
+  --config "$stage_directory/infra/tunnel-config.yml" \
+  tunnel ingress validate
+systemd-analyze --user verify "$stage_directory/infra/systemd"/*.service
+
+for pair in \
+  "$stage_directory/config/server.env:$CONFIG_ROOT/server.env" \
+  "$stage_directory/config/client.env:$CONFIG_ROOT/client.env"; do
+  source_file=${pair%%:*}
+  destination_file=${pair#*:}
+  if [[ -e $destination_file ]] && ! cmp -s "$source_file" "$destination_file"; then
+    echo "ERROR: existing canonical config differs; refusing overwrite: $destination_file" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$DEPLOY_ROOT/backups/host-config"
+backup_directory=$(mktemp -d "$DEPLOY_ROOT/backups/host-config/config.XXXXXX")
+for path in \
+  "$CONFIG_ROOT/server.env" \
+  "$CONFIG_ROOT/client.env" \
+  "$INFRA_ROOT/.env" \
+  "$INFRA_ROOT/compose.yml" \
+  "$INFRA_ROOT/tunnel-config.yml" \
+  "$RENDERED_ROOT"; do
+  if [[ -e $path ]]; then cp -a "$path" "$backup_directory/"; fi
+done
+
+mkdir -p "$CONFIG_ROOT" "$INFRA_ROOT" "$RENDERED_ROOT"
+chmod 0700 "$CONFIG_ROOT"
+install -m 0600 "$stage_directory/config/server.env" "$CONFIG_ROOT/server.env"
+install -m 0600 "$stage_directory/config/client.env" "$CONFIG_ROOT/client.env"
+install -m 0600 "$stage_directory/infra/.env" "$INFRA_ROOT/.env"
+install -m 0644 "$stage_directory/infra/compose.yml" "$INFRA_ROOT/compose.yml"
+install -m 0644 "$stage_directory/infra/tunnel-config.yml" "$INFRA_ROOT/tunnel-config.yml"
+for unit in "$stage_directory/infra/systemd"/*.service; do
+  install -m 0644 "$unit" "$RENDERED_ROOT/$(basename -- "$unit")"
+done
+
+echo "Staged canonical host config. Active services and unit files were not changed."
+echo "Backup: $backup_directory"

--- a/apps/questura/infra/softprod/stage-host-config.test.sh
+++ b/apps/questura/infra/softprod/stage-host-config.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+DEPLOY_ROOT="$TEST_ROOT/host"
+APP_ROOT="$TEST_ROOT/app"
+FAKE_BIN="$TEST_ROOT/bin"
+LOG="$TEST_ROOT/commands.log"
+EXPECTED_COMPOSE_ENV="$TEST_ROOT/expected-compose.env"
+mkdir -p \
+  "$APP_ROOT/apps/questura/apps/server" \
+  "$APP_ROOT/apps/questura/apps/client" \
+  "$DEPLOY_ROOT/infra" \
+  "$FAKE_BIN"
+printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$APP_ROOT/apps/questura/apps/server/.env"
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$APP_ROOT/apps/questura/apps/client/.env.production.local"
+printf '%s\n' \
+  'services:' \
+  '  postgres:' \
+  '    environment:' \
+  '      POSTGRES_PASSWORD: fixture-password' > "$DEPLOY_ROOT/infra/compose.yml"
+FAKE_COMPOSE_PASSWORD=$'fixture\\path\'quote$dollar\nline2'
+printf '%s\n' "POSTGRES_PASSWORD=\"fixture\\\\path'quote\$\$dollar\\nline2\"" > "$EXPECTED_COMPOSE_ENV"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "docker|%s\\n" "$*" >> "$HOST_CONFIG_TEST_LOG"' \
+  'if [[ $* == *"--env-file"* ]]; then' \
+  '  previous=""; env_file=""; for argument in "$@"; do if [[ $previous == --env-file ]]; then env_file=$argument; break; fi; previous=$argument; done' \
+  '  cmp "$EXPECTED_COMPOSE_ENV" "$env_file"' \
+  'fi' \
+  'if [[ $* == *"--format json"* ]]; then python3 -c '\''import json,os; print(json.dumps({"services":{"postgres":{"environment":{"POSTGRES_PASSWORD":os.environ["FAKE_COMPOSE_PASSWORD"]}}}}))'\''; fi' > "$FAKE_BIN/docker"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "cloudflared|%s\\n" "$*" >> "$HOST_CONFIG_TEST_LOG"' > "$FAKE_BIN/cloudflared"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "systemd-analyze|%s\\n" "$*" >> "$HOST_CONFIG_TEST_LOG"' > "$FAKE_BIN/systemd-analyze"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$FAKE_BIN/pnpm"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [[ ${FAIL_FLOCK:-0} == 1 ]]; then exit 73; fi' > "$FAKE_BIN/flock"
+chmod +x "$FAKE_BIN"/*
+
+run_installer() {
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_APP_ROOT="$APP_ROOT" \
+    QUESTURA_PNPM_BIN="$FAKE_BIN/pnpm" \
+    QUESTURA_NODE_BIN_DIR="$FAKE_BIN" \
+    QUESTURA_CLOUDFLARED_BIN="$FAKE_BIN/cloudflared" \
+    HOST_CONFIG_TEST_LOG="$LOG" \
+    EXPECTED_COMPOSE_ENV="$EXPECTED_COMPOSE_ENV" \
+    FAKE_COMPOSE_PASSWORD="$FAKE_COMPOSE_PASSWORD" \
+    FAIL_FLOCK="${FAIL_FLOCK:-0}" \
+    "$SCRIPT_DIR/stage-host-config.sh"
+}
+
+run_installer > "$TEST_ROOT/install.out" 2> "$TEST_ROOT/install.err"
+cmp "$APP_ROOT/apps/questura/apps/server/.env" "$DEPLOY_ROOT/config/server.env"
+cmp "$APP_ROOT/apps/questura/apps/client/.env.production.local" "$DEPLOY_ROOT/config/client.env"
+cmp "$SCRIPT_DIR/host/compose.yml" "$DEPLOY_ROOT/infra/compose.yml"
+cmp "$SCRIPT_DIR/host/tunnel-config.yml" "$DEPLOY_ROOT/infra/tunnel-config.yml"
+cmp "$EXPECTED_COMPOSE_ENV" "$DEPLOY_ROOT/infra/.env"
+[[ $(stat -f '%Lp' "$DEPLOY_ROOT/infra/.env" 2>/dev/null || stat -c '%a' "$DEPLOY_ROOT/infra/.env") == 600 ]]
+[[ $(stat -f '%Lp' "$DEPLOY_ROOT/config/server.env" 2>/dev/null || stat -c '%a' "$DEPLOY_ROOT/config/server.env") == 600 ]]
+grep -q "ExecStart=$FAKE_BIN/pnpm exec next start -H 127.0.0.1 -p 4000" "$DEPLOY_ROOT/infra/systemd/questura-server.service"
+grep -q "ExecStart=$FAKE_BIN/cloudflared" "$DEPLOY_ROOT/infra/systemd/questura-tunnel.service"
+! rg -q '@(NODE_BIN_DIR|PNPM_BIN|CLOUDFLARED_BIN)@' "$DEPLOY_ROOT/infra/systemd"
+grep -q 'docker|.*config --quiet' "$LOG"
+grep -q 'cloudflared|.*tunnel ingress validate' "$LOG"
+grep -q 'systemd-analyze|--user verify' "$LOG"
+! grep -Fq "$FAKE_COMPOSE_PASSWORD" "$TEST_ROOT/install.out" "$TEST_ROOT/install.err"
+
+# Idempotent rerun keeps secrets quiet and creates another recoverable backup.
+run_installer > "$TEST_ROOT/repeat.out" 2> "$TEST_ROOT/repeat.err"
+[[ $(find "$DEPLOY_ROOT/backups/host-config" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ') == 2 ]]
+! grep -Fq "$FAKE_COMPOSE_PASSWORD" "$TEST_ROOT/repeat.out" "$TEST_ROOT/repeat.err"
+
+# Canonical-config drift aborts instead of overwriting operator-owned values.
+printf '%s\n' 'DATABASE_URI=postgres://changed' > "$APP_ROOT/apps/questura/apps/server/.env"
+set +e
+run_installer > "$TEST_ROOT/drift.out" 2> "$TEST_ROOT/drift.err"
+drift_code=$?
+set -e
+[[ $drift_code == 1 ]]
+grep -q 'refusing overwrite' "$TEST_ROOT/drift.err"
+grep -Fxq 'DATABASE_URI=postgres://fixture' "$DEPLOY_ROOT/config/server.env"
+
+set +e
+FAIL_FLOCK=1 run_installer > "$TEST_ROOT/lock.out" 2> "$TEST_ROOT/lock.err"
+lock_code=$?
+set -e
+[[ $lock_code == 1 ]]
+grep -q 'another Questura deploy or host-config operation is running' "$TEST_ROOT/lock.err"
+
+echo 'host-config staging tests passed'


### PR DESCRIPTION
## Summary
- migrate existing app env files into mode-0600 canonical config
- extract existing Compose password without output and verify exact round-trip
- install sanitized Compose/Tunnel config and rendered units into staging paths
- back up prior files; fail closed on config drift and lock contention
- never reload, enable, restart, or mutate active services

## Validation
- `pnpm --dir apps/questura/apps/server test:softprod`
- actual target-host Docker Compose special-character round-trip: 8 cases passed
- `git diff --check origin/main...HEAD`
- independent spec review: no findings
- independent standards/security review: no findings