### PR TITLE
fix: declare client lint plugin for filtered releases

### DIFF
--- a/apps/questura/apps/client/package.json
+++ b/apps/questura/apps/client/package.json
@@ -30,6 +30,7 @@
     "@types/react-dom": "^19.2.3",
     "eslint": "^9",
     "eslint-config-next": "15.4.11",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,9 @@ importers:
       eslint-config-next:
         specifier: 15.4.11
         version: 15.4.11(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       tailwindcss:
         specifier: ^4
         version: 4.1.18


### PR DESCRIPTION
## Summary
- declare the React Hooks ESLint plugin directly in the Questura client
- preserve pnpm strict dependency resolution in filtered immutable installs
- allow Next build lint to run instead of skipping with a missing-plugin error

## Verification
- exact Linux filtered frozen install for Questura server + client
- `pnpm build` in the clean filtered client archive (BUILD_ID produced, zero stderr)
- Next lint reaches source and reports four existing warnings
- `git diff --check`