### PR TITLE
payments: drop the superseded membership columns (2/2)

### DIFF
--- a/apps/questura/apps/server/src/migrations/20260814_020000_drop_legacy_membership_columns.ts
+++ b/apps/questura/apps/server/src/migrations/20260814_020000_drop_legacy_membership_columns.ts
@@ -1,0 +1,42 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Drops `visitor_profiles.subscription_renews_at` and
+ * `visitor_profiles.membership_expiration`.
+ *
+ * Both held the same Stripe value, `current_period_end`, stored under two names
+ * chosen by what was expected to happen next -- which is why neither was
+ * populated during a failed renewal, and why entitlement fell back to reading
+ * the status enum instead (ADR-0008). `paid_through_at` replaced them, and
+ * nothing has read either column since that shipped and was verified live.
+ *
+ * This is destructive and the data is not recoverable from the database. It is
+ * recoverable from Stripe, which is the actual source of truth for what a
+ * visitor paid for: `scripts/reconcile-stripe-visitor-profiles.ts` rebuilds
+ * `paid_through_at` from live subscriptions and does not consult either column.
+ * `down()` restores the columns but not their contents; run the reconcile
+ * script after a rollback rather than expecting the old values back.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      ALTER TABLE "visitor_profiles"
+        DROP COLUMN IF EXISTS "subscription_renews_at";
+
+      ALTER TABLE "visitor_profiles"
+        DROP COLUMN IF EXISTS "membership_expiration";
+    `),
+  )
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      ALTER TABLE "visitor_profiles"
+        ADD COLUMN IF NOT EXISTS "subscription_renews_at" timestamp(3) with time zone;
+
+      ALTER TABLE "visitor_profiles"
+        ADD COLUMN IF NOT EXISTS "membership_expiration" timestamp(3) with time zone;
+    `),
+  )
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -27,6 +27,7 @@ import * as migration_20260812_080000_enforce_identity_email_ownership from './2
 import * as migration_20260813_000000_add_service_accounts_preferences_rel from './20260813_000000_add_service_accounts_preferences_rel'
 import * as migration_20260813_010000_add_visitor_profile_billing_email from './20260813_010000_add_visitor_profile_billing_email'
 import * as migration_20260814_010000_add_visitor_profile_paid_through from './20260814_010000_add_visitor_profile_paid_through'
+import * as migration_20260814_020000_drop_legacy_membership_columns from './20260814_020000_drop_legacy_membership_columns'
 
 export const migrations = [
   {
@@ -173,5 +174,10 @@ export const migrations = [
     up: migration_20260814_010000_add_visitor_profile_paid_through.up,
     down: migration_20260814_010000_add_visitor_profile_paid_through.down,
     name: '20260814_010000_add_visitor_profile_paid_through',
+  },
+  {
+    up: migration_20260814_020000_drop_legacy_membership_columns.up,
+    down: migration_20260814_020000_drop_legacy_membership_columns.down,
+    name: '20260814_020000_drop_legacy_membership_columns',
   },
 ]


### PR DESCRIPTION
Half two of the split. Half one is #263 — merged and deployed (`a20d230b` live on both hosts).

Just the migration and its registration. Nothing else.

## Why this is separate

Dropping `subscription_renews_at` / `membership_expiration` while the running code still declares them makes Payload query columns that do not exist, on every login, checkout and account page load. And `check-pending-migrations.mjs` blocks *any* deploy while a destructive migration is pending — so the two could not ship together: the drop would have blocked the deploy that made the drop safe.

#263 removed the declarations and is live. The columns are now unread.

## Applying it

Not applied by a deploy. Manual procedure per `AGENTS.md` + `infra/softprod/README.md`:

1. `pg_dump -Fc` of the live DB
2. record row counts for `visitor_profiles`, `visitor_auth_*`, `users`, `locations`, `articles`, `media_assets`, `media_sets`
3. show the owner the exact two `ALTER TABLE … DROP COLUMN` statements and get explicit approval
4. apply, verify the columns are gone and the site still reads profiles
5. confirm a normal deploy passes preflight again

## Rollback restores code, not data

`down()` re-adds the columns empty. That is acceptable because neither column was a source of truth: Stripe is, and `scripts/reconcile-stripe-visitor-profiles.ts` rebuilds `paid_through_at` from live subscriptions without consulting either one.

## Verification

- `pnpm test:deploy` passes — the preflight parses this migration and classifies it `blocked (destructive SQL, column or table rewrite)`, which is the intended classification, not a failure.