### PR TITLE
Serve a Gated item's full body from a dynamic, no-store route

### DIFF
--- a/apps/questura/apps/server/src/app/api/public/articles/full/route.test.ts
+++ b/apps/questura/apps/server/src/app/api/public/articles/full/route.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NextRequest } from 'next/server'
+
+/**
+ * The route is the unit under test, so Payload, auth and the block serializer
+ * are all stubbed. What matters here is the order of the checks and what comes
+ * back when one of them says no -- a paywall is only as good as its refusals.
+ */
+const requireVisitorPrincipal = vi.fn()
+const find = vi.fn()
+const serializeArticleByCollection = vi.fn(async () => undefined)
+
+vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
+  get requireVisitorPrincipal() {
+    return requireVisitorPrincipal
+  },
+}))
+
+vi.mock('payload', () => ({
+  getPayload: async () => ({ find }),
+}))
+
+vi.mock('@/payload.config', () => ({ default: {} }))
+
+vi.mock('@/features/articles/public/serializeArticleBlocks', () => ({
+  get serializeArticleByCollection() {
+    return serializeArticleByCollection
+  },
+}))
+
+const { GET } = await import('./route')
+
+function request(query: Record<string, string>): NextRequest {
+  const url = new URL('https://cms.example.test/api/public/articles/full')
+  for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value)
+
+  return {
+    headers: new Headers(),
+    nextUrl: url,
+  } as unknown as NextRequest
+}
+
+function entitled(active: boolean) {
+  return {
+    error: null,
+    status: 200,
+    principal: { membership: { active } },
+  }
+}
+
+const GATED_DOC = { id: 42, access: 'member', contentBlocks: [1, 2, 3, 4, 5] }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  find.mockResolvedValue({ totalDocs: 1, docs: [{ ...GATED_DOC }] })
+  requireVisitorPrincipal.mockResolvedValue(entitled(true))
+})
+
+describe('GET /api/public/articles/full — refusals', () => {
+  it('rejects an unknown type before touching auth or the database', async () => {
+    const res = await GET(request({ type: 'novels', id: '42' }))
+
+    expect(res.status).toBe(400)
+    expect(requireVisitorPrincipal).not.toHaveBeenCalled()
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('requires an id', async () => {
+    const res = await GET(request({ type: 'articles' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an unsupported lang', async () => {
+    const res = await GET(request({ type: 'articles', id: '42', lang: 'xx' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('401s an anonymous reader without querying the database', async () => {
+    requireVisitorPrincipal.mockResolvedValue({
+      error: 'Authentication required',
+      status: 401,
+      principal: null,
+    })
+
+    const res = await GET(request({ type: 'articles', id: '42' }))
+
+    expect(res.status).toBe(401)
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('403s an authenticated reader with no active membership', async () => {
+    requireVisitorPrincipal.mockResolvedValue(entitled(false))
+
+    const res = await GET(request({ type: 'articles', id: '42' }))
+
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ message: 'Membership required' })
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('does not require a verified email', async () => {
+    // Checkout does not require verification either. Gating the read while
+    // checkout stays open would let someone pay and then be refused.
+    await GET(request({ type: 'articles', id: '42' }))
+
+    expect(requireVisitorPrincipal).toHaveBeenCalledWith(expect.any(Headers))
+    const options = requireVisitorPrincipal.mock.calls[0][1]
+    expect(options?.requireVerified).toBeFalsy()
+  })
+
+  it('404s a free article rather than serving it here', async () => {
+    find.mockResolvedValue({ totalDocs: 1, docs: [{ id: 7, access: 'free' }] })
+
+    const res = await GET(request({ type: 'articles', id: '7' }))
+
+    expect(res.status).toBe(404)
+    expect(serializeArticleByCollection).not.toHaveBeenCalled()
+  })
+
+  it('404s when nothing matches', async () => {
+    find.mockResolvedValue({ totalDocs: 0, docs: [] })
+
+    const res = await GET(request({ type: 'articles', id: '999' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /api/public/articles/full — success', () => {
+  it('returns the whole body, untruncated and with no gate state', async () => {
+    const res = await GET(request({ type: 'articles', id: '42' }))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.contentBlocks).toHaveLength(5)
+    expect(body.gate).toBeUndefined()
+  })
+
+  it('never allows the response to be stored', async () => {
+    const res = await GET(request({ type: 'itineraries', id: '42' }))
+
+    expect(res.headers.get('cache-control')).toContain('no-store')
+  })
+
+  it('sends no-store on refusals too', async () => {
+    requireVisitorPrincipal.mockResolvedValue(entitled(false))
+
+    const res = await GET(request({ type: 'articles', id: '42' }))
+
+    expect(res.headers.get('cache-control')).toContain('no-store')
+  })
+
+  it('queries only published articles in the requested language', async () => {
+    await GET(request({ type: 'maps', id: '42', lang: 'en' }))
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'single-type-listicles',
+        where: {
+          and: [
+            { id: { equals: '42' } },
+            { status: { equals: 'published' } },
+            { language: { equals: 'en' } },
+          ],
+        },
+      }),
+    )
+  })
+})

--- a/apps/questura/apps/server/src/app/api/public/articles/full/route.ts
+++ b/apps/questura/apps/server/src/app/api/public/articles/full/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+
+import config from '@/payload.config'
+import { DEFAULT_LANG, isSupportedLang } from '@/shared/i18n/languageField'
+import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
+import { serializeArticleByCollection } from '@/features/articles/public/serializeArticleBlocks'
+import { isArticleTypeKey, TYPE_TO_COLLECTION } from '@/features/articles/public/scope'
+import { isGatedItem } from '@/shared/content/accessTier'
+
+/**
+ * Full body of a Gated item, for a reader who has paid for it (ADR-0009).
+ *
+ * Deliberately separate from the cached public routes. Those live under a
+ * `force-static` shell with hourly ISR, so their response is shared by every
+ * caller and must never depend on who is asking; this one depends on nothing
+ * else and must never be stored. Keeping them apart is what lets the public
+ * site stay cached and indexable while paid content stays paid.
+ */
+export const dynamic = 'force-dynamic'
+
+/**
+ * `no-store` rather than `private`. A shared cache honouring `private` is the
+ * failure this design exists to make impossible, and there is nothing here
+ * worth caching anyway.
+ */
+const NO_STORE = { 'Cache-Control': 'no-store, no-cache, must-revalidate' }
+
+function fail(req: NextRequest, message: string, status: number) {
+  return NextResponse.json(
+    { message },
+    { status, headers: { ...getCorsHeaders(req), ...NO_STORE } },
+  )
+}
+
+// GET /api/public/articles/full?type=itineraries&id=42&lang=en
+export async function GET(req: NextRequest) {
+  try {
+    const params = req.nextUrl.searchParams
+
+    const type = params.get('type')
+    if (!isArticleTypeKey(type)) return fail(req, 'type must be articles, maps or itineraries', 400)
+
+    const id = params.get('id')
+    if (!id) return fail(req, 'id required', 400)
+
+    const lang = params.get('lang') ?? DEFAULT_LANG
+    if (!isSupportedLang(lang)) return fail(req, `unsupported lang: ${lang}`, 400)
+
+    // Verification is deliberately not required. Checkout does not require it
+    // either, so demanding it here would let a visitor complete a real charge
+    // and then be refused the content they just bought.
+    const auth = await requireVisitorPrincipal(req.headers)
+    if (auth.error || !auth.principal) {
+      return fail(req, auth.error ?? 'Authentication required', auth.status)
+    }
+
+    // Entitlement is the paid-through date plus any dunning grace (ADR-0008),
+    // never the mirrored subscription status.
+    if (!auth.principal.membership.active) {
+      return fail(req, 'Membership required', 403)
+    }
+
+    const collection = TYPE_TO_COLLECTION[type]
+    const payload = await getPayload({ config })
+
+    const result = await payload.find({
+      collection,
+      where: {
+        and: [
+          { id: { equals: id } },
+          { status: { equals: 'published' } },
+          { language: { equals: lang } },
+        ],
+      },
+      limit: 1,
+      depth: 2,
+      overrideAccess: true,
+    })
+
+    if (result.totalDocs === 0) return fail(req, 'Article not found.', 404)
+
+    const article = result.docs[0] as unknown as Record<string, unknown>
+
+    // Free items do not need this route -- the cached route already served
+    // their whole body -- so a request for one is a client bug rather than a
+    // thing to satisfy quietly. Refusing keeps this route's contract to exactly
+    // one sentence: paid content, for someone who paid.
+    if (!isGatedItem(article)) return fail(req, 'Article is not gated.', 404)
+
+    await serializeArticleByCollection(collection, article, payload)
+
+    // No gate state attached on purpose. This response is the unlocked view by
+    // definition, and a `locked: false` here would be a second, contradictable
+    // source of truth for a question the status code already answers.
+    return NextResponse.json(article, { headers: { ...getCorsHeaders(req), ...NO_STORE } })
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message ? error.message : 'Failed to load article.'
+    return fail(req, message, 500)
+  }
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return handleCorsOptions(req)
+}


### PR DESCRIPTION
Fifth of the gating series. Completes the server side.

## What

`GET /api/public/articles/full?type=&id=&lang=` — `force-dynamic`, `no-store`, requires a Current principal with an active Membership entitlement.

This is the other half of the split. Cached routes answer *"what may anyone see"*; this one answers *"what has this reader paid for"*, and the two never share a response.

## Order of refusals

Cheap and identity-free checks first, so an anonymous flood never reaches Postgres:

| Condition | Status | DB queried |
|---|---|---|
| bad `type` | 400 | no |
| missing `id` / bad `lang` | 400 | no |
| anonymous | 401 | no |
| authenticated, no entitlement | 403 | **no** |
| gated + entitled | 200 | yes |

## Three decisions worth reviewing

**`no-store`, not `private`.** A shared cache honouring `private` is exactly the failure this design exists to make impossible. Sent on refusals too — a cached 403 outlives the membership that fixes it.

**Verification deliberately not required**, mirroring `create-checkout-session`. A test pins this, because it is precisely the check someone adds later in good faith and thereby lets a paying visitor be refused what they bought.

**A free item 404s here** rather than being served. The cached route already sent its whole body, so a request for one is a client bug. Refusing keeps the contract to one sentence: paid content, for someone who paid.

No `gate` state on the response — this is the unlocked view by definition, and `locked: false` would be a second, contradictable answer to what the status code already settles.

## Verification

12 route tests, Payload/auth/serializer all stubbed — no database is touched by the suite.