### PR TITLE
Record the webhook handler's connection budget

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -56,6 +56,36 @@ export async function POST(req: NextRequest) {
     // The lock makes duplicate detection one operation across all server
     // processes. Without it, two parallel deliveries can both pass the lookup,
     // both run side effects, then race on the unique event record.
+    //
+    // Connection budget, measured 2026-08-15 and recorded because the failure
+    // mode is self-amplifying and nobody wants to derive this mid-incident.
+    //
+    // This lock holds one pooled connection for the whole handler, across every
+    // Stripe call and email send. `resyncSubscription` then takes a second for
+    // its per-subscription lock, and Payload's own queries borrow briefly on
+    // top. Against `pool.max: 20` that is roughly 7-9 concurrent deliveries
+    // before `pool.connect()` starts waiting, at which point
+    // `connectionTimeoutMillis: 10000` turns the wait into a 500, Stripe
+    // retries, and the retries add concurrency. That loop is the risk, not the
+    // steady state.
+    //
+    // Throughput is not affected: this key is per *event*, so two different
+    // events never wait on each other. The cost is connections only.
+    //
+    // If exhaustion is ever observed, in increasing order of risk:
+    //   1. Raise `pool.max` in payload.config.ts. Postgres allows 100 here and
+    //      the app peaked at 8; 20 -> 40 is a one-line doubling.
+    //   2. Give the advisory lock its own small pool, so holding a lock cannot
+    //      starve the queries the lock is protecting.
+    //   3. Drop this outer lock and rely on the per-subscription lock inside
+    //      `resyncSubscription` plus the unique `eventId`. Every handler
+    //      currently funnels into resync, so this is plausible — but it is a
+    //      correctness argument about duplicate side effects on the payments
+    //      path and needs proving handler by handler, not assuming.
+    //
+    // Deliberately not done in advance: at three subscriptions the trigger
+    // needs a retry storm, and (3) would trade a measured, bounded problem for
+    // an unmeasured one.
     return await withAdvisoryLock(payload, `stripe:event:${event.id}`, async () => {
       const alreadyProcessed = await payload.find({
         collection: 'stripe-webhook-events',


### PR DESCRIPTION
## Why a comment and not a fix

The last loose end from the payments review. It is real, it is not urgent, and the honest response is to write down what was measured rather than change the most correctness-sensitive path in the app on speculation.

**The budget.** The outer `stripe:event:${event.id}` lock holds one pooled connection for the entire handler — every Stripe call, every email. `resyncSubscription` then takes a second for its per-subscription lock, and Payload's queries borrow briefly on top. Against `pool.max: 20`, roughly 7–9 concurrent deliveries start contention; `connectionTimeoutMillis: 10000` then converts waiting into a 500, Stripe retries, and the retries add concurrency.

**That loop is the risk**, not the steady state — which is exactly why it deserves notes: the failure amplifies itself, so it will be met under pressure.

**One thing that makes it milder than it looks:** the key is per *event*, so two different events never wait on each other. The cost is connections, never throughput.

## Why not fix it now

Three subscriptions. Reaching the trigger needs a retry storm after an outage, not a busy renewal day.

The change that would actually remove the cost is option 3 below — dropping the outer lock and relying on the per-subscription lock inside `resyncSubscription` plus the unique `eventId`. Every handler does currently funnel into resync, so it is plausible. But "plausible" is not the standard for duplicate side effects on a payments path, and it would need proving handler by handler, with no load to verify against and no way to reproduce the failure it prevents. That trades a measured, bounded problem for an unmeasured one.

## What the comment records

Measured numbers (`pool.max: 20`, Postgres `max_connections: 100`, app peak 8 observed on the host), the ~7–9 trigger, and the responses in increasing order of risk:

1. Raise `pool.max` — one line, 20 → 40, plenty of Postgres headroom.
2. Give the advisory lock its own small pool, so holding a lock cannot starve the queries it protects.
3. Drop the outer lock — the real fix, and the one that needs the proof.

## Verification

No behaviour change; comment only.

- `stripe-webhook.route.test.ts` — 38 tests pass.
- `tsc --noEmit` clean, `eslint` clean.