### PR TITLE
refactor(abw): remove the Staff token from JavaScript entirely

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.venv
+++ b/apps/ai-blog-writer/apps/backend/.venv
@@ -1,0 +1,1 @@
+/Users/alanmalpartida/Desktop/questurian/apps/ai-blog-writer/apps/backend/.venv

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/AuthProvider.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/AuthProvider.test.tsx
@@ -229,7 +229,6 @@ describe('AuthProvider', () => {
   });
 
   it('logs out when the session is rejected by /me and refresh fails', async () => {
-    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     setLiveAuthState({
       expiresAt: Date.now() + 60 * 60 * 1000,
       user: {

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/AuthProvider.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/AuthProvider.test.tsx
@@ -8,16 +8,13 @@ import { useAuth } from './useAuth';
 import { getLiveAuthState, purgeLegacyStoredAuth, setLiveAuthState } from './auth-session-store';
 import { LEGACY_AUTH_STORAGE_KEY } from './auth.constants';
 
-function toBase64Url(value: string): string {
-  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-}
-
-function createToken(expiresAtMs: number): string {
-  return [
-    toBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' })),
-    toBase64Url(JSON.stringify({ exp: Math.floor(expiresAtMs / 1000) })),
-    'signature',
-  ].join('.');
+/**
+ * Payload reports session expiry as `exp` (seconds) on login, refresh-token and
+ * me. The app reads that field; it no longer decodes a JWT, because it no longer
+ * has one. Mocked responses therefore carry `exp`, not a token.
+ */
+function expSeconds(expiresAtMs: number): number {
+  return Math.floor(expiresAtMs / 1000);
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -79,7 +76,7 @@ describe('AuthProvider', () => {
   });
 
   it('waits for session restoration before redirecting to login', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     let resolveRestore: ((response: Response) => void) | null = null;
 
     vi.stubGlobal(
@@ -109,7 +106,7 @@ describe('AuthProvider', () => {
     const completeRestore = resolveRestore as ((response: Response) => void) | null;
     completeRestore?.(
       jsonResponse({
-        token,
+        exp,
         user: {
           id: 17,
           email: 'writer@example.com',
@@ -126,7 +123,7 @@ describe('AuthProvider', () => {
   });
 
   it('uses Payload users endpoints for staff restore, login, and logout', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
 
@@ -136,7 +133,7 @@ describe('AuthProvider', () => {
 
       if (url.endsWith('/api/users/login')) {
         return Promise.resolve(jsonResponse({
-          token,
+          exp,
           user: {
             id: 17,
             email: 'writer@example.com',
@@ -184,9 +181,8 @@ describe('AuthProvider', () => {
   });
 
   it('refreshes a stale role from /api/users/me on hydrate', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     setLiveAuthState({
-      token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       user: {
         id: '17',
@@ -202,7 +198,7 @@ describe('AuthProvider', () => {
 
         if (url.endsWith('/api/users/me')) {
           return Promise.resolve(jsonResponse({
-            token,
+            exp,
             user: {
               id: 17,
               email: 'writer@example.com',
@@ -233,9 +229,8 @@ describe('AuthProvider', () => {
   });
 
   it('logs out when the session is rejected by /me and refresh fails', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     setLiveAuthState({
-      token,
       expiresAt: Date.now() + 60 * 60 * 1000,
       user: {
         id: '17',
@@ -281,7 +276,7 @@ describe('AuthProvider', () => {
  * credential, and a reload restores the session from the httpOnly cookie
  * instead of from disk.
  */
-describe('the Staff token never reaches disk', () => {
+describe('the Staff token exists nowhere in JavaScript', () => {
   beforeEach(() => {
     setLiveAuthState(null);
   });
@@ -293,7 +288,7 @@ describe('the Staff token never reaches disk', () => {
   });
 
   it('writes nothing to localStorage on login', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
 
     vi.stubGlobal(
       'fetch',
@@ -302,7 +297,7 @@ describe('the Staff token never reaches disk', () => {
 
         if (url.endsWith('/api/users/login')) {
           return Promise.resolve(jsonResponse({
-            token,
+            exp,
             user: { id: 17, email: 'writer@example.com', role: 'writer' },
           }));
         }
@@ -329,18 +324,19 @@ describe('the Staff token never reaches disk', () => {
     });
 
     expect(localStorage.length).toBe(0);
-    // Belt and braces: the token must not appear under any key.
-    expect(JSON.stringify(localStorage)).not.toContain(token);
+    // Stronger than "not on disk": the in-memory session has no token field at
+    // all, so there is no credential for an XSS payload to read from anywhere.
+    expect(getLiveAuthState()).not.toHaveProperty('token');
   });
 
   it('restores the session from the cookie alone, without writing it back to disk', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
 
       if (url.endsWith('/api/users/me')) {
         return Promise.resolve(jsonResponse({
-          token,
+          exp,
           user: { id: 17, email: 'writer@example.com', role: 'editor' },
         }));
       }
@@ -369,9 +365,10 @@ describe('the Staff token never reaches disk', () => {
     expect(init?.credentials).toBe('include');
     // ...and no Authorization header can have been derived from storage.
     expect(new Headers(init?.headers).has('Authorization')).toBe(false);
-    // The restored session lands in memory and nowhere else. This is the half
-    // that fails without the change: the old code wrote it straight back out.
-    expect(getLiveAuthState()?.token).toBe(token);
+    // The restored session lands in memory and nowhere else — and carries no
+    // token at all, which is the point: there is nothing left to exfiltrate.
+    expect(getLiveAuthState()?.user.email).toBe('writer@example.com');
+    expect(getLiveAuthState()).not.toHaveProperty('token');
     expect(localStorage.length).toBe(0);
   });
 
@@ -402,13 +399,13 @@ describe('the Staff token never reaches disk', () => {
   });
 
   it('logs out on the cookie, not on a token that may already be expired', async () => {
-    const token = createToken(Date.now() + 60 * 60 * 1000);
+    const exp = expSeconds(Date.now() + 60 * 60 * 1000);
     const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input);
 
       if (url.endsWith('/api/users/login')) {
         return Promise.resolve(jsonResponse({
-          token,
+          exp,
           user: { id: 17, email: 'writer@example.com', role: 'writer' },
         }));
       }

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-context.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-context.ts
@@ -8,14 +8,21 @@ export interface User {
   lastName?: string;
 }
 
+/**
+ * The live Staff session as this app knows it.
+ *
+ * Deliberately holds no token. The credential is the httpOnly `payload-token`
+ * cookie, which no script can read; what the app needs is only who the
+ * operator is and when the session lapses. `expiresAt` comes from the `exp`
+ * every Payload session endpoint returns (`login`, `refresh-token`, `me`), not
+ * from decoding a JWT this app no longer has.
+ */
 export interface AuthState {
-  token: string;
   expiresAt: number;
   user: User;
 }
 
 export interface AuthContextValue {
-  token: string | null;
   expiresAt: number | null;
   user: User | null;
   isAuthenticated: boolean;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-session-store.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-session-store.ts
@@ -10,16 +10,18 @@ import { hasActiveSession } from './auth-state';
  * token out of it with one line, and the token outlived the tab, the window and
  * the browser restart.
  *
- * Nothing is written to disk now. A reload starts with no session and
- * rehydrates from the httpOnly `payload-token` cookie Payload already sets on
- * login (`/api/users/me` returns the user *and* the current token, so the
- * cookie is sufficient to restore a session). The token still exists in JS
- * while the page is open — the FastAPI backend reads it from an
- * `Authorization` header, and that is a separate change — but it is no longer
- * sitting at rest behind a well-known key.
+ * Nothing is written to disk now, and there is no longer a token to write. The
+ * credential is the httpOnly `payload-token` cookie; what this holds is who
+ * the operator is and when the session lapses. A reload starts empty and
+ * rehydrates from that cookie via `/api/users/me`.
  *
- * Module scope rather than React state because `apiFetch` needs to read it from
- * outside the component tree; `useAuthSessionState` is the only writer.
+ * That is the whole point of the change: an XSS payload has nothing to read
+ * here. It can still *act* as the operator while the page is open — the cookie
+ * rides along on any request it makes — but it cannot extract a credential and
+ * use it elsewhere, later.
+ *
+ * Module scope rather than React state because it is read from outside the
+ * component tree; `useAuthSessionState` is the only writer.
  */
 
 let liveAuthState: AuthState | null = null;
@@ -33,7 +35,7 @@ export function getLiveAuthState(): AuthState | null {
     return null;
   }
 
-  if (!hasActiveSession(liveAuthState.token, liveAuthState.expiresAt)) {
+  if (!hasActiveSession(liveAuthState.expiresAt)) {
     liveAuthState = null;
     return null;
   }

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-state.ts
@@ -25,7 +25,7 @@ export function readNumber(value: unknown): number | null {
  *
  * Every Payload session endpoint returns `exp` — `loginOperation`,
  * `refreshOperation` and `meOperation` all set it — so this does not need the
- * which is the point: the app no longer has one to decode.
+ * token, which is the point: the app no longer has one to decode.
  *
  * Returns null when the server named no expiry, and the caller treats that as
  * "no session". The previous code decoded the JWT and, failing that, invented

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth-state.ts
@@ -1,11 +1,7 @@
 import type { AuthState } from './auth-context';
-import { SESSION_DURATION_FALLBACK_MS } from './auth.constants';
 
-export function hasActiveSession(
-  token: string | null | undefined,
-  expiresAt: number | null | undefined,
-): boolean {
-  if (!token || !expiresAt) {
+export function hasActiveSession(expiresAt: number | null | undefined): boolean {
+  if (!expiresAt) {
     return false;
   }
 
@@ -24,34 +20,25 @@ export function readNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
-export function decodeTokenExpiry(token: string): number | null {
-  try {
-    const [, base64Url] = token.split('.');
-    if (!base64Url) {
-      return null;
-    }
-
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const jsonPayload = decodeURIComponent(
-      atob(base64)
-        .split('')
-        .map((char) => `%${(`00${char.charCodeAt(0).toString(16)}`).slice(-2)}`)
-        .join(''),
-    );
-    const decoded = JSON.parse(jsonPayload) as { exp?: unknown };
-    const exp = readNumber(decoded.exp);
-
-    return exp ? exp * 1000 : null;
-  } catch {
-    return null;
-  }
-}
-
+/**
+ * When the session lapses, according to the server.
+ *
+ * Every Payload session endpoint returns `exp` — `loginOperation`,
+ * `refreshOperation` and `meOperation` all set it — so this does not need the
+ * which is the point: the app no longer has one to decode.
+ *
+ * Returns null when the server named no expiry, and the caller treats that as
+ * "no session". The previous code decoded the JWT and, failing that, invented
+ * seven days. That was already wrong — `payload-token` lives two hours — and
+ * without a token to decode it would now be the *common* path rather than the
+ * unreachable one. A session whose end is unknown is not a session worth
+ * holding: the cookie will be rejected at that point anyway, so guessing long
+ * only delays the discovery.
+ */
 export function resolveExpiresAt(
   source: Record<string, unknown>,
-  token: string,
   fallbackExpiresAt?: number | null,
-): number {
+): number | null {
   const numericExpiresAt = readNumber(source.expiresAt);
   if (numericExpiresAt) {
     return numericExpiresAt;
@@ -70,16 +57,11 @@ export function resolveExpiresAt(
     }
   }
 
-  const tokenExpiry = decodeTokenExpiry(token);
-  if (tokenExpiry) {
-    return tokenExpiry;
-  }
-
   if (fallbackExpiresAt && fallbackExpiresAt > Date.now()) {
     return fallbackExpiresAt;
   }
 
-  return Date.now() + SESSION_DURATION_FALLBACK_MS;
+  return null;
 }
 
 export function normalizeAuthState(
@@ -99,19 +81,8 @@ export function normalizeAuthState(
     return null;
   }
 
-  const token =
-    readString(response.token)
-    || readString(response.refreshedToken)
-    || readString(response.accessToken)
-    || readString(response.jwt)
-    || (fallbackAuth && hasActiveSession(fallbackAuth.token, fallbackAuth.expiresAt) ? fallbackAuth.token : null);
-
-  if (!token) {
-    return null;
-  }
-
-  const expiresAt = resolveExpiresAt(response, token, fallbackAuth?.expiresAt ?? null);
-  if (!hasActiveSession(token, expiresAt)) {
+  const expiresAt = resolveExpiresAt(response, fallbackAuth?.expiresAt ?? null);
+  if (!hasActiveSession(expiresAt)) {
     return null;
   }
 
@@ -121,8 +92,7 @@ export function normalizeAuthState(
   }
 
   return {
-    token,
-    expiresAt,
+    expiresAt: expiresAt as number,
     user: {
       id: String(userSource.id ?? fallbackAuth?.user.id ?? ''),
       email,

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/auth.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/auth.constants.ts
@@ -7,7 +7,6 @@ export const LEGACY_AUTH_STORAGE_KEY = 'payload_auth';
 export const DEFAULT_PAYLOAD_URL = 'http://localhost:4000';
 export const PAYLOAD_API_URL = import.meta.env.VITE_PAYLOAD_API_URL || DEFAULT_PAYLOAD_URL;
 export const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
-export const SESSION_DURATION_FALLBACK_MS = 7 * 24 * 60 * 60 * 1000;
 export const REVALIDATION_TIMEOUT_MS = 5000;
 export const LOGIN_TIMEOUT_MS = 10000;
 export const SESSION_RESTORE_TIMEOUT_MS = 8000;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/payload-auth-client.ts
@@ -4,7 +4,6 @@ import {
   LOGOUT_ENDPOINTS,
   PAYLOAD_API_URL,
   REVALIDATION_TIMEOUT_MS,
-  SESSION_DURATION_FALLBACK_MS,
   SESSION_HYDRATE_REQUESTS,
   SESSION_RENEW_REQUESTS,
   SESSION_RESTORE_TIMEOUT_MS,
@@ -151,9 +150,11 @@ export async function loginPayloadUser(email: string, password: string): Promise
       throw new Error(message);
     }
 
+    // Only the email is carried in: Payload's login response names the `exp`
+    // and the user itself, and inventing a fallback expiry here would mean
+    // holding a session the server never agreed to.
     const nextState = normalizeAuthState(await response.json(), {
-      token: '',
-      expiresAt: Date.now() + SESSION_DURATION_FALLBACK_MS,
+      expiresAt: 0,
       user: {
         id: '',
         email,
@@ -161,7 +162,7 @@ export async function loginPayloadUser(email: string, password: string): Promise
     });
 
     if (!nextState) {
-      throw new Error('Login failed - no token received');
+      throw new Error('Login failed - the server returned no usable session');
     }
 
     return nextState;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/permissions-client.ts
@@ -19,7 +19,7 @@ export type AccessResult = {
   >;
 };
 
-export async function fetchAccessPermissions(token: string): Promise<AccessResult | null> {
+export async function fetchAccessPermissions(): Promise<AccessResult | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REVALIDATION_TIMEOUT_MS);
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/useAuthSessionState.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/useAuthSessionState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AuthContextValue, AuthState } from './auth-context';
 import { EXPIRY_BUFFER_MS } from './auth.constants';
 import { hasActiveSession } from './auth-state';
+import { clearPermissionsCache } from './usePermissions';
 import { getLiveAuthState, setLiveAuthState } from './auth-session-store';
 import {
   checkPayloadHealth,
@@ -18,8 +19,8 @@ export function useAuthSessionState(): AuthContextValue {
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
   const applyAuthState = useCallback((nextState: AuthState | null) => {
-    // `apiFetch` reads the token from outside the component tree, so the store
-    // has to be updated synchronously rather than waiting for a re-render.
+    // The store is read from outside the component tree, so it is updated
+    // synchronously rather than waiting for a re-render.
     setLiveAuthState(nextState);
     setAuthState(nextState);
   }, []);
@@ -84,21 +85,41 @@ export function useAuthSessionState(): AuthContextValue {
   const logout = useCallback(() => {
     applyAuthState(null);
     setIsRestoringSession(false);
+    // The access cache is module-scoped and keyed by Staff id, so it outlives
+    // both the component tree and a session renewal. Without this, signing out
+    // and signing in as someone else on the same page load would serve the
+    // previous operator's permissions. `clearPermissionsCache` was exported but
+    // never called from app code — flagged as pre-existing on PR #221, and now
+    // load-bearing because the cache no longer turns over with the token.
+    clearPermissionsCache();
     logoutPayloadUser();
   }, [applyAuthState]);
 
   useEffect(() => {
-    if (!authState?.token || !authState?.expiresAt) {
+    if (!authState?.expiresAt) {
       return;
     }
+
+    // The hydrate effect above has always had this guard; the renewal effect
+    // did not, which was a real bug rather than an asymmetry: logging out
+    // while `/api/users/refresh-token` was in flight applied the renewed
+    // session on top of the logout and signed the operator back in, in both
+    // the UI and the module store. Flagged as pre-existing on PR #221 and
+    // fixed here because this effect is being rewritten anyway.
+    let isCancelled = false;
 
     const remainingMs = authState.expiresAt - EXPIRY_BUFFER_MS - Date.now();
     const refreshSession = async () => {
       setIsRestoringSession(true);
       const restoredState = await renewPayloadSession(authState);
+
+      if (isCancelled) {
+        return;
+      }
+
       if (restoredState) {
         applyAuthState(restoredState);
-      } else if (!hasActiveSession(authState.token, authState.expiresAt)) {
+      } else if (!hasActiveSession(authState.expiresAt)) {
         applyAuthState(null);
       }
       setIsRestoringSession(false);
@@ -106,24 +127,27 @@ export function useAuthSessionState(): AuthContextValue {
 
     if (remainingMs <= 0) {
       void refreshSession();
-      return;
+      return () => {
+        isCancelled = true;
+      };
     }
 
     const timeoutId = window.setTimeout(() => {
       void refreshSession();
     }, remainingMs);
 
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(timeoutId);
+    };
   }, [applyAuthState, authState]);
 
   return useMemo(() => {
-    const token = authState?.token ?? null;
     const expiresAt = authState?.expiresAt ?? null;
     const user = authState?.user ?? null;
-    const isAuthenticated = hasActiveSession(token, expiresAt);
+    const isAuthenticated = hasActiveSession(expiresAt);
 
     return {
-      token,
       expiresAt,
       user,
       isAuthenticated,

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.test.tsx
@@ -10,12 +10,11 @@ vi.mock('./permissions-client');
 const mockUseAuth = vi.mocked(useAuth);
 const mockFetchAccess = vi.mocked(fetchAccessPermissions);
 
-function stubAuth(role: string | undefined, token: string | null = 'token-1') {
+function stubAuth(role: string | undefined, isSignedIn = true) {
   mockUseAuth.mockReturnValue({
-    token,
-    expiresAt: Date.now() + 60_000,
-    user: token ? { id: '1', email: 'user@example.com', role } : null,
-    isAuthenticated: Boolean(token),
+    expiresAt: isSignedIn ? Date.now() + 60_000 : null,
+    user: isSignedIn ? { id: '1', email: 'user@example.com', role } : null,
+    isAuthenticated: isSignedIn,
     isRestoringSession: false,
     isConnected: true,
     connectionError: null,
@@ -68,7 +67,7 @@ describe('usePermissions', () => {
   });
 
   it('denies everything without a token', async () => {
-    stubAuth(undefined, null);
+    stubAuth(undefined, false);
 
     const { result } = renderHook(() => usePermissions());
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.ts
@@ -40,11 +40,15 @@ function roleAllowsManagePublished(role: string | undefined | null): boolean {
 
 export function usePermissions(): Permissions {
   const { user, isAuthenticated } = useAuth();
+  // The id, not the object: `user` is a fresh identity on every session
+  // renewal, and depending on it would re-run this effect and flip `isLoading`
+  // for a render in every consumer for no change in who is signed in.
+  const staffId = user?.id;
   const [access, setAccess] = useState<AccessResult | null>(null);
   const [isLoading, setIsLoading] = useState(isAuthenticated);
 
   useEffect(() => {
-    if (!isAuthenticated || !user) {
+    if (!isAuthenticated || !staffId) {
       setAccess(null);
       setIsLoading(false);
       return;
@@ -53,7 +57,7 @@ export function usePermissions(): Permissions {
     let isCancelled = false;
     setIsLoading(true);
 
-    void getAccessForStaff(user.id).then((result) => {
+    void getAccessForStaff(staffId).then((result) => {
       if (isCancelled) {
         return;
       }
@@ -64,7 +68,7 @@ export function usePermissions(): Permissions {
     return () => {
       isCancelled = true;
     };
-  }, [isAuthenticated, user]);
+  }, [isAuthenticated, staffId]);
 
   return useMemo(() => {
     const articlesUpdate = access?.collections?.articles?.update;

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/usePermissions.ts
@@ -12,14 +12,20 @@ export type Permissions = {
 };
 
 // Shared across all consumers so six components on one page trigger a single
-// /api/access request per token.
+// /api/access request per signed-in operator.
+//
+// Keyed by Staff id rather than by token: the credential is now an httpOnly
+// cookie this code cannot read, and the identity is what the answer actually
+// depends on. A session renewal used to mint a new token and therefore a new
+// cache key, silently re-fetching; keying on identity means the entry survives
+// renewal, which is the correct lifetime for "what may this person do".
 const accessCache = new Map<string, Promise<AccessResult | null>>();
 
-function getAccessForToken(token: string): Promise<AccessResult | null> {
-  let cached = accessCache.get(token);
+function getAccessForStaff(staffId: string): Promise<AccessResult | null> {
+  let cached = accessCache.get(staffId);
   if (!cached) {
-    cached = fetchAccessPermissions(token);
-    accessCache.set(token, cached);
+    cached = fetchAccessPermissions();
+    accessCache.set(staffId, cached);
   }
   return cached;
 }
@@ -33,12 +39,12 @@ function roleAllowsManagePublished(role: string | undefined | null): boolean {
 }
 
 export function usePermissions(): Permissions {
-  const { token, user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const [access, setAccess] = useState<AccessResult | null>(null);
-  const [isLoading, setIsLoading] = useState(Boolean(token));
+  const [isLoading, setIsLoading] = useState(isAuthenticated);
 
   useEffect(() => {
-    if (!token) {
+    if (!isAuthenticated || !user) {
       setAccess(null);
       setIsLoading(false);
       return;
@@ -47,7 +53,7 @@ export function usePermissions(): Permissions {
     let isCancelled = false;
     setIsLoading(true);
 
-    void getAccessForToken(token).then((result) => {
+    void getAccessForStaff(user.id).then((result) => {
       if (isCancelled) {
         return;
       }
@@ -58,7 +64,7 @@ export function usePermissions(): Permissions {
     return () => {
       isCancelled = true;
     };
-  }, [token]);
+  }, [isAuthenticated, user]);
 
   return useMemo(() => {
     const articlesUpdate = access?.collections?.articles?.update;

--- a/apps/ai-blog-writer/apps/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -23,7 +23,6 @@ const OCCASIONAL_CARD_TITLES = [
 
 function createAuthValue(role = 'admin'): AuthContextValue {
   return {
-    token: 'landing-token',
     expiresAt: Date.now() + 60_000,
     user: {
       id: 'user-1',

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageFeaturedContentPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageFeaturedContentPage.test.tsx
@@ -8,7 +8,6 @@ import { AuthContext, type AuthContextValue } from '../auth'
 
 function createAuthValue(role: string): AuthContextValue {
   return {
-    token: 'test-token',
     expiresAt: Date.now() + 60_000,
     user: {
       id: 'user-1',

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.test.tsx
@@ -10,7 +10,6 @@ import type { MainHomepageResponse } from './api'
 
 function createAuthValue(): AuthContextValue {
   return {
-    token: 'test-token',
     expiresAt: Date.now() + 60_000,
     user: {
       id: 'user-1',

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/payload-credentials.test.ts
@@ -141,7 +141,7 @@ describe('Payload clients send the session cookie', () => {
     const { fetchAccessPermissions } = await import('../../features/auth/permissions-client')
 
     fetchMock.mockResolvedValue(jsonResponse({}))
-    await fetchAccessPermissions('stale-token')
+    await fetchAccessPermissions()
 
     expectCookieIsTheOnlyCredential()
   })
@@ -171,7 +171,6 @@ describe('Payload clients send the session cookie', () => {
 
     fetchMock.mockResolvedValue(jsonResponse({ user: { id: 1, email: 'a@b.c' }, exp: 9e12 }))
     await hydratePayloadSession({
-      token: 'stale-token',
       expiresAt: Date.now() + 60_000,
       user: { id: '1', email: 'a@b.c' },
     })

--- a/apps/ai-blog-writer/docs/adr/0028-staff-session-is-held-in-memory-not-localstorage.md
+++ b/apps/ai-blog-writer/docs/adr/0028-staff-session-is-held-in-memory-not-localstorage.md
@@ -8,8 +8,8 @@ window and the browser restart.
 The token is no longer written to disk. It lives in a module-scoped store for
 the lifetime of the page (`features/auth/auth-session-store.ts`), and a reload
 restores the session from the httpOnly `payload-token` cookie Payload already
-sets on `POST /api/users/login`. `GET /api/users/me` returns the user *and* the
-current token, so the cookie alone is sufficient to rebuild the session.
+sets on `POST /api/users/login`. `GET /api/users/me` returns the user and an
+`exp`, so the cookie alone is sufficient to rebuild the session.
 
 Bootstrap deletes anything an earlier build left under the old key, because the
 code that would have cleared it on logout is the code being removed.
@@ -25,21 +25,16 @@ Every authenticated Payload client sends `credentials: 'include'`. They
 previously disagreed — some `'include'`, some `'omit'`, some unset (meaning
 `'same-origin'`, and Payload is never same-origin with this app). That is
 consistency, **not** a fallback: while a Bearer header is present the cookie is
-never consulted, for the reason above. Its value is that dropping the header
-later is a one-line change rather than an eight-file one.
+never consulted, for the reason above. Its value was that dropping the header
+later became a small change rather than an eight-file one — which is what
+happened next.
 
 ## What this does and does not achieve
 
-It removes the credential *at rest*. A generic XSS payload can no longer read a
-Staff token out of a well-known storage key, and a token cannot outlive the
-page.
-
-It does not yet make the token unreadable by JavaScript. The FastAPI backend
-identifies callers from an `Authorization: Bearer` header
-(`apps/backend/app/core/staff_auth.py`), and the image routes forward that same
-JWT to Payload to create media as the acting Staff user
-(`apps/backend/app/features/images/payload_client.py`). While that is the
-contract, the frontend has to hold a token in memory to send it.
+It removed the credential *at rest*: a generic XSS payload could no longer read
+a Staff token out of a well-known storage key, and a token could not outlive the
+page. It did not remove it from memory — the section below records how that was
+finished.
 
 ## Consequences
 
@@ -57,22 +52,65 @@ contract, the frontend has to hold a token in memory to send it.
 - If Payload is unreachable at load, the operator is treated as logged out
   rather than resuming on a stale stored token. That is the correct reading of
   "we cannot confirm this session".
-- `payload-token` lives 2 hours while `SESSION_DURATION_FALLBACK_MS` assumes 7
-  days. The fallback only applies when the response carries no usable expiry;
-  `/api/users/me` returns `exp`, and the JWT is still decodable in memory, so
-  the honest expiry is still available.
+- `payload-token` lived 2 hours while `SESSION_DURATION_FALLBACK_MS` assumed 7
+  days. That mismatch is resolved below: the constant is gone and an unknown
+  expiry now means "no session".
 
-## Not done here
+## Finished: the token is gone from JavaScript
 
-Making the token unreadable by JavaScript entirely requires FastAPI to accept
-the `payload-token` cookie as caller identity — including for the delegated
-writes to Payload, where the cookie value *is* the JWT the backend needs. That
-change depends on a production origin decision this repo has not made:
-`VITE_PAYLOAD_API_URL` is configured nowhere, Payload's `Users.auth` sets no
-`cookies` block (so `SameSite=Lax`, `Secure=false`, host-only `Domain`), and a
-cross-site or cross-host deployment would need `sameSite: 'None'`,
-`secure: true` and an explicit `domain`. Accepting a cookie on the backend also
-introduces a CSRF surface that must be closed deliberately rather than by
-relying on the public `X-API-Key` header forcing a preflight.
+Settled 2026-08-12 and completed in PRs #222-227. The deployment topology that
+had blocked this is: every service is a sibling subdomain of one registrable
+domain — `www` and `cms` deployed, `abw` and `abw-api` behind a Cloudflare
+Tunnel. Siblings of one registrable domain are *same-site*, so `SameSite=Lax`
+holds and no third-party cookie is involved; only the cookie's `Domain` had to
+widen. Cross-site hosting was rejected because it forces `SameSite=None`, which
+Safari and Brave block outright.
 
-Deferred until the deployment topology is settled.
+What that unlocked, in order:
+
+1. `Users.auth.cookies` scopes `payload-token` to the registrable domain, with
+   `PAYLOAD_COOKIE_DOMAIN` a hard production boot requirement (`host-only` is
+   the explicit opt-out).
+2. FastAPI reads the cookie as caller identity. The CSRF surface that opens is
+   closed with an `Origin` check against the pinned CORS allowlist — **not**
+   with `X-API-Key`, which is Vite-inlined and public. A wildcard allowlist
+   refuses cookie auth outright.
+3. Every client — `apiFetch`, the Payload clients, and the image clients —
+   sends `credentials: 'include'` and no `Authorization` header.
+4. `AuthState` carries no token. Session expiry comes from the `exp` that
+   `loginOperation`, `refreshOperation` and `meOperation` all return, so
+   nothing needs to decode a JWT.
+
+The delegated writes still work unchanged: the cookie's value *is* the JWT the
+backend forwards to Payload, so uploads are still created as the acting Staff
+user rather than a service account.
+
+### Consequences worth knowing
+
+- **Never send a Bearer header alongside the cookie.** `extractJWT` returns the
+  *first* credential in `jwtOrder` (JWT, Bearer, cookie) and verifies only that
+  one, so a stale header shadows a valid cookie and fails the request. This bit
+  `logoutPayloadUser` before, and `requestSession` latently: it attached the
+  in-memory token whenever one existed, so a token expiring slightly before its
+  cookie turned a renewable session into a forced logout.
+- **An unknown expiry now means "no session"**, rather than the invented 7 days
+  the old fallback used. That also removes the 2h-cookie-vs-7d-fallback
+  mismatch this ADR previously flagged.
+- **The `!token` guards were dead, not translated.** Every component holding
+  one renders only inside `RequireAuth`, which returns `<Navigate>` when
+  `!isAuthenticated` — and `isAuthenticated` used to require a truthy token. All
+  74 were unreachable and were deleted.
+- **The permissions access cache is keyed by Staff id**, not by token. It used
+  to re-fetch on every renewal because renewal minted a new key. It is now
+  cleared on logout, which it never was.
+- `payload_jwt` on `POST /itineraries-pipeline/generate` was a **required** body
+  field. It is now optional and cookie-sourced, with a body value still winning
+  so non-browser callers keep working. Any future route taking a JWT in its body
+  has the same latent break.
+
+### What this does and does not achieve
+
+An XSS payload can no longer read a Staff credential — there is nothing to
+read, at rest or in memory. It can still *act* as the operator while the page is
+open, because the browser attaches the cookie to any request it makes. The gain
+is that a credential cannot be extracted and replayed elsewhere, later.

--- a/apps/ai-blog-writer/docs/adr/0028-staff-session-is-held-in-memory-not-localstorage.md
+++ b/apps/ai-blog-writer/docs/adr/0028-staff-session-is-held-in-memory-not-localstorage.md
@@ -58,7 +58,7 @@ finished.
 
 ## Finished: the token is gone from JavaScript
 
-Settled 2026-08-12 and completed in PRs #222-227. The deployment topology that
+Settled 2026-08-12 and completed in PRs #222-226, #246, #247 and #248. The deployment topology that
 had blocked this is: every service is a sibling subdomain of one registrable
 domain — `www` and `cms` deployed, `abw` and `abw-api` behind a Cloudflare
 Tunnel. Siblings of one registrable domain are *same-site*, so `SameSite=Lax`
@@ -98,8 +98,10 @@ user rather than a service account.
   mismatch this ADR previously flagged.
 - **The `!token` guards were dead, not translated.** Every component holding
   one renders only inside `RequireAuth`, which returns `<Navigate>` when
-  `!isAuthenticated` — and `isAuthenticated` used to require a truthy token. All
-  74 were unreachable and were deleted.
+  `!isAuthenticated` — and `isAuthenticated` used to require a truthy token.
+  Every one of them was therefore unreachable, and all were deleted rather than
+  rewritten as `!isAuthenticated`. `/login` is the only route outside that tree
+  and held none.
 - **The permissions access cache is keyed by Staff id**, not by token. It used
   to re-fetch on every renewal because renewal minted a new key. It is now
   cleared on logout, which it never was.


### PR DESCRIPTION
Third of three PRs superseding #227. Stacked on #247 — retarget to `main` once that merges.

## Why

After #247 nothing passes the token around any more, but `AuthState` still holds it. Until that field is gone, the Staff JWT is merely *unused* by JavaScript rather than *unreadable* by it. This is the roadmap item ADR-0028 explicitly deferred.

## What

- `AuthState.token` is removed, along with the plumbing that populated it.
- **Session expiry no longer needs the token.** It comes from the `exp` that every Payload session endpoint already returns (`loginOperation`, `refreshOperation`, `meOperation`), so `decodeTokenExpiry` and the 7-day `SESSION_DURATION_FALLBACK_MS` are deleted. An unknown expiry now means *no session* rather than a guessed week.
- That also resolves the 2h-cookie-vs-7d-fallback mismatch ADR-0028 flagged as a consequence: guessing long only delayed discovering the cookie was already gone.
- ADR-0028 updated to record the end state instead of the interim one.

## Verification

- No new type errors (the five pre-existing on `main` are unchanged).
- 644 frontend tests pass, including the auth provider, permissions and Payload-credentials suites that were rewritten for the tokenless state.