### PR TITLE
ci: run tests, lint and typecheck on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,143 @@
+name: CI
+
+# Machine-shaped guarantee for what was previously gated by hand: every PR runs
+# the suites that were run manually before merging, plus the two checks that a
+# green test run does not give you (typecheck and lint).
+#
+# Jobs are split so a failure names the thing that broke rather than "CI".
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Satisfies apps/questura/apps/server engines (^18.20.2 || >=20.9.0). pnpm
+  # comes from the root package.json "packageManager" field.
+  NODE_VERSION: '22'
+  PYTHON_VERSION: '3.13'
+
+jobs:
+  questura-deploy-scripts:
+    name: Questura deploy scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # Two of the softprod suites assert on script contents with ripgrep.
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # Pure shell + node stdlib; deliberately no `pnpm install`.
+      - name: Softprod shell suites
+        run: pnpm --dir apps/questura/apps/server run test:softprod
+
+      - name: Migration guard tests
+        run: pnpm --dir apps/questura/apps/server run test:deploy
+
+  questura-server:
+    name: Questura server tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @questura/server...
+
+      - name: Unit tests
+        run: pnpm --dir apps/questura/apps/server run test:int
+
+  writer-web:
+    name: Writer frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/ai-blog-writer
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter @questurian/ai-blog-writer
+
+      # Cheapest checks first, so an obvious break fails fast.
+      - name: Module boundaries
+        run: node apps/frontend/scripts/check-boundaries.cjs
+
+      - name: Lint
+        run: ./node_modules/.bin/eslint apps/frontend/src --ext .ts,.tsx
+
+      # A green test run does not imply the branch typechecks on its own; that
+      # is exactly the gap this gate exists to close.
+      - name: Typecheck
+        run: ./node_modules/.bin/tsc -p apps/frontend/tsconfig.json --noEmit
+
+      - name: Tests
+        run: ./node_modules/.bin/vitest run --config apps/frontend/vite.config.ts
+
+  writer-api:
+    name: Writer backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # tests/conftest.py already redirects DATA_DIR to a temp dir before any
+      # app module is imported. This is the second lock on the same door: the
+      # backend writes pipeline.db under DATA_DIR, and a suite that reached a
+      # real data directory once cost real data.
+      DATA_DIR: ${{ runner.temp }}/abw-test-data
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Cache uv downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('apps/ai-blog-writer/apps/backend/requirements*.txt') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-
+
+      - name: Install dependencies
+        working-directory: apps/ai-blog-writer
+        run: |
+          uv venv --python "$(command -v python)" --allow-existing .venv
+          uv pip install --python .venv/bin/python \
+            -r apps/backend/requirements.txt \
+            -r apps/backend/requirements-dev.txt
+
+      - name: Tests
+        working-directory: apps/ai-blog-writer/apps/backend
+        run: ../../.venv/bin/python -m pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,6 @@ jobs:
     name: Writer backend
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      # tests/conftest.py already redirects DATA_DIR to a temp dir before any
-      # app module is imported. This is the second lock on the same door: the
-      # backend writes pipeline.db under DATA_DIR, and a suite that reached a
-      # real data directory once cost real data.
-      DATA_DIR: ${{ runner.temp }}/abw-test-data
     steps:
       - uses: actions/checkout@v4
 
@@ -140,4 +134,11 @@ jobs:
 
       - name: Tests
         working-directory: apps/ai-blog-writer/apps/backend
+        # tests/conftest.py already redirects DATA_DIR to a temp dir before any
+        # app module is imported. This is the second lock on the same door: the
+        # backend writes pipeline.db under DATA_DIR, and a suite that reached a
+        # real data directory once cost real data. (Step-level env because the
+        # runner context is not available in job-level env.)
+        env:
+          DATA_DIR: ${{ runner.temp }}/abw-test-data
         run: ../../.venv/bin/python -m pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ env:
   PYTHON_VERSION: '3.13'
 
 jobs:
-  questura-deploy-scripts:
-    name: Questura deploy scripts
+  questura-softprod:
+    name: Questura softprod scripts
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -42,12 +42,11 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # Pure shell + node stdlib; deliberately no `pnpm install`.
+      # Pure shell; deliberately no `pnpm install`. (test:deploy looks like it
+      # belongs here too, but check-pending-migrations.mjs imports dotenv, so it
+      # runs in the job that installs.)
       - name: Softprod shell suites
         run: pnpm --dir apps/questura/apps/server run test:softprod
