### PR TITLE
Let visitors check out without a verified email

### DIFF
--- a/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
@@ -46,9 +46,6 @@ export default function PurchasePage({
   }
 
   const handleSubscribe = () => {
-    if (!user?.emailVerified) {
-      return;
-    }
     checkoutMutation.mutate({});
   };
 
@@ -154,10 +151,18 @@ export default function PurchasePage({
                 </div>
               ) : null}
 
-              {!user?.emailVerified ? (
-                <div className="space-y-3 text-center">
+              <button
+                onClick={handleSubscribe}
+                disabled={checkoutMutation.isPending}
+                className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+              >
+                {checkoutMutation.isPending ? 'Creating session...' : `Subscribe Now - $${amount}/month`}
+              </button>
+
+              {!user?.emailVerified && (
+                <div className="mt-4 space-y-2 text-center">
                   <p className="text-sm text-gray-600 dark:text-gray-300">
-                    Verify your email before starting checkout.
+                    Your email isn&apos;t verified yet. You can subscribe now and verify later.
                   </p>
                   <button
                     type="button"
@@ -173,14 +178,6 @@ export default function PurchasePage({
                     </p>
                   )}
                 </div>
-              ) : (
-                <button
-                  onClick={handleSubscribe}
-                  disabled={checkoutMutation.isPending}
-                  className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-                >
-                  {checkoutMutation.isPending ? 'Creating session...' : `Subscribe Now - $${amount}/month`}
-                </button>
               )}
             </div>
           )}

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -28,7 +28,13 @@ export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
 
   try {
-    const authResult = await requireVisitorPrincipal(req.headers, { requireVerified: true })
+    // Deliberately not requiring a verified email. Verification before checkout
+    // costs the sale at peak intent for a rare failure (a mistyped signup
+    // address). Stripe collects and confirms its own email during checkout, and
+    // `checkout.session.completed` records it as `billingEmail` whenever it
+    // differs from the account address — so a typo stays recoverable without
+    // blocking anyone.
+    const authResult = await requireVisitorPrincipal(req.headers)
 
     if (authResult.error) {
       return NextResponse.json(

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -84,28 +84,53 @@ describe('create checkout session route auth guard', () => {
     consoleLogSpy = null
   })
 
-  it('requires a verified Visitor principal', async () => {
+  it('rejects an unauthenticated request', async () => {
     mocks.requireVisitorPrincipal.mockResolvedValue({
       result: { authenticated: false, principal: null },
       principal: null,
-      error: 'Email verification required',
-      status: 403,
+      error: 'Authentication required',
+      status: 401,
     })
 
     const response = await POST(createRequest())
 
     await expect(response.json()).resolves.toEqual({
-      error: 'Email verification required',
+      error: 'Authentication required',
     })
-    expect(response.status).toBe(403)
-    expect(mocks.requireVisitorPrincipal).toHaveBeenCalledWith(expect.anything(), {
-      requireVerified: true,
-    })
+    expect(response.status).toBe(401)
     expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
     expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled()
   })
 
-  it('creates checkout only for verified Visitor principals', async () => {
+  it('does not require a verified email to start checkout', async () => {
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      result: { authenticated: true },
+      principal: {
+        kind: 'visitor',
+        id: 'visitor_123',
+        email: 'visitor@example.com',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        profileId: 10,
+        emailVerified: false,
+      },
+      error: null,
+      status: 200,
+    })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(200)
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalled()
+    // The gate is gone at the call site, not just satisfied by the mock: the
+    // route must not ask for verification at all.
+    expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requireVerified: true })
+    )
+  })
+
+  it('creates checkout for an authenticated Visitor principal', async () => {
     mocks.requireVisitorPrincipal.mockResolvedValue({
       result: { authenticated: true },
       principal: {

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -219,6 +219,57 @@ describe('Stripe webhook route', () => {
     )
   })
 
+  it('records the Stripe billing email when it differs from the account email', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+      subscription: 'sub_1',
+      customer_details: { email: 'grace@real-inbox.example' },
+    })
+    mocks.getStripeSubscriptionDetails.mockResolvedValue({
+      currentPeriodEnd: new Date(FUTURE_TS * 1000),
+    })
+    mocks.findVisitorProfileByStripeCustomerId.mockResolvedValue({
+      id: 10,
+      email: 'typo@gmial.example',
+      firstName: 'Grace',
+      lastName: 'Hopper',
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
+      'cus_1',
+      expect.objectContaining({ billingEmail: 'grace@real-inbox.example' }),
+    )
+  })
+
+  it('does not record a billing email that matches the account email', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+      subscription: 'sub_1',
+      // Same address, different casing and padding: not a mismatch.
+      customer_details: { email: '  Visitor@Example.com ' },
+    })
+    mocks.getStripeSubscriptionDetails.mockResolvedValue({
+      currentPeriodEnd: new Date(FUTURE_TS * 1000),
+    })
+    mocks.findVisitorProfileByStripeCustomerId.mockResolvedValue({
+      id: 10,
+      email: 'visitor@example.com',
+      firstName: 'Grace',
+      lastName: 'Hopper',
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
+      'cus_1',
+      expect.not.objectContaining({ billingEmail: expect.anything() }),
+    )
+  })
+
   it('prefers the webhook period end over the Stripe API on subscription created', async () => {
     givenEvent('customer.subscription.created', {
       id: 'sub_1',

--- a/apps/questura/apps/server/src/features/payments/types/payment-service.types.ts
+++ b/apps/questura/apps/server/src/features/payments/types/payment-service.types.ts
@@ -6,6 +6,7 @@ export interface UserSubscriptionUpdate {
   cancelAtPeriodEnd?: boolean
   firstName?: string
   lastName?: string
+  billingEmail?: string
   affiliateReferralId?: string
   affiliateReferredAt?: string
 }

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -52,12 +52,30 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
   // visitor profile doesn't already have a name (don't clobber a name the user
   // set themselves in settings/account).
   const billingName = session.customer_details?.name?.trim()
-  if (billingName) {
+  const billingEmail = session.customer_details?.email?.trim()
+
+  if (billingName || billingEmail) {
     const profile = await findVisitorProfileByStripeCustomerId(customerId)
-    if (profile && !profile.firstName && !profile.lastName) {
+
+    if (billingName && profile && !profile.firstName && !profile.lastName) {
       const { firstName, lastName } = splitDisplayName(billingName)
       updateData.firstName = firstName
       updateData.lastName = lastName
+    }
+
+    // Checkout no longer requires a verified email, so the account address may
+    // be mistyped. Stripe's address is confirmed by the payment, which makes it
+    // the better fallback contact — but only worth storing when the two differ.
+    // Compare case-insensitively so casing alone doesn't flag a mismatch.
+    if (billingEmail && profile) {
+      const accountEmail = typeof profile.email === 'string' ? profile.email.trim() : ''
+      if (accountEmail.toLowerCase() !== billingEmail.toLowerCase()) {
+        updateData.billingEmail = billingEmail
+        logger.warn('Checkout billing email differs from account email', {
+          subscriptionId,
+          profileId: profile.id,
+        })
+      }
     }
   }
 

--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
@@ -56,6 +56,16 @@ export const VisitorProfiles: CollectionConfig = {
       },
     },
     {
+      name: 'billingEmail',
+      type: 'email',
+      index: true,
+      admin: {
+        readOnly: true,
+        description:
+          'Email Stripe collected at checkout, recorded only when it differs from the account email. Checkout does not require a verified address, so this is the fallback contact when the signup address was mistyped.',
+      },
+    },
+    {
       type: 'row',
       fields: [
         {

--- a/apps/questura/apps/server/src/migrations/20260813_010000_add_visitor_profile_billing_email.ts
+++ b/apps/questura/apps/server/src/migrations/20260813_010000_add_visitor_profile_billing_email.ts
@@ -1,0 +1,39 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Adds `visitor_profiles.billing_email`.
+ *
+ * Checkout no longer requires a verified email (see the comment in
+ * `app/api/payments/create-checkout-session/route.ts`): the verification wall
+ * cost the sale at peak intent to guard against a rare mistyped signup
+ * address. Stripe collects its own email during checkout and the payment
+ * confirms the customer actually reached it, which makes that address the
+ * better fallback contact when the account address is wrong.
+ *
+ * `handleCheckoutSessionCompleted` writes this column only when the Stripe
+ * address differs from the account address, so a populated value is exactly
+ * the "signup email may be mistyped" signal — queryable from the admin UI.
+ *
+ * Nullable and additive: existing rows keep working untouched.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      ALTER TABLE "visitor_profiles"
+        ADD COLUMN IF NOT EXISTS "billing_email" varchar;
+
+      CREATE INDEX IF NOT EXISTS "visitor_profiles_billing_email_idx"
+        ON "visitor_profiles" USING btree ("billing_email");
+    `),
+  )
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      DROP INDEX IF EXISTS "visitor_profiles_billing_email_idx";
+      ALTER TABLE "visitor_profiles"
+        DROP COLUMN IF EXISTS "billing_email";
+    `),
+  )
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -25,6 +25,7 @@ import * as migration_20260811_030000_retire_users_public_profile from './202608
 import * as migration_20260811_040000_add_service_accounts from './20260811_040000_add_service_accounts'
 import * as migration_20260812_080000_enforce_identity_email_ownership from './20260812_080000_enforce_identity_email_ownership'
 import * as migration_20260813_000000_add_service_accounts_preferences_rel from './20260813_000000_add_service_accounts_preferences_rel'
+import * as migration_20260813_010000_add_visitor_profile_billing_email from './20260813_010000_add_visitor_profile_billing_email'
 
 export const migrations = [
   {
@@ -161,5 +162,10 @@ export const migrations = [
     up: migration_20260813_000000_add_service_accounts_preferences_rel.up,
     down: migration_20260813_000000_add_service_accounts_preferences_rel.down,
     name: '20260813_000000_add_service_accounts_preferences_rel',
+  },
+  {
+    up: migration_20260813_010000_add_visitor_profile_billing_email.up,
+    down: migration_20260813_010000_add_visitor_profile_billing_email.down,
+    name: '20260813_010000_add_visitor_profile_billing_email',
   },
 ]


### PR DESCRIPTION
## Why

The subscribe button was hidden behind email verification (`requireVerified: true` on the checkout route, plus a branch in `PurchasePage`). That inserts an inbox round-trip at peak purchase intent to guard against a rare failure — a mistyped signup address. Standard practice for consumer subscriptions is to take the payment first.

## What

- `create-checkout-session` no longer passes `requireVerified`. Login is still required.
- `PurchasePage`: subscribe button is always live; the verification prompt is demoted to a nudge beneath it, keeping the resend affordance.
- New `visitor_profiles.billing_email`, written by `handleCheckoutSessionCompleted` **only when Stripe's checkout email differs from the account email**. A populated value is exactly the "signup address may be mistyped" signal, and gives a fallback contact confirmed by the payment itself.
  - Comparison is case-insensitive and trims, so casing alone never flags a mismatch.
  - The warning log carries the profile id, not either address — no PII in logs.

`emailVerified` gates nothing else in the codebase, so content access is unchanged.

## Migration

`20260813_010000_add_visitor_profile_billing_email` — hand-written in the house idempotent style. `up()` is purely additive (`ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`); the only `DROP`s are in `down()`. Nullable, so the 2 existing rows are untouched. Applied on the host by `infra/softprod/deploy.sh`.

## Verification

- Server suite: 638 passed / 92 files
- Server `tsc --noEmit`: 51 errors, all pre-existing, none in touched files (baseline was 53)
- Client `tsc --noEmit`: 0 errors; `pnpm lint`: clean, only pre-existing warnings
- New tests: billing email recorded on mismatch; not recorded when it matches modulo case/padding; checkout succeeds for an unverified principal, asserted at the call site so the gate can't silently return