### PR TITLE
payments: derive membership entitlement from dates, not Stripe status

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/membership-transitions.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-transitions.ts
@@ -1,0 +1,67 @@
+import type { DerivedSubscriptionState } from './subscription-state'
+
+/**
+ * Membership emails are decided by what changed on the profile, not by which
+ * Stripe event arrived (ADR-0008).
+ *
+ * Keying off event types meant a duplicate delivery re-sent an email, a stale
+ * delivery sent the wrong one, and a single cancellation produced two, because
+ * the API call and the webhook both announced it. A transition that did not
+ * happen produces nothing, which makes duplicate and out-of-order deliveries
+ * free.
+ */
+export type MembershipSnapshot = {
+  subscriptionStatus?: string | null
+  cancelAtPeriodEnd?: boolean | null
+  paidThroughAt?: string | null
+}
+
+export type MembershipTransition =
+  | { kind: 'membership_started' }
+  | { kind: 'cancellation_scheduled'; endsAt: string | null }
+  | { kind: 'reactivated'; renewsAt: string | null }
+  | { kind: 'membership_ended'; wasImmediate: boolean }
+
+function isFuture(value: string | null | undefined): boolean {
+  if (!value) return false
+  const at = new Date(value)
+  return !Number.isNaN(at.getTime()) && at > new Date()
+}
+
+/**
+ * Compare the profile as it was against the state Stripe now reports.
+ *
+ * Recovery from a failed payment deliberately produces nothing: the visitor
+ * never lost access, so telling them their membership just started would be
+ * both wrong and alarming.
+ */
+export function resolveMembershipTransitions(
+  before: MembershipSnapshot,
+  after: DerivedSubscriptionState
+): MembershipTransition[] {
+  const transitions: MembershipTransition[] = []
+
+  const wasCancelling = Boolean(before.cancelAtPeriodEnd)
+  const previousStatus = before.subscriptionStatus ?? 'none'
+
+  const startedFrom = previousStatus === 'none' || previousStatus === 'cancelled'
+  if (startedFrom && after.subscriptionStatus === 'active') {
+    transitions.push({ kind: 'membership_started' })
+  }
+
+  if (!wasCancelling && after.cancelAtPeriodEnd && after.subscriptionStatus === 'active') {
+    transitions.push({ kind: 'cancellation_scheduled', endsAt: after.paidThroughAt })
+  }
+
+  if (wasCancelling && !after.cancelAtPeriodEnd && after.subscriptionStatus === 'active') {
+    transitions.push({ kind: 'reactivated', renewsAt: after.paidThroughAt })
+  }
+
+  // A subscription that ends after the visitor scheduled it was already
+  // announced when they cancelled; only an unannounced ending needs an email.
+  if (previousStatus !== 'cancelled' && after.subscriptionStatus === 'cancelled' && !wasCancelling) {
+    transitions.push({ kind: 'membership_ended', wasImmediate: !isFuture(after.paidThroughAt) })
+  }
+
+  return transitions
+}

--- a/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
@@ -1,14 +1,27 @@
 import { getPayload } from 'payload'
+import type Stripe from 'stripe'
 import config from '@/payload.config'
 import { logger } from '@/shared/utils/logger'
 import { stripe } from './stripe'
-import { sendSubscriptionCancelledEmail, sendSubscriptionReactivatedEmail } from '@/emails'
-import { convertStripeTimestamp, getSubscriptionProductName } from './payment-helpers'
+import { convertStripeTimestamp } from './payment-helpers'
 import type { StripeSubscriptionExpanded, UserSubscriptionUpdate } from '../types'
+import { resyncSubscription } from './subscription-resync'
 import {
   findVisitorProfileByAuthUserId,
   findVisitorProfileByStripeCustomerId,
 } from '@/features/visitor-auth/lib/visitor-profile'
