### PR TITLE
Collapse duplicate Stripe subscriptions at checkout

### DIFF
--- a/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
+++ b/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/payments/lib/stripe', () => ({
   },
 }))
 
-import { findLiveSubscription, syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
+import { findLiveSubscription, listBillableSubscriptions, syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
 
@@ -97,5 +97,27 @@ describe('findLiveSubscription', () => {
       status: 'all',
       limit: 100,
     })
+  })
+})
+
+describe('listBillableSubscriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
+  })
+
+  it('includes incomplete subscriptions that checkout completion must collapse', async () => {
+    mocks.stripeSubscriptionList.mockResolvedValue({
+      data: [
+        { id: 'sub_old', status: 'canceled' },
+        { id: 'sub_open', status: 'incomplete' },
+        { id: 'sub_live', status: 'active' },
+      ],
+    })
+
+    await expect(listBillableSubscriptions('cus_123')).resolves.toEqual([
+      expect.objectContaining({ id: 'sub_open', status: 'incomplete' }),
+      expect.objectContaining({ id: 'sub_live', status: 'active' }),
+    ])
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -113,6 +113,27 @@ const LIVE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
 ])
 
 /**
+ * Statuses that will bill, including `incomplete` from a Checkout that has
+ * not finished confirming. Creation-time checkout still ignores incomplete
+ * so a visitor can retry after abandoned 3DS; completion-time duplicate
+ * detection must count it or two parallel Checkouts both land.
+ */
+const BILLABLE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
+  ...LIVE_SUBSCRIPTION_STATUSES,
+  'incomplete',
+])
+
+async function listCustomerSubscriptions(customerId: string): Promise<Stripe.Subscription[]> {
+  const listed = await stripe.subscriptions.list({
+    customer: customerId,
+    status: 'all',
+    limit: 100,
+  })
+
+  return listed.data
+}
+
+/**
  * A subscription Stripe is still collecting on, or retrying.
  *
  * Local `subscriptionStatus === 'active'` was the old checkout gate. That let a
@@ -123,11 +144,15 @@ const LIVE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
 export async function findLiveSubscription(
   customerId: string
 ): Promise<Stripe.Subscription | null> {
-  const listed = await stripe.subscriptions.list({
-    customer: customerId,
-    status: 'all',
-    limit: 100,
-  })
+  const listed = await listCustomerSubscriptions(customerId)
 
-  return listed.data.find((subscription) => LIVE_SUBSCRIPTION_STATUSES.has(subscription.status)) ?? null
+  return listed.find((subscription) => LIVE_SUBSCRIPTION_STATUSES.has(subscription.status)) ?? null
+}
+
+export async function listBillableSubscriptions(
+  customerId: string
+): Promise<Stripe.Subscription[]> {
+  const listed = await listCustomerSubscriptions(customerId)
+
+  return listed.filter((subscription) => BILLABLE_SUBSCRIPTION_STATUSES.has(subscription.status))
 }

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -6,6 +6,9 @@ const mocks = vi.hoisted(() => ({
   invoiceRetrieve: vi.fn(),
   chargeRetrieve: vi.fn(),
   subscriptionUpdate: vi.fn(),
+  subscriptionList: vi.fn(),
+  subscriptionCancel: vi.fn(),
+  refundCreate: vi.fn(),
   updateUserSubscription: vi.fn(),
   getStripeSubscriptionDetails: vi.fn(),
   getSubscriptionProductName: vi.fn(),
@@ -44,7 +47,12 @@ vi.mock('@/payments/lib/stripe', () => ({
     webhooks: { constructEvent: mocks.constructEvent },
     invoices: { retrieve: mocks.invoiceRetrieve },
     charges: { retrieve: mocks.chargeRetrieve },
-    subscriptions: { update: mocks.subscriptionUpdate },
+    subscriptions: {
+      update: mocks.subscriptionUpdate,
+      list: mocks.subscriptionList,
+      cancel: mocks.subscriptionCancel,
+    },
+    refunds: { create: mocks.refundCreate },
   },
 }))
 
@@ -139,6 +147,9 @@ describe('Stripe webhook route', () => {
     mocks.updateUserSubscription.mockResolvedValue(true)
     mocks.resyncSubscription.mockResolvedValue({ profileId: 10, state: null, transitions: [] })
     mocks.subscriptionUpdate.mockResolvedValue({})
+    mocks.subscriptionList.mockResolvedValue({ data: [] })
+    mocks.subscriptionCancel.mockResolvedValue({})
+    mocks.refundCreate.mockResolvedValue({})
     mocks.getSubscriptionProductName.mockResolvedValue('Premium Membership')
     mocks.findVisitorProfileByStripeCustomerId.mockResolvedValue({
       id: 10,
@@ -599,5 +610,33 @@ describe('Stripe webhook route', () => {
 
     expect(mocks.subscriptionUpdate).not.toHaveBeenCalled()
     expect(mocks.resyncSubscription).not.toHaveBeenCalled()
+  })
+
+  it('cancels and refunds a newer duplicate subscription, then resyncs the oldest', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_2',
+      customer: 'cus_1',
+      subscription: 'sub_new',
+    })
+    mocks.subscriptionList.mockResolvedValue({
+      data: [
+        { id: 'sub_old', status: 'active', created: 100, latest_invoice: 'in_old' },
+        { id: 'sub_new', status: 'active', created: 200, latest_invoice: 'in_new' },
+      ],
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({
+      id: 'in_new',
+      payment_intent: 'pi_new',
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.refundCreate).toHaveBeenCalledWith(
+      { payment_intent: 'pi_new' },
+      { idempotencyKey: 'dup-sub-refund-sub_new' },
+    )
+    expect(mocks.subscriptionCancel).toHaveBeenCalledWith('sub_new')
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_old')
+    expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
   })
 })

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -5,7 +5,118 @@ import type { UserSubscriptionUpdate } from '@/payments/types'
 import { APP_CONFIG } from '@/shared/config'
 import { splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
 import { resolveProfileForStripeCustomer } from '@/payments/lib/subscription-profile'
+import { listBillableSubscriptions } from '@/payments/lib/customer-linkage'
+import { stripe } from '@/payments/lib/stripe'
 import { logger } from '@/shared/utils/logger'
+
+type InvoiceWithPayment = Stripe.Invoice & {
+  payment_intent?: string | Stripe.PaymentIntent | null
+  charge?: string | Stripe.Charge | null
+  payments?: { data?: Array<{ payment?: { payment_intent?: string | Stripe.PaymentIntent; charge?: string | Stripe.Charge } }> }
+}
+
+function paymentRefFromInvoice(invoice: InvoiceWithPayment): { paymentIntent?: string; charge?: string } {
+  const paymentIntent =
+    typeof invoice.payment_intent === 'string'
+      ? invoice.payment_intent
+      : invoice.payment_intent?.id
+  const charge = typeof invoice.charge === 'string' ? invoice.charge : invoice.charge?.id
+  if (paymentIntent || charge) return { paymentIntent, charge }
+
+  for (const payment of invoice.payments?.data ?? []) {
+    const intent = payment.payment?.payment_intent
+    const intentId = typeof intent === 'string' ? intent : intent?.id
+    if (intentId) return { paymentIntent: intentId }
+
+    const paidCharge = payment.payment?.charge
+    const chargeId = typeof paidCharge === 'string' ? paidCharge : paidCharge?.id
+    if (chargeId) return { charge: chargeId }
+  }
+
+  return {}
+}
+
+async function refundDuplicateSubscription(subscription: Stripe.Subscription) {
+  const invoiceId =
+    typeof subscription.latest_invoice === 'string'
+      ? subscription.latest_invoice
+      : subscription.latest_invoice?.id
+
+  if (!invoiceId) {
+    logger.error('Duplicate subscription has no invoice to refund', {
+      subscriptionId: subscription.id,
+    })
+    return
+  }
+
+  const invoice = (await stripe.invoices.retrieve(invoiceId, {
+    expand: ['payments'],
+  })) as InvoiceWithPayment
+  const { paymentIntent, charge } = paymentRefFromInvoice(invoice)
+
+  try {
+    if (paymentIntent) {
+      await stripe.refunds.create(
+        { payment_intent: paymentIntent },
+        { idempotencyKey: `dup-sub-refund-${subscription.id}` }
+      )
+      return
+    }
+
+    if (charge) {
+      await stripe.refunds.create(
+        { charge },
+        { idempotencyKey: `dup-sub-refund-${subscription.id}` }
+      )
+      return
+    }
+  } catch (error) {
+    logger.error('Failed to refund duplicate subscription', {
+      subscriptionId: subscription.id,
+      invoiceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return
+  }
+
+  logger.error('Duplicate subscription cancelled but no charge was found to refund', {
+    subscriptionId: subscription.id,
+    invoiceId,
+  })
+}
+
+/**
+ * Two Checkout sessions can both complete after the creation-time live-sub
+ * check. Keep the oldest billable subscription, cancel and refund the rest,
+ * then resync the one that remains.
+ */
+async function collapseDuplicateSubscriptions(
+  customerId: string,
+  checkoutSubscriptionId: string
+): Promise<string> {
+  const billable = await listBillableSubscriptions(customerId)
+
+  if (billable.length <= 1) {
+    return checkoutSubscriptionId
+  }
+
+  const kept = billable.reduce((oldest, subscription) =>
+    subscription.created < oldest.created ? subscription : oldest
+  )
+  const extras = billable.filter((subscription) => subscription.id !== kept.id)
+
+  logger.error('Customer has multiple live Stripe subscriptions; cancelling extras', {
+    keptSubscriptionId: kept.id,
+    extraSubscriptionIds: extras.map((subscription) => subscription.id),
+  })
+
+  for (const extra of extras) {
+    await refundDuplicateSubscription(extra)
+    await stripe.subscriptions.cancel(extra.id)
+  }
+
+  return kept.id
+}
 
 /**
  * Handle successful checkout completion.
@@ -29,10 +140,11 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
     )
   }
 
-  const { profileId } = await resyncSubscription(subscriptionId)
+  const keptSubscriptionId = await collapseDuplicateSubscriptions(customerId, subscriptionId)
+  const { profileId } = await resyncSubscription(keptSubscriptionId)
 
   if (!profileId) {
-    throw new Error(`Failed to resync subscription ${subscriptionId} after checkout`)
+    throw new Error(`Failed to resync subscription ${keptSubscriptionId} after checkout`)
   }
 
   const extras: UserSubscriptionUpdate = {}


### PR DESCRIPTION
## Why

`create-checkout-session` checks `findLiveSubscription` then creates a Checkout session. Check and completion are minutes apart. Two tabs / double-click can complete two sessions, creating two live subscriptions. The profile stores only the last `stripeSubscriptionId`, so the app can only cancel one; the orphan bills forever.

## What

- at `checkout.session.completed`, list billable subscriptions for the customer (including `incomplete`)
- if more than one, keep the oldest, refund and cancel the extras, then resync the kept one
- refund uses an idempotency key so a webhook retry cannot double-refund
- creation-time checkout still ignores `incomplete`, so abandoned 3DS can retry

## Verification

- 42 customer-linkage + webhook + checkout-route tests pass
- `git diff --check` clean

No schema migration. Does not trigger a live checkout. If this handler ever fires on live, it will refund the duplicate — that is the intended money path.

Made with [Cursor](https://cursor.com)