### PR TITLE
fix(server): require 32+ char PAYLOAD_SECRET and BETTER_AUTH_SECRET in production

### DIFF
--- a/apps/questura/apps/server/src/shared/config/assert-production-config.test.ts
+++ b/apps/questura/apps/server/src/shared/config/assert-production-config.test.ts
@@ -16,6 +16,8 @@ const VALID_PRODUCTION_ENV = {
   REDIS_URL: 'redis://cache.internal:6379',
   PAYLOAD_COOKIE_DOMAIN: 'questurian.com',
   PAYLOAD_COOKIE_REQUIRED_HOSTS: 'api.questurian.com,questurian.com',
+  PAYLOAD_SECRET: 'p'.repeat(32),
+  BETTER_AUTH_SECRET: 'b'.repeat(48),
 }
 
 describe('production config assertion', () => {
@@ -27,6 +29,8 @@ describe('production config assertion', () => {
     vi.stubEnv('REDIS_URL', '')
     vi.stubEnv('PAYLOAD_COOKIE_DOMAIN', '')
     vi.stubEnv('PAYLOAD_COOKIE_REQUIRED_HOSTS', '')
+    vi.stubEnv('PAYLOAD_SECRET', '')
+    vi.stubEnv('BETTER_AUTH_SECRET', '')
   })
 
   afterEach(() => {
@@ -112,6 +116,88 @@ describe('production config assertion', () => {
     })
 
     expect(collectProductionConfigProblems().join('\n')).toContain('REDIS_URL is not set')
+  })
+
+  it.each(['PAYLOAD_SECRET', 'BETTER_AUTH_SECRET'])(
+    'rejects a production boot with no %s',
+    async (name) => {
+      const { collectProductionConfigProblems } = await load({
+        ...VALID_PRODUCTION_ENV,
+        [name]: '',
+      })
+
+      expect(collectProductionConfigProblems().join('\n')).toContain(`${name} is not set`)
+    }
+  )
+
+  it.each(['PAYLOAD_SECRET', 'BETTER_AUTH_SECRET'])(
+    'rejects a 31-character %s',
+    async (name) => {
+      const { collectProductionConfigProblems } = await load({
+        ...VALID_PRODUCTION_ENV,
+        [name]: 's'.repeat(31),
+      })
+
+      expect(collectProductionConfigProblems().join('\n')).toContain(
+        `${name} is shorter than the 32-character minimum`
+      )
+    }
+  )
+
+  it.each(['PAYLOAD_SECRET', 'BETTER_AUTH_SECRET'])('accepts a 32-character %s', async (name) => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      [name]: 's'.repeat(32),
+    })
+
+    expect(collectProductionConfigProblems()).toEqual([])
+  })
+
+  // Whitespace is not entropy — a padded short secret must not pass the floor.
+  it('rejects a whitespace-padded short secret', async () => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      PAYLOAD_SECRET: `  ${'s'.repeat(24)}          `,
+    })
+
+    expect(collectProductionConfigProblems().join('\n')).toContain('PAYLOAD_SECRET is shorter')
+  })
+
+  // Better Auth falls back to PAYLOAD_SECRET when BETTER_AUTH_SECRET is unset.
+  // A long PAYLOAD_SECRET must not satisfy the check for the missing one.
+  it('does not let PAYLOAD_SECRET stand in for BETTER_AUTH_SECRET', async () => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      PAYLOAD_SECRET: 'p'.repeat(64),
+      BETTER_AUTH_SECRET: '',
+    })
+
+    expect(collectProductionConfigProblems().join('\n')).toContain('BETTER_AUTH_SECRET is not set')
+  })
+
+  // Boot errors reach logs and process supervisors, so a rejection must never
+  // carry the secret itself — nor a length or prefix that narrows a guess.
+  it('never puts a secret value in the thrown message', async () => {
+    const shortSecret = 'correct-horse-battery-x'
+    const { assertProductionConfig } = await load({
+      ...VALID_PRODUCTION_ENV,
+      PAYLOAD_SECRET: shortSecret,
+      BETTER_AUTH_SECRET: 'staple-tribune-nonsense-value',
+    })
+
+    let message = ''
+    try {
+      assertProductionConfig()
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).toContain('PAYLOAD_SECRET')
+    expect(message).toContain('BETTER_AUTH_SECRET')
+    expect(message).not.toContain(shortSecret)
+    expect(message).not.toContain('correct-horse')
+    expect(message).not.toContain('staple-tribune')
+    expect(message).not.toContain(String(shortSecret.length))
   })
 
   it('rejects a production boot with no session cookie domain decision', async () => {

--- a/apps/questura/apps/server/src/shared/config/assert-production-config.ts
+++ b/apps/questura/apps/server/src/shared/config/assert-production-config.ts
@@ -24,6 +24,8 @@ import {
 
 type ConfigProblem = string
 
+const MIN_SECRET_LENGTH = 32
+
 function isLocalhost(url: string): boolean {
   return /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?/i.test(url)
 }
@@ -85,6 +87,50 @@ export function collectProductionConfigProblems(): ConfigProblem[] {
       'REDIS_URL is not set — the shared rate limiters have no cross-instance ' +
         'counter and refuse to count in production.'
     )
+  }
+
+  // `PAYLOAD_SECRET` signs the staff session JWT *and* encrypts service-account
+  // API keys, including the HMAC index they are looked up by. `BETTER_AUTH_SECRET`
+  // carries every visitor session. Both are checked here because neither failure
+  // is visible at boot: a missing value does not stop Payload or Better Auth from
+  // starting, it just derives keys from whatever it was handed. The two are
+  // checked separately on purpose — `better-auth.ts` falls back to
+  // `PAYLOAD_SECRET` when `BETTER_AUTH_SECRET` is unset, which silently collapses
+  // staff and visitor sessions onto one secret and makes either rotation break
+  // both. Requiring the variable in its own right keeps that fallback a
+  // development convenience.
+  //
+  // The 32-character floor is the repo's stated policy, not a cryptographic
+  // boundary — Payload derives a fixed-size key from any non-empty string.
+  // Diagnostics name the variable and nothing else: no value, no length, no
+  // prefix, no hash. Boot errors reach logs and process supervisors.
+  const requiredSecrets: Array<{ name: string; value: string | undefined; role: string }> = [
+    {
+      name: 'PAYLOAD_SECRET',
+      value: process.env.PAYLOAD_SECRET,
+      role: 'signs staff sessions and encrypts service-account API keys',
+    },
+    {
+      name: 'BETTER_AUTH_SECRET',
+      value: process.env.BETTER_AUTH_SECRET,
+      role: 'signs visitor sessions',
+    },
+  ]
+
+  for (const { name, value, role } of requiredSecrets) {
+    const secret = value?.trim() ?? ''
+
+    if (!secret) {
+      problems.push(`${name} is not set — it ${role}.`)
+      continue
+    }
+
+    if (secret.length < MIN_SECRET_LENGTH) {
+      problems.push(
+        `${name} is shorter than the ${MIN_SECRET_LENGTH}-character minimum — it ${role}. ` +
+          'Rotating it invalidates the sessions it signs, so change it in a maintenance window.'
+      )
+    }
   }
 
   // The staff session cookie is host-only unless a `Domain` is set, and the AI


### PR DESCRIPTION
## What

Adds a production boot assertion that `PAYLOAD_SECRET` and `BETTER_AUTH_SECRET` are each present and at least 32 characters, alongside the existing `REDIS_URL` / `PAYLOAD_COOKIE_DOMAIN` checks.

## Why

Neither secret failing is visible at boot — Payload and Better Auth both start on whatever string they are handed and derive keys from it. A missing or under-length value is only discovered by its consequences.

The two are checked **separately** because `better-auth.ts:55` falls back to `PAYLOAD_SECRET` when `BETTER_AUTH_SECRET` is unset. That fallback silently collapses staff and visitor sessions onto one secret and makes either rotation break both; requiring the variable in its own right keeps it a development convenience.

The 32-character floor is stated repo policy, not a cryptographic boundary — Payload derives a fixed-size key from any non-empty string.

## Ordering

This is deliberately the **last** step of the secret rotation. Soft-production's `PAYLOAD_SECRET` has already been rotated from 24 to 64 characters and the service-account key reissued, so this assertion passes on the live host. Merging it before that rotation would have failed the boot assertion and taken the site down.

## Safety

Diagnostics name the variable and its role only — no value, no length, no prefix, no hash — since boot errors reach journald and process supervisors. One test asserts the secret never appears in the thrown message.

## Tests

9 new cases: missing rejected (both vars), 31 chars rejected (both), 32 accepted (both), whitespace-padded short rejected, `PAYLOAD_SECRET` cannot stand in for a missing `BETTER_AUTH_SECRET`, and the thrown message carries no value/prefix/length.

`pnpm vitest run src/shared/config` — 3 files, 72 tests pass.
Full server suite — 92 files, 635 tests pass.