### PR TITLE
Revoke membership on refunds and disputes

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -18,6 +18,11 @@ import {
   handleInvoicePaymentSucceeded,
   handleInvoicePaymentFailed,
 } from '@/payments/webhooks/handlers/invoice-payment'
+import {
+  handleChargeRefunded,
+  handleDisputeCreated,
+  handleDisputeClosed,
+} from '@/payments/webhooks/handlers/charge-revocation'
 
 export async function POST(req: NextRequest) {
   const body = await req.text()
@@ -114,6 +119,18 @@ export async function POST(req: NextRequest) {
 
         case 'invoice.payment_failed':
           await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice)
+          break
+
+        case 'charge.refunded':
+          await handleChargeRefunded(event.data.object as Stripe.Charge)
+          break
+
+        case 'charge.dispute.created':
+          await handleDisputeCreated(event.data.object as Stripe.Dispute)
+          break
+
+        case 'charge.dispute.closed':
+          await handleDisputeClosed(event.data.object as Stripe.Dispute)
           break
 
         default:

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
@@ -188,4 +188,19 @@ describe('deriveSubscriptionState', () => {
       new Date(now.getTime() + DUNNING_GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString()
     )
   })
+
+  it('clears paid-through and grace when Stripe metadata says access was revoked', () => {
+    const active = firstWhere((s) => s.status === 'active' && !s.cancel_at_period_end)
+    const revoked = {
+      ...active,
+      metadata: { access_revoked: 'true' },
+    } as Stripe.Subscription
+
+    expect(deriveSubscriptionState(revoked, {
+      previousDunningGraceUntil: '2026-09-20T00:00:00.000Z',
+    })).toMatchObject({
+      paidThroughAt: null,
+      dunningGraceUntil: null,
+    })
+  })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
@@ -14,6 +14,14 @@ import { mapStripeStatusToInternal } from './payment-service'
  */
 export const DUNNING_GRACE_DAYS = 5
 
+/**
+ * Written onto the Stripe subscription when a charge is fully refunded or
+ * disputed. Resync reads this so a later `customer.subscription.deleted`
+ * cannot restore `paidThroughAt` from the unpaid period end.
+ */
+export const ACCESS_REVOKED_METADATA_KEY = 'access_revoked'
+export const ACCESS_REVOKED_METADATA_VALUE = 'true'
+
 const DAY_MS = 24 * 60 * 60 * 1000
 
 /**
@@ -133,6 +141,16 @@ export function deriveSubscriptionState(
   context: DeriveContext = {}
 ): DerivedSubscriptionState {
   const subscriptionStatus = mapStripeStatusToInternal(subscription.status)
+
+  if (subscription.metadata?.[ACCESS_REVOKED_METADATA_KEY] === ACCESS_REVOKED_METADATA_VALUE) {
+    return {
+      subscriptionStatus,
+      cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+      paidThroughAt: null,
+      dunningGraceUntil: null,
+    }
+  }
+
   const paidThrough = resolvePaidThrough(subscription)
 
   return {

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -4,6 +4,8 @@ import { headers } from 'next/headers'
 const mocks = vi.hoisted(() => ({
   constructEvent: vi.fn(),
   invoiceRetrieve: vi.fn(),
+  chargeRetrieve: vi.fn(),
+  subscriptionUpdate: vi.fn(),
   updateUserSubscription: vi.fn(),
   getStripeSubscriptionDetails: vi.fn(),
   getSubscriptionProductName: vi.fn(),
@@ -41,6 +43,8 @@ vi.mock('@/payments/lib/stripe', () => ({
   stripe: {
     webhooks: { constructEvent: mocks.constructEvent },
     invoices: { retrieve: mocks.invoiceRetrieve },
+    charges: { retrieve: mocks.chargeRetrieve },
+    subscriptions: { update: mocks.subscriptionUpdate },
   },
 }))
 
@@ -134,6 +138,7 @@ describe('Stripe webhook route', () => {
     mocks.payloadCreate.mockResolvedValue({})
     mocks.updateUserSubscription.mockResolvedValue(true)
     mocks.resyncSubscription.mockResolvedValue({ profileId: 10, state: null, transitions: [] })
+    mocks.subscriptionUpdate.mockResolvedValue({})
     mocks.getSubscriptionProductName.mockResolvedValue('Premium Membership')
     mocks.findVisitorProfileByStripeCustomerId.mockResolvedValue({
       id: 10,
@@ -499,5 +504,100 @@ describe('Stripe webhook route', () => {
     expect(response.status).toBe(500)
     expect(mocks.resyncSubscription).not.toHaveBeenCalled()
     expect(mocks.payloadCreate).not.toHaveBeenCalled()
+  })
+
+  it('revokes membership on a fully refunded subscription charge', async () => {
+    givenEvent('charge.refunded', {
+      id: 'ch_1',
+      refunded: true,
+      invoice: 'in_1',
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
+
+    const response = await POST(createRequest())
+
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
+      metadata: { access_revoked: 'true' },
+    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('ignores a partial refund so a tax correction does not kill access', async () => {
+    givenEvent('charge.refunded', {
+      id: 'ch_1',
+      refunded: false,
+      amount_refunded: 100,
+      invoice: 'in_1',
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
+  })
+
+  it('revokes membership when a dispute is opened', async () => {
+    givenEvent('charge.dispute.created', {
+      id: 'dp_1',
+      charge: { id: 'ch_1', invoice: 'in_1' },
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({
+      id: 'in_1',
+      parent: { subscription_details: { subscription: 'sub_1' } },
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
+      metadata: { access_revoked: 'true' },
+    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('restores membership when a dispute is won', async () => {
+    givenEvent('charge.dispute.closed', {
+      id: 'dp_1',
+      status: 'won',
+      charge: { id: 'ch_1', invoice: 'in_1' },
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
+      metadata: { access_revoked: '' },
+    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('keeps membership revoked when a dispute is lost', async () => {
+    givenEvent('charge.dispute.closed', {
+      id: 'dp_1',
+      status: 'lost',
+      charge: { id: 'ch_1', invoice: 'in_1' },
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
+      metadata: { access_revoked: 'true' },
+    })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('does not resync a refunded charge that is not tied to a subscription', async () => {
+    givenEvent('charge.refunded', {
+      id: 'ch_1',
+      refunded: true,
+      invoice: 'in_1',
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1' })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
   })
 })

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
@@ -1,0 +1,125 @@
+import type Stripe from 'stripe'
+import { stripe } from '@/payments/lib/stripe'
+import { resyncSubscription } from '@/payments/lib/subscription-resync'
+import {
+  ACCESS_REVOKED_METADATA_KEY,
+  ACCESS_REVOKED_METADATA_VALUE,
+} from '@/payments/lib/subscription-state'
+import { logger } from '@/shared/utils/logger'
+import { resolveInvoiceSubscriptionId } from '../invoice-subscription'
+
+const RESTORE_ON_DISPUTE_STATUS = new Set<Stripe.Dispute.Status>(['won', 'warning_closed'])
+
+async function resolveChargeSubscriptionId(charge: Stripe.Charge): Promise<string | null> {
+  const invoiceId = typeof charge.invoice === 'string' ? charge.invoice : charge.invoice?.id
+  if (!invoiceId) return null
+
+  const invoice =
+    typeof charge.invoice === 'object' && charge.invoice && 'id' in charge.invoice
+      ? (charge.invoice as Stripe.Invoice)
+      : await stripe.invoices.retrieve(invoiceId)
+
+  return resolveInvoiceSubscriptionId(invoice)
+}
+
+async function chargeFromDispute(dispute: Stripe.Dispute): Promise<Stripe.Charge | null> {
+  if (typeof dispute.charge !== 'string') {
+    return dispute.charge ?? null
+  }
+
+  return stripe.charges.retrieve(dispute.charge)
+}
+
+async function markAccessRevoked(subscriptionId: string, revoked: boolean) {
+  await stripe.subscriptions.update(subscriptionId, {
+    metadata: {
+      [ACCESS_REVOKED_METADATA_KEY]: revoked ? ACCESS_REVOKED_METADATA_VALUE : '',
+    },
+  })
+
+  await resyncSubscription(subscriptionId)
+}
+
+async function revokeForCharge(charge: Stripe.Charge, reason: string) {
+  const subscriptionId = await resolveChargeSubscriptionId(charge)
+
+  if (!subscriptionId) {
+    logger.warn('Refund or dispute has no subscription; cannot revoke membership', {
+      chargeId: charge.id,
+      reason,
+    })
+    return
+  }
+
+  logger.warn('Revoking membership after refund or dispute', {
+    chargeId: charge.id,
+    subscriptionId,
+    reason,
+  })
+
+  await markAccessRevoked(subscriptionId, true)
+}
+
+/**
+ * Full refunds and disputes must not leave `paidThroughAt` at period end.
+ *
+ * Stripe may cancel the subscription, but a cancelled sub still reports the
+ * period that was (no longer) paid for. Writing `access_revoked` onto the
+ * subscription makes every later resync — including `subscription.deleted` —
+ * clear entitlement instead of restoring it. Partial refunds are left alone:
+ * those are often corrections, not "this period was never paid".
+ */
+export async function handleChargeRefunded(charge: Stripe.Charge) {
+  logger.info('Processing charge.refunded', { chargeId: charge.id })
+
+  if (!charge.refunded) {
+    logger.info('Partial refund ignored; membership unchanged', { chargeId: charge.id })
+    return
+  }
+
+  await revokeForCharge(charge, 'charge.refunded')
+}
+
+export async function handleDisputeCreated(dispute: Stripe.Dispute) {
+  logger.info('Processing charge.dispute.created', { disputeId: dispute.id })
+
+  const charge = await chargeFromDispute(dispute)
+  if (!charge) {
+    logger.warn('Dispute has no charge; cannot revoke membership', { disputeId: dispute.id })
+    return
+  }
+
+  await revokeForCharge(charge, 'charge.dispute.created')
+}
+
+export async function handleDisputeClosed(dispute: Stripe.Dispute) {
+  logger.info('Processing charge.dispute.closed', {
+    disputeId: dispute.id,
+    status: dispute.status,
+  })
+
+  const charge = await chargeFromDispute(dispute)
+  if (!charge) {
+    logger.warn('Closed dispute has no charge; cannot update membership', { disputeId: dispute.id })
+    return
+  }
+
+  const subscriptionId = await resolveChargeSubscriptionId(charge)
+  if (!subscriptionId) {
+    logger.warn('Closed dispute has no subscription; cannot update membership', {
+      disputeId: dispute.id,
+      chargeId: charge.id,
+    })
+    return
+  }
+
+  const restore = RESTORE_ON_DISPUTE_STATUS.has(dispute.status)
+
+  logger.info(restore ? 'Restoring membership after won dispute' : 'Keeping membership revoked after lost dispute', {
+    disputeId: dispute.id,
+    subscriptionId,
+    status: dispute.status,
+  })
+
+  await markAccessRevoked(subscriptionId, !restore)
+}


### PR DESCRIPTION
## Why

There was no handler for `charge.refunded`, `charge.dispute.created`, or `charge.dispute.closed`. Refunding or disputing a charge in the Dashboard may cancel the subscription, but `paidThroughAt` stayed at period end, so the visitor kept access they no longer paid for.

## What

- handle those three events
- stamp `access_revoked=true` on the Stripe subscription, then resync (ADR-0008 still has a single writer)
- derive entitlement as unpaid when that metadata is present, so a later `subscription.deleted` cannot restore the period end
- restore access only when a dispute closes as `won` or `warning_closed`
- ignore partial refunds (tax corrections should not kill the period)

**Operator note:** enable `charge.refunded`, `charge.dispute.created`, and `charge.dispute.closed` on the live webhook endpoint or these handlers never run.

## Verification

- 41 subscription-state + webhook route tests pass
- `git diff --check` clean

No schema migration. No financial transaction triggered.

Made with [Cursor](https://cursor.com)