### PR TITLE
Price /join from Stripe instead of hardcoded figures

### DIFF
--- a/apps/questura/apps/client/src/app/join/layout.tsx
+++ b/apps/questura/apps/client/src/app/join/layout.tsx
@@ -1,4 +1,5 @@
 import JoinNavbar from "@/features/Navigation/JoinNavbar";
+import { QueryProvider } from "@/components/providers/QueryProvider";
 import {
   GLOBE_FALLBACK_SRC,
   GLOBE_SIZES,
@@ -29,7 +30,13 @@ export default function JoinLayout({
         fetchPriority="high"
       />
       <JoinNavbar />
-      <main className="flex-1">{children}</main>
+      {/*
+       * The plan cards read their prices from /api/payments/plans rather than
+       * hardcoding them, so this static route still needs a query client.
+       */}
+      <QueryProvider>
+        <main className="flex-1">{children}</main>
+      </QueryProvider>
     </>
   );
 }

--- a/apps/questura/apps/client/src/app/join/page.tsx
+++ b/apps/questura/apps/client/src/app/join/page.tsx
@@ -3,8 +3,10 @@ import PricingDisplay from '@/features/Payments/components/PricingDisplay';
 
 export const metadata: Metadata = {
   title: 'Join Questurian — Every Article and Itinerary, One Membership',
+  // No price here on purpose: metadata is static, so any figure in it would
+  // drift from the Stripe price the page and checkout actually use.
   description:
-    'One membership unlocks everything our travel experts publish — in-depth articles and day-by-day itineraries for every city we cover. From less than $1.55 a week.',
+    'One membership unlocks everything our travel experts publish — in-depth articles and day-by-day itineraries for every city we cover. Monthly or annual, cancel anytime.',
 };
 
 export default function JoinPage() {

--- a/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
+++ b/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
@@ -36,9 +36,14 @@ export default function SubscribeButton() {
         550:h-[40px] 550:w-[234px] 550:px-1.5 550:text-[.850rem]
       `}
     >
+      {/*
+       * No price in this label: it is static chrome on every page and cannot
+       * know the Stripe price, so it used to advertise $1.50/wk against a real
+       * $0.50/month. /join states the price it reads from Stripe.
+       */}
       <span className="380:hidden">Subscribe</span>
-      <span className="hidden 380:inline 550:hidden">Join: $1.50/wk</span>
-      <span className="hidden 550:inline">Subscribe: Less than $1.50/wk</span>
+      <span className="hidden 380:inline 550:hidden">Join</span>
+      <span className="hidden 550:inline">Become a member</span>
 
     </button>
   );

--- a/apps/questura/apps/client/src/features/Payments/components/PricingDisplay.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/PricingDisplay.tsx
@@ -1,5 +1,15 @@
+'use client';
+
 import Link from 'next/link';
 import JoinHeroVisual from './JoinHeroVisual';
+import {
+  formatPerMonthEquivalent,
+  formatPlanAmount,
+  formatPlanInterval,
+  getAnnualSaving,
+  useMembershipPlans,
+  type MembershipPlan,
+} from '../hooks/useMembershipPlan';
 
 const tickerItems = [
   'Neighborhood deep-dives',
@@ -34,13 +44,9 @@ const unlocks = [
   },
 ];
 
-const faqs = [
-  {
-    question: 'What’s the difference between the plans?',
-    answer:
-      'Nothing but the billing. Both plans unlock every article, itinerary, and expert we publish. Annual simply costs about half as much per month.',
-  },
-];
+const PLAN_DIFFERENCE_QUESTION = 'What’s the difference between the plans?';
+const PLAN_DIFFERENCE_ANSWER =
+  'Nothing but the billing. Both plans unlock every article, itinerary, and expert we publish.';
 
 function PlanArrowLink({ href, label }: { href: string; label: string }) {
   return (
@@ -82,7 +88,132 @@ function PlanArrowLink({ href, label }: { href: string; label: string }) {
   );
 }
 
+/**
+ * The annual card, priced from Stripe.
+ *
+ * Every figure here — the price, the crossed-out "full price", the discount
+ * badge, the per-month equivalent — is derived from the two prices the checkout
+ * charges. This page used to hardcode $79.99 / $155.88 / $6.67 / "Save 49%"
+ * against a real price of $0.50 a month, which is the drift /purchase was fixed
+ * for. See `useMembershipPlan`.
+ */
+function AnnualPlanCard({
+  plan,
+  monthly,
+}: {
+  plan: MembershipPlan;
+  monthly: MembershipPlan | null;
+}) {
+  const saving = getAnnualSaving(plan, monthly);
+  const perMonth = formatPerMonthEquivalent(plan);
+
+  return (
+    <div
+      className="
+        join-plan-card join-plan-card--annual
+        relative flex flex-col overflow-hidden
+        bg-[#FAF7F2] text-[#1A1A1A]
+        shadow-[0_18px_44px_-36px_rgba(26,26,26,0.45)]
+        768:order-last
+      "
+    >
+      <div className="flex flex-1 flex-col p-8 480:p-10">
+        <div className="flex items-start justify-between gap-4">
+          <p className="font-mono text-[0.64rem] uppercase tracking-[0.2em] text-[#3451C7]">
+            Annual · Most popular
+          </p>
+          {saving ? (
+            <p
+              className="
+                shrink-0 rounded-sm bg-[#3B5BDB] px-2 py-1 font-mono
+                text-[0.6rem] font-bold uppercase tracking-[0.14em]
+                text-white
+              "
+            >
+              Save {saving.percentOff}%
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mt-6 flex flex-wrap items-baseline gap-x-3">
+          {saving ? (
+            <span className="text-[0.95rem] text-[#1A1A1A]/45 line-through">
+              <span className="sr-only">Full price at the monthly rate: </span>
+              {saving.compareAt}
+            </span>
+          ) : null}
+          <span className="font-display text-[2.6rem] leading-none 768:text-[3rem]">
+            {formatPlanAmount(plan)}
+          </span>
+          <span className="text-[0.9rem] text-[#6b6a68]">
+            /{formatPlanInterval(plan)}
+          </span>
+        </div>
+        {perMonth ? (
+          <p className="mt-2.5 text-[0.86rem] font-medium text-[#9DACF2]">
+            {perMonth} a month
+          </p>
+        ) : null}
+
+        <p className="mt-6 mb-8 flex-1 text-[0.95rem] leading-[1.75] text-[#4f4e4b]">
+          The complete Questurian library, billed once a year. Every article and
+          itinerary we publish, for one yearly payment.
+        </p>
+
+        <PlanArrowLink href="/purchase/yearly" label="Continue with Annual" />
+      </div>
+    </div>
+  );
+}
+
+function MonthlyPlanCard({ plan }: { plan: MembershipPlan }) {
+  return (
+    <div
+      className="
+        join-plan-card
+        relative flex flex-col
+        bg-[#FAF7F2] p-8
+        shadow-[0_18px_44px_-36px_rgba(26,26,26,0.45)]
+        480:p-10
+      "
+    >
+      <p className="font-mono text-[0.64rem] uppercase tracking-[0.2em] text-[#8a857c]">
+        Monthly
+      </p>
+
+      <div className="mt-6 flex items-baseline gap-x-3">
+        <span className="font-display text-[2.6rem] leading-none text-[#1A1A1A] 768:text-[3rem]">
+          {formatPlanAmount(plan)}
+        </span>
+        <span className="text-[0.9rem] text-[#6b6a68]">
+          /{formatPlanInterval(plan)}
+        </span>
+      </div>
+      <p className="mt-6 mb-8 flex-1 text-[0.95rem] leading-[1.75] text-[#4f4e4b]">
+        The same full access to every article and itinerary from all of our
+        travel experts, billed month to month.
+      </p>
+
+      <PlanArrowLink href="/purchase/monthly" label="Continue with Monthly" />
+    </div>
+  );
+}
+
 export default function PricingDisplay() {
+  const { monthly, yearly, isLoading } = useMembershipPlans();
+
+  const annualPerMonth = yearly ? formatPerMonthEquivalent(yearly) : null;
+  const hasBothPlans = Boolean(monthly && yearly);
+
+  // No plan means nothing is purchasable, so the page says so instead of
+  // advertising a number the checkout would not honour.
+  const hasAnyPlan = Boolean(monthly || yearly);
+
+  // Only meaningful while there is more than one plan to choose between.
+  const faqs = hasBothPlans
+    ? [{ question: PLAN_DIFFERENCE_QUESTION, answer: PLAN_DIFFERENCE_ANSWER }]
+    : [];
+
   return (
     <div className="min-h-screen bg-[#F5F0E8]">
       {/* ── Hero ── */}
@@ -121,7 +252,7 @@ export default function PricingDisplay() {
       >
         <div className="mb-8 text-center 768:mb-10">
           <h2 className="font-display text-[2rem] font-semibold leading-tight text-[#1A1A1A] 768:text-[2.4rem]">
-            Choose your plan.
+            {hasBothPlans ? 'Choose your plan.' : 'Become a member.'}
           </h2>
           <p className="mt-2 text-[0.9rem] text-[#6f6a62]">
             You can{' '}
@@ -131,96 +262,39 @@ export default function PricingDisplay() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 items-stretch gap-6 768:grid-cols-[1fr_1.12fr] 768:gap-8">
-          {/* Annual — the member pass */}
-          <div
-            className="
-              join-plan-card join-plan-card--annual
-              relative flex flex-col overflow-hidden
-              bg-[#FAF7F2] text-[#1A1A1A]
-              shadow-[0_18px_44px_-36px_rgba(26,26,26,0.45)]
-              768:order-last
-            "
+        {isLoading ? (
+          <p
+            className="py-10 text-center text-[0.9rem] text-[#6f6a62]"
+            role="status"
           >
-            <div className="flex flex-1 flex-col p-8 480:p-10">
-              <div className="flex items-start justify-between gap-4">
-                <p className="font-mono text-[0.64rem] uppercase tracking-[0.2em] text-[#3451C7]">
-                  Annual · Most popular
-                </p>
-                <p
-                  className="
-                    shrink-0 rounded-sm bg-[#3B5BDB] px-2 py-1 font-mono
-                    text-[0.6rem] font-bold uppercase tracking-[0.14em]
-                    text-white
-                  "
-                >
-                  Save 49%
-                </p>
-              </div>
-
-              <div className="mt-6 flex flex-wrap items-baseline gap-x-3">
-                <span className="text-[0.95rem] text-[#1A1A1A]/45 line-through">
-                  <span className="sr-only">Full price at the monthly rate: </span>
-                  $155.88
-                </span>
-                <span className="font-display text-[2.6rem] leading-none 768:text-[3rem]">
-                  $79.99
-                </span>
-                <span className="text-[0.9rem] text-[#6b6a68]">/year</span>
-              </div>
-              <p className="mt-2.5 text-[0.86rem] font-medium text-[#9DACF2]">
-                $6.67 a month — less than $1.55 a week
-              </p>
-
-              <p className="mt-6 mb-8 flex-1 text-[0.95rem] leading-[1.75] text-[#4f4e4b]">
-                The complete Questurian library, billed once a year. Twelve
-                months of every article and itinerary for the price
-                of&nbsp;six.
-              </p>
-
-              <PlanArrowLink
-                href="/purchase/yearly"
-                label="Continue with Annual"
-              />
-            </div>
-          </div>
-
-          {/* Monthly */}
+            Loading plans…
+          </p>
+        ) : hasAnyPlan ? (
           <div
-            className="
-              join-plan-card
-              relative flex flex-col
-              bg-[#FAF7F2] p-8
-              shadow-[0_18px_44px_-36px_rgba(26,26,26,0.45)]
-              480:p-10
-            "
+            className={`grid grid-cols-1 items-stretch gap-6 768:gap-8 ${
+              hasBothPlans
+                ? '768:grid-cols-[1fr_1.12fr]'
+                : 'mx-auto max-w-md'
+            }`}
           >
-            <p className="font-mono text-[0.64rem] uppercase tracking-[0.2em] text-[#8a857c]">
-              Monthly
-            </p>
-
-            <div className="mt-6 flex items-baseline gap-x-3">
-              <span className="font-display text-[2.6rem] leading-none text-[#1A1A1A] 768:text-[3rem]">
-                $12.99
-              </span>
-              <span className="text-[0.9rem] text-[#6b6a68]">/month</span>
-            </div>
-            <p className="mt-6 mb-8 flex-1 text-[0.95rem] leading-[1.75] text-[#4f4e4b]">
-              The same full access to every article and itinerary from all
-              of our travel experts, billed month to month.
-            </p>
-
-            <PlanArrowLink
-              href="/purchase/monthly"
-              label="Continue with Monthly"
-            />
+            {/* Annual — the member pass. Absent from Stripe means absent here. */}
+            {yearly ? (
+              <AnnualPlanCard plan={yearly} monthly={monthly} />
+            ) : null}
+            {monthly ? <MonthlyPlanCard plan={monthly} /> : null}
           </div>
-        </div>
+        ) : (
+          <p className="py-10 text-center text-[0.9rem] text-[#6f6a62]">
+            Memberships are temporarily unavailable. Please try again shortly.
+          </p>
+        )}
 
-        <p className="mt-6 text-center text-[0.72rem] tracking-[0.01em] text-[#9a9894]">
-          Secure payment via Stripe · Visa, Mastercard, American Express,
-          Apple&nbsp;Pay
-        </p>
+        {hasAnyPlan ? (
+          <p className="mt-6 text-center text-[0.72rem] tracking-[0.01em] text-[#9a9894]">
+            Secure payment via Stripe · Visa, Mastercard, American Express,
+            Apple&nbsp;Pay
+          </p>
+        ) : null}
       </section>
 
       {/* ── Pull quote ── */}
@@ -280,34 +354,36 @@ export default function PricingDisplay() {
       </section>
 
       {/* ── FAQ ── */}
-      <section className="join-faq px-6 pb-16 max-w-2xl mx-auto 768:pb-20">
-        <h2 className="text-center font-display text-[1.35rem] text-[#1A1A1A] 768:text-[1.5rem]">
-          Before you ask
-        </h2>
-        <div className="mt-8 border-b border-[#1A1A1A]/15">
-          {faqs.map((faq) => (
-            <details key={faq.question} className="group border-t border-[#1A1A1A]/15">
-              <summary
-                className="
-                  flex items-center justify-between gap-4 py-5
-                  text-[0.95rem] font-medium text-[#1A1A1A]
-                "
-              >
-                {faq.question}
-                <span
-                  className="join-faq-plus shrink-0 text-[1.1rem] font-light leading-none text-[#3B5BDB]"
-                  aria-hidden="true"
+      {faqs.length > 0 ? (
+        <section className="join-faq px-6 pb-16 max-w-2xl mx-auto 768:pb-20">
+          <h2 className="text-center font-display text-[1.35rem] text-[#1A1A1A] 768:text-[1.5rem]">
+            Before you ask
+          </h2>
+          <div className="mt-8 border-b border-[#1A1A1A]/15">
+            {faqs.map((faq) => (
+              <details key={faq.question} className="group border-t border-[#1A1A1A]/15">
+                <summary
+                  className="
+                    flex items-center justify-between gap-4 py-5
+                    text-[0.95rem] font-medium text-[#1A1A1A]
+                  "
                 >
-                  +
-                </span>
-              </summary>
-              <p className="pb-5 pr-8 text-[0.88rem] leading-[1.75] text-[#5c5b58]">
-                {faq.answer}
-              </p>
-            </details>
-          ))}
-        </div>
-      </section>
+                  {faq.question}
+                  <span
+                    className="join-faq-plus shrink-0 text-[1.1rem] font-light leading-none text-[#3B5BDB]"
+                    aria-hidden="true"
+                  >
+                    +
+                  </span>
+                </summary>
+                <p className="pb-5 pr-8 text-[0.88rem] leading-[1.75] text-[#5c5b58]">
+                  {faq.answer}
+                </p>
+              </details>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {/* ── Final CTA ── */}
       <section className="bg-[#2D4A3E] px-6 py-16 text-center text-[#FAF7F2] 768:py-20">
@@ -333,9 +409,16 @@ export default function PricingDisplay() {
           >
             Become a member
           </a>
-          <p className="mt-4 text-[0.76rem] text-[#FAF7F2]/60">
-            From $6.67 a month, billed annually
-          </p>
+          {annualPerMonth ? (
+            <p className="mt-4 text-[0.76rem] text-[#FAF7F2]/60">
+              From {annualPerMonth} a month, billed annually
+            </p>
+          ) : monthly ? (
+            <p className="mt-4 text-[0.76rem] text-[#FAF7F2]/60">
+              {formatPlanAmount(monthly)} per {formatPlanInterval(monthly)},
+              cancel anytime
+            </p>
+          ) : null}
         </div>
       </section>
 

--- a/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
+++ b/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
@@ -35,19 +35,42 @@ function formatMinorUnits(minorUnits: number, currency: string): string {
   }).format(minorUnits / 100);
 }
 
-function formatAmount(plan: MembershipPlan): string {
+export function formatPlanAmount(plan: MembershipPlan): string {
   return formatMinorUnits(plan.amount, plan.currency);
 }
 
 /** "month", or "3 months" when Stripe is billing in multiples. */
-function formatInterval(plan: MembershipPlan): string {
+export function formatPlanInterval(plan: MembershipPlan): string {
   return plan.intervalCount === 1
     ? plan.interval
     : `${plan.intervalCount} ${plan.interval}s`;
 }
 
 export function formatPlanPrice(plan: MembershipPlan): string {
-  return `${formatAmount(plan)}/${formatInterval(plan)}`;
+  return `${formatPlanAmount(plan)}/${formatPlanInterval(plan)}`;
+}
+
+/**
+ * How many months one billing period covers, or null when Stripe bills in a
+ * unit that does not divide into months (`day`, `week`).
+ */
+function billingMonths(plan: MembershipPlan): number | null {
+  if (plan.interval === 'year') return 12 * plan.intervalCount;
+  if (plan.interval === 'month') return plan.intervalCount;
+  return null;
+}
+
+/**
+ * A multi-month plan's price expressed per month, or null when the plan is
+ * already billed monthly (or in a unit months cannot express).
+ *
+ * Rounded up: a derived figure must never undercut what Stripe will charge.
+ */
+export function formatPerMonthEquivalent(plan: MembershipPlan): string | null {
+  const months = billingMonths(plan);
+  if (!months || months <= 1) return null;
+
+  return formatMinorUnits(Math.ceil(plan.amount / months), plan.currency);
 }
 
 export type PlanSaving = {
@@ -75,8 +98,45 @@ export function getPlanSaving(plan: MembershipPlan): PlanSaving | null {
   };
 }
 
-export function useMembershipPlan(planId: PlanId) {
-  const query = useQuery({
+/**
+ * The saving an annual plan can honestly advertise.
+ *
+ * Preferred form is the real cross-plan comparison: what the same span of
+ * months costs at the monthly price the checkout actually charges. That is what
+ * the crossed-out "full price" on /join claims to be, so it is derived rather
+ * than written down. Falls back to the price's own `compare_at_amount` when the
+ * monthly plan is not offered.
+ */
+export type AnnualSaving = {
+  compareAt: string;
+  percentOff: number;
+};
+
+export function getAnnualSaving(
+  yearly: MembershipPlan,
+  monthly: MembershipPlan | null,
+): AnnualSaving | null {
+  const months = billingMonths(yearly);
+
+  if (monthly && months && months > 1 && monthly.currency === yearly.currency) {
+    const fullPrice = monthly.amount * months;
+
+    if (fullPrice > yearly.amount) {
+      return {
+        compareAt: formatMinorUnits(fullPrice, yearly.currency),
+        percentOff: Math.round(((fullPrice - yearly.amount) / fullPrice) * 100),
+      };
+    }
+  }
+
+  const declared = getPlanSaving(yearly);
+  return declared
+    ? { compareAt: declared.compareAt, percentOff: declared.percentOff }
+    : null;
+}
+
+function useMembershipPlansQuery() {
+  return useQuery({
     queryKey: ['membership-plans'],
     queryFn: async () => {
       const response = await get<{ plans: MembershipPlan[] }>('/api/payments/plans');
@@ -84,6 +144,26 @@ export function useMembershipPlan(planId: PlanId) {
     },
     staleTime: 60 * 60 * 1000,
   });
+}
+
+/**
+ * Every plan Stripe currently offers. A plan missing from the list is a plan
+ * that cannot be bought, so callers hide it rather than advertise it.
+ */
+export function useMembershipPlans() {
+  const query = useMembershipPlansQuery();
+  const plans = query.data ?? [];
+
+  return {
+    monthly: plans.find((plan) => plan.id === 'monthly') ?? null,
+    yearly: plans.find((plan) => plan.id === 'yearly') ?? null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}
+
+export function useMembershipPlan(planId: PlanId) {
+  const query = useMembershipPlansQuery();
 
   const plan = query.data?.find((candidate) => candidate.id === planId) ?? null;
 


### PR DESCRIPTION
## Problem

`/purchase` was fixed to read its price from Stripe (`useMembershipPlan` + `/api/payments/plans`). `/join` was not — the same drift, one page upstream.

`PricingDisplay.tsx` hardcoded `$155.88` / `$79.99/year` / `$6.67 a month` / `$12.99/month` / `Save 49%`; `app/join/page.tsx` hardcoded "less than $1.55 a week". The configured live price is **$0.50/month**, so /join stated a price ~26x the real one — a legal/chargeback exposure, not just stale copy.

The annual card also linked to `/purchase/yearly`, which answers "That plan is not available right now" whenever `STRIPE_PRICE_ID_YEARLY` is unset.

## Fix

- `PricingDisplay` is now a client component fed by `/api/payments/plans` (already public, 5-min server cache, 30/min/IP rate limit).
- Every figure is derived from the prices checkout charges:
  - amount and interval via `formatPlanAmount` / `formatPlanInterval`
  - per-month equivalent via `formatPerMonthEquivalent` — `Math.ceil` so a derived figure can never undercut what Stripe bills
  - crossed-out "full price" and discount % via `getAnnualSaving`, computed as the monthly price over the same span of months (which is exactly what `$155.88` claimed to be), falling back to the price's `compare_at_amount`
- **A plan absent from Stripe is not rendered.** The dead `/purchase/yearly` link goes away with the card, the grid collapses to one column, and the "difference between the plans" FAQ hides.
- No plan at all → "Memberships are temporarily unavailable" instead of an invented number.
- Static copy that cannot know the price no longer states one: the `/join` metadata description, and the nav `SubscribeButton` which advertised "$1.50/wk" on every page.
- `/join` is a static route with no query client, so `join/layout.tsx` now wraps children in the existing `QueryProvider` singleton.

## Verification

- `pnpm typecheck` clean
- `pnpm lint` — only pre-existing warnings in unrelated files
- `pnpm build` clean; `/join` still prerendered static (`○ /join`)