### PR TITLE
Lift a refund's access revocation once a later period is paid

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
@@ -22,6 +22,28 @@ export const DUNNING_GRACE_DAYS = 5
 export const ACCESS_REVOKED_METADATA_KEY = 'access_revoked'
 export const ACCESS_REVOKED_METADATA_VALUE = 'true'
 
+/**
+ * Why access was revoked, and the end of the period the revoked charge bought.
+ *
+ * A refund and a dispute both stop entitlement, but they do not end the same
+ * way. A dispute is money still being contested, so only its resolution may
+ * restore access. A refund covers one period; when a later period is paid for
+ * successfully, that refund has nothing left to say and the flag has to lift —
+ * otherwise the visitor keeps being billed with no access, forever and silently.
+ *
+ * The period end is what separates "a new period was paid" from "the refunded
+ * invoice was simply retried".
+ */
+export const ACCESS_REVOKED_REASON_METADATA_KEY = 'access_revoked_reason'
+export const ACCESS_REVOKED_PERIOD_END_METADATA_KEY = 'access_revoked_period_end'
+
+export const ACCESS_REVOKED_REASON_REFUND = 'refund'
+export const ACCESS_REVOKED_REASON_DISPUTE = 'dispute'
+
+export type AccessRevokedReason =
+  | typeof ACCESS_REVOKED_REASON_REFUND
+  | typeof ACCESS_REVOKED_REASON_DISPUTE
+
 const DAY_MS = 24 * 60 * 60 * 1000
 
 /**
@@ -67,7 +89,9 @@ const RETRY_COVER_BUFFER_MS = 6 * 60 * 60 * 1000
  * subscription item. Read only the item: handlers refetch through the SDK, so
  * there is exactly one shape to support (ADR-0008).
  */
