### PR TITLE
account: show a payment problem as a payment problem, not as no membership

### DIFF
--- a/apps/questura/apps/client/src/features/AccountPage/components/Membership/MembershipSection.tsx
+++ b/apps/questura/apps/client/src/features/AccountPage/components/Membership/MembershipSection.tsx
@@ -59,7 +59,9 @@ export function MembershipSection({ user }: MembershipSectionProps) {
         onConfirm={vm.handleCancelSubscription}
         onClose={vm.handleCloseModal}
         isLoading={vm.isCancelling}
-        membershipExpiration={user?.membershipExpiration}
+        // Before cancelling, the paid-through date is the renewal date; the
+        // modal needs it either way to say when access actually stops.
+        membershipExpiration={user?.membershipExpiration ?? user?.subscriptionRenewsAt}
       />
     </div>
   );

--- a/apps/questura/apps/client/src/features/AccountPage/services/membership.service.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/services/membership.service.ts
@@ -91,6 +91,27 @@ export function getMembershipState(user: User | null): MembershipState {
         showReactivateButton: false,
       };
 
+    // A failed renewal is a payment problem, not the end of a membership.
+    // This case was missing entirely, so a visitor being retried by Stripe fell
+    // through to "Free Member" with an Upgrade button -- and could buy a second
+    // subscription while still holding the first.
+    case 'past_due': {
+      const graceEnds = user.dunningGraceUntil ? new Date(user.dunningGraceUntil) : null;
+      const stillCovered = Boolean(graceEnds && graceEnds > now);
+
+      return {
+        type: stillCovered ? 'payment_issue' : 'expired',
+        label: stillCovered ? 'Premium - Payment Issue' : 'Membership Expired',
+        badgeClass: 'bg-[#fff3e0] text-[#e65100] border border-[#ffe0b2]',
+        description: stillCovered
+          ? `We could not take your last payment. Your access continues until ${graceEnds!.toLocaleDateString()} while we retry — update your payment method to keep it.`
+          : 'We could not take your last payment and your premium access has ended. Update your payment method to restore it.',
+        showCancelButton: stillCovered,
+        showUpgradeButton: !stillCovered,
+        showReactivateButton: false,
+      };
+    }
+
     case 'canceled':
     case 'cancelled':
       if (isExpired) {
@@ -112,8 +133,12 @@ export function getMembershipState(user: User | null): MembershipState {
           badgeClass: 'bg-[#fff3e0] text-[#e65100] border border-[#ffe0b2]',
           description: `Your membership was cancelled but remains active until ${expirationDate.toLocaleDateString()}.`,
           showCancelButton: false,
-          showUpgradeButton: false,
-          showReactivateButton: true,
+          // Not reactivatable: this status means Stripe has already deleted the
+          // subscription, so the endpoint can only refuse. Resuming before the
+          // end date is offered by the `expiring` state above, while the
+          // subscription still exists.
+          showUpgradeButton: true,
+          showReactivateButton: false,
         };
       }
 

--- a/apps/questura/apps/client/src/features/AccountPage/types/membership.types.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/types/membership.types.ts
@@ -4,7 +4,15 @@ export interface MembershipSectionProps {
   user: User | null;
 }
 
-export type MembershipType = 'free' | 'active' | 'expiring' | 'expired' | 'cancelled' | 'inactive';
+export type MembershipType =
+  | 'free'
+  | 'active'
+  | 'expiring'
+  | 'expired'
+  | 'cancelled'
+  | 'inactive'
+  /** Renewal charge failed; Stripe is retrying and access is still covered. */
+  | 'payment_issue';
 
 export interface MembershipState {
   type: MembershipType;

--- a/apps/questura/apps/client/src/features/Payments/components/CancelSubscriptionModal.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/CancelSubscriptionModal.tsx
@@ -37,7 +37,8 @@ export function CancelSubscriptionModal({
 
         <div className="bg-[#fff3e0] border border-[#ffe0b2] rounded-sm p-3.5 mb-6">
           <p className="text-[0.84rem] text-[#e65100] leading-[1.55]">
-            <strong>Note:</strong> This action cannot be undone. You&apos;ll need to subscribe again to regain premium access.
+            <strong>Note:</strong> You can resume your membership at any time before it ends, and
+            nothing further will be charged in the meantime.
           </p>
         </div>
 

--- a/apps/questura/apps/client/src/features/Payments/hooks/useSubscriptionMutations.ts
+++ b/apps/questura/apps/client/src/features/Payments/hooks/useSubscriptionMutations.ts
@@ -7,6 +7,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { resolveCheckoutReferralId } from '../services/checkout-referral.service';
 import {
+  invalidateUser,
   invalidateUserAfterCheckout,
   applyCancelAtPeriodEndOptimisticUpdate,
   rollbackUserMutation,
@@ -35,6 +36,11 @@ export function useCancelSubscriptionMutation() {
     onError: (_error, _variables, context) => {
       rollbackUserMutation(queryClient, context);
     },
+    // The optimistic patch flips one flag; the server also moves the dates the
+    // account page renders. Without this the panel keeps showing stale ones.
+    onSettled: () => {
+      invalidateUser(queryClient);
+    },
   });
 }
 
@@ -46,6 +52,9 @@ export function useRenewSubscriptionMutation() {
     onMutate: async () => applyCancelAtPeriodEndOptimisticUpdate(queryClient, false),
     onError: (_error, _variables, context) => {
       rollbackUserMutation(queryClient, context);
+    },
+    onSettled: () => {
+      invalidateUser(queryClient);
     },
   });
 }