+
+/**
+ * Stripe states in which a subscription is still live enough to cancel or
+ * reactivate. `past_due` is deliberately included: a visitor being dunned is
+ * the one most likely to want out, and the old `active`-only guard refused them.
+ */
+const CANCELLABLE_STRIPE_STATUSES = new Set<Stripe.Subscription.Status>([
+  'active',
+  'trialing',
+  'past_due',
+  'unpaid',
+])
 
 /**
  * Stripe returns current_period_end/start on the first subscription item,
@@ -106,62 +119,49 @@ export async function cancelUserSubscription(authUserId: string): Promise<{
   membershipExpiresAt?: string
 }> {
   try {
-    const payload = await getPayload({ config })
-
     const profile = await findVisitorProfileByAuthUserId(authUserId)
 
     if (!profile) {
       return { success: false, message: 'Visitor profile not found' }
     }
 
-    if (!profile.stripeSubscriptionId || profile.subscriptionStatus !== 'active') {
-      return { success: false, message: 'No active subscription found' }
+    if (!profile.stripeSubscriptionId) {
+      return { success: false, message: 'No subscription found' }
     }
 
-    const cancelledSubscription = await stripe.subscriptions.update(profile.stripeSubscriptionId, {
-      cancel_at_period_end: true
-    }) as unknown as StripeSubscriptionExpanded
+    // Eligibility is Stripe's to judge, not the mirrored enum's. Requiring a
+    // local `active` status locked visitors in dunning out of cancelling, which
+    // is exactly when someone most wants to stop the retries (ADR-0008).
+    const current = await stripe.subscriptions.retrieve(profile.stripeSubscriptionId)
 
-    // Calculate when membership will actually expire
-    const membershipExpiresAt = getCurrentPeriodEnd(cancelledSubscription)
+    if (!CANCELLABLE_STRIPE_STATUSES.has(current.status)) {
+      return { success: false, message: 'This subscription can no longer be cancelled.' }
+    }
 
-    await payload.update({
-      collection: 'visitor-profiles',
-      id: profile.id,
-      data: {
-        cancelAtPeriodEnd: true,
-        membershipExpiration: membershipExpiresAt ? membershipExpiresAt.toISOString() : null
-      }
+    if (current.cancel_at_period_end) {
+      return { success: false, message: 'Subscription is already scheduled to cancel.' }
+    }
+
+    await stripe.subscriptions.update(profile.stripeSubscriptionId, {
+      cancel_at_period_end: true,
     })
+
+    // Writing state is resync's job; this returns what resync actually wrote so
+    // the response is derived truth rather than a local guess.
+    const { state } = await resyncSubscription(profile.stripeSubscriptionId)
+    const endsAt = state?.paidThroughAt ?? null
 
     logger.info('Cancelled subscription', {
       subscriptionId: profile.stripeSubscriptionId,
-      expiresAt: membershipExpiresAt?.toISOString() ?? null,
+      endsAt,
     })
-
-    const subscriptionType = await getSubscriptionProductName(profile.stripeSubscriptionId)
-
-    // Send cancellation email
-    try {
-      await sendSubscriptionCancelledEmail(payload, {
-        email: profile.email,
-        firstName: profile.firstName ?? undefined,
-        lastName: profile.lastName ?? undefined,
-        subscriptionType,
-        membershipExpiresAt: membershipExpiresAt || undefined,
-        wasImmediate: false // User-initiated cancellations honor paid period
-      })
-    } catch (error) {
-      logger.error('Failed to send cancellation email', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-      // Don't fail the cancellation if email fails
-    }
 
     return {
       success: true,
-      message: membershipExpiresAt ? `Subscription cancelled. Access will continue until ${membershipExpiresAt.toLocaleDateString()}` : 'Subscription cancelled',
-      membershipExpiresAt: membershipExpiresAt ? membershipExpiresAt.toISOString() : undefined
+      message: endsAt
+        ? `Subscription cancelled. Access will continue until ${new Date(endsAt).toLocaleDateString()}`
+        : 'Subscription cancelled',
+      membershipExpiresAt: endsAt ?? undefined,
     }
 
   } catch (error) {
@@ -182,8 +182,6 @@ export async function reactivateUserSubscription(authUserId: string): Promise<{
   renewsAt?: string
 }> {
   try {
-    const payload = await getPayload({ config })
-
     const profile = await findVisitorProfileByAuthUserId(authUserId)
 
     if (!profile) {
@@ -197,72 +195,36 @@ export async function reactivateUserSubscription(authUserId: string): Promise<{
       }
     }
 
-    // Check if subscription is actually cancelled
-    if (!profile.cancelAtPeriodEnd) {
-      // If subscription is active and not cancelled, no need to reactivate
-      if (profile.subscriptionStatus === 'active') {
+    const current = await stripe.subscriptions.retrieve(profile.stripeSubscriptionId)
+
+    if (!current.cancel_at_period_end) {
+      if (CANCELLABLE_STRIPE_STATUSES.has(current.status)) {
         return { success: false, message: 'Subscription is already active' }
       }
-      // If subscription is in another state (cancelled, past_due), it can't be reactivated
       return {
         success: false,
         message: 'Subscription cannot be reactivated. Please create a new subscription.'
       }
     }
 
-    // Remove the cancellation flag in Stripe
-    const updatedSubscription = await stripe.subscriptions.update(profile.stripeSubscriptionId, {
-      cancel_at_period_end: false
-    }) as unknown as StripeSubscriptionExpanded
-
-    // Get the new renewal date
-    const renewsAt = getCurrentPeriodEnd(updatedSubscription)
-
-    if (!renewsAt) {
-      return {
-        success: false,
-        message: 'Failed to get renewal date from Stripe'
-      }
-    }
-
-    // Update user record to reflect reactivation
-    await payload.update({
-      collection: 'visitor-profiles',
-      id: profile.id,
-      data: {
-        cancelAtPeriodEnd: false,
-        membershipExpiration: null, // Clear expiration since subscription will renew
-        subscriptionRenewsAt: renewsAt.toISOString()
-      }
+    await stripe.subscriptions.update(profile.stripeSubscriptionId, {
+      cancel_at_period_end: false,
     })
+
+    const { state } = await resyncSubscription(profile.stripeSubscriptionId)
+    const renewsAt = state?.paidThroughAt ?? null
 
     logger.info('Reactivated subscription', {
       subscriptionId: profile.stripeSubscriptionId,
-      renewsAt: renewsAt.toISOString(),
+      renewsAt,
     })
-
-    const subscriptionType = await getSubscriptionProductName(profile.stripeSubscriptionId)
-
-    // Send reactivation confirmation email
-    try {
-      await sendSubscriptionReactivatedEmail(payload, {
-        email: profile.email,
-        firstName: profile.firstName ?? undefined,
-        lastName: profile.lastName ?? undefined,
-        subscriptionType,
-        renewsAt
-      })
-    } catch (error) {
-      logger.error('Failed to send reactivation email', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-      // Don't fail the reactivation if email fails
-    }
 
     return {
       success: true,
-      message: `Subscription reactivated. Will renew on ${renewsAt.toLocaleDateString()}`,
-      renewsAt: renewsAt.toISOString()
+      message: renewsAt
+        ? `Subscription reactivated. Will renew on ${new Date(renewsAt).toLocaleDateString()}`
+        : 'Subscription reactivated',
+      renewsAt: renewsAt ?? undefined,
     }
 
   } catch (error) {

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
@@ -1,0 +1,158 @@
+import { getPayload } from 'payload'
+import type Stripe from 'stripe'
+import config from '@/payload.config'
+import { logger } from '@/shared/utils/logger'
+import { withAdvisoryLock } from '@/shared/utils/advisory-lock'
+import { findVisitorProfileByStripeCustomerId } from '@/features/visitor-auth/lib/visitor-profile'
+import {
+  sendMembershipConfirmationEmail,
+  sendSubscriptionCancelledEmail,
+  sendSubscriptionReactivatedEmail,
+} from '@/emails'
+import { stripe } from './stripe'
+import { getSubscriptionProductName } from './payment-helpers'
+import { deriveSubscriptionState, type DerivedSubscriptionState } from './subscription-state'
+import { resolveMembershipTransitions, type MembershipTransition } from './membership-transitions'
+
+/**
+ * The single writer of subscription state on a Visitor profile (ADR-0008).
+ *
+ * Webhooks are treated as triggers, never as data: the delivered payload is
+ * rendered at whatever API version the endpoint is pinned to, which on this
+ * account is five years behind the SDK. Refetching gives one known shape, and
+ * means a stale delivery writes current truth rather than truth as of
+ * emission.
+ */
+
+type ResyncResult = {
+  profileId: string | number | null
+  state: DerivedSubscriptionState | null
+  transitions: MembershipTransition[]
+}
+
+/** `next_payment_attempt` lives on the invoice, so the grace needs it expanded. */
+async function fetchSubscription(subscriptionId: string): Promise<Stripe.Subscription> {
+  return stripe.subscriptions.retrieve(subscriptionId, {
+    expand: ['latest_invoice'],
+  }) as unknown as Promise<Stripe.Subscription>
+}
+
+function nextPaymentAttemptOf(subscription: Stripe.Subscription): number | null {
+  const invoice = subscription.latest_invoice
+
+  if (!invoice || typeof invoice === 'string') return null
+
+  return (invoice as Stripe.Invoice).next_payment_attempt ?? null
+}
+
+async function sendTransitionEmails(
+  payload: Awaited<ReturnType<typeof getPayload>>,
+  profile: { email: string; firstName?: string | null; lastName?: string | null },
+  subscriptionId: string,
+  transitions: MembershipTransition[]
+) {
+  if (transitions.length === 0) return
+
+  const subscriptionType = await getSubscriptionProductName(subscriptionId)
+  const recipient = {
+    email: profile.email,
+    firstName: profile.firstName ?? undefined,
+    lastName: profile.lastName ?? undefined,
+    subscriptionType,
+  }
+
+  for (const transition of transitions) {
+    try {
+      switch (transition.kind) {
+        case 'membership_started':
+          await sendMembershipConfirmationEmail(payload, { ...recipient, isRecurring: true })
+          break
+        case 'cancellation_scheduled':
+          await sendSubscriptionCancelledEmail(payload, {
+            ...recipient,
+            membershipExpiresAt: transition.endsAt ? new Date(transition.endsAt) : undefined,
+            wasImmediate: false,
+          })
+          break
+        case 'reactivated':
+          await sendSubscriptionReactivatedEmail(payload, {
+            ...recipient,
+            renewsAt: transition.renewsAt ? new Date(transition.renewsAt) : new Date(),
+          })
+          break
+        case 'membership_ended':
+          await sendSubscriptionCancelledEmail(payload, {
+            ...recipient,
+            wasImmediate: transition.wasImmediate,
+          })
+          break
+      }
+    } catch (error) {
+      // A failed email must not fail the state write; the profile is the record
+      // that gates access, the email is a courtesy.
+      logger.error('Failed to send membership transition email', {
+        subscriptionId,
+        transition: transition.kind,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}
+
+/**
+ * Refetch a subscription from Stripe and write everything it implies onto the
+ * matching Visitor profile, emitting emails for whatever actually changed.
+ *
+ * Serialised per subscription: the read, the Stripe call and the write are not
+ * atomic, so without the lock two parallel deliveries would each observe the
+ * same before-state and each decide the same transition occurred.
+ */
+export async function resyncSubscription(subscriptionId: string): Promise<ResyncResult> {
+  const payload = await getPayload({ config })
+
+  return withAdvisoryLock(payload, `stripe:subscription:${subscriptionId}`, async () => {
+    const subscription = await fetchSubscription(subscriptionId)
+    const customerId =
+      typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
+
+    if (!customerId) {
+      logger.error('Subscription has no customer; cannot resync', { subscriptionId })
+      return { profileId: null, state: null, transitions: [] }
+    }
+
+    const profile = await findVisitorProfileByStripeCustomerId(customerId)
+
+    if (!profile) {
+      logger.error('No VisitorProfile found for Stripe customer', { customerId, subscriptionId })
+      return { profileId: null, state: null, transitions: [] }
+    }
+
+    const state = deriveSubscriptionState(subscription, {
+      previousDunningGraceUntil: profile.dunningGraceUntil,
+      nextPaymentAttempt: nextPaymentAttemptOf(subscription),
+    })
+
+    const transitions = resolveMembershipTransitions(profile, state)
+
+    await payload.update({
+      collection: 'visitor-profiles',
+      id: profile.id,
+      data: {
+        stripeSubscriptionId: subscription.id,
+        ...state,
+      },
+    })
+
+    logger.info('Resynced subscription from Stripe', {
+      subscriptionId,
+      profileId: profile.id,
+      status: state.subscriptionStatus,
+      paidThroughAt: state.paidThroughAt,
+      transitions: transitions.map((transition) => transition.kind),
+    })
+
+    await sendTransitionEmails(payload, profile, subscription.id, transitions)
+
+    return { profileId: profile.id, state, transitions }
+  })
+}

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import type Stripe from 'stripe'
+
+import fixture from '../__fixtures__/membership-lifecycle.events.json'
+import { DUNNING_GRACE_DAYS, deriveSubscriptionState } from './subscription-state'
+
+/**
+ * These run against payloads Stripe genuinely emitted during a test-clock run,
+ * not hand-built objects. That distinction is the whole point: the previous
+ * suite invented a `current_period_end` at the subscription root, which the
+ * SDK's API version does not produce, and stayed green over a real bug.
+ */
+type CapturedEvent = {
+  type: string
+  data: { object: Record<string, unknown> }
+}
+
+const events = fixture.events as CapturedEvent[]
+
+function subscriptionEvents(): Stripe.Subscription[] {
+  return events
+    .filter((event) => event.data.object.object === 'subscription')
+    .map((event) => event.data.object as unknown as Stripe.Subscription)
+}
+
+function firstWhere(predicate: (subscription: Stripe.Subscription) => boolean): Stripe.Subscription {
+  const found = subscriptionEvents().find(predicate)
+  if (!found) throw new Error('Fixture is missing a subscription matching that condition')
+  return found
+}
+
+function periodOf(subscription: Stripe.Subscription) {
+  const item = subscription.items.data[0] as unknown as {
+    current_period_start: number
+    current_period_end: number
+  }
+  return {
+    start: new Date(item.current_period_start * 1000).toISOString(),
+    end: new Date(item.current_period_end * 1000).toISOString(),
+  }
+}
+
+describe('deriveSubscriptionState', () => {
+  it('captures the full lifecycle, so the fixtures cover what we claim they cover', () => {
+    const types = events.map((event) => event.type)
+
+    expect(types).toContain('customer.subscription.created')
+    expect(types).toContain('invoice.payment_failed')
+    expect(types).toContain('customer.subscription.deleted')
+    expect(subscriptionEvents().some((s) => s.status === 'past_due')).toBe(true)
+  })
+
+  it('uses the period end while the current period is paid', () => {
+    const active = firstWhere((s) => s.status === 'active' && !s.cancel_at_period_end)
+
+    expect(deriveSubscriptionState(active)).toMatchObject({
+      subscriptionStatus: 'active',
+      cancelAtPeriodEnd: false,
+      paidThroughAt: periodOf(active).end,
+    })
+  })
+
+  it('falls back to the period START while the current period is unpaid', () => {
+    const pastDue = firstWhere((s) => s.status === 'past_due')
+    const period = periodOf(pastDue)
+
+    // The regression this guards: Stripe advanced the period at renewal before
+    // the charge cleared, so the end date describes an unpaid month.
+    expect(period.start).not.toEqual(period.end)
+    expect(deriveSubscriptionState(pastDue).paidThroughAt).toEqual(period.start)
+  })
+
+  it('never reports paid-through beyond the last paid period during dunning', () => {
+    const pastDue = firstWhere((s) => s.status === 'past_due')
+    const derived = deriveSubscriptionState(pastDue)
+
+    expect(new Date(derived.paidThroughAt!).getTime()).toBeLessThan(
+      new Date(periodOf(pastDue).end).getTime()
+    )
+  })
+
+  it('opens a bounded dunning grace when the subscription goes past due', () => {
+    const pastDue = firstWhere((s) => s.status === 'past_due')
+    const now = new Date('2026-09-15T13:10:00.000Z')
+
+    const derived = deriveSubscriptionState(pastDue, { now })
+
+    const expected = new Date(now.getTime() + DUNNING_GRACE_DAYS * 24 * 60 * 60 * 1000)
+    expect(derived.dunningGraceUntil).toEqual(expected.toISOString())
+  })
+
+  it('covers the first Stripe retry even when observed at the earliest moment', () => {
+    const failure = events.find((event) => event.type === 'invoice.payment_failed')!
+    const nextAttempt = (failure.data.object as { next_payment_attempt: number }).next_payment_attempt
+    const pastDue = firstWhere((s) => s.status === 'past_due')
+
+    // Worst case: grace opened at the very start of the unpaid period. The
+    // fixed five-day window alone expires seven hours before this retry, so
+    // this passes only because the retry time is taken into account.
+    const observedAt = new Date(periodOf(pastDue).start)
+    const graceEnds = new Date(
+      deriveSubscriptionState(pastDue, { now: observedAt, nextPaymentAttempt: nextAttempt })
+        .dunningGraceUntil!
+    )
+
+    expect(graceEnds.getTime()).toBeGreaterThan(nextAttempt * 1000)
+  })
+
+  it('still honours the fixed window when the retry is scheduled sooner', () => {
+    const pastDue = firstWhere((s) => s.status === 'past_due')
+    const now = new Date('2026-09-15T13:10:00.000Z')
+    const soon = Math.floor(now.getTime() / 1000) + 60 * 60
+
+    const derived = deriveSubscriptionState(pastDue, { now, nextPaymentAttempt: soon })
+
+    expect(derived.dunningGraceUntil).toEqual(
+      new Date(now.getTime() + DUNNING_GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString()
+    )
+  })
+
+  it('keeps a grace already running rather than restarting it on every retry', () => {
+    const pastDue = firstWhere((s) => s.status === 'past_due')
+    const existing = '2026-09-20T00:00:00.000Z'
+
+    const derived = deriveSubscriptionState(pastDue, {
+      previousDunningGraceUntil: existing,
+      now: new Date('2026-09-19T00:00:00.000Z'),
+    })
+
+    expect(derived.dunningGraceUntil).toEqual(existing)
+  })
+
+  it('clears the grace once the subscription recovers', () => {
+    const recovered = firstWhere((s) => s.status === 'active')
+
+    const derived = deriveSubscriptionState(recovered, {
+      previousDunningGraceUntil: '2026-09-20T00:00:00.000Z',
+    })
+
+    expect(derived.dunningGraceUntil).toBeNull()
+  })
+
+  it('marks a pending cancellation without ending paid access early', () => {
+    const cancelling = firstWhere((s) => s.status === 'active' && s.cancel_at_period_end)
+
+    expect(deriveSubscriptionState(cancelling)).toMatchObject({
+      subscriptionStatus: 'active',
+      cancelAtPeriodEnd: true,
+      paidThroughAt: periodOf(cancelling).end,
+    })
+  })
+
+  it('honours the paid period on a deleted subscription', () => {
+    const deleted = firstWhere((s) => s.status === 'canceled')
+
+    // The old handler read current_period_end off the subscription root, which
+    // the SDK's API version does not populate, so this silently became null.
+    expect(deriveSubscriptionState(deleted)).toMatchObject({
+      subscriptionStatus: 'cancelled',
+      paidThroughAt: periodOf(deleted).end,
+    })
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
@@ -1,0 +1,140 @@
+import type Stripe from 'stripe'
+import { logger } from '@/shared/utils/logger'
+import { convertStripeTimestamp } from './payment-helpers'
+import { mapStripeStatusToInternal } from './payment-service'
+
+/**
+ * How long paid access survives a failed renewal while Stripe retries the card.
+ *
+ * Five days is measured, not chosen by taste: in the captured test-clock run
+ * (`__fixtures__/membership-lifecycle.events.json`) the charge failed at
+ * 09-15 13:10 and Stripe scheduled its first retry for 09-19 20:26, about four
+ * days and seven hours later. A shorter grace revokes access before Stripe has
+ * even retried once, locking out exactly the visitors that retry recovers.
+ */
+export const DUNNING_GRACE_DAYS = 5
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Stripe statuses where the *current* period has not been paid for. In these
+ * states the subscription's period has already rolled forward optimistically,
+ * so its end date describes time the visitor has not bought.
+ */
+const UNPAID_CURRENT_PERIOD = new Set<Stripe.Subscription.Status>([
+  'past_due',
+  'unpaid',
+  'incomplete',
+  'incomplete_expired',
+])
+
+export type DerivedSubscriptionState = {
+  subscriptionStatus: 'none' | 'active' | 'cancelled' | 'past_due'
+  cancelAtPeriodEnd: boolean
+  paidThroughAt: string | null
+  dunningGraceUntil: string | null
+}
+
+export type DeriveContext = {
+  /** Existing grace on the profile; a live grace is kept rather than restarted. */
+  previousDunningGraceUntil?: string | null
+  now?: Date
+  graceDays?: number
+  /**
+   * `next_payment_attempt` from the subscription's latest invoice, when known.
+   * Stripe states outright when it will try the card again; the grace uses that
+   * rather than assuming the fixed window outlasts it.
+   */
+  nextPaymentAttempt?: number | null
+}
+
+/**
+ * Slack added past Stripe's scheduled retry so the grace cannot expire in the
+ * minutes around the attempt, and so a recovered payment has time to land.
+ */
+const RETRY_COVER_BUFFER_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Stripe moved `current_period_end` off the subscription root and onto the
+ * subscription item. Read only the item: handlers refetch through the SDK, so
+ * there is exactly one shape to support (ADR-0008).
+ */
+function getPeriod(subscription: Stripe.Subscription): { start: Date | null; end: Date | null } {
+  const item = subscription.items?.data?.[0] as
+    | { current_period_start?: number | null; current_period_end?: number | null }
+    | undefined
+
+  if (!item) {
+    logger.warn('Subscription has no items; cannot resolve billing period', {
+      subscriptionId: subscription.id,
+    })
+    return { start: null, end: null }
+  }
+
+  return {
+    start: convertStripeTimestamp(item.current_period_start ?? null),
+    end: convertStripeTimestamp(item.current_period_end ?? null),
+  }
+}
+
+/**
+ * The end of the last period the visitor actually paid for.
+ *
+ * Stripe advances the period at the renewal moment, before the charge clears,
+ * so `current_period_end` overstates paid time whenever the current period is
+ * unpaid. In that case the *start* of the current period is precisely the end
+ * of the last paid one, which is what this returns.
+ */
+function resolvePaidThrough(subscription: Stripe.Subscription): Date | null {
+  const { start, end } = getPeriod(subscription)
+
+  return UNPAID_CURRENT_PERIOD.has(subscription.status) ? start : end
+}
+
+/**
+ * A grace already running is never extended by a later event, otherwise every
+ * retry failure would push the deadline out and the grace would never expire.
+ *
+ * The window is the fixed grace, or Stripe's next scheduled retry plus a
+ * buffer, whichever is later. The fixed window alone is not reliably enough:
+ * in the captured run, five days measured from the start of the unpaid period
+ * expired seven hours before Stripe's first retry, which would revoke access
+ * from a visitor about to be recovered.
+ */
+function resolveDunningGrace(
+  status: DerivedSubscriptionState['subscriptionStatus'],
+  context: DeriveContext
+): string | null {
+  if (status !== 'past_due') return null
+
+  const existing = context.previousDunningGraceUntil
+  if (existing) return existing
+
+  const now = context.now ?? new Date()
+  const graceDays = context.graceDays ?? DUNNING_GRACE_DAYS
+  const fixedWindow = now.getTime() + graceDays * DAY_MS
+
+  const retryAt = convertStripeTimestamp(context.nextPaymentAttempt ?? null)
+  const coversRetry = retryAt ? retryAt.getTime() + RETRY_COVER_BUFFER_MS : 0
+
+  return new Date(Math.max(fixedWindow, coversRetry)).toISOString()
+}
+
+/**
+ * Turn a freshly fetched Stripe subscription into the profile fields it implies.
+ * Pure: every input is an argument, so it is testable against captured payloads.
+ */
+export function deriveSubscriptionState(
+  subscription: Stripe.Subscription,
+  context: DeriveContext = {}
+): DerivedSubscriptionState {
+  const subscriptionStatus = mapStripeStatusToInternal(subscription.status)
+  const paidThrough = resolvePaidThrough(subscription)
+
+  return {
+    subscriptionStatus,
+    cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+    paidThroughAt: paidThrough ? paidThrough.toISOString() : null,
+    dunningGraceUntil: resolveDunningGrace(subscriptionStatus, context),
+  }
+}

--- a/apps/questura/apps/server/src/features/payments/payment-service.test.ts
+++ b/apps/questura/apps/server/src/features/payments/payment-service.test.ts
@@ -8,6 +8,13 @@ const mocks = vi.hoisted(() => ({
   findVisitorProfileByAuthUserId: vi.fn(),
   findVisitorProfileByStripeCustomerId: vi.fn(),
   payloadUpdate: vi.fn(),
+  resyncSubscription: vi.fn(),
+}))
+
+// cancel/reactivate call Stripe then hand the write to resync, so these tests
+// assert delegation rather than re-checking what resync derives.
+vi.mock('@/payments/lib/subscription-resync', () => ({
+  resyncSubscription: mocks.resyncSubscription,
 }))
 
 vi.mock('@/payments/lib/stripe', () => ({
@@ -74,6 +81,12 @@ beforeEach(() => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined),
   ]
   mocks.payloadUpdate.mockResolvedValue({})
+  // clearAllMocks keeps implementations, so a rejection set by one test would
+  // otherwise leak into the next.
+  mocks.stripeSubscriptionUpdate.mockReset()
+  mocks.stripeSubscriptionUpdate.mockResolvedValue({ id: 'sub_1' })
+  mocks.resyncSubscription.mockReset()
+  mocks.resyncSubscription.mockResolvedValue({ profileId: 10, state: null, transitions: [] })
   // getSubscriptionProductName path (expand items.data.price.product)
   mocks.stripeSubscriptionRetrieve.mockResolvedValue({
     items: { data: [{ price: { product: { name: 'Premium Membership' } } }] },
@@ -148,63 +161,115 @@ describe('cancelUserSubscription', () => {
   it('fails when the visitor profile does not exist', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue(null)
 
-    await expect(cancelUserSubscription('user_1')).resolves.toEqual({
+    await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
       success: false,
       message: 'Visitor profile not found',
-    })
-  })
-
-  it('fails when there is no active subscription', async () => {
-    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
-      ...activeProfile,
-      subscriptionStatus: 'cancelled',
-    })
-
-    await expect(cancelUserSubscription('user_1')).resolves.toEqual({
-      success: false,
-      message: 'No active subscription found',
     })
     expect(mocks.stripeSubscriptionUpdate).not.toHaveBeenCalled()
   })
 
-  it('cancels at period end, stores the expiration, and emails the visitor', async () => {
-    mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
-    mocks.stripeSubscriptionUpdate.mockResolvedValue(subscriptionWithItemPeriodEnd(FUTURE_TS))
+  it('fails when the profile has no subscription at all', async () => {
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      ...activeProfile,
+      stripeSubscriptionId: null,
+    })
 
-    const result = await cancelUserSubscription('user_1')
+    await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message: 'No subscription found',
+    })
+  })
 
+  it('lets a visitor in dunning cancel, which the old active-only guard refused', async () => {
+    // Someone being retried is the person most likely to want out; requiring a
+    // local `active` status turned them away (ADR-0008).
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      ...activeProfile,
+      subscriptionStatus: 'past_due',
+    })
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'past_due',
+      cancel_at_period_end: false,
+    })
+    mocks.resyncSubscription.mockResolvedValue({
+      profileId: 10,
+      state: { paidThroughAt: new Date(FUTURE_TS * 1000).toISOString() },
+      transitions: [],
+    })
+
+    const result = await cancelUserSubscription('auth_1')
+
+    expect(result.success).toBe(true)
     expect(mocks.stripeSubscriptionUpdate).toHaveBeenCalledWith('sub_1', {
       cancel_at_period_end: true,
     })
-    expect(mocks.payloadUpdate).toHaveBeenCalledWith({
-      collection: 'visitor-profiles',
-      id: 10,
-      data: {
-        cancelAtPeriodEnd: true,
-        membershipExpiration: new Date(FUTURE_TS * 1000).toISOString(),
-      },
-    })
-    expect(mocks.sendSubscriptionCancelledEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ email: 'visitor@example.com', wasImmediate: false }),
-    )
-    expect(result.success).toBe(true)
-    expect(result.membershipExpiresAt).toBe(new Date(FUTURE_TS * 1000).toISOString())
   })
 
-  it('still succeeds when the cancellation email fails', async () => {
+  it('refuses when Stripe reports the subscription already gone', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
-    mocks.stripeSubscriptionUpdate.mockResolvedValue(subscriptionWithItemPeriodEnd(FUTURE_TS))
-    mocks.sendSubscriptionCancelledEmail.mockRejectedValue(new Error('email down'))
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'canceled',
+      cancel_at_period_end: false,
+    })
 
-    await expect(cancelUserSubscription('user_1')).resolves.toMatchObject({ success: true })
+    await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message: 'This subscription can no longer be cancelled.',
+    })
+    expect(mocks.stripeSubscriptionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refuses a second cancellation of an already-cancelling subscription', async () => {
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: true,
+    })
+
+    await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message: 'Subscription is already scheduled to cancel.',
+    })
+    expect(mocks.stripeSubscriptionUpdate).not.toHaveBeenCalled()
+  })
+
+  it('delegates the write to resync and reports the date resync derived', async () => {
+    const endsAt = new Date(FUTURE_TS * 1000).toISOString()
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: false,
+    })
+    mocks.resyncSubscription.mockResolvedValue({
+      profileId: 10,
+      state: { paidThroughAt: endsAt },
+      transitions: [],
+    })
+
+    const result = await cancelUserSubscription('auth_1')
+
+    expect(result.success).toBe(true)
+    expect(result.membershipExpiresAt).toBe(endsAt)
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+    // The endpoint no longer writes state or emails directly; resync owns both.
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+    expect(mocks.sendSubscriptionCancelledEmail).not.toHaveBeenCalled()
   })
 
   it('fails cleanly when Stripe rejects the cancellation', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: false,
+    })
     mocks.stripeSubscriptionUpdate.mockRejectedValue(new Error('stripe down'))
 
