### PR TITLE
feat: adopt initial immutable host release

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -32,7 +32,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
-    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh && bash ../../infra/softprod/adopt-host-release.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts"
   },
   "dependencies": {

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -62,18 +62,18 @@ pnpm db:migrate
 
 There is no bypass or `--force` switch in automated deployment.
 
-## First install
+## Wrapper reinstall
 
-Install the wrapper. Installer preserves any existing copy under
-`~/questura/backups/deploy/`:
+After initial release adoption, reinstall the stable wrapper if needed. Installer
+preserves any existing copy under `~/questura/backups/deploy/`:
 
 ```bash
 ~/questura/app/apps/questura/infra/softprod/install-deploy-wrapper.sh
 ```
 
-Deploy requires release-based host units and aligned `current-*` pointers.
-Install/adopt those through host-bootstrap tooling before replacing current
-wrapper. Until then, existing host deploy path remains unchanged.
+Normal deploy requires release-based host units and aligned `current-*`
+pointers. Fresh legacy-host migration uses the staged adoption flow below;
+adoption backs up and replaces the wrapper transactionally.
 
 ## Versioned host configuration
 
@@ -115,6 +115,33 @@ Preparation builds, tests, and certifies server/client artifacts from exact Git
 SHA; checks and applies forward-only migrations; leaves services, units, and
 `current-*` links untouched. A failed migration never builds client. Partial
 published releases remain safe to inspect/retry.
+
+Adopt the prepared release only after preparation succeeds at the checkout's
+current `HEAD`:
+
+```bash
+~/questura/app/apps/questura/infra/softprod/adopt-host-release.sh
+```
+
+Adoption is initial-only: all `current-*` and `previous-*` paths must be absent.
+It takes the shared deploy lock, re-certifies the paired release for exact
+`HEAD`, validates staged/live user units and service state, then backs up live
+units and the legacy wrapper under `~/questura/backups/host-adoption/`. It
+atomically installs both release pointers, versioned units, and the stable
+wrapper. Server and client must report the exact release locally and publicly;
+the same checks run again after restarting Cloudflare Tunnel. Installed units
+switch app and tunnel logging to journald.
+
+Any install, restart, health, interrupt, or termination failure restores exact
+legacy unit/wrapper bytes and modes, reloads and restarts those services,
+rechecks their captured baseline health, and removes only adoption's unchanged
+initial links. An incomplete rollback prints `CRITICAL` with its retained backup
+path. Adoption never builds artifacts, installs dependencies, runs Compose, or
+migrates the database.
+
+The prepared release must match the commit containing the adoption script. If
+preparation ran before that commit was checked out, rerun preparation first; it
+will safely reuse completed work where certification still matches.
 
 ## Validation
 

--- a/apps/questura/infra/softprod/adopt-host-release.sh
+++ b/apps/questura/infra/softprod/adopt-host-release.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# Adopt the first prepared immutable release and versioned host units atomically.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SOURCE_REPO=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+RELEASES_ROOT=${QUESTURA_RELEASES_ROOT:-"$DEPLOY_ROOT/releases"}
+CONFIG_ROOT=${QUESTURA_CONFIG_ROOT:-"$DEPLOY_ROOT/config"}
+INFRA_ROOT=${QUESTURA_INFRA_ROOT:-"$DEPLOY_ROOT/infra"}
+RENDERED_ROOT=${QUESTURA_RENDERED_UNITS_ROOT:-"$INFRA_ROOT/systemd"}
+USER_UNIT_ROOT=${QUESTURA_USER_UNIT_ROOT:-"${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"}
+WRAPPER_SOURCE=${QUESTURA_DEPLOY_WRAPPER_SOURCE:-"$SCRIPT_DIR/host-deploy-wrapper.sh"}
+WRAPPER_TARGET=${QUESTURA_DEPLOY_WRAPPER_TARGET:-"$DEPLOY_ROOT/deploy.sh"}
+TARGET_SHA=''
+TARGET_RELEASE=''
+TARGET_SERVER=''
+TARGET_CLIENT=''
+CHECKOUT_STATUS=''
+BACKUP_DIRECTORY=''
+BACKUP_READY=0
+MUTATION_STARTED=0
+ADOPTION_COMPLETE=0
+stage=initialization
+
+UNITS=(questura-server questura-client questura-tunnel)
+
+export QUESTURA_RELEASES_ROOT="$RELEASES_ROOT"
+# shellcheck source=release-lib.sh
+. "$SCRIPT_DIR/release-lib.sh"
+# shellcheck source=release-builder.sh
+. "$SCRIPT_DIR/release-builder.sh"
+
+file_mode() {
+  python3 - "$1" <<'PY'
+import pathlib
+import stat
+import sys
+print(f"{stat.S_IMODE(pathlib.Path(sys.argv[1]).stat().st_mode):04o}")
+PY
+}
+
+require_regular_file() {
+  local path=$1
+  if [[ ! -f $path || -L $path || ! -r $path ]]; then
+    echo "ERROR: required readable regular file is missing: $path" >&2
+    return 1
+  fi
+}
+
+atomic_install() {
+  local source=$1
+  local destination=$2
+  local mode=$3
+  local directory temporary status
+
+  directory=$(dirname -- "$destination") || return
+  mkdir -p "$directory"
+  temporary=$(mktemp "$directory/.$(basename -- "$destination").adopt.XXXXXX") || return
+  if install -m "$mode" "$source" "$temporary"; then
+    :
+  else
+    status=$?
+    rm -f -- "$temporary"
+    return "$status"
+  fi
+  if mv -f "$temporary" "$destination"; then
+    :
+  else
+    status=$?
+    rm -f -- "$temporary"
+    return "$status"
+  fi
+}
+
+atomic_restore() {
+  local source=$1
+  local destination=$2
+  local directory temporary
+
+  directory=$(dirname -- "$destination") || return
+  temporary=$(mktemp "$directory/.$(basename -- "$destination").restore.XXXXXX") || return
+  if ! cp -p "$source" "$temporary" || ! mv -f "$temporary" "$destination"; then
+    rm -f -- "$temporary"
+    return 1
+  fi
+  cmp -s "$source" "$destination" && [[ $(file_mode "$source") == "$(file_mode "$destination")" ]]
+}
+
+healthy_release_sha() {
+  python3 -c '
+import json
+import sys
+try:
+    body = json.load(sys.stdin)
+except (json.JSONDecodeError, UnicodeDecodeError):
+    raise SystemExit(1)
+value = body.get("releaseSha") if isinstance(body, dict) and body.get("status") == "healthy" else None
+if not isinstance(value, str) or not value:
+    raise SystemExit(1)
+print(value)
+'
+}
+
+capture_health_sha() {
+  local label=$1
+  local url=$2
+  local attempt body release
+
+  for attempt in $(seq 1 "$SOFTPROD_HEALTH_ATTEMPTS"); do
+    body=$(curl --fail --silent --show-error --max-time 10 "$url" 2>/dev/null || true)
+    release=$(healthy_release_sha <<< "$body" || true)
+    if [[ -n $release ]]; then
+      echo "    captured $label baseline" >&2
+      printf '%s\n' "$release"
+      return 0
+    fi
+    sleep "$SOFTPROD_HEALTH_SLEEP_SECONDS"
+  done
+
+  echo "ERROR: $label baseline is not healthy: $url" >&2
+  return 1
+}
+
+require_service_state() {
+  local unit=$1
+  if ! systemctl --user is-active --quiet "$unit"; then
+    echo "ERROR: required user service is not active: $unit" >&2
+    return 1
+  fi
+  if ! systemctl --user is-enabled --quiet "$unit"; then
+    echo "ERROR: required user service is not enabled: $unit" >&2
+    return 1
+  fi
+}
+
+restore_one_file() {
+  local backup=$1
+  local destination=$2
+  local label=$3
+
+  if ! atomic_restore "$backup" "$destination"; then
+    echo "CRITICAL: failed to restore $label from $backup" >&2
+    return 1
+  fi
+}
+
+remove_attempted_link() {
+  local link=$1
+  local expected=$2
+  local actual
+
+  if [[ -L $link ]]; then
+    actual=$(canonical_path "$link") || {
+      echo "CRITICAL: failed to resolve attempted release link: $link" >&2
+      return 1
+    }
+    if [[ $actual != "$expected" ]]; then
+      echo "CRITICAL: refusing to remove changed release link: $link -> $actual" >&2
+      return 1
+    fi
+    if ! unlink "$link"; then
+      echo "CRITICAL: failed to remove attempted release link: $link" >&2
+      return 1
+    fi
+  elif [[ -e $link ]]; then
+    echo "CRITICAL: attempted release link became a non-symlink: $link" >&2
+    return 1
+  fi
+}
+
+rollback_adoption() {
+  local failed=0
+  local unit
+
+  echo "==> Restoring pre-adoption host state" >&2
+  for unit in "${UNITS[@]}"; do
+    restore_one_file \
+      "$BACKUP_DIRECTORY/units/$unit.service" \
+      "$USER_UNIT_ROOT/$unit.service" \
+      "$unit.service" || failed=1
+  done
+  restore_one_file "$BACKUP_DIRECTORY/wrapper/deploy.sh" "$WRAPPER_TARGET" "deploy wrapper" || failed=1
+
+  if ! systemctl --user daemon-reload; then
+    echo "CRITICAL: failed to reload restored user units" >&2
+    failed=1
+  fi
+  for unit in "${UNITS[@]}"; do
+    if ! systemctl --user restart "$unit"; then
+      echo "CRITICAL: failed to restart restored service: $unit" >&2
+      failed=1
+    fi
+  done
+
+  wait_for_release_health "restored local server" "http://127.0.0.1:4000/api/health" "$BASELINE_SERVER_LOCAL" || failed=1
+  wait_for_release_health "restored public server" "https://cms.questurian.com/api/health" "$BASELINE_SERVER_PUBLIC" || failed=1
+  wait_for_release_health "restored local client" "http://127.0.0.1:3000/api/health" "$BASELINE_CLIENT_LOCAL" || failed=1
+  wait_for_release_health "restored public client" "https://www.questurian.com/api/health" "$BASELINE_CLIENT_PUBLIC" || failed=1
+
+  for unit in "${UNITS[@]}"; do
+    if ! require_service_state "$unit"; then failed=1; fi
+  done
+
+  remove_attempted_link "$DEPLOY_ROOT/current-server" "$TARGET_SERVER" || failed=1
+  remove_attempted_link "$DEPLOY_ROOT/current-client" "$TARGET_CLIENT" || failed=1
+  return "$failed"
+}
+
+report_failure() {
+  local exit_code=${1:-1}
+  local rollback_failed=0
+
+  trap - ERR INT TERM
+  set +e
+  if ((BACKUP_READY == 1 && MUTATION_STARTED == 1 && ADOPTION_COMPLETE == 0)); then
+    rollback_adoption || rollback_failed=1
+  fi
+  if ((rollback_failed == 1)); then
+    echo "CRITICAL: initial release adoption rollback is incomplete; recover from $BACKUP_DIRECTORY" >&2
+  fi
+  echo "ERROR: initial release adoption failed during $stage (exit $exit_code)" >&2
+  exit "$exit_code"
+}
+trap 'report_failure "$?"' ERR
+trap 'report_failure 130' INT
+trap 'report_failure 143' TERM
+
+if (($# > 0)); then
+  echo "ERROR: adopt-host-release.sh takes no arguments" >&2
+  exit 2
+fi
+
+mkdir -p "$DEPLOY_ROOT"
+exec 9>"$DEPLOY_ROOT/deploy.lock"
+if ! flock -n 9; then
+  echo "ERROR: another Questura deploy or host operation is running" >&2
+  exit 1
+fi
+
+# Capture every mutable prerequisite only while holding the shared host lock.
+stage="release preflight"
+TARGET_SHA=$(git -C "$SOURCE_REPO" rev-parse --verify 'HEAD^{commit}')
+if [[ ! $TARGET_SHA =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: target is not a full commit SHA: $TARGET_SHA" >&2
+  exit 1
+fi
+CHECKOUT_STATUS=$(git -C "$SOURCE_REPO" status --porcelain --untracked-files=normal) || report_failure "$?"
+if [[ -n $CHECKOUT_STATUS ]]; then
+  echo "ERROR: deployment checkout is not clean" >&2
+  exit 1
+fi
+for link in \
+  "$DEPLOY_ROOT/current-server" \
+  "$DEPLOY_ROOT/current-client" \
+  "$DEPLOY_ROOT/previous-server" \
+  "$DEPLOY_ROOT/previous-client"; do
+  if [[ -e $link || -L $link ]]; then
+    echo "ERROR: initial release link already exists: $link" >&2
+    exit 1
+  fi
+done
+
+require_complete_release "$TARGET_SHA"
+TARGET_RELEASE=$(canonical_path "$RELEASES_ROOT/$TARGET_SHA")
+TARGET_SERVER="$TARGET_RELEASE/apps/questura/apps/server"
+TARGET_CLIENT="$TARGET_RELEASE/apps/questura/apps/client"
+
+require_regular_file "$CONFIG_ROOT/server.env"
+require_regular_file "$CONFIG_ROOT/client.env"
+require_regular_file "$INFRA_ROOT/tunnel-config.yml"
+require_regular_file "$WRAPPER_SOURCE"
+require_regular_file "$WRAPPER_TARGET"
+if [[ ! -x $WRAPPER_SOURCE || ! -x $WRAPPER_TARGET ]]; then
+  echo "ERROR: deploy wrappers must be executable" >&2
+  exit 1
+fi
+
+STAGED_UNIT_PATHS=()
+for unit in "${UNITS[@]}"; do
+  require_regular_file "$RENDERED_ROOT/$unit.service"
+  require_regular_file "$USER_UNIT_ROOT/$unit.service"
+  STAGED_UNIT_PATHS+=("$RENDERED_ROOT/$unit.service")
+done
+systemd-analyze --user verify "${STAGED_UNIT_PATHS[@]}"
+for unit in "${UNITS[@]}"; do require_service_state "$unit"; done
+
+stage="baseline health capture"
+BASELINE_SERVER_LOCAL=$(capture_health_sha "local server" "http://127.0.0.1:4000/api/health") || report_failure "$?"
+BASELINE_SERVER_PUBLIC=$(capture_health_sha "public server" "https://cms.questurian.com/api/health") || report_failure "$?"
+BASELINE_CLIENT_LOCAL=$(capture_health_sha "local client" "http://127.0.0.1:3000/api/health") || report_failure "$?"
+BASELINE_CLIENT_PUBLIC=$(capture_health_sha "public client" "https://www.questurian.com/api/health") || report_failure "$?"
+
+stage="host backup"
+mkdir -p "$DEPLOY_ROOT/backups/host-adoption"
+BACKUP_DIRECTORY=$(mktemp -d "$DEPLOY_ROOT/backups/host-adoption/adoption.XXXXXX")
+chmod 0700 "$BACKUP_DIRECTORY"
+mkdir -p "$BACKUP_DIRECTORY/units" "$BACKUP_DIRECTORY/wrapper"
+for unit in "${UNITS[@]}"; do
+  cp -p "$USER_UNIT_ROOT/$unit.service" "$BACKUP_DIRECTORY/units/$unit.service"
+  cmp -s "$USER_UNIT_ROOT/$unit.service" "$BACKUP_DIRECTORY/units/$unit.service"
+  [[ $(file_mode "$USER_UNIT_ROOT/$unit.service") == "$(file_mode "$BACKUP_DIRECTORY/units/$unit.service")" ]]
+done
+cp -p "$WRAPPER_TARGET" "$BACKUP_DIRECTORY/wrapper/deploy.sh"
+cmp -s "$WRAPPER_TARGET" "$BACKUP_DIRECTORY/wrapper/deploy.sh"
+[[ $(file_mode "$WRAPPER_TARGET") == "$(file_mode "$BACKUP_DIRECTORY/wrapper/deploy.sh")" ]]
+printf '%s\n' \
+  "QUESTURA_RELEASE_SHA=$TARGET_SHA" \
+  "BASELINE_SERVER_LOCAL=$BASELINE_SERVER_LOCAL" \
+  "BASELINE_SERVER_PUBLIC=$BASELINE_SERVER_PUBLIC" \
+  "BASELINE_CLIENT_LOCAL=$BASELINE_CLIENT_LOCAL" \
+  "BASELINE_CLIENT_PUBLIC=$BASELINE_CLIENT_PUBLIC" \
+  'questura-server=active,enabled' \
+  'questura-client=active,enabled' \
+  'questura-tunnel=active,enabled' > "$BACKUP_DIRECTORY/manifest"
+chmod 0600 "$BACKUP_DIRECTORY/manifest"
+BACKUP_READY=1
+
+stage="release link installation"
+MUTATION_STARTED=1
+atomic_symlink "$TARGET_SERVER" "$DEPLOY_ROOT/current-server"
+atomic_symlink "$TARGET_CLIENT" "$DEPLOY_ROOT/current-client"
+
+stage="unit and wrapper installation"
+for unit in "${UNITS[@]}"; do
+  atomic_install "$RENDERED_ROOT/$unit.service" "$USER_UNIT_ROOT/$unit.service" 0644
+done
+atomic_install "$WRAPPER_SOURCE" "$WRAPPER_TARGET" 0755
+
+stage="user unit reload"
+systemctl --user daemon-reload
+
+stage="server activation"
+systemctl --user restart questura-server
+verify_component server "$TARGET_SHA"
+
+stage="client activation"
+systemctl --user restart questura-client
+verify_component client "$TARGET_SHA"
+
+stage="tunnel activation"
+systemctl --user restart questura-tunnel
+verify_component server "$TARGET_SHA"
+verify_component client "$TARGET_SHA"
+for unit in "${UNITS[@]}"; do require_service_state "$unit"; done
+
+ADOPTION_COMPLETE=1
+trap - ERR INT TERM
+echo "Adopted initial immutable release $TARGET_SHA"
+echo "Backup: $BACKUP_DIRECTORY"

--- a/apps/questura/infra/softprod/adopt-host-release.test.sh
+++ b/apps/questura/infra/softprod/adopt-host-release.test.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SUITE_ROOT=$(mktemp -d)
+cleanup_suite() {
+  if [[ ${KEEP_ADOPT_TEST_ROOT:-0} == 1 ]]; then
+    echo "kept adoption test root: $SUITE_ROOT" >&2
+  else
+    rm -rf -- "$SUITE_ROOT"
+  fi
+}
+trap cleanup_suite EXIT
+REAL_INSTALL=$(command -v install)
+
+file_mode() {
+  python3 - "$1" <<'PY'
+import pathlib
+import stat
+import sys
+print(f"{stat.S_IMODE(pathlib.Path(sys.argv[1]).stat().st_mode):04o}")
+PY
+}
+
+new_fixture() {
+  local name=$1
+  CASE_ROOT="$SUITE_ROOT/$name"
+  REPO="$CASE_ROOT/repo"
+  DEPLOY_ROOT="$CASE_ROOT/host"
+  CONFIG_ROOT="$DEPLOY_ROOT/config"
+  INFRA_ROOT="$DEPLOY_ROOT/infra"
+  RENDERED_ROOT="$INFRA_ROOT/systemd"
+  USER_UNIT_ROOT="$CASE_ROOT/user-units"
+  FAKE_BIN="$CASE_ROOT/bin"
+  STATE="$CASE_ROOT/state"
+  EXPECTED="$CASE_ROOT/expected"
+  LOG="$CASE_ROOT/commands.log"
+  mkdir -p \
+    "$REPO/apps/questura/infra/softprod" \
+    "$REPO/apps/questura/apps/server" \
+    "$REPO/apps/questura/apps/client" \
+    "$CONFIG_ROOT" \
+    "$RENDERED_ROOT" \
+    "$USER_UNIT_ROOT" \
+    "$FAKE_BIN" \
+    "$STATE" \
+    "$EXPECTED/units"
+
+  cp \
+    "$SCRIPT_DIR/adopt-host-release.sh" \
+    "$SCRIPT_DIR/host-deploy-wrapper.sh" \
+    "$SCRIPT_DIR/release-builder.sh" \
+    "$SCRIPT_DIR/release-lib.sh" \
+    "$REPO/apps/questura/infra/softprod/"
+  chmod +x "$REPO/apps/questura/infra/softprod/adopt-host-release.sh" \
+    "$REPO/apps/questura/infra/softprod/host-deploy-wrapper.sh"
+  printf '%s\n' '{"name":"@questura/server"}' > "$REPO/apps/questura/apps/server/package.json"
+  printf '%s\n' '{"name":"@questura/client"}' > "$REPO/apps/questura/apps/client/package.json"
+  printf '%s\n' 'DATABASE_URI=postgres://fixture' > "$CONFIG_ROOT/server.env"
+  printf '%s\n' 'NEXT_PUBLIC_SERVER_URL=https://cms.questurian.com' > "$CONFIG_ROOT/client.env"
+  printf '%s\n' 'tunnel: fixture' > "$INFRA_ROOT/tunnel-config.yml"
+
+  printf '%s\n' '[Service]' 'ExecStart=legacy-server' > "$USER_UNIT_ROOT/questura-server.service"
+  printf '%s\n' '[Service]' 'ExecStart=legacy-client' > "$USER_UNIT_ROOT/questura-client.service"
+  printf '%s\n' '[Service]' 'ExecStart=legacy-tunnel' > "$USER_UNIT_ROOT/questura-tunnel.service"
+  chmod 0600 "$USER_UNIT_ROOT/questura-server.service"
+  chmod 0640 "$USER_UNIT_ROOT/questura-client.service"
+  chmod 0644 "$USER_UNIT_ROOT/questura-tunnel.service"
+  printf '%s\n' '#!/usr/bin/env bash' 'echo legacy-wrapper' > "$DEPLOY_ROOT/deploy.sh"
+  chmod 0740 "$DEPLOY_ROOT/deploy.sh"
+
+  cp -p "$USER_UNIT_ROOT"/*.service "$EXPECTED/units/"
+  cp -p "$DEPLOY_ROOT/deploy.sh" "$EXPECTED/deploy.sh"
+
+  printf '%s\n' '[Service]' 'WorkingDirectory=%h/questura/current-server' 'ExecStart=new-server' > "$RENDERED_ROOT/questura-server.service"
+  printf '%s\n' '[Service]' 'WorkingDirectory=%h/questura/current-client' 'ExecStart=new-client' > "$RENDERED_ROOT/questura-client.service"
+  printf '%s\n' '[Service]' 'ExecStart=new-tunnel' '# journald' > "$RENDERED_ROOT/questura-tunnel.service"
+  chmod 0644 "$RENDERED_ROOT"/*.service
+
+  git -C "$REPO" init --quiet
+  git -C "$REPO" config user.email adoption-test@example.invalid
+  git -C "$REPO" config user.name adoption-test
+  git -C "$REPO" add .
+  git -C "$REPO" commit --quiet -m fixture
+  SHA=$(git -C "$REPO" rev-parse HEAD)
+  RELEASE="$DEPLOY_ROOT/releases/$SHA"
+  mkdir -p \
+    "$RELEASE/apps/questura/apps/server" \
+    "$RELEASE/apps/questura/apps/client" \
+    "$RELEASE/node_modules/.pnpm/fixture"
+  printf '%s\n' server-artifact > "$RELEASE/apps/questura/apps/server/server.js"
+  printf '%s\n' client-artifact > "$RELEASE/apps/questura/apps/client/client.js"
+  printf '%s\n' dependency > "$RELEASE/node_modules/.pnpm/fixture/index.js"
+  (
+    export QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT"
+    export QUESTURA_RELEASES_ROOT="$DEPLOY_ROOT/releases"
+    SOURCE_REPO="$REPO"
+    CONFIG_ROOT="$CONFIG_ROOT"
+    # shellcheck source=release-lib.sh
+    . "$REPO/apps/questura/infra/softprod/release-lib.sh"
+    # shellcheck source=release-builder.sh
+    . "$REPO/apps/questura/infra/softprod/release-builder.sh"
+    write_release_metadata "$RELEASE" "$SHA"
+    ensure_config_link "$RELEASE" server
+    ensure_config_link "$RELEASE" client
+    server_config=$(config_fingerprint server)
+    client_config=$(config_fingerprint client)
+    write_release_inputs "$RELEASE" "$SHA" "$server_config" "$client_config"
+    write_marker "$RELEASE" server-ready server "$SHA" "$server_config"
+    write_marker "$RELEASE" release-ready client "$SHA" "$client_config"
+  )
+
+  printf '%s\n' legacy-server > "$STATE/server-release"
+  printf '%s\n' legacy-client > "$STATE/client-release"
+  : > "$LOG"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'line=$1' \
+    'for rule in trigger rollback; do' \
+    '  if [[ $rule == trigger ]]; then' \
+    '    match=${TRIGGER_MATCH:-}; occurrence=${TRIGGER_OCCURRENCE:-1}; status=${TRIGGER_STATUS:-41}; counter=$ADOPT_TEST_STATE/trigger.count' \
+    '  else' \
+    '    match=${ROLLBACK_FAIL_MATCH:-}; occurrence=${ROLLBACK_FAIL_OCCURRENCE:-1}; status=${ROLLBACK_FAIL_STATUS:-42}; counter=$ADOPT_TEST_STATE/rollback.count' \
+    '  fi' \
+    '  if [[ -n $match && $line == *"$match"* ]]; then' \
+    '    count=0; [[ -f $counter ]] && read -r count < "$counter"' \
+    '    count=$((count + 1)); printf "%s\\n" "$count" > "$counter"' \
+    '    if ((count == occurrence)); then exit "$status"; fi' \
+    '  fi' \
+    'done' \
+    'exit 0' > "$FAKE_BIN/adopt-test-maybe-fail"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [[ ${FAIL_FLOCK:-0} == 1 ]]; then exit 73; fi' > "$FAKE_BIN/flock"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'line="systemd-analyze|$*"' \
+    'printf "%s\\n" "$line" >> "$ADOPT_TEST_LOG"' \
+    '"$(dirname "$0")/adopt-test-maybe-fail" "$line"' > "$FAKE_BIN/systemd-analyze"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'line="systemctl|$*"' \
+    'printf "%s\\n" "$line" >> "$ADOPT_TEST_LOG"' \
+    '"$(dirname "$0")/adopt-test-maybe-fail" "$line" || exit $?' \
+    'if [[ -n ${SIGNAL_MATCH:-} && $line == *"$SIGNAL_MATCH"* && ! -e $ADOPT_TEST_STATE/signal-fired ]]; then' \
+    '  : > "$ADOPT_TEST_STATE/signal-fired"' \
+    '  kill -"${SIGNAL_NAME:-TERM}" "$PPID"' \
+    '  sleep 1' \
+    'fi' \
+    'case "$*" in' \
+    '  *"is-active"*) [[ ${INACTIVE_UNIT:-} != "${!#}" ]] ;;' \
+    '  *"is-enabled"*) [[ ${DISABLED_UNIT:-} != "${!#}" ]] ;;' \
+    '  *"restart questura-server")' \
+    '    if grep -q new-server "$ADOPT_TEST_USER_UNITS/questura-server.service"; then printf "%s\\n" "$ADOPT_TEST_TARGET_SHA" > "$ADOPT_TEST_STATE/server-release"; else printf "%s\\n" legacy-server > "$ADOPT_TEST_STATE/server-release"; fi ;;' \
+    '  *"restart questura-client")' \
+    '    if grep -q new-client "$ADOPT_TEST_USER_UNITS/questura-client.service"; then printf "%s\\n" "$ADOPT_TEST_TARGET_SHA" > "$ADOPT_TEST_STATE/client-release"; else printf "%s\\n" legacy-client > "$ADOPT_TEST_STATE/client-release"; fi ;;' \
+    'esac' > "$FAKE_BIN/systemctl"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'url=${!#}' \
+    'line="curl|$url"' \
+    'printf "%s\\n" "$line" >> "$ADOPT_TEST_LOG"' \
+    '"$(dirname "$0")/adopt-test-maybe-fail" "$line" || exit $?' \
+    'case "$url" in *4000*|*cms.questurian.com*) component=server ;; *) component=client ;; esac' \
+    'read -r release < "$ADOPT_TEST_STATE/$component-release"' \
+    'if [[ -n ${HEALTH_MISMATCH_MATCH:-} && $url == *"$HEALTH_MISMATCH_MATCH"* && $release == "$ADOPT_TEST_TARGET_SHA" && ! -e $ADOPT_TEST_STATE/health-mismatch-fired ]]; then' \
+    '  : > "$ADOPT_TEST_STATE/health-mismatch-fired"; release=wrong-release' \
+    'fi' \
+    'printf "%s\n" "{\"status\":\"healthy\",\"releaseSha\":\"$release\"}"' > "$FAKE_BIN/curl"
+
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$FAKE_BIN/sleep"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'line="install|$*"' \
+    'printf "%s\\n" "$line" >> "$ADOPT_TEST_LOG"' \
+    '"$(dirname "$0")/adopt-test-maybe-fail" "$line" || exit $?' \
+    'exec "$ADOPT_TEST_REAL_INSTALL" "$@"' > "$FAKE_BIN/install"
+  chmod +x "$FAKE_BIN"/*
+}
+
+run_adopt() {
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_RELEASES_ROOT="$DEPLOY_ROOT/releases" \
+    QUESTURA_CONFIG_ROOT="$CONFIG_ROOT" \
+    QUESTURA_INFRA_ROOT="$INFRA_ROOT" \
+    QUESTURA_RENDERED_UNITS_ROOT="$RENDERED_ROOT" \
+    QUESTURA_USER_UNIT_ROOT="$USER_UNIT_ROOT" \
+    QUESTURA_DEPLOY_WRAPPER_TARGET="$DEPLOY_ROOT/deploy.sh" \
+    QUESTURA_HEALTH_ATTEMPTS=1 \
+    QUESTURA_HEALTH_SLEEP_SECONDS=0 \
+    ADOPT_TEST_LOG="$LOG" \
+    ADOPT_TEST_STATE="$STATE" \
+    ADOPT_TEST_TARGET_SHA="$SHA" \
+    ADOPT_TEST_USER_UNITS="$USER_UNIT_ROOT" \
+    ADOPT_TEST_REAL_INSTALL="$REAL_INSTALL" \
+    FAIL_FLOCK="${FAIL_FLOCK:-0}" \
+    INACTIVE_UNIT="${INACTIVE_UNIT:-}" \
+    DISABLED_UNIT="${DISABLED_UNIT:-}" \
+    TRIGGER_MATCH="${TRIGGER_MATCH:-}" \
+    TRIGGER_OCCURRENCE="${TRIGGER_OCCURRENCE:-1}" \
+    TRIGGER_STATUS="${TRIGGER_STATUS:-41}" \
+    ROLLBACK_FAIL_MATCH="${ROLLBACK_FAIL_MATCH:-}" \
+    ROLLBACK_FAIL_OCCURRENCE="${ROLLBACK_FAIL_OCCURRENCE:-1}" \
+    ROLLBACK_FAIL_STATUS="${ROLLBACK_FAIL_STATUS:-42}" \
+    HEALTH_MISMATCH_MATCH="${HEALTH_MISMATCH_MATCH:-}" \
+    SIGNAL_MATCH="${SIGNAL_MATCH:-}" \
+    SIGNAL_NAME="${SIGNAL_NAME:-TERM}" \
+    "$REPO/apps/questura/infra/softprod/adopt-host-release.sh"
+}
+
+assert_status() {
+  local expected=$1
+  local actual=$2
+  if [[ $actual != "$expected" ]]; then
+    echo "expected exit $expected, got $actual for $CASE_ROOT" >&2
+    exit 1
+  fi
+}
+
+assert_no_mutation() {
+  [[ ! -e $DEPLOY_ROOT/current-server && ! -L $DEPLOY_ROOT/current-server ]]
+  [[ ! -e $DEPLOY_ROOT/current-client && ! -L $DEPLOY_ROOT/current-client ]]
+  cmp -s "$EXPECTED/deploy.sh" "$DEPLOY_ROOT/deploy.sh"
+  for unit in questura-server questura-client questura-tunnel; do
+    cmp -s "$EXPECTED/units/$unit.service" "$USER_UNIT_ROOT/$unit.service"
+  done
+}
+
+assert_restored() {
+  assert_no_mutation
+  [[ $(file_mode "$EXPECTED/deploy.sh") == "$(file_mode "$DEPLOY_ROOT/deploy.sh")" ]]
+  for unit in questura-server questura-client questura-tunnel; do
+    [[ $(file_mode "$EXPECTED/units/$unit.service") == "$(file_mode "$USER_UNIT_ROOT/$unit.service")" ]]
+  done
+  grep -qF 'systemctl|--user restart questura-tunnel' "$LOG"
+  grep -qF 'curl|https://www.questurian.com/api/health' "$LOG"
+}
+
+# Happy path: exact files/modes, paired links, deterministic activation order.
+new_fixture happy
+run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err"
+grep -q "Adopted initial immutable release $SHA" "$CASE_ROOT/out"
+[[ $(readlink "$DEPLOY_ROOT/current-server") == "$RELEASE/apps/questura/apps/server" ]]
+[[ $(readlink "$DEPLOY_ROOT/current-client") == "$RELEASE/apps/questura/apps/client" ]]
+[[ ! -e $DEPLOY_ROOT/previous-server && ! -L $DEPLOY_ROOT/previous-server ]]
+[[ ! -e $DEPLOY_ROOT/previous-client && ! -L $DEPLOY_ROOT/previous-client ]]
+for unit in questura-server questura-client questura-tunnel; do
+  cmp -s "$RENDERED_ROOT/$unit.service" "$USER_UNIT_ROOT/$unit.service"
+  [[ $(file_mode "$USER_UNIT_ROOT/$unit.service") == 0644 ]]
+done
+cmp -s "$REPO/apps/questura/infra/softprod/host-deploy-wrapper.sh" "$DEPLOY_ROOT/deploy.sh"
+[[ $(file_mode "$DEPLOY_ROOT/deploy.sh") == 0755 ]]
+BACKUP=$(find "$DEPLOY_ROOT/backups/host-adoption" -mindepth 1 -maxdepth 1 -type d -print -quit)
+[[ $(file_mode "$BACKUP") == 0700 && $(file_mode "$BACKUP/manifest") == 0600 ]]
+cmp -s "$EXPECTED/deploy.sh" "$BACKUP/wrapper/deploy.sh"
+for unit in questura-server questura-client questura-tunnel; do
+  cmp -s "$EXPECTED/units/$unit.service" "$BACKUP/units/$unit.service"
+done
+python3 - "$LOG" <<'PY'
+import pathlib
+import sys
+text = pathlib.Path(sys.argv[1]).read_text()
+text = text[text.index("systemctl|--user daemon-reload"):]
+ordered = [
+    "systemctl|--user restart questura-server",
+    "curl|http://127.0.0.1:4000/api/health",
+    "curl|https://cms.questurian.com/api/health",
+    "systemctl|--user restart questura-client",
+    "curl|http://127.0.0.1:3000/api/health",
+    "curl|https://www.questurian.com/api/health",
+    "systemctl|--user restart questura-tunnel",
+    "curl|http://127.0.0.1:4000/api/health",
+    "curl|https://cms.questurian.com/api/health",
+    "curl|http://127.0.0.1:3000/api/health",
+    "curl|https://www.questurian.com/api/health",
+]
+position = -1
+for token in ordered:
+    position = text.index(token, position + 1)
+PY
+
+# Preflight failures occur before backup or mutation.
+new_fixture lock
+code=0
+FAIL_FLOCK=1 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 1 "$code"
+grep -q 'another Questura deploy or host operation is running' "$CASE_ROOT/err"
+assert_no_mutation
+
+for link_name in current-server previous-client; do
+  new_fixture "dangling-${link_name}"
+  ln -s "$DEPLOY_ROOT/releases/missing" "$DEPLOY_ROOT/$link_name"
+  code=0
+  run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+  assert_status 1 "$code"
+  grep -q 'initial release link already exists' "$CASE_ROOT/err"
+  [[ -L $DEPLOY_ROOT/$link_name ]]
+done
+
+new_fixture incomplete
+rm "$RELEASE/.questura/release-ready"
+code=0
+run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 1 "$code"
+grep -q 'release is not complete' "$CASE_ROOT/err"
+assert_no_mutation
+
+new_fixture dirty
+printf '%s\n' dirty > "$REPO/untracked"
+code=0
+run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 1 "$code"
+grep -q 'deployment checkout is not clean' "$CASE_ROOT/err"
+assert_no_mutation
+
+new_fixture inactive
+code=0
+INACTIVE_UNIT=questura-tunnel run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 1 "$code"
+grep -q 'required user service is not active: questura-tunnel' "$CASE_ROOT/err"
+assert_no_mutation
+
+new_fixture invalid-unit
+code=0
+TRIGGER_MATCH='systemd-analyze|' TRIGGER_STATUS=45 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 45 "$code"
+assert_no_mutation
+
+# Failures after links, unit replacement, activation, health, and tunnel restore all state.
+new_fixture unit-install-failure
+code=0
+TRIGGER_MATCH='questura-client.service.adopt' TRIGGER_STATUS=46 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 46 "$code"
+assert_restored
+
+new_fixture reload-failure
+code=0
+TRIGGER_MATCH='systemctl|--user daemon-reload' TRIGGER_STATUS=47 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 47 "$code"
+assert_restored
+
+new_fixture server-restart-failure
+code=0
+TRIGGER_MATCH='restart questura-server' TRIGGER_STATUS=48 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 48 "$code"
+assert_restored
+
+new_fixture public-health-mismatch
+code=0
+HEALTH_MISMATCH_MATCH='cms.questurian.com' run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 1 "$code"
+grep -q 'public server did not report release' "$CASE_ROOT/err"
+assert_restored
+
+new_fixture tunnel-restart-failure
+code=0
+TRIGGER_MATCH='restart questura-tunnel' TRIGGER_STATUS=49 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 49 "$code"
+assert_restored
+
+# TERM after mutation uses same rollback path and preserves signal status.
+new_fixture signal
+code=0
+SIGNAL_MATCH='restart questura-server' SIGNAL_NAME=TERM run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 143 "$code"
+assert_restored
+
+# Rollback failure is loud, retains original status, and does not skip later cleanup.
+new_fixture rollback-failure
+code=0
+TRIGGER_MATCH='restart questura-server' \
+  TRIGGER_STATUS=50 \
+  ROLLBACK_FAIL_MATCH='systemctl|--user daemon-reload' \
+  ROLLBACK_FAIL_OCCURRENCE=2 \
+  ROLLBACK_FAIL_STATUS=51 \
+  run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 50 "$code"
+grep -q 'CRITICAL: initial release adoption rollback is incomplete' "$CASE_ROOT/err"
+assert_restored
+
+# Adoption must consume prepared artifacts only.
+if rg -n '(pnpm (install|build)|db:migrate|docker compose|prepare_server_release|complete_client_release)' "$SCRIPT_DIR/adopt-host-release.sh"; then
+  echo 'initial adoption contains a forbidden build, install, migration, or compose operation' >&2
+  exit 1
+fi
+
+echo 'initial release adoption tests passed'


### PR DESCRIPTION
## Summary
- add an initial-only atomic host adoption transaction for prepared immutable releases
- back up and restore legacy units/wrapper on any install, restart, health, or signal failure
- verify exact local/public release identity and wire comprehensive shell regressions into `test:softprod`

## Validation
- `bash apps/questura/infra/softprod/adopt-host-release.test.sh`
- `pnpm --dir apps/questura/apps/server test:softprod`
- `git diff --check origin/main...HEAD`

Host state is not changed by this PR.