### PR TITLE
Do not grant membership grace to incomplete subscriptions

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
@@ -160,4 +160,32 @@ describe('deriveSubscriptionState', () => {
       paidThroughAt: periodOf(deleted).end,
     })
   })
+
+  it('does not open dunning grace for an incomplete subscription that never paid', () => {
+    const incomplete = {
+      ...firstWhere((s) => s.status === 'active'),
+      status: 'incomplete',
+    } as Stripe.Subscription
+    const now = new Date('2026-09-15T13:10:00.000Z')
+
+    const derived = deriveSubscriptionState(incomplete, { now })
+
+    expect(derived.subscriptionStatus).toBe('past_due')
+    expect(derived.dunningGraceUntil).toBeNull()
+    expect(derived.paidThroughAt).toEqual(periodOf(incomplete).start)
+  })
+
+  it('still opens dunning grace for unpaid, which is a failed collection after a real period', () => {
+    const unpaid = {
+      ...firstWhere((s) => s.status === 'past_due'),
+      status: 'unpaid',
+    } as Stripe.Subscription
+    const now = new Date('2026-09-15T13:10:00.000Z')
+
+    const derived = deriveSubscriptionState(unpaid, { now })
+
+    expect(derived.dunningGraceUntil).toEqual(
+      new Date(now.getTime() + DUNNING_GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString()
+    )
+  })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
@@ -100,12 +100,16 @@ function resolvePaidThrough(subscription: Stripe.Subscription): Date | null {
  * in the captured run, five days measured from the start of the unpaid period
  * expired seven hours before Stripe's first retry, which would revoke access
  * from a visitor about to be recovered.
+ *
+ * Grace is for recovering a payment that once worked. `incomplete` is mapped
+ * to internal `past_due` for display, but that subscription never collected,
+ * so it must not open a membership window.
  */
 function resolveDunningGrace(
-  status: DerivedSubscriptionState['subscriptionStatus'],
+  stripeStatus: Stripe.Subscription.Status,
   context: DeriveContext
 ): string | null {
-  if (status !== 'past_due') return null
+  if (stripeStatus !== 'past_due' && stripeStatus !== 'unpaid') return null
 
   const existing = context.previousDunningGraceUntil
   if (existing) return existing
@@ -135,6 +139,6 @@ export function deriveSubscriptionState(
     subscriptionStatus,
     cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
     paidThroughAt: paidThrough ? paidThrough.toISOString() : null,
-    dunningGraceUntil: resolveDunningGrace(subscriptionStatus, context),
+    dunningGraceUntil: resolveDunningGrace(subscription.status, context),
   }
 }


### PR DESCRIPTION
## Why

`mapStripeStatusToInternal` maps `incomplete` → `past_due`, and `resolveDunningGrace` opened a 5-day window for anything mapped `past_due`. Combined with date-based entitlement, a subscription created in `incomplete` (abandoned 3DS, delayed payment method) became `membership.active === true` with no successful payment.

## What

- derive grace from the raw Stripe status, not the mapped one
- open grace only for `past_due` and `unpaid`
- keep `incomplete` mapped to internal `past_due` for display; it just no longer carries access

## Verification

- 13 `subscription-state` tests pass, including incomplete (no grace) and unpaid (still grace)
- `git diff --check` clean

No schema migration. No Stripe configuration changes. No financial transaction triggered.

Made with [Cursor](https://cursor.com)