### PR TITLE
Fix concurrent Stripe webhook idempotency

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -6,6 +6,7 @@ import config from '@/payload.config'
 import Stripe from 'stripe'
 import { APP_CONFIG } from '@/shared/config'
 import { logger } from '@/shared/utils/logger'
+import { withAdvisoryLock } from '@/shared/utils/advisory-lock'
 import { getSubscriptionIdFromEvent, recordProcessedEvent } from '@/payments/webhooks/event-log'
 import { handleCheckoutSessionCompleted } from '@/payments/webhooks/handlers/checkout-session'
 import {
@@ -46,83 +47,85 @@ export async function POST(req: NextRequest) {
   logger.info('Stripe webhook received', { eventId: event.id, eventType: event.type })
 
   const payload = await getPayload({ config })
-
-  // Idempotency guard: Stripe retries deliveries, so the same event can arrive
-  // more than once. Skip events we've already processed.
-  const alreadyProcessed = await payload.find({
-    collection: 'stripe-webhook-events',
-    where: { eventId: { equals: event.id } },
-    limit: 1,
-  })
-
-  if (alreadyProcessed.totalDocs > 0) {
-    logger.info('Duplicate Stripe event delivery skipped', { eventId: event.id })
-    return NextResponse.json({ received: true, duplicate: true })
-  }
-
-  // Ordering guard: Stripe does not guarantee delivery order. If we've already
-  // processed a newer event for this subscription (e.g. subscription.deleted),
-  // don't let this older event overwrite that state.
-  const subscriptionId = getSubscriptionIdFromEvent(event)
-
-  if (subscriptionId) {
-    const newerEvent = await payload.find({
-      collection: 'stripe-webhook-events',
-      where: {
-        and: [
-          { subscriptionId: { equals: subscriptionId } },
-          { eventCreated: { greater_than: event.created } },
-        ],
-      },
-      limit: 1,
-    })
-
-    if (newerEvent.totalDocs > 0) {
-      logger.info('Stale Stripe event skipped: newer event already processed', {
-        eventId: event.id,
-        subscriptionId,
-      })
-      // Record it so retries of this stale event are also skipped
-      await recordProcessedEvent(payload, event, subscriptionId)
-      return NextResponse.json({ received: true, stale: true })
-    }
-  }
-
   try {
-    // Handle Stripe subscription events
-    switch (event.type) {
-      case 'checkout.session.completed':
-        await handleCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session)
-        break
+    // The lock makes duplicate detection one operation across all server
+    // processes. Without it, two parallel deliveries can both pass the lookup,
+    // both run side effects, then race on the unique event record.
+    return await withAdvisoryLock(payload, `stripe:event:${event.id}`, async () => {
+      const alreadyProcessed = await payload.find({
+        collection: 'stripe-webhook-events',
+        where: { eventId: { equals: event.id } },
+        limit: 1,
+      })
 
-      case 'customer.subscription.created':
-        await handleSubscriptionCreated(event.data.object as Stripe.Subscription)
-        break
+      if (alreadyProcessed.totalDocs > 0) {
+        logger.info('Duplicate Stripe event delivery skipped', { eventId: event.id })
+        return NextResponse.json({ received: true, duplicate: true })
+      }
 
-      case 'customer.subscription.updated':
-        await handleSubscriptionUpdated(event.data.object as Stripe.Subscription)
-        break
+      // Ordering guard: Stripe does not guarantee delivery order. If we've
+      // already processed a newer event for this subscription, don't let this
+      // older event overwrite that state.
+      const subscriptionId = getSubscriptionIdFromEvent(event)
 
-      case 'customer.subscription.deleted':
-        await handleSubscriptionDeleted(event.data.object as Stripe.Subscription)
-        break
+      if (subscriptionId) {
+        const newerEvent = await payload.find({
+          collection: 'stripe-webhook-events',
+          where: {
+            and: [
+              { subscriptionId: { equals: subscriptionId } },
+              { eventCreated: { greater_than: event.created } },
+            ],
+          },
+          limit: 1,
+        })
 
-      case 'invoice.payment_succeeded':
-        await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice)
-        break
+        if (newerEvent.totalDocs > 0) {
+          logger.info('Stale Stripe event skipped: newer event already processed', {
+            eventId: event.id,
+            subscriptionId,
+          })
+          // Record it so retries of this stale event are also skipped.
+          await recordProcessedEvent(payload, event, subscriptionId)
+          return NextResponse.json({ received: true, stale: true })
+        }
+      }
 
-      case 'invoice.payment_failed':
-        await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice)
-        break
+      switch (event.type) {
+        case 'checkout.session.completed':
+          await handleCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session)
+          break
 
-      default:
-        logger.info('Unhandled Stripe event type', { eventId: event.id, eventType: event.type })
-    }
+        case 'customer.subscription.created':
+          await handleSubscriptionCreated(event.data.object as Stripe.Subscription)
+          break
 
-    // Only record after successful processing so failed events are retried by Stripe
-    await recordProcessedEvent(payload, event, subscriptionId)
+        case 'customer.subscription.updated':
+          await handleSubscriptionUpdated(event.data.object as Stripe.Subscription)
+          break
 
-    return NextResponse.json({ received: true })
+        case 'customer.subscription.deleted':
+          await handleSubscriptionDeleted(event.data.object as Stripe.Subscription)
+          break
+
+        case 'invoice.payment_succeeded':
+          await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice)
+          break
+
+        case 'invoice.payment_failed':
+          await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice)
+          break
+
+        default:
+          logger.info('Unhandled Stripe event type', { eventId: event.id, eventType: event.type })
+      }
+
+      // Recording is part of successful processing. If storage fails, throw so
+      // Stripe retries instead of acknowledging an event we cannot deduplicate.
+      await recordProcessedEvent(payload, event, subscriptionId)
+
+      return NextResponse.json({ received: true })
+    })
   } catch (error) {
     logger.error('Error processing Stripe webhook', {
       eventId: event.id,

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -15,6 +15,21 @@ const mocks = vi.hoisted(() => ({
   resyncSubscription: vi.fn(),
 }))
 
+const eventLock = vi.hoisted(() => ({ tail: Promise.resolve() as Promise<unknown> }))
+
+vi.mock('@/shared/utils/advisory-lock', () => ({
+  withAdvisoryLock: vi.fn(
+    (_payload: unknown, _key: string, work: () => Promise<unknown>) => {
+      const result = eventLock.tail.then(work, work)
+      eventLock.tail = result.then(
+        () => undefined,
+        () => undefined,
+      )
+      return result
+    },
+  ),
+}))
+
 // Subscription state is written by resync alone (ADR-0008); these tests assert
 // that each event reaches it, and subscription-state.test.ts covers what it
 // then derives, against payloads Stripe actually sent.
@@ -107,6 +122,7 @@ function givenEvent(type: string, object: Record<string, unknown>, extra: Partia
 describe('Stripe webhook route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    eventLock.tail = Promise.resolve()
     consoleSpies = [
       vi.spyOn(console, 'log').mockImplementation(() => undefined),
       vi.spyOn(console, 'warn').mockImplementation(() => undefined),
@@ -163,6 +179,31 @@ describe('Stripe webhook route', () => {
     await expect(response.json()).resolves.toEqual({ received: true, duplicate: true })
     expect(mocks.resyncSubscription).not.toHaveBeenCalled()
     expect(mocks.payloadCreate).not.toHaveBeenCalled()
+  })
+
+  it('serializes concurrent deliveries before checking whether the event was processed', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+      subscription: 'sub_1',
+    })
+    let processed = false
+    mocks.payloadFind.mockImplementation(async () => ({
+      totalDocs: processed ? 1 : 0,
+      docs: processed ? [{}] : [],
+    }))
+    mocks.payloadCreate.mockImplementation(async () => {
+      processed = true
+      return {}
+    })
+
+    const responses = await Promise.all([POST(createRequest()), POST(createRequest())])
+    const bodies = await Promise.all(responses.map((response) => response.json()))
+
+    expect(bodies).toContainEqual({ received: true })
+    expect(bodies).toContainEqual({ received: true, duplicate: true })
+    expect(mocks.resyncSubscription).toHaveBeenCalledTimes(1)
+    expect(mocks.payloadCreate).toHaveBeenCalledTimes(1)
   })
 
   it('skips stale subscription events when a newer one was already processed', async () => {
@@ -402,6 +443,20 @@ describe('Stripe webhook route', () => {
     await expect(response.json()).resolves.toEqual({ error: 'Processing failed' })
     // Not recorded, so Stripe's retry will be processed again
     expect(mocks.payloadCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when the processed-event record cannot be stored', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_1',
+      customer: 'cus_1',
+      subscription: 'sub_1',
+    })
+    mocks.payloadCreate.mockRejectedValue(new Error('event store unavailable'))
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Processing failed' })
   })
 
   it('returns 500 when checkout cannot resync, so Stripe retries', async () => {

--- a/apps/questura/apps/server/src/features/payments/webhooks/event-log.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/event-log.ts
@@ -1,6 +1,5 @@
 import type { getPayload } from 'payload'
 import type Stripe from 'stripe'
-import { logger } from '@/shared/utils/logger'
 
 /**
  * Extract the subscription ID from subscription lifecycle events.
@@ -20,28 +19,23 @@ export function getSubscriptionIdFromEvent(event: Stripe.Event): string | null {
 
 /**
  * Persist a processed event ID so duplicate deliveries can be skipped.
- * A concurrent duplicate delivery can hit the unique constraint on eventId —
- * that just means the other delivery won, so the error is safe to swallow.
+ *
+ * Failure must propagate. A webhook is not safely processed until its event
+ * record is durable; acknowledging after a failed write would let a later
+ * duplicate repeat side effects without Stripe retrying this delivery.
  */
 export async function recordProcessedEvent(
   payload: Awaited<ReturnType<typeof getPayload>>,
   event: Stripe.Event,
   subscriptionId: string | null
 ) {
-  try {
-    await payload.create({
-      collection: 'stripe-webhook-events',
-      data: {
-        eventId: event.id,
-        eventType: event.type,
-        eventCreated: event.created,
-        subscriptionId,
-      },
-    })
-  } catch (error) {
-    logger.warn('Could not record processed Stripe event', {
+  await payload.create({
+    collection: 'stripe-webhook-events',
+    data: {
       eventId: event.id,
-      error: error instanceof Error ? error.message : String(error),
-    })
-  }
+      eventType: event.type,
+      eventCreated: event.created,
+      subscriptionId,
+    },
+  })
 }


### PR DESCRIPTION
## Why

Two simultaneous deliveries of one Stripe event could both pass the processed-event lookup and repeat checkout side effects before the unique event record was written.

## What

- serialize each event ID with a PostgreSQL advisory lock
- repeat duplicate detection inside that lock
- keep event processing and durable recording under the same lock
- return 500 when the processed-event record cannot be stored, allowing Stripe to retry
- cover concurrent delivery and event-store failure

## Verification

- 700 Questura server tests pass
- 104 payment tests pass
- 23 Stripe webhook route tests pass
- lint: 0 errors (5 existing warnings)
- deploy guard: 8 tests pass
- `git diff --check` and secret scan clean

No schema migration. No Stripe configuration changes. No financial transaction triggered.