--- a/apps/questura/apps/client/src/features/Payments/services/subscription-cache.service.ts
+++ b/apps/questura/apps/client/src/features/Payments/services/subscription-cache.service.ts
@@ -35,6 +35,9 @@ export function rollbackUserMutation(
   }
 }
 
-export function invalidateUserAfterCheckout(queryClient: QueryClient): void {
+export function invalidateUser(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: queryKeys.userMe() });
 }
+
+/** @deprecated Use {@link invalidateUser}; kept for the checkout call site's readability. */
+export const invalidateUserAfterCheckout = invalidateUser;

--- a/apps/questura/apps/client/src/lib/user/hooks/useUserQuery.ts
+++ b/apps/questura/apps/client/src/lib/user/hooks/useUserQuery.ts
@@ -9,13 +9,19 @@ function principalToUser(response: CurrentPrincipalResponse): User | null {
   if (!response.authenticated || !response.principal) return null;
 
   const principal = response.principal;
+  const { cancelAtPeriodEnd, expiresAt } = principal.membership;
 
   return {
     ...principal,
     membershipStatusSummary: principal.membership.active ? 'active' : principal.membership.status,
     subscriptionStatus: principal.membership.status,
-    membershipExpiration: principal.membership.expiresAt,
-    cancelAtPeriodEnd: principal.membership.cancelAtPeriodEnd,
+    // One server value, two meanings, resolved here: the paid-through date is
+    // when access ends if the subscription is cancelling, and when the next
+    // charge falls due if it is not.
+    membershipExpiration: cancelAtPeriodEnd ? expiresAt : null,
+    subscriptionRenewsAt: cancelAtPeriodEnd ? null : expiresAt,
+    dunningGraceUntil: principal.membership.graceUntil,
+    cancelAtPeriodEnd,
   };
 }
 

--- a/apps/questura/apps/client/src/lib/user/types.ts
+++ b/apps/questura/apps/client/src/lib/user/types.ts
@@ -15,7 +15,10 @@ export type VisitorPrincipal = {
     active: boolean;
     source: MembershipSource;
     status: string;
+    /** End of the last period actually paid for. Not necessarily when access ends. */
     expiresAt: string | null;
+    /** Bounded extension while Stripe retries a failed renewal; null otherwise. */
+    graceUntil: string | null;
     cancelAtPeriodEnd: boolean;
   };
 };
@@ -42,6 +45,7 @@ type LegacyUserFields = {
   subscriptionStatus?: string;
   subscriptionRenewsAt?: string | null;
   membershipExpiration?: string | null;
+  dunningGraceUntil?: string | null;
   cancelAtPeriodEnd?: boolean;
   stripeCustomerId?: string | null;
   stripeSubscriptionId?: string | null;


### PR DESCRIPTION
Stacked on #257.

## Why this ships with #257

#257 keeps a visitor entitled while Stripe retries their card. Without this PR the account page still calls that visitor a **Free Member** and offers an Upgrade button — so the fix would be invisible to the person it protects, and they could buy a second subscription while holding the first.

## Changes

**The missing `past_due` case.** There was no branch for it; it fell through to the default. Now:

| grace still running | reads as |
|---|---|
| yes | "Premium - Payment Issue", names the date access ends, asks for a new payment method, offers Cancel |
| no | "Membership Expired", offers Upgrade |

**The modal was lying.** It said *"This action cannot be undone. You'll need to subscribe again to regain premium access."* Cancelling sets `cancel_at_period_end`, and the same panel renders a Reactivate button for that exact state. It now says the membership can be resumed any time before it ends and nothing further is charged.

**Cancel and renew never invalidated the user query.** The optimistic patch flips `cancelAtPeriodEnd` only, while the server also moves the dates the panel renders, so it kept showing stale ones. Both mutations now `onSettled` into an invalidation.

**Paid-through reaches the client with its meaning resolved at the read site** — end date when cancelling, renewal date when not. This also fixes a quieter bug: `subscriptionRenewsAt` was never mapped from the principal, so the renewal date could not render at all.

**Dead Reactivate button removed** for `cancelled` with time remaining — that status means Stripe already deleted the subscription, so the endpoint could only refuse. Resuming lives in the `expiring` state, while the subscription still exists.

## Verification

Client `tsc` clean (0 errors), eslint clean on all touched trees. This app has no client test infrastructure and no client job in CI, so these paths are covered by types and by verification on the real site after deploy.

## Not included

`billingPeriod` is still hardcoded `'Monthly'`. It belongs with the deferred `/purchase` price work ($12.99 and $79.99 advertised against one $0.50/mo price), not here.