### PR TITLE
Serve a Free sample for Gated items on the cached public routes

### DIFF
--- a/apps/questura/apps/server/src/app/api/public/articles/by-canonical-path/route.ts
+++ b/apps/questura/apps/server/src/app/api/public/articles/by-canonical-path/route.ts
@@ -4,6 +4,7 @@ import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { DEFAULT_LANG, isSupportedLang } from '@/shared/i18n/languageField'
 import { serializeArticleByCollection } from '@/features/articles/public/serializeArticleBlocks'
+import { gatePublicArticle } from '@/features/articles/public/gatePublicArticle'
 
 function badRequest(message: string) {
   return NextResponse.json({ message }, { status: 400 })
@@ -43,6 +44,7 @@ export async function GET(req: NextRequest) {
 
     const article = result.docs[0] as unknown as Record<string, unknown>
     await serializeArticleByCollection('articles', article, payload)
+    gatePublicArticle('articles', article)
 
     return NextResponse.json(article)
   } catch (error) {

--- a/apps/questura/apps/server/src/app/api/public/articles/by-id/route.ts
+++ b/apps/questura/apps/server/src/app/api/public/articles/by-id/route.ts
@@ -7,6 +7,7 @@ import {
   serializeArticleByCollection,
   type ArticleCollectionSlug,
 } from '@/features/articles/public/serializeArticleBlocks'
+import { gatePublicArticle } from '@/features/articles/public/gatePublicArticle'
 import {
   isArticleScopeKind,
   isArticleTypeKey,
@@ -86,6 +87,7 @@ export async function GET(req: NextRequest) {
     }
 
     await serializeArticleByCollection(collection, article, payload)
+    gatePublicArticle(collection, article)
 
     return NextResponse.json(article)
   } catch (error) {

--- a/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { gatePublicArticle } from './gatePublicArticle'
+
+const blocks = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ blockType: 'text', content: `block ${i}` }))
+
+describe('gatePublicArticle', () => {
+  it('leaves a free article whole and says so', () => {
+    const doc: Record<string, unknown> = { access: 'free', contentBlocks: blocks(9) }
+
+    const state = gatePublicArticle('articles', doc)
+
+    expect(state.locked).toBe(false)
+    expect(state.access).toBe('free')
+    expect(doc.contentBlocks).toHaveLength(9)
+    expect(doc.gate).toEqual(state)
+  })
+
+  it('reduces a gated article to its Free sample', () => {
+    const doc: Record<string, unknown> = { access: 'member', contentBlocks: blocks(9) }
+
+    const state = gatePublicArticle('articles', doc)
+
+    expect(state).toEqual({ access: 'member', locked: true, unit: 'blocks', shown: 3, total: 9 })
+    expect(doc.contentBlocks).toHaveLength(3)
+  })
+
+  it('treats a document with no tier as free rather than locking it', () => {
+    // Fails open: content served free is the bug this closes, but content a
+    // paying member cannot read is the bug that generates chargebacks.
+    const doc: Record<string, unknown> = { contentBlocks: blocks(9) }
+
+    const state = gatePublicArticle('articles', doc)
+
+    expect(state.locked).toBe(false)
+    expect(state.access).toBe('free')
+    expect(doc.contentBlocks).toHaveLength(9)
+  })
+
+  it('treats an unrecognised tier as free', () => {
+    const doc: Record<string, unknown> = { access: 'premium', contentBlocks: blocks(9) }
+
+    const state = gatePublicArticle('articles', doc)
+
+    expect(state.locked).toBe(false)
+    expect(state.access).toBe('free')
+    expect(doc.contentBlocks).toHaveLength(9)
+  })
+
+  it('still reports locked when the item is shorter than its own sample limit', () => {
+    // Nothing was cut, but it is still paid content. Reporting it unlocked
+    // would quietly turn every short gated item into a free one.
+    const doc: Record<string, unknown> = { access: 'member', contentBlocks: blocks(2) }
+
+    const state = gatePublicArticle('articles', doc)
+
+    expect(state.locked).toBe(true)
+    expect(state).toMatchObject({ shown: 2, total: 2 })
+  })
+
+  it('locks an itinerary down to Day 1 and counts in days', () => {
+    const doc: Record<string, unknown> = {
+      access: 'member',
+      itineraryDays: Array.from({ length: 5 }, () => ({ items: [], whereStaying: [] })),
+    }
+
+    const state = gatePublicArticle('listicle-itineraries', doc)
+
+    expect(state).toEqual({ access: 'member', locked: true, unit: 'days', shown: 1, total: 5 })
+    expect(doc.itineraryDays).toHaveLength(1)
+  })
+
+  it('always attaches gate state, so the client never infers lock from absence', () => {
+    const free: Record<string, unknown> = { access: 'free' }
+    const gated: Record<string, unknown> = { access: 'member' }
+
+    gatePublicArticle('articles', free)
+    gatePublicArticle('articles', gated)
+
+    expect(free.gate).toBeDefined()
+    expect(gated.gate).toBeDefined()
+  })
+})

