### PR TITLE
Preload only the fonts a route actually renders

### DIFF
--- a/apps/questura/apps/client/src/app/(private)/layout.tsx
+++ b/apps/questura/apps/client/src/app/(private)/layout.tsx
@@ -2,6 +2,7 @@ import Footer from "@/components/layout/Footer";
 import { ClientInteractionProvider } from "@/components/providers/ClientInteractionProvider";
 import { AffiliateTracking } from "@/components/providers/AffiliateTracking";
 import { Navbar } from "@/features/Navigation";
+import { SiteFonts } from "@/components/layout/SiteFonts";
 
 export const dynamic = "force-dynamic";
 
@@ -11,11 +12,13 @@ export default function MainLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClientInteractionProvider>
-      <AffiliateTracking />
-      <Navbar />
-      <main className="flex-1 ">{children}</main>
-      <Footer />
-    </ClientInteractionProvider>
+    <SiteFonts>
+      <ClientInteractionProvider>
+        <AffiliateTracking />
+        <Navbar />
+        <main className="flex-1 ">{children}</main>
+        <Footer />
+      </ClientInteractionProvider>
+    </SiteFonts>
   );
 }

--- a/apps/questura/apps/client/src/app/(public)/layout.tsx
+++ b/apps/questura/apps/client/src/app/(public)/layout.tsx
@@ -1,4 +1,5 @@
 import { PublicChrome } from "@/components/layout/PublicChrome";
+import { SiteFonts } from "@/components/layout/SiteFonts";
 
 export const dynamic = "force-static";
 export const revalidate = 3600;
@@ -8,5 +9,9 @@ export default function PublicLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <PublicChrome>{children}</PublicChrome>;
+  return (
+    <SiteFonts>
+      <PublicChrome>{children}</PublicChrome>
+    </SiteFonts>
+  );
 }

--- a/apps/questura/apps/client/src/app/(search)/layout.tsx
+++ b/apps/questura/apps/client/src/app/(search)/layout.tsx
@@ -1,4 +1,5 @@
 import { PublicChrome } from "@/components/layout/PublicChrome";
+import { SiteFonts } from "@/components/layout/SiteFonts";
 
 // Same chrome as the (public) group, but rendered dynamically so the
 // search page can read query params on the server.
@@ -9,5 +10,9 @@ export default function SearchLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <PublicChrome>{children}</PublicChrome>;
+  return (
+    <SiteFonts>
+      <PublicChrome>{children}</PublicChrome>
+    </SiteFonts>
+  );
 }

--- a/apps/questura/apps/client/src/app/layout.tsx
+++ b/apps/questura/apps/client/src/app/layout.tsx
@@ -1,25 +1,21 @@
 import type { Metadata } from "next";
 import {
   Cormorant_Garamond,
-  DM_Sans,
   Geist,
   Geist_Mono,
   Playfair_Display,
-  Roboto,
-  Unbounded,
 } from "next/font/google";
 import "./globals.css";
 import { DEFAULT_LOCALE } from "@/lib/i18n/locales";
 
+/*
+ * Only the families every route renders belong here: next/font preloads a
+ * family on every route whose module graph loads it. DM Sans and Roboto are
+ * declared in SiteFonts, which the site route groups mount but /join does
+ * not.
+ */
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
-const roboto = Roboto({ variable: "--font-roboto", weight: ["400", "500", "700"], subsets: ["latin"] });
-const dmSans = DM_Sans({ variable: "--font-dm-sans", subsets: ["latin"] });
-const itineraryTitle = Unbounded({
-  variable: "--font-itinerary-title",
-  weight: "variable",
-  subsets: ["latin"],
-});
 const playfair = Playfair_Display({
   variable: "--font-display",
   weight: ["400", "500", "600", "700"],
@@ -43,7 +39,7 @@ export default async function RootLayout({
   return (
     <html lang={DEFAULT_LOCALE} style={{ colorScheme: 'light' }}>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${roboto.variable} ${dmSans.variable} ${itineraryTitle.variable} ${playfair.variable} ${editorialSerif.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${playfair.variable} ${editorialSerif.variable} antialiased`}
       >
         <div className="flex min-h-screen min-w-[280px] flex-col overflow-x-clip">
           {children}

--- a/apps/questura/apps/client/src/components/layout/SiteFonts.tsx
+++ b/apps/questura/apps/client/src/components/layout/SiteFonts.tsx
@@ -1,0 +1,38 @@
+import { DM_Sans, Roboto } from "next/font/google";
+
+/*
+ * Fonts used by the site chrome and content routes, but not by the /join
+ * funnel.
+ *
+ * next/font preloads a family on every route whose module graph pulls it in,
+ * so declaring these in the root layout put their woff2 files in front of
+ * every page — including /join, which renders neither family and was pushing
+ * its hero image down the queue behind them. Declared here, they are
+ * preloaded only on the routes that mount this wrapper.
+ */
+const dmSans = DM_Sans({ variable: "--font-dm-sans", subsets: ["latin"] });
+const roboto = Roboto({
+  variable: "--font-roboto",
+  weight: ["400", "500", "700"],
+  subsets: ["latin"],
+});
+
+/*
+ * display: contents keeps the variables inheriting to the whole subtree
+ * without the wrapper becoming a flex item of the root layout's column —
+ * the navbar, <main> and footer stay direct children of that flex context.
+ */
+export function SiteFonts({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div
+      className={`${dmSans.variable} ${roboto.variable}`}
+      style={{ display: "contents" }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Follow-up to #292. The root layout declared **seven** Google families, and `next/font` preloads a family on every route whose module graph loads it — so all seven woff2 files were preloaded at high priority on every page. On `/join` that is **254KB of fonts ahead of the 72KB hero globe**, on a page that renders four of them.

(Note: `next/font/google` already self-hosts — the files are fetched at build time and served from `/_next/static/media`. The problem was preload scope, not the origin.)

## What

- **Unbounded deleted.** `--font-itinerary-title` had no consumers anywhere in the client — the only references were its own declaration and the body className.
- **DM Sans and Roboto moved** to `SiteFonts`, mounted by the `(public)`, `(private)` and `(search)` layouts. Declaring them outside the root layout is what scopes the preload; the wrapper uses `display: contents` so it carries the CSS variables without becoming a flex item in the root layout's column (navbar / `<main>` / footer stay direct children of that flex context).
- Root layout keeps the four families every route renders: Geist, Geist Mono, Playfair Display, Cormorant Garamond.

`/join` renders Geist (body), Geist Mono (`font-mono` labels), Playfair (`font-display`, incl. the logo) and Cormorant (hero title) — verified against `PricingDisplay`, `JoinNavbar`/`Logo`, `membership.css` and `foundations.css`. It renders neither DM Sans nor Roboto.

## Verification

- `pnpm run check:global-css` — pass
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec next lint --dir src/app --dir src/components` — 0 warnings
- `pnpm run build` — pass
- Prerendered `join.html`: **7 font preloads → 4**, 254KB → 126KB; `<body>` carries exactly the four expected variable classes
- `app-build-manifest.json`: the site-fonts CSS chunk is attached to `/(public)/layout`, `/(private)/layout` and `/(search)/layout`, and to neither `/join/layout` nor `/join/page` — the intended split
- No `Unbounded` / `itinerary-title` reference remains in any built CSS

Site routes are not prerendered to HTML at build time, so their preload set is confirmed live after deploy.