### PR TITLE
Fix paid checkout leaving membership ungranted

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
@@ -116,8 +116,7 @@ export async function resyncSubscription(subscriptionId: string): Promise<Resync
       typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
 
     if (!customerId) {
-      logger.error('Subscription has no customer; cannot resync', { subscriptionId })
-      return { profileId: null, state: null, transitions: [] }
+      throw new Error(`Subscription ${subscriptionId} has no customer; cannot resync`)
     }
 
     // Checkout copies its metadata onto the subscription, so even a renewal
@@ -129,8 +128,9 @@ export async function resyncSubscription(subscriptionId: string): Promise<Resync
     )
 
     if (!profile) {
-      logger.error('No VisitorProfile found for Stripe customer', { customerId, subscriptionId })
-      return { profileId: null, state: null, transitions: [] }
+      throw new Error(
+        `No VisitorProfile found for Stripe customer ${customerId} on subscription ${subscriptionId}`
+      )
     }
 
     const state = deriveSubscriptionState(subscription, {

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -181,36 +181,22 @@ describe('Stripe webhook route', () => {
     )
   })
 
-  it('activates the subscription and sends a confirmation email on checkout completion', async () => {
+  it('resyncs the paid subscription on checkout completion instead of stamping active', async () => {
     givenEvent('checkout.session.completed', {
       id: 'cs_1',
       customer: 'cus_1',
       subscription: 'sub_1',
-      customer_details: { name: 'Grace Hopper' },
+      metadata: { visitorAuthUserId: 'visitor_123' },
     })
-    // Needed by the confirmation email, not by the profile write
-    mocks.getStripeSubscriptionDetails.mockResolvedValue({
-      currentPeriodEnd: new Date(FUTURE_TS * 1000),
-    })
-    // Profile already has a name, so billing name must not overwrite it
+
     const response = await POST(createRequest())
 
     await expect(response.json()).resolves.toEqual({ received: true })
-    // Exact match, not objectContaining: checkout links the subscription and
-    // nothing else. Any date it wrote would be `current_period_end`, which
-    // ADR-0008 rejects as an entitlement date.
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
-      'cus_1',
-      {
-        stripeSubscriptionId: 'sub_1',
-        subscriptionStatus: 'active',
-      },
-      null,
-    )
-    expect(mocks.sendMembershipConfirmationEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ email: 'visitor@example.com', isRecurring: true }),
-    )
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+    // Entitlement dates come from resync. Writing `active` here granted no
+    // access (paidThroughAt was still empty) and blocked a retry checkout.
+    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
+    expect(mocks.sendMembershipConfirmationEmail).not.toHaveBeenCalled()
     expect(mocks.payloadCreate).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ eventId: 'evt_1' }) }),
     )
@@ -235,9 +221,10 @@ describe('Stripe webhook route', () => {
 
     await POST(createRequest())
 
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
     expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
       'cus_1',
-      expect.objectContaining({ firstName: 'Grace', lastName: 'Brewster Hopper' }),
+      { firstName: 'Grace', lastName: 'Brewster Hopper' },
       null,
     )
   })
@@ -261,9 +248,10 @@ describe('Stripe webhook route', () => {
 
     await POST(createRequest())
 
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
     expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
       'cus_1',
-      expect.objectContaining({ billingEmail: 'grace@real-inbox.example' }),
+      { billingEmail: 'grace@real-inbox.example' },
       null,
     )
   })
@@ -288,11 +276,8 @@ describe('Stripe webhook route', () => {
 
     await POST(createRequest())
 
-    expect(mocks.updateUserSubscription).toHaveBeenCalledWith(
-      'cus_1',
-      expect.not.objectContaining({ billingEmail: expect.anything() }),
-      null,
-    )
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+    expect(mocks.updateUserSubscription).not.toHaveBeenCalled()
   })
 
   it('resyncs from Stripe on subscription created rather than trusting the payload', async () => {
@@ -416,6 +401,48 @@ describe('Stripe webhook route', () => {
     expect(response.status).toBe(500)
     await expect(response.json()).resolves.toEqual({ error: 'Processing failed' })
     // Not recorded, so Stripe's retry will be processed again
+    expect(mocks.payloadCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when checkout cannot resync, so Stripe retries', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+      subscription: 'sub_1',
+    })
+    mocks.resyncSubscription.mockResolvedValue({ profileId: null, state: null, transitions: [] })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(500)
+    expect(mocks.payloadCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when checkout extras cannot be stored', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+      subscription: 'sub_1',
+      customer_details: { email: 'grace@real-inbox.example' },
+    })
+    mocks.updateUserSubscription.mockResolvedValue(false)
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(500)
+    expect(mocks.payloadCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when a paid checkout session has no subscription id', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+    })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(500)
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
     expect(mocks.payloadCreate).not.toHaveBeenCalled()
   })
 })

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -1,56 +1,51 @@
 import type Stripe from 'stripe'
 import { updateUserSubscription } from '@/payments/lib/payment-service'
