### PR TITLE
fix(softprod): accept a legacy pre-adoption health baseline

### DIFF
--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -133,16 +133,20 @@ the same checks run again after restarting Cloudflare Tunnel. Installed units
 switch app and tunnel logging to journald.
 
 The deployment being adopted predates release-aware health, so its baseline is
-captured leniently: an endpoint that reports a healthy `releaseSha` is recorded
-exactly, and one that does not — a server without the field, or a client whose
-`/api/health` route does not exist yet — is recorded as `legacy` only if it is
-still serving (the client's own root answers with a redirect, which counts).
-A service that is genuinely down fails the preflight instead. Verification of
-the adopted release is unaffected and still demands the exact SHA everywhere.
+captured leniently. An endpoint reporting a healthy 40-hex `releaseSha` is
+recorded exactly; anything else is recorded as `legacy`, and only after proving
+the service still answers. The server proves it through its own health body,
+which still reports `status` and answers 503 when the database is down; the
+client has no `/api/health` route yet, so its own root is used and any 2xx or
+3xx counts. A service that is genuinely down fails the preflight instead.
+Verification of the adopted release is unaffected and still demands the exact
+SHA on all four endpoints.
 
 Any install, restart, health, interrupt, or termination failure restores exact
 legacy unit/wrapper bytes and modes, reloads and restarts those services,
-rechecks their captured baseline health, and removes only adoption's unchanged
+rechecks whichever baseline it captured — the exact release, or for a legacy
+baseline that the service answers again and is not reporting the release the
+adoption was trying to install — and removes only adoption's unchanged
 initial links. An incomplete rollback prints `CRITICAL` with its retained backup
 path. Adoption never builds artifacts, installs dependencies, runs Compose, or
 migrates the database.

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -132,6 +132,14 @@ wrapper. Server and client must report the exact release locally and publicly;
 the same checks run again after restarting Cloudflare Tunnel. Installed units
 switch app and tunnel logging to journald.
 
+The deployment being adopted predates release-aware health, so its baseline is
+captured leniently: an endpoint that reports a healthy `releaseSha` is recorded
+exactly, and one that does not — a server without the field, or a client whose
+`/api/health` route does not exist yet — is recorded as `legacy` only if it is
+still serving (the client's own root answers with a redirect, which counts).
+A service that is genuinely down fails the preflight instead. Verification of
+the adopted release is unaffected and still demands the exact SHA everywhere.
+
 Any install, restart, health, interrupt, or termination failure restores exact
 legacy unit/wrapper bytes and modes, reloads and restarts those services,
 rechecks their captured baseline health, and removes only adoption's unchanged

--- a/apps/questura/infra/softprod/adopt-host-release.sh
+++ b/apps/questura/infra/softprod/adopt-host-release.sh
@@ -25,6 +25,16 @@ stage=initialization
 
 UNITS=(questura-server questura-client questura-tunnel)
 
+LEGACY_BASELINE=legacy
+SERVER_LOCAL_HEALTH='http://127.0.0.1:4000/api/health'
+SERVER_PUBLIC_HEALTH='https://cms.questurian.com/api/health'
+CLIENT_LOCAL_HEALTH='http://127.0.0.1:3000/api/health'
+CLIENT_PUBLIC_HEALTH='https://www.questurian.com/api/health'
+# A client old enough to lack `/api/health` still answers its own root, so that
+# is the only liveness signal shared by both the legacy and the adopted client.
+CLIENT_LOCAL_ROOT='http://127.0.0.1:3000/'
+CLIENT_PUBLIC_ROOT='https://www.questurian.com/'
+
 export QUESTURA_RELEASES_ROOT="$RELEASES_ROOT"
 # shellcheck source=release-lib.sh
 . "$SCRIPT_DIR/release-lib.sh"
@@ -102,23 +112,67 @@ print(value)
 '
 }
 
-capture_health_sha() {
+serving() {
+  # No `--location`, so a 2xx or 3xx means the process answered and only a 4xx,
+  # 5xx or transport failure counts as down. The legacy client answers `/` with
+  # a locale redirect, which is exactly the shape this must accept.
+  curl --fail --silent --show-error --max-time 10 --output /dev/null "$1" 2>/dev/null
+}
+
+# The deployment being adopted is the one that predates release-aware health:
+# its server omits `releaseSha` and its client has no `/api/health` route at
+# all. Demanding a release SHA from it would make adoption impossible on the
+# only host that can ever need it. A pre-adoption endpoint therefore records
+# either its exact release or `legacy`, and `legacy` still has to prove the
+# service is serving, so a real outage is never mistaken for an old build.
+# Post-adoption verification is untouched and still requires the exact SHA.
+capture_baseline() {
   local label=$1
-  local url=$2
+  local health_url=$2
+  local liveness_url=$3
   local attempt body release
 
   for attempt in $(seq 1 "$SOFTPROD_HEALTH_ATTEMPTS"); do
-    body=$(curl --fail --silent --show-error --max-time 10 "$url" 2>/dev/null || true)
+    body=$(curl --fail --silent --show-error --max-time 10 "$health_url" 2>/dev/null || true)
     release=$(healthy_release_sha <<< "$body" || true)
     if [[ -n $release ]]; then
       echo "    captured $label baseline" >&2
       printf '%s\n' "$release"
       return 0
     fi
+    if serving "$liveness_url"; then
+      echo "    captured $label baseline (legacy, no release health)" >&2
+      printf '%s\n' "$LEGACY_BASELINE"
+      return 0
+    fi
     sleep "$SOFTPROD_HEALTH_SLEEP_SECONDS"
   done
 
-  echo "ERROR: $label baseline is not healthy: $url" >&2
+  echo "ERROR: $label baseline is not serving: $liveness_url" >&2
+  return 1
+}
+
+wait_for_baseline() {
+  local label=$1
+  local health_url=$2
+  local liveness_url=$3
+  local expected=$4
+  local attempt
+
+  if [[ $expected != "$LEGACY_BASELINE" ]]; then
+    wait_for_release_health "$label" "$health_url" "$expected"
+    return
+  fi
+
+  for attempt in $(seq 1 "$SOFTPROD_HEALTH_ATTEMPTS"); do
+    if serving "$liveness_url"; then
+      echo "    $label serving (legacy baseline)"
+      return 0
+    fi
+    sleep "$SOFTPROD_HEALTH_SLEEP_SECONDS"
+  done
+
+  echo "ERROR: $label did not return to its legacy baseline: $liveness_url" >&2
   return 1
 }
 
@@ -193,10 +247,14 @@ rollback_adoption() {
     fi
   done
 
-  wait_for_release_health "restored local server" "http://127.0.0.1:4000/api/health" "$BASELINE_SERVER_LOCAL" || failed=1
-  wait_for_release_health "restored public server" "https://cms.questurian.com/api/health" "$BASELINE_SERVER_PUBLIC" || failed=1
-  wait_for_release_health "restored local client" "http://127.0.0.1:3000/api/health" "$BASELINE_CLIENT_LOCAL" || failed=1
-  wait_for_release_health "restored public client" "https://www.questurian.com/api/health" "$BASELINE_CLIENT_PUBLIC" || failed=1
+  wait_for_baseline "restored local server" \
+    "$SERVER_LOCAL_HEALTH" "$SERVER_LOCAL_HEALTH" "$BASELINE_SERVER_LOCAL" || failed=1
+  wait_for_baseline "restored public server" \
+    "$SERVER_PUBLIC_HEALTH" "$SERVER_PUBLIC_HEALTH" "$BASELINE_SERVER_PUBLIC" || failed=1
+  wait_for_baseline "restored local client" \
+    "$CLIENT_LOCAL_HEALTH" "$CLIENT_LOCAL_ROOT" "$BASELINE_CLIENT_LOCAL" || failed=1
+  wait_for_baseline "restored public client" \
+    "$CLIENT_PUBLIC_HEALTH" "$CLIENT_PUBLIC_ROOT" "$BASELINE_CLIENT_PUBLIC" || failed=1
 
   for unit in "${UNITS[@]}"; do
     if ! require_service_state "$unit"; then failed=1; fi
@@ -286,10 +344,14 @@ systemd-analyze --user verify "${STAGED_UNIT_PATHS[@]}"
 for unit in "${UNITS[@]}"; do require_service_state "$unit"; done
 
 stage="baseline health capture"
-BASELINE_SERVER_LOCAL=$(capture_health_sha "local server" "http://127.0.0.1:4000/api/health") || report_failure "$?"
-BASELINE_SERVER_PUBLIC=$(capture_health_sha "public server" "https://cms.questurian.com/api/health") || report_failure "$?"
-BASELINE_CLIENT_LOCAL=$(capture_health_sha "local client" "http://127.0.0.1:3000/api/health") || report_failure "$?"
-BASELINE_CLIENT_PUBLIC=$(capture_health_sha "public client" "https://www.questurian.com/api/health") || report_failure "$?"
+BASELINE_SERVER_LOCAL=$(capture_baseline "local server" \
+  "$SERVER_LOCAL_HEALTH" "$SERVER_LOCAL_HEALTH") || report_failure "$?"
+BASELINE_SERVER_PUBLIC=$(capture_baseline "public server" \
+  "$SERVER_PUBLIC_HEALTH" "$SERVER_PUBLIC_HEALTH") || report_failure "$?"
+BASELINE_CLIENT_LOCAL=$(capture_baseline "local client" \
+  "$CLIENT_LOCAL_HEALTH" "$CLIENT_LOCAL_ROOT") || report_failure "$?"
+BASELINE_CLIENT_PUBLIC=$(capture_baseline "public client" \
+  "$CLIENT_PUBLIC_HEALTH" "$CLIENT_PUBLIC_ROOT") || report_failure "$?"
 
 stage="host backup"
 mkdir -p "$DEPLOY_ROOT/backups/host-adoption"

--- a/apps/questura/infra/softprod/adopt-host-release.sh
+++ b/apps/questura/infra/softprod/adopt-host-release.sh
@@ -26,12 +26,10 @@ stage=initialization
 UNITS=(questura-server questura-client questura-tunnel)
 
 LEGACY_BASELINE=legacy
-SERVER_LOCAL_HEALTH='http://127.0.0.1:4000/api/health'
-SERVER_PUBLIC_HEALTH='https://cms.questurian.com/api/health'
-CLIENT_LOCAL_HEALTH='http://127.0.0.1:3000/api/health'
-CLIENT_PUBLIC_HEALTH='https://www.questurian.com/api/health'
 # A client old enough to lack `/api/health` still answers its own root, so that
-# is the only liveness signal shared by both the legacy and the adopted client.
+# is the only signal shared by both the legacy and the adopted client. The
+# health URLs themselves come from release-lib.sh, so a baseline is captured
+# from exactly the endpoints `verify_component` later verifies.
 CLIENT_LOCAL_ROOT='http://127.0.0.1:3000/'
 CLIENT_PUBLIC_ROOT='https://www.questurian.com/'
 
@@ -112,11 +110,33 @@ print(value)
 '
 }
 
-serving() {
-  # No `--location`, so a 2xx or 3xx means the process answered and only a 4xx,
-  # 5xx or transport failure counts as down. The legacy client answers `/` with
-  # a locale redirect, which is exactly the shape this must accept.
-  curl --fail --silent --show-error --max-time 10 --output /dev/null "$1" 2>/dev/null
+healthy_status() {
+  python3 -c '
+import json
+import sys
+try:
+    body = json.load(sys.stdin)
+except (json.JSONDecodeError, UnicodeDecodeError):
+    raise SystemExit(1)
+raise SystemExit(0 if isinstance(body, dict) and body.get("status") == "healthy" else 1)
+'
+}
+
+adoption_endpoint_answers() {
+  # No `--location`, so any 2xx or 3xx counts as answered and a 4xx, 5xx or
+  # transport failure does not. Used only where no body contract exists — the
+  # legacy client has no `/api/health` route, so its own root is the only
+  # signal it shares with the adopted client. On a public URL this is
+  # origin-blind: an edge redirect would answer with the origin down. Output is
+  # discarded because callers read this function's *status*, while their own
+  # value travels on stdout.
+  curl --fail --silent --show-error --max-time 10 --output /dev/null "$1" >/dev/null 2>&1
+}
+
+adoption_endpoint_is_target() {
+  local body
+  body=$(curl --fail --silent --show-error --max-time 10 "$1" 2>/dev/null || true)
+  [[ $(healthy_release_sha <<< "$body" || true) == "$TARGET_SHA" ]]
 }
 
 # The deployment being adopted is the one that predates release-aware health:
@@ -124,23 +144,42 @@ serving() {
 # all. Demanding a release SHA from it would make adoption impossible on the
 # only host that can ever need it. A pre-adoption endpoint therefore records
 # either its exact release or `legacy`, and `legacy` still has to prove the
-# service is serving, so a real outage is never mistaken for an old build.
+# service is answering, so a real outage is never mistaken for an old build.
 # Post-adoption verification is untouched and still requires the exact SHA.
+#
+# `legacy_probe` is `body` where a JSON health contract already exists — the
+# legacy server still reports `status`, and its route answers 503 when the
+# database is down, so that is a strictly stronger signal than a status code —
+# and `answers` where none does.
 capture_baseline() {
   local label=$1
   local health_url=$2
-  local liveness_url=$3
+  local legacy_probe=$3
+  local answers_url=$4
   local attempt body release
+
+  # This runs inside a command substitution. Rollback belongs to the parent
+  # shell, which turns a non-zero return into its own `report_failure`.
+  trap - ERR INT TERM
 
   for attempt in $(seq 1 "$SOFTPROD_HEALTH_ATTEMPTS"); do
     body=$(curl --fail --silent --show-error --max-time 10 "$health_url" 2>/dev/null || true)
     release=$(healthy_release_sha <<< "$body" || true)
-    if [[ -n $release ]]; then
+    # An exact baseline has to be a commit. `unknown` is what the health route
+    # emits with no release env var, and `legacy` is this script's own
+    # sentinel — neither may be mistaken for a release to restore to.
+    if [[ $release =~ ^[0-9a-f]{40}$ ]]; then
       echo "    captured $label baseline" >&2
       printf '%s\n' "$release"
       return 0
     fi
-    if serving "$liveness_url"; then
+    if [[ $legacy_probe == body ]]; then
+      if healthy_status <<< "$body"; then
+        echo "    captured $label baseline (legacy, no release health)" >&2
+        printf '%s\n' "$LEGACY_BASELINE"
+        return 0
+      fi
+    elif adoption_endpoint_answers "$answers_url"; then
       echo "    captured $label baseline (legacy, no release health)" >&2
       printf '%s\n' "$LEGACY_BASELINE"
       return 0
@@ -148,16 +187,17 @@ capture_baseline() {
     sleep "$SOFTPROD_HEALTH_SLEEP_SECONDS"
   done
 
-  echo "ERROR: $label baseline is not serving: $liveness_url" >&2
+  echo "ERROR: $label baseline is not serving: $health_url" >&2
   return 1
 }
 
 wait_for_baseline() {
   local label=$1
   local health_url=$2
-  local liveness_url=$3
-  local expected=$4
-  local attempt
+  local legacy_probe=$3
+  local answers_url=$4
+  local expected=$5
+  local attempt restored
 
   if [[ $expected != "$LEGACY_BASELINE" ]]; then
     wait_for_release_health "$label" "$health_url" "$expected"
@@ -165,14 +205,25 @@ wait_for_baseline() {
   fi
 
   for attempt in $(seq 1 "$SOFTPROD_HEALTH_ATTEMPTS"); do
-    if serving "$liveness_url"; then
+    restored=0
+    if [[ $legacy_probe == body ]]; then
+      if healthy_status <<< "$(curl --fail --silent --show-error --max-time 10 "$health_url" 2>/dev/null || true)"; then
+        restored=1
+      fi
+    elif adoption_endpoint_answers "$answers_url"; then
+      restored=1
+    fi
+    # The adopted service answers too, so "answering" alone would call a failed
+    # restore a success. The restored service is the legacy one, which cannot
+    # report the release being adopted.
+    if ((restored == 1)) && ! adoption_endpoint_is_target "$health_url"; then
       echo "    $label serving (legacy baseline)"
       return 0
     fi
     sleep "$SOFTPROD_HEALTH_SLEEP_SECONDS"
   done
 
-  echo "ERROR: $label did not return to its legacy baseline: $liveness_url" >&2
+  echo "ERROR: $label did not return to its legacy baseline: $health_url" >&2
   return 1
 }
 
@@ -248,13 +299,13 @@ rollback_adoption() {
   done
 
   wait_for_baseline "restored local server" \
-    "$SERVER_LOCAL_HEALTH" "$SERVER_LOCAL_HEALTH" "$BASELINE_SERVER_LOCAL" || failed=1
+    "$SOFTPROD_SERVER_LOCAL_HEALTH" body '' "$BASELINE_SERVER_LOCAL" || failed=1
   wait_for_baseline "restored public server" \
-    "$SERVER_PUBLIC_HEALTH" "$SERVER_PUBLIC_HEALTH" "$BASELINE_SERVER_PUBLIC" || failed=1
+    "$SOFTPROD_SERVER_PUBLIC_HEALTH" body '' "$BASELINE_SERVER_PUBLIC" || failed=1
   wait_for_baseline "restored local client" \
-    "$CLIENT_LOCAL_HEALTH" "$CLIENT_LOCAL_ROOT" "$BASELINE_CLIENT_LOCAL" || failed=1
+    "$SOFTPROD_CLIENT_LOCAL_HEALTH" answers "$CLIENT_LOCAL_ROOT" "$BASELINE_CLIENT_LOCAL" || failed=1
   wait_for_baseline "restored public client" \
-    "$CLIENT_PUBLIC_HEALTH" "$CLIENT_PUBLIC_ROOT" "$BASELINE_CLIENT_PUBLIC" || failed=1
+    "$SOFTPROD_CLIENT_PUBLIC_HEALTH" answers "$CLIENT_PUBLIC_ROOT" "$BASELINE_CLIENT_PUBLIC" || failed=1
 
   for unit in "${UNITS[@]}"; do
     if ! require_service_state "$unit"; then failed=1; fi
@@ -345,13 +396,13 @@ for unit in "${UNITS[@]}"; do require_service_state "$unit"; done
 
 stage="baseline health capture"
 BASELINE_SERVER_LOCAL=$(capture_baseline "local server" \
-  "$SERVER_LOCAL_HEALTH" "$SERVER_LOCAL_HEALTH") || report_failure "$?"
+  "$SOFTPROD_SERVER_LOCAL_HEALTH" body '') || report_failure "$?"
 BASELINE_SERVER_PUBLIC=$(capture_baseline "public server" \
-  "$SERVER_PUBLIC_HEALTH" "$SERVER_PUBLIC_HEALTH") || report_failure "$?"
+  "$SOFTPROD_SERVER_PUBLIC_HEALTH" body '') || report_failure "$?"
 BASELINE_CLIENT_LOCAL=$(capture_baseline "local client" \
-  "$CLIENT_LOCAL_HEALTH" "$CLIENT_LOCAL_ROOT") || report_failure "$?"
+  "$SOFTPROD_CLIENT_LOCAL_HEALTH" answers "$CLIENT_LOCAL_ROOT") || report_failure "$?"
 BASELINE_CLIENT_PUBLIC=$(capture_baseline "public client" \
-  "$CLIENT_PUBLIC_HEALTH" "$CLIENT_PUBLIC_ROOT") || report_failure "$?"
+  "$SOFTPROD_CLIENT_PUBLIC_HEALTH" answers "$CLIENT_PUBLIC_ROOT") || report_failure "$?"
 
 stage="host backup"
 mkdir -p "$DEPLOY_ROOT/backups/host-adoption"

--- a/apps/questura/infra/softprod/adopt-host-release.test.sh
+++ b/apps/questura/infra/softprod/adopt-host-release.test.sh
@@ -168,6 +168,14 @@ new_fixture() {
     '"$(dirname "$0")/adopt-test-maybe-fail" "$line" || exit $?' \
     'case "$url" in *4000*|*cms.questurian.com*) component=server ;; *) component=client ;; esac' \
     'read -r release < "$ADOPT_TEST_STATE/$component-release"' \
+    'if [[ ${LEGACY_BASELINE_MODE:-0} == 1 && $release == legacy-* ]]; then' \
+    '  if [[ ${DOWN_COMPONENT:-} == "$component" ]]; then exit 7; fi' \
+    '  if [[ $url == */api/health ]]; then' \
+    '    if [[ $component == client ]]; then exit 22; fi' \
+    '    printf "%s\n" "{\"status\":\"healthy\"}"; exit 0' \
+    '  fi' \
+    '  exit 0' \
+    'fi' \
     'if [[ -n ${HEALTH_MISMATCH_MATCH:-} && $url == *"$HEALTH_MISMATCH_MATCH"* && $release == "$ADOPT_TEST_TARGET_SHA" && ! -e $ADOPT_TEST_STATE/health-mismatch-fired ]]; then' \
     '  : > "$ADOPT_TEST_STATE/health-mismatch-fired"; release=wrong-release' \
     'fi' \
@@ -211,6 +219,8 @@ run_adopt() {
     ROLLBACK_FAIL_OCCURRENCE="${ROLLBACK_FAIL_OCCURRENCE:-1}" \
     ROLLBACK_FAIL_STATUS="${ROLLBACK_FAIL_STATUS:-42}" \
     HEALTH_MISMATCH_MATCH="${HEALTH_MISMATCH_MATCH:-}" \
+    LEGACY_BASELINE_MODE="${LEGACY_BASELINE_MODE:-0}" \
+    DOWN_COMPONENT="${DOWN_COMPONENT:-}" \
     SIGNAL_MATCH="${SIGNAL_MATCH:-}" \
     SIGNAL_NAME="${SIGNAL_NAME:-TERM}" \
     "$REPO/apps/questura/infra/softprod/adopt-host-release.sh"
@@ -385,6 +395,37 @@ TRIGGER_MATCH='restart questura-server' \
 assert_status 50 "$code"
 grep -q 'CRITICAL: initial release adoption rollback is incomplete' "$CASE_ROOT/err"
 assert_restored
+
+# The deployment actually being adopted predates release-aware health: its
+# server omits `releaseSha` and its client answers `/api/health` with a 404.
+new_fixture legacy-baseline
+LEGACY_BASELINE_MODE=1 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err"
+grep -q "Adopted initial immutable release $SHA" "$CASE_ROOT/out"
+grep -q 'captured local client baseline (legacy, no release health)' "$CASE_ROOT/err"
+grep -qxF 'curl|http://127.0.0.1:3000/' "$LOG"
+[[ $(readlink "$DEPLOY_ROOT/current-server") == "$RELEASE/apps/questura/apps/server" ]]
+[[ $(readlink "$DEPLOY_ROOT/current-client") == "$RELEASE/apps/questura/apps/client" ]]
+# The adopted release still has to prove the exact SHA on all four endpoints.
+grep -qF "curl|https://www.questurian.com/api/health" "$LOG"
+BACKUP=$(find "$DEPLOY_ROOT/backups/host-adoption" -mindepth 1 -maxdepth 1 -type d -print -quit)
+grep -qxF 'BASELINE_CLIENT_PUBLIC=legacy' "$BACKUP/manifest"
+
+# Rolling back to a legacy baseline proves the restored services serve again.
+new_fixture legacy-rollback
+code=0
+LEGACY_BASELINE_MODE=1 TRIGGER_MATCH='restart questura-client' TRIGGER_STATUS=52 \
+  run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 52 "$code"
+assert_restored
+grep -q 'restored public client serving (legacy baseline)' "$CASE_ROOT/out"
+
+# A service that is genuinely down is never mistaken for an old build.
+new_fixture legacy-down
+code=0
+LEGACY_BASELINE_MODE=1 DOWN_COMPONENT=client run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+assert_status 1 "$code"
+grep -q 'local client baseline is not serving' "$CASE_ROOT/err"
+assert_no_mutation
 
 # Adoption must consume prepared artifacts only.
 if rg -n '(pnpm (install|build)|db:migrate|docker compose|prepare_server_release|complete_client_release)' "$SCRIPT_DIR/adopt-host-release.sh"; then

--- a/apps/questura/infra/softprod/adopt-host-release.test.sh
+++ b/apps/questura/infra/softprod/adopt-host-release.test.sh
@@ -163,8 +163,13 @@ new_fixture() {
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'url=${!#}' \
+    'output=' \
+    'for ((i = 1; i <= $#; i++)); do' \
+    '  if [[ ${!i} == --output ]]; then next=$((i + 1)); output=${!next}; fi' \
+    'done' \
     'line="curl|$url"' \
     'printf "%s\\n" "$line" >> "$ADOPT_TEST_LOG"' \
+    'if [[ -n $output ]]; then exec > "$output"; fi' \
     '"$(dirname "$0")/adopt-test-maybe-fail" "$line" || exit $?' \
     'case "$url" in *4000*|*cms.questurian.com*) component=server ;; *) component=client ;; esac' \
     'read -r release < "$ADOPT_TEST_STATE/$component-release"' \
@@ -401,31 +406,55 @@ assert_restored
 new_fixture legacy-baseline
 LEGACY_BASELINE_MODE=1 run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err"
 grep -q "Adopted initial immutable release $SHA" "$CASE_ROOT/out"
+grep -q 'captured local server baseline (legacy, no release health)' "$CASE_ROOT/err"
 grep -q 'captured local client baseline (legacy, no release health)' "$CASE_ROOT/err"
 grep -qxF 'curl|http://127.0.0.1:3000/' "$LOG"
 [[ $(readlink "$DEPLOY_ROOT/current-server") == "$RELEASE/apps/questura/apps/server" ]]
 [[ $(readlink "$DEPLOY_ROOT/current-client") == "$RELEASE/apps/questura/apps/client" ]]
-# The adopted release still has to prove the exact SHA on all four endpoints.
-grep -qF "curl|https://www.questurian.com/api/health" "$LOG"
 BACKUP=$(find "$DEPLOY_ROOT/backups/host-adoption" -mindepth 1 -maxdepth 1 -type d -print -quit)
-grep -qxF 'BASELINE_CLIENT_PUBLIC=legacy' "$BACKUP/manifest"
+for endpoint in SERVER_LOCAL SERVER_PUBLIC CLIENT_LOCAL CLIENT_PUBLIC; do
+  grep -qxF "BASELINE_$endpoint=legacy" "$BACKUP/manifest"
+done
+# A legacy baseline must not soften what the adopted release has to prove.
+for endpoint in 'local server' 'public server' 'local client' 'public client'; do
+  grep -qF "$endpoint healthy at ${SHA:0:12}" "$CASE_ROOT/out"
+done
 
-# Rolling back to a legacy baseline proves the restored services serve again.
+# Rolling back to a legacy baseline proves the restored services are the legacy
+# ones, and must not report the rollback as incomplete.
 new_fixture legacy-rollback
 code=0
 LEGACY_BASELINE_MODE=1 TRIGGER_MATCH='restart questura-client' TRIGGER_STATUS=52 \
   run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
 assert_status 52 "$code"
 assert_restored
-grep -q 'restored public client serving (legacy baseline)' "$CASE_ROOT/out"
+! grep -q 'rollback is incomplete' "$CASE_ROOT/err"
+for endpoint in 'local server' 'public server' 'local client' 'public client'; do
+  grep -qF "restored $endpoint serving (legacy baseline)" "$CASE_ROOT/out"
+done
 
-# A service that is genuinely down is never mistaken for an old build.
-new_fixture legacy-down
-code=0
-LEGACY_BASELINE_MODE=1 DOWN_COMPONENT=client run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
-assert_status 1 "$code"
-grep -q 'local client baseline is not serving' "$CASE_ROOT/err"
-assert_no_mutation
+# A service that is genuinely down is never mistaken for an old build, and the
+# preflight failure is reported once.
+for down in client server; do
+  new_fixture "legacy-down-$down"
+  code=0
+  LEGACY_BASELINE_MODE=1 DOWN_COMPONENT="$down" run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err" || code=$?
+  assert_status 1 "$code"
+  grep -q "local $down baseline is not serving" "$CASE_ROOT/err"
+  [[ $(grep -c 'adoption failed during baseline health capture' "$CASE_ROOT/err") == 1 ]]
+  assert_no_mutation
+done
+
+# `unknown` is what the health route reports with no release env var, and
+# `legacy` is this script's own sentinel: neither is a release to restore to.
+for fake_sha in unknown legacy; do
+  new_fixture "baseline-not-a-sha-$fake_sha"
+  printf '%s\n' "$fake_sha" > "$STATE/server-release"
+  printf '%s\n' "$fake_sha" > "$STATE/client-release"
+  run_adopt > "$CASE_ROOT/out" 2> "$CASE_ROOT/err"
+  BACKUP=$(find "$DEPLOY_ROOT/backups/host-adoption" -mindepth 1 -maxdepth 1 -type d -print -quit)
+  grep -qxF 'BASELINE_SERVER_LOCAL=legacy' "$BACKUP/manifest"
+done
 
 # Adoption must consume prepared artifacts only.
 if rg -n '(pnpm (install|build)|db:migrate|docker compose|prepare_server_release|complete_client_release)' "$SCRIPT_DIR/adopt-host-release.sh"; then

--- a/apps/questura/infra/softprod/release-lib.sh
+++ b/apps/questura/infra/softprod/release-lib.sh
@@ -6,6 +6,14 @@ SOFTPROD_RELEASES=${QUESTURA_RELEASES_ROOT:-"$SOFTPROD_ROOT/releases"}
 SOFTPROD_HEALTH_ATTEMPTS=${QUESTURA_HEALTH_ATTEMPTS:-30}
 SOFTPROD_HEALTH_SLEEP_SECONDS=${QUESTURA_HEALTH_SLEEP_SECONDS:-3}
 
+# The four endpoints that decide whether a release is live. Named here so that
+# a pre-adoption baseline and post-deploy verification cannot drift apart and
+# start describing different endpoints.
+SOFTPROD_SERVER_LOCAL_HEALTH='http://127.0.0.1:4000/api/health'
+SOFTPROD_SERVER_PUBLIC_HEALTH='https://cms.questurian.com/api/health'
+SOFTPROD_CLIENT_LOCAL_HEALTH='http://127.0.0.1:3000/api/health'
+SOFTPROD_CLIENT_PUBLIC_HEALTH='https://www.questurian.com/api/health'
+
 canonical_path() {
   python3 - "$1" <<'PY'
 import os
@@ -152,12 +160,12 @@ verify_component() {
 
   case "$component" in
     server)
-      wait_for_release_health "local server" "http://127.0.0.1:4000/api/health" "$expected_sha" &&
-        wait_for_release_health "public server" "https://cms.questurian.com/api/health" "$expected_sha"
+      wait_for_release_health "local server" "$SOFTPROD_SERVER_LOCAL_HEALTH" "$expected_sha" &&
+        wait_for_release_health "public server" "$SOFTPROD_SERVER_PUBLIC_HEALTH" "$expected_sha"
       ;;
     client)
-      wait_for_release_health "local client" "http://127.0.0.1:3000/api/health" "$expected_sha" &&
-        wait_for_release_health "public client" "https://www.questurian.com/api/health" "$expected_sha"
+      wait_for_release_health "local client" "$SOFTPROD_CLIENT_LOCAL_HEALTH" "$expected_sha" &&
+        wait_for_release_health "public client" "$SOFTPROD_CLIENT_PUBLIC_HEALTH" "$expected_sha"
       ;;
     *) echo "ERROR: unknown component: $component" >&2; return 1 ;;
   esac


### PR DESCRIPTION
## Why

Adoption cannot start on the host it was written for.

`adopt-host-release.sh` captures a pre-adoption baseline from four endpoints and requires each to return a healthy body with a `releaseSha`. The live legacy deployment predates that work:

- `http://127.0.0.1:4000/api/health` -> `{"status":"healthy", ..., "version":"unknown"}` with **no** `releaseSha`
- `http://127.0.0.1:3000/api/health` -> **404** (route added later)

So `capture_health_sha` fails and adoption aborts in preflight — on the only host that can ever run an initial adoption.

## What changed

- Baselines record either the exact release SHA or the sentinel `legacy`.
- `legacy` is only accepted when the endpoint proves it is **serving**: `curl --fail` without `--location`, so 2xx/3xx pass and 4xx/5xx/transport failures do not. The legacy client answers `/` with a locale redirect (307), which is the only liveness signal shared by the legacy and adopted client.
- Rollback rechecks whichever baseline it captured (`wait_for_baseline`).
- **Unchanged:** post-adoption verification. The adopted release still must report the exact SHA on all four endpoints, local and public, before and after the tunnel restart.

## Tests

Three new cases in `adopt-host-release.test.sh`:

1. `legacy-baseline` — server without `releaseSha` + client `/api/health` 404 still adopts, records `BASELINE_CLIENT_PUBLIC=legacy` in the backup manifest, and still proves the exact SHA afterwards.
2. `legacy-rollback` — failure after mutation restores exact bytes/modes and re-proves the legacy baseline is serving.
3. `legacy-down` — a genuinely down service fails preflight (`baseline is not serving`) with no mutation.

Verified non-vacuous: the suite fails against the pre-fix script and passes with it.

`pnpm --dir apps/questura/apps/server test:softprod` green (all five suites). `bash -n` and `git diff --check` clean.