-function getPeriod(subscription: Stripe.Subscription): { start: Date | null; end: Date | null } {
+export function getSubscriptionPeriodSeconds(
+  subscription: Stripe.Subscription
+): { start: number | null; end: number | null } {
   const item = subscription.items?.data?.[0] as
     | { current_period_start?: number | null; current_period_end?: number | null }
     | undefined
@@ -80,8 +104,17 @@ function getPeriod(subscription: Stripe.Subscription): { start: Date | null; end
   }
 
   return {
-    start: convertStripeTimestamp(item.current_period_start ?? null),
-    end: convertStripeTimestamp(item.current_period_end ?? null),
+    start: item.current_period_start ?? null,
+    end: item.current_period_end ?? null,
+  }
+}
+
+function getPeriod(subscription: Stripe.Subscription): { start: Date | null; end: Date | null } {
+  const { start, end } = getSubscriptionPeriodSeconds(subscription)
+
+  return {
+    start: convertStripeTimestamp(start),
+    end: convertStripeTimestamp(end),
   }
 }
 

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   invoiceRetrieve: vi.fn(),
   chargeRetrieve: vi.fn(),
   subscriptionUpdate: vi.fn(),
+  subscriptionRetrieve: vi.fn(),
   subscriptionList: vi.fn(),
   subscriptionCancel: vi.fn(),
   refundCreate: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock('@/payments/lib/stripe', () => ({
     charges: { retrieve: mocks.chargeRetrieve },
     subscriptions: {
       update: mocks.subscriptionUpdate,
+      retrieve: mocks.subscriptionRetrieve,
       list: mocks.subscriptionList,
       cancel: mocks.subscriptionCancel,
     },
@@ -147,6 +149,7 @@ describe('Stripe webhook route', () => {
     mocks.updateUserSubscription.mockResolvedValue(true)
     mocks.resyncSubscription.mockResolvedValue({ profileId: 10, state: null, transitions: [] })
     mocks.subscriptionUpdate.mockResolvedValue({})
+    mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', metadata: {}, items: { data: [{}] } })
     mocks.subscriptionList.mockResolvedValue({ data: [] })
     mocks.subscriptionCancel.mockResolvedValue({})
     mocks.refundCreate.mockResolvedValue({})
@@ -523,13 +526,21 @@ describe('Stripe webhook route', () => {
       refunded: true,
       invoice: 'in_1',
     })
-    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
+    mocks.invoiceRetrieve.mockResolvedValue({
+      id: 'in_1',
+      subscription: 'sub_1',
+      lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
+    })
 
     const response = await POST(createRequest())
 
     await expect(response.json()).resolves.toEqual({ received: true })
     expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
-      metadata: { access_revoked: 'true' },
+      metadata: {
+        access_revoked: 'true',
+        access_revoked_reason: 'refund',
+        access_revoked_period_end: '2000',
+      },
     })
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
@@ -556,12 +567,17 @@ describe('Stripe webhook route', () => {
     mocks.invoiceRetrieve.mockResolvedValue({
       id: 'in_1',
       parent: { subscription_details: { subscription: 'sub_1' } },
+      lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
     })
 
     await POST(createRequest())
 
     expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
-      metadata: { access_revoked: 'true' },
+      metadata: {
+        access_revoked: 'true',
+        access_revoked_reason: 'dispute',
+        access_revoked_period_end: '2000',
+      },
     })
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
@@ -577,7 +593,11 @@ describe('Stripe webhook route', () => {
     await POST(createRequest())
 
     expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
-      metadata: { access_revoked: '' },
+      metadata: {
+        access_revoked: '',
+        access_revoked_reason: '',
+        access_revoked_period_end: '',
+      },
     })
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
@@ -588,12 +608,20 @@ describe('Stripe webhook route', () => {
       status: 'lost',
       charge: { id: 'ch_1', invoice: 'in_1' },
     })
-    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
+    mocks.invoiceRetrieve.mockResolvedValue({
+      id: 'in_1',
+      subscription: 'sub_1',
+      lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
+    })
 
     await POST(createRequest())
 
     expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', {
-      metadata: { access_revoked: 'true' },
+      metadata: {
+        access_revoked: 'true',
+        access_revoked_reason: 'dispute',
+        access_revoked_period_end: '2000',
+      },
     })
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
@@ -690,5 +718,109 @@ describe('Stripe webhook route', () => {
 
     expect(mocks.resyncSubscription).toHaveBeenLastCalledWith('sub_old')
     expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
+  })
+
+  const CLEARED_REVOCATION_METADATA = {
+    metadata: {
+      access_revoked: '',
+      access_revoked_reason: '',
+      access_revoked_period_end: '',
+    },
+  }
+
+  function givenPaidRenewal(subscription: Record<string, unknown>) {
+    givenEvent('invoice.payment_succeeded', {
+      id: 'in_2',
+      subscription: 'sub_1',
+      billing_reason: 'subscription_cycle',
+    })
+    mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', ...subscription })
+  }
+
+  it('restores access when a period after the refunded one is paid', async () => {
+    givenPaidRenewal({
+      metadata: {
+        access_revoked: 'true',
+        access_revoked_reason: 'refund',
+        access_revoked_period_end: '2000',
+      },
+      items: { data: [{ current_period_start: 2_000, current_period_end: 5_000 }] },
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', CLEARED_REVOCATION_METADATA)
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('keeps access revoked when the refunded invoice itself is paid again', async () => {
+    givenPaidRenewal({
+      metadata: {
+        access_revoked: 'true',
+        access_revoked_reason: 'refund',
+        access_revoked_period_end: '2000',
+      },
+      // Still sitting in the period that was refunded.
+      items: { data: [{ current_period_start: 1_000, current_period_end: 2_000 }] },
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  // The money is still contested; only charge.dispute.closed may resolve it.
+  it('keeps access revoked through a paid renewal while a dispute is open', async () => {
+    givenPaidRenewal({
+      metadata: {
+        access_revoked: 'true',
+        access_revoked_reason: 'dispute',
+        access_revoked_period_end: '2000',
+      },
+      items: { data: [{ current_period_start: 2_000, current_period_end: 5_000 }] },
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  // Written before the reason and period were recorded.
+  it('restores access on a paid renewal for a revocation that recorded no reason', async () => {
+    givenPaidRenewal({
+      metadata: { access_revoked: 'true' },
+      items: { data: [{ current_period_start: 5_000, current_period_end: 8_000 }] },
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).toHaveBeenCalledWith('sub_1', CLEARED_REVOCATION_METADATA)
+  })
+
+  it('leaves an unrevoked subscription untouched on a paid renewal', async () => {
+    givenPaidRenewal({
+      metadata: {},
+      items: { data: [{ current_period_start: 2_000, current_period_end: 5_000 }] },
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionUpdate).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+
+  it('does not look up the subscription on a checkout invoice', async () => {
+    givenEvent('invoice.payment_succeeded', {
+      id: 'in_1',
+      subscription: 'sub_1',
+      billing_reason: 'subscription_create',
+    })
+
+    await POST(createRequest())
+
+    expect(mocks.subscriptionRetrieve).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 })

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
@@ -4,22 +4,37 @@ import { resyncSubscription } from '@/payments/lib/subscription-resync'
 import {
   ACCESS_REVOKED_METADATA_KEY,
   ACCESS_REVOKED_METADATA_VALUE,
+  ACCESS_REVOKED_PERIOD_END_METADATA_KEY,
+  ACCESS_REVOKED_REASON_DISPUTE,
+  ACCESS_REVOKED_REASON_METADATA_KEY,
+  ACCESS_REVOKED_REASON_REFUND,
+  type AccessRevokedReason,
 } from '@/payments/lib/subscription-state'
 import { logger } from '@/shared/utils/logger'
 import { resolveInvoiceSubscriptionId } from '../invoice-subscription'
 
 const RESTORE_ON_DISPUTE_STATUS = new Set<Stripe.Dispute.Status>(['won', 'warning_closed'])
 
-async function resolveChargeSubscriptionId(charge: Stripe.Charge): Promise<string | null> {
-  const invoiceId = typeof charge.invoice === 'string' ? charge.invoice : charge.invoice?.id
+/** `invoice` is on the wire but absent from the pinned SDK's `Charge`. */
+type ChargeWithInvoice = Stripe.Charge & {
+  invoice?: string | Stripe.Invoice | null
+}
+
+/** The subscription period a charge's invoice covers, in Stripe's seconds. */
+type InvoicePeriod = { end: number | null }
+
+async function resolveChargeInvoice(charge: Stripe.Charge): Promise<Stripe.Invoice | null> {
+  const chargeInvoice = (charge as ChargeWithInvoice).invoice
+  const invoiceId = typeof chargeInvoice === 'string' ? chargeInvoice : chargeInvoice?.id
   if (!invoiceId) return null
 
-  const invoice =
-    typeof charge.invoice === 'object' && charge.invoice && 'id' in charge.invoice
-      ? (charge.invoice as Stripe.Invoice)
-      : await stripe.invoices.retrieve(invoiceId)
+  return typeof chargeInvoice === 'object' && chargeInvoice && 'id' in chargeInvoice
+    ? chargeInvoice
+    : stripe.invoices.retrieve(invoiceId)
+}
 
-  return resolveInvoiceSubscriptionId(invoice)
+function invoicePeriod(invoice: Stripe.Invoice): InvoicePeriod {
+  return { end: invoice.lines?.data?.[0]?.period?.end ?? null }
 }
 
 async function chargeFromDispute(dispute: Stripe.Dispute): Promise<Stripe.Charge | null> {
@@ -30,34 +45,50 @@ async function chargeFromDispute(dispute: Stripe.Dispute): Promise<Stripe.Charge
   return stripe.charges.retrieve(dispute.charge)
 }
 
-async function markAccessRevoked(subscriptionId: string, revoked: boolean) {
+async function markAccessRevoked(
+  subscriptionId: string,
+  revocation: { reason: AccessRevokedReason; periodEnd: number | null } | null
+) {
+  // Stripe deletes a metadata key when its value is the empty string, so a
+  // restore clears all three in one update.
   await stripe.subscriptions.update(subscriptionId, {
     metadata: {
-      [ACCESS_REVOKED_METADATA_KEY]: revoked ? ACCESS_REVOKED_METADATA_VALUE : '',
+      [ACCESS_REVOKED_METADATA_KEY]: revocation ? ACCESS_REVOKED_METADATA_VALUE : '',
+      [ACCESS_REVOKED_REASON_METADATA_KEY]: revocation ? revocation.reason : '',
+      [ACCESS_REVOKED_PERIOD_END_METADATA_KEY]:
+        revocation && revocation.periodEnd ? String(revocation.periodEnd) : '',
     },
   })
 
   await resyncSubscription(subscriptionId)
 }
 
-async function revokeForCharge(charge: Stripe.Charge, reason: string) {
-  const subscriptionId = await resolveChargeSubscriptionId(charge)
+async function revokeForCharge(
+  charge: Stripe.Charge,
+  reason: AccessRevokedReason,
+  event: string
+) {
+  const invoice = await resolveChargeInvoice(charge)
+  const subscriptionId = invoice ? await resolveInvoiceSubscriptionId(invoice) : null
 
-  if (!subscriptionId) {
+  if (!invoice || !subscriptionId) {
     logger.warn('Refund or dispute has no subscription; cannot revoke membership', {
       chargeId: charge.id,
-      reason,
+      reason: event,
     })
     return
   }
 
+  const { end } = invoicePeriod(invoice)
+
   logger.warn('Revoking membership after refund or dispute', {
     chargeId: charge.id,
     subscriptionId,
-    reason,
+    reason: event,
+    revokedPeriodEnd: end,
   })
 
-  await markAccessRevoked(subscriptionId, true)
+  await markAccessRevoked(subscriptionId, { reason, periodEnd: end })
 }
 
 /**
@@ -77,7 +108,7 @@ export async function handleChargeRefunded(charge: Stripe.Charge) {
     return
   }
 
-  await revokeForCharge(charge, 'charge.refunded')
+  await revokeForCharge(charge, ACCESS_REVOKED_REASON_REFUND, 'charge.refunded')
 }
 
 export async function handleDisputeCreated(dispute: Stripe.Dispute) {
@@ -89,7 +120,7 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute) {
     return
   }
 
-  await revokeForCharge(charge, 'charge.dispute.created')
+  await revokeForCharge(charge, ACCESS_REVOKED_REASON_DISPUTE, 'charge.dispute.created')
 }
 
 export async function handleDisputeClosed(dispute: Stripe.Dispute) {
@@ -104,8 +135,9 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute) {
     return
   }
 
-  const subscriptionId = await resolveChargeSubscriptionId(charge)
-  if (!subscriptionId) {
+  const invoice = await resolveChargeInvoice(charge)
+  const subscriptionId = invoice ? await resolveInvoiceSubscriptionId(invoice) : null
+  if (!invoice || !subscriptionId) {
     logger.warn('Closed dispute has no subscription; cannot update membership', {
       disputeId: dispute.id,
       chargeId: charge.id,
@@ -121,5 +153,10 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute) {
     status: dispute.status,
   })
 
-  await markAccessRevoked(subscriptionId, !restore)
+  await markAccessRevoked(
+    subscriptionId,
+    restore
+      ? null
+      : { reason: ACCESS_REVOKED_REASON_DISPUTE, periodEnd: invoicePeriod(invoice).end }
+  )
 }

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/invoice-payment.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/invoice-payment.ts
@@ -1,6 +1,15 @@
 import type Stripe from 'stripe'
 import { logger } from '@/shared/utils/logger'
+import { stripe } from '@/payments/lib/stripe'
 import { resyncSubscription } from '@/payments/lib/subscription-resync'
+import {
+  ACCESS_REVOKED_METADATA_KEY,
+  ACCESS_REVOKED_METADATA_VALUE,
+  ACCESS_REVOKED_PERIOD_END_METADATA_KEY,
+  ACCESS_REVOKED_REASON_METADATA_KEY,
+  ACCESS_REVOKED_REASON_REFUND,
+  getSubscriptionPeriodSeconds,
+} from '@/payments/lib/subscription-state'
 import { resolveInvoiceSubscriptionId } from '../invoice-subscription'
 
 /**
@@ -13,6 +22,81 @@ import { resolveInvoiceSubscriptionId } from '../invoice-subscription'
  * handlers now resolve the subscription and let the subscription object decide.
  */
 
+/**
+ * Billing reasons that mean money was collected for a period that had not been
+ * paid for yet. `subscription_create` is excluded: nothing can have been
+ * revoked before the subscription's first invoice, and skipping it keeps the
+ * extra subscription fetch off the checkout path.
+ */
+const NEW_PERIOD_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
+  'subscription_cycle',
+  'subscription_update',
+])
+
+/**
+ * Lift a refund's revocation once a later period has actually been paid for.
+ *
+ * `access_revoked` is written when a charge is fully refunded, and
+ * `deriveSubscriptionState` then forces `paidThroughAt: null` on every resync
+ * that follows. Stripe does not cancel a subscription because one of its
+ * invoices was refunded, so without this the visitor keeps being billed
+ * successfully, month after month, while the flag silently denies them access
+ * — and nothing but a won dispute ever clears it.
+ *
+ * Two things must not clear it. A dispute is money still being contested, so
+ * only `charge.dispute.closed` may resolve one. And a retry of the refunded
+ * invoice itself is not a new period: comparing the subscription's current
+ * period start against the revoked period's end separates the two, because a
+ * retry leaves the subscription sitting in the period that was refunded.
+ *
+ * A revocation written before this metadata existed carries no reason and no
+ * period end. Those are treated as refunds and cleared: a wrongly cleared
+ * dispute is corrected by its own `closed` event, whereas a wrongly kept
+ * refund locks a paying visitor out permanently.
+ */
+async function clearRefundRevocationOnNewPeriod(
+  invoice: Stripe.Invoice,
+  subscriptionId: string
+): Promise<void> {
+  const billingReason = invoice.billing_reason
+  if (!billingReason || !NEW_PERIOD_BILLING_REASONS.has(billingReason)) return
+
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+  const metadata = subscription.metadata ?? {}
+
+  if (metadata[ACCESS_REVOKED_METADATA_KEY] !== ACCESS_REVOKED_METADATA_VALUE) return
+
+  const reason = metadata[ACCESS_REVOKED_REASON_METADATA_KEY]
+  if (reason && reason !== ACCESS_REVOKED_REASON_REFUND) return
+
+  const revokedPeriodEnd = Number(metadata[ACCESS_REVOKED_PERIOD_END_METADATA_KEY])
+  const { start: paidPeriodStart } = getSubscriptionPeriodSeconds(subscription)
+
+  if (
+    Number.isFinite(revokedPeriodEnd) &&
+    revokedPeriodEnd > 0 &&
+    paidPeriodStart !== null &&
+    paidPeriodStart < revokedPeriodEnd
+  ) {
+    return
+  }
+
+  logger.warn('Restoring membership: a period after the refunded one was paid', {
+    invoiceId: invoice.id,
+    subscriptionId,
+    revokedPeriodEnd: Number.isFinite(revokedPeriodEnd) ? revokedPeriodEnd : null,
+    paidPeriodStart,
+  })
+
+  await stripe.subscriptions.update(subscriptionId, {
+    metadata: {
+      [ACCESS_REVOKED_METADATA_KEY]: '',
+      [ACCESS_REVOKED_REASON_METADATA_KEY]: '',
+      [ACCESS_REVOKED_PERIOD_END_METADATA_KEY]: '',
+    },
+  })
+}
+
 export async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
   logger.info('Processing invoice.payment_succeeded', { invoiceId: invoice.id })
 
@@ -22,6 +106,9 @@ export async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
     logger.info('Invoice not related to subscription, skipping', { invoiceId: invoice.id })
     return
   }
+
+  // Before the resync, so the state it derives already reflects the cleared flag.
+  await clearRefundRevocationOnNewPeriod(invoice, subscriptionId)
 
   await resyncSubscription(subscriptionId)
 }


### PR DESCRIPTION
## Why

`access_revoked` on the Stripe subscription is permanent in practice.

`handleChargeRefunded` sets it on a full refund. `deriveSubscriptionState` then returns `paidThroughAt: null` on **every** later resync. The only thing that ever cleared it was a won dispute (`handleDisputeClosed`).

Stripe does not cancel a subscription because one of its invoices was refunded. So: goodwill-refund month 3 → months 4, 5, 6 bill successfully → each `invoice.payment_succeeded` resyncs → `paidThroughAt` still `null`. A paying customer with zero access, indefinitely, with nothing in the product or the logs saying so.

## What

A refund and a dispute stop entitlement for different reasons and must end differently, so the flag now records which one it was and what it covered:

| metadata key | value |
|---|---|
| `access_revoked` | `'true'` — unchanged, still the only key `deriveSubscriptionState` reads |
| `access_revoked_reason` | `'refund'` or `'dispute'` |
| `access_revoked_period_end` | period end of the revoked charge's invoice |

`handleInvoicePaymentSucceeded` clears a **refund** revocation when a later period has been paid for.

- **Disputes are never cleared this way.** The money is still contested; only `charge.dispute.closed` resolves one.
- **A retry of the refunded invoice is not a new period.** The subscription is still inside the period that was refunded, so `current_period_start < access_revoked_period_end` and the flag stays.
- **Legacy revocations** (written before these keys existed) carry no reason and no period. They are treated as refunds and cleared: a wrongly cleared dispute is put back by its own `closed` event, whereas a wrongly kept refund locks a paying visitor out for good.

The subscription lookup only runs for billing reasons that pay for a new period (`subscription_cycle`, `subscription_update`), so `subscription_create` — the checkout path — costs nothing extra.

`deriveSubscriptionState` is untouched; it still reads only `access_revoked`.

## Also

`Charge.invoice` is on the wire but absent from the pinned SDK's type, and those were the lines being rewritten here. Typed via `ChargeWithInvoice`, following the existing `InvoiceWithPayment` pattern in `checkout-session.ts`. **`pnpm typecheck` is now clean** — those 7 were the whole of the server's pre-existing error list.

## Verification

- `pnpm test:int` — 97 files, 734 tests, all pass.
- `pnpm typecheck` — 0 errors (was 7, all in this file).
- New coverage: paid renewal after a refund restores access; the refunded invoice retried does not; a paid renewal during an open dispute does not; a reason-less legacy flag does; an unrevoked subscription is untouched; a `subscription_create` invoice never fetches the subscription.
- The five existing revocation tests were updated for the wider metadata write.

No Payload collection or field changes; no migration. All new state lives in Stripe metadata.

## Follow-up

Any subscription already carrying a stuck flag is not fixed by deploying this — it is fixed by its next successful renewal. A read-only audit script to find them is next.