### PR TITLE
Add the Sample rule that derives a Free sample per collection

### DIFF
--- a/apps/questura/apps/server/src/features/articles/public/freeSample.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/freeSample.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_SAMPLE_LIMITS, applySampleRule } from './freeSample'
+
+const blocks = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ blockType: 'text', content: `block ${i}` }))
+
+const items = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ blockType: 'dining', blurb: `stop ${i}` }))
+
+const days = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    items: items(3),
+    whereStaying: [{ blockType: 'itinerary-where-staying', blurb: `hotel ${i}` }],
+  }))
+
+describe('applySampleRule — standard articles', () => {
+  it('keeps the leading blocks and drops the rest', () => {
+    const doc: Record<string, unknown> = { contentBlocks: blocks(9) }
+
+    const outcome = applySampleRule('articles', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 3, total: 9 })
+    expect(doc.contentBlocks).toHaveLength(3)
+    expect((doc.contentBlocks as { content: string }[])[0].content).toBe('block 0')
+  })
+
+  it('reports nothing applied when the body is already at or under the limit', () => {
+    const doc: Record<string, unknown> = { contentBlocks: blocks(2) }
+
+    const outcome = applySampleRule('articles', doc)
+
+    expect(outcome).toEqual({ applied: false, unit: 'blocks', shown: 2, total: 2 })
+    expect(doc.contentBlocks).toHaveLength(2)
+  })
+
+  it('survives a document with no body at all', () => {
+    const doc: Record<string, unknown> = {}
+
+    expect(applySampleRule('articles', doc)).toEqual({
+      applied: false,
+      unit: 'blocks',
+      shown: 0,
+      total: 0,
+    })
+  })
+})
+
+describe('applySampleRule — single-type listicles', () => {
+  it('keeps the leading ranked items', () => {
+    const doc: Record<string, unknown> = { items: items(12) }
+
+    const outcome = applySampleRule('single-type-listicles', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'items', shown: 3, total: 12 })
+    expect(doc.items).toHaveLength(3)
+  })
+})
+
+describe('applySampleRule — listicle itineraries', () => {
+  it('keeps Day 1 whole, including its lodging', () => {
+    const doc: Record<string, unknown> = { itineraryDays: days(5) }
+
+    const outcome = applySampleRule('listicle-itineraries', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'days', shown: 1, total: 5 })
+    expect(doc.itineraryDays).toHaveLength(1)
+
+    const dayOne = (doc.itineraryDays as { items: unknown[]; whereStaying: unknown[] }[])[0]
+    expect(dayOne.items).toHaveLength(3)
+    expect(dayOne.whereStaying).toHaveLength(1)
+  })
+
+  it('strips the legacy top-level body on a day-shaped itinerary', () => {
+    // Both shapes can be populated at once. Truncating days while leaving the
+    // legacy arrays would hand back the very stops the day cut removed.
+    const doc: Record<string, unknown> = {
+      itineraryDays: days(4),
+      items: items(20),
+      whereStaying: [{ blockType: 'itinerary-where-staying' }],
+    }
+
+    const outcome = applySampleRule('listicle-itineraries', doc)
+
+    expect(outcome.applied).toBe(true)
+    expect(doc.itineraryDays).toHaveLength(1)
+    expect(doc.items).toEqual([])
+    expect(doc.whereStaying).toEqual([])
+  })
+
+  it('falls back to the item rule for a legacy itinerary with no days', () => {
+    const doc: Record<string, unknown> = {
+      itineraryDays: [],
+      items: items(10),
+      whereStaying: [{ blockType: 'itinerary-where-staying' }],
+    }
+
+    const outcome = applySampleRule('listicle-itineraries', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'items', shown: 3, total: 10 })
+    expect(doc.items).toHaveLength(3)
+    expect(doc.whereStaying).toEqual([])
+  })
+
+  it('reports applied when only lodging had to be removed', () => {
+    const doc: Record<string, unknown> = {
+      items: items(2),
+      whereStaying: [{ blockType: 'itinerary-where-staying' }],
+    }
+
+    const outcome = applySampleRule('listicle-itineraries', doc)
+
+    expect(outcome.applied).toBe(true)
+    expect(doc.items).toHaveLength(2)
+    expect(doc.whereStaying).toEqual([])
+  })
+})
+
+describe('applySampleRule — limits', () => {
+  it('honours caller-supplied limits over the defaults', () => {
+    const doc: Record<string, unknown> = { contentBlocks: blocks(9) }
+
+    const outcome = applySampleRule('articles', doc, {
+      ...DEFAULT_SAMPLE_LIMITS,
+      articleBlocks: 5,
+    })
+
+    expect(outcome.shown).toBe(5)
+    expect(doc.contentBlocks).toHaveLength(5)
+  })
+
+  it('treats a zero limit as a full lock rather than as no limit', () => {
+    const doc: Record<string, unknown> = { contentBlocks: blocks(4) }
+
+    const outcome = applySampleRule('articles', doc, {
+      ...DEFAULT_SAMPLE_LIMITS,
+      articleBlocks: 0,
+    })
+
+    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 0, total: 4 })
+    expect(doc.contentBlocks).toEqual([])
+  })
+})

