### PR TITLE
Cache Stripe membership plan reads

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
-import { getMembershipPlans } from './membership-plans'
+import { getMembershipPlans, resetMembershipPlansCache } from './membership-plans'
 
 function givenPrice(overrides: Record<string, unknown> = {}) {
   return {
@@ -35,6 +35,7 @@ function givenPrice(overrides: Record<string, unknown> = {}) {
 describe('getMembershipPlans', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetMembershipPlansCache()
   })
 
   it('reports the price and interval Stripe actually holds', async () => {
@@ -98,5 +99,15 @@ describe('getMembershipPlans', () => {
     mocks.priceRetrieve.mockRejectedValue(new Error('no such price'))
 
     await expect(getMembershipPlans()).resolves.toEqual([])
+  })
+
+  it('reuses a successful fetch within the TTL instead of hitting Stripe again', async () => {
+    mocks.priceRetrieve.mockResolvedValue(givenPrice())
+
+    const first = await getMembershipPlans()
+    const second = await getMembershipPlans()
+
+    expect(second).toEqual(first)
+    expect(mocks.priceRetrieve).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
@@ -91,8 +91,28 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
 }
 
 /** Every plan that is actually purchasable right now. */
-export async function getMembershipPlans(): Promise<MembershipPlan[]> {
-  const plans = await Promise.all([fetchPlan('monthly'), fetchPlan('yearly')])
+const PLAN_CACHE_TTL_MS = 5 * 60 * 1000
 
-  return plans.filter((plan): plan is MembershipPlan => plan !== null)
+let planCache: { storedAt: number; plans: MembershipPlan[] } | null = null
+
+export async function getMembershipPlans(): Promise<MembershipPlan[]> {
+  if (planCache && Date.now() - planCache.storedAt < PLAN_CACHE_TTL_MS) {
+    return planCache.plans
+  }
+
+  const plans = await Promise.all([fetchPlan('monthly'), fetchPlan('yearly')])
+  const resolved = plans.filter((plan): plan is MembershipPlan => plan !== null)
+
+  // Do not cache an empty result: a Stripe blip would hide both plans for
+  // the whole TTL, and prices change ~never so a successful fetch is stable.
+  if (resolved.length > 0) {
+    planCache = { storedAt: Date.now(), plans: resolved }
+  }
+
+  return resolved
+}
+
+/** Test seam: drop the in-process cache between cases. */
+export function resetMembershipPlansCache(): void {
+  planCache = null
 }


### PR DESCRIPTION
## Why

`GET /api/payments/plans` is public, uncached, and did two `prices.retrieve` calls per request. An unauthenticated flood could exhaust Stripe read rate limits and take down checkout and webhooks.

## What

- 5-minute in-process TTL cache inside `getMembershipPlans`
- do not cache an empty result, so a Stripe blip cannot hide both plans for the TTL
- test seam to reset the cache

## Verification

- 7 membership-plans tests pass
- `git diff --check` clean

No schema migration. No financial transaction triggered.

Made with [Cursor](https://cursor.com)