### PR TITLE
payments: attribute Stripe events by metadata when the linkage is gone

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
@@ -6,10 +6,8 @@ import { stripe } from './stripe'
 import { convertStripeTimestamp } from './payment-helpers'
 import type { StripeSubscriptionExpanded, UserSubscriptionUpdate } from '../types'
 import { resyncSubscription } from './subscription-resync'
-import {
-  findVisitorProfileByAuthUserId,
-  findVisitorProfileByStripeCustomerId,
-} from '@/features/visitor-auth/lib/visitor-profile'
+import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
+import { resolveProfileForStripeCustomer } from './subscription-profile'
 
 /**
  * Stripe states in which a subscription is still live enough to cancel or
@@ -46,18 +44,23 @@ export function getCurrentPeriodEnd(subscription: StripeSubscriptionExpanded): D
 
 /**
  * Updates a VisitorProfile subscription based on Stripe customer ID.
+ *
+ * `visitorAuthUserId` comes from the event's own metadata and is only a
+ * fallback: it recovers the visitor when the customer linkage was never stored
+ * or has since been cleared, which would otherwise leave a paid subscription
+ * attached to nobody.
  */
 export async function updateUserSubscription(
   stripeCustomerId: string,
-  updates: UserSubscriptionUpdate
+  updates: UserSubscriptionUpdate,
+  visitorAuthUserId?: string | null
 ): Promise<boolean> {
   try {
     const payload = await getPayload({ config })
 
-    const profile = await findVisitorProfileByStripeCustomerId(stripeCustomerId)
+    const profile = await resolveProfileForStripeCustomer(stripeCustomerId, visitorAuthUserId)
 
     if (!profile) {
-      logger.error('No VisitorProfile found for Stripe customer', { stripeCustomerId })
       return false
     }
 

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-profile.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-profile.ts
@@ -1,0 +1,82 @@
+import { logger } from '@/shared/utils/logger'
+import {
+  findVisitorProfileByAuthUserId,
+  findVisitorProfileByStripeCustomerId,
+  updateVisitorProfileByAuthUserId,
+} from '@/features/visitor-auth/lib/visitor-profile'
+
+/**
+ * Find the profile a Stripe event belongs to.
+ *
+ * The customer id is the normal route, and the only one that works for events
+ * Stripe raises on its own (renewals, dunning, portal cancellations). But it is
+ * a link the application has to have stored, and storing it can fail: the
+ * profile row may be missing when checkout runs, or an admin may clear it
+ * later. The visitor then pays and nothing marks them a member, because the
+ * lookup silently found nobody.
+ *
+ * Checkout writes `visitorAuthUserId` into the session and subscription
+ * metadata, which survives all of that. Falling back to it turns a lost linkage
+ * into a self-repair: the profile is found by the id Stripe carried all along,
+ * and the customer is stitched back onto it.
+ *
+ * Deliberately not a search by email. Matching a payment to a person by address
+ * is the failure this whole area exists to prevent — see
+ * `payments/lib/customer-linkage.ts`.
+ */
+export async function resolveProfileForStripeCustomer(
+  stripeCustomerId: string,
+  fallbackVisitorAuthUserId?: string | null
+) {
+  const byCustomer = await findVisitorProfileByStripeCustomerId(stripeCustomerId)
+
+  if (byCustomer) return byCustomer
+
+  if (!fallbackVisitorAuthUserId) {
+    logger.error('No VisitorProfile for Stripe customer and no metadata to fall back on', {
+      stripeCustomerId,
+    })
+    return null
+  }
+
+  const byAuthUser = await findVisitorProfileByAuthUserId(fallbackVisitorAuthUserId)
+
+  if (!byAuthUser) {
+    logger.error('No VisitorProfile for Stripe customer or its metadata visitor', {
+      stripeCustomerId,
+      visitorAuthUserId: fallbackVisitorAuthUserId,
+    })
+    return null
+  }
+
+  // The visitor is already linked to a *different* customer. Repointing them
+  // would move their membership onto someone else's billing, which is precisely
+  // the mix-up this module refuses to make. Report it instead.
+  if (byAuthUser.stripeCustomerId && byAuthUser.stripeCustomerId !== stripeCustomerId) {
+    logger.error('Stripe event customer disagrees with the profile linkage; not repointing', {
+      stripeCustomerId,
+      profileId: byAuthUser.id,
+      linkedCustomerId: byAuthUser.stripeCustomerId,
+    })
+    return null
+  }
+
+  try {
+    await updateVisitorProfileByAuthUserId(fallbackVisitorAuthUserId, { stripeCustomerId })
+
+    logger.warn('Recovered a lost Stripe linkage from event metadata', {
+      stripeCustomerId,
+      profileId: byAuthUser.id,
+    })
+  } catch (error) {
+    // `stripe_customer_id` is unique, so a racing writer can claim it first.
+    // The profile is still the right one to act on; only the repair failed.
+    logger.error('Could not restore the Stripe linkage on the profile', {
+      stripeCustomerId,
+      profileId: byAuthUser.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return { ...byAuthUser, stripeCustomerId }
+}

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
@@ -3,7 +3,7 @@ import type Stripe from 'stripe'
 import config from '@/payload.config'
 import { logger } from '@/shared/utils/logger'
 import { withAdvisoryLock } from '@/shared/utils/advisory-lock'
-import { findVisitorProfileByStripeCustomerId } from '@/features/visitor-auth/lib/visitor-profile'
+import { resolveProfileForStripeCustomer } from './subscription-profile'
 import {
   sendMembershipConfirmationEmail,
   sendSubscriptionCancelledEmail,
@@ -120,7 +120,13 @@ export async function resyncSubscription(subscriptionId: string): Promise<Resync
       return { profileId: null, state: null, transitions: [] }
     }
 
-    const profile = await findVisitorProfileByStripeCustomerId(customerId)
+    // Checkout copies its metadata onto the subscription, so even a renewal
+    // years later still carries the visitor it belongs to. That is what makes a
+    // lost customer linkage recoverable instead of terminal.
+    const profile = await resolveProfileForStripeCustomer(
+      customerId,
+      subscription.metadata?.visitorAuthUserId ?? null
+    )
 
     if (!profile) {
       logger.error('No VisitorProfile found for Stripe customer', { customerId, subscriptionId })

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -51,8 +51,14 @@ vi.mock('@/emails', () => ({
   sendSubscriptionCancelledEmail: mocks.sendSubscriptionCancelledEmail,
 }))
 
+vi.mock('@/payments/lib/subscription-profile', () => ({
+  resolveProfileForStripeCustomer: mocks.findVisitorProfileByStripeCustomerId,
+}))
+
 vi.mock('@/features/visitor-auth/lib/visitor-profile', () => ({
   findVisitorProfileByStripeCustomerId: mocks.findVisitorProfileByStripeCustomerId,
+  findVisitorProfileByAuthUserId: vi.fn(),
+  updateVisitorProfileByAuthUserId: vi.fn(),
   splitDisplayName: (name: string | null | undefined) => {
     const parts = (name ?? '').trim().split(/\s+/).filter(Boolean)
     return { firstName: parts[0] ?? '', lastName: parts.slice(1).join(' ') }
@@ -193,10 +199,14 @@ describe('Stripe webhook route', () => {
     // Exact match, not objectContaining: checkout links the subscription and
     // nothing else. Any date it wrote would be `current_period_end`, which
     // ADR-0008 rejects as an entitlement date.
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith('cus_1', {
-      stripeSubscriptionId: 'sub_1',
-      subscriptionStatus: 'active',
-    })
+    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
+      'cus_1',
+      {
+        stripeSubscriptionId: 'sub_1',
+        subscriptionStatus: 'active',
+      },
+      null,
+    )
     expect(mocks.sendMembershipConfirmationEmail).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ email: 'visitor@example.com', isRecurring: true }),
@@ -228,6 +238,7 @@ describe('Stripe webhook route', () => {
     expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
       'cus_1',
       expect.objectContaining({ firstName: 'Grace', lastName: 'Brewster Hopper' }),
+      null,
     )
   })
 
@@ -253,6 +264,7 @@ describe('Stripe webhook route', () => {
     expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
       'cus_1',
       expect.objectContaining({ billingEmail: 'grace@real-inbox.example' }),
+      null,
     )
   })
 
@@ -279,6 +291,7 @@ describe('Stripe webhook route', () => {
     expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
       'cus_1',
       expect.not.objectContaining({ billingEmail: expect.anything() }),
+      null,
     )
   })
 

--- a/apps/questura/apps/server/src/features/payments/subscription-profile.test.ts
+++ b/apps/questura/apps/server/src/features/payments/subscription-profile.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findByCustomer: vi.fn(),
+  findByAuthUser: vi.fn(),
+  updateByAuthUser: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+}))
+
+vi.mock('@/features/visitor-auth/lib/visitor-profile', () => ({
+  findVisitorProfileByStripeCustomerId: mocks.findByCustomer,
+  findVisitorProfileByAuthUserId: mocks.findByAuthUser,
+  updateVisitorProfileByAuthUserId: mocks.updateByAuthUser,
+}))
+
+vi.mock('@/shared/utils/logger', () => ({
+  logger: {
+    error: mocks.loggerError,
+    warn: mocks.loggerWarn,
+    info: vi.fn(),
+  },
+}))
+
+import { resolveProfileForStripeCustomer } from '@/payments/lib/subscription-profile'
+
+describe('resolveProfileForStripeCustomer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.updateByAuthUser.mockResolvedValue({ id: 10 })
+  })
+
+  it('resolves by customer id and leaves the linkage alone', async () => {
+    mocks.findByCustomer.mockResolvedValue({ id: 10, stripeCustomerId: 'cus_1' })
+
+    await expect(resolveProfileForStripeCustomer('cus_1', 'visitor_123')).resolves.toEqual({
+      id: 10,
+      stripeCustomerId: 'cus_1',
+    })
+    expect(mocks.findByAuthUser).not.toHaveBeenCalled()
+    expect(mocks.updateByAuthUser).not.toHaveBeenCalled()
+  })
+
+  // The paid-but-unattributed case: nothing stored the customer on the profile,
+  // so the customer id alone finds nobody.
+  it('recovers the visitor from event metadata and restores the linkage', async () => {
+    mocks.findByCustomer.mockResolvedValue(null)
+    mocks.findByAuthUser.mockResolvedValue({ id: 10, stripeCustomerId: null })
+
+    const profile = await resolveProfileForStripeCustomer('cus_1', 'visitor_123')
+
+    expect(profile).toEqual({ id: 10, stripeCustomerId: 'cus_1' })
+    expect(mocks.updateByAuthUser).toHaveBeenCalledWith('visitor_123', {
+      stripeCustomerId: 'cus_1',
+    })
+  })
+
+  // Repointing here would move a membership onto someone else's billing --
+  // the same mix-up the ownership check at checkout exists to prevent.
+  it('refuses to repoint a visitor already linked to another customer', async () => {
+    mocks.findByCustomer.mockResolvedValue(null)
+    mocks.findByAuthUser.mockResolvedValue({ id: 10, stripeCustomerId: 'cus_other' })
+
+    await expect(resolveProfileForStripeCustomer('cus_1', 'visitor_123')).resolves.toBeNull()
+    expect(mocks.updateByAuthUser).not.toHaveBeenCalled()
+    expect(mocks.loggerError).toHaveBeenCalled()
+  })
+
+  it('reports rather than guesses when the event carries no visitor', async () => {
+    mocks.findByCustomer.mockResolvedValue(null)
+
+    await expect(resolveProfileForStripeCustomer('cus_1', null)).resolves.toBeNull()
+    expect(mocks.findByAuthUser).not.toHaveBeenCalled()
+    expect(mocks.loggerError).toHaveBeenCalled()
+  })
+
+  it('reports when neither the customer nor the metadata visitor exists', async () => {
+    mocks.findByCustomer.mockResolvedValue(null)
+    mocks.findByAuthUser.mockResolvedValue(null)
+
+    await expect(resolveProfileForStripeCustomer('cus_1', 'visitor_gone')).resolves.toBeNull()
+    expect(mocks.loggerError).toHaveBeenCalled()
+  })
+
+  // `stripe_customer_id` is unique, so a racing writer can claim it first. The
+  // profile is still the right one to act on; only the repair failed.
+  it('still returns the profile when restoring the linkage fails', async () => {
+    mocks.findByCustomer.mockResolvedValue(null)
+    mocks.findByAuthUser.mockResolvedValue({ id: 10, stripeCustomerId: null })
+    mocks.updateByAuthUser.mockRejectedValue(new Error('duplicate key value'))
+
+    await expect(resolveProfileForStripeCustomer('cus_1', 'visitor_123')).resolves.toEqual({
+      id: 10,
+      stripeCustomerId: 'cus_1',
+    })
+    expect(mocks.loggerError).toHaveBeenCalled()
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -2,7 +2,8 @@ import type Stripe from 'stripe'
 import { updateUserSubscription } from '@/payments/lib/payment-service'
 import type { UserSubscriptionUpdate } from '@/payments/types'
 import { APP_CONFIG } from '@/shared/config'
-import { findVisitorProfileByStripeCustomerId, splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
+import { splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
+import { resolveProfileForStripeCustomer } from '@/payments/lib/subscription-profile'
 import { logger } from '@/shared/utils/logger'
 import { sendMembershipConfirmationAfterPayment } from '../notifications'
 
@@ -15,6 +16,10 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
 
   const customerId = session.customer as string
   const subscriptionId = session.subscription as string
+  // Written by the checkout route. Survives a profile row that lost, or never
+  // stored, its Stripe linkage — without it a completed payment can land on
+  // nobody.
+  const visitorAuthUserId = session.metadata?.visitorAuthUserId ?? null
 
   if (!customerId || !subscriptionId) {
     logger.error('Missing customer or subscription ID in checkout session', {
@@ -50,7 +55,7 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
   const billingEmail = session.customer_details?.email?.trim()
 
   if (billingName || billingEmail) {
-    const profile = await findVisitorProfileByStripeCustomerId(customerId)
+    const profile = await resolveProfileForStripeCustomer(customerId, visitorAuthUserId)
 
     if (billingName && profile && !profile.firstName && !profile.lastName) {
       const { firstName, lastName } = splitDisplayName(billingName)
@@ -75,7 +80,7 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
   }
 
   // Update user with subscription info
-  const success = await updateUserSubscription(customerId, updateData)
+  const success = await updateUserSubscription(customerId, updateData, visitorAuthUserId)
 
   if (success) {
     logger.info('Visitor subscription activated via checkout completion', { subscriptionId })


### PR DESCRIPTION
Follow-up to #266 / #267, closing the last hole on the same path.

## The gap

Every webhook resolved its profile through the Stripe customer id alone — `findVisitorProfileByStripeCustomerId`. That id is a link the application has to have stored, and storing it can fail:

- the profile row is missing when checkout runs (`updateVisitorProfileByAuthUserId` returns `null` and there is nothing to write to — #266 made that loud, but not survivable),
- or an admin clears the field later.

Either way the visitor pays, `checkout.session.completed` arrives, the lookup finds nobody, and the only trace is `No VisitorProfile found for Stripe customer`. Money taken, no membership. Every later renewal and cancellation for that subscription misses too.

## The fix

Checkout already writes `visitorAuthUserId` into both the session metadata and `subscription_data.metadata`, so Stripe carries the answer on every event for the life of the subscription. `resolveProfileForStripeCustomer` tries the customer id first, then that metadata, and restores the linkage when it succeeds.

Wired into the three places that resolve a profile from a Stripe event: `updateUserSubscription`, the `checkout.session.completed` handler, and `resyncSubscription` — which is the path every renewal, dunning cycle and portal cancellation already takes.

## What it deliberately will not do

- **No email fallback.** Matching a payment to a person by address is the takeover this area exists to prevent (#266).
- **No repointing.** If the metadata visitor is already linked to a *different* customer, it logs and returns nothing rather than moving their membership onto someone else's billing.
- **Failed repairs are not fatal.** `stripe_customer_id` is unique as of #267, so a racing writer can claim it first; the profile is still the right one to act on, so only the repair is abandoned.

## Verification

`pnpm vitest run` — 96 files, 682 tests passing. `pnpm typecheck` clean. Six new cases cover the resolver: normal path, metadata recovery with linkage restore, the refusal to repoint, no-metadata, unknown visitor, and a failed repair still returning the profile. The webhook route tests were updated for the added argument and now mock the resolver explicitly.