### PR TITLE
Identify rate-limited callers from one configured proxy header

### DIFF
--- a/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/better-auth.ts
@@ -239,7 +239,13 @@ export const visitorAuth = betterAuth({
     cookiePrefix: 'questura_visitor',
     useSecureCookies: APP_CONFIG.isProduction,
     ipAddress: {
-      ipAddressHeaders: ['x-forwarded-for', 'x-real-ip'],
+      // One header, chosen by `TRUSTED_PROXY`, matching `getClientIp`. Better
+      // Auth takes the first header present in this list, so listing several
+      // would let a caller pick which one identifies them. `x-forwarded-for`
+      // remains only as the development fallback, where nothing fronts the app.
+      ipAddressHeaders: APP_CONFIG.trustedProxy.header
+        ? [APP_CONFIG.trustedProxy.header]
+        : ['x-forwarded-for', 'x-real-ip'],
       disableIpTracking: false,
     },
   },

--- a/apps/questura/apps/server/src/shared/config/assert-production-config.test.ts
+++ b/apps/questura/apps/server/src/shared/config/assert-production-config.test.ts
@@ -21,6 +21,7 @@ const VALID_PRODUCTION_ENV = {
   STRIPE_SECRET_KEY: 'sk_test_placeholder_not_a_real_key',
   STRIPE_WEBHOOK_SECRET: 'whsec_placeholder_not_a_real_secret',
   STRIPE_PRICE_ID: 'price_monthly_placeholder',
+  TRUSTED_PROXY: 'cloudflare',
 }
 
 describe('production config assertion', () => {
@@ -38,6 +39,7 @@ describe('production config assertion', () => {
     vi.stubEnv('STRIPE_WEBHOOK_SECRET', '')
     vi.stubEnv('STRIPE_PRICE_ID', '')
     vi.stubEnv('STRIPE_PRICE_ID_MONTHLY', '')
+    vi.stubEnv('TRUSTED_PROXY', '')
   })
 
   afterEach(() => {
@@ -349,6 +351,31 @@ describe('production config assertion', () => {
     })
 
     expect(collectProductionConfigProblems()).toEqual([])
+  })
+
+  // Unset, `getClientIp` reads the first x-forwarded-for entry, which the
+  // caller writes — so every rate limit becomes bypassable by rotating one
+  // header. Refusing the boot is the point: a platform move must restate this.
+  it('refuses a production boot that has not said which proxy fronts it', async () => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      TRUSTED_PROXY: '',
+    })
+
+    expect(collectProductionConfigProblems()).toEqual([
+      expect.stringContaining('TRUSTED_PROXY is not set'),
+    ])
+  })
+
+  it('refuses a misspelled proxy rather than falling back', async () => {
+    const { collectProductionConfigProblems } = await load({
+      ...VALID_PRODUCTION_ENV,
+      TRUSTED_PROXY: 'cloudfare',
+    })
+
+    expect(collectProductionConfigProblems()).toEqual([
+      expect.stringContaining('TRUSTED_PROXY is set to an unknown value'),
+    ])
   })
 
   it('reports every problem at once rather than one per boot', async () => {

--- a/apps/questura/apps/server/src/shared/config/assert-production-config.ts
+++ b/apps/questura/apps/server/src/shared/config/assert-production-config.ts
@@ -4,6 +4,7 @@ import {
   readRequiredCookieHosts,
   validateCookieDomain,
 } from './session-cookie'
+import { TRUSTED_PROXY_NAMES } from './trusted-proxy'
 
 /**
  * Fail fast on a production boot that is still carrying development defaults.
@@ -86,6 +87,23 @@ export function collectProductionConfigProblems(): ConfigProblem[] {
     problems.push(
       'REDIS_URL is not set — the shared rate limiters have no cross-instance ' +
         'counter and refuse to count in production.'
+    )
+  }
+
+  // Every limiter identifies its caller through `getClientIp`, which reads the
+  // one header the configured proxy overwrites. Unset, it falls back to the
+  // first entry of `X-Forwarded-For` — a list the caller may start, since
+  // Cloudflare appends the real address rather than replacing what arrived.
+  // That fallback is not a smaller limit, it is no limit: rotate the header and
+  // every request is a new identity. Named here so a deployment must state what
+  // it is behind, and so moving platforms cannot silently reinstate the bypass.
+  if (!APP_CONFIG.trustedProxy.header) {
+    const configured = APP_CONFIG.trustedProxy.name
+    problems.push(
+      configured
+        ? `TRUSTED_PROXY is set to an unknown value — expected one of: ${TRUSTED_PROXY_NAMES.join(', ')}.`
+        : 'TRUSTED_PROXY is not set — rate limiters would identify callers from a ' +
+            `caller-writable header, which makes every limit bypassable. Expected one of: ${TRUSTED_PROXY_NAMES.join(', ')}.`
     )
   }
 

--- a/apps/questura/apps/server/src/shared/config/index.ts
+++ b/apps/questura/apps/server/src/shared/config/index.ts
@@ -1,5 +1,6 @@
 import { APP_URLS } from './urls'
 import { readCookieDomain, resolveSessionCookieConfig } from './session-cookie'
+import { resolveTrustedProxyHeader } from './trusted-proxy'
 
 // Centralized application configuration
 
@@ -88,6 +89,14 @@ export const APP_CONFIG = {
   // Redis Configuration
   redis: {
     url: process.env.REDIS_URL || '',
+  },
+
+  // Which proxy fronts this deployment. Names the one header allowed to
+  // identify a caller; see `trusted-proxy.ts` for why this is configured
+  // rather than sniffed. Required in production.
+  trustedProxy: {
+    name: process.env.TRUSTED_PROXY || '',
+    header: resolveTrustedProxyHeader(process.env.TRUSTED_PROXY),
   },
 
   // Email Configuration

--- a/apps/questura/apps/server/src/shared/config/trusted-proxy.test.ts
+++ b/apps/questura/apps/server/src/shared/config/trusted-proxy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  TRUSTED_PROXY_HEADERS,
+  TRUSTED_PROXY_NAMES,
+  resolveTrustedProxyHeader,
+} from './trusted-proxy'
+
+describe('resolveTrustedProxyHeader', () => {
+  it('maps a configured platform to its one header', () => {
+    expect(resolveTrustedProxyHeader('cloudflare')).toBe('cf-connecting-ip')
+  })
+
+  it('accepts the value as written in an env file', () => {
+    expect(resolveTrustedProxyHeader('  Cloudflare  ')).toBe('cf-connecting-ip')
+  })
+
+  it('refuses an unset deployment rather than guessing one', () => {
+    expect(resolveTrustedProxyHeader(undefined)).toBeNull()
+    expect(resolveTrustedProxyHeader('')).toBeNull()
+    expect(resolveTrustedProxyHeader('   ')).toBeNull()
+  })
+
+  // A typo must not resolve to something plausible: production refuses to boot
+  // on null, which is the intended outcome of a misspelled platform name.
+  it('refuses a name it does not know', () => {
+    expect(resolveTrustedProxyHeader('cloudfare')).toBeNull()
+    expect(resolveTrustedProxyHeader('aws')).toBeNull()
+  })
+
+  it('never resolves to a header a caller is free to write', () => {
+    const callerWritable = ['x-forwarded-for', 'x-real-ip', 'forwarded']
+
+    for (const header of Object.values(TRUSTED_PROXY_HEADERS)) {
+      expect(callerWritable).not.toContain(header)
+    }
+  })
+
+  it('exposes every configured name for the boot diagnostic', () => {
+    expect(TRUSTED_PROXY_NAMES).toContain('cloudflare')
+    expect(TRUSTED_PROXY_NAMES.length).toBe(Object.keys(TRUSTED_PROXY_HEADERS).length)
+  })
+})

--- a/apps/questura/apps/server/src/shared/config/trusted-proxy.ts
+++ b/apps/questura/apps/server/src/shared/config/trusted-proxy.ts
@@ -1,0 +1,62 @@
+/**
+ * Which proxy stands in front of this deployment, and therefore which header
+ * carries a client address worth believing.
+ *
+ * Why this is configuration and not detection
+ * -------------------------------------------
+ * A header is not trustworthy because of its name. It is trustworthy because
+ * the proxy in front overwrites it, discarding whatever the caller claimed.
+ * `CF-Connecting-IP` is authoritative behind Cloudflare and worthless anywhere
+ * else, where nobody is stripping it and a caller can simply set it.
+ *
+ * That is why this is a lookup with exactly one live answer rather than a list
+ * of candidates to try. Reading "whichever of these headers is present" would
+ * be strictly worse than reading none of them: an attacker just sends the first
+ * name on the list. The chain would be the vulnerability.
+ *
+ * What this replaces
+ * ------------------
+ * The first entry of `X-Forwarded-For`. That header is a list the caller may
+ * start: Cloudflare *appends* the real address to whatever arrived, so the
+ * first entry is written by the very person being rate limited. Verified
+ * against the live tunnel on 2026-08-15 — a request carrying a forged
+ * `X-Forwarded-For` produced a rate-limit bucket under the forged address, so
+ * every limiter in the app could be bypassed by rotating one header.
+ *
+ * Adding a platform
+ * -----------------
+ * Confirm against that platform's own documentation that it overwrites the
+ * header for inbound requests, and that the value is a single address rather
+ * than a list. Do not add a name on the strength of this file.
+ *
+ * The remaining assumption
+ * ------------------------
+ * The proxy must be the only route in. These headers say nothing about a caller
+ * who reaches the origin directly, so the origin must not be publicly
+ * reachable — today it listens on localhost and only `cloudflared` can reach
+ * it.
+ */
+
+export const TRUSTED_PROXY_HEADERS = {
+  cloudflare: 'cf-connecting-ip',
+  vercel: 'x-vercel-forwarded-for',
+  netlify: 'x-nf-client-connection-ip',
+  fly: 'fly-client-ip',
+} as const
+
+export type TrustedProxyName = keyof typeof TRUSTED_PROXY_HEADERS
+
+export const TRUSTED_PROXY_NAMES = Object.keys(TRUSTED_PROXY_HEADERS) as TrustedProxyName[]
+
+/**
+ * The header to read, or `null` when the deployment has not said what it is
+ * behind. Production refuses to boot on `null` (`assertProductionConfig`);
+ * development falls back to `X-Forwarded-For`, where there is usually no proxy
+ * and nothing to spoof past.
+ */
+export function resolveTrustedProxyHeader(configured: string | undefined): string | null {
+  const name = configured?.trim().toLowerCase()
+  if (!name) return null
+
+  return TRUSTED_PROXY_HEADERS[name as TrustedProxyName] ?? null
+}

--- a/apps/questura/apps/server/src/shared/lib/rate-limit-counter.test.ts
+++ b/apps/questura/apps/server/src/shared/lib/rate-limit-counter.test.ts
@@ -159,5 +159,41 @@ describe('shared rate-limit counter', () => {
 
       expect(getClientIp(new Headers())).toBe('unknown')
     })
+
+    // The bypass this replaced: Cloudflare appends the real address to whatever
+    // arrived, so the first x-forwarded-for entry is written by the caller.
+    it('ignores a forged x-forwarded-for once a trusted proxy is configured', async () => {
+      const { getClientIp } = await loadCounter({
+        NODE_ENV: 'development',
+        TRUSTED_PROXY: 'cloudflare',
+      })
+
+      const headers = new Headers({
+        'x-forwarded-for': '203.0.113.77',
+        'cf-connecting-ip': '192.0.2.1',
+      })
+
+      expect(getClientIp(headers)).toBe('192.0.2.1')
+    })
+
+    it('does not fall back to a caller-writable header when the trusted one is absent', async () => {
+      const { getClientIp } = await loadCounter({
+        NODE_ENV: 'development',
+        TRUSTED_PROXY: 'cloudflare',
+      })
+
+      expect(getClientIp(new Headers({ 'x-forwarded-for': '203.0.113.77' }))).toBe('unknown')
+    })
+
+    it('does not split the trusted header, so a comma cannot smuggle an identity', async () => {
+      const { getClientIp } = await loadCounter({
+        NODE_ENV: 'development',
+        TRUSTED_PROXY: 'cloudflare',
+      })
+
+      expect(getClientIp(new Headers({ 'cf-connecting-ip': '203.0.113.77, 192.0.2.1' }))).toBe(
+        '203.0.113.77, 192.0.2.1'
+      )
+    })
   })
 })

