### PR TITLE
feat(softprod): passive host health monitor

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -32,7 +32,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
-    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh && bash ../../infra/softprod/adopt-host-release.test.sh",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh && bash ../../infra/softprod/adopt-host-release.test.sh && bash ../../infra/softprod/healthcheck.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts"
   },
   "dependencies": {

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -172,6 +172,56 @@ The prepared release must match the commit containing the adoption script. If
 preparation ran before that commit was checked out, rerun preparation first; it
 will safely reuse completed work where certification still matches.
 
+## Passive monitoring
+
+`healthcheck.sh` verifies the adopted host every five minutes — and two minutes
+after boot, once the app units have had time to answer — without changing it. The check requires aligned, valid `current-server` and `current-client`
+release metadata, then verifies that exact commit through all four local and
+public `/api/health` endpoints. The server endpoint performs a real Payload
+database query. It also requires the server, client, and tunnel user units to be
+active; validates canonical Compose config; and checks the stable Postgres and
+Redis containers for the `infra` project, expected service labels, running
+state, and healthy Docker health checks.
+
+Results go to journald under `questura-healthcheck`. Failures are aggregated and
+sanitized: app response bodies, Compose output, and environment values are
+never logged. The monitor never restarts a unit, changes a release link, runs a
+migration, or writes to Postgres or Redis. If a deploy holds `deploy.lock`, or
+the paired release changes while checks run, that pass logs `SKIP` and exits
+successfully; the monitor probes but never holds the deployment lock.
+
+`stage-host-config.sh` renders the monitor service and timer alongside the app
+units, but does not install or enable them. After immutable-release adoption is
+complete and all three app units are healthy:
+
+```bash
+mkdir -p ~/.config/systemd/user ~/questura/backups/health-monitor
+cp -a ~/.config/systemd/user/questura-healthcheck.service \
+  ~/.config/systemd/user/questura-healthcheck.timer \
+  ~/questura/backups/health-monitor/ 2>/dev/null || true
+install -m 0644 ~/questura/infra/systemd/questura-healthcheck.service \
+  ~/.config/systemd/user/questura-healthcheck.service
+install -m 0644 ~/questura/infra/systemd/questura-healthcheck.timer \
+  ~/.config/systemd/user/questura-healthcheck.timer
+systemd-analyze --user verify \
+  ~/.config/systemd/user/questura-healthcheck.service \
+  ~/.config/systemd/user/questura-healthcheck.timer
+systemctl --user daemon-reload
+systemctl --user start questura-healthcheck.service
+journalctl --user -u questura-healthcheck.service -n 100 --no-pager
+systemctl --user enable --now questura-healthcheck.timer
+systemctl --user list-timers questura-healthcheck.timer
+```
+
+Enable the timer only after the manual service run exits successfully. To undo
+adoption, disable the timer, restore or remove only these two user-unit files,
+then run `systemctl --user daemon-reload`.
+
+This is diagnostics, not alerting. Journald records failures, but does not
+notify anyone, and an on-host monitor cannot report laptop power, sleep, or
+total network failure. External uptime/heartbeat alerting remains separate
+follow-up work.
+
 ## Validation
 
 Migration-preflight and deploy-runner regression tests are part of the server

--- a/apps/questura/infra/softprod/healthcheck.sh
+++ b/apps/questura/infra/softprod/healthcheck.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Passive Questura soft-production health monitor. Never mutates live services.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+DEPLOY_ROOT=${QUESTURA_DEPLOY_ROOT:-"$HOME/questura"}
+RELEASES_ROOT=${QUESTURA_RELEASES_ROOT:-"$DEPLOY_ROOT/releases"}
+INFRA_ROOT=${QUESTURA_INFRA_ROOT:-"$DEPLOY_ROOT/infra"}
+COMPOSE_FILE=${QUESTURA_COMPOSE_FILE:-"$INFRA_ROOT/compose.yml"}
+COMPOSE_ENV=${QUESTURA_COMPOSE_ENV_FILE:-"$INFRA_ROOT/.env"}
+CURL_MAX_TIME=${QUESTURA_MONITOR_CURL_MAX_TIME:-10}
+CURL_CONNECT_TIMEOUT=${QUESTURA_MONITOR_CURL_CONNECT_TIMEOUT:-5}
+
+LOCAL_SERVER_URL=${QUESTURA_MONITOR_LOCAL_SERVER_URL:-http://127.0.0.1:4000/api/health}
+PUBLIC_SERVER_URL=${QUESTURA_MONITOR_PUBLIC_SERVER_URL:-https://cms.questurian.com/api/health}
+LOCAL_CLIENT_URL=${QUESTURA_MONITOR_LOCAL_CLIENT_URL:-http://127.0.0.1:3000/api/health}
+PUBLIC_CLIENT_URL=${QUESTURA_MONITOR_PUBLIC_CLIENT_URL:-https://www.questurian.com/api/health}
+
+export QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT"
+export QUESTURA_RELEASES_ROOT="$RELEASES_ROOT"
+# shellcheck source=release-lib.sh
+. "$SCRIPT_DIR/release-lib.sh"
+
+declare -a diagnostics=()
+failures=0
+
+record_ok() {
+  diagnostics+=("OK $*")
+}
+
+record_failure() {
+  diagnostics+=("FAIL $*")
+  failures=$((failures + 1))
+}
+
+print_diagnostics() {
+  local line
+  for line in "${diagnostics[@]}"; do
+    printf '%s\n' "$line"
+  done
+}
+
+# Return 0 when held elsewhere, 1 when idle, 2 when probe is unavailable.
+# The descriptor closes immediately: monitoring must never block a real deploy.
+deploy_lock_is_busy() {
+  local result
+
+  if [[ ! -r $DEPLOY_ROOT/deploy.lock ]] || ! command -v flock >/dev/null 2>&1; then
+    return 2
+  fi
+  if ! exec 8<"$DEPLOY_ROOT/deploy.lock"; then
+    return 2
+  fi
+
+  flock -n 8 >/dev/null 2>&1
+  result=$?
+  exec 8<&-
+
+  case "$result" in
+    0) return 1 ;;
+    1) return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
+# Print one validated, paired release snapshot as SHA|server-path|client-path.
+release_pair_snapshot() {
+  local server_link="$DEPLOY_ROOT/current-server"
+  local client_link="$DEPLOY_ROOT/current-client"
+  local server_target client_target server_sha client_sha
+
+  [[ -L $server_link && -L $client_link ]] || return 1
+  server_target=$(canonical_path "$server_link" 2>/dev/null) || return 1
+  client_target=$(canonical_path "$client_link" 2>/dev/null) || return 1
+  require_component_release_directory server "$server_target" >/dev/null 2>&1 || return 1
+  require_component_release_directory client "$client_target" >/dev/null 2>&1 || return 1
+  server_sha=$(release_sha "$server_target" 2>/dev/null) || return 1
+  client_sha=$(release_sha "$client_target" 2>/dev/null) || return 1
+  [[ $server_sha == "$client_sha" ]] || return 1
+
+  printf '%s|%s|%s\n' "$server_sha" "$server_target" "$client_target"
+}
+
+check_endpoint() {
+  local label=$1
+  local url=$2
+  local expected_sha=$3
+  local body_file http_code curl_code parsed parse_code observed_status observed_sha
+
+  body_file=$(mktemp) || {
+    record_failure "check=endpoint label=$label reason=temp-file-unavailable"
+    return
+  }
+
+  http_code=$(curl \
+    --silent \
+    --show-error \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+    --max-time "$CURL_MAX_TIME" \
+    --output "$body_file" \
+    --write-out '%{http_code}' \
+    "$url" 2>/dev/null)
+  curl_code=$?
+
+  if ((curl_code != 0)); then
+    rm -f -- "$body_file"
+    record_failure "check=endpoint label=$label reason=request-failed"
+    return
+  fi
+
+  parsed=$(python3 - "$body_file" "$expected_sha" <<'PY'
+import json
+import re
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as source:
+        body = json.load(source)
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(2)
+
+if not isinstance(body, dict):
+    raise SystemExit(2)
+
+status = body.get("status")
+release_sha = body.get("releaseSha")
+safe_status = status if status in {"healthy", "unhealthy"} else "invalid"
+safe_sha = release_sha if isinstance(release_sha, str) and re.fullmatch(r"[0-9a-f]{40}", release_sha) else "invalid"
+print(f"{safe_status}|{safe_sha}")
+raise SystemExit(0 if status == "healthy" and release_sha == sys.argv[2] else 1)
+PY
+  )
+  parse_code=$?
+  rm -f -- "$body_file"
+
+  if [[ ! $http_code =~ ^[0-9]{3}$ ]]; then
+    record_failure "check=endpoint label=$label reason=invalid-http-status"
+    return
+  fi
+  if [[ $http_code != 200 ]]; then
+    record_failure "check=endpoint label=$label reason=http status=$http_code"
+    return
+  fi
+  if ((parse_code == 2)); then
+    record_failure "check=endpoint label=$label reason=invalid-json"
+    return
+  fi
+  if ((parse_code != 0)); then
+    IFS='|' read -r observed_status observed_sha <<< "$parsed"
+    record_failure "check=endpoint label=$label reason=identity expected_sha=$expected_sha observed_status=${observed_status:-invalid} observed_sha=${observed_sha:-invalid}"
+    return
+  fi
+
+  record_ok "check=endpoint label=$label release_sha=$expected_sha"
+}
+
+check_unit() {
+  local unit=$1
+  local state code safe_state
+
+  state=$(systemctl --user is-active "$unit" 2>/dev/null)
+  code=$?
+  case "$state" in
+    active|inactive|failed|activating|deactivating) safe_state=$state ;;
+    *) safe_state=unknown ;;
+  esac
+
+  if ((code == 0)) && [[ $state == active ]]; then
+    record_ok "check=unit unit=$unit state=active"
+  else
+    record_failure "check=unit unit=$unit state=$safe_state"
+  fi
+}
+
+check_compose() {
+  if [[ ! -r $COMPOSE_FILE || ! -r $COMPOSE_ENV ]]; then
+    record_failure "check=compose reason=missing-config"
+    return
+  fi
+
+  if docker compose \
+    --env-file "$COMPOSE_ENV" \
+    -f "$COMPOSE_FILE" \
+    config --quiet >/dev/null 2>&1; then
+    record_ok "check=compose state=valid"
+  else
+    record_failure "check=compose reason=invalid-config"
+  fi
+}
+
+check_container() {
+  local container=$1
+  local expected_service=$2
+  local inspection code status health project service
+
+  inspection=$(docker inspect \
+    --format '{{.State.Status}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}|{{index .Config.Labels "com.docker.compose.project"}}|{{index .Config.Labels "com.docker.compose.service"}}' \
+    "$container" 2>/dev/null)
+  code=$?
+  if ((code != 0)); then
+    record_failure "check=container container=$container reason=inspect-failed"
+    return
+  fi
+
+  IFS='|' read -r status health project service <<< "$inspection"
+  if [[ $status == running && $health == healthy && $project == infra && $service == "$expected_service" ]]; then
+    record_ok "check=container container=$container state=running health=healthy"
+  else
+    case "$status" in running|created|restarting|removing|paused|exited|dead) ;; *) status=unknown ;; esac
+    case "$health" in healthy|unhealthy|starting|missing) ;; *) health=unknown ;; esac
+    record_failure "check=container container=$container reason=state-or-label-mismatch state=$status health=$health"
+  fi
+}
+
+deploy_lock_is_busy
+start_lock_state=$?
+if ((start_lock_state == 0)); then
+  printf '%s\n' 'SKIP check=monitor reason=deploy-active phase=start'
+  exit 0
+elif ((start_lock_state == 2)); then
+  record_failure "check=deploy-lock phase=start reason=probe-failed"
+fi
+
+start_snapshot=''
+start_sha=''
+if start_snapshot=$(release_pair_snapshot); then
+  IFS='|' read -r start_sha _ _ <<< "$start_snapshot"
+  record_ok "check=release-pair phase=start release_sha=$start_sha"
+else
+  record_failure "check=release-pair phase=start reason=invalid-or-mismatched"
+fi
+
+if [[ -n $start_sha ]]; then
+  check_endpoint local-server "$LOCAL_SERVER_URL" "$start_sha"
+  check_endpoint public-server "$PUBLIC_SERVER_URL" "$start_sha"
+  check_endpoint local-client "$LOCAL_CLIENT_URL" "$start_sha"
+  check_endpoint public-client "$PUBLIC_CLIENT_URL" "$start_sha"
+else
+  for label in local-server public-server local-client public-client; do
+    record_failure "check=endpoint label=$label reason=release-identity-unavailable"
+  done
+fi
+
+check_unit questura-server
+check_unit questura-client
+check_unit questura-tunnel
+check_compose
+check_container questura-postgres postgres
+check_container questura-redis redis
+
+deploy_lock_is_busy
+end_lock_state=$?
+if ((end_lock_state == 0)); then
+  printf '%s\n' 'SKIP check=monitor reason=deploy-active phase=end'
+  exit 0
+elif ((end_lock_state == 2)); then
+  record_failure "check=deploy-lock phase=end reason=probe-failed"
+fi
+
+end_snapshot=''
+if end_snapshot=$(release_pair_snapshot); then
+  IFS='|' read -r end_sha _ _ <<< "$end_snapshot"
+  if [[ -n $start_snapshot && $end_snapshot != "$start_snapshot" ]]; then
+    printf 'SKIP check=monitor reason=release-transition from_sha=%s to_sha=%s\n' "$start_sha" "$end_sha"
+    exit 0
+  fi
+  record_ok "check=release-pair phase=end release_sha=$end_sha"
+elif [[ -n $start_snapshot ]]; then
+  record_failure "check=release-pair phase=end reason=invalid-or-mismatched"
+fi
+
+if ((failures > 0)); then
+  print_diagnostics
+  printf 'FAIL check=summary failures=%s release_sha=%s\n' "$failures" "${start_sha:-unknown}"
+  exit 1
+fi
+
+print_diagnostics
+printf 'OK check=summary release_sha=%s\n' "$start_sha"