-    await expect(cancelUserSubscription('user_1')).resolves.toEqual({
+    await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
       success: false,
       message: 'Failed to cancel subscription',
     })
@@ -215,7 +280,7 @@ describe('reactivateUserSubscription', () => {
   it('fails when the visitor profile does not exist', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue(null)
 
-    await expect(reactivateUserSubscription('user_1')).resolves.toEqual({
+    await expect(reactivateUserSubscription('auth_1')).resolves.toEqual({
       success: false,
       message: 'Visitor profile not found',
     })
@@ -227,58 +292,85 @@ describe('reactivateUserSubscription', () => {
       stripeSubscriptionId: null,
     })
 
-    const result = await reactivateUserSubscription('user_1')
-    expect(result.success).toBe(false)
-    expect(result.message).toContain('cannot be reactivated')
+    await expect(reactivateUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message:
+        'Subscription has expired and cannot be reactivated. Please create a new subscription.',
+    })
   })
 
   it('rejects reactivation when the subscription is already active and not cancelling', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: false,
+    })
 
-    await expect(reactivateUserSubscription('user_1')).resolves.toEqual({
+    await expect(reactivateUserSubscription('auth_1')).resolves.toEqual({
       success: false,
       message: 'Subscription is already active',
     })
     expect(mocks.stripeSubscriptionUpdate).not.toHaveBeenCalled()
   })
 
-  it('clears the cancellation flag and restores the renewal date', async () => {
+  it('refuses to reactivate a subscription Stripe has already ended', async () => {
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'canceled',
+      cancel_at_period_end: false,
+    })
+
+    await expect(reactivateUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message: 'Subscription cannot be reactivated. Please create a new subscription.',
+    })
+  })
+
+  it('clears the cancellation flag and reports the date resync derived', async () => {
+    const renewsAt = new Date(FUTURE_TS * 1000).toISOString()
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
       ...activeProfile,
       cancelAtPeriodEnd: true,
     })
