### PR TITLE
Refuse a second live Stripe subscription at checkout

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/payments/lib/stripe'
-import { resolveStripeCustomerForVisitor } from '@/payments/lib/customer-linkage'
+import { resolveStripeCustomerForVisitor, findLiveSubscription } from '@/payments/lib/customer-linkage'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
@@ -125,8 +125,11 @@ export async function POST(req: NextRequest) {
       console.log('Using existing Stripe customer:', stripeCustomerId)
     }
 
-    // 5. Check if user already has an active subscription
-    if (profile?.subscriptionStatus === 'active' && profile?.stripeSubscriptionId) {
+    // 5. Refuse a second live subscription on this customer. Local
+    // `subscriptionStatus === 'active'` missed past_due / unpaid, so a visitor
+    // being dunned could open another Checkout and get charged twice.
+    const liveSubscription = await findLiveSubscription(stripeCustomerId)
+    if (liveSubscription) {
       return NextResponse.json(
         { error: 'Visitor already has an active subscription' },
         { status: 400, headers: corsHeaders }

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   updateVisitorProfileByAuthUserId: vi.fn(),
   stripeCustomerCreate: vi.fn(),
   stripeCustomerList: vi.fn(),
+  stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
 }))
 
@@ -23,6 +24,9 @@ vi.mock('@/payments/lib/stripe', () => ({
     customers: {
       create: mocks.stripeCustomerCreate,
       list: mocks.stripeCustomerList,
+    },
+    subscriptions: {
+      list: mocks.stripeSubscriptionList,
     },
     checkout: {
       sessions: {
@@ -85,6 +89,7 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     })
     mocks.stripeCustomerCreate.mockResolvedValue({ id: 'cus_new' })
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
     mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
     mocks.stripeCheckoutCreate.mockResolvedValue({
       id: 'cs_123',

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   updateVisitorProfileByAuthUserId: vi.fn(),
   stripeCustomerCreate: vi.fn(),
   stripeCustomerList: vi.fn(),
+  stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
 }))
 
@@ -23,6 +24,9 @@ vi.mock('@/payments/lib/stripe', () => ({
     customers: {
       create: mocks.stripeCustomerCreate,
       list: mocks.stripeCustomerList,
+    },
+    subscriptions: {
+      list: mocks.stripeSubscriptionList,
     },
     checkout: {
       sessions: {
@@ -70,6 +74,7 @@ describe('create checkout session referral ID validation', () => {
     vi.clearAllMocks()
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
     mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
     mocks.requireVisitorPrincipal.mockResolvedValue({
       result: { authenticated: true },

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   updateVisitorProfileByAuthUserId: vi.fn(),
   stripeCustomerCreate: vi.fn(),
   stripeCustomerList: vi.fn(),
+  stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
 }))
 
@@ -23,6 +24,9 @@ vi.mock('@/payments/lib/stripe', () => ({
     customers: {
       create: mocks.stripeCustomerCreate,
       list: mocks.stripeCustomerList,
+    },
+    subscriptions: {
+      list: mocks.stripeSubscriptionList,
     },
     checkout: {
       sessions: {
@@ -75,6 +79,7 @@ describe('create checkout session route auth guard', () => {
     })
     mocks.stripeCustomerCreate.mockResolvedValue({ id: 'cus_123' })
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
     mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
     mocks.stripeCheckoutCreate.mockResolvedValue({
       id: 'cs_123',
@@ -210,5 +215,71 @@ describe('create checkout session route auth guard', () => {
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({ line_items: [{ price: 'price_123', quantity: 1 }] }),
     )
+  })
+
+  it('refuses checkout when Stripe already has a past_due subscription', async () => {
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'past_due',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeSubscriptionList.mockResolvedValue({
+      data: [{ id: 'sub_dunning', status: 'past_due' }],
+    })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Visitor already has an active subscription',
+    })
+    expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled()
+  })
+
+  it('refuses checkout when Stripe is live even if the local profile looks empty', async () => {
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'none',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeSubscriptionList.mockResolvedValue({
+      data: [{ id: 'sub_live', status: 'active' }],
+    })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(400)
+    expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled()
+  })
+
+  it('allows checkout after the only Stripe subscription is canceled', async () => {
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'cancelled',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeSubscriptionList.mockResolvedValue({
+      data: [{ id: 'sub_old', status: 'canceled' }],
+    })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(200)
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalled()
   })
 })

--- a/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
+++ b/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   stripeCustomerUpdate: vi.fn(),
+  stripeSubscriptionList: vi.fn(),
 }))
 
 vi.mock('@/payments/lib/stripe', () => ({
@@ -9,10 +10,13 @@ vi.mock('@/payments/lib/stripe', () => ({
     customers: {
       update: mocks.stripeCustomerUpdate,
     },
+    subscriptions: {
+      list: mocks.stripeSubscriptionList,
+    },
   },
 }))
 
-import { syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
+import { findLiveSubscription, syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
 
@@ -55,5 +59,43 @@ describe('syncStripeCustomerEmail', () => {
 
     await expect(syncStripeCustomerEmail('cus_123', 'new@example.com')).resolves.toBe(false)
     expect(consoleErrorSpy).toHaveBeenCalled()
+  })
+})
+
+describe('findLiveSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
+  })
+
+  it('returns a past_due subscription that local status would have ignored', async () => {
+    mocks.stripeSubscriptionList.mockResolvedValue({
+      data: [{ id: 'sub_dunning', status: 'past_due' }],
+    })
+
+    await expect(findLiveSubscription('cus_123')).resolves.toEqual(
+      expect.objectContaining({ id: 'sub_dunning', status: 'past_due' })
+    )
+  })
+
+  it('ignores canceled and incomplete subscriptions so the visitor can pay again', async () => {
+    mocks.stripeSubscriptionList.mockResolvedValue({
+      data: [
+        { id: 'sub_old', status: 'canceled' },
+        { id: 'sub_open', status: 'incomplete' },
+      ],
+    })
+
+    await expect(findLiveSubscription('cus_123')).resolves.toBeNull()
+  })
+
+  it('asks Stripe for every status, not only active', async () => {
+    await findLiveSubscription('cus_123')
+
+    expect(mocks.stripeSubscriptionList).toHaveBeenCalledWith({
+      customer: 'cus_123',
+      status: 'all',
+      limit: 100,
+    })
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -104,3 +104,30 @@ export async function resolveStripeCustomerForVisitor(params: {
 
   return { customerId: customer.id, created: true }
 }
+
+const LIVE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
+  'active',
+  'trialing',
+  'past_due',
+  'unpaid',
+])
+
+/**
+ * A subscription Stripe is still collecting on, or retrying.
+ *
+ * Local `subscriptionStatus === 'active'` was the old checkout gate. That let a
+ * `past_due` visitor open a second Checkout session on the same customer, so
+ * Stripe billed them twice and the last webhook won. Incomplete / canceled
+ * are left out: those visitors need to be able to pay again.
+ */
+export async function findLiveSubscription(
+  customerId: string
+): Promise<Stripe.Subscription | null> {
+  const listed = await stripe.subscriptions.list({
+    customer: customerId,
+    status: 'all',
+    limit: 100,
+  })
+
+  return listed.data.find((subscription) => LIVE_SUBSCRIPTION_STATUSES.has(subscription.status)) ?? null
+}


### PR DESCRIPTION
## Why

Checkout only blocked when the local profile said `subscriptionStatus === 'active'`. A `past_due` or `unpaid` customer could open another Checkout session on the same Stripe customer and get charged twice.

## What

Ask Stripe for subscriptions on that customer before creating a session. `active`, `trialing`, `past_due`, and `unpaid` refuse a new checkout. Canceled / incomplete still allow the visitor to pay again.

Depends on #269 (already merged).

## Verification

```
pnpm exec vitest run --config ./vitest.config.ts \
  src/features/payments/create-checkout-session.route.test.ts \
  src/features/payments/create-checkout-session.customer-reuse.test.ts \
  src/features/payments/create-checkout-session.referral.test.ts \
  src/features/payments/customer-linkage.test.ts
```

29 passed. No live checkout triggered.

Made with [Cursor](https://cursor.com)