### PR TITLE
payments: add paidThroughAt and dunningGraceUntil to visitor profiles

### DIFF
--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
@@ -97,14 +97,38 @@ export const VisitorProfiles: CollectionConfig = {
       type: 'row',
       fields: [
         {
+          name: 'paidThroughAt',
+          type: 'date',
+          admin: {
+            description:
+              'End of the last billing period actually paid for. Never advances on an unpaid period, so it is not the same as Stripe current_period_end, which moves at renewal before the charge clears.',
+          },
+        },
+        {
+          name: 'dunningGraceUntil',
+          type: 'date',
+          admin: {
+            description:
+              'Bounded extension of access while Stripe retries a failed renewal. Set when the subscription enters past_due, cleared on recovery.',
+          },
+        },
+      ],
+    },
+    {
+      type: 'row',
+      fields: [
+        {
           name: 'subscriptionRenewsAt',
           type: 'date',
+          admin: {
+            description: 'Superseded by paidThroughAt; retained until the follow-up migration drops it.',
+          },
         },
         {
           name: 'membershipExpiration',
           type: 'date',
           admin: {
-            description: 'When paid access ends for a cancelled subscription with remaining paid time.',
+            description: 'Superseded by paidThroughAt; retained until the follow-up migration drops it.',
           },
         },
         {

--- a/apps/questura/apps/server/src/migrations/20260814_010000_add_visitor_profile_paid_through.ts
+++ b/apps/questura/apps/server/src/migrations/20260814_010000_add_visitor_profile_paid_through.ts
@@ -1,0 +1,61 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Adds `visitor_profiles.paid_through_at` and `visitor_profiles.dunning_grace_until`.
+ *
+ * Membership entitlement used to be read off `subscription_status`, so a single
+ * failed renewal charge revoked paid access immediately even though Stripe goes
+ * on retrying that card for weeks (see ADR-0008). The status enum answers "what
+ * is Stripe doing", not "has this visitor paid" -- entitlement now reads a date
+ * instead.
+ *
+ * `paid_through_at` is deliberately NOT Stripe's `current_period_end`. Stripe
+ * advances the period at the renewal moment, before the charge clears: a real
+ * test-clock capture shows the period jumping a month forward while the invoice
+ * is still unpaid, and staying there after it fails. Using that value would
+ * grant a full month to someone who paid nothing. This column advances only
+ * when a period is actually paid, and `dunning_grace_until` carries the bounded
+ * extension that keeps a recoverable visitor reading during retries.
+ *
+ * The backfill takes whichever of the two legacy columns holds a value.
+ * `membership_expiration` wins when both are set: it is only ever written for a
+ * subscription that is ending, which is the more conservative of the two.
+ * `dunning_grace_until` is intentionally left NULL -- no existing row can be
+ * mid-dunning, because the old code revoked instead of granting grace.
+ *
+ * Both columns are nullable and additive; the legacy columns are left in place
+ * and are dropped by a separate migration once this is proven on the host.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      ALTER TABLE "visitor_profiles"
+        ADD COLUMN IF NOT EXISTS "paid_through_at" timestamp(3) with time zone;
+
+      ALTER TABLE "visitor_profiles"
+        ADD COLUMN IF NOT EXISTS "dunning_grace_until" timestamp(3) with time zone;
+
+      UPDATE "visitor_profiles"
+        SET "paid_through_at" = COALESCE("membership_expiration", "subscription_renews_at")
+        WHERE "paid_through_at" IS NULL
+          AND COALESCE("membership_expiration", "subscription_renews_at") IS NOT NULL;
+
+      CREATE INDEX IF NOT EXISTS "visitor_profiles_paid_through_at_idx"
+        ON "visitor_profiles" USING btree ("paid_through_at");
+    `),
+  )
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      DROP INDEX IF EXISTS "visitor_profiles_paid_through_at_idx";
+
+      ALTER TABLE "visitor_profiles"
+        DROP COLUMN IF EXISTS "dunning_grace_until";
+
+      ALTER TABLE "visitor_profiles"
+        DROP COLUMN IF EXISTS "paid_through_at";
+    `),
+  )
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -26,6 +26,7 @@ import * as migration_20260811_040000_add_service_accounts from './20260811_0400
 import * as migration_20260812_080000_enforce_identity_email_ownership from './20260812_080000_enforce_identity_email_ownership'
 import * as migration_20260813_000000_add_service_accounts_preferences_rel from './20260813_000000_add_service_accounts_preferences_rel'
 import * as migration_20260813_010000_add_visitor_profile_billing_email from './20260813_010000_add_visitor_profile_billing_email'
+import * as migration_20260814_010000_add_visitor_profile_paid_through from './20260814_010000_add_visitor_profile_paid_through'
 
 export const migrations = [
   {
@@ -167,5 +168,10 @@ export const migrations = [
     up: migration_20260813_010000_add_visitor_profile_billing_email.up,
     down: migration_20260813_010000_add_visitor_profile_billing_email.down,
     name: '20260813_010000_add_visitor_profile_billing_email',
+  },
+  {
+    up: migration_20260814_010000_add_visitor_profile_paid_through.up,
+    down: migration_20260814_010000_add_visitor_profile_paid_through.down,
+    name: '20260814_010000_add_visitor_profile_paid_through',
   },
 ]


### PR DESCRIPTION
Stacked on #255.

## Why

Entitlement is read off `subscriptionStatus`, so one failed renewal revokes paid access immediately while Stripe is still retrying the card for weeks. The enum answers *"what is Stripe doing"*, not *"has this visitor paid"*. Entitlement needs a date to read, and there is nowhere to put one.

Worse, the old code nulls both date columns whenever status leaves `active` — so the moment a visitor goes `past_due` the profile retains **no record of what they paid for**.

## What

Adds two nullable columns, backfills `paid_through_at` from whichever legacy column holds a value.

```
paidThroughAt      date   <- end of the last period actually paid for
dunningGraceUntil  date   <- bounded extension while Stripe retries
```

`subscriptionRenewsAt` and `membershipExpiration` were always the same Stripe value under two names picked by what was expected to happen next — which is exactly why neither was populated during dunning. They collapse into `paidThroughAt`.

**`paidThroughAt` is deliberately not `current_period_end`.** Stripe advances the period at renewal before the charge clears, so that value describes time the visitor has not bought (evidence in #255 / ADR-0008).

## Backfill

Prefers `membership_expiration`, which is only ever written for an ending subscription, so it is the conservative choice. `dunning_grace_until` stays NULL — no existing row can be mid-dunning, because the old code revoked rather than granting grace.

Verified against live data:

| profile | status | renews_at | expiration | -> paid_through_at |
|---|---|---|---|---|
| 8 | active | 2026-09-14 12:21 | — | 2026-09-14 12:21 |
| 9 | none | — | — | NULL |

## Risk

Purely additive; `up()` is two `ADD COLUMN IF NOT EXISTS`, one scoped `UPDATE`, one index. No `DROP` outside `down()`. Nothing reads the columns yet, so runtime behaviour is unchanged. Legacy columns are dropped in a separate later PR.

Hand-written rather than generated: `migrate:create` diffs against a database connection, and the local Postgres is stale scratch, so it would emit SQL to repair drift the live database does not have. Matches the two most recent migrations in the repo.