-    mocks.stripeSubscriptionUpdate.mockResolvedValue(subscriptionWithItemPeriodEnd(FUTURE_TS))
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: true,
+    })
+    mocks.resyncSubscription.mockResolvedValue({
+      profileId: 10,
+      state: { paidThroughAt: renewsAt },
+      transitions: [],
+    })
 
-    const result = await reactivateUserSubscription('user_1')
+    const result = await reactivateUserSubscription('auth_1')
 
+    expect(result.success).toBe(true)
+    expect(result.renewsAt).toBe(renewsAt)
     expect(mocks.stripeSubscriptionUpdate).toHaveBeenCalledWith('sub_1', {
       cancel_at_period_end: false,
     })
-    expect(mocks.payloadUpdate).toHaveBeenCalledWith({
-      collection: 'visitor-profiles',
-      id: 10,
-      data: {
-        cancelAtPeriodEnd: false,
-        membershipExpiration: null,
-        subscriptionRenewsAt: new Date(FUTURE_TS * 1000).toISOString(),
-      },
-    })
-    expect(mocks.sendSubscriptionReactivatedEmail).toHaveBeenCalled()
-    expect(result.success).toBe(true)
-    expect(result.renewsAt).toBe(new Date(FUTURE_TS * 1000).toISOString())
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+    expect(mocks.sendSubscriptionReactivatedEmail).not.toHaveBeenCalled()
   })
 
