### PR TITLE
payments: one profile per Stripe customer

### DIFF
--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
@@ -133,9 +133,15 @@ export const VisitorProfiles: CollectionConfig = {
           type: 'row',
           fields: [
             {
+              // One customer, one profile. Subscription webhooks resolve a
+              // profile from the customer id alone, so a second profile holding
+              // the same id makes that lookup a coin toss: someone else's
+              // payment could grant, or revoke, this visitor's membership.
+              // The database is the only place that can refuse the second row.
               name: 'stripeCustomerId',
               type: 'text',
               index: true,
+              unique: true,
             },
             {
               name: 'stripeSubscriptionId',

--- a/apps/questura/apps/server/src/migrations/20260814_030000_unique_visitor_profile_stripe_customer_id.ts
+++ b/apps/questura/apps/server/src/migrations/20260814_030000_unique_visitor_profile_stripe_customer_id.ts
@@ -1,0 +1,48 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Makes `visitor_profiles.stripe_customer_id` unique.
+ *
+ * Subscription webhooks resolve a profile from the Stripe customer id alone
+ * (`findVisitorProfileByStripeCustomerId`, a `limit: 1` query with no
+ * ordering). A second profile carrying the same customer id therefore makes
+ * that lookup a coin toss: one person's payment could grant — or one person's
+ * cancellation revoke — another person's membership, and the customer portal
+ * would show them each other's cards and invoices.
+ *
+ * Application code no longer links a customer it cannot prove the visitor owns
+ * (`payments/lib/customer-linkage.ts`), but only the database can refuse the
+ * second row. Postgres permits any number of NULLs under a unique index, so
+ * visitors who have never reached Stripe are unaffected.
+ *
+ * Additive on purpose. The natural form of this change — drop the plain index,
+ * recreate it unique — trips the `DROP` guard in
+ * `scripts/deploy/check-pending-migrations.mjs` and blocks every deploy until
+ * someone applies it by hand on the host. Dropping an index destroys no data,
+ * so the guard is a false positive here, but a second index on a table this
+ * small is cheaper than the manual procedure. The existing
+ * `visitor_profiles_stripe_customer_id_idx` stays; this adds the constraint
+ * beside it under its own name.
+ *
+ * It will refuse to build if duplicates already exist, which is the point —
+ * check with:
+ *
+ *   SELECT stripe_customer_id, count(*) FROM visitor_profiles
+ *   WHERE stripe_customer_id IS NOT NULL GROUP BY 1 HAVING count(*) > 1;
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "visitor_profiles_stripe_customer_id_unique_idx"
+        ON "visitor_profiles" USING btree ("stripe_customer_id");
+    `),
+  )
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      DROP INDEX IF EXISTS "visitor_profiles_stripe_customer_id_unique_idx";
+    `),
+  )
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -28,6 +28,7 @@ import * as migration_20260813_000000_add_service_accounts_preferences_rel from 
 import * as migration_20260813_010000_add_visitor_profile_billing_email from './20260813_010000_add_visitor_profile_billing_email'
 import * as migration_20260814_010000_add_visitor_profile_paid_through from './20260814_010000_add_visitor_profile_paid_through'
 import * as migration_20260814_020000_drop_legacy_membership_columns from './20260814_020000_drop_legacy_membership_columns'
+import * as migration_20260814_030000_unique_visitor_profile_stripe_customer_id from './20260814_030000_unique_visitor_profile_stripe_customer_id'
 
 export const migrations = [
   {
@@ -179,5 +180,10 @@ export const migrations = [
     up: migration_20260814_020000_drop_legacy_membership_columns.up,
     down: migration_20260814_020000_drop_legacy_membership_columns.down,
     name: '20260814_020000_drop_legacy_membership_columns',
+  },
+  {
+    up: migration_20260814_030000_unique_visitor_profile_stripe_customer_id.up,
+    down: migration_20260814_030000_unique_visitor_profile_stripe_customer_id.down,
+    name: '20260814_030000_unique_visitor_profile_stripe_customer_id',
   },
 ]


### PR DESCRIPTION
**Merge #266 first.** This adds the database constraint that #266's ownership check makes safe; on its own it would let the old email-adoption path hit a unique violation at checkout.

## Why

Every subscription webhook resolves a profile from the Stripe customer id alone — `findVisitorProfileByStripeCustomerId`, a `limit: 1` query with no ordering. Two profiles carrying the same id make that lookup a coin toss: one person's payment could grant, or one person's cancellation revoke, another person's membership, and the customer portal would show them each other's cards and invoices.

#266 stops the application from creating that state. Only the database can refuse the second row.

Postgres permits any number of NULLs under a unique index, so visitors who have never reached Stripe are unaffected.

## Shape of the migration

Additive, not the natural drop-and-recreate. `scripts/deploy/check-pending-migrations.mjs:15` flags any pending migration containing `DROP` or `TRUNCATE` and blocks **every** deploy until it is applied by hand on the host. Dropping a plain index destroys no data, so the guard is a false positive here — but a second index on a 3-row table is cheaper than the manual procedure. The existing `visitor_profiles_stripe_customer_id_idx` stays; this adds `..._unique_idx` beside it.

Preflight agrees: `20260814_030000_unique_visitor_profile_stripe_customer_id: automatic-safe`.

## Safe to apply

Checked on soft-prod before writing it:

```
 profiles | linked | distinct_customers
        3 |      2 |                  2

 stripe_customer_id | count
 (0 rows)
```

No duplicates, so the index builds. If one ever did exist the build would fail rather than pick a winner, which is the intent.

## Verification

`pnpm vitest run` — 676 tests passing. `pnpm typecheck` clean. `pnpm generate:types` produces no diff: `unique` changes the constraint, not the TypeScript shape.