-
-      - name: Migration guard tests
-        run: pnpm --dir apps/questura/apps/server run test:deploy
 
   questura-server:
     name: Questura server tests
@@ -64,6 +63,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter @questura/server...
+
+      - name: Migration guard tests
+        run: pnpm --dir apps/questura/apps/server run test:deploy
 
       - name: Unit tests
         run: pnpm --dir apps/questura/apps/server run test:int

--- a/apps/ai-blog-writer/apps/backend/requirements-dev.txt
+++ b/apps/ai-blog-writer/apps/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==24.4.2
 flake8==7.1.0
 pytest==8.2.2
+pytest-asyncio==1.3.0

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/MainHomepagePage.tsx
@@ -7,7 +7,8 @@ import HomepageDraftPublishSummary from './HomepageDraftPublishSummary'
 import MainHomepageBlockRenderer from './MainHomepageBlockRenderer'
 import PublishedHomepagePreview from './PublishedHomepagePreview'
 import './homepageFeaturedContent.css'
-import { homepageBlockEditorIdentity, type PageBlockResponse } from './pageBlocks'
+import { mainHomepageBlockKey } from './mainHomepageBlockKey'
+import { type PageBlockResponse } from './pageBlocks'
 import { useMainHomepageEditor } from './useMainHomepageEditor'
 
 function usedKeysOutsideBlock(
@@ -189,7 +190,7 @@ export default function MainHomepagePage() {
             >
               {(block: PageBlockResponse, blockIndex: number) => (
                 <MainHomepageBlockRenderer
-                  key={homepageBlockEditorIdentity(block).join(':')}
+                  key={mainHomepageBlockKey(block)}
                   block={block}
                   blockIndex={blockIndex}
                   canManage={canManage}

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.utils.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/homepageHotelGridSlots.utils.ts
@@ -8,7 +8,7 @@ import type { HotelGridSlotValue } from './homepageHotelGridSlots.types'
 export function mapHotelSelectionToSlots(
   selection: HomepageHotelGridSelection
 ): HotelGridSlotValue[] {
-  const slots = Array.from<HotelGridSlotValue>(
+  const slots: HotelGridSlotValue[] = Array.from(
     { length: selection.totalSlots },
     () => null
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepageBlockKey.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/mainHomepageBlockKey.ts
@@ -1,0 +1,36 @@
+import {
+  homepageBlockEditorIdentity,
+  isHotelGridBlock,
+  isTourGridBlock,
+  isThingsToDoAttractionsBlock,
+  isArticleCuratedHomepageBlock,
+  isLocationGridBlock,
+  isNewsletterSignupBlock,
+  type PageBlockResponse,
+} from './pageBlocks'
+
+/**
+ * React key for a rendered block on the main homepage. Same reasoning as
+ * `locationHomepageBlockKey`: the sortable list keys its wrappers by `block.id`
+ * alone, so a convert (same id, new blockType/slotCount) would otherwise reuse
+ * the mounted editor and its TanStack cache entry.
+ *
+ * Branch order mirrors MainHomepageBlockRenderer — an unknown block falls
+ * through to the placeholder and must key on `block.id`, because
+ * `homepageBlockEditorIdentity` reads `selection.totalSlots` which
+ * `UnknownBlockResponse` does not have. Unlike the location page, a
+ * location-grid block here has no child-level condition.
+ */
+export function mainHomepageBlockKey(block: PageBlockResponse): string {
+  if (
+    isArticleCuratedHomepageBlock(block)
+    || isLocationGridBlock(block)
+    || isNewsletterSignupBlock(block)
+    || isHotelGridBlock(block)
+    || isTourGridBlock(block)
+    || isThingsToDoAttractionsBlock(block)
+  ) {
+    return homepageBlockEditorIdentity(block).join(':')
+  }
+  return block.id
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/ItineraryBasicsFields.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/ItineraryBasicsFields.tsx
@@ -14,7 +14,7 @@ import { ItineraryTitlePipelineButton } from './ItineraryTitlePipelineButton'
 type ItineraryBasicsFieldsProps = {
   draft: ListicleItineraryDraft
   locations: LocationOption[]
-  selectedPrimaryLocation: LocationOption | undefined
+  selectedPrimaryLocation: LocationOption | null | undefined
   isSetupLocked: boolean
   isSynced: boolean
   aiTitleDisabledReason?: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/singleTypeListicles/pages/SingleTypeListicleBuilderPage.tsx
@@ -195,7 +195,7 @@ export default function SingleTypeListicleBuilderPage() {
               isIntroAiGenerating={aiWriting.isIntroAiGenerating}
               introAiQueueCount={aiWriting.introAiQueueCount}
               introAiStatus={aiWriting.introAiStatus}
-              introAiDisabledReason={aiWriting.introAiDisabledReason}
+              introAiDisabledReason={aiWriting.introAiDisabledReason ?? undefined}
               onIntroInspect={() => aiWriting.openInspect(aiWriting.introTargetId, 'Intro')}
               introHasInspectableSteps={Boolean(
                 aiWriting.stepsByTargetId[aiWriting.introTargetId]?.length,

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/editorial-stage-publish-workflow.service.test.ts
@@ -248,7 +248,7 @@ describe('runEditorialStagePublishWorkflow', () => {
 
     await runEditorialStagePublishWorkflow(params)
 
-    expect(events.at(-1)).toBe(
+    expect(events[events.length - 1]).toBe(
       'success:Saved draft article #42 (local run record missing, sync status not recorded)'
     )
     expect(params.updateStagedArticle).toHaveBeenCalledOnce()
@@ -292,6 +292,6 @@ describe('runEditorialStagePublishWorkflow', () => {
     expect(JSON.stringify(secondPayload.seoSection?.structuredData)).toContain(
       '"name":"Jane Doe"'
     )
-    expect(events.at(-1)).toBe('success:Published article #42')
+    expect(events[events.length - 1]).toBe('success:Published article #42')
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/test/payload-credentials.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/test/payload-credentials.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { payloadRequest, payloadMutation } from './client/http'
-import { fetchStaffUsers, uploadAvatarAsset } from '../../features/staff/api/staff.api'
-import { fetchMediaSetOptions } from '../../features/locationDocuments/api'
-import { fetchListicles } from '../../features/singleTypeListicles/api'
-import { payloadRequest as itineraryPayloadRequest } from '../../features/listicleItineraries/api/payloadClient'
-import { getArticleLocationScope } from '../locationScope/scope'
+import { payloadRequest, payloadMutation } from '../shared/api/client/http'
+import { fetchStaffUsers, uploadAvatarAsset } from '../features/staff/api/staff.api'
+import { fetchMediaSetOptions } from '../features/locationDocuments/api'
+import { fetchListicles } from '../features/singleTypeListicles/api'
+import { payloadRequest as itineraryPayloadRequest } from '../features/listicleItineraries/api/payloadClient'
+import { getArticleLocationScope } from '../shared/locationScope/scope'
 
 /**
  * Every authenticated call to Payload sends the session cookie, and nothing
@@ -129,7 +129,7 @@ describe('Payload clients send the session cookie', () => {
   })
 
   it('staging articles', async () => {
-    const { fetchPayloadArticles } = await import('../../features/staging/api/articles/articles.api')
+    const { fetchPayloadArticles } = await import('../features/staging/api/articles/articles.api')
 
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await fetchPayloadArticles()
@@ -138,7 +138,7 @@ describe('Payload clients send the session cookie', () => {
   })
 
   it('access permissions', async () => {
-    const { fetchAccessPermissions } = await import('../../features/auth/permissions-client')
+    const { fetchAccessPermissions } = await import('../features/auth/permissions-client')
 
     fetchMock.mockResolvedValue(jsonResponse({}))
     await fetchAccessPermissions()
@@ -148,7 +148,7 @@ describe('Payload clients send the session cookie', () => {
 
   it('homepage featured content', async () => {
     const { mainHomepageRequest } = await import(
-      '../../features/homepageFeaturedContent/mainHomepage/request')
+      '../features/homepageFeaturedContent/mainHomepage/request')
 
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await mainHomepageRequest('/api/pages')
@@ -158,7 +158,7 @@ describe('Payload clients send the session cookie', () => {
 
   it('location homepages', async () => {
     const { locationHomepageRequest } = await import(
-      '../../features/homepageFeaturedContent/locationHomepages/request')
+      '../features/homepageFeaturedContent/locationHomepages/request')
 
     fetchMock.mockResolvedValue(jsonResponse({ docs: [] }))
     await locationHomepageRequest('/api/pages')
@@ -167,7 +167,7 @@ describe('Payload clients send the session cookie', () => {
   })
 
   it('session hydrate and renew', async () => {
-    const { hydratePayloadSession } = await import('../../features/auth/payload-auth-client')
+    const { hydratePayloadSession } = await import('../features/auth/payload-auth-client')
 
     fetchMock.mockResolvedValue(jsonResponse({ user: { id: 1, email: 'a@b.c' }, exp: 9e12 }))
     await hydratePayloadSession({
@@ -181,7 +181,7 @@ describe('Payload clients send the session cookie', () => {
   })
 
   it('leaves the unauthenticated health check uncredentialed', async () => {
-    const { checkPayloadHealth } = await import('../../features/auth/payload-auth-client')
+    const { checkPayloadHealth } = await import('../features/auth/payload-auth-client')
 
     fetchMock.mockResolvedValue({ ok: true, status: 200 } as Response)
     await checkPayloadHealth()

--- a/apps/ai-blog-writer/apps/frontend/tsconfig.json
+++ b/apps/ai-blog-writer/apps/frontend/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["vite/client", "vitest/globals"]
+    "types": ["vite/client", "vitest/globals"],
+    "paths": {
+      "@shared/types": ["packages/shared/types.ts"],
+      "react": ["node_modules/@types/react"],
+      "react/*": ["node_modules/@types/react/*"],
+      "react-dom": ["node_modules/@types/react-dom"],
+      "react-dom/*": ["node_modules/@types/react-dom/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Closes the gap in handoff 05: the repo had no CI. No checks ran on any pull request, `main` was unprotected, and rulesets were empty.

## What runs now

Four jobs on every PR, split so a failure names the thing that broke.

| Job | Covers | Local baseline |
|---|---|---|
| Questura deploy scripts | softprod shell suites + migration guard | 6 suites + 4 node tests |
| Questura server tests | `test:int` | 626 tests / 92 files |
| Writer frontend | boundaries, eslint, tsc, vitest | 644 tests / 136 files |
| Writer backend | pytest | 632 tests |

All six commands were run locally on this branch and are green.

## The typecheck trap, resolved

The handoff flagged that typecheck could not be a naive gate: the writer frontend reported ~136 `tsc` errors on a clean `main`.

The cause was the recorded `@types/react` duplication. Packages resolved out of the root `.pnpm` store find `@types/react` 19.2.10 walking up to `node_modules/.pnpm/node_modules`, while app source finds the app's own 18.3.27. So `react-router`'s `Routes`/`Route` return a `ReactElement` from one program and get checked against a `ReactNode` from the other — 131 `TS2786` errors, none of them real.

Pinning `react`'s types to the app copy via `paths` in the frontend tsconfig removes all 131. This is typecheck-only: vite resolves through its own `alias` list and does not read tsconfig `paths` (no `vite-tsconfig-paths` plugin in that config).

The remaining 7 were genuine and are fixed in the first commit. `tsc` now exits clean, so the gate is a hard pass/fail rather than an error-count comparison.

## Also fixed to make lint a full gate

`check-boundaries.cjs` failed on `main` — the repo's own boundary rule, which `nx lint` runs. The single violation was `shared/api/payload-credentials.test.ts`, a cross-cutting contract test that deliberately names every Payload client in the app and therefore has to import from features. Moved to `src/test/`, where it is what it always was. The check passes.

`requirements-dev.txt` gained the `pytest-asyncio` pin the working venv already had installed but never recorded. Without it a fresh environment cannot run the async backend tests — which is exactly what CI is.

## Data safety

The backend job pins `DATA_DIR` to a runner temp path. `tests/conftest.py` already redirects it before any app module is imported (verified on this branch); the env var is a second lock on the same door, given that suite reaching a real data directory has cost real data before.

The softprod suites were checked for writes outside their sandbox: all six `mktemp -d` with an `EXIT` trap, and none reference `$HOME` or a deploy root.

## Not done

No branch protection. Worth deciding after seeing the real wall-clock time of a run.

No application behaviour changes: no schema edits, no Payload `push: true`, no host changes.