### PR TITLE
Let only the owning subscription write the profile

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -184,12 +184,16 @@ async function listCustomerSubscriptions(customerId: string): Promise<Stripe.Sub
  * Stripe billed them twice and the last webhook won. Incomplete / canceled
  * are left out: those visitors need to be able to pay again.
  */
+export function isLiveSubscription(subscription: Stripe.Subscription): boolean {
+  return LIVE_SUBSCRIPTION_STATUSES.has(subscription.status)
+}
+
 export async function findLiveSubscription(
   customerId: string
 ): Promise<Stripe.Subscription | null> {
   const listed = await listCustomerSubscriptions(customerId)
 
-  return listed.find((subscription) => LIVE_SUBSCRIPTION_STATUSES.has(subscription.status)) ?? null
+  return listed.find(isLiveSubscription) ?? null
 }
 
 export async function listBillableSubscriptions(

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
@@ -10,6 +10,7 @@ import {
   sendSubscriptionReactivatedEmail,
 } from '@/emails'
 import { stripe } from './stripe'
+import { findLiveSubscription, isLiveSubscription } from './customer-linkage'
 import { getSubscriptionProductName } from './payment-helpers'
 import { deriveSubscriptionState, type DerivedSubscriptionState } from './subscription-state'
 import { resolveMembershipTransitions, type MembershipTransition } from './membership-transitions'
@@ -43,6 +44,61 @@ function nextPaymentAttemptOf(subscription: Stripe.Subscription): number | null 
   if (!invoice || typeof invoice === 'string') return null
 
   return (invoice as Stripe.Invoice).next_payment_attempt ?? null
+}
+
+/**
+ * Retrieve the subscription the profile currently points at, tolerating an id
+ * Stripe no longer knows. A cancelled subscription is still retrievable, so a
+ * `resource_missing` means the stored id is stale beyond repair (wrong account,
+ * hand-edited row) and must not be allowed to freeze the profile forever. Any
+ * other Stripe failure is transient and propagates, so the webhook retries
+ * rather than deciding ownership on missing information.
+ */
+async function fetchIncumbent(subscriptionId: string): Promise<Stripe.Subscription | null> {
+  try {
+    return await stripe.subscriptions.retrieve(subscriptionId)
+  } catch (error) {
+    if ((error as { code?: string }).code === 'resource_missing') {
+      logger.warn('Profile points at a subscription Stripe no longer has', { subscriptionId })
+      return null
+    }
+    throw error
+  }
+}
+
+/**
+ * Whether this subscription is the one whose state the profile should mirror.
+ *
+ * A profile holds one subscription, but a customer accumulates many, and every
+ * one of them keeps emitting events for years: a goodwill refund on a
+ * subscription cancelled last spring raises `charge.refunded` today, and the
+ * duplicate-checkout collapse deliberately refunds and cancels the extras it
+ * just made. Writing each of those onto the profile unconditionally stamps a
+ * dead subscription over a live membership — the visitor loses access while
+ * Stripe keeps billing them, and `/account` then points its cancel button at
+ * the dead one, so they cannot even stop the charge.
+ *
+ * `charge.refunded` and `charge.dispute.*` carry no subscription id, so the
+ * webhook ordering guard cannot see this collision; ownership has to be decided
+ * here, against Stripe rather than against the delivery.
+ *
+ * The subscription that is billing owns the row. When none is, the newest one
+ * does, so an old cancellation cannot overwrite a newer one's final state.
+ */
+async function ownsProfileRow(
+  customerId: string,
+  subscription: Stripe.Subscription,
+  incumbentId: string
+): Promise<boolean> {
+  if (isLiveSubscription(subscription)) return true
+
+  const live = await findLiveSubscription(customerId)
+  if (live) return false
+
+  const incumbent = await fetchIncumbent(incumbentId)
+  if (!incumbent) return true
+
+  return subscription.created >= incumbent.created
 }
 
 async function sendTransitionEmails(
@@ -131,6 +187,23 @@ export async function resyncSubscription(subscriptionId: string): Promise<Resync
       throw new Error(
         `No VisitorProfile found for Stripe customer ${customerId} on subscription ${subscriptionId}`
       )
+    }
+
+    const incumbentId = profile.stripeSubscriptionId
+
+    if (incumbentId && incumbentId !== subscription.id) {
+      const owns = await ownsProfileRow(customerId, subscription, incumbentId)
+
+      if (!owns) {
+        logger.warn('Ignoring resync of a subscription the profile has moved on from', {
+          subscriptionId,
+          incumbentSubscriptionId: incumbentId,
+          profileId: profile.id,
+          status: subscription.status,
+        })
+
+        return { profileId: profile.id, state: null, transitions: [] }
+      }
     }
 
     const state = deriveSubscriptionState(subscription, {

--- a/apps/questura/apps/server/src/features/payments/subscription-resync.test.ts
+++ b/apps/questura/apps/server/src/features/payments/subscription-resync.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type Stripe from 'stripe'
+
+const mocks = vi.hoisted(() => ({
+  retrieve: vi.fn(),
+  list: vi.fn(),
+  resolveProfile: vi.fn(),
+  payloadUpdate: vi.fn(),
+  loggerWarn: vi.fn(),
+  sendMembershipConfirmationEmail: vi.fn(),
+  sendSubscriptionCancelledEmail: vi.fn(),
+  sendSubscriptionReactivatedEmail: vi.fn(),
+}))
+
+vi.mock('@/payments/lib/stripe', () => ({
+  stripe: {
+    subscriptions: {
+      retrieve: mocks.retrieve,
+      list: mocks.list,
+    },
+  },
+}))
+
+vi.mock('@/payments/lib/subscription-profile', () => ({
+  resolveProfileForStripeCustomer: mocks.resolveProfile,
+}))
+
+vi.mock('@/emails', () => ({
+  sendMembershipConfirmationEmail: mocks.sendMembershipConfirmationEmail,
+  sendSubscriptionCancelledEmail: mocks.sendSubscriptionCancelledEmail,
+  sendSubscriptionReactivatedEmail: mocks.sendSubscriptionReactivatedEmail,
+}))
+
+vi.mock('@/shared/utils/logger', () => ({
+  logger: { info: vi.fn(), warn: mocks.loggerWarn, error: vi.fn() },
+}))
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockImplementation(async () => ({
+    db: {},
+    update: mocks.payloadUpdate,
+  })),
+}))
+
+vi.mock('@/payload.config', () => ({ default: {} }))
+
+import { resyncSubscription } from '@/payments/lib/subscription-resync'
+
+const HOUR = 60 * 60
+const NOW = Math.floor(Date.now() / 1000)
+
+function subscription(
+  id: string,
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id,
+    object: 'subscription',
+    customer: 'cus_1',
+    status: 'active',
+    cancel_at_period_end: false,
+    created: NOW - HOUR,
+    metadata: {},
+    latest_invoice: null,
+    items: {
+      data: [{ id: `si_${id}`, current_period_start: NOW - HOUR, current_period_end: NOW + HOUR }],
+    },
+    ...overrides,
+  } as unknown as Stripe.Subscription
+}
+
+/** A refunded subscription, as `charge.refunded` leaves it before resyncing. */
+function revoked(id: string, overrides: Partial<Stripe.Subscription> = {}): Stripe.Subscription {
+  return subscription(id, {
+    status: 'canceled',
+    metadata: { access_revoked: 'true', access_revoked_reason: 'refund' },
+    ...overrides,
+  } as Partial<Stripe.Subscription>)
+}
+
+function profile(stripeSubscriptionId: string | null) {
+  return {
+    id: 10,
+    email: 'visitor@example.com',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    stripeSubscriptionId,
+    subscriptionStatus: 'active',
+    cancelAtPeriodEnd: false,
+    paidThroughAt: new Date((NOW + HOUR) * 1000).toISOString(),
+    dunningGraceUntil: null,
+  }
+}
+
+/** Serve `retrieve` from a set of subscriptions keyed by id. */
+function stripeHas(...subscriptions: Stripe.Subscription[]) {
+  mocks.retrieve.mockImplementation(async (id: string) => {
+    const found = subscriptions.find((candidate) => candidate.id === id)
+    if (found) return found
+    const error = new Error(`No such subscription: ${id}`) as Error & { code: string }
+    error.code = 'resource_missing'
+    throw error
+  })
+  mocks.list.mockResolvedValue({ data: subscriptions })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.payloadUpdate.mockResolvedValue({})
+})
+
+describe('resyncSubscription', () => {
+  it('writes when the profile carries no subscription yet', async () => {
+    stripeHas(subscription('sub_new'))
+    mocks.resolveProfile.mockResolvedValue(profile(null))
+
+    const result = await resyncSubscription('sub_new')
+
+    expect(result.state?.subscriptionStatus).toBe('active')
+    expect(mocks.payloadUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 10,
+        data: expect.objectContaining({ stripeSubscriptionId: 'sub_new' }),
+      })
+    )
+  })
+
+  it('writes the subscription the profile already points at', async () => {
+    stripeHas(subscription('sub_1'))
+    mocks.resolveProfile.mockResolvedValue(profile('sub_1'))
+
+    await resyncSubscription('sub_1')
+
+    expect(mocks.payloadUpdate).toHaveBeenCalledTimes(1)
+    // The incumbent is this subscription, so ownership costs no extra API call.
+    expect(mocks.list).not.toHaveBeenCalled()
+  })
+
+  // The goodwill-refund case: refunding an old subscription's last charge used
+  // to stamp it over the membership the visitor is currently being billed for.
+  it('refuses to write an old subscription over a live membership', async () => {
+    const live = subscription('sub_c', { created: NOW - HOUR })
+    stripeHas(revoked('sub_a', { created: NOW - 100 * HOUR }), live)
+    mocks.resolveProfile.mockResolvedValue(profile('sub_c'))
+
+    const result = await resyncSubscription('sub_a')
+
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+    expect(result).toEqual({ profileId: 10, state: null, transitions: [] })
+    expect(mocks.loggerWarn).toHaveBeenCalled()
+  })
+
+  // The duplicate-checkout collapse refunds and cancels the extra it just made;
+  // that refund must not undo the resync of the subscription that was kept.
+  it('refuses to write a cancelled duplicate over the subscription that was kept', async () => {
+    stripeHas(revoked('sub_b'), subscription('sub_a'))
+    mocks.resolveProfile.mockResolvedValue(profile('sub_a'))
+
+    await resyncSubscription('sub_b')
+
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('lets a billing subscription take over from a dead one', async () => {
+    stripeHas(subscription('sub_c'), subscription('sub_a', { status: 'canceled' }))
+    mocks.resolveProfile.mockResolvedValue(profile('sub_a'))
+
+    await resyncSubscription('sub_c')
+
+    expect(mocks.payloadUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ stripeSubscriptionId: 'sub_c' }) })
+    )
+  })
+
+  // An unconfirmed Checkout is not billing yet, so it must not displace the
+  // subscription the visitor is actually paying on.
+  it('refuses to let an incomplete subscription displace a live one', async () => {
+    stripeHas(
+      subscription('sub_new', { status: 'incomplete', created: NOW }),
+      subscription('sub_live', { status: 'past_due' })
+    )
+    mocks.resolveProfile.mockResolvedValue(profile('sub_live'))
+
+    await resyncSubscription('sub_new')
+
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('lets the newest subscription win when none is billing', async () => {
+    stripeHas(
+      subscription('sub_new', { status: 'incomplete', created: NOW }),
+      subscription('sub_old', { status: 'canceled', created: NOW - 100 * HOUR })
+    )
+    mocks.resolveProfile.mockResolvedValue(profile('sub_old'))
+
+    await resyncSubscription('sub_new')
+
+    expect(mocks.payloadUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ stripeSubscriptionId: 'sub_new' }) })
+    )
+  })
+
+  it('refuses an older cancellation when none is billing', async () => {
+    stripeHas(
+      subscription('sub_old', { status: 'canceled', created: NOW - 100 * HOUR }),
+      subscription('sub_new', { status: 'canceled', created: NOW })
+    )
+    mocks.resolveProfile.mockResolvedValue(profile('sub_new'))
+
+    await resyncSubscription('sub_old')
+
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+  })
+
+  // A stale id Stripe has never heard of must not freeze the profile forever.
+  it('writes when the profile points at a subscription Stripe no longer has', async () => {
+    stripeHas(subscription('sub_new', { status: 'canceled' }))
+    mocks.resolveProfile.mockResolvedValue(profile('sub_gone'))
+
+    await resyncSubscription('sub_new')
+
+    expect(mocks.payloadUpdate).toHaveBeenCalled()
+  })
+
+  // Deciding ownership on a failed lookup would guess; the webhook retries.
+  it('propagates a transient failure while resolving the incumbent', async () => {
+    mocks.retrieve.mockImplementation(async (id: string) => {
+      if (id === 'sub_new') return subscription('sub_new', { status: 'canceled' })
+      throw new Error('Stripe is down')
+    })
+    mocks.list.mockResolvedValue({ data: [] })
+    mocks.resolveProfile.mockResolvedValue(profile('sub_a'))
+
+    await expect(resyncSubscription('sub_new')).rejects.toThrow('Stripe is down')
+    expect(mocks.payloadUpdate).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Why

`resyncSubscription` wrote unconditionally onto whatever profile owns the Stripe customer, with no check that the subscription it was resyncing is the one the profile currently holds. A customer accumulates subscriptions over the years and every one of them keeps emitting events, so ordinary support actions clobbered a live membership:

- **Goodwill refund.** Visitor subscribes (A), cancels, later resubscribes (C). Refunding A's last charge in the Dashboard raises `charge.refunded` → `revokeForCharge` → `markAccessRevoked(A)` → `resyncSubscription(A)`, which rewrote the profile to `stripeSubscriptionId: A`, `paidThroughAt: null`, `cancelled`. The visitor loses access while Stripe keeps billing them on C — and `/account`, cancel and reactivate all then point at dead sub A, so they cannot even stop the charge.
- **Duplicate-checkout collapse.** `collapseDuplicateSubscriptions` refunds and cancels extra sub B; Stripe then emits `charge.refunded` and `customer.subscription.deleted` for B, both of which resynced B onto the profile and undid the resync of the kept sub A from seconds earlier.

`charge.refunded` and `charge.dispute.*` carry no subscription id (`event-log.ts`), so the webhook ordering guard gives zero protection here. Ownership has to be decided against Stripe, not against the delivery.

## What

`subscription-resync.ts` — when the event names a subscription other than the one the profile holds, decide whether it may write:

1. incoming subscription is live (`active`/`trialing`/`past_due`/`unpaid`) → write; the subscription that is billing owns the row
2. else another live subscription exists on the customer → refuse, log, return `{ profileId, state: null, transitions: [] }`
3. else nothing is billing → newest `created` wins, so an old cancellation cannot overwrite a newer one's final state
4. incumbent id 404s (`resource_missing`) → treat as gone and write, so a stale id cannot freeze the profile forever; any other Stripe error propagates and the webhook retries rather than guessing

The guard only runs when the ids differ, so renewals, cancel, reactivate and checkout are unchanged and cost no extra API call. Legitimate takeover on resubscribe still passes via rule 1, and an unconfirmed `incomplete` Checkout can no longer displace a live subscription.

`customer-linkage.ts` — extracted `isLiveSubscription` from `findLiveSubscription` (the status set was private); no behaviour change.

## Verification

- New `subscription-resync.test.ts`, 10 cases: both clobber paths above, incomplete-vs-live, newest-wins, missing incumbent, transient-failure propagation, and the unchanged write paths.
- Full server suite: 100 files / 758 tests pass.
- `tsc --noEmit` clean.
- No schema change: payments lib logic and a test only, no collections or fields touched.