--- a/apps/questura/apps/server/src/shared/lib/rate-limit-counter.ts
+++ b/apps/questura/apps/server/src/shared/lib/rate-limit-counter.ts
@@ -102,11 +102,30 @@ export function resetLocalCounters(): void {
 }
 
 /**
- * A caller's IP, taken from the proxy headers Better Auth is also configured to
- * trust. Falls back to a constant so an unidentifiable caller still shares a
- * bucket rather than escaping the limit entirely.
+ * A caller's IP, read from the single header the configured proxy overwrites.
+ *
+ * This used to take the first entry of `X-Forwarded-For`, which is a list the
+ * caller may start — Cloudflare appends the real address to whatever arrived
+ * rather than replacing it, so the first entry belonged to the person being
+ * limited. Every limiter in the app was bypassable by rotating that header.
+ * `trusted-proxy.ts` explains why the replacement is one configured header and
+ * not a search across several.
+ *
+ * The `X-Forwarded-For` path survives for development only, where nothing sits
+ * in front to spoof past; production cannot boot without `TRUSTED_PROXY`.
+ *
+ * Falls back to a constant so an unidentifiable caller shares one bucket rather
+ * than escaping the limit entirely.
  */
 export function getClientIp(headers: Headers): string {
+  const trustedHeader = APP_CONFIG.trustedProxy.header
+
+  if (trustedHeader) {
+    // Deliberately not split on commas: a trusted header carries one address,
+    // and splitting is the habit that created the bypass.
+    return headers.get(trustedHeader)?.trim() || 'unknown'
+  }
+
   const forwardedFor = headers.get('x-forwarded-for')?.split(',')[0]?.trim()
   return forwardedFor || headers.get('x-real-ip')?.trim() || 'unknown'
 }