--- a/apps/questura/apps/server/src/features/articles/public/freeSample.ts
+++ b/apps/questura/apps/server/src/features/articles/public/freeSample.ts
@@ -1,0 +1,142 @@
+import type { ArticleCollectionSlug } from './serializeArticleBlocks'
+
+/**
+ * Sample rule: derives a Free sample from a Gated item's body (ADR-0009).
+ *
+ * Structural per collection rather than an editor-placed marker. A marker has
+ * an unset state, and a paywall with an unset state fails silently in both
+ * directions -- a forgotten marker ships the item either entirely free or
+ * entirely locked, and nobody finds out from the code. These rules have no
+ * unset state.
+ *
+ * The cut also lands on each shape's natural seam. An itinerary keeps Day 1
+ * whole, which is both a clean boundary and the best pitch available: "see
+ * Day 1 free, unlock all five days". A block count would have cut mid-day.
+ *
+ * This module only derives; it does not decide who gets the sample. Callers
+ * pair it with the Access tier and the reader's Membership entitlement.
+ */
+
+export type SampleUnit = 'blocks' | 'items' | 'days'
+
+export type SampleLimits = {
+  /** Leading `contentBlocks` kept on a standard article. */
+  articleBlocks: number
+  /** Leading `items` kept on a single-type listicle. */
+  listicleItems: number
+  /** Leading `itineraryDays` kept whole on a listicle itinerary. */
+  itineraryDays: number
+}
+
+/**
+ * Guesses, deliberately centralised so they can move on conversion evidence
+ * rather than being scattered across call sites.
+ */
+export const DEFAULT_SAMPLE_LIMITS: SampleLimits = {
+  articleBlocks: 3,
+  listicleItems: 3,
+  itineraryDays: 1,
+}
+
+export type SampleOutcome = {
+  /** Whether anything was actually removed. */
+  applied: boolean
+  /** What `shown` and `total` are counted in, so the client can phrase the lock. */
+  unit: SampleUnit
+  shown: number
+  total: number
+}
+
+function asArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null
+}
+
+/**
+ * Truncates `doc[key]` to `limit` entries in place.
+ *
+ * In-place because `serializeArticleByCollection` already mutates the document
+ * it is handed and the routes serialize that same object; returning a copy here
+ * would leave two divergent notions of the response body.
+ */
+function truncate(
+  doc: Record<string, unknown>,
+  key: string,
+  limit: number,
+): { shown: number; total: number; applied: boolean } {
+  const list = asArray(doc[key])
+  if (!list) return { shown: 0, total: 0, applied: false }
+
+  const total = list.length
+  const shown = Math.max(0, Math.min(limit, total))
+  if (shown >= total) return { shown: total, total, applied: false }
+
+  doc[key] = list.slice(0, shown)
+  return { shown, total, applied: true }
+}
+
+/**
+ * Applies the Sample rule for `collection` to `doc`, mutating it.
+ *
+ * Callers must have already decided that this reader gets a sample. Calling it
+ * on a free item or for an entitled member would silently truncate content
+ * they are allowed to read.
+ */
+export function applySampleRule(
+  collection: ArticleCollectionSlug,
+  doc: Record<string, unknown>,
+  limits: SampleLimits = DEFAULT_SAMPLE_LIMITS,
+): SampleOutcome {
+  if (collection === 'articles') {
+    const r = truncate(doc, 'contentBlocks', limits.articleBlocks)
+    return { applied: r.applied, unit: 'blocks', shown: r.shown, total: r.total }
+  }
+
+  if (collection === 'single-type-listicles') {
+    const r = truncate(doc, 'items', limits.listicleItems)
+    return { applied: r.applied, unit: 'items', shown: r.shown, total: r.total }
+  }
+
+  // Listicle itineraries carry two body shapes. `itineraryDays` is current;
+  // top-level `items`/`whereStaying` are the legacy pre-days layout that
+  // beforeValidate still normalises. Cut whichever one this document uses.
+  const days = asArray(doc.itineraryDays)
+  if (days && days.length > 0) {
+    const r = truncate(doc, 'itineraryDays', limits.itineraryDays)
+    // Legacy top-level body is not part of a day-shaped itinerary's sample.
+    // Leaving it would hand back the very stops the day cut removed.
+    const hadLegacy = stripLegacyItineraryBody(doc)
+    return {
+      applied: r.applied || hadLegacy,
+      unit: 'days',
+      shown: r.shown,
+      total: r.total,
+    }
+  }
+
+  // Legacy itinerary: no days to cut on, so fall back to the listicle rule and
+  // drop lodging, which is the part worth paying for.
+  const r = truncate(doc, 'items', limits.listicleItems)
+  const hadLodging = stripWhereStaying(doc)
+  return { applied: r.applied || hadLodging, unit: 'items', shown: r.shown, total: r.total }
+}
+
+function stripWhereStaying(doc: Record<string, unknown>): boolean {
+  const lodging = asArray(doc.whereStaying)
+  if (!lodging || lodging.length === 0) return false
+  doc.whereStaying = []
+  return true
+}
+
+function stripLegacyItineraryBody(doc: Record<string, unknown>): boolean {
+  let stripped = false
+
+  const legacyItems = asArray(doc.items)
+  if (legacyItems && legacyItems.length > 0) {
+    doc.items = []
+    stripped = true
+  }
+
+  if (stripWhereStaying(doc)) stripped = true
+
+  return stripped
+}


