### PR TITLE
Add the Access tier field to the three editorial collections

### DIFF
--- a/apps/questura/apps/server/src/features/articles/articles/collections/Articles.ts
+++ b/apps/questura/apps/server/src/features/articles/articles/collections/Articles.ts
@@ -11,6 +11,7 @@ import {
 } from '@/shared/location/server/articleLocationScope'
 import { syncLocationFields } from '@/shared/location/server/syncLocationFields'
 import { languageField } from '@/shared/i18n/languageField'
+import { accessTierField } from '@/shared/content/accessTier'
 import { revalidateArticleCollection } from '@/features/public-revalidation/revalidate-client'
 import {
   assertCanDeleteHomepageFeaturedContent,
@@ -143,6 +144,7 @@ export const Articles: CollectionConfig = {
     // Sidebar / Meta fields
     status,
     languageField,
+    accessTierField,
     author,
     publishedAt,
     canonicalPath,

--- a/apps/questura/apps/server/src/features/articles/listicle-itineraries/collections/ListicleItineraries.ts
+++ b/apps/questura/apps/server/src/features/articles/listicle-itineraries/collections/ListicleItineraries.ts
@@ -8,6 +8,7 @@ import {
 } from '@/shared/location/server/articleLocationScope'
 import { syncLocationFields } from '@/shared/location/server/syncLocationFields'
 import { languageField } from '@/shared/i18n/languageField'
+import { accessTierField } from '@/shared/content/accessTier'
 import { revalidateArticleCollection } from '@/features/public-revalidation/revalidate-client'
 import {
   assertCanDeleteHomepageFeaturedContent,
@@ -146,6 +147,7 @@ export const ListicleItineraries: CollectionConfig = {
 
     status,
     languageField,
+    accessTierField,
     author,
     publishedAt,
     articleType,

--- a/apps/questura/apps/server/src/features/articles/single-type-listicles/collections/SingleTypeListicles.ts
+++ b/apps/questura/apps/server/src/features/articles/single-type-listicles/collections/SingleTypeListicles.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from 'payload'
 import { languageField } from '@/shared/i18n/languageField'
+import { accessTierField } from '@/shared/content/accessTier'
 import { singleTypeListicleAccess } from './access'
 import {
   articleType,
@@ -55,6 +56,7 @@ export const SingleTypeListicles: CollectionConfig = {
 
     status,
     languageField,
+    accessTierField,
     author,
     publishedAt,
     articleType,

--- a/apps/questura/apps/server/src/migrations/20260815_010000_add_access_tier.ts
+++ b/apps/questura/apps/server/src/migrations/20260815_010000_add_access_tier.ts
@@ -1,0 +1,74 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Access tier on the three editorial collections (ADR-0009).
+ *
+ * Every existing row backfills to `free` through the column default, so this
+ * migration is inert by construction: nothing on the live site changes tier
+ * until an editor sets one. That is the point of landing the shape before the
+ * behaviour -- the paywall's first deploy proves the machinery without being
+ * able to lock anyone out of anything.
+ *
+ * `NOT NULL` with a default rather than a nullable column, because
+ * `isGatedItem` treats anything that is not exactly `member` as free. A
+ * nullable column would make that fallback load-bearing in production instead
+ * of a convenience for hand-built test objects, and "gated" is not a state
+ * anything should arrive at by accident.
+ *
+ * One enum type per table, matching what the Payload postgres adapter derives
+ * from a `select` field. Adding a third tier later means `ALTER TYPE`, which
+ * the deploy preflight blocks as a type rewrite -- that is deliberate friction,
+ * not an oversight, and the split recipe in infra/softprod/README.md covers it.
+ *
+ * DDL only. No backfill statement, because the default does the backfill and
+ * the preflight blocks `UPDATE` as a data rewrite.
+ */
+const TABLES = [
+  ['articles', 'enum_articles_access'],
+  ['listicle_itineraries', 'enum_listicle_itineraries_access'],
+  ['single_type_listicles', 'enum_single_type_listicles_access'],
+] as const
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(
+    sql.raw(`
+      DO $$ BEGIN
+        CREATE TYPE "public"."enum_articles_access" AS ENUM('free', 'member');
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+
+      DO $$ BEGIN
+        CREATE TYPE "public"."enum_listicle_itineraries_access" AS ENUM('free', 'member');
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+
+      DO $$ BEGIN
+        CREATE TYPE "public"."enum_single_type_listicles_access" AS ENUM('free', 'member');
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+    `),
+  )
+
+  await db.execute(
+    sql.raw(`
+      ALTER TABLE "articles"
+      ADD COLUMN IF NOT EXISTS "access" "public"."enum_articles_access" DEFAULT 'free' NOT NULL;
+
+      ALTER TABLE "listicle_itineraries"
+      ADD COLUMN IF NOT EXISTS "access" "public"."enum_listicle_itineraries_access" DEFAULT 'free' NOT NULL;
+
+      ALTER TABLE "single_type_listicles"
+      ADD COLUMN IF NOT EXISTS "access" "public"."enum_single_type_listicles_access" DEFAULT 'free' NOT NULL;
+    `),
+  )
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  for (const [table, enumName] of TABLES) {
+    await db.execute(sql.raw(`ALTER TABLE "${table}" DROP COLUMN IF EXISTS "access";`))
+    await db.execute(sql.raw(`DROP TYPE IF EXISTS "public"."${enumName}";`))
+  }
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -29,6 +29,7 @@ import * as migration_20260813_010000_add_visitor_profile_billing_email from './
 import * as migration_20260814_010000_add_visitor_profile_paid_through from './20260814_010000_add_visitor_profile_paid_through'
 import * as migration_20260814_020000_drop_legacy_membership_columns from './20260814_020000_drop_legacy_membership_columns'
 import * as migration_20260814_030000_unique_visitor_profile_stripe_customer_id from './20260814_030000_unique_visitor_profile_stripe_customer_id'
+import * as migration_20260815_010000_add_access_tier from './20260815_010000_add_access_tier'
 
 export const migrations = [
   {
@@ -185,5 +186,10 @@ export const migrations = [
     up: migration_20260814_030000_unique_visitor_profile_stripe_customer_id.up,
     down: migration_20260814_030000_unique_visitor_profile_stripe_customer_id.down,
     name: '20260814_030000_unique_visitor_profile_stripe_customer_id',
+  },
+  {
+    up: migration_20260815_010000_add_access_tier.up,
+    down: migration_20260815_010000_add_access_tier.down,
+    name: '20260815_010000_add_access_tier',
   },
 ]

--- a/apps/questura/apps/server/src/shared/content/accessTier.ts
+++ b/apps/questura/apps/server/src/shared/content/accessTier.ts
@@ -1,0 +1,53 @@
+import type { Field } from 'payload'
+
+/**
+ * Access tier: what an editorial item costs to read (ADR-0009).
+ *
+ * Declared per document and never inferred from collection, category or tag.
+ * A blanket rule cannot express "this itinerary is the free sample", which is
+ * the thing that sells the paid ones.
+ */
+export const ACCESS_TIERS = ['free', 'member'] as const
+
+export type AccessTier = (typeof ACCESS_TIERS)[number]
+
+/**
+ * New and pre-existing documents are `free`. The safe direction is the one
+ * where forgetting to think about a document leaves it readable rather than
+ * silently paywalled, and it is what makes the field's first deploy inert.
+ */
+export const DEFAULT_ACCESS_TIER: AccessTier = 'free'
+
+export function isAccessTier(value: unknown): value is AccessTier {
+  return typeof value === 'string' && (ACCESS_TIERS as readonly string[]).includes(value)
+}
+
+/**
+ * Whether a document is a Gated item.
+ *
+ * Fails closed the other way on purpose: an unrecognised or absent value reads
+ * as `free`, so a document can never become unreadable because of a bad tier
+ * string. Gating something requires saying so explicitly; the money bug this
+ * work exists to close is content served for free, and the mirror-image bug --
+ * content a paying member cannot read -- is the one that generates disputes.
+ */
+export function isGatedItem(doc: unknown): boolean {
+  if (!doc || typeof doc !== 'object') return false
+  return (doc as { access?: unknown }).access === 'member'
+}
+
+export const accessTierField: Field = {
+  name: 'access',
+  type: 'select',
+  required: true,
+  defaultValue: DEFAULT_ACCESS_TIER,
+  options: [
+    { label: 'Free — the whole item is public', value: 'free' },
+    { label: 'Members only — free sample, then paywall', value: 'member' },
+  ],
+  admin: {
+    position: 'sidebar',
+    description:
+      'Members only shows every reader a free sample and requires a membership for the rest. The sample is derived automatically — there is nothing to mark up in the body.',
+  },
+}


### PR DESCRIPTION
Second of the gating series. **Inert** — every row backfills to `free`, so live behaviour is unchanged.

## What

- `shared/content/accessTier.ts` — `ACCESS_TIERS`, `AccessTier`, `isAccessTier`, `isGatedItem`, and the shared `accessTierField`.
- Field wired into `articles`, `listicle-itineraries`, `single-type-listicles`, mirroring `languageField`.
- `20260815_010000_add_access_tier` — one enum type + one defaulted `NOT NULL` column per table.

## Why the migration is hand-written

`migrate:create` diffs the Payload schema against the **connected** database. This machine's `.env` points at stale scratch (`google-login` @5432), so generating here would emit the drift between that database and current schema as a destructive migration. Every migration since `20260811` is hand-written for the same reason; this one follows `20260811_000000_add_users_status` exactly.

## Migration safety — verified, not asserted

Ran the deploy preflight's own `inspectMigration()` against the file:

```
risks: []
```

`up()` is `CREATE TYPE` (guarded by `duplicate_object`) plus `ADD COLUMN IF NOT EXISTS`. It trips none of the five rules — notably not *column or table rewrite*, which matches `ALTER COLUMN`/`DROP COLUMN`/`RENAME` but not `ADD COLUMN`. The `DROP`s live only in `down()`, which the preflight parses out and does not scan.

No backfill statement: the column default does the backfill, and the preflight blocks `UPDATE` as a data rewrite.

## Deliberate friction

One enum type per table, matching what the Payload postgres adapter derives from a `select`. Adding a third tier later needs `ALTER TYPE`, which the preflight blocks as a type rewrite. That is intended — a tier change should go through the documented split recipe, not ride along in a feature PR.

## Fail-open

`isGatedItem` treats anything that is not exactly `member` as free. Content served free is the bug this series closes; content a paying member cannot read is the bug that generates chargebacks. Only one of those can be caused by a bad enum string, so the fallback points away from it.

## Verification

- `test:deploy` — 8 pass
- `test:int` — 761 pass
- `generate:types` clean; `payload-types.ts` is gitignored and regenerated at build