### PR TITLE
fix: report missing bootstrap token once

### DIFF
--- a/apps/questura/apps/server/docs/first-admin-bootstrap.md
+++ b/apps/questura/apps/server/docs/first-admin-bootstrap.md
@@ -54,7 +54,7 @@ that cannot set headers; it is not a stored field.
 | Environment | `BOOTSTRAP_ADMIN_TOKEN` | First-user create |
 |---|---|---|
 | Production | set | Allowed only with a matching token |
-| Production | unset | **Refused**, with an explanatory server log |
+| Production | unset | **Refused**, with one explanatory log per server process |
 | Development | set | Enforced, exactly as production — use this to rehearse |
 | Development | unset | Allowed, unchanged from before this guard existed |
 

--- a/apps/questura/apps/server/src/features/auth/lib/bootstrap-token.test.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/bootstrap-token.test.ts
@@ -34,14 +34,16 @@ describe('bootstrap token', () => {
       expect(isBootstrapRequestAuthorized({ req: reqWithHeader(null) })).toBe(true)
     })
 
-    it('refuses bootstrap in production and explains how to enable it', async () => {
+    it('refuses every production bootstrap but explains how to enable it once', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
       const { isBootstrapRequestAuthorized } = await load({ NODE_ENV: 'production' })
 
       expect(isBootstrapRequestAuthorized({ req: reqWithHeader(null) })).toBe(false)
+      expect(isBootstrapRequestAuthorized({ req: reqWithHeader(null) })).toBe(false)
       expect(consoleError).toHaveBeenCalledWith(
         expect.stringContaining('BOOTSTRAP_ADMIN_TOKEN is not set')
       )
+      expect(consoleError).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/apps/questura/apps/server/src/features/auth/lib/bootstrap-token.ts
+++ b/apps/questura/apps/server/src/features/auth/lib/bootstrap-token.ts
@@ -36,6 +36,7 @@ import { APP_CONFIG } from '@/shared/config'
 export const BOOTSTRAP_TOKEN_HEADER = 'x-bootstrap-token'
 
 const BOOTSTRAP_TOKEN_ENV_VAR = 'BOOTSTRAP_ADMIN_TOKEN'
+let missingProductionTokenReported = false
 
 type HeaderReader = { get?: (name: string) => string | null | undefined }
 
@@ -83,11 +84,14 @@ export function isBootstrapRequestAuthorized(args: BootstrapAccessArgs): boolean
   if (!expected) {
     if (!APP_CONFIG.isProduction) return true
 
-    console.error(
-      `Refusing unauthenticated first-user bootstrap: ${BOOTSTRAP_TOKEN_ENV_VAR} is not set. ` +
-        `Set it to a random secret, create the first admin with an ` +
-        `\`${BOOTSTRAP_TOKEN_HEADER}\` header carrying that value, then unset it.`
-    )
+    if (!missingProductionTokenReported) {
+      missingProductionTokenReported = true
+      console.error(
+        `Refusing unauthenticated first-user bootstrap: ${BOOTSTRAP_TOKEN_ENV_VAR} is not set. ` +
+          `Set it to a random secret, create the first admin with an ` +
+          `\`${BOOTSTRAP_TOKEN_HEADER}\` header carrying that value, then unset it.`
+      )
+    }
     return false
   }
 


### PR DESCRIPTION
## Summary
- keep production first-user bootstrap fail-closed when the token is unset
- emit its operator guidance once per server process instead of every access check
- document the log lifecycle

## Verification
- focused bootstrap-token suite: 9 tests pass
- server lint: 0 errors, 5 pre-existing warnings
- `git diff --check`