### PR TITLE
Rate-limit Stripe-backed payment APIs

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/cancel-subscription/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/cancel-subscription/route.ts
@@ -2,11 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { cancelUserSubscription } from '@/payments/lib/payment-service'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
+import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
   const blocked = forbiddenOriginResponse(req, corsHeaders)
   if (blocked) return blocked
+
+  const rateLimit = await checkPaymentsRateLimit(req.headers, 'cancel')
+  if (!rateLimit.allowed) {
+    return paymentsRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -5,6 +5,7 @@ import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
+import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 import {
   findVisitorProfileByAuthUserId,
   updateVisitorProfileByAuthUserId,
@@ -30,6 +31,11 @@ export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
   const blocked = forbiddenOriginResponse(req, corsHeaders)
   if (blocked) return blocked
+
+  const rateLimit = await checkPaymentsRateLimit(req.headers, 'checkout')
+  if (!rateLimit.allowed) {
+    return paymentsRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
 
   try {
     // Deliberately not requiring a verified email. Verification before checkout

--- a/apps/questura/apps/server/src/app/api/payments/create-portal-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-portal-session/route.ts
@@ -4,11 +4,17 @@ import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
+import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
   const blocked = forbiddenOriginResponse(req, corsHeaders)
   if (blocked) return blocked
+
+  const rateLimit = await checkPaymentsRateLimit(req.headers, 'portal')
+  if (!rateLimit.allowed) {
+    return paymentsRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/app/api/payments/plans/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/plans/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { getMembershipPlans } from '@/payments/lib/membership-plans'
+import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 import { logger } from '@/shared/utils/logger'
 
 /**
@@ -12,6 +13,11 @@ import { logger } from '@/shared/utils/logger'
  */
 export async function GET(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+
+  const rateLimit = await checkPaymentsRateLimit(req.headers, 'plans')
+  if (!rateLimit.allowed) {
+    return paymentsRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
 
   try {
     const plans = await getMembershipPlans()

--- a/apps/questura/apps/server/src/app/api/payments/reactivate-subscription/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/reactivate-subscription/route.ts
@@ -2,11 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { reactivateUserSubscription } from '@/payments/lib/payment-service'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
+import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
   const blocked = forbiddenOriginResponse(req, corsHeaders)
   if (blocked) return blocked
+
+  const rateLimit = await checkPaymentsRateLimit(req.headers, 'reactivate')
+  if (!rateLimit.allowed) {
+    return paymentsRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
@@ -3,9 +3,15 @@ import { getStripeSubscriptionDetails } from '@/payments/lib/payment-service'
 import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
+import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function GET(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+
+  const rateLimit = await checkPaymentsRateLimit(req.headers, 'details')
+  if (!rateLimit.allowed) {
+    return paymentsRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
 
   try {
     const authResult = await requireVisitorPrincipal(req.headers)

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -36,6 +36,11 @@ vi.mock('@/payments/lib/stripe', () => ({
   },
 }))
 
+vi.mock('@/payments/lib/payments-rate-limit', () => ({
+  checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  paymentsRateLimitResponse: vi.fn(),
+}))
+
 vi.mock('@/shared/config', () => ({
   APP_CONFIG: {
     CORS_ORIGINS: ['http://localhost:3000'],

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -36,6 +36,11 @@ vi.mock('@/payments/lib/stripe', () => ({
   },
 }))
 
+vi.mock('@/payments/lib/payments-rate-limit', () => ({
+  checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  paymentsRateLimitResponse: vi.fn(),
+}))
+
 vi.mock('@/shared/config', () => ({
   APP_CONFIG: {
     CORS_ORIGINS: ['http://localhost:3000'],

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -36,6 +36,11 @@ vi.mock('@/payments/lib/stripe', () => ({
   },
 }))
 
+vi.mock('@/payments/lib/payments-rate-limit', () => ({
+  checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  paymentsRateLimitResponse: vi.fn(),
+}))
+
 vi.mock('@/shared/config', () => ({
   APP_CONFIG: {
     CORS_ORIGINS: ['http://localhost:3000'],

--- a/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetLocalCounters } from '@/shared/lib/rate-limit-counter'
+import {
+  PAYMENTS_RATE_LIMITS,
+  checkPaymentsRateLimit,
+} from './payments-rate-limit'
+
+function headersWithIp(ip: string) {
+  return new Headers({ 'x-forwarded-for': ip })
+}
+
+describe('payments rate limit', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    resetLocalCounters()
+  })
+
+  it('allows checkout under the per-IP ceiling', async () => {
+    const headers = headersWithIp('192.0.2.10')
+
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+      await expect(checkPaymentsRateLimit(headers, 'checkout')).resolves.toEqual({ allowed: true })
+    }
+  })
+
+  it('rejects the next checkout over the ceiling', async () => {
+    const headers = headersWithIp('192.0.2.11')
+
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+      await checkPaymentsRateLimit(headers, 'checkout')
+    }
+
+    await expect(checkPaymentsRateLimit(headers, 'checkout')).resolves.toEqual({
+      allowed: false,
+      retryAfterSeconds: expect.any(Number),
+    })
+  })
+
+  it('does not share a budget across scopes', async () => {
+    const headers = headersWithIp('192.0.2.12')
+
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+      await checkPaymentsRateLimit(headers, 'checkout')
+    }
+
+    await expect(checkPaymentsRateLimit(headers, 'plans')).resolves.toEqual({ allowed: true })
+  })
+
+  it('does not share a budget across IPs', async () => {
+    const first = headersWithIp('192.0.2.13')
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+      await checkPaymentsRateLimit(first, 'checkout')
+    }
+
+    await expect(checkPaymentsRateLimit(headersWithIp('192.0.2.14'), 'checkout')).resolves.toEqual({
+      allowed: true,
+    })
+  })
+
+  it('builds a 429 with Retry-After', async () => {
+    const { paymentsRateLimitResponse } = await import('./payments-rate-limit')
+    const response = paymentsRateLimitResponse({ 'Access-Control-Allow-Origin': 'http://localhost:3000' }, 17)
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('Retry-After')).toBe('17')
+    await expect(response.json()).resolves.toEqual({
+      error: 'Too many attempts. Please try again shortly.',
+    })
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server'
+
+import {
+  getClientIp,
+  hashIdentifier,
+  incrementCounter,
+} from '@/shared/lib/rate-limit-counter'
+import { logger } from '@/shared/utils/logger'
+
+/**
+ * Throttle for `/api/payments/*` except the Stripe webhook.
+ *
+ * Checkout, portal, cancel, and reactivate each call Stripe. An unbounded
+ * visitor can burn the shared Stripe rate budget that webhook processing
+ * also uses. Plans is public and was two Stripe reads per unauthenticated
+ * hit. Webhooks are excluded: Stripe retries must not 429.
+ */
+
+const WINDOW_SECONDS = 60
+
+export const PAYMENTS_RATE_LIMITS = {
+  checkout: 8,
+  portal: 8,
+  cancel: 8,
+  reactivate: 8,
+  details: 20,
+  plans: 30,
+} as const
+
+export type PaymentsRateLimitScope = keyof typeof PAYMENTS_RATE_LIMITS
+
+export type PaymentsRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number }
+
+export async function checkPaymentsRateLimit(
+  headers: Headers,
+  scope: PaymentsRateLimitScope
+): Promise<PaymentsRateLimitResult> {
+  const ipKey = `payments:rate-limit:${scope}:ip:${hashIdentifier(getClientIp(headers))}`
+
+  let counter
+  try {
+    counter = await incrementCounter(ipKey, WINDOW_SECONDS)
+  } catch (error) {
+    logger.error('Payments rate limit unavailable; denying', {
+      scope,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { allowed: false, retryAfterSeconds: WINDOW_SECONDS }
+  }
+
+  if (counter.count > PAYMENTS_RATE_LIMITS[scope]) {
+    return { allowed: false, retryAfterSeconds: counter.ttlSeconds }
+  }
+
+  return { allowed: true }
+}
+
+export function paymentsRateLimitResponse(
+  corsHeaders: HeadersInit,
+  retryAfterSeconds: number
+) {
+  const response = NextResponse.json(
+    { error: 'Too many attempts. Please try again shortly.' },
+    { status: 429, headers: corsHeaders }
+  )
+  response.headers.set('Retry-After', String(retryAfterSeconds))
+  return response
+}


### PR DESCRIPTION
## Why

`/api/payments/*` had no rate limit. A logged-in visitor could loop checkout creation (`customers.list` + `subscriptions.list` + `sessions.create` per hit) and burn the Stripe rate budget shared with webhook processing. `/api/payments/plans` is public and was two Stripe reads per unauthenticated request.

## What

- IP-keyed fixed window on checkout, portal, cancel, reactivate, details, and plans
- fail closed if the counter backend is down
- leave the Stripe webhook unthrottled so retries are not 429ed

## Verification

- 28 rate-limit + checkout tests pass
- `git diff --check` clean

No schema migration. No financial transaction triggered.

Made with [Cursor](https://cursor.com)