### PR TITLE
Reveal join hero copy after the globe, not before

### DIFF
--- a/apps/questura/apps/client/src/app/styles/global/membership.css
+++ b/apps/questura/apps/client/src/app/styles/global/membership.css
@@ -48,15 +48,28 @@
 .join-hero-title span,
 .join-hero-title em {
   display: inline-block;
-  animation:
-    join-hero-copy-reveal 820ms cubic-bezier(0.16, 1, 0.3, 1)
-    both;
+  opacity: 0;
 }
 
 .join-hero-title em {
   color: #cde7f0;
   font-weight: 400;
-  animation-delay: 280ms;
+}
+
+/*
+ * Globe leads (1.05s enter). Copy starts once the globe is clearly on
+ * screen (~420ms into that ease), then the italic follows 280ms later.
+ */
+.join-hero.is-ready .join-hero-title span {
+  animation:
+    join-hero-copy-reveal 820ms cubic-bezier(0.16, 1, 0.3, 1) 420ms
+    both;
+}
+
+.join-hero.is-ready .join-hero-title em {
+  animation:
+    join-hero-copy-reveal 820ms cubic-bezier(0.16, 1, 0.3, 1) 700ms
+    both;
 }
 
 .join-hero-visual {
@@ -77,7 +90,7 @@
   transform: translate3d(0, 80px, 0);
 }
 
-.join-hero-visual-stage.is-ready {
+.join-hero.is-ready .join-hero-visual-stage {
   animation: join-hero-visual-enter 1.05s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
@@ -547,7 +560,9 @@
     transform: none;
   }
 
-  .join-hero-visual-stage.is-ready {
+  .join-hero.is-ready .join-hero-visual-stage,
+  .join-hero.is-ready .join-hero-title span,
+  .join-hero.is-ready .join-hero-title em {
     animation: none;
     opacity: 1;
   }

--- a/apps/questura/apps/client/src/features/Payments/components/JoinHeroVisual.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/JoinHeroVisual.tsx
@@ -89,10 +89,12 @@ export default function JoinHeroVisual() {
   }, [ready, reveal]);
 
   return (
+    <section
+      className={`join-hero${ready ? ' is-ready' : ''}`}
+      aria-labelledby="join-hero-title"
+    >
     <div className="join-hero-visual" aria-hidden="true">
-      <div
-        className={`join-hero-visual-stage${ready ? ' is-ready' : ''}`}
-      >
+      <div className="join-hero-visual-stage">
         <Image
           ref={globeRef}
           src="/images/join/questurian-globe.png"
@@ -194,5 +196,13 @@ export default function JoinHeroVisual() {
         </div>
       </div>
     </div>
+
+    <div className="join-hero-copy">
+      <h1 id="join-hero-title" className="join-hero-title">
+        <span>Know more.</span>{' '}
+        <em>Travel better.</em>
+      </h1>
+    </div>
+    </section>
   );
 }

--- a/apps/questura/apps/client/src/features/Payments/components/PricingDisplay.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/PricingDisplay.tsx
@@ -86,16 +86,7 @@ export default function PricingDisplay() {
   return (
     <div className="min-h-screen bg-[#F5F0E8]">
       {/* ── Hero ── */}
-      <section className="join-hero" aria-labelledby="join-hero-title">
-        <JoinHeroVisual />
-
-        <div className="join-hero-copy">
-          <h1 id="join-hero-title" className="join-hero-title">
-            <span>Know more.</span>{' '}
-            <em>Travel better.</em>
-          </h1>
-        </div>
-      </section>
+      <JoinHeroVisual />
 
       {/* ── Departures-board ticker ── */}
       <div


### PR DESCRIPTION
## Why
The join headline animated on page load while the globe still waited to decode, so the text arrived first.

## What
Hold the title until the globe is ready. Globe rises immediately; “Know more.” follows at 420ms; “Travel better.” at 700ms.

## Verification
- Hard-refresh `/join` and confirm globe + routes enter first, then the two title lines.
- Cached reload should keep the same order (no title flash before globe).
- Reduced-motion: both snap in once the globe is ready.


Made with [Cursor](https://cursor.com)