### PR TITLE
Keep the subscription that paid when collapsing checkout duplicates

### DIFF
--- a/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
+++ b/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
@@ -16,7 +16,12 @@ vi.mock('@/payments/lib/stripe', () => ({
   },
 }))
 
-import { findLiveSubscription, listBillableSubscriptions, syncStripeCustomerEmail } from '@/payments/lib/customer-linkage'
+import {
+  findLiveSubscription,
+  listBillableSubscriptions,
+  selectSubscriptionToKeep,
+  syncStripeCustomerEmail,
+} from '@/payments/lib/customer-linkage'
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
 
@@ -119,5 +124,53 @@ describe('listBillableSubscriptions', () => {
       expect.objectContaining({ id: 'sub_open', status: 'incomplete' }),
       expect.objectContaining({ id: 'sub_live', status: 'active' }),
     ])
+  })
+})
+
+describe('selectSubscriptionToKeep', () => {
+  const subscription = (
+    id: string,
+    status: string,
+    created: number,
+  ) => ({ id, status, created }) as never
+
+  it('returns null when nothing is billable', () => {
+    expect(selectSubscriptionToKeep([])).toBeNull()
+  })
+
+  it('keeps the subscription that paid over an older abandoned 3DS attempt', () => {
+    const kept = selectSubscriptionToKeep([
+      subscription('sub_abandoned', 'incomplete', 100),
+      subscription('sub_paid', 'active', 200),
+    ])
+
+    expect(kept).toEqual(expect.objectContaining({ id: 'sub_paid' }))
+  })
+
+  it('keeps the oldest when both subscriptions actually collected', () => {
+    const kept = selectSubscriptionToKeep([
+      subscription('sub_old', 'active', 100),
+      subscription('sub_new', 'active', 200),
+    ])
+
+    expect(kept).toEqual(expect.objectContaining({ id: 'sub_old' }))
+  })
+
+  it('prefers a subscription Stripe is still retrying over one that never confirmed', () => {
+    const kept = selectSubscriptionToKeep([
+      subscription('sub_never_confirmed', 'incomplete', 100),
+      subscription('sub_retrying', 'past_due', 200),
+    ])
+
+    expect(kept).toEqual(expect.objectContaining({ id: 'sub_retrying' }))
+  })
+
+  it('falls back to age when every candidate is equally unpaid', () => {
+    const kept = selectSubscriptionToKeep([
+      subscription('sub_newer', 'incomplete', 200),
+      subscription('sub_older', 'incomplete', 100),
+    ])
+
+    expect(kept).toEqual(expect.objectContaining({ id: 'sub_older' }))
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -123,6 +123,49 @@ const BILLABLE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
   'incomplete',
 ])
 
+/**
+ * How much a status is worth when only one subscription may survive. Lower
+ * wins. Collected money outranks money Stripe is still chasing, which outranks
+ * a Checkout that never confirmed at all.
+ */
+const KEEP_PRIORITY_BY_STATUS: Partial<Record<Stripe.Subscription.Status, number>> = {
+  active: 0,
+  trialing: 0,
+  past_due: 1,
+  unpaid: 1,
+  incomplete: 2,
+}
+
+const LOWEST_KEEP_PRIORITY = 3
+
+/**
+ * Pick the one subscription a customer keeps when several are billable.
+ *
+ * Age alone is the wrong tiebreak. A visitor who abandons 3DS leaves an
+ * `incomplete` subscription sitting on the customer for ~23 hours, so their
+ * successful retry that same day is always the *newer* of the two. Keeping the
+ * older one there cancels and refunds the subscription that actually paid, then
+ * derives entitlement from one that never collected — the visitor pays, is
+ * refunded, and gets nothing.
+ *
+ * Paid-ness is therefore ranked first and `created` only breaks ties, which is
+ * what the genuine duplicate case (two Checkouts both confirming) needs.
+ */
+export function selectSubscriptionToKeep(
+  billable: Stripe.Subscription[]
+): Stripe.Subscription | null {
+  return billable.reduce<Stripe.Subscription | null>((best, subscription) => {
+    if (!best) return subscription
+
+    const candidate = KEEP_PRIORITY_BY_STATUS[subscription.status] ?? LOWEST_KEEP_PRIORITY
+    const incumbent = KEEP_PRIORITY_BY_STATUS[best.status] ?? LOWEST_KEEP_PRIORITY
+
+    if (candidate !== incumbent) return candidate < incumbent ? subscription : best
+
+    return subscription.created < best.created ? subscription : best
+  }, null)
+}
+
 async function listCustomerSubscriptions(customerId: string): Promise<Stripe.Subscription[]> {
   const listed = await stripe.subscriptions.list({
     customer: customerId,

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -639,4 +639,56 @@ describe('Stripe webhook route', () => {
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_old')
     expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
   })
+
+  it('keeps the paid subscription when an older one was abandoned at 3DS', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_3',
+      customer: 'cus_1',
+      subscription: 'sub_paid',
+    })
+    mocks.subscriptionList.mockResolvedValue({
+      data: [
+        { id: 'sub_abandoned', status: 'incomplete', created: 100, latest_invoice: 'in_abandoned' },
+        { id: 'sub_paid', status: 'active', created: 200, latest_invoice: 'in_paid' },
+      ],
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionCancel).toHaveBeenCalledWith('sub_abandoned')
+    expect(mocks.subscriptionCancel).not.toHaveBeenCalledWith('sub_paid')
+    // Nothing was ever collected on an incomplete subscription.
+    expect(mocks.refundCreate).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_paid')
+  })
+
+  it('resyncs the surviving subscription when a failed delivery is retried', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_4',
+      customer: 'cus_1',
+      subscription: 'sub_new',
+    })
+    mocks.subscriptionList.mockResolvedValueOnce({
+      data: [
+        { id: 'sub_old', status: 'active', created: 100, latest_invoice: 'in_old' },
+        { id: 'sub_new', status: 'active', created: 200, latest_invoice: 'in_new' },
+      ],
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_new', payment_intent: 'pi_new' })
+    mocks.resyncSubscription.mockRejectedValueOnce(new Error('Stripe unavailable'))
+
+    const failed = await POST(createRequest())
+    expect(failed.status).toBe(500)
+
+    // Stripe retries. The extras this handler already cancelled are no longer
+    // billable, so the session's own subscription is the cancelled, refunded one.
+    mocks.subscriptionList.mockResolvedValue({
+      data: [{ id: 'sub_old', status: 'active', created: 100, latest_invoice: 'in_old' }],
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.resyncSubscription).toHaveBeenLastCalledWith('sub_old')
+    expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
+  })
 })

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -5,7 +5,7 @@ import type { UserSubscriptionUpdate } from '@/payments/types'
 import { APP_CONFIG } from '@/shared/config'
 import { splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
 import { resolveProfileForStripeCustomer } from '@/payments/lib/subscription-profile'
-import { listBillableSubscriptions } from '@/payments/lib/customer-linkage'
+import { listBillableSubscriptions, selectSubscriptionToKeep } from '@/payments/lib/customer-linkage'
 import { stripe } from '@/payments/lib/stripe'
 import { logger } from '@/shared/utils/logger'
 
@@ -87,22 +87,29 @@ async function refundDuplicateSubscription(subscription: Stripe.Subscription) {
 
 /**
  * Two Checkout sessions can both complete after the creation-time live-sub
- * check. Keep the oldest billable subscription, cancel and refund the rest,
- * then resync the one that remains.
+ * check. Keep the billable subscription that actually collected, cancel and
+ * refund the rest, then resync the one that remains.
  */
 async function collapseDuplicateSubscriptions(
   customerId: string,
   checkoutSubscriptionId: string
 ): Promise<string> {
   const billable = await listBillableSubscriptions(customerId)
+  const kept = selectSubscriptionToKeep(billable)
 
-  if (billable.length <= 1) {
+  if (!kept) {
     return checkoutSubscriptionId
   }
 
-  const kept = billable.reduce((oldest, subscription) =>
-    subscription.created < oldest.created ? subscription : oldest
-  )
+  // On a retry of this webhook the extras have already been cancelled, so only
+  // the kept subscription is still billable. Returning the session's id here
+  // instead would resync whichever subscription the *session* names — which,
+  // when this handler cancelled and refunded it on the first run, stamps a dead
+  // subscription onto the profile and revokes a membership that was paid for.
+  if (billable.length === 1) {
+    return kept.id
+  }
+
   const extras = billable.filter((subscription) => subscription.id !== kept.id)
 
   logger.error('Customer has multiple live Stripe subscriptions; cancelling extras', {
@@ -111,7 +118,12 @@ async function collapseDuplicateSubscriptions(
   })
 
   for (const extra of extras) {
-    await refundDuplicateSubscription(extra)
+    // An `incomplete` subscription never collected, so there is nothing to give
+    // back; attempting it only logs a missing-charge error for every abandoned
+    // 3DS attempt.
+    if (extra.status !== 'incomplete') {
+      await refundDuplicateSubscription(extra)
+    }
     await stripe.subscriptions.cancel(extra.id)
   }
 


### PR DESCRIPTION
## Why

Two money bugs in `handleCheckoutSessionCompleted`'s duplicate collapse.

**1. Retry-after-abandoned-3DS refunded the subscription that paid.**
`listBillableSubscriptions` includes `incomplete`, and the collapse kept the *oldest*. A visitor whose card needs 3DS and who abandons leaves an `incomplete` subscription on the customer for ~23h. Their successful retry that same day is therefore the newer one — so the handler cancelled and refunded the subscription that collected, then resynced the `incomplete` one. `incomplete` is in `UNPAID_CURRENT_PERIOD`, so `paidThroughAt` resolved to the period *start*, in the past. Net effect: visitor pays, is refunded, gets no membership.

**2. A webhook retry could resync the cancelled, refunded subscription.**
`if (billable.length <= 1) return checkoutSubscriptionId`. When the first delivery cancelled the extras and then threw (resync failure, missing profile), Stripe retried; the extras were no longer billable, so the guard fired and returned whatever id the *session* named — potentially the subscription this handler had just cancelled and refunded. Resync then wrote `cancelled` onto the profile and stamped a dead `stripeSubscriptionId`, which cancel / reactivate / details all subsequently read.

## What

- New pure `selectSubscriptionToKeep` in `customer-linkage.ts`: ranks status (collected > still-being-retried > never-confirmed), `created` only breaks ties.
- `collapseDuplicateSubscriptions` uses it, and returns the survivor rather than the session's id.
- Extras with status `incomplete` are cancelled without an attempted refund — they never collected, and the attempt only logged a missing-charge error for every abandoned 3DS.

## Verification

- `pnpm test:int` — 97 files, 728 tests, all pass.
- New coverage: 5 unit tests on the ranking, plus two route tests (incomplete-then-paid keeps the paid one and refunds nothing; a failed delivery retried resyncs the survivor, never the session's id).
- `pnpm typecheck` — 7 errors, all pre-existing in `charge-revocation.ts`, none in the changed files.
- `eslint` clean on all four files.

No Payload collection or field changes; no migration.