### PR TITLE
End paid access when dunning cancels a subscription

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
@@ -153,11 +153,70 @@ describe('deriveSubscriptionState', () => {
   it('honours the paid period on a deleted subscription', () => {
     const deleted = firstWhere((s) => s.status === 'canceled')
 
+    // This fixture is the *voluntary* ending: cancel at period end, so Stripe
+    // stopped the subscription exactly when the paid period ran out. Asserting
+    // that keeps the test honest — it is not evidence about a dunning cancel,
+    // which ends mid-period and is covered below.
+    expect(deleted.ended_at! * 1000).toEqual(new Date(periodOf(deleted).end).getTime())
+
     // The old handler read current_period_end off the subscription root, which
     // the SDK's API version does not populate, so this silently became null.
     expect(deriveSubscriptionState(deleted)).toMatchObject({
       subscriptionStatus: 'cancelled',
       paidThroughAt: periodOf(deleted).end,
+    })
+  })
+
+  describe('a subscription Stripe cancelled after dunning', () => {
+    /**
+     * The renewal advanced the period, the charge never cleared, Stripe retried
+     * for three weeks and then cancelled. `current_period_end` is still in the
+     * future here, and it describes time nobody paid for.
+     */
+    function dunningCancelled(overrides: Partial<Stripe.Subscription> = {}) {
+      const pastDue = firstWhere((s) => s.status === 'past_due')
+      const period = periodOf(pastDue)
+      const endedAt = new Date(new Date(period.start).getTime() + 21 * 24 * 60 * 60 * 1000)
+
+      expect(endedAt.getTime()).toBeLessThan(new Date(period.end).getTime())
+
+      return {
+        subscription: {
+          ...pastDue,
+          status: 'canceled',
+          ended_at: Math.floor(endedAt.getTime() / 1000),
+          ...overrides,
+        } as Stripe.Subscription,
+        period,
+      }
+    }
+
+    it('stops paid access at the last collected period when the invoice never paid', () => {
+      const { subscription, period } = dunningCancelled({
+        latest_invoice: { id: 'in_dunning', status: 'open' } as unknown as Stripe.Invoice,
+      })
+
+      expect(deriveSubscriptionState(subscription)).toMatchObject({
+        subscriptionStatus: 'cancelled',
+        paidThroughAt: period.start,
+      })
+    })
+
+    it('falls back to ended_at when latest_invoice was not expanded', () => {
+      const { subscription, period } = dunningCancelled()
+
+      expect(typeof subscription.latest_invoice).toBe('string')
+      expect(deriveSubscriptionState(subscription).paidThroughAt).toEqual(period.start)
+    })
+
+    it('keeps the period end when the final invoice was actually paid', () => {
+      // Same mid-period ending, opposite money: an immediate cancellation on a
+      // period the visitor already bought must not claw back the rest of it.
+      const { subscription, period } = dunningCancelled({
+        latest_invoice: { id: 'in_paid', status: 'paid' } as unknown as Stripe.Invoice,
+      })
+
+      expect(deriveSubscriptionState(subscription).paidThroughAt).toEqual(period.end)
     })
   })
 

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
@@ -50,6 +50,9 @@ const DAY_MS = 24 * 60 * 60 * 1000
  * Stripe statuses where the *current* period has not been paid for. In these
  * states the subscription's period has already rolled forward optimistically,
  * so its end date describes time the visitor has not bought.
+ *
+ * `canceled` is deliberately absent: it means both endings at once and has to
+ * be decided per subscription — see `canceledPeriodWasPaid`.
  */
 const UNPAID_CURRENT_PERIOD = new Set<Stripe.Subscription.Status>([
   'past_due',
@@ -119,6 +122,55 @@ function getPeriod(subscription: Stripe.Subscription): { start: Date | null; end
 }
 
 /**
+ * Whether the invoice Stripe last raised on this subscription was collected.
+ *
+ * `null` means the answer is unavailable rather than negative: `latest_invoice`
+ * is an id unless the caller expanded it, and a missing expansion must not be
+ * read as a failed payment.
+ */
+function latestInvoiceWasPaid(subscription: Stripe.Subscription): boolean | null {
+  const invoice = subscription.latest_invoice
+
+  if (!invoice || typeof invoice === 'string') return null
+
+  const { status, paid } = invoice as Stripe.Invoice & { paid?: boolean }
+
+  if (status) return status === 'paid'
+  if (typeof paid === 'boolean') return paid
+
+  return null
+}
+
+/**
+ * Whether a cancelled subscription's current period was ever bought.
+ *
+ * `canceled` covers two opposite endings. A visitor who cancels at period end
+ * has paid for the period they are sitting in, and Stripe ends the subscription
+ * exactly when that period expires. Dunning ends the other way round: the
+ * renewal advanced the period first, the charge never cleared, Stripe retried
+ * for weeks and then cancelled — mid-period, on time nobody paid for. Reading
+ * `current_period_end` there hands out the remainder free, about nine days on a
+ * monthly plan and most of a year on an annual one.
+ *
+ * The invoice is the direct evidence, and the resync path expands it. Where it
+ * is absent, `ended_at` still separates the two shapes: a cancel-at-period-end
+ * lands on the period boundary, a dunning cancel lands before it. With neither
+ * signal the period is treated as paid, so silence never revokes access.
+ */
+function canceledPeriodWasPaid(
+  subscription: Stripe.Subscription,
+  periodEnd: Date | null
+): boolean {
+  const invoicePaid = latestInvoiceWasPaid(subscription)
+  if (invoicePaid !== null) return invoicePaid
+
+  const endedAt = convertStripeTimestamp(subscription.ended_at ?? null)
+  if (!endedAt || !periodEnd) return true
+
+  return endedAt.getTime() >= periodEnd.getTime()
+}
+
+/**
  * The end of the last period the visitor actually paid for.
  *
  * Stripe advances the period at the renewal moment, before the charge clears,
@@ -129,7 +181,13 @@ function getPeriod(subscription: Stripe.Subscription): { start: Date | null; end
 function resolvePaidThrough(subscription: Stripe.Subscription): Date | null {
   const { start, end } = getPeriod(subscription)
 
-  return UNPAID_CURRENT_PERIOD.has(subscription.status) ? start : end
+  if (UNPAID_CURRENT_PERIOD.has(subscription.status)) return start
+
+  if (subscription.status === 'canceled') {
+    return canceledPeriodWasPaid(subscription, end) ? end : start
+  }
+
+  return end
 }
 
 /**


### PR DESCRIPTION
`canceled` was treated as a paid period, so `paidThroughAt` came from
`current_period_end`. When Stripe exhausts its retries and cancels — the
default Billing setting — the subscription is sitting in a renewed period
that was never collected, and that end date is in the future: about nine
free days on monthly, most of a year on annual.

The status alone cannot tell the two cancellations apart, so decide per
subscription: the expanded `latest_invoice` says outright whether the
period was collected, and where it is absent `ended_at` still separates a
cancel-at-period-end (lands on the boundary) from a dunning cancel (lands
before it). With neither signal the period stays paid, so missing evidence
never revokes access.

The existing deleted-subscription test only covered the voluntary shape;
it now asserts that is what its fixture is, and the dunning shape is
covered alongside it.