-  it('fails when Stripe returns no renewal date', async () => {
+  it('fails cleanly when Stripe rejects the reactivation', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
       ...activeProfile,
       cancelAtPeriodEnd: true,
     })
-    mocks.stripeSubscriptionUpdate.mockResolvedValue(subscriptionWithItemPeriodEnd(null))
-
-    await expect(reactivateUserSubscription('user_1')).resolves.toEqual({
-      success: false,
-      message: 'Failed to get renewal date from Stripe',
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: true,
     })
-    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+    mocks.stripeSubscriptionUpdate.mockRejectedValue(new Error('stripe down'))
+
+    await expect(reactivateUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message: 'Failed to reactivate subscription',
+    })
   })
 })

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -12,6 +12,14 @@ const mocks = vi.hoisted(() => ({
   findVisitorProfileByStripeCustomerId: vi.fn(),
   payloadFind: vi.fn(),
   payloadCreate: vi.fn(),
+  resyncSubscription: vi.fn(),
+}))
+
+// Subscription state is written by resync alone (ADR-0008); these tests assert
+// that each event reaches it, and subscription-state.test.ts covers what it
+// then derives, against payloads Stripe actually sent.
+vi.mock('@/payments/lib/subscription-resync', () => ({
+  resyncSubscription: mocks.resyncSubscription,
 }))
 
 vi.mock('@/payments/lib/stripe', () => ({
@@ -103,6 +111,7 @@ describe('Stripe webhook route', () => {
     mocks.payloadFind.mockResolvedValue({ totalDocs: 0, docs: [] })
     mocks.payloadCreate.mockResolvedValue({})
     mocks.updateUserSubscription.mockResolvedValue(true)
+    mocks.resyncSubscription.mockResolvedValue({ profileId: 10, state: null, transitions: [] })
     mocks.getSubscriptionProductName.mockResolvedValue('Premium Membership')
     mocks.findVisitorProfileByStripeCustomerId.mockResolvedValue({
       id: 10,
@@ -136,7 +145,7 @@ describe('Stripe webhook route', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({ error: 'Invalid signature' })
-    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
   })
 
   it('skips duplicate deliveries of an already-processed event', async () => {
@@ -146,7 +155,7 @@ describe('Stripe webhook route', () => {
     const response = await POST(createRequest())
 
     await expect(response.json()).resolves.toEqual({ received: true, duplicate: true })
-    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
     expect(mocks.payloadCreate).not.toHaveBeenCalled()
   })
 
@@ -159,7 +168,7 @@ describe('Stripe webhook route', () => {
     const response = await POST(createRequest())
 
     await expect(response.json()).resolves.toEqual({ received: true, stale: true })
-    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
     // Recorded so retries of the stale event are also skipped
     expect(mocks.payloadCreate).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ eventId: 'evt_1' }) }),
@@ -270,167 +279,73 @@ describe('Stripe webhook route', () => {
     )
   })
 
-  it('prefers the webhook period end over the Stripe API on subscription created', async () => {
+  it('resyncs from Stripe on subscription created rather than trusting the payload', async () => {
+    // The payload carries a full subscription object and is deliberately
+    // ignored: it renders at the endpoint's API version, not the SDK's.
     givenEvent('customer.subscription.created', {
       id: 'sub_1',
       customer: 'cus_1',
       status: 'active',
       current_period_end: FUTURE_TS,
     })
-    // The confirmation-email path also fetches details; give the API a
-    // different date to prove the renewal date came from the webhook payload.
-    mocks.getStripeSubscriptionDetails.mockResolvedValue({
-      currentPeriodEnd: new Date((FUTURE_TS + 999) * 1000),
-    })
 
     await POST(createRequest())
 
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      stripeSubscriptionId: 'sub_1',
-      subscriptionStatus: 'active',
-      subscriptionRenewsAt: new Date(FUTURE_TS * 1000).toISOString(),
-    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 
-  it('falls back to the Stripe API when the webhook payload has no period end', async () => {
-    givenEvent('customer.subscription.created', {
-      id: 'sub_1',
-      customer: 'cus_1',
-      status: 'active',
-    })
-    mocks.getStripeSubscriptionDetails.mockResolvedValue({
-      currentPeriodEnd: new Date(FUTURE_TS * 1000),
-    })
-
-    await POST(createRequest())
-
-    expect(mocks.getStripeSubscriptionDetails).toHaveBeenCalledWith('sub_1')
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
-      'cus_1',
-      expect.objectContaining({ subscriptionRenewsAt: new Date(FUTURE_TS * 1000).toISOString() }),
-    )
-  })
-
-  it('sets membershipExpiration when the subscription is cancelled at period end', async () => {
+  it('resyncs on subscription updated', async () => {
     givenEvent('customer.subscription.updated', {
       id: 'sub_1',
       customer: 'cus_1',
       status: 'active',
       cancel_at_period_end: true,
-      current_period_end: FUTURE_TS,
     })
 
     await POST(createRequest())
 
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      stripeSubscriptionId: 'sub_1',
-      subscriptionStatus: 'active',
-      subscriptionRenewsAt: new Date(FUTURE_TS * 1000).toISOString(),
-      cancelAtPeriodEnd: true,
-      membershipExpiration: new Date(FUTURE_TS * 1000).toISOString(),
-    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 
-  it('clears membershipExpiration when the subscription is renewing normally', async () => {
-    givenEvent('customer.subscription.updated', {
-      id: 'sub_1',
-      customer: 'cus_1',
-      status: 'active',
-      cancel_at_period_end: false,
-      current_period_end: FUTURE_TS,
-    })
+  it('resyncs on subscription deleted instead of reading a root period end', async () => {
+    // The old handler read `current_period_end` off the subscription root,
+    // which the SDK's API version does not populate.
+    givenEvent('customer.subscription.deleted', { id: 'sub_1', customer: 'cus_1' })
 
     await POST(createRequest())
 
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
-      'cus_1',
-      expect.objectContaining({ cancelAtPeriodEnd: false, membershipExpiration: null }),
-    )
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 
-  it('honors the paid period when a deleted subscription has time remaining', async () => {
-    givenEvent('customer.subscription.deleted', {
-      id: 'sub_1',
-      customer: 'cus_1',
-      current_period_end: FUTURE_TS,
-    })
-
-    await POST(createRequest())
-
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      subscriptionStatus: 'cancelled',
-      membershipExpiration: new Date(FUTURE_TS * 1000).toISOString(),
-      subscriptionRenewsAt: null,
-      cancelAtPeriodEnd: false,
-    })
-    expect(mocks.sendSubscriptionCancelledEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ wasImmediate: false }),
-    )
-  })
-
-  it('revokes immediately when a deleted subscription period already ended', async () => {
-    givenEvent('customer.subscription.deleted', {
-      id: 'sub_1',
-      customer: 'cus_1',
-      current_period_end: PAST_TS,
-    })
-
-    await POST(createRequest())
-
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
-      'cus_1',
-      expect.objectContaining({ subscriptionStatus: 'cancelled', membershipExpiration: null }),
-    )
-    expect(mocks.sendSubscriptionCancelledEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ wasImmediate: true }),
-    )
-  })
-
-  it('updates the renewal date on subscription_cycle invoice payments', async () => {
+  it('resyncs on successful invoice payments', async () => {
     givenEvent('invoice.payment_succeeded', {
       id: 'in_1',
       customer: 'cus_1',
       subscription: 'sub_1',
       billing_reason: 'subscription_cycle',
     })
-    mocks.getStripeSubscriptionDetails.mockResolvedValue({
-      currentPeriodEnd: new Date(FUTURE_TS * 1000),
-    })
 
     await POST(createRequest())
 
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      subscriptionRenewsAt: new Date(FUTURE_TS * 1000).toISOString(),
-    })
-    expect(mocks.sendMembershipConfirmationEmail).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 
   it('fetches a successful invoice when its webhook omits the subscription', async () => {
-    givenEvent('invoice.payment_succeeded', {
-      id: 'in_success_fallback',
-      customer: 'cus_1',
-      billing_reason: 'subscription_cycle',
-    })
+    givenEvent('invoice.payment_succeeded', { id: 'in_1', customer: 'cus_1' })
     mocks.invoiceRetrieve.mockResolvedValue({
-      id: 'in_success_fallback',
-      subscription: 'sub_from_api',
-    })
-    mocks.getStripeSubscriptionDetails.mockResolvedValue({
-      currentPeriodEnd: new Date(FUTURE_TS * 1000),
+      id: 'in_1',
+      parent: { subscription_details: { subscription: 'sub_1' } },
     })
 
     await POST(createRequest())
 
-    expect(mocks.invoiceRetrieve).toHaveBeenCalledWith('in_success_fallback')
-    expect(mocks.getStripeSubscriptionDetails).toHaveBeenCalledWith('sub_from_api')
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      subscriptionRenewsAt: new Date(FUTURE_TS * 1000).toISOString(),
-    })
+    expect(mocks.invoiceRetrieve).toHaveBeenCalledWith('in_1')
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 
-  it('marks the subscription past_due on failed invoice payments', async () => {
+  it('resyncs on failed invoice payments rather than writing past_due itself', async () => {
+    // Writing past_due here was the P0 bug: it revoked a paying visitor's
+    // access on the first decline. The subscription object now decides.
     givenEvent('invoice.payment_failed', {
       id: 'in_1',
       customer: 'cus_1',
@@ -439,27 +354,27 @@ describe('Stripe webhook route', () => {
 
     await POST(createRequest())
 
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      subscriptionStatus: 'past_due',
-    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
   })
 
   it('fetches a failed invoice when its webhook omits the subscription', async () => {
-    givenEvent('invoice.payment_failed', {
-      id: 'in_failed_fallback',
-      customer: 'cus_1',
-    })
-    mocks.invoiceRetrieve.mockResolvedValue({
-      id: 'in_failed_fallback',
-      subscription: 'sub_from_api',
-    })
+    givenEvent('invoice.payment_failed', { id: 'in_1', customer: 'cus_1' })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
 
     await POST(createRequest())
 
-    expect(mocks.invoiceRetrieve).toHaveBeenCalledWith('in_failed_fallback')
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      subscriptionStatus: 'past_due',
-    })
+    expect(mocks.invoiceRetrieve).toHaveBeenCalledWith('in_1')
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('ignores an invoice with no subscription at all', async () => {
+    givenEvent('invoice.payment_succeeded', { id: 'in_1', customer: 'cus_1' })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1' })
+
+    await POST(createRequest())
+
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
   })
 
   it('acknowledges unhandled event types and records them for idempotency', async () => {
@@ -468,7 +383,7 @@ describe('Stripe webhook route', () => {
     const response = await POST(createRequest())
 
     await expect(response.json()).resolves.toEqual({ received: true })
-    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
     expect(mocks.payloadCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ eventId: 'evt_1', eventType: 'customer.updated' }),
@@ -477,12 +392,8 @@ describe('Stripe webhook route', () => {
   })
 
   it('returns 500 and does not record the event when a handler fails', async () => {
-    givenEvent('customer.subscription.deleted', {
-      id: 'sub_1',
-      customer: 'cus_1',
-      current_period_end: FUTURE_TS,
-    })
-    mocks.updateUserSubscription.mockRejectedValue(new Error('db down'))
+    givenEvent('customer.subscription.deleted', { id: 'sub_1', customer: 'cus_1' })
+    mocks.resyncSubscription.mockRejectedValue(new Error('db down'))
 
     const response = await POST(createRequest())
 

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/invoice-payment.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/invoice-payment.ts
@@ -1,18 +1,20 @@
 import type Stripe from 'stripe'
-import { updateUserSubscription, getStripeSubscriptionDetails } from '@/payments/lib/payment-service'
 import { logger } from '@/shared/utils/logger'
+import { resyncSubscription } from '@/payments/lib/subscription-resync'
 import { resolveInvoiceSubscriptionId } from '../invoice-subscription'
-import { sendMembershipConfirmationAfterPayment } from '../notifications'
 
 /**
- * Handle successful invoice payments
- * This is triggered for recurring subscription payments and serves as payment confirmation
- * Also updates the renewal date for subscription renewals
+ * Invoice webhooks are re-sync triggers, not writers (ADR-0008).
+ *
+ * `invoice.payment_failed` used to write `past_due` from its own reasoning.
+ * Two independent writers of the same fields had to agree forever, and invoice
+ * events were never covered by the ordering guard, so a late failure could
+ * stamp `past_due` over a subscription that had already recovered. Both
+ * handlers now resolve the subscription and let the subscription object decide.
  */
+
 export async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
   logger.info('Processing invoice.payment_succeeded', { invoiceId: invoice.id })
-
-  const customerId = invoice.customer as string
 
   const subscriptionId = await resolveInvoiceSubscriptionId(invoice)
 
@@ -21,64 +23,24 @@ export async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
     return
   }
 
-  const billingReason = (invoice as any).billing_reason
-
-  logger.info('Payment successful for subscription', { subscriptionId, billingReason })
-
-  // For renewal payments, update the subscription renewal date
-  if (billingReason === 'subscription_cycle') {
-    try {
-      const subscriptionDetails = await getStripeSubscriptionDetails(subscriptionId)
-      if (subscriptionDetails?.currentPeriodEnd) {
-        const updatedRenewalDate = subscriptionDetails.currentPeriodEnd.toISOString()
-
-        await updateUserSubscription(customerId, {
-          subscriptionRenewsAt: updatedRenewalDate
-        })
-
-        logger.info('Renewal date updated after renewal payment', {
-          subscriptionId,
-          subscriptionRenewsAt: updatedRenewalDate,
-        })
-      }
-    } catch (error) {
-      logger.error('Failed to update renewal date on subscription renewal', {
-        subscriptionId,
-        error: error instanceof Error ? error.message : String(error),
-      })
-      // Don't fail the webhook if renewal date update fails - the subscription is still active
-    }
-  }
-
-  // Send membership confirmation email only for new subscriptions
-  // Regular renewals are handled silently (renewal date already updated above)
-  if (billingReason === 'subscription_create') {
-    await sendMembershipConfirmationAfterPayment(customerId, subscriptionId, true)
-  }
+  await resyncSubscription(subscriptionId)
 }
 
-/**
- * Handle failed invoice payments
- * This can lead to past_due status
- */
 export async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
   logger.info('Processing invoice.payment_failed', { invoiceId: invoice.id })
 
   const subscriptionId = await resolveInvoiceSubscriptionId(invoice)
+
   if (!subscriptionId) {
     logger.info('Invoice not related to subscription, skipping', { invoiceId: invoice.id })
     return
   }
 
-  const customerId = invoice.customer as string
+  // Resync opens the dunning grace when Stripe reports past_due, so paid access
+  // survives the retry window instead of ending on the first decline.
+  await resyncSubscription(subscriptionId)
 
-  // Mark as past due, but don't immediately revoke membership
-  // Stripe will handle the subscription status updates
-  await updateUserSubscription(customerId, {
-    subscriptionStatus: 'past_due'
-  })
-
-  logger.warn('User subscription marked as past due after payment failure', {
+  logger.warn('Subscription payment failed; dunning grace applies', {
     invoiceId: invoice.id,
     subscriptionId,
   })

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/subscription-lifecycle.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/subscription-lifecycle.ts
@@ -1,126 +1,37 @@
 import type Stripe from 'stripe'
-import { updateUserSubscription, mapStripeStatusToInternal } from '@/payments/lib/payment-service'
-import { convertStripeTimestamp } from '@/payments/lib/payment-helpers'
-import type { StripeSubscriptionExpanded } from '@/payments/types'
 import { logger } from '@/shared/utils/logger'
-import { resolveRenewalDate } from '../renewal-date'
-import { sendMembershipConfirmationAfterPayment, sendSubscriptionCancellationEmail } from '../notifications'
+import { resyncSubscription } from '@/payments/lib/subscription-resync'
 
 /**
- * Handle subscription creation
+ * Subscription lifecycle webhooks.
+ *
+ * These carry a full subscription object, and deliberately do not use it: the
+ * payload is rendered at the webhook endpoint's API version, which on this
+ * account still places `current_period_end` at the subscription root, while
+ * the SDK pins a version that puts it on the subscription item. Reading the
+ * payload made that difference invisible until it broke. Every handler now
+ * takes the id and refetches (ADR-0008).
  */
+
 export async function handleSubscriptionCreated(subscription: Stripe.Subscription) {
   logger.info('Processing customer.subscription.created', { subscriptionId: subscription.id })
 
-  const customerId = subscription.customer as string
-
-  const status = mapStripeStatusToInternal(subscription.status)
-
-  // Get renewal date for active subscriptions
-  const subscriptionRenewsAt = status === 'active' ? await resolveRenewalDate(subscription) : null
-
-  await updateUserSubscription(customerId, {
-    stripeSubscriptionId: subscription.id,
-    subscriptionStatus: status,
-    subscriptionRenewsAt
-  })
-
-  logger.info('User subscription created', { subscriptionId: subscription.id, status })
-
-  // Send membership confirmation email for active subscriptions
-  if (status === 'active') {
-    await sendMembershipConfirmationAfterPayment(customerId, subscription.id, true)
-  }
+  await resyncSubscription(subscription.id)
 }
 
-/**
- * Handle subscription status updates
- * This covers status changes like active -> past_due -> cancelled
- */
 export async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
   logger.info('Processing customer.subscription.updated', {
     subscriptionId: subscription.id,
-    status: subscription.status,
-  })
-  const expandedSubscription = subscription as StripeSubscriptionExpanded
-
-  const customerId = subscription.customer as string
-
-  // GUARD: Skip webhook for staff members
-  const status = mapStripeStatusToInternal(subscription.status)
-  const cancelAtPeriodEnd = expandedSubscription.cancel_at_period_end || false
-
-  // Get renewal date for active subscriptions, clear for inactive ones
-  const subscriptionRenewsAt = status === 'active' ? await resolveRenewalDate(subscription) : null
-
-  // Set membershipExpiration when subscription is cancelled but still active
-  // (the paid period runs to the same current-period-end a renewal would use).
-  // Stays null when the subscription is renewing, which clears any previous value.
-  let membershipExpiration: string | null = null
-  if (cancelAtPeriodEnd && status === 'active') {
-    membershipExpiration = subscriptionRenewsAt
-    if (membershipExpiration) {
-      logger.info('Subscription cancelled but active until period end', {
-        subscriptionId: subscription.id,
-        membershipExpiration,
-      })
-    }
-  }
-
-  await updateUserSubscription(customerId, {
-    stripeSubscriptionId: subscription.id,
-    subscriptionStatus: status,
-    subscriptionRenewsAt,
-    cancelAtPeriodEnd,
-    membershipExpiration
+    payloadStatus: subscription.status,
   })
 
-  logger.info('User subscription updated', {
-    subscriptionId: subscription.id,
-    status,
-    cancelAtPeriodEnd,
-  })
+  await resyncSubscription(subscription.id)
 }
 
-/**
- * Handle subscription deletion/cancellation
- * Honor the paid period by setting membershipExpiration to current_period_end
- */
 export async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
   logger.info('Processing customer.subscription.deleted', { subscriptionId: subscription.id })
 
-  const customerId = subscription.customer as string
-
-  const expandedSubscription = subscription as StripeSubscriptionExpanded
-
-  // Calculate when the paid period actually ends
-  const currentPeriodEnd = convertStripeTimestamp(expandedSubscription.current_period_end)
-  const now = new Date()
-
-  // If the subscription period hasn't ended yet, honor the paid time
-  let membershipExpiration: string | null = null
-  if (currentPeriodEnd && currentPeriodEnd > now) {
-    membershipExpiration = currentPeriodEnd.toISOString()
-    logger.info('Honoring paid period after cancellation', {
-      subscriptionId: subscription.id,
-      membershipExpiration,
-    })
-  } else if (!currentPeriodEnd) {
-    logger.warn('Could not convert subscription period end date, treating as immediate revocation', {
-      subscriptionId: subscription.id,
-    })
-  }
-
-  await updateUserSubscription(customerId, {
-    subscriptionStatus: 'cancelled',
-    membershipExpiration,
-    subscriptionRenewsAt: null, // Clear renewal date for cancelled subscriptions
-    cancelAtPeriodEnd: false // Clear cancel flag since subscription is now fully deleted
-  })
-
-  logger.info('User subscription cancelled', { subscriptionId: subscription.id })
-
-  // Send cancellation email - this is typically triggered by Stripe when the subscription period actually ends
-  const wasImmediate = !membershipExpiration // If no expiration, access was revoked immediately
-  await sendSubscriptionCancellationEmail(customerId, subscription.id, membershipExpiration ? new Date(membershipExpiration) : null, wasImmediate)
+  // A deleted subscription is still retrievable, and still reports the period
+  // it was cancelled in, so paid time is honoured the same way as anywhere else.
+  await resyncSubscription(subscription.id)
 }

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/current-principal.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/current-principal.test.ts
@@ -57,11 +57,14 @@ describe('Current principal', () => {
       { providerId: 'credential' },
       { providerId: 'google' },
     ])
+    const paidThroughAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
       id: 10,
       firstName: 'Ada',
       lastName: 'Lovelace',
       subscriptionStatus: 'active',
+      paidThroughAt,
       cancelAtPeriodEnd: false,
     })
 
@@ -84,7 +87,8 @@ describe('Current principal', () => {
           active: true,
           source: 'stripe',
           status: 'active',
-          expiresAt: null,
+          expiresAt: paidThroughAt,
+          graceUntil: null,
           cancelAtPeriodEnd: false,
         },
       },

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/membership-entitlement.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/membership-entitlement.test.ts
@@ -6,41 +6,74 @@ const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
 const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 
 describe('deriveVisitorMembership', () => {
-  it('treats an active subscription as an entitled Stripe membership', () => {
-    expect(deriveVisitorMembership({ subscriptionStatus: 'active' })).toEqual({
+  it('entitles a visitor whose paid period has not ended', () => {
+    expect(deriveVisitorMembership({ subscriptionStatus: 'active', paidThroughAt: FUTURE })).toEqual({
       active: true,
       source: 'stripe',
       status: 'active',
-      expiresAt: null,
+      expiresAt: FUTURE,
+      graceUntil: null,
       cancelAtPeriodEnd: false,
     })
   })
 
   it.each([
+    ['active', FUTURE, true],
+    ['active', PAST, false],
+    ['active', null, false],
     ['cancelled', FUTURE, true],
     ['cancelled', PAST, false],
     ['cancelled', null, false],
     ['none', FUTURE, true],
     ['none', PAST, false],
     ['none', null, false],
-  ])('status %s with expiration %s → active: %s', (subscriptionStatus, membershipExpiration, active) => {
-    const membership = deriveVisitorMembership({ subscriptionStatus, membershipExpiration })
+  ])('status %s paid through %s -> active: %s', (subscriptionStatus, paidThroughAt, active) => {
+    const membership = deriveVisitorMembership({ subscriptionStatus, paidThroughAt })
 
     expect(membership.active).toBe(active)
     expect(membership.source).toBe(active ? 'stripe' : null)
     expect(membership.status).toBe(subscriptionStatus)
-    expect(membership.expiresAt).toBe(membershipExpiration)
+    expect(membership.expiresAt).toBe(paidThroughAt)
   })
 
-  it('treats past_due as not entitled, even with a future expiration', () => {
+  it('status alone never grants entitlement', () => {
+    // The regression this guards: `subscriptionStatus === 'active'` used to
+    // short-circuit to entitled, so a stale enum could outlive paid time.
+    expect(deriveVisitorMembership({ subscriptionStatus: 'active' }).active).toBe(false)
+  })
+
+  it('keeps a past_due visitor entitled while the dunning grace runs', () => {
+    // The P0 bug: one failed charge revoked access immediately, even though
+    // Stripe was still retrying the card.
     const membership = deriveVisitorMembership({
       subscriptionStatus: 'past_due',
-      membershipExpiration: FUTURE,
+      paidThroughAt: PAST,
+      dunningGraceUntil: FUTURE,
+    })
+
+    expect(membership.active).toBe(true)
+    expect(membership.source).toBe('stripe')
+    expect(membership.graceUntil).toBe(FUTURE)
+  })
+
+  it('drops a past_due visitor once the grace expires', () => {
+    const membership = deriveVisitorMembership({
+      subscriptionStatus: 'past_due',
+      paidThroughAt: PAST,
+      dunningGraceUntil: PAST,
     })
 
     expect(membership.active).toBe(false)
-    expect(membership.source).toBe(null)
-    expect(membership.status).toBe('past_due')
+  })
+
+  it('does not entitle a past_due visitor with no grace at all', () => {
+    expect(
+      deriveVisitorMembership({ subscriptionStatus: 'past_due', paidThroughAt: PAST }).active
+    ).toBe(false)
+  })
+
+  it('ignores a malformed date rather than granting access', () => {
+    expect(deriveVisitorMembership({ paidThroughAt: 'not-a-date' }).active).toBe(false)
   })
 
   it.each([null, undefined])('treats a missing profile (%s) as not entitled', (profile) => {
@@ -49,6 +82,7 @@ describe('deriveVisitorMembership', () => {
       source: null,
       status: 'none',
       expiresAt: null,
+      graceUntil: null,
       cancelAtPeriodEnd: false,
     })
   })
@@ -64,7 +98,7 @@ describe('deriveVisitorMembership', () => {
     const membership = deriveVisitorMembership({
       subscriptionStatus: 'active',
       cancelAtPeriodEnd: true,
-      membershipExpiration: FUTURE,
+      paidThroughAt: FUTURE,
     })
 
     expect(membership.active).toBe(true)

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/membership-entitlement.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/membership-entitlement.ts
@@ -2,7 +2,8 @@ export type MembershipSource = 'stripe' | null
 
 export type MembershipFields = {
   subscriptionStatus?: string | null
-  membershipExpiration?: string | null
+  paidThroughAt?: string | null
+  dunningGraceUntil?: string | null
   cancelAtPeriodEnd?: boolean | null
 }
 
@@ -11,21 +12,32 @@ export type VisitorMembership = {
   source: MembershipSource
   status: string
   expiresAt: string | null
+  graceUntil: string | null
   cancelAtPeriodEnd: boolean
 }
 
+function isFuture(value: string | null | undefined): boolean {
+  if (!value) return false
+
+  const at = new Date(value)
+  if (Number.isNaN(at.getTime())) return false
+
+  return at > new Date()
+}
+
+/**
+ * Access is a question about dates, not about Stripe's status enum (ADR-0008).
+ *
+ * Reading `subscriptionStatus` directly is what revoked a paying visitor's
+ * access the moment one renewal charge failed, while Stripe went on retrying
+ * that card for weeks. `paidThroughAt` covers time actually paid for, and
+ * `dunningGraceUntil` covers a recoverable failure; either one being in the
+ * future means the visitor is entitled.
+ */
 function hasActiveStripeMembership(profile: MembershipFields | null | undefined): boolean {
   if (!profile) return false
-  if (profile.subscriptionStatus === 'active') return true
 
-  if (
-    (profile.subscriptionStatus === 'cancelled' || profile.subscriptionStatus === 'none') &&
-    profile.membershipExpiration
-  ) {
-    return new Date(profile.membershipExpiration) > new Date()
-  }
-
-  return false
+  return isFuture(profile.paidThroughAt) || isFuture(profile.dunningGraceUntil)
 }
 
 export function deriveVisitorMembership(profile: MembershipFields | null | undefined): VisitorMembership {
@@ -35,7 +47,8 @@ export function deriveVisitorMembership(profile: MembershipFields | null | undef
     active,
     source: active ? 'stripe' : null,
     status: profile?.subscriptionStatus ?? 'none',
-    expiresAt: profile?.membershipExpiration ?? null,
+    expiresAt: profile?.paidThroughAt ?? null,
+    graceUntil: profile?.dunningGraceUntil ?? null,
     cancelAtPeriodEnd: Boolean(profile?.cancelAtPeriodEnd),
   }
 }

--- a/apps/questura/apps/server/src/shared/utils/advisory-lock.ts
+++ b/apps/questura/apps/server/src/shared/utils/advisory-lock.ts
@@ -1,0 +1,69 @@
+import { createHash } from 'node:crypto'
+import type { getPayload } from 'payload'
+import { logger } from './logger'
+
+/**
+ * Postgres advisory locks, for serialising work that spans a read, a network
+ * call and a write.
+ *
+ * Payload has no way to express "hold a row against a concurrent handler while
+ * I go and ask Stripe something", and the operation is not a single statement,
+ * so ordinary row locks do not help. Stripe delivers webhooks in parallel, so
+ * two events for the same subscription can otherwise interleave: both read the
+ * same before-state, both write, and both conclude the same transition
+ * happened and send the same email twice.
+ *
+ * This is the only raw SQL in runtime server code. It is deliberate and narrow:
+ * one lock, keyed per subscription, so unrelated visitors never contend.
+ */
+
+/** Postgres advisory locks take a bigint; hash the key into a stable signed 64-bit value. */
+function lockKey(key: string): bigint {
+  const digest = createHash('sha256').update(key).digest()
+
+  return digest.readBigInt64BE(0)
+}
+
+type Payload = Awaited<ReturnType<typeof getPayload>>
+
+/**
+ * Run `work` while holding an exclusive advisory lock on `key`.
+ *
+ * Uses a session-level lock on a dedicated pooled connection rather than a
+ * transaction-scoped one, because the work runs through Payload on its own
+ * connections. The lock is always released, including when `work` throws.
+ */
+export async function withAdvisoryLock<T>(
+  payload: Payload,
+  key: string,
+  work: () => Promise<T>
+): Promise<T> {
+  const pool = (payload.db as { pool?: { connect: () => Promise<PoolClient> } }).pool
+
+  if (!pool) {
+    // A non-postgres adapter (or a test double) cannot serialise here. Losing
+    // the lock is not worth losing the operation, so proceed unserialised.
+    logger.warn('No Postgres pool available; running without an advisory lock', { key })
+    return work()
+  }
+
+  const id = lockKey(key)
+  const client = await pool.connect()
+
+  try {
+    await client.query('SELECT pg_advisory_lock($1)', [id.toString()])
+
+    try {
+      return await work()
+    } finally {
+      await client.query('SELECT pg_advisory_unlock($1)', [id.toString()])
+    }
+  } finally {
+    client.release()
+  }
+}
+
+type PoolClient = {
+  query: (text: string, values?: unknown[]) => Promise<unknown>
+  release: () => void
+}


### PR DESCRIPTION
Stacked on #256 (which is stacked on #255).

## The bug

A visitor whose renewal charge failed lost paid access **immediately**, while Stripe went on retrying that card for ~3 weeks and would have recovered most of them.

`invoice.payment_failed` wrote `past_due`; the entitlement function honoured remaining paid time only for `cancelled` and `none`. The status enum silently became the authorization. The account page has no `past_due` branch either, so the locked-out payer saw *"Free Member"* and an Upgrade button — and could buy a second subscription.

Reproduced on a test clock; fixtures in #255.

## The fix

```
entitled = paidThroughAt > now || dunningGraceUntil > now
```

Status never grants or revokes on its own.

**Grace = 5 days, or Stripe's next retry + buffer, whichever is later.** Five days alone is not reliably enough: in the captured run the first retry landed 4d7h after the failure, so a grace measured from the start of the unpaid period expired **7 hours before** the attempt that would have saved the visitor. A test caught this while writing it.

## Webhooks become triggers, not data

Payloads render at the endpoint's API version — `2020-08-27` here, where `current_period_end` is at the subscription root — while the SDK pins `2025-08-27.basil`, where it exists only on the item. `handleSubscriptionDeleted` read the root field with no fallback: dead code against any SDK-shaped object, alive only because the account version is stale.

Every handler now refetches. One known shape, and a stale delivery writes *current* truth rather than truth as of emission.

## Consequences

- **Single writer.** Invoice handlers stop writing status, closing the hole where a late `invoice.payment_failed` could stamp `past_due` over a recovered subscription. Invoice events were never covered by the ordering guard.
- **Cancel/reactivate delegate** to resync, so responses carry derived truth. Eligibility moves to Stripe: any visitor with a live subscription may cancel — including someone in dunning, who previously got *"No active subscription found"* at the exact moment they most wanted out.
- **Emails follow state transitions**, not event types. Duplicate/stale deliveries send nothing; one cancellation no longer sends two emails; the `wasImmediate` flag derived from the corrupted field is gone.
- **Advisory lock per subscription.** Resync spans read → network call → write; without it two parallel deliveries each observe the same before-state and each decide the same transition happened. First raw SQL in runtime server code, deliberately narrow.

## Verification

- 11 new tests against **real captured payloads**, including that paid-through never exceeds the last paid period during dunning.
- 19 entitlement tests including the dunning cases.
- Webhook and payment-service suites rewritten to the new architecture.
- Full suite **656/657**; the one failure is a 5s image-processing timeout in `media/pipeline/from-source.test.ts`, untouched here, which passes in isolation (15/15) — pre-existing flakiness under parallel load.
- Lint clean; tsc unchanged at the 52 pre-existing errors, none in new code.

## Not included

- Client screens (`past_due` UI, the cancel modal that wrongly says cancellation "cannot be undone") — next PR. **Worth deploying together**, since until then the server keeps a dunning visitor entitled while the account page still calls them a free member.
- No "your payment failed" email template exists; a visitor in dunning hears nothing from us. Gap, noted, not addressed here.