### PR TITLE
Make Google account linking explicit only

### DIFF
--- a/apps/questura/apps/client/src/features/Auth/pages/AuthErrorPage.tsx
+++ b/apps/questura/apps/client/src/features/Auth/pages/AuthErrorPage.tsx
@@ -20,6 +20,12 @@ function AuthErrorContent() {
         case 'account_exists':
           setError('An account with this email already exists. Please sign in with your existing credentials.');
           break;
+        // Google will not attach itself to an account that already exists under
+        // the same address. Without this case the visitor gets the generic
+        // "try again" and loops, because trying again does the same thing.
+        case 'account_not_linked':
+          setError('This email already has an account. Sign in the way you created it, then connect Google from your account settings.');
+          break;
         case 'oauth_cancelled':
           setError('Google sign-in was cancelled. Please try again.');
           break;

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
@@ -92,6 +92,22 @@ export const visitorAuth = betterAuth({
     // default is doing security work and is easy to switch off by accident.
     accountLinking: {
       enabled: true,
+      // Linking is explicit only. Signing in with Google will never attach
+      // itself to an account that already exists under that address; the
+      // visitor signs in the way that account was made and connects Google from
+      // their account page, which goes through `link-social` and is unaffected
+      // by this flag.
+      //
+      // `requireLocalEmailVerified` already refused to link onto an *unverified*
+      // local account, which closed the obvious version of this. What it could
+      // not close is that `sendOnSignUp` mails a genuine verification link to
+      // whatever address was registered — so someone who signs up as a stranger
+      // gets that stranger to do the verifying for them, and inherits the
+      // account, its billing portal and its subscription the moment the real
+      // owner tries Google. Implicit linking is the only thing that turns
+      // "someone typed your address" into "someone is in your account", and it
+      // buys one saved click.
+      disableImplicitLinking: true,
       trustedProviders: ['google'],
       allowDifferentEmails: false,
     },


### PR DESCRIPTION
## The decision

Of the three options for the residual pre-hijack, this is `disableImplicitLinking: true` — and it is the one worth taking, because the recovery path already exists in the product and the alternative contradicts a decision you already made.

- ~~`requireEmailVerification: true`~~ — narrows the window without closing it, and contradicts the deliberate "checkout no longer requires a verified email" choice (`checkout-session.ts:173-175`).
- ~~Revoke the password credential on link~~ — correct but custom, and it fires on legitimate links too.
- **`disableImplicitLinking: true`** — closes the class outright, and the account page already has full connect/disconnect Google plus add-password flows for anyone who lands on the new error.

## Why it still needed closing after #286

`requireLocalEmailVerified` (default `true`) refuses to implicitly link onto an **unverified** local account, which is what made the originally reported attack not reproduce.

What it cannot refuse is a *verified* one. `emailVerification.sendOnSignUp: true` mails a genuine verification link to whatever address was registered — so an attacker who signs up as `victim@…` gets the victim to do the verifying, and inherits the account the moment the victim tries "Sign in with Google". The attacker's password still opens it: billing portal, cancel subscription, billing email, name.

Implicit linking is the only thing turning "someone typed your address" into "someone is in your account", and it buys one saved click.

## Blast radius

`disableImplicitLinking` is read in exactly two places in `better-auth@1.6.11` — `oauth2/link-account.mjs:22` (implicit sign-in) and `plugins/one-tap/index.mjs:78` (plugin not used here). **Explicit linking is untouched**: `/api/visitor-auth/link-social` from the account page goes through `api/routes/account.mjs` and never consults this flag.

So:

| flow | before | after |
|---|---|---|
| New user, Google | works | unchanged |
| Existing Google user, Google | works | unchanged |
| Account page → Connect Google | works | unchanged |
| Password account, then clicks "Sign in with Google" | **silently linked** | error + told to sign in and connect from settings |

That last row is both the attack and the only legitimate case affected, and it now has an accurate message instead of a silent merge.

## The error page

Refused linking redirects with `error=account_not_linked` (`callback.mjs:162` slugs `"account not linked"`). `AuthErrorPage` had no case for it, so it fell to the generic "please try again" — and trying again does exactly the same thing, so the visitor loops. Added a case that names the cause and points at the account page.

## Verification

- `pnpm test:int` — 97 files, 734 tests, pass.
- `tsc --noEmit` clean on **both** server and client.
- `eslint` clean.
- Error code confirmed by reading `better-auth@1.6.11` dist rather than assumed.

No Payload collection or field changes; no migration.