--- a/apps/questura/infra/softprod/healthcheck.test.sh
+++ b/apps/questura/infra/softprod/healthcheck.test.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+DEPLOY_ROOT="$TEST_ROOT/host"
+RELEASES_ROOT="$DEPLOY_ROOT/releases"
+INFRA_ROOT="$DEPLOY_ROOT/infra"
+FAKE_BIN="$TEST_ROOT/bin"
+LOG="$TEST_ROOT/commands.log"
+FLOCK_COUNT="$TEST_ROOT/flock-count"
+TRANSITION_MARKER="$TEST_ROOT/transitioned"
+SECRET_SENTINEL='postgres://monitor-secret:never-print@example.invalid/db'
+mkdir -p "$RELEASES_ROOT" "$INFRA_ROOT" "$FAKE_BIN"
+printf '%s\n' 'services: {}' > "$INFRA_ROOT/compose.yml"
+printf '%s\n' 'POSTGRES_PASSWORD=monitor-secret-never-print' > "$INFRA_ROOT/.env"
+: > "$DEPLOY_ROOT/deploy.lock"
+
+make_release() {
+  local sha=$1
+  local component=$2
+  local directory="$RELEASES_ROOT/$sha/apps/questura/apps/$component"
+  mkdir -p "$directory"
+  printf 'QUESTURA_RELEASE_SHA=%s\n' "$sha" > "$directory/.env.release"
+  printf '%s\n' "$directory"
+}
+
+OLD_SHA=1111111111111111111111111111111111111111
+NEW_SHA=2222222222222222222222222222222222222222
+OLD_SERVER=$(make_release "$OLD_SHA" server)
+OLD_CLIENT=$(make_release "$OLD_SHA" client)
+NEW_SERVER=$(make_release "$NEW_SHA" server)
+NEW_CLIENT=$(make_release "$NEW_SHA" client)
+ln -s "$OLD_SERVER" "$DEPLOY_ROOT/current-server"
+ln -s "$OLD_CLIENT" "$DEPLOY_ROOT/current-client"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -u' \
+  'printf "systemctl|%s\\n" "$*" >> "$MONITOR_TEST_LOG"' \
+  'unit=${*: -1}' \
+  'if [[ ${FAIL_UNIT:-} == "$unit" ]]; then printf "%s\\n" failed; exit 3; fi' \
+  'printf "%s\\n" active' > "$FAKE_BIN/systemctl"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -u' \
+  'printf "docker|%s\\n" "$*" >> "$MONITOR_TEST_LOG"' \
+  'if [[ ${1:-} == compose ]]; then' \
+  '  [[ ${FAIL_COMPOSE:-0} != 1 ]]' \
+  '  exit' \
+  'fi' \
+  'container=${*: -1}' \
+  'case "$container" in' \
+  '  questura-postgres) printf "%s|%s|%s|%s\\n" "${POSTGRES_STATUS:-running}" "${POSTGRES_HEALTH:-healthy}" "${POSTGRES_PROJECT:-infra}" "${POSTGRES_SERVICE:-postgres}" ;;' \
+  '  questura-redis) printf "%s|%s|%s|%s\\n" "${REDIS_STATUS:-running}" "${REDIS_HEALTH:-healthy}" "${REDIS_PROJECT:-infra}" "${REDIS_SERVICE:-redis}" ;;' \
+  '  *) exit 1 ;;' \
+  'esac' > "$FAKE_BIN/docker"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -u' \
+  'printf "curl|%s\\n" "$*" >> "$MONITOR_TEST_LOG"' \
+  'output=""; previous=""; url=""' \
+  'for argument in "$@"; do' \
+  '  if [[ $previous == --output ]]; then output=$argument; fi' \
+  '  previous=$argument; url=$argument' \
+  'done' \
+  'case "$url" in' \
+  '  *127.0.0.1:4000*) label=local-server; metadata="$QUESTURA_DEPLOY_ROOT/current-server/.env.release" ;;' \
+  '  *cms.questurian.com*) label=public-server; metadata="$QUESTURA_DEPLOY_ROOT/current-server/.env.release" ;;' \
+  '  *127.0.0.1:3000*) label=local-client; metadata="$QUESTURA_DEPLOY_ROOT/current-client/.env.release" ;;' \
+  '  *www.questurian.com*) label=public-client; metadata="$QUESTURA_DEPLOY_ROOT/current-client/.env.release" ;;' \
+  '  *) exit 2 ;;' \
+  'esac' \
+  '. "$metadata"' \
+  'mode=healthy' \
+  'if [[ ${FAIL_ENDPOINT:-} == "$label" ]]; then mode=${ENDPOINT_MODE:-wrong-sha}; fi' \
+  'case "$mode" in' \
+  '  healthy) printf '\''{"status":"healthy","releaseSha":"%s"}'\'' "$QUESTURA_RELEASE_SHA" > "$output"; code=200 ;;' \
+  '  wrong-sha) printf '\''{"status":"healthy","releaseSha":"3333333333333333333333333333333333333333"}'\'' > "$output"; code=200 ;;' \
+  '  unhealthy) printf '\''{"status":"unhealthy","releaseSha":"%s","error":"%s"}'\'' "$QUESTURA_RELEASE_SHA" "$MONITOR_TEST_SECRET" > "$output"; code=503 ;;' \
+  '  invalid-json) printf '\''%s'\'' "$MONITOR_TEST_SECRET" > "$output"; code=200 ;;' \
+  '  http) printf '\''{"status":"healthy","releaseSha":"%s"}'\'' "$QUESTURA_RELEASE_SHA" > "$output"; code=502 ;;' \
+  '  curl) exit 7 ;;' \
+  'esac' \
+  'if [[ ${TRANSITION_ON_CURL:-0} == 1 && ! -e $TRANSITION_MARKER ]]; then' \
+  '  touch "$TRANSITION_MARKER"' \
+  '  ln -sfn "$NEW_SERVER" "$QUESTURA_DEPLOY_ROOT/current-server"' \
+  '  ln -sfn "$NEW_CLIENT" "$QUESTURA_DEPLOY_ROOT/current-client"' \
+  'fi' \
+  'printf "%s" "$code"' > "$FAKE_BIN/curl"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -u' \
+  'printf "flock|%s\\n" "$*" >> "$MONITOR_TEST_LOG"' \
+  'count=0; if [[ -f $FLOCK_COUNT ]]; then count=$(cat "$FLOCK_COUNT"); fi; count=$((count + 1)); printf "%s\\n" "$count" > "$FLOCK_COUNT"' \
+  'case ${BUSY_PHASE:-} in start) ((count == 1)) && exit 1 ;; end) ((count == 2)) && exit 1 ;; always) exit 1 ;; esac' \
+  'exit 0' > "$FAKE_BIN/flock"
+chmod +x "$FAKE_BIN"/*
+
+run_monitor() {
+  rm -f "$FLOCK_COUNT" "$TRANSITION_MARKER"
+  env \
+    PATH="$FAKE_BIN:$PATH" \
+    QUESTURA_DEPLOY_ROOT="$DEPLOY_ROOT" \
+    QUESTURA_RELEASES_ROOT="$RELEASES_ROOT" \
+    QUESTURA_INFRA_ROOT="$INFRA_ROOT" \
+    QUESTURA_MONITOR_CURL_MAX_TIME=1 \
+    MONITOR_TEST_LOG="$LOG" \
+    MONITOR_TEST_SECRET="$SECRET_SENTINEL" \
+    FAIL_UNIT="${FAIL_UNIT:-}" \
+    FAIL_COMPOSE="${FAIL_COMPOSE:-0}" \
+    FAIL_ENDPOINT="${FAIL_ENDPOINT:-}" \
+    ENDPOINT_MODE="${ENDPOINT_MODE:-}" \
+    POSTGRES_STATUS="${POSTGRES_STATUS:-running}" \
+    POSTGRES_HEALTH="${POSTGRES_HEALTH:-healthy}" \
+    POSTGRES_PROJECT="${POSTGRES_PROJECT:-infra}" \
+    POSTGRES_SERVICE="${POSTGRES_SERVICE:-postgres}" \
+    REDIS_STATUS="${REDIS_STATUS:-running}" \
+    REDIS_HEALTH="${REDIS_HEALTH:-healthy}" \
+    REDIS_PROJECT="${REDIS_PROJECT:-infra}" \
+    REDIS_SERVICE="${REDIS_SERVICE:-redis}" \
+    BUSY_PHASE="${BUSY_PHASE:-}" \
+    FLOCK_COUNT="$FLOCK_COUNT" \
+    TRANSITION_ON_CURL="${TRANSITION_ON_CURL:-0}" \
+    TRANSITION_MARKER="$TRANSITION_MARKER" \
+    NEW_SERVER="$NEW_SERVER" \
+    NEW_CLIENT="$NEW_CLIENT" \
+    "$SCRIPT_DIR/healthcheck.sh"
+}
+
+reset_pair() {
+  ln -sfn "$OLD_SERVER" "$DEPLOY_ROOT/current-server"
+  ln -sfn "$OLD_CLIENT" "$DEPLOY_ROOT/current-client"
+}
+
+expect_failure() {
+  local output=$1
+  shift
+  set +e
+  "$@" > "$output" 2>&1
+  local code=$?
+  set -e
+  [[ $code == 1 ]]
+}
+
+# Healthy run covers exact release identity, every endpoint, units, Compose,
+# and both stable data containers without mutating host state.
+: > "$LOG"
+if ! run_monitor > "$TEST_ROOT/healthy.out" 2>&1; then
+  echo 'healthy monitor fixture failed:' >&2
+  tail -40 "$TEST_ROOT/healthy.out" >&2
+  exit 1
+fi
+grep -q "OK check=summary release_sha=$OLD_SHA" "$TEST_ROOT/healthy.out"
+[[ $(grep -c '^curl|' "$LOG") == 4 ]]
+[[ $(grep -c '^systemctl|' "$LOG") == 3 ]]
+[[ $(grep -c '^docker|inspect ' "$LOG") == 2 ]]
+grep -q '^docker|compose .* config --quiet$' "$LOG"
+for url in \
+  'http://127.0.0.1:4000/api/health' \
+  'https://cms.questurian.com/api/health' \
+  'http://127.0.0.1:3000/api/health' \
+  'https://www.questurian.com/api/health'; do
+  grep -Fq "$url" "$LOG"
+done
+! grep -Eq 'systemctl\|.*restart|docker\|.*(up|restart|exec)|db:migrate' "$LOG"
+[[ $(readlink "$DEPLOY_ROOT/current-server") == "$OLD_SERVER" ]]
+[[ $(readlink "$DEPLOY_ROOT/current-client") == "$OLD_CLIENT" ]]
+
+# Each endpoint must report exact SHA; parser and HTTP failures stay sanitized.
+for endpoint in local-server public-server local-client public-client; do
+  export FAIL_ENDPOINT=$endpoint ENDPOINT_MODE=wrong-sha
+  expect_failure "$TEST_ROOT/$endpoint.out" run_monitor
+  grep -q "FAIL check=endpoint label=$endpoint" "$TEST_ROOT/$endpoint.out"
+done
+for mode in unhealthy invalid-json http curl; do
+  export FAIL_ENDPOINT=public-server ENDPOINT_MODE=$mode
+  expect_failure "$TEST_ROOT/endpoint-$mode.out" run_monitor
+  grep -q 'FAIL check=endpoint label=public-server' "$TEST_ROOT/endpoint-$mode.out"
+  ! grep -Fq "$SECRET_SENTINEL" "$TEST_ROOT/endpoint-$mode.out"
+done
+unset FAIL_ENDPOINT ENDPOINT_MODE
+
+# Invalid release pointers fail closed before endpoint checks.
+ln -sfn "$NEW_CLIENT" "$DEPLOY_ROOT/current-client"
+: > "$LOG"
+expect_failure "$TEST_ROOT/mismatched.out" run_monitor
+grep -q 'FAIL check=release-pair phase=start reason=invalid-or-mismatched' "$TEST_ROOT/mismatched.out"
+[[ $(grep -c '^curl|' "$LOG" || true) == 0 ]]
+reset_pair
+
+mv "$OLD_SERVER/.env.release" "$OLD_SERVER/.env.release.missing"
+expect_failure "$TEST_ROOT/missing-metadata.out" run_monitor
+grep -q 'FAIL check=release-pair phase=start reason=invalid-or-mismatched' "$TEST_ROOT/missing-metadata.out"
+mv "$OLD_SERVER/.env.release.missing" "$OLD_SERVER/.env.release"
+
+OUTSIDE="$TEST_ROOT/outside/apps/questura/apps/server"
+mkdir -p "$OUTSIDE"
+printf 'QUESTURA_RELEASE_SHA=%s\n' "$OLD_SHA" > "$OUTSIDE/.env.release"
+ln -sfn "$OUTSIDE" "$DEPLOY_ROOT/current-server"
+expect_failure "$TEST_ROOT/outside.out" run_monitor
+grep -q 'FAIL check=release-pair phase=start reason=invalid-or-mismatched' "$TEST_ROOT/outside.out"
+reset_pair
+
+# Unit, Compose, and container failures aggregate instead of short-circuiting.
+export FAIL_UNIT=questura-client FAIL_COMPOSE=1 FAIL_ENDPOINT=local-server ENDPOINT_MODE=wrong-sha POSTGRES_HEALTH=unhealthy REDIS_STATUS=stopped
+expect_failure "$TEST_ROOT/aggregate.out" run_monitor
+grep -q 'FAIL check=unit unit=questura-client' "$TEST_ROOT/aggregate.out"
+grep -q 'FAIL check=compose reason=invalid-config' "$TEST_ROOT/aggregate.out"
+grep -q 'FAIL check=container container=questura-postgres' "$TEST_ROOT/aggregate.out"
+grep -q 'FAIL check=container container=questura-redis' "$TEST_ROOT/aggregate.out"
+grep -q 'FAIL check=endpoint label=local-server' "$TEST_ROOT/aggregate.out"
+grep -q 'FAIL check=summary failures=' "$TEST_ROOT/aggregate.out"
+unset FAIL_UNIT FAIL_COMPOSE FAIL_ENDPOINT ENDPOINT_MODE POSTGRES_HEALTH REDIS_STATUS
+
+for unit in questura-server questura-client questura-tunnel; do
+  export FAIL_UNIT=$unit
+  expect_failure "$TEST_ROOT/unit-$unit.out" run_monitor
+  grep -q "FAIL check=unit unit=$unit" "$TEST_ROOT/unit-$unit.out"
+done
+unset FAIL_UNIT
+
+export POSTGRES_PROJECT=other
+expect_failure "$TEST_ROOT/postgres-label.out" run_monitor
+grep -q 'FAIL check=container container=questura-postgres' "$TEST_ROOT/postgres-label.out"
+unset POSTGRES_PROJECT
+
+# Deploy activity or a valid paired release transition discards transient
+# failures and exits successfully without ever holding the deploy lock.
+export BUSY_PHASE=start FAIL_ENDPOINT=local-server ENDPOINT_MODE=wrong-sha
+run_monitor > "$TEST_ROOT/busy-start.out" 2>&1
+grep -q 'SKIP check=monitor reason=deploy-active phase=start' "$TEST_ROOT/busy-start.out"
+! grep -q '^FAIL ' "$TEST_ROOT/busy-start.out"
+unset BUSY_PHASE
+
+export BUSY_PHASE=end
+run_monitor > "$TEST_ROOT/busy-end.out" 2>&1
+grep -q 'SKIP check=monitor reason=deploy-active phase=end' "$TEST_ROOT/busy-end.out"
+! grep -q '^FAIL ' "$TEST_ROOT/busy-end.out"
+unset BUSY_PHASE FAIL_ENDPOINT ENDPOINT_MODE
+
+export TRANSITION_ON_CURL=1 FAIL_ENDPOINT=public-client ENDPOINT_MODE=wrong-sha
+run_monitor > "$TEST_ROOT/transition.out" 2>&1
+grep -q "SKIP check=monitor reason=release-transition from_sha=$OLD_SHA to_sha=$NEW_SHA" "$TEST_ROOT/transition.out"
+! grep -q '^FAIL ' "$TEST_ROOT/transition.out"
+unset TRANSITION_ON_CURL FAIL_ENDPOINT ENDPOINT_MODE
+reset_pair
+
+export FAIL_ENDPOINT=local-server ENDPOINT_MODE=wrong-sha
+expect_failure "$TEST_ROOT/unchanged-outage.out" run_monitor
+grep -q 'FAIL check=endpoint label=local-server' "$TEST_ROOT/unchanged-outage.out"
+unset FAIL_ENDPOINT ENDPOINT_MODE
+
+echo 'health monitor tests passed'

--- a/apps/questura/infra/softprod/host/systemd/questura-healthcheck.service.in
+++ b/apps/questura/infra/softprod/host/systemd/questura-healthcheck.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Questura passive health monitor (soft production)
+Documentation=https://github.com/Questurian/questurian
+After=network-online.target questura-server.service questura-client.service questura-tunnel.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/env bash %h/questura/app/apps/questura/infra/softprod/healthcheck.sh
+TimeoutStartSec=90
+SyslogIdentifier=questura-healthcheck

--- a/apps/questura/infra/softprod/host/systemd/questura-healthcheck.timer.in
+++ b/apps/questura/infra/softprod/host/systemd/questura-healthcheck.timer.in
@@ -1,0 +1,17 @@
+[Unit]
+Description=Run Questura passive health monitor every five minutes
+Documentation=https://github.com/Questurian/questurian
+
+[Timer]
+# The app units start at boot; two minutes gives the server, client, and tunnel
+# time to answer before the first pass, so a normal restart is not reported as
+# an outage.
+OnBootSec=2min
+OnCalendar=*:0/5
+RandomizedDelaySec=30s
+AccuracySec=30s
+Persistent=true
+Unit=questura-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/apps/questura/infra/softprod/stage-host-config.sh
+++ b/apps/questura/infra/softprod/stage-host-config.sh
@@ -132,7 +132,7 @@ PY
   chmod 0644 "$destination"
 }
 
-for template in "$HOST_SOURCE/systemd"/*.service.in; do
+for template in "$HOST_SOURCE/systemd"/*.service.in "$HOST_SOURCE/systemd"/*.timer.in; do
   unit_name=$(basename -- "$template" .in)
   render_unit "$template" "$stage_directory/infra/systemd/$unit_name"
 done
@@ -169,7 +169,9 @@ PY
 "$CLOUDFLARED_BIN" \
   --config "$stage_directory/infra/tunnel-config.yml" \
   tunnel ingress validate
-systemd-analyze --user verify "$stage_directory/infra/systemd"/*.service
+systemd-analyze --user verify \
+  "$stage_directory/infra/systemd"/*.service \
+  "$stage_directory/infra/systemd"/*.timer
 
 for pair in \
   "$stage_directory/config/server.env:$CONFIG_ROOT/server.env" \
@@ -201,7 +203,7 @@ install -m 0600 "$stage_directory/config/client.env" "$CONFIG_ROOT/client.env"
 install -m 0600 "$stage_directory/infra/.env" "$INFRA_ROOT/.env"
 install -m 0644 "$stage_directory/infra/compose.yml" "$INFRA_ROOT/compose.yml"
 install -m 0644 "$stage_directory/infra/tunnel-config.yml" "$INFRA_ROOT/tunnel-config.yml"
-for unit in "$stage_directory/infra/systemd"/*.service; do
+for unit in "$stage_directory/infra/systemd"/*.service "$stage_directory/infra/systemd"/*.timer; do
   install -m 0644 "$unit" "$RENDERED_ROOT/$(basename -- "$unit")"
 done
 

--- a/apps/questura/infra/softprod/stage-host-config.test.sh
+++ b/apps/questura/infra/softprod/stage-host-config.test.sh
@@ -70,10 +70,15 @@ cmp "$EXPECTED_COMPOSE_ENV" "$DEPLOY_ROOT/infra/.env"
 [[ $(stat -c '%a' "$DEPLOY_ROOT/config/server.env" 2>/dev/null || stat -f '%Lp' "$DEPLOY_ROOT/config/server.env") == 600 ]]
 grep -q "ExecStart=$FAKE_BIN/pnpm exec next start -H 127.0.0.1 -p 4000" "$DEPLOY_ROOT/infra/systemd/questura-server.service"
 grep -q "ExecStart=$FAKE_BIN/cloudflared" "$DEPLOY_ROOT/infra/systemd/questura-tunnel.service"
+grep -q 'ExecStart=/usr/bin/env bash %h/questura/app/apps/questura/infra/softprod/healthcheck.sh' "$DEPLOY_ROOT/infra/systemd/questura-healthcheck.service"
+grep -q '^OnBootSec=2min$' "$DEPLOY_ROOT/infra/systemd/questura-healthcheck.timer"
+grep -q '^OnCalendar=\*:0/5$' "$DEPLOY_ROOT/infra/systemd/questura-healthcheck.timer"
+grep -q '^Persistent=true$' "$DEPLOY_ROOT/infra/systemd/questura-healthcheck.timer"
 ! rg -q '@(NODE_BIN_DIR|PNPM_BIN|CLOUDFLARED_BIN)@' "$DEPLOY_ROOT/infra/systemd"
 grep -q 'docker|.*config --quiet' "$LOG"
 grep -q 'cloudflared|.*tunnel ingress validate' "$LOG"
 grep -q 'systemd-analyze|--user verify' "$LOG"
+grep -q 'systemd-analyze|.*questura-healthcheck.service.*questura-healthcheck.timer' "$LOG"
 ! grep -Fq "$FAKE_COMPOSE_PASSWORD" "$TEST_ROOT/install.out" "$TEST_ROOT/install.err"
 
 # Idempotent rerun keeps secrets quiet and creates another recoverable backup.


### PR DESCRIPTION
## Why

The soft-production host has no monitoring. Today a failure is discovered by someone noticing the site is down.

## What

`healthcheck.sh` — a strictly read-only check, plus a systemd timer that runs it.

It proves **one identity end to end**: `current-server` and `current-client` must resolve to valid, paired release metadata for the same commit, and all four local/public `/api/health` endpoints must report exactly that SHA. Then: the three app units active; canonical Compose config valid (quietly); the stable Postgres and Redis containers inspected for project `infra`, expected service labels, `running`, and `healthy` per their own Docker healthchecks.

**Passive by construction:** no restart, no link change, no migration, no DB or cache write. The suite asserts the script contains no build/install/migrate/compose-up operation.

**Deploy race:** it probes `deploy.lock` without ever holding it, and re-checks the release pair at start and end. A pass that overlaps a deploy, or sees the pair move underneath it, prints `SKIP` and exits 0 rather than reporting a false outage.

**Sanitized output:** aggregated `OK`/`FAIL` lines only. Response bodies, Compose output, environment values and DB errors are never logged. Exit 0 healthy, 1 unhealthy.

**Timer:** every five minutes and two minutes after boot, 30s randomized delay, into journald. No auto-heal.

`stage-host-config.sh` now renders `.timer.in` templates alongside `.service.in` and validates both, but installs nothing live — the README documents the manual, reversible enable, to be done only after adoption is verified.

## Scope limit, stated plainly

Journald is diagnostics, not alerting: it records failures and notifies nobody, and an on-host monitor cannot report laptop power, sleep, or total network loss. Off-host uptime/heartbeat alerting remains separate follow-up work.

## Tests

`healthcheck.test.sh` (wired into `test:softprod`) covers the healthy path, per-endpoint SHA mismatch, HTTP and parser failures, invalid/unpaired release pointers, aggregation across unit/Compose/container failures, and both `SKIP` paths. Full `pnpm --dir apps/questura/apps/server test:softprod` green on this branch (all six suites), rebased onto `35dd7867`.