### PR TITLE
Require an allowed origin on subscription-details

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
@@ -1,12 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getStripeSubscriptionDetails } from '@/payments/lib/payment-service'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
 import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function GET(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
+
+  // The only payments route that skipped this. Being a GET with no reflected
+  // CORS header makes it hard to read cross-origin, but "hard to exploit" is
+  // not the guarantee the other five give: this one authenticates from an
+  // ambient cookie and answers with the visitor's billing state. The rule is
+  // that a cookie-authenticated payments route states its allowed origins,
+  // rather than each route being argued about separately.
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
 
   const rateLimit = await checkPaymentsRateLimit(req.headers, 'details')
   if (!rateLimit.allowed) {

--- a/apps/questura/apps/server/src/features/payments/subscription-details.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/subscription-details.route.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  requireVisitorPrincipal: vi.fn(),
+  findVisitorProfileByAuthUserId: vi.fn(),
+  getStripeSubscriptionDetails: vi.fn(),
+  checkPaymentsRateLimit: vi.fn(),
+}))
+
+vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
+  requireVisitorPrincipal: mocks.requireVisitorPrincipal,
+}))
+
+vi.mock('@/features/visitor-auth/lib/visitor-profile', () => ({
+  findVisitorProfileByAuthUserId: mocks.findVisitorProfileByAuthUserId,
+}))
+
+vi.mock('@/payments/lib/payment-service', () => ({
+  getStripeSubscriptionDetails: mocks.getStripeSubscriptionDetails,
+}))
+
+vi.mock('@/payments/lib/payments-rate-limit', () => ({
+  checkPaymentsRateLimit: mocks.checkPaymentsRateLimit,
+  paymentsRateLimitResponse: vi.fn(),
+}))
+
+vi.mock('@/shared/config', () => ({
+  APP_CONFIG: {
+    CORS_ORIGINS: ['http://localhost:3000'],
+  },
+}))
+
+import { GET } from '@/app/api/payments/subscription-details/route'
+
+function createRequest(headers: Record<string, string>) {
+  return new Request('http://localhost:4000/api/payments/subscription-details', {
+    method: 'GET',
+    headers,
+  }) as never
+}
+
+describe('subscription-details route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.checkPaymentsRateLimit.mockResolvedValue({ allowed: true })
+    mocks.requireVisitorPrincipal.mockResolvedValue({ principal: { id: 'visitor_1' } })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      stripeSubscriptionId: 'sub_123',
+      subscriptionStatus: 'active',
+      paidThroughAt: '2026-09-01T00:00:00.000Z',
+      dunningGraceUntil: null,
+    })
+    mocks.getStripeSubscriptionDetails.mockResolvedValue({
+      status: 'active',
+      currentPeriodEnd: '2026-09-01T00:00:00.000Z',
+      currentPeriodStart: '2026-08-01T00:00:00.000Z',
+      cancelAtPeriodEnd: false,
+    })
+  })
+
+  // This route reads a visitor's billing state from an ambient cookie, so the
+  // origin has to be on the allowlist before the session is even resolved.
+  it('rejects a cookie session from an untrusted origin before resolving the visitor', async () => {
+    const response = await GET(
+      createRequest({
+        origin: 'https://evil.example',
+        cookie: 'questura_visitor.session_token=abc',
+      })
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Origin not allowed.' })
+    expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalled()
+    expect(mocks.getStripeSubscriptionDetails).not.toHaveBeenCalled()
+  })
+
+  it('rejects a cookie session carrying no origin at all', async () => {
+    const response = await GET(
+      createRequest({ cookie: 'questura_visitor.session_token=abc' })
+    )
+
+    expect(response.status).toBe(403)
+    expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalled()
+  })
+
+  it('serves the visitor their own subscription from an allowed origin', async () => {
+    const response = await GET(
+      createRequest({
+        origin: 'http://localhost:3000',
+        cookie: 'questura_visitor.session_token=abc',
+      })
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      subscriptionId: 'sub_123',
+      internalStatus: 'active',
+      paidThroughAt: '2026-09-01T00:00:00.000Z',
+    })
+  })
+})


### PR DESCRIPTION
## Why

Five of the six payments routes call `forbiddenOriginResponse` before doing anything. `subscription-details` was the one that did not — the loose end noted in the original review.

It is a GET, and `getCorsHeaders` reflects no `Access-Control-Allow-Origin` for a disallowed origin, so a browser blocks another site from *reading* the response. That is real, but it is a property of how browsers treat the reply rather than a guarantee this route makes. Meanwhile the route authenticates from an ambient cookie and answers with the visitor's subscription status, `paidThroughAt` and `dunningGraceUntil`.

The rule worth holding is the simple one: a cookie-authenticated payments route states its allowed origins. Then no individual route has to be re-argued later, and nobody has to reason about browser behaviour to know whether this one is fine.

## What

- `forbiddenOriginResponse` before the session is resolved, matching the placement in the other five routes.
- New `subscription-details.route.test.ts`: an untrusted origin is rejected before `requireVisitorPrincipal` or Stripe are touched; a cookie with no origin at all is rejected; an allowed origin still gets the subscription.

## Verification

- `pnpm test:int` — 99 files, **748 tests**, all pass.
- `tsc --noEmit` clean, `eslint` clean.

No Payload collection or field changes; no migration.