### PR TITLE
Pin Stripe API version

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/stripe.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/stripe.ts
@@ -1,6 +1,16 @@
 import Stripe from 'stripe'
 import { APP_CONFIG } from '@/shared/config'
 
+/**
+ * Pin the Stripe API version the SDK was typed against.
+ *
+ * `current_period_end` lives on the subscription item in this version
+ * (ADR-0008). An unpinned client follows whatever the installed SDK defaults
+ * to after an upgrade, and `getPeriod` starts returning nulls — every member
+ * loses access. Bumping this is a deliberate, reviewed change.
+ */
+export const STRIPE_API_VERSION: Stripe.LatestApiVersion = '2025-08-27.basil'
+
 let stripeInstance: Stripe | null = null
 
 export function getStripe(): Stripe {
@@ -9,6 +19,7 @@ export function getStripe(): Stripe {
       throw new Error('STRIPE_SECRET_KEY is not set in environment variables')
     }
     stripeInstance = new Stripe(APP_CONFIG.stripe.secretKey, {
+      apiVersion: STRIPE_API_VERSION,
       typescript: true,
     })
   }


### PR DESCRIPTION
## Why

The Stripe client was constructed without `apiVersion`. After an SDK upgrade the default version can change silently, `current_period_end` moves off the subscription item, `getPeriod` returns nulls, and every member loses access.

## What

- pin the client to `2025-08-27.basil` (the version this SDK is typed against)
- export `STRIPE_API_VERSION` so a bump is a reviewed change

## Verification

- no runtime behavior change on the current SDK
- `git diff --check` clean

No schema migration. No Stripe configuration changes. No financial transaction triggered.

Made with [Cursor](https://cursor.com)