### PR DESCRIPTION
Third of the gating series. **Pure derivation — nothing calls it yet.**

(Replaces #299, which GitHub auto-closed when its stacked base branch was deleted on merge. Same commit, rebased onto `main`.)

## What

`features/articles/public/freeSample.ts` — `applySampleRule(collection, doc, limits?)` plus `DEFAULT_SAMPLE_LIMITS`.

| Collection | Rule | Unit reported |
|---|---|---|
| `articles` | first 3 `contentBlocks` | `blocks` |
| `single-type-listicles` | first 3 `items` | `items` |
| `listicle-itineraries` | first 1 `itineraryDays`, whole | `days` |

Returns `{ applied, unit, shown, total }` so the client can phrase the lock precisely — "Day 1 of 5", "3 of 12 stops" — rather than a generic wall.

## The itinerary case is the one worth reviewing

Itineraries carry **two** body shapes, and both can be populated on the same document: `itineraryDays` (current) and top-level `items`/`whereStaying` (legacy, still normalised by `beforeValidate`).

Truncating days while leaving the legacy arrays would hand back exactly the stops the day cut removed. So a day-shaped itinerary strips the legacy body too. A genuinely legacy itinerary — no days — falls back to the item rule and drops lodging, which is the part worth paying for. Both paths are tested.

## Why in-place mutation

`serializeArticleByCollection` already mutates the document the routes then serialize. Returning a copy here would leave two divergent notions of the response body — the exact ambiguity a paywall should not have.

## Deliberate choices

- **Limits centralised** — they are guesses and should move on conversion evidence.
- **Zero limit means a full lock**, not an absent limit.
- **No entitlement logic here.** This module cannot leak anything on its own, and cannot be misread as the enforcement point.

## Verification

10 tests, all passing.