--- a/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.ts
+++ b/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.ts
@@ -1,0 +1,66 @@
+import { DEFAULT_ACCESS_TIER, isAccessTier, isGatedItem } from '@/shared/content/accessTier'
+import type { AccessTier } from '@/shared/content/accessTier'
+import { applySampleRule, type SampleUnit } from './freeSample'
+import type { ArticleCollectionSlug } from './serializeArticleBlocks'
+
+/**
+ * Reader-facing lock state attached to a public article payload.
+ *
+ * Always present, on free items too. An absent key is indistinguishable from a
+ * key the client forgot to read, and "is this locked" is not a question a
+ * paywall should answer by omission.
+ */
+export type GateState = {
+  access: AccessTier
+  locked: boolean
+  /** What `shown`/`total` count, so the client can say "Day 1 of 5". */
+  unit: SampleUnit
+  shown: number
+  total: number
+}
+
+/**
+ * Reduces a public article document to what an unentitled reader may see, and
+ * records why (ADR-0009).
+ *
+ * This is the enforcement point for the **cached** public routes, and it takes
+ * no reader identity on purpose. Those routes are served from a `force-static`
+ * shell with hourly ISR, so their response is shared by every caller --
+ * anonymous readers, members and search crawlers alike. Varying it by reader
+ * is what turns a shared cache into a paywall leak in one direction and a
+ * lockout in the other. A member's full body comes from a separate dynamic
+ * route instead.
+ *
+ * Gating happens where the body is serialized rather than where it is queried,
+ * because every public read runs `overrideAccess: true` -- Payload collection
+ * access control is bypassed on all of them and cannot gate anything here.
+ */
+export function gatePublicArticle(
+  collection: ArticleCollectionSlug,
+  doc: Record<string, unknown>,
+): GateState {
+  const access = isAccessTier(doc.access) ? doc.access : DEFAULT_ACCESS_TIER
+
+  if (!isGatedItem(doc)) {
+    const state: GateState = { access, locked: false, unit: 'blocks', shown: 0, total: 0 }
+    doc.gate = state
+    return state
+  }
+
+  const outcome = applySampleRule(collection, doc)
+
+  // `locked` is the tier, not the outcome. A Gated item shorter than its own
+  // sample limit loses nothing to the cut, but it is still paid content and
+  // still has to render as such -- otherwise a short itinerary would quietly
+  // become the free one.
+  const state: GateState = {
+    access,
+    locked: true,
+    unit: outcome.unit,
+    shown: outcome.shown,
+    total: outcome.total,
+  }
+
+  doc.gate = state
+  return state
+}


### PR DESCRIPTION
Fourth of the gating series. **Inert** — everything is `free` today, so no response changes.

## What

`gatePublicArticle(collection, doc)` — reduces a Gated item to its Free sample and attaches `gate` state. Wired into the only two public routes that emit a full document: `articles/by-canonical-path` and `articles/by-id`.

```json
{ "access": "member",
  "gate": { "access": "member", "locked": true, "unit": "days", "shown": 1, "total": 5 } }
```

## Why this covers the whole surface

Audited every public read path. Exactly two emit a full document; both now go through this. Everything else — `index`, `by-location`, `related`, `search`, and the curated homepage formatter — emits card-shaped data by construction (`indexItem.ts:50-58`). Search indexes the full body into its tsvector but returns only `{type, id, rank}`, so a Gated item can *rank* on locked text without ever displaying it.

## Two things reviewers should push on

**It takes no reader identity, and that is the point.** These routes are served from a `force-static` shell with hourly ISR (`(public)/layout.tsx:4`), so one response is shared by anonymous readers, members and crawlers alike. Varying it by reader turns a shared cache into a leak one way and a lockout the other. A member's full body comes from a separate dynamic route (next PR).

**Enforcement is at serialization, not at query.** Every public read runs `overrideAccess: true`, so Payload collection access control is bypassed on all of them. Tightening `Articles.access.read` would produce a comforting diff with no effect — worth knowing before someone "fixes" this later.

## Two deliberate details

- `locked` reflects the **tier**, not whether the cut removed anything. A Gated item shorter than its sample limit loses nothing but is still paid content; reporting it unlocked would quietly turn every short gated item free.
- `gate` is attached to **free** items too. An absent key is indistinguishable from a key the client forgot to read.

## Verification

- 7 new tests including empty, unrecognised and short-item tiers
- `test:int` — 778 pass