### PR TITLE
feat(abw): itinerary autobuild accepts the session cookie

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
@@ -153,6 +153,7 @@ async def generate_itinerary(
     The JWT comes from the session cookie unless the body supplied one. The
     frontend stopped sending it once the Staff credential left JavaScript, and
     the cookie carries the same token, so the Payload reads are unaffected.
+    `require_staff` still decides whether the caller may be here at all.
     """
     payload_jwt = request.payload_jwt or session_token
     if not payload_jwt:

--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from app.core.staff_auth import require_staff
+from app.core.staff_token import staff_token
 from app.shared.writer_invocation import invoke_writer_model
 
 from .day_shells import BUILT_IN_DAY_SHELL_IDS
@@ -141,13 +142,29 @@ async def remove_day_shell(shell_id: str) -> dict[str, bool]:
 )
 async def generate_itinerary(
     request: GenerateItineraryRequest,
+    session_token: str | None = Depends(staff_token),
 ) -> GenerateItineraryResponse:
     """Itinerary Autobuild: fill an itinerary's day slots from the brief.
 
     Reads candidate records from Payload with the operator's JWT, scores and
     selects them, orders each day, and returns the plan (slots + reasons only —
     no blurbs/images). The frontend persists the result.
+
+    The JWT comes from the session cookie unless the body supplied one. The
+    frontend stopped sending it once the Staff credential left JavaScript, and
+    the cookie carries the same token, so the Payload reads are unaffected.
     """
+    payload_jwt = request.payload_jwt or session_token
+    if not payload_jwt:
+        raise HTTPException(
+            status_code=401,
+            detail=(
+                "Reading Payload candidates needs the operator's session: send "
+                "the payload-token cookie or payload_jwt in the body"
+            ),
+        )
+    request = request.model_copy(update={"payload_jwt": payload_jwt})
+
     try:
         return await run_itinerary_pipeline(request)
     except Exception as exc:  # noqa: BLE001

--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/schemas.py
@@ -70,10 +70,16 @@ class DayShellSelection(BaseModel):
 
 
 class GenerateItineraryRequest(BaseModel):
-    """Inputs from Step 1 of the builder plus the operator's Payload JWT.
+    """Inputs from Step 1 of the builder.
 
     `payload_jwt` is used only to read candidate records over Payload REST; the
     backend never writes. `brief` is the Generation Brief (core creative input).
+
+    The JWT is optional in the body because the frontend no longer has one to
+    send: the operator's credential is an httpOnly cookie it cannot read. The
+    route fills this in from that cookie (`app.core.staff_token`), which carries
+    the same JWT. A body-supplied value still wins, so non-browser callers and
+    older frontend builds keep working.
     """
 
     location: str = Field(
@@ -87,7 +93,7 @@ class GenerateItineraryRequest(BaseModel):
         ..., min_length=1, max_length=MAX_BRIEF_CHARS, description="Generation Brief"
     )
     day_count: int = Field(..., ge=MIN_DAYS, le=MAX_DAYS)
-    payload_jwt: str = Field(..., min_length=1)
+    payload_jwt: str | None = Field(default=None, min_length=1)
     shared_neighborhoods: list[int] = Field(default_factory=list)
     day_shells: list[DayShellSelection] = Field(..., min_length=1)
     model_name: str | None = Field(default=None, max_length=120)

--- a/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/itineraries_pipeline/schemas.py
@@ -78,8 +78,10 @@ class GenerateItineraryRequest(BaseModel):
     The JWT is optional in the body because the frontend no longer has one to
     send: the operator's credential is an httpOnly cookie it cannot read. The
     route fills this in from that cookie (`app.core.staff_token`), which carries
-    the same JWT. A body-supplied value still wins, so non-browser callers and
-    older frontend builds keep working.
+    the same JWT. A body-supplied value still wins, so older frontend builds
+    keep working. It does not exempt anyone from staff auth: with
+    ABW_REQUIRE_STAFF_AUTH on, `require_staff` rejects a caller with no cookie
+    or bearer header before this field is ever read.
     """
 
     location: str = Field(

--- a/apps/ai-blog-writer/apps/backend/tests/test_itineraries_pipeline_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_itineraries_pipeline_routes.py
@@ -40,3 +40,100 @@ def test_generate_titles_rejects_short_prompt():
         json={"prompt": "short"},
     )
     assert response.status_code == 422
+
+
+def _generate_body(**overrides) -> dict:
+    body = {
+        "location": "peru|lima|miraflores",
+        "title": "Three days in Miraflores",
+        "brief": "A walkable long weekend for a first-time visitor.",
+        "day_count": 1,
+        "shared_neighborhoods": [],
+        "day_shells": [
+            {
+                "day_index": 0,
+                "shell_id": "classic",
+                "shell_name": "Classic",
+                "shell_description": "A standard day",
+                "slots": [
+                    {
+                        "id": "s1",
+                        "label": "Morning",
+                        "daypart": "morning",
+                        "acceptable_collections": ["attractions"],
+                    }
+                ],
+            }
+        ],
+    }
+    body.update(overrides)
+    return body
+
+
+def _capture_pipeline(monkeypatch) -> dict:
+    """Record the request the pipeline receives, without running it."""
+    seen: dict = {}
+
+    async def fake_pipeline(request):
+        seen["payload_jwt"] = request.payload_jwt
+        return itineraries_pipeline_routes.GenerateItineraryResponse(
+            days=[], model_used="stub"
+        )
+
+    monkeypatch.setattr(
+        itineraries_pipeline_routes, "run_itinerary_pipeline", fake_pipeline
+    )
+    return seen
+
+
+def test_generate_takes_the_jwt_from_the_session_cookie(monkeypatch):
+    """The frontend has no token to put in the body any more.
+
+    `payload_jwt` used to be a required field; the cookie carries the same JWT,
+    so the Payload reads are unaffected.
+    """
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+    monkeypatch.setenv("ABW_ALLOWED_ORIGINS", "https://abw.questurian.com")
+    seen = _capture_pipeline(monkeypatch)
+
+    client = _build_client()
+    client.cookies.set("payload-token", "cookie-jwt")
+    response = client.post(
+        "/itineraries-pipeline/generate",
+        json=_generate_body(),
+        headers={"Origin": "https://abw.questurian.com"},
+    )
+
+    assert response.status_code == 200
+    assert seen["payload_jwt"] == "cookie-jwt"
+
+
+def test_generate_prefers_an_explicit_body_jwt(monkeypatch):
+    """Non-browser callers and older frontend builds keep working."""
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+    monkeypatch.setenv("ABW_ALLOWED_ORIGINS", "https://abw.questurian.com")
+    seen = _capture_pipeline(monkeypatch)
+
+    client = _build_client()
+    client.cookies.set("payload-token", "cookie-jwt")
+    response = client.post(
+        "/itineraries-pipeline/generate",
+        json=_generate_body(payload_jwt="body-jwt"),
+        headers={"Origin": "https://abw.questurian.com"},
+    )
+
+    assert response.status_code == 200
+    assert seen["payload_jwt"] == "body-jwt"
+
+
+def test_generate_401s_with_no_credential_at_all(monkeypatch):
+    """Neither a cookie nor a body field means there is nothing to read Payload
+    with — a 401, not a 500 deep inside the retrieval stage."""
+    monkeypatch.delenv("ABW_API_KEY", raising=False)
+    _capture_pipeline(monkeypatch)
+
+    client = _build_client()
+    response = client.post("/itineraries-pipeline/generate", json=_generate_body())
+
+    assert response.status_code == 401
+    assert "session" in response.json()["detail"]


### PR DESCRIPTION
First of three PRs superseding #227 (172 files), which is not reviewable as one change.

## Why

`POST /itineraries-pipeline/generate` requires `payload_jwt` in the request body. The frontend can no longer produce one — the Staff credential is an httpOnly cookie it cannot read (#223–#226). Without this, autobuild breaks the moment the frontend stops sending a token.

## What

The route resolves the JWT from the `payload-token` cookie via the existing `staff_token` dependency when the body does not carry one. `payload_jwt` becomes optional in the schema, and a body-supplied value still wins, so non-browser callers and older frontend builds are unaffected. A request with neither now fails with an explicit 401 rather than a schema validation error.

Payload reads with that JWT are unchanged; the backend still never writes through it.

## Tests

`tests/test_itineraries_pipeline_routes.py` (+97 lines): cookie-only request works, body value takes precedence, neither yields 401. Focused suite green; full backend suite green on the branch this was split from.