### PR TITLE
docs: state why the laptop serves the live domains, and that it is temporary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Always use caveman skill to save tokens.
 - Do not enable Payload `push: true` for Questura server.
+- The Linux laptop serving the live domains is a **temporary live-like test environment**, not the production platform; production will be serverless once the site is proven there. Do not propose work whose value dies with that machine (uptime alerting, hosting extra services on it). See `apps/questura/infra/softprod/README.md`.
 - When editing Payload collections or fields under `apps/questura/apps/server/src`, treat it as a database schema change:
   1. Run `pnpm db:migrate:create <descriptive-name> > /tmp/questura-migrate-create.log 2>&1` from `apps/questura/apps/server`.
   2. Do not paste full migration output or full migration diffs into chat. Report only `git diff --stat`, `git diff --numstat`, destructive-SQL search results, and targeted lines for the intended field/table.

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -1,5 +1,43 @@
 # Questura soft-production deployment
 
+## What this environment is, and what it is not
+
+This Linux laptop serves the live domains, but it is **not the production
+platform**. It exists for one reason: some things cannot be proven anywhere
+else. Stripe has to reach a real webhook URL, OAuth has to redirect to a real
+origin, and cookies only behave like cookies over real HTTPS on real
+subdomains. A localhost stack cannot exercise any of that honestly.
+
+So this is a **live-like test environment that happens to be publicly
+reachable**. The only transactions on it are the owner's own tests. It is not
+serving customers, and nobody but the owner depends on it being up.
+
+**It has an expiry date.** Once the site is proven end to end here, this
+machine is switched off and production moves to a serverless deployment. That
+is the plan of record, not a vague intention.
+
+Two consequences worth stating plainly, because they have already caused
+wasted work:
+
+- **Do not build things whose value dies with this machine.** Uptime alerting
+  is the clearest example: a laptop that is deliberately slept, closed and
+  eventually retired will page you constantly for events that are not
+  incidents. This was proposed and rejected on 2026-08-13, correctly. The same
+  reasoning applies to hosting additional services here for convenience.
+- **Do build things that travel with the repository.** The production config
+  assertions at boot, the `/api/health` endpoints that report an exact release
+  SHA, secret hygiene, CI, and the Stripe configuration all keep their value
+  in a serverless environment. The machinery in *this folder* — immutable
+  release directories, `current-*` symlinks, user systemd units, the passive
+  healthcheck timer — does not. It is correct for this host and is not an
+  argument for keeping this host.
+
+Nothing here commits the project to systemd-and-symlinks as a production
+deployment model. It is the cheapest safe way to run a real environment on
+hardware that is already paid for.
+
+## Deploying
+
 `host-deploy-wrapper.sh` is installed as `~/questura/deploy.sh` on the Linux
 laptop. It serializes deploys, resets the dedicated deployment checkout to
 `origin/main`, then executes the freshly fetched `deploy.sh` from this folder.


### PR DESCRIPTION
## Why

The soft-production host serves `www`, `questurian.com` and `cms` over real DNS and TLS, which reads as *production* to anyone arriving cold — including me. That misreading has already cost work: I proposed off-host uptime alerting for a machine that is deliberately slept, closed, and due to be switched off, and ranked hosting an internal tool on it as the highest-value item available. Both were wrong for the same missing fact.

## What it records

- **What the environment is for:** Stripe reaching a real webhook URL, OAuth redirecting to a real origin, and cookies behaving like cookies over real HTTPS on real subdomains — none of which localhost can exercise honestly.
- **What it is not:** a customer-facing platform. The only transactions on it are the owner's own tests.
- **That it has an expiry date:** production moves to serverless once the site is proven end to end here.
- **The consequence, stated both ways** — don't build what dies with the machine (alerting, hosting more services on it); do build what travels with the repo (boot-time config assertions, health endpoints reporting an exact release SHA, secret hygiene, CI, Stripe config).
- That none of this commits the project to systemd-and-symlinks as a production model.

`AGENTS.md` gets a one-line pointer so an agent meets the constraint before proposing host-lifecycle work, not after.

Documentation only — no code, config or host changes.