+import { resyncSubscription } from '@/payments/lib/subscription-resync'
 import type { UserSubscriptionUpdate } from '@/payments/types'
 import { APP_CONFIG } from '@/shared/config'
 import { splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
 import { resolveProfileForStripeCustomer } from '@/payments/lib/subscription-profile'
 import { logger } from '@/shared/utils/logger'
-import { sendMembershipConfirmationAfterPayment } from '../notifications'
 
 /**
- * Handle successful checkout completion
- * This is triggered when a user completes their subscription checkout
+ * Handle successful checkout completion.
+ *
+ * Entitlement is resync's job (ADR-0008). This handler only attaches
+ * checkout-only fields (name, billing email, affiliate) after that write.
+ * Returning without throwing used to 200 the webhook, so Stripe never retried
+ * a paid session that failed to find a profile.
  */
 export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) {
   logger.info('Processing checkout.session.completed', { sessionId: session.id })
 
-  const customerId = session.customer as string
-  const subscriptionId = session.subscription as string
-  // Written by the checkout route. Survives a profile row that lost, or never
-  // stored, its Stripe linkage — without it a completed payment can land on
-  // nobody.
+  const customerId = typeof session.customer === 'string' ? session.customer : session.customer?.id
+  const subscriptionId =
+    typeof session.subscription === 'string' ? session.subscription : session.subscription?.id
   const visitorAuthUserId = session.metadata?.visitorAuthUserId ?? null
 
   if (!customerId || !subscriptionId) {
-    logger.error('Missing customer or subscription ID in checkout session', {
-      sessionId: session.id,
-    })
-    return
+    throw new Error(
+      `Checkout session ${session.id} is missing a customer or subscription id`
+    )
   }
 
-  // No date is captured here. Checkout only links the subscription and marks it
-  // active; `paidThroughAt` is written by the subscription resync, which is the
-  // single writer of subscription state and derives the date from an invoice
-  // that has actually been paid rather than from `current_period_end`
-  // (ADR-0008).
-  const updateData: UserSubscriptionUpdate = {
-    stripeSubscriptionId: subscriptionId,
-    subscriptionStatus: 'active'
+  const { profileId } = await resyncSubscription(subscriptionId)
+
+  if (!profileId) {
+    throw new Error(`Failed to resync subscription ${subscriptionId} after checkout`)
   }
+
+  const extras: UserSubscriptionUpdate = {}
 
   if (APP_CONFIG.features.endorselyAffiliates) {
     const referralId = session.metadata?.endorsely_referral
     if (referralId) {
       logger.info('Subscription created via affiliate referral', { referralId, subscriptionId })
-      // Store affiliate referral info
-      updateData.affiliateReferralId = referralId
-      updateData.affiliateReferredAt = new Date().toISOString()
+      extras.affiliateReferralId = referralId
+      extras.affiliateReferredAt = new Date().toISOString()
     }
   }
 
-  // Capture the billing name Stripe collected at checkout, but only if the
-  // visitor profile doesn't already have a name (don't clobber a name the user
-  // set themselves in settings/account).
   const billingName = session.customer_details?.name?.trim()
   const billingEmail = session.customer_details?.email?.trim()
 
@@ -59,18 +54,17 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
 
     if (billingName && profile && !profile.firstName && !profile.lastName) {
       const { firstName, lastName } = splitDisplayName(billingName)
-      updateData.firstName = firstName
-      updateData.lastName = lastName
+      extras.firstName = firstName
+      extras.lastName = lastName
     }
 
     // Checkout no longer requires a verified email, so the account address may
     // be mistyped. Stripe's address is confirmed by the payment, which makes it
     // the better fallback contact — but only worth storing when the two differ.
-    // Compare case-insensitively so casing alone doesn't flag a mismatch.
     if (billingEmail && profile) {
       const accountEmail = typeof profile.email === 'string' ? profile.email.trim() : ''
       if (accountEmail.toLowerCase() !== billingEmail.toLowerCase()) {
-        updateData.billingEmail = billingEmail
+        extras.billingEmail = billingEmail
         logger.warn('Checkout billing email differs from account email', {
           subscriptionId,
           profileId: profile.id,
@@ -79,15 +73,16 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
     }
   }
 
-  // Update user with subscription info
-  const success = await updateUserSubscription(customerId, updateData, visitorAuthUserId)
-
-  if (success) {
-    logger.info('Visitor subscription activated via checkout completion', { subscriptionId })
-
-    // Send membership confirmation email for new subscription
-    await sendMembershipConfirmationAfterPayment(customerId, subscriptionId, true)
-  } else {
-    logger.error('Failed to update visitor subscription from checkout', { subscriptionId })
+  if (Object.keys(extras).length === 0) {
+    logger.info('Visitor subscription resynced via checkout completion', { subscriptionId })
+    return
   }
+
+  const success = await updateUserSubscription(customerId, extras, visitorAuthUserId)
+
+  if (!success) {
+    throw new Error(`Failed to store checkout extras for subscription ${subscriptionId}`)
+  }
+
+  logger.info('Visitor subscription activated via checkout completion', { subscriptionId })
 }


### PR DESCRIPTION
## Why

A completed Checkout payment could leave the visitor unentitled. `checkout.session.completed` wrote `subscriptionStatus: active` without `paidThroughAt` (access is date-based), and a failed profile lookup still returned 200, so Stripe never retried.

## What

- `resyncSubscription` throws when the customer or visitor profile is missing, so the webhook returns 500 and Stripe retries.
- Checkout completion calls resync for entitlement, then stores name / billing email / affiliate extras only. It no longer stamps `active`.
- Confirmation email stays with resync transition mail (ADR-0008), so checkout does not send a second one.

## Verification

```
pnpm exec vitest run --config ./vitest.config.ts src/features/payments/stripe-webhook.route.test.ts src/features/payments/payment-service.test.ts
```

49 passed. No live checkout triggered.

Made with [Cursor](https://cursor.com)