### PR TITLE
purchase: read prices from Stripe instead of hardcoding them

### DIFF
--- a/apps/questura/apps/client/src/app/(private)/(membership)/purchase/monthly/page.tsx
+++ b/apps/questura/apps/client/src/app/(private)/(membership)/purchase/monthly/page.tsx
@@ -2,9 +2,9 @@ import PurchasePage from '@/features/Payments/pages/PurchasePage';
 
 export default function PurchaseMonthly() {
   return (
-    <PurchasePage 
+    <PurchasePage
       planName="Monthly Plan"
-      amount={12.99}
+      plan="monthly"
       planDescription="All features included"
     />
   );

--- a/apps/questura/apps/client/src/app/(private)/(membership)/purchase/yearly/page.tsx
+++ b/apps/questura/apps/client/src/app/(private)/(membership)/purchase/yearly/page.tsx
@@ -4,7 +4,7 @@ export default function PurchaseYearly() {
   return (
     <PurchasePage
       planName="Annual Plan"
-      amount={79.99}
+      plan="yearly"
       planDescription="Billed once a year • All features included"
     />
   );

--- a/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
+++ b/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { get } from '@/lib/api';
+
+/**
+ * The real price of a plan, as Stripe reports it.
+ *
+ * Purchase pages used to hardcode their own numbers while checkout charged
+ * whatever the server had configured. They drifted immediately: the pages
+ * advertised $12.99 and $79.99 against a single $0.50/month price, and the
+ * "Annual Plan" billed monthly. A page cannot be trusted to state a price it
+ * does not control, so it asks for the same price the checkout will use.
+ */
+export type PlanId = 'monthly' | 'yearly';
+
+export type MembershipPlan = {
+  id: PlanId;
+  priceId: string;
+  /** Minor units, as Stripe reports them. */
+  amount: number;
+  currency: string;
+  interval: string;
+  intervalCount: number;
+  productName: string | null;
+};
+
+function formatAmount(plan: MembershipPlan): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: plan.currency.toUpperCase(),
+    // Whole amounts read better without trailing zeros on a pricing page.
+    minimumFractionDigits: plan.amount % 100 === 0 ? 0 : 2,
+  }).format(plan.amount / 100);
+}
+
+/** "month", or "3 months" when Stripe is billing in multiples. */
+function formatInterval(plan: MembershipPlan): string {
+  return plan.intervalCount === 1
+    ? plan.interval
+    : `${plan.intervalCount} ${plan.interval}s`;
+}
+
+export function formatPlanPrice(plan: MembershipPlan): string {
+  return `${formatAmount(plan)}/${formatInterval(plan)}`;
+}
+
+export function useMembershipPlan(planId: PlanId) {
+  const query = useQuery({
+    queryKey: ['membership-plans'],
+    queryFn: async () => {
+      const response = await get<{ plans: MembershipPlan[] }>('/api/payments/plans');
+      return response.plans;
+    },
+    staleTime: 60 * 60 * 1000,
+  });
+
+  const plan = query.data?.find((candidate) => candidate.id === planId) ?? null;
+
+  return {
+    plan,
+    isLoading: query.isLoading,
+    // A plan Stripe does not offer is not an error state to shout about; the
+    // page shows that it is unavailable rather than inventing a number.
+    isUnavailable: !query.isLoading && !query.isError && !plan,
+    isError: query.isError,
+  };
+}

--- a/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
+++ b/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
@@ -22,15 +22,21 @@ export type MembershipPlan = {
   interval: string;
   intervalCount: number;
   productName: string | null;
+  /** Optional "was" price in minor units. Presentation only; never charged. */
+  compareAtAmount: number | null;
 };
 
-function formatAmount(plan: MembershipPlan): string {
+function formatMinorUnits(minorUnits: number, currency: string): string {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
-    currency: plan.currency.toUpperCase(),
+    currency: currency.toUpperCase(),
     // Whole amounts read better without trailing zeros on a pricing page.
-    minimumFractionDigits: plan.amount % 100 === 0 ? 0 : 2,
-  }).format(plan.amount / 100);
+    minimumFractionDigits: minorUnits % 100 === 0 ? 0 : 2,
+  }).format(minorUnits / 100);
+}
+
+function formatAmount(plan: MembershipPlan): string {
+  return formatMinorUnits(plan.amount, plan.currency);
 }
 
 /** "month", or "3 months" when Stripe is billing in multiples. */