### PR DESCRIPTION
## This is a live bypass, verified not inferred

Every rate limiter in the app identified its caller with the first entry of `X-Forwarded-For`. That header is a **list the caller may start** — Cloudflare *appends* the real address to whatever arrived instead of replacing it.

I confirmed it against the running site rather than reasoning about docs. One request:

```
curl -H "X-Forwarded-For: 203.0.113.77" https://cms.questurian.com/api/visitor-auth/get-session
```

The rate-limit key the server created:

```
203.0.113.77|/get-session
```

`203.0.113.77` is TEST-NET-3, reserved for documentation and belonging to nobody. The server believed it. Rotate that header per request and you are a new identity every time — **the visitor auth limits (sign-in, sign-up, password reset) and the `/api/payments/*` limits were all bypassable**. The key expired after 60s; nothing persistent was written.

Topology confirming it: Cloudflare edge → `cloudflared` → app on localhost, with no nginx in between to normalize the header.

## The fix

Read **one** header, named by `TRUSTED_PROXY`.

| `TRUSTED_PROXY` | header read |
|---|---|
| `cloudflare` | `cf-connecting-ip` |
| `vercel` | `x-vercel-forwarded-for` |
| `netlify` | `x-nf-client-connection-ip` |
| `fly` | `fly-client-ip` |

