### PR TITLE
Drop the inert email-password entry from trustedProviders

### DIFF
--- a/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
@@ -77,9 +77,22 @@ export const visitorAuth = betterAuth({
     modelName: 'visitor_auth_accounts',
     encryptOAuthTokens: true,
     storeStateStrategy: 'database',
+    // `trustedProviders` is only ever compared against an OAuth provider id
+    // (Better Auth checks it in the OAuth callback, the implicit-link path and
+    // `linkAccount`), so listing `email-password` here did nothing — it read
+    // like a decision to trust password accounts for linking while having no
+    // effect at all.
+    //
+    // What actually protects this surface is `requireLocalEmailVerified`, which
+    // defaults to true: signing in with Google cannot implicitly link onto an
+    // existing local account whose address was never verified. That is what
+    // stops someone registering a stranger's address with a password and
+    // waiting to inherit the session — and the subscription — they later create
+    // with Google. Left at its default deliberately; stated here because the
+    // default is doing security work and is easy to switch off by accident.
     accountLinking: {
       enabled: true,
-      trustedProviders: ['google', 'email-password'],
+      trustedProviders: ['google'],
       allowDifferentEmails: false,
     },
   },


### PR DESCRIPTION
## Why

`accountLinking.trustedProviders: ['google', 'email-password']` reads like a decision to trust password accounts for automatic linking. It is not one — the entry has no effect.

Better Auth 1.6.11 consults the list in exactly three places, and every one compares it against an **OAuth** provider id:

- `oauth2/link-account.mjs:20` — implicit linking during sign-in
- `api/routes/callback.mjs:104` — the OAuth callback's explicit link branch
- `api/routes/account.mjs:145` — `linkAccount`

`email-password` is never a candidate in any of them.

## What actually guards this

While removing the dead entry, the comment records the setting that is doing the work, because it is a default and therefore invisible:

```js
// oauth2/link-account.mjs:20-22
const requireLocalEmailVerified = accountLinking?.requireLocalEmailVerified ?? true
if (!isTrustedProvider && !userInfo.emailVerified
    || requireLocalEmailVerified && !dbUser.user.emailVerified
    || ...) { return { error: 'account not linked' } }
```

`requireLocalEmailVerified` defaults to **true** and this config never overrides it. So Google sign-in cannot implicitly link onto a local account whose address was never verified — which is what stops someone registering a stranger's address with a password and inheriting the account, and the subscription, that stranger later creates with Google. Worth a comment: it is load-bearing, unset, and easy to turn off without knowing what it was holding up.

## Verification

Behaviour-neutral by construction — the removed value could not match any provider id.

- `pnpm test:int` on `visitor-auth` — 14 files, 95 tests, pass.
- `eslint` clean.
- `pnpm typecheck` — 7 errors, all pre-existing in `charge-revocation.ts`, and all fixed by #285.

## Not included

There is a narrower residual in this area: `emailVerification.sendOnSignUp` mails a real verification link to the address an attacker registered, so a victim who clicks it verifies the attacker's account and makes it linkable. Closing that costs either `requireEmailVerification: true` (which contradicts the deliberate "checkout no longer requires a verified email" choice) or `disableImplicitLinking: true` (which sends every Google-on-existing-password user through settings). That is a product call, not a code one, and is left for a decision rather than folded in here.