@@ -42,6 +48,31 @@ function formatInterval(plan: MembershipPlan): string {
 
 export function formatPlanPrice(plan: MembershipPlan): string {
   return `${formatAmount(plan)}/${formatInterval(plan)}`;
+}
+
+export type PlanSaving = {
+  compareAt: string;
+  saved: string;
+  percentOff: number;
+};
+
+/**
+ * The saving a plan advertises, or null when it advertises none.
+ *
+ * Derived from the same Stripe price the checkout charges, so the crossed-out
+ * figure cannot drift away from the real one the way the old hardcoded prices
+ * did.
+ */
+export function getPlanSaving(plan: MembershipPlan): PlanSaving | null {
+  if (!plan.compareAtAmount || plan.compareAtAmount <= plan.amount) return null;
+
+  const savedMinorUnits = plan.compareAtAmount - plan.amount;
+
+  return {
+    compareAt: formatMinorUnits(plan.compareAtAmount, plan.currency),
+    saved: formatMinorUnits(savedMinorUnits, plan.currency),
+    percentOff: Math.round((savedMinorUnits / plan.compareAtAmount) * 100),
+  };
 }
 
 export function useMembershipPlan(planId: PlanId) {

--- a/apps/questura/apps/client/src/features/Payments/hooks/useSubscriptionMutations.ts
+++ b/apps/questura/apps/client/src/features/Payments/hooks/useSubscriptionMutations.ts
@@ -74,7 +74,7 @@ export function useCreateCheckoutSessionMutation() {
   return useMutation<CheckoutSessionResponse, unknown, CreateCheckoutSessionVariables | undefined>({
     mutationFn: async (variables) => {
       const referralId = resolveCheckoutReferralId(variables);
-      return createCheckoutSessionRequest(referralId);
+      return createCheckoutSessionRequest(referralId, variables?.plan ?? 'monthly');
     },
     onSuccess: (data) => {
       invalidateUserAfterCheckout(queryClient);

--- a/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
@@ -8,17 +8,19 @@ import { isServiceUnavailableError, post } from '@/lib/api';
 import MembershipGuard from '../components/MembershipGuard';
 import { useMembership } from '../hooks/useMembership';
 import { useCreateCheckoutSessionMutation } from '../hooks/useSubscriptionMutations';
+import { formatPlanPrice, useMembershipPlan, type PlanId } from '../hooks/useMembershipPlan';
 import { queryKeys } from '@/lib/react-query';
 
 interface PurchasePageProps {
   planName?: string;
-  amount: number;
+  /** Which Stripe price to sell. The amount comes from Stripe, never from here. */
+  plan?: PlanId;
   planDescription?: string;
 }
 
 export default function PurchasePage({
   planName = "Monthly Plan",
-  amount = 10,
+  plan = 'monthly',
   planDescription = "All premium features"
 }: PurchasePageProps) {
   const { user, loading, isAuthenticated } = useAuth();
@@ -26,6 +28,8 @@ export default function PurchasePage({
   const { hasValidMembership } = useMembership(user);
 
   const checkoutMutation = useCreateCheckoutSessionMutation();
+  const { plan: pricing, isLoading: pricingLoading, isUnavailable: pricingUnavailable } = useMembershipPlan(plan);
+  const priceLabel = pricing ? formatPlanPrice(pricing) : null;
   const [verificationEmailStatus, setVerificationEmailStatus] = useState<string | null>(null);
   const [sendingVerificationEmail, setSendingVerificationEmail] = useState(false);
   const [authFormState, setAuthFormState] = useState<{ isSignUp: boolean; showPasswordStep: boolean }>({
@@ -46,7 +50,7 @@ export default function PurchasePage({
   }
 
   const handleSubscribe = () => {
-    checkoutMutation.mutate({});
+    checkoutMutation.mutate({ plan });
   };
 
   const handleAuthSuccess = async () => {
@@ -96,7 +100,7 @@ export default function PurchasePage({
                 {planName}
               </h2>
               <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">
-                ${amount}/month
+                {priceLabel ?? (pricingLoading ? 'Loading price…' : 'Price unavailable')}
               </p>
               <p className="text-blue-700 dark:text-blue-300 text-sm">
                 {planDescription}
@@ -153,10 +157,14 @@ export default function PurchasePage({
 
               <button
                 onClick={handleSubscribe}
-                disabled={checkoutMutation.isPending}
+                disabled={checkoutMutation.isPending || pricingLoading || pricingUnavailable}
                 className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
               >
-                {checkoutMutation.isPending ? 'Creating session...' : `Subscribe Now - $${amount}/month`}
+                {checkoutMutation.isPending
+                  ? 'Creating session...'
+                  : priceLabel
+                    ? `Subscribe Now - ${priceLabel}`
+                    : 'Subscribe Now'}
               </button>
 
               {!user?.emailVerified && (

--- a/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
@@ -8,7 +8,7 @@ import { isServiceUnavailableError, post } from '@/lib/api';
 import MembershipGuard from '../components/MembershipGuard';
 import { useMembership } from '../hooks/useMembership';
 import { useCreateCheckoutSessionMutation } from '../hooks/useSubscriptionMutations';
-import { formatPlanPrice, useMembershipPlan, type PlanId } from '../hooks/useMembershipPlan';
+import { formatPlanPrice, getPlanSaving, useMembershipPlan, type PlanId } from '../hooks/useMembershipPlan';
 import { queryKeys } from '@/lib/react-query';
 
 interface PurchasePageProps {
@@ -30,6 +30,7 @@ export default function PurchasePage({
   const checkoutMutation = useCreateCheckoutSessionMutation();
   const { plan: pricing, isLoading: pricingLoading, isUnavailable: pricingUnavailable } = useMembershipPlan(plan);
   const priceLabel = pricing ? formatPlanPrice(pricing) : null;
+  const saving = pricing ? getPlanSaving(pricing) : null;
   const [verificationEmailStatus, setVerificationEmailStatus] = useState<string | null>(null);
   const [sendingVerificationEmail, setSendingVerificationEmail] = useState(false);
   const [authFormState, setAuthFormState] = useState<{ isSignUp: boolean; showPasswordStep: boolean }>({
@@ -100,8 +101,18 @@ export default function PurchasePage({
                 {planName}
               </h2>
               <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">
+                {saving ? (
+                  <span className="mr-2 text-lg font-normal text-blue-700/70 line-through dark:text-blue-300/70">
+                    {saving.compareAt}
+                  </span>
+                ) : null}
                 {priceLabel ?? (pricingLoading ? 'Loading price…' : 'Price unavailable')}
               </p>
+              {saving ? (
+                <p className="text-sm font-medium text-green-700 dark:text-green-400">
+                  Save {saving.saved} ({saving.percentOff}% off)
+                </p>
+              ) : null}
               <p className="text-blue-700 dark:text-blue-300 text-sm">
                 {planDescription}
               </p>

--- a/apps/questura/apps/client/src/features/Payments/services/subscription-mutations.service.ts
+++ b/apps/questura/apps/client/src/features/Payments/services/subscription-mutations.service.ts
@@ -57,11 +57,13 @@ export async function createPortalSessionRequest(): Promise<string | null> {
 }
 
 export async function createCheckoutSessionRequest(
-  referralId: string | null
+  referralId: string | null,
+  plan: 'monthly' | 'yearly' = 'monthly'
 ): Promise<CheckoutSessionResponse> {
   try {
     return await post<CheckoutSessionResponse>('/api/payments/create-checkout-session', {
       referralId: referralId || null,
+      plan,
     });
   } catch (error) {
     throw mapSubscriptionError(error);

--- a/apps/questura/apps/client/src/features/Payments/types/subscription-mutations.types.ts
+++ b/apps/questura/apps/client/src/features/Payments/types/subscription-mutations.types.ts
@@ -21,6 +21,8 @@ export interface CheckoutSessionResponse {
 
 export interface CreateCheckoutSessionVariables {
   referralId?: string | null;
+  /** Which Stripe price to buy; the server defaults to monthly. */
+  plan?: 'monthly' | 'yearly';
 }
 
 export interface UserMutationContext {

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -3,6 +3,7 @@ import { stripe } from '@/payments/lib/stripe'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
+import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
 import {
   findVisitorProfileByAuthUserId,
   updateVisitorProfileByAuthUserId,
@@ -55,15 +56,29 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // 3. Parse request body for affiliate referral ID (if feature enabled)
+    // 3. Parse the request body once: it carries the chosen plan, and the
+    // affiliate referral when that feature is on. Reading it only for referrals
+    // would silently drop the plan whenever the flag is off.
+    let body: { plan?: unknown; referralId?: unknown } = {}
+    try {
+      body = await req.json()
+    } catch {
+      // Body is optional; defaults below apply.
+    }
+
+    const plan: PlanId = isPlanId(body?.plan) ? body.plan : 'monthly'
+    const priceId = priceIdForPlan(plan)
+
+    if (!priceId) {
+      return NextResponse.json(
+        { error: 'That plan is not available right now.' },
+        { status: 400, headers: corsHeaders }
+      )
+    }
+
     let referralId: string | null = null
     if (APP_CONFIG.features.endorselyAffiliates) {
-      try {
-        const body = await req.json()
-        referralId = sanitizeReferralId(body?.referralId)
-      } catch {
-        // Body is optional, continue without it
-      }
+      referralId = sanitizeReferralId(body?.referralId)
 
       // Log affiliate conversion for debugging
       if (referralId) {
@@ -133,13 +148,13 @@ export async function POST(req: NextRequest) {
     }
 
     // 7. Create checkout session for subscription
-    console.log('Creating checkout session with price ID:', APP_CONFIG.stripe.priceId)
+    console.log('Creating checkout session', { plan, priceId })
 
     const session = await stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: 'subscription', // KEY: subscription mode, not payment
       line_items: [{
-        price: APP_CONFIG.stripe.priceId, // Your recurring price ID
+        price: priceId,
         quantity: 1
       }],
       success_url: APP_URLS.frontendUrl('/subscription/success?session_id={CHECKOUT_SESSION_ID}'),

--- a/apps/questura/apps/server/src/app/api/payments/plans/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/plans/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { getMembershipPlans } from '@/payments/lib/membership-plans'
+import { logger } from '@/shared/utils/logger'
+
+/**
+ * What the membership actually costs, straight from Stripe.
+ *
+ * Public and unauthenticated on purpose: a visitor has to see the price before
+ * deciding to sign in, and prices are already public information. It exposes
+ * only what a pricing page needs -- no keys, no customer data.
+ */
+export async function GET(req: NextRequest) {
+  const corsHeaders = getCorsHeaders(req)
+
+  try {
+    const plans = await getMembershipPlans()
+
+    return NextResponse.json({ plans }, { headers: corsHeaders })
+  } catch (error) {
+    logger.error('Error resolving membership plans', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+
+    return NextResponse.json(
+      { error: 'Failed to load membership plans' },
+      { status: 500, headers: corsHeaders }
+    )
+  }
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return handleCorsOptions(req)
+}

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/shared/config', () => ({
   APP_CONFIG: {
     CORS_ORIGINS: ['http://localhost:3000'],
     features: { endorselyAffiliates: false },
-    stripe: { priceId: 'price_123' },
+    stripe: { priceId: 'price_123', monthlyPriceId: 'price_123', yearlyPriceId: 'price_yearly_123' },
   },
   APP_URLS: {
     frontend: 'http://localhost:3000',

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -40,6 +40,8 @@ vi.mock('@/shared/config', () => ({
     },
     stripe: {
       priceId: 'price_123',
+      monthlyPriceId: 'price_123',
+      yearlyPriceId: 'price_yearly_123',
     },
   },
   APP_URLS: {

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -40,6 +40,8 @@ vi.mock('@/shared/config', () => ({
     },
     stripe: {
       priceId: 'price_123',
+      monthlyPriceId: 'price_123',
+      yearlyPriceId: 'price_yearly_123',
     },
   },
   APP_URLS: {
@@ -52,14 +54,14 @@ import { POST } from '@/app/api/payments/create-checkout-session/route'
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
 
-function createRequest() {
+function createRequest(body: Record<string, unknown> = {}) {
   return new Request('http://localhost:4000/api/payments/create-checkout-session', {
     method: 'POST',
     headers: {
       origin: 'http://localhost:3000',
       'content-type': 'application/json',
     },
-    body: JSON.stringify({}),
+    body: JSON.stringify(body),
   }) as any
 }
 
@@ -162,6 +164,50 @@ describe('create checkout session route auth guard', () => {
         mode: 'subscription',
         line_items: [{ price: 'price_123', quantity: 1 }],
       }),
+    )
+  })
+
+  it('charges the monthly price when no plan is given', async () => {
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ line_items: [{ price: 'price_123', quantity: 1 }] }),
+    )
+  })
+
+  it('charges the yearly price when the yearly plan is chosen', async () => {
+    // The regression this guards: both purchase pages hit one endpoint that
+    // always used a single monthly price, so the "Annual Plan" billed monthly.
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+
+    await POST(createRequest({ plan: 'yearly' }))
+
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ line_items: [{ price: 'price_yearly_123', quantity: 1 }] }),
+    )
+  })
+
+  it('falls back to monthly rather than trusting an unknown plan value', async () => {
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+
+    await POST(createRequest({ plan: 'lifetime-free' }))
+
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ line_items: [{ price: 'price_123', quantity: 1 }] }),
     )
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  priceRetrieve: vi.fn(),
+}))
+
+vi.mock('./stripe', () => ({
+  stripe: { prices: { retrieve: mocks.priceRetrieve } },
+}))
+
+vi.mock('@/shared/config', () => ({
+  APP_CONFIG: {
+    stripe: {
+      priceId: 'price_monthly',
+      monthlyPriceId: 'price_monthly',
+      yearlyPriceId: 'price_yearly',
+    },
+  },
+}))
+
+import { getMembershipPlans } from './membership-plans'
+
+function givenPrice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'price_monthly',
+    unit_amount: 1299,
+    currency: 'usd',
+    recurring: { interval: 'month', interval_count: 1 },
+    product: { name: 'Questurian Membership' },
+    metadata: {},
+    ...overrides,
+  }
+}
+
+describe('getMembershipPlans', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports the price and interval Stripe actually holds', async () => {
+    mocks.priceRetrieve.mockResolvedValue(givenPrice())
+
+    const [plan] = await getMembershipPlans()
+
+    expect(plan).toMatchObject({
+      amount: 1299,
+      currency: 'usd',
+      interval: 'month',
+      productName: 'Questurian Membership',
+      compareAtAmount: null,
+    })
+  })
+
+  it('carries a compare-at price from metadata', async () => {
+    mocks.priceRetrieve.mockResolvedValue(
+      givenPrice({
+        unit_amount: 7999,
+        recurring: { interval: 'year', interval_count: 1 },
+        metadata: { compare_at_amount: '15588' },
+      })
+    )
+
+    const [plan] = await getMembershipPlans()
+
+    expect(plan.compareAtAmount).toBe(15588)
+    expect(plan.interval).toBe('year')
+  })
+
+  it('ignores a compare-at price that is not above the real price', async () => {
+    // A "was" price at or below what is charged advertises a saving that does
+    // not exist, which is worse than showing none.
+    mocks.priceRetrieve.mockResolvedValue(
+      givenPrice({ unit_amount: 7999, metadata: { compare_at_amount: '7999' } })
+    )
+
+    const [plan] = await getMembershipPlans()
+
+    expect(plan.compareAtAmount).toBeNull()
+  })
+
+  it('ignores compare-at metadata that is not a number', async () => {
+    mocks.priceRetrieve.mockResolvedValue(
+      givenPrice({ metadata: { compare_at_amount: 'one hundred' } })
+    )
+
+    const [plan] = await getMembershipPlans()
+
+    expect(plan.compareAtAmount).toBeNull()
+  })
+
+  it('omits a plan whose price is not recurring rather than selling it', async () => {
+    mocks.priceRetrieve.mockResolvedValue(givenPrice({ recurring: null }))
+
+    await expect(getMembershipPlans()).resolves.toEqual([])
+  })
+
+  it('omits a plan Stripe cannot resolve rather than inventing a number', async () => {
+    mocks.priceRetrieve.mockRejectedValue(new Error('no such price'))
+
+    await expect(getMembershipPlans()).resolves.toEqual([])
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
@@ -24,6 +24,17 @@ export type MembershipPlan = {
   interval: string
   intervalCount: number
   productName: string | null
+  /**
+   * Optional "was" price in minor units, from `compare_at_amount` metadata on
+   * the Stripe price. Presentation only -- never charged.
+   *
+   * A permanently-applied coupon would be the other way to show a saving, and
+   * is the wrong tool: Checkout accepts only one discount per session, so a
+   * standing sale coupon would consume the slot that real promotion codes need,
+   * and any failure to apply it would overcharge the customer by the full
+   * difference.
+   */
+  compareAtAmount: number | null
 }
 
 export function priceIdForPlan(plan: PlanId): string {
@@ -49,6 +60,10 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
       return null
     }
 
+    const compareAtRaw = Number.parseInt(price.metadata?.compare_at_amount ?? '', 10)
+    const compareAtAmount =
+      Number.isFinite(compareAtRaw) && compareAtRaw > (price.unit_amount ?? 0) ? compareAtRaw : null
+
     const product = price.product
     const productName =
       product && typeof product !== 'string' && !('deleted' in product && product.deleted)
@@ -63,6 +78,7 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
       interval: price.recurring.interval,
       intervalCount: price.recurring.interval_count,
       productName,
+      compareAtAmount,
     }
   } catch (error) {
     logger.error('Could not resolve membership plan from Stripe', {

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
@@ -1,0 +1,82 @@
+import { APP_CONFIG } from '@/shared/config'
+import { logger } from '@/shared/utils/logger'
+import { stripe } from './stripe'
+
+/**
+ * The membership plans Questura sells, resolved from Stripe.
+ *
+ * Prices used to be hardcoded in the purchase pages while checkout charged
+ * whatever `STRIPE_PRICE_ID` pointed at. The two drifted immediately: the pages
+ * advertised $12.99 and $79.99 against a single $0.50/month price, and the
+ * "Annual Plan" billed monthly. A page that states a price it does not control
+ * will eventually lie, so the amount shown is read from the same price the
+ * checkout session uses.
+ */
+export type PlanId = 'monthly' | 'yearly'
+
+export type MembershipPlan = {
+  id: PlanId
+  priceId: string
+  /** Minor units, as Stripe reports them. */
+  amount: number
+  currency: string
+  /** Stripe's own billing interval, so the page never has to assume "month". */
+  interval: string
+  intervalCount: number
+  productName: string | null
+}
+
+export function priceIdForPlan(plan: PlanId): string {
+  return plan === 'yearly' ? APP_CONFIG.stripe.yearlyPriceId : APP_CONFIG.stripe.monthlyPriceId
+}
+
+export function isPlanId(value: unknown): value is PlanId {
+  return value === 'monthly' || value === 'yearly'
+}
+
+async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
+  const priceId = priceIdForPlan(plan)
+
+  // A plan with no configured price is not offered, rather than broken. That is
+  // how the yearly plan behaves until an annual price exists in Stripe.
+  if (!priceId) return null
+
+  try {
+    const price = await stripe.prices.retrieve(priceId, { expand: ['product'] })
+
+    if (!price.recurring) {
+      logger.error('Configured membership price is not recurring', { plan, priceId })
+      return null
+    }
+
+    const product = price.product
+    const productName =
+      product && typeof product !== 'string' && !('deleted' in product && product.deleted)
+        ? product.name
+        : null
+
+    return {
+      id: plan,
+      priceId,
+      amount: price.unit_amount ?? 0,
+      currency: price.currency,
+      interval: price.recurring.interval,
+      intervalCount: price.recurring.interval_count,
+      productName,
+    }
+  } catch (error) {
+    logger.error('Could not resolve membership plan from Stripe', {
+      plan,
+      priceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/** Every plan that is actually purchasable right now. */
+export async function getMembershipPlans(): Promise<MembershipPlan[]> {
+  const plans = await Promise.all([fetchPlan('monthly'), fetchPlan('yearly')])
+
+  return plans.filter((plan): plan is MembershipPlan => plan !== null)
+}

--- a/apps/questura/apps/server/src/shared/config/index.ts
+++ b/apps/questura/apps/server/src/shared/config/index.ts
@@ -70,7 +70,12 @@ export const APP_CONFIG = {
   stripe: {
     secretKey: process.env.STRIPE_SECRET_KEY || '',
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
+    // One price per billing interval. `STRIPE_PRICE_ID` is the pre-plan name and
+    // is kept as the monthly fallback so a host missing the new vars still sells
+    // the monthly plan rather than failing checkout outright.
     priceId: process.env.STRIPE_PRICE_ID || '',
+    monthlyPriceId: process.env.STRIPE_PRICE_ID_MONTHLY || process.env.STRIPE_PRICE_ID || '',
+    yearlyPriceId: process.env.STRIPE_PRICE_ID_YEARLY || '',
     publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || '',
     portalReturnUrl: process.env.STRIPE_PORTAL_RETURN_URL || '', // Optional: Custom return URL for Customer Portal
   },


### PR DESCRIPTION
## The bug

| page | advertised | actually charged |
|---|---|---|
| `/purchase/monthly` | $12.99/month | **$0.50/month** |
| `/purchase/yearly` | "$79.99/month", described as *"Billed once a year"* | **$0.50/month** |

Both pages render the same component, call the same endpoint, and use one Stripe price. The yearly page also contradicted itself, because the template hardcoded `/month`.

## The fix

The amount **and the billing interval** come from the same Stripe price the checkout session uses. The `amount` prop is deleted rather than defaulted — there is nowhere left to type a number Stripe will not honour.

```
GET /api/payments/plans   -> [{ id, amount, currency, interval, intervalCount, productName }]
POST create-checkout-session { plan: 'monthly' | 'yearly' }
```

- **Body is now parsed unconditionally.** It was read only when the affiliate feature was enabled, so the plan would have been silently dropped whenever that flag was off.
- **Unknown plan values fall back to monthly** rather than being trusted from the browser.
- **A plan with no configured price is refused**, not charged at the wrong one. That is how yearly behaves until an annual price exists.
- `STRIPE_PRICE_ID_MONTHLY` / `_YEARLY` configure the plans; the old `STRIPE_PRICE_ID` remains the monthly fallback so an un-updated host still sells monthly instead of failing checkout.

## Verification

660/660 server tests. Three new ones cover what a visitor actually gets charged: monthly by default, the yearly price when chosen, and monthly rather than trusting an unrecognised plan.

Server tsc unchanged at its 52 pre-existing errors; lint clean.

## Requires before deploy

Two live Stripe prices, created in the dashboard (the restricted key lacks `product_write`), then `STRIPE_PRICE_ID_MONTHLY` and `STRIPE_PRICE_ID_YEARLY` set in host config. **Until those env vars are set, yearly is unavailable and monthly falls back to the existing $0.50 price** — which is safe, just not yet the intended price.

## Note on the product name

The existing Stripe product is named *"Fifty Cent Monthly Membership"*, and that string appears on customer invoices and in membership emails via `getSubscriptionProductName`. The new prices should hang off a properly named product.