### PR TITLE
Assert Stripe env vars at production boot

### DIFF
--- a/apps/questura/apps/server/src/shared/config/assert-production-config.test.ts
+++ b/apps/questura/apps/server/src/shared/config/assert-production-config.test.ts
@@ -18,6 +18,9 @@ const VALID_PRODUCTION_ENV = {
   PAYLOAD_COOKIE_REQUIRED_HOSTS: 'api.questurian.com,questurian.com',
   PAYLOAD_SECRET: 'p'.repeat(32),
   BETTER_AUTH_SECRET: 'b'.repeat(48),
+  STRIPE_SECRET_KEY: 'sk_test_placeholder_not_a_real_key',
+  STRIPE_WEBHOOK_SECRET: 'whsec_placeholder_not_a_real_secret',
+  STRIPE_PRICE_ID: 'price_monthly_placeholder',
 }
 
 describe('production config assertion', () => {
@@ -31,6 +34,10 @@ describe('production config assertion', () => {
     vi.stubEnv('PAYLOAD_COOKIE_REQUIRED_HOSTS', '')
     vi.stubEnv('PAYLOAD_SECRET', '')
     vi.stubEnv('BETTER_AUTH_SECRET', '')
+    vi.stubEnv('STRIPE_SECRET_KEY', '')
+    vi.stubEnv('STRIPE_WEBHOOK_SECRET', '')
+    vi.stubEnv('STRIPE_PRICE_ID', '')
+    vi.stubEnv('STRIPE_PRICE_ID_MONTHLY', '')
   })
 
   afterEach(() => {
@@ -175,14 +182,50 @@ describe('production config assertion', () => {
     expect(collectProductionConfigProblems().join('\n')).toContain('BETTER_AUTH_SECRET is not set')
   })
 
+  it.each(['STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET'])(
+    'rejects a production boot with no %s',
+    async (name) => {
+      const { collectProductionConfigProblems } = await load({
+        ...VALID_PRODUCTION_ENV,
+        [name]: '',
+      })
+
+      expect(collectProductionConfigProblems().join('\n')).toContain(`${name} is not set`)
+    }
+  )
+
+  it('rejects a production boot with no monthly Stripe price id', async () => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      STRIPE_PRICE_ID: '',
+      STRIPE_PRICE_ID_MONTHLY: '',
+    })
+
+    expect(collectProductionConfigProblems().join('\n')).toContain('STRIPE_PRICE_ID')
+  })
+
+  it('accepts STRIPE_PRICE_ID_MONTHLY when STRIPE_PRICE_ID is unset', async () => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      STRIPE_PRICE_ID: '',
+      STRIPE_PRICE_ID_MONTHLY: 'price_monthly_from_new_var',
+    })
+
+    expect(collectProductionConfigProblems()).toEqual([])
+  })
+
   // Boot errors reach logs and process supervisors, so a rejection must never
   // carry the secret itself — nor a length or prefix that narrows a guess.
   it('never puts a secret value in the thrown message', async () => {
     const shortSecret = 'correct-horse-battery-x'
+    const stripeSecret = 'sk_live_this-must-not-appear-in-logs'
+    const webhookSecret = 'whsec_this-must-not-appear-either'
     const { assertProductionConfig } = await load({
       ...VALID_PRODUCTION_ENV,
       PAYLOAD_SECRET: shortSecret,
       BETTER_AUTH_SECRET: 'staple-tribune-nonsense-value',
+      STRIPE_SECRET_KEY: stripeSecret,
+      STRIPE_WEBHOOK_SECRET: webhookSecret,
     })
 
     let message = ''
@@ -198,6 +241,10 @@ describe('production config assertion', () => {
     expect(message).not.toContain('correct-horse')
     expect(message).not.toContain('staple-tribune')
     expect(message).not.toContain(String(shortSecret.length))
+    expect(message).not.toContain(stripeSecret)
+    expect(message).not.toContain(webhookSecret)
+    expect(message).not.toContain('sk_live_')
+    expect(message).not.toContain('whsec_this')
   })
 
   it('rejects a production boot with no session cookie domain decision', async () => {

--- a/apps/questura/apps/server/src/shared/config/assert-production-config.ts
+++ b/apps/questura/apps/server/src/shared/config/assert-production-config.ts
@@ -179,6 +179,31 @@ export function collectProductionConfigProblems(): ConfigProblem[] {
     if (problem) problems.push(`PAYLOAD_COOKIE_DOMAIN ${problem}`)
   }
 
+  // Empty Stripe secrets do not fail the process: checkout still takes money
+  // and `constructEvent` throws on every delivery, so nobody is ever marked a
+  // member. Catch that at boot rather than as a silent provisioning outage.
+  // Diagnostics name the variable and nothing else — no value, no prefix.
+  if (!(process.env.STRIPE_SECRET_KEY?.trim())) {
+    problems.push(
+      'STRIPE_SECRET_KEY is not set — checkout and webhooks cannot talk to Stripe.'
+    )
+  }
+
+  if (!(process.env.STRIPE_WEBHOOK_SECRET?.trim())) {
+    problems.push(
+      'STRIPE_WEBHOOK_SECRET is not set — every webhook delivery would 400 and ' +
+        'paid visitors would never be marked members.'
+    )
+  }
+
+  const monthlyPriceId =
+    process.env.STRIPE_PRICE_ID_MONTHLY?.trim() || process.env.STRIPE_PRICE_ID?.trim() || ''
+  if (!monthlyPriceId) {
+    problems.push(
+      'STRIPE_PRICE_ID (or STRIPE_PRICE_ID_MONTHLY) is not set — checkout would 400 at peak intent.'
+    )
+  }
+
   return problems
 }
 


### PR DESCRIPTION
## Why

`collectProductionConfigProblems` checked URLs, CORS, Redis, and auth secrets, but not Stripe. `STRIPE_WEBHOOK_SECRET` defaults to `''`, so `constructEvent` throws on every delivery: checkouts still succeed, money is taken, nobody is ever marked a member. Same class of outage for a blank monthly price id.

## What

- require `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and a monthly price id (`STRIPE_PRICE_ID` or `STRIPE_PRICE_ID_MONTHLY`) at production boot
- keep diagnostics name-only (no value, prefix, or length)
- cover missing vars, the monthly-price fallback, and secret-in-message leakage

## Verification

- 36 production-config tests pass
- `git diff --check` clean

No schema migration. No Stripe configuration changes. No financial transaction triggered.

Made with [Cursor](https://cursor.com)