### PR TITLE
test: make softprod suite portable and hermetic

### DIFF
--- a/apps/questura/infra/softprod/deploy.test.sh
+++ b/apps/questura/infra/softprod/deploy.test.sh
@@ -6,6 +6,11 @@ CLIENT_CONFIG="$SCRIPT_DIR/../../apps/client/next.config.ts"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf -- "$TEST_ROOT"' EXIT
 
+# Production preparation exports these before running the suite. Keep the
+# fixture hermetic instead of accidentally targeting the real release root.
+export QUESTURA_RELEASES_ROOT="$TEST_ROOT/inherited-releases-root"
+export QUESTURA_RELEASE_SHA=ffffffffffffffffffffffffffffffffffffffff
+
 REPO="$TEST_ROOT/repo"
 FAKE_BIN="$TEST_ROOT/bin"
 DEPLOY_ROOT="$TEST_ROOT/host"
@@ -89,6 +94,7 @@ run_deploy() {
     PATH="$FAKE_BIN:$PATH" \
     NVM_DIR="$TEST_ROOT/no-nvm" \
     QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_RELEASES_ROOT="$DEPLOY_ROOT/releases" \
     QUESTURA_CONFIG_ROOT="$CONFIG_ROOT" \
     QUESTURA_HEALTH_ATTEMPTS=1 \
     QUESTURA_HEALTH_SLEEP_SECONDS=0 \
@@ -413,6 +419,7 @@ env \
   PATH="$FAKE_BIN:$PATH" \
   NVM_DIR="$TEST_ROOT/no-nvm" \
   QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+  QUESTURA_RELEASES_ROOT="$DEPLOY_ROOT/releases" \
   QUESTURA_CONFIG_ROOT="$CONFIG_ROOT" \
   QUESTURA_HEALTH_ATTEMPTS=1 \
   QUESTURA_HEALTH_SLEEP_SECONDS=0 \
@@ -430,6 +437,6 @@ QUESTURA_DEPLOY_ROOT="$INSTALL_ROOT" \
   "$SCRIPT_DIR/install-deploy-wrapper.sh" > "$TEST_ROOT/install.out"
 cmp "$SCRIPT_DIR/host-deploy-wrapper.sh" "$INSTALL_ROOT/deploy.sh"
 [[ $(find "$INSTALL_ROOT/backups/deploy" -type f | wc -l | tr -d ' ') == 1 ]]
-[[ $(stat -f '%Lp' "$INSTALL_ROOT/deploy.sh" 2>/dev/null || stat -c '%a' "$INSTALL_ROOT/deploy.sh") == 755 ]]
+[[ $(stat -c '%a' "$INSTALL_ROOT/deploy.sh" 2>/dev/null || stat -f '%Lp' "$INSTALL_ROOT/deploy.sh") == 755 ]]
 
 echo 'deploy sequencing tests passed'

--- a/apps/questura/infra/softprod/stage-host-config.test.sh
+++ b/apps/questura/infra/softprod/stage-host-config.test.sh
@@ -66,8 +66,8 @@ cmp "$APP_ROOT/apps/questura/apps/client/.env.production.local" "$DEPLOY_ROOT/co
 cmp "$SCRIPT_DIR/host/compose.yml" "$DEPLOY_ROOT/infra/compose.yml"
 cmp "$SCRIPT_DIR/host/tunnel-config.yml" "$DEPLOY_ROOT/infra/tunnel-config.yml"
 cmp "$EXPECTED_COMPOSE_ENV" "$DEPLOY_ROOT/infra/.env"
-[[ $(stat -f '%Lp' "$DEPLOY_ROOT/infra/.env" 2>/dev/null || stat -c '%a' "$DEPLOY_ROOT/infra/.env") == 600 ]]
-[[ $(stat -f '%Lp' "$DEPLOY_ROOT/config/server.env" 2>/dev/null || stat -c '%a' "$DEPLOY_ROOT/config/server.env") == 600 ]]
+[[ $(stat -c '%a' "$DEPLOY_ROOT/infra/.env" 2>/dev/null || stat -f '%Lp' "$DEPLOY_ROOT/infra/.env") == 600 ]]
+[[ $(stat -c '%a' "$DEPLOY_ROOT/config/server.env" 2>/dev/null || stat -f '%Lp' "$DEPLOY_ROOT/config/server.env") == 600 ]]
 grep -q "ExecStart=$FAKE_BIN/pnpm exec next start -H 127.0.0.1 -p 4000" "$DEPLOY_ROOT/infra/systemd/questura-server.service"
 grep -q "ExecStart=$FAKE_BIN/cloudflared" "$DEPLOY_ROOT/infra/systemd/questura-tunnel.service"
 ! rg -q '@(NODE_BIN_DIR|PNPM_BIN|CLOUDFLARED_BIN)@' "$DEPLOY_ROOT/infra/systemd"


### PR DESCRIPTION
## Summary
- isolate deploy fixtures from production release environment variables
- make file-mode assertions portable across GNU and BSD stat
- reproduce the initial host-preparation failure in regression coverage

## Verification
- `pnpm --dir apps/questura/apps/server test:softprod` (macOS)
- all four softprod shell suites from a clean branch archive (Linux host)
- ShellCheck on modified tests (Linux host)
- `git diff --check`