It is deliberately a lookup with a single live answer, **not** a fallback chain. A header is trustworthy because the proxy in front overwrites it, discarding what the caller claimed — `CF-Connecting-IP` is authoritative behind Cloudflare and worthless anywhere else, where nobody strips it. Accepting "whichever of these is present" would be strictly worse than accepting none: an attacker sends the first name on the list. The chain would be the vulnerability.

Both readers use it: `getClientIp()` and Better Auth's `ipAddressHeaders` (which takes the first header present, so listing several would let a caller choose their own identity).

The trusted value is **not split on commas**. Splitting is the habit that created this.

## Required in production

`assertProductionConfig` refuses the boot without it, alongside `REDIS_URL` and `PAYLOAD_COOKIE_DOMAIN`.

Unset, the fallback isn't a smaller limit — it's *no* limit, and nothing about it is visible. This codebase already reserves boot-refusal for config that fails silently, which is exactly this. It also means the eventual move off this host has to restate the decision instead of inheriting a bypass, which matters given the platform isn't chosen yet.

`X-Forwarded-For` survives as the development fallback, where nothing fronts the app.

## Host config — already applied

`TRUSTED_PROXY=cloudflare` was added to `~/questura/config/server.env` **and** the legacy source at `~/questura/app/.../server/.env`, kept byte-identical so `stage-host-config.sh` cannot fail closed on drift. Backed up first to `server.env.bak-1786813618`.

Done **before** this merges, on purpose: the variable is inert to the currently-running release, so setting it early is a no-op, whereas setting it late would mean a deploy that cannot boot.

## Remaining assumption

Stated in `trusted-proxy.ts`: these headers say nothing about a caller who reaches the origin directly, so the origin must not be publicly reachable. Today it listens on localhost and only `cloudflared` reaches it. Worth re-checking at the serverless move.

Header names for platforms other than Cloudflare should be confirmed against that platform's own docs before use — the map is a starting point, not authority.

## Verification

- `pnpm test:int` — 98 files, **745 tests**, all pass.
- New: forged `x-forwarded-for` is ignored when a trusted proxy is configured; no fallback to a caller-writable header when the trusted one is absent; the trusted value is not comma-split; unset and misspelled `TRUSTED_PROXY` each refuse the boot; no mapped header is one a caller can write.
- `tsc --noEmit` clean, `eslint` clean.

No Payload collection or field changes; no migration.