### PR TITLE
payments: link Stripe customers by ownership, not by email

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/payments/lib/stripe'
+import { resolveStripeCustomerForVisitor } from '@/payments/lib/customer-linkage'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
@@ -90,40 +91,35 @@ export async function POST(req: NextRequest) {
     let stripeCustomerId = profile?.stripeCustomerId ?? null
 
     if (!stripeCustomerId) {
-      // The profile carries no Stripe linkage, but that does not mean this human
-      // is new to Stripe. A `visitor-profiles` row can be hard-deleted by an
-      // admin, or lost, while the Better Auth user lives on; the next `/api/me`
-      // silently recreates a blank profile without `stripeCustomerId`. Creating
-      // unconditionally here would then bill the same person through a second
-      // Stripe customer, splitting their billing history and leaving the
-      // original subscription orphaned. Adopt an existing customer first.
-      const existing = await stripe.customers.list({ email: visitor.email, limit: 1 })
-      const adopted = existing.data[0]
+      const resolved = await resolveStripeCustomerForVisitor({
+        email: visitor.email,
+        visitorAuthUserId,
+        visitorProfileId: visitor.profileId,
+        name:
+          visitor.firstName && visitor.lastName
+            ? `${visitor.firstName} ${visitor.lastName}`
+            : visitor.email,
+      })
 
-      if (adopted) {
-        stripeCustomerId = adopted.id
-        console.log('Adopted existing Stripe customer by email:', stripeCustomerId)
+      stripeCustomerId = resolved.customerId
+      console.log(
+        resolved.created
+          ? 'Created Stripe customer:'
+          : 'Recovered this visitor\'s existing Stripe customer:',
+        stripeCustomerId
+      )
 
-        // Re-link the profile so the lookup above succeeds next time.
-        await updateVisitorProfileByAuthUserId(visitorAuthUserId, { stripeCustomerId })
-      } else {
-        console.log('Creating new Stripe customer for visitor:', visitorAuthUserId)
+      // Re-link the profile so the lookup above succeeds next time. A missing
+      // profile row means nothing stores the linkage, and the payment that
+      // follows would land on a customer no profile points at — worth shouting
+      // about, since only the logs can connect the charge back to the visitor.
+      const linked = await updateVisitorProfileByAuthUserId(visitorAuthUserId, { stripeCustomerId })
 
-        const customer = await stripe.customers.create({
-          email: visitor.email,
-          name: visitor.firstName && visitor.lastName ? `${visitor.firstName} ${visitor.lastName}` : visitor.email,
-          metadata: {
-            visitorAuthUserId,
-            visitorProfileId: String(visitor.profileId ?? ''),
-          }
-        })
-
-        stripeCustomerId = customer.id
-        console.log('Created Stripe customer:', stripeCustomerId)
-
-        await updateVisitorProfileByAuthUserId(visitorAuthUserId, { stripeCustomerId })
-
-        console.log('Updated VisitorProfile with stripeCustomerId')
+      if (!linked) {
+        console.error(
+          'Could not link Stripe customer to a visitor profile; no profile row for auth user',
+          { visitorAuthUserId, stripeCustomerId }
+        )
       }
     } else {
       console.log('Using existing Stripe customer:', stripeCustomerId)

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -85,6 +85,7 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     })
     mocks.stripeCustomerCreate.mockResolvedValue({ id: 'cus_new' })
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
     mocks.stripeCheckoutCreate.mockResolvedValue({
       id: 'cs_123',
       url: 'https://checkout.stripe.test/session',
@@ -95,15 +96,17 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     consoleLogSpy?.mockRestore()
   })
 
-  it('adopts an existing Stripe customer instead of creating a second one', async () => {
-    mocks.stripeCustomerList.mockResolvedValue({ data: [{ id: 'cus_existing' }] })
+  it('recovers a customer this visitor owns instead of creating a second one', async () => {
+    mocks.stripeCustomerList.mockResolvedValue({
+      data: [{ id: 'cus_existing', metadata: { visitorAuthUserId: 'visitor_123' } }],
+    })
 
     const response = await POST(createRequest())
 
     expect(response.status).toBe(200)
     expect(mocks.stripeCustomerList).toHaveBeenCalledWith({
       email: 'visitor@example.com',
-      limit: 1,
+      limit: 10,
     })
     expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
@@ -111,14 +114,96 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     )
   })
 
-  it('re-links the recovered profile to the adopted customer', async () => {
-    mocks.stripeCustomerList.mockResolvedValue({ data: [{ id: 'cus_existing' }] })
+  it('re-links the recovered profile to the recovered customer', async () => {
+    mocks.stripeCustomerList.mockResolvedValue({
+      data: [{ id: 'cus_existing', metadata: { visitorAuthUserId: 'visitor_123' } }],
+    })
 
     await POST(createRequest())
 
     expect(mocks.updateVisitorProfileByAuthUserId).toHaveBeenCalledWith('visitor_123', {
       stripeCustomerId: 'cus_existing',
     })
+  })
+
+  // The address is not the person. A Stripe customer's email is frozen at
+  // creation, so an address a visitor has since changed away from stays on
+  // their customer and is free for the next signup to register.
+  it('never takes over a customer belonging to a different visitor', async () => {
+    mocks.stripeCustomerList.mockResolvedValue({
+      data: [{ id: 'cus_someone_else', metadata: { visitorAuthUserId: 'visitor_999' } }],
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.stripeCustomerCreate).toHaveBeenCalledTimes(1)
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: 'cus_new' })
+    )
+    expect(mocks.updateVisitorProfileByAuthUserId).toHaveBeenCalledWith('visitor_123', {
+      stripeCustomerId: 'cus_new',
+    })
+  })
+
+  // Customers created by hand in the Dashboard, or imported, carry no ownership
+  // metadata. Unclaimed is not the same as ours.
+  it('never takes over an unattributed customer', async () => {
+    mocks.stripeCustomerList.mockResolvedValue({
+      data: [{ id: 'cus_legacy', metadata: {} }, { id: 'cus_legacy_2' }],
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.stripeCustomerCreate).toHaveBeenCalledTimes(1)
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: 'cus_new' })
+    )
+  })
+
+  // Duplicates share the address, so the visitor's own customer is not
+  // necessarily the newest one Stripe returns.
+  it('picks its own customer out of a same-email crowd', async () => {
+    mocks.stripeCustomerList.mockResolvedValue({
+      data: [
+        { id: 'cus_newest_stranger', metadata: { visitorAuthUserId: 'visitor_999' } },
+        { id: 'cus_legacy' },
+        { id: 'cus_mine', metadata: { visitorAuthUserId: 'visitor_123' } },
+      ],
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: 'cus_mine' })
+    )
+  })
+
+  it('stamps ownership metadata on every customer it creates', async () => {
+    await POST(createRequest())
+
+    expect(mocks.stripeCustomerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'visitor@example.com',
+        metadata: { visitorAuthUserId: 'visitor_123', visitorProfileId: '10' },
+      })
+    )
+  })
+
+  // Without a profile row nothing stores the linkage, so the charge that
+  // follows would land on a customer no profile points at.
+  it('shouts when the linkage cannot be persisted', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue(null)
+
+    await POST(createRequest())
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Could not link Stripe customer'),
+      expect.objectContaining({ visitorAuthUserId: 'visitor_123' })
+    )
+
+    consoleErrorSpy.mockRestore()
   })
 
   it('creates a customer when the email is genuinely new to Stripe', async () => {

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -70,6 +70,7 @@ describe('create checkout session referral ID validation', () => {
     vi.clearAllMocks()
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
     mocks.requireVisitorPrincipal.mockResolvedValue({
       result: { authenticated: true },
       principal: {

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -75,6 +75,7 @@ describe('create checkout session route auth guard', () => {
     })
     mocks.stripeCustomerCreate.mockResolvedValue({ id: 'cus_123' })
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
     mocks.stripeCheckoutCreate.mockResolvedValue({
       id: 'cs_123',
       url: 'https://checkout.stripe.test/session',

--- a/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
+++ b/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  stripeCustomerUpdate: vi.fn(),
+}))
+
+vi.mock('@/payments/lib/stripe', () => ({
+  stripe: {
+    customers: {
+      update: mocks.stripeCustomerUpdate,
+    },
+  },
+}))
+
+import { syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
+
+describe('syncStripeCustomerEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mocks.stripeCustomerUpdate.mockResolvedValue({ id: 'cus_123' })
+  })
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore()
+  })
+
+  it('writes the new address onto the linked customer', async () => {
+    await expect(syncStripeCustomerEmail('cus_123', 'new@example.com')).resolves.toBe(true)
+
+    expect(mocks.stripeCustomerUpdate).toHaveBeenCalledWith('cus_123', {
+      email: 'new@example.com',
+    })
+  })
+
+  it('does nothing for a visitor who has never reached Stripe', async () => {
+    await expect(syncStripeCustomerEmail(null, 'new@example.com')).resolves.toBe(false)
+    await expect(syncStripeCustomerEmail(undefined, 'new@example.com')).resolves.toBe(false)
+
+    expect(mocks.stripeCustomerUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does nothing without an address to write', async () => {
+    await expect(syncStripeCustomerEmail('cus_123', null)).resolves.toBe(false)
+
+    expect(mocks.stripeCustomerUpdate).not.toHaveBeenCalled()
+  })
+
+  // This runs inside email verification: a Stripe outage must not cost someone
+  // their verified address.
+  it('survives a Stripe failure instead of failing verification', async () => {
+    mocks.stripeCustomerUpdate.mockRejectedValue(new Error('stripe is down'))
+
+    await expect(syncStripeCustomerEmail('cus_123', 'new@example.com')).resolves.toBe(false)
+    expect(consoleErrorSpy).toHaveBeenCalled()
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -1,0 +1,106 @@
+import type Stripe from 'stripe'
+
+import { stripe } from './stripe'
+
+/**
+ * How many same-email customers to inspect when hunting for the one this
+ * visitor owns. Stripe returns newest first; a handful is enough to survive
+ * accidental duplicates without paging the whole account.
+ */
+const CUSTOMER_SEARCH_LIMIT = 10
+
+export type ResolvedStripeCustomer = {
+  customerId: string
+  /** True when no owned customer existed and a fresh one was created. */
+  created: boolean
+}
+
+/**
+ * Email alone never proves ownership.
+ *
+ * A Stripe customer's email is written once, at creation, and nothing syncs it
+ * afterwards — so a visitor who changes their account address leaves their old
+ * address sitting on their customer, free for the next signup to claim. This
+ * account also predates the site and holds customers created by hand. Matching
+ * on email alone would hand a stranger's card, invoices and portal to whoever
+ * registers that address next, and — because two profiles may then carry the
+ * same `stripeCustomerId` — would let their subscription webhooks land on the
+ * wrong profile.
+ *
+ * `metadata.visitorAuthUserId` is stamped by us at creation and is the only
+ * claim of ownership we trust. A legacy customer without it is treated as
+ * someone else's: the visitor gets a new customer, and the old one can be
+ * merged by hand in the Dashboard if it really was theirs.
+ */
+function isOwnedBy(customer: Stripe.Customer, visitorAuthUserId: string): boolean {
+  return customer.metadata?.visitorAuthUserId === visitorAuthUserId
+}
+
+/**
+ * Push a visitor's current address onto their Stripe customer.
+ *
+ * Stripe writes a customer's email once and never hears about a change, so
+ * without this every address change leaves the old one stranded on the customer
+ * — the drift `isOwnedBy` exists to survive. Keeping the two in step also keeps
+ * Stripe's receipts and dunning mail going somewhere the visitor still reads.
+ *
+ * Best-effort by design: this runs inside email verification, and a Stripe
+ * outage must not cost someone their verified address.
+ */
+export async function syncStripeCustomerEmail(
+  stripeCustomerId: string | null | undefined,
+  email: string | null | undefined
+): Promise<boolean> {
+  if (!stripeCustomerId || !email) return false
+
+  try {
+    await stripe.customers.update(stripeCustomerId, { email })
+    return true
+  } catch (error) {
+    console.error('Failed to sync visitor email to Stripe customer', {
+      stripeCustomerId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+/**
+ * Find the Stripe customer this visitor owns, or create one.
+ *
+ * Callers must persist the returned id on the visitor profile; the lookup here
+ * is a recovery path for a lost linkage, not a substitute for storing it.
+ */
+export async function resolveStripeCustomerForVisitor(params: {
+  email: string
+  visitorAuthUserId: string
+  visitorProfileId?: string | number | null
+  name?: string | null
+}): Promise<ResolvedStripeCustomer> {
+  const { email, visitorAuthUserId, visitorProfileId, name } = params
+
+  // The profile carries no Stripe linkage, but that does not mean this human is
+  // new to Stripe. A `visitor-profiles` row can be hard-deleted by an admin, or
+  // lost, while the Better Auth user lives on; the next `/api/me` silently
+  // recreates a blank profile without `stripeCustomerId`. Creating
+  // unconditionally would then bill the same person through a second Stripe
+  // customer, splitting their billing history and leaving the original
+  // subscription orphaned. Adopt their own customer first — theirs only.
+  const existing = await stripe.customers.list({ email, limit: CUSTOMER_SEARCH_LIMIT })
+  const owned = (existing.data ?? []).find((customer) => isOwnedBy(customer, visitorAuthUserId))
+
+  if (owned) {
+    return { customerId: owned.id, created: false }
+  }
+
+  const customer = await stripe.customers.create({
+    email,
+    name: name || email,
+    metadata: {
+      visitorAuthUserId,
+      visitorProfileId: String(visitorProfileId ?? ''),
+    },
+  })
+
+  return { customerId: customer.id, created: true }
+}

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
@@ -6,6 +6,7 @@ import { Pool } from 'pg'
 
 import config from '@/payload.config'
 import { sendPasswordResetLinkEmail, sendVisitorEmailVerificationLinkEmail } from '@/emails'
+import { syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { normalizeEmail } from '@/shared/lib/normalize-email'
 import { redisSecondaryStorage } from './redis-secondary-storage'
@@ -130,9 +131,17 @@ export const visitorAuth = betterAuth({
       }
     },
     afterEmailVerification: async (user) => {
-      await updateVisitorProfileByAuthUserId(user.id, {
-        email: normalizeEmail(user.email),
-      })
+      const email = normalizeEmail(user.email)
+      const profile = await updateVisitorProfileByAuthUserId(user.id, { email })
+
+      // This is also where an email *change* lands, and Stripe never learns of
+      // one on its own: a customer's address is written at creation and left
+      // there. Leaving it stale strands the old address on a live customer,
+      // where the next person to register it could be mistaken for its owner.
+      await syncStripeCustomerEmail(
+        typeof profile?.stripeCustomerId === 'string' ? profile.stripeCustomerId : null,
+        email
+      )
     },
   },
   socialProviders: googleProvider,


### PR DESCRIPTION
## The bug

`create-checkout-session` adopted whichever Stripe customer shared the visitor's email address, with no ownership check:

```ts
const existing = await stripe.customers.list({ email: visitor.email, limit: 1 })
const adopted = existing.data[0]
if (adopted) { stripeCustomerId = adopted.id; /* linked */ }
```

An address is not a person. A Stripe customer's email is written once, at creation, and nothing syncs it afterwards — so an address a visitor changes away from stays on their customer, free for the next signup to register. `/change-email` is enabled and reachable today (verified against better-auth 1.6.11's `change-email` → `verify-email` path), and this account predates the site, so it also holds customers created by hand.

**Impact when it fires:** the new visitor's checkout and Customer Portal sit on someone else's customer — their cards, their invoices — and two profiles end up carrying one `stripeCustomerId`. Every webhook resolves a profile through `findVisitorProfileByStripeCustomerId` (`limit: 1`, no ordering), so whose membership a payment grants, or a cancellation revokes, becomes a coin toss.

**Damage so far: none.** `visitor_profiles` on soft-prod holds 3 rows, 2 linked, 0 duplicate customer ids.

## The fix

Ownership is `metadata.visitorAuthUserId` — stamped by us at creation, the only claim we trust. A legacy customer without it is treated as someone else's: the visitor gets a new customer. That splits billing history, which is the cheaper mistake. The same-email search widened from 1 to 10, because duplicates would otherwise hide the customer the visitor actually owns.

Both live customers were checked and now carry matching `visitorAuthUserId` (one was legacy, holding only `payloadUserId`), so this change cannot mint a duplicate for either of them.

Two things around it:

- **Email sync.** Verifying an email now pushes the address to Stripe, so the two stop drifting apart at the source. Best-effort — a Stripe outage must not cost someone their verified address.
- **Linkage failure was silent.** A missing profile row meant nothing stored the customer id and the charge that followed landed on a customer no profile pointed at. It now logs an error.

## Follow-ups, not in here

- A unique index on `stripe_customer_id` — separate PR, because a pending migration containing `DROP`/`TRUNCATE` blocks every deploy, this one included.
- Webhooks could fall back to `session.metadata.visitorAuthUserId` when the customer lookup misses, which would make the paid-but-no-profile case self-healing rather than a log line.

## Verification

`pnpm vitest run` — 95 files, 676 tests, all passing. `pnpm typecheck` clean. The old test asserted the unsafe behaviour and was rewritten; added cases for the cross-visitor takeover, unattributed legacy customers, picking one's own customer out of a same-email crowd, the metadata stamp, the linkage-failure log, and 4 for the email sync.