### PR TITLE
Reject untrusted origins on billing cookie POSTs

### DIFF
--- a/apps/questura/apps/server/src/app/api/account/set-password/route.ts
+++ b/apps/questura/apps/server/src/app/api/account/set-password/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { visitorAuth } from '@/features/visitor-auth/lib/better-auth'
 import { checkSetPasswordRateLimit } from '@/features/visitor-auth/lib/set-password-rate-limit'
 import { getPasswordStrengthError } from '@/shared/lib/password-strength'
-import { getCorsHeaders, handleCorsOptions, isAllowedOrigin } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 
 /**
  * Server adapter for Better Auth's `setPassword`, which the browser client does
@@ -30,16 +30,8 @@ import { getCorsHeaders, handleCorsOptions, isAllowedOrigin } from '@/shared/uti
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
 
-  // Better Auth's own `validateOrigin` treats a missing or literal-"null"
-  // Origin as forbidden whenever a Cookie is present, so match that rather than
-  // only rejecting a named-but-untrusted origin. (The session cookie is
-  // SameSite=Lax, so a genuinely cross-site POST arrives without it; this
-  // closes the same-site-but-untrusted case the router would have handled.)
-  const origin = req.headers.get('origin')
-  const carriesCookie = Boolean(req.headers.get('cookie'))
-  if (carriesCookie ? !origin || !isAllowedOrigin(origin) : origin && !isAllowedOrigin(origin)) {
-    return NextResponse.json({ error: 'Origin not allowed.' }, { status: 403, headers: corsHeaders })
-  }
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
 
   const rateLimit = await checkSetPasswordRateLimit(req.headers)
   if (!rateLimit.allowed) {

--- a/apps/questura/apps/server/src/app/api/payments/cancel-subscription/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/cancel-subscription/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { cancelUserSubscription } from '@/payments/lib/payment-service'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/payments/lib/stripe'
 import { resolveStripeCustomerForVisitor, findLiveSubscription } from '@/payments/lib/customer-linkage'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
 import {
@@ -28,6 +28,8 @@ function sanitizeReferralId(value: unknown): string | null {
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
 
   try {
     // Deliberately not requiring a verified email. Verification before checkout

--- a/apps/questura/apps/server/src/app/api/payments/create-portal-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-portal-session/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/payments/lib/stripe'
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/app/api/payments/reactivate-subscription/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/reactivate-subscription/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { reactivateUserSubscription } from '@/payments/lib/payment-service'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -282,4 +282,23 @@ describe('create checkout session route auth guard', () => {
     expect(response.status).toBe(200)
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalled()
   })
+
+  it('rejects a cookie session from an untrusted origin before touching Stripe', async () => {
+    const response = await POST(
+      new Request('http://localhost:4000/api/payments/create-checkout-session', {
+        method: 'POST',
+        headers: {
+          origin: 'https://evil.example',
+          cookie: 'questura_visitor.session_token=abc',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      }) as any
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Origin not allowed.' })
+    expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalled()
+    expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled()
+  })
 })

--- a/apps/questura/apps/server/src/shared/utils/cors.test.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
-import { getCorsHeaders } from './cors'
+import { forbiddenOriginResponse, getCorsHeaders, isForbiddenOrigin } from './cors'
 
 function requestWithOrigin(origin?: string) {
   return new NextRequest('http://localhost:4000/api/health', {
@@ -36,5 +36,46 @@ describe('getCorsHeaders', () => {
 
     expect(headers).not.toHaveProperty('Access-Control-Allow-Origin')
     expect(headers).not.toHaveProperty('Access-Control-Allow-Credentials')
+  })
+})
+
+function request({ origin, cookie }: { origin?: string; cookie?: string } = {}) {
+  const headers = new Headers()
+  if (origin) headers.set('origin', origin)
+  if (cookie) headers.set('cookie', cookie)
+  return { headers } as NextRequest
+}
+
+describe('isForbiddenOrigin', () => {
+  it('rejects an origin that is not this deployment', () => {
+    expect(isForbiddenOrigin(request({ origin: 'https://evil.example' }))).toBe(true)
+  })
+
+  it('rejects the literal null origin a sandboxed iframe sends', () => {
+    expect(isForbiddenOrigin(request({ origin: 'null' }))).toBe(true)
+  })
+
+  it('rejects a cookie-bearing request with no Origin', () => {
+    expect(isForbiddenOrigin(request({ cookie: 'questura_visitor.session_token=abc' }))).toBe(true)
+  })
+
+  it('allows a cookieless request with no Origin', () => {
+    expect(isForbiddenOrigin(request())).toBe(false)
+  })
+
+  it('allows an allowlisted origin', () => {
+    expect(isForbiddenOrigin(request({ origin: 'http://localhost:3000', cookie: 'sid=1' }))).toBe(
+      false
+    )
+  })
+})
+
+describe('forbiddenOriginResponse', () => {
+  it('returns 403 for a forbidden origin and null otherwise', async () => {
+    const blocked = forbiddenOriginResponse(request({ origin: 'https://evil.example' }), {})
+    expect(blocked?.status).toBe(403)
+    await expect(blocked?.json()).resolves.toEqual({ error: 'Origin not allowed.' })
+
+    expect(forbiddenOriginResponse(request({ origin: 'http://localhost:3000' }), {})).toBeNull()
   })
 })

--- a/apps/questura/apps/server/src/shared/utils/cors.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.ts
@@ -13,6 +13,29 @@ export function isAllowedOrigin(origin: string): boolean {
   return ALLOWED_ORIGINS.includes(origin)
 }
 
+/**
+ * Same rule Better Auth's router uses: a cookie session with a missing or
+ * untrusted Origin is rejected, not merely CORS-blocked. Cross-site POST
+ * already drops SameSite=Lax cookies; this closes same-site-but-untrusted
+ * hosts (any sibling under the cookie's eTLD+1).
+ */
+export function isForbiddenOrigin(req: { headers: Headers }): boolean {
+  const origin = req.headers.get('origin')
+  const carriesCookie = Boolean(req.headers.get('cookie'))
+
+  if (carriesCookie) {
+    return !origin || !isAllowedOrigin(origin)
+  }
+
+  return Boolean(origin && !isAllowedOrigin(origin))
+}
+
+export function forbiddenOriginResponse(req: NextRequest, corsHeaders: Record<string, string>) {
+  if (!isForbiddenOrigin(req)) return null
+
+  return NextResponse.json({ error: 'Origin not allowed.' }, { status: 403, headers: corsHeaders })
+}
+
 export function getCorsHeaders(req: NextRequest): Record<string, string> {
   const origin = req.headers.get('origin')
 


### PR DESCRIPTION
## Why

CORS only stops a browser *reading* the response. Cancel, reactivate, checkout and portal change money state using the visitor session cookie. `set-password` already rejected a missing or untrusted Origin; these routes did not, so a same-site sibling host could drive them.

## What

Shared `isForbiddenOrigin` / `forbiddenOriginResponse` (same rule as Better Auth: cookie + missing/untrusted Origin → 403). Wired into checkout, cancel, reactivate, portal, and set-password.

Depends on #270 (already merged).

## Verification

```
pnpm exec vitest run --config ./vitest.config.ts \
  src/shared/utils/cors.test.ts \
  src/app/api/account/set-password/route.test.ts \
  src/features/payments/create-checkout-session.route.test.ts
```

34 passed.

Made with [Cursor](https://cursor.com)