### PR TITLE
ops(questura): prepare initial immutable host release

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -32,7 +32,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
-    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts"
   },
   "dependencies": {

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -105,6 +105,17 @@ installs sanitized Compose/Tunnel config, and renders validated units under
 `~/questura/infra/systemd`. It backs up prior files and never changes active
 unit files or service state. Any differing canonical app config fails closed.
 
+Prepare first immutable release after config staging:
+
+```bash
+~/questura/app/apps/questura/infra/softprod/prepare-host-release.sh
+```
+
+Preparation builds, tests, and certifies server/client artifacts from exact Git
+SHA; checks and applies forward-only migrations; leaves services, units, and
+`current-*` links untouched. A failed migration never builds client. Partial
+published releases remain safe to inspect/retry.
+
 ## Validation
 
 Migration-preflight and deploy-runner regression tests are part of the server

--- a/apps/questura/infra/softprod/prepare-host-release.sh
+++ b/apps/questura/infra/softprod/prepare-host-release.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Prepare and migrate the first immutable host release without activating it.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SOURCE_REPO=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+RELEASES_ROOT=${QUESTURA_RELEASES_ROOT:-"$DEPLOY_ROOT/releases"}
+CONFIG_ROOT=${QUESTURA_CONFIG_ROOT:-"$DEPLOY_ROOT/config"}
+TARGET_SHA=''
+stage=initialization
+
+export QUESTURA_RELEASES_ROOT="$RELEASES_ROOT"
+# shellcheck source=release-lib.sh
+. "$SCRIPT_DIR/release-lib.sh"
+# shellcheck source=release-builder.sh
+. "$SCRIPT_DIR/release-builder.sh"
+
+report_failure() {
+  local exit_code=${1:-1}
+  trap - ERR INT TERM
+  if ! cleanup_release_staging; then
+    echo "CRITICAL: failed to clean release staging directory." >&2
+  fi
+  echo "ERROR: initial release preparation failed during $stage (exit $exit_code)" >&2
+  exit "$exit_code"
+}
+trap 'report_failure "$?"' ERR
+trap 'report_failure 130' INT
+trap 'report_failure 143' TERM
+
+if (($# > 0)); then
+  echo "ERROR: prepare-host-release.sh takes no arguments" >&2
+  exit 2
+fi
+
+exec 9>"$DEPLOY_ROOT/deploy.lock"
+if ! flock -n 9; then
+  echo "ERROR: another Questura deploy or host operation is running" >&2
+  exit 1
+fi
+
+# Capture and validate all mutable state only after holding shared host lock.
+TARGET_SHA=$(git -C "$SOURCE_REPO" rev-parse HEAD)
+if [[ ! $TARGET_SHA =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: target is not a full commit SHA: $TARGET_SHA" >&2
+  exit 1
+fi
+if [[ -e $DEPLOY_ROOT/current-server || -L $DEPLOY_ROOT/current-server || -e $DEPLOY_ROOT/current-client || -L $DEPLOY_ROOT/current-client ]]; then
+  echo "ERROR: current release links already exist; use normal deploy.sh" >&2
+  exit 1
+fi
+if ! git -C "$SOURCE_REPO" diff --quiet || ! git -C "$SOURCE_REPO" diff --cached --quiet; then
+  echo "ERROR: deployment checkout has tracked changes" >&2
+  exit 1
+fi
+
+export NVM_DIR=${NVM_DIR:-"$HOME/.nvm"}
+if [[ -s $NVM_DIR/nvm.sh ]]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+  nvm use "${QUESTURA_NODE_VERSION:-22}" >/dev/null
+fi
+
+stage="server release preparation"
+echo "==> Preparing initial release ${TARGET_SHA:0:12}"
+prepare_server_release "$TARGET_SHA"
+RELEASE=$(canonical_path "$RELEASES_ROOT/$TARGET_SHA")
+SERVER="$RELEASE/apps/questura/apps/server"
+export QUESTURA_RELEASE_SHA="$TARGET_SHA"
+
+stage="migration preflight"
+echo "==> Checking pending database migrations"
+cd "$SERVER"
+node scripts/deploy/check-pending-migrations.mjs
+
+stage="database migration"
+echo "==> Running database migrations"
+pnpm db:migrate
+node scripts/deploy/check-pending-migrations.mjs --require-clean
+
+stage="client release completion"
+echo "==> Completing client release against current public server"
+complete_client_release "$TARGET_SHA"
+
+stage="release verification"
+require_complete_release "$TARGET_SHA"
+echo "Prepared release $TARGET_SHA. Active services and release links were not changed."

--- a/apps/questura/infra/softprod/prepare-host-release.test.sh
+++ b/apps/questura/infra/softprod/prepare-host-release.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+REPO="$TEST_ROOT/repo"
+DEPLOY_ROOT="$TEST_ROOT/host"
+CONFIG_ROOT="$DEPLOY_ROOT/config"
+FAKE_BIN="$TEST_ROOT/bin"
+LOG="$TEST_ROOT/commands.log"
+mkdir -p \
+  "$REPO/apps/questura/infra/softprod" \
+  "$REPO/apps/questura/apps/server/scripts/deploy" \
+  "$REPO/apps/questura/apps/client" \
+  "$CONFIG_ROOT" \
+  "$FAKE_BIN"
+cp \
+  "$SCRIPT_DIR/prepare-host-release.sh" \
+  "$SCRIPT_DIR/release-builder.sh" \
+  "$SCRIPT_DIR/release-lib.sh" \
+  "$REPO/apps/questura/infra/softprod/"
+printf '%s\n' '{"name":"@questura/server"}' > "$REPO/apps/questura/apps/server/package.json"
+printf '%s\n' 'export {}' > "$REPO/apps/questura/apps/server/scripts/deploy/check-pending-migrations.mjs"
+printf '%s\n' '{"name":"@questura/client"}' > "$REPO/apps/questura/apps/client/package.json"
+printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$CONFIG_ROOT/server.env"
+printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$CONFIG_ROOT/client.env"
+
+git -C "$REPO" init --quiet
+git -C "$REPO" config user.email prepare-test@example.invalid
+git -C "$REPO" config user.name prepare-test
+git -C "$REPO" add .
+git -C "$REPO" commit --quiet -m fixture
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -eu' \
+  'printf "%s|%s|%s\\n" "$PWD" "$(basename "$0")" "$*" >> "$PREPARE_TEST_LOG"' \
+  'if [[ $(basename "$0") == pnpm && $* == install* ]]; then mkdir -p "$PWD/node_modules/.pnpm/fake"; printf "dependency\\n" > "$PWD/node_modules/.pnpm/fake/runtime.js"; fi' \
+  'if [[ $(basename "$0") == pnpm && $* == db:migrate && ${FAIL_MIGRATE:-0} == 1 ]]; then exit 42; fi' > "$FAKE_BIN/pnpm"
+cp "$FAKE_BIN/pnpm" "$FAKE_BIN/node"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [[ ${FAIL_FLOCK:-0} == 1 ]]; then exit 73; fi' > "$FAKE_BIN/flock"
+chmod +x "$FAKE_BIN"/*
+
+run_prepare() {
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    NVM_DIR="$TEST_ROOT/no-nvm" \
+    QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_CONFIG_ROOT="$CONFIG_ROOT" \
+    PREPARE_TEST_LOG="$LOG" \
+    FAIL_MIGRATE="${FAIL_MIGRATE:-0}" \
+    FAIL_FLOCK="${FAIL_FLOCK:-0}" \
+    "$REPO/apps/questura/infra/softprod/prepare-host-release.sh"
+}
+
+SHA=$(git -C "$REPO" rev-parse HEAD)
+RELEASE="$DEPLOY_ROOT/releases/$SHA"
+run_prepare > "$TEST_ROOT/success.out" 2> "$TEST_ROOT/success.err"
+grep -q "Prepared release $SHA" "$TEST_ROOT/success.out"
+grep -q "QUESTURA_RELEASE_SHA=$SHA" "$RELEASE/.questura/server-ready"
+grep -q "QUESTURA_RELEASE_SHA=$SHA" "$RELEASE/.questura/release-ready"
+[[ ! -e $DEPLOY_ROOT/current-server && ! -e $DEPLOY_ROOT/current-client ]]
+if rg -q 'systemctl|docker|cloudflared' "$LOG"; then
+  echo 'initial release preparation touched active host services' >&2
+  exit 1
+fi
+preflight=$(grep -n 'node|scripts/deploy/check-pending-migrations.mjs$' "$LOG" | cut -d: -f1)
+migrate=$(grep -n 'pnpm|db:migrate$' "$LOG" | cut -d: -f1)
+client_build=$(grep -n '/client|pnpm|build$' "$LOG" | cut -d: -f1)
+((preflight < migrate && migrate < client_build))
+
+# Complete release retry validates and reruns migration clean check, not builds.
+: > "$LOG"
+run_prepare > "$TEST_ROOT/repeat.out" 2> "$TEST_ROOT/repeat.err"
+if grep -Eq '\|pnpm\|(install |build$|test$|lint$)' "$LOG"; then
+  echo 'complete initial release was rebuilt on retry' >&2
+  exit 1
+fi
+
+# Migration failure leaves release inactive and never runs client build.
+printf '%s\n' next > "$REPO/fixture.txt"
+git -C "$REPO" add fixture.txt
+git -C "$REPO" commit --quiet -m next
+NEXT_SHA=$(git -C "$REPO" rev-parse HEAD)
+: > "$LOG"
+set +e
+FAIL_MIGRATE=1 run_prepare > "$TEST_ROOT/migrate.out" 2> "$TEST_ROOT/migrate.err"
+migrate_code=$?
+set -e
+[[ $migrate_code == 42 ]]
+grep -q 'failed during database migration' "$TEST_ROOT/migrate.err"
+[[ ! -e $DEPLOY_ROOT/current-server && ! -e $DEPLOY_ROOT/current-client ]]
+if grep -q '/client|pnpm|build$' "$LOG"; then
+  echo 'client built after migration failure' >&2
+  exit 1
+fi
+[[ -f $DEPLOY_ROOT/releases/$NEXT_SHA/.questura/server-ready ]]
+[[ ! -f $DEPLOY_ROOT/releases/$NEXT_SHA/.questura/release-ready ]]
+
+set +e
+FAIL_FLOCK=1 run_prepare > "$TEST_ROOT/lock.out" 2> "$TEST_ROOT/lock.err"
+lock_code=$?
+set -e
+[[ $lock_code == 1 ]]
+grep -q 'another Questura deploy or host operation is running' "$TEST_ROOT/lock.err"
+
+# Existing or dangling release links abort after lock, before build/migration.
+ln -s "$DEPLOY_ROOT/releases/missing" "$DEPLOY_ROOT/current-server"
+: > "$LOG"
+set +e
+run_prepare > "$TEST_ROOT/current-link.out" 2> "$TEST_ROOT/current-link.err"
+current_link_code=$?
+set -e
+[[ $current_link_code == 1 ]]
+grep -q 'current release links already exist' "$TEST_ROOT/current-link.err"
+if grep -Eq '\|(pnpm|node)\|' "$LOG"; then
+  echo 'initial preparation continued after current-link guard' >&2
+  exit 1
+fi
+
+echo 'initial release preparation tests passed'


### PR DESCRIPTION
## Summary
- add initial-only exact-SHA release preparation under shared host lock
- run guarded forward migration before client build
- certify complete server/client release without changing links, units, or services
- retain partial published release for safe retry; clean private staging on failure/signals

## Validation
- `pnpm --dir apps/questura/apps/server test:softprod`
- focused initial-release preparation suite
- `git diff --check origin/main...HEAD`
- independent spec review: no findings
- independent standards/security review: no findings