### PR TITLE
Show a paywall notice and paywall structured data on gated articles

### DIFF
--- a/apps/questura/apps/client/src/features/articles/ArticlePage.tsx
+++ b/apps/questura/apps/client/src/features/articles/ArticlePage.tsx
@@ -1,5 +1,7 @@
 import { Bookmark, Share2 } from 'lucide-react'
 import { PublicImage } from '@/components/media/PublicImage'
+import { PaywallNotice } from '@/features/articles/components/PaywallNotice'
+import { readGate } from '@/features/articles/lib/gate'
 import { AuthorLink } from '@/features/authors/components/AuthorLink'
 import {
   Article,
@@ -309,9 +311,10 @@ function BlockRenderer({ block }: { block: ContentBlock }) {
 
 // ── Main component ───────────────────────────────────────────────────────────
 
-export function ArticlePage({ article }: { article: Article }) {
+export function ArticlePage({ article, path }: { article: Article; path?: string }) {
   const { publishedAt, updatedAt, headerSection, contentBlocks } = article
   const featuredImage = headerSection?.featuredImage
+  const gate = readGate(article)
 
   return (
     <article
@@ -352,6 +355,8 @@ export function ArticlePage({ article }: { article: Article }) {
             {contentBlocks?.map((block) => (
               <BlockRenderer key={block.id} block={block} />
             ))}
+
+            {gate?.locked ? <PaywallNotice gate={gate} returnTo={path ?? '/'} /> : null}
           </div>
         </div>
 

--- a/apps/questura/apps/client/src/features/articles/components/PaywallNotice.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/PaywallNotice.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link'
+import { Lock } from 'lucide-react'
+
+import { describeSample, type GateState } from '@/features/articles/lib/gate'
+
+type PaywallNoticeProps = {
+  gate: GateState
+  /** Path the reader is on, so checkout can return them to it. */
+  returnTo: string
+}
+
+/**
+ * Stands in for the withheld body of a Gated item.
+ *
+ * Carries `data-paywalled`, which is what the page's paywall JSON-LD points at
+ * with `cssSelector`. Renaming or removing that attribute silently breaks the
+ * structured data, so the two live and change together (ADR-0009).
+ *
+ * Server-rendered inside the cached public shell, so it must not depend on who
+ * is reading. A member sees this too, until the client swaps the full body in.
+ */
+export function PaywallNotice({ gate, returnTo }: PaywallNoticeProps) {
+  const summary = describeSample(gate)
+  const href = `/join?returnTo=${encodeURIComponent(returnTo)}`
+
+  return (
+    <aside
+      data-paywalled
+      aria-label="Members-only content"
+      className="rounded-lg border border-foreground/12 bg-foreground/[0.03] px-6 py-10 text-center sm:px-10"
+    >
+      <span className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-wider text-foreground/50">
+        <Lock aria-hidden="true" className="h-3.5 w-3.5" />
+        Members only
+      </span>
+
+      <p className="mx-auto mt-4 max-w-[34ch] text-balance text-xl font-medium leading-snug">
+        {summary ? `You're reading ${summary}.` : 'The rest of this is for members.'}
+      </p>
+
+      <p className="mx-auto mt-3 max-w-[46ch] text-sm leading-relaxed text-foreground/60">
+        Join to unlock the rest of this and everything else on Questurian.
+      </p>
+
+      <Link
+        href={href}
+        className="mt-7 inline-flex items-center justify-center rounded-md bg-foreground px-6 py-3 text-sm font-medium text-background transition-opacity hover:opacity-90"
+      >
+        Unlock the full guide
+      </Link>
+
+      <p className="mt-4 font-mono text-[11px] text-foreground/45">
+        Already a member?{' '}
+        <Link href={href} className="underline underline-offset-2 hover:text-foreground/70">
+          Sign in
+        </Link>
+      </p>
+    </aside>
+  )
+}

--- a/apps/questura/apps/client/src/features/articles/lib/gate.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/gate.ts
@@ -1,0 +1,55 @@
+/**
+ * Reader-facing lock state, as sent by the Questura Server public routes.
+ *
+ * Always present on an article payload, on free items too, so the client never
+ * has to infer "locked" from an absent key.
+ */
+export type GateState = {
+  access: 'free' | 'member'
+  locked: boolean
+  unit: 'blocks' | 'items' | 'days'
+  shown: number
+  total: number
+}
+
+/** Marks the element standing in for the withheld content, for `cssSelector`. */
+export const PAYWALL_SELECTOR = '[data-paywalled]'
+
+export function readGate(article: unknown): GateState | null {
+  if (!article || typeof article !== 'object') return null
+  const gate = (article as { gate?: unknown }).gate
+  if (!gate || typeof gate !== 'object') return null
+
+  const candidate = gate as Partial<GateState>
+  if (typeof candidate.locked !== 'boolean') return null
+
+  return {
+    access: candidate.access === 'member' ? 'member' : 'free',
+    locked: candidate.locked,
+    unit:
+      candidate.unit === 'items' || candidate.unit === 'days' ? candidate.unit : 'blocks',
+    shown: Number.isFinite(candidate.shown) ? Number(candidate.shown) : 0,
+    total: Number.isFinite(candidate.total) ? Number(candidate.total) : 0,
+  }
+}
+
+export function isLocked(article: unknown): boolean {
+  return readGate(article)?.locked === true
+}
+
+/**
+ * How much is being withheld, phrased in the unit the server cut on: "Day 1 of
+ * 5" reads as a sample, where "part of this article" reads as an error.
+ */
+export function describeSample(gate: GateState): string | null {
+  if (!gate.locked || gate.total <= 0) return null
+
+  if (gate.unit === 'days') {
+    return gate.total > gate.shown
+      ? `Day ${gate.shown} of ${gate.total}`
+      : `${gate.total} day${gate.total === 1 ? '' : 's'}`
+  }
+
+  const noun = gate.unit === 'items' ? 'stop' : 'section'
+  return `${gate.shown} of ${gate.total} ${noun}${gate.total === 1 ? '' : 's'}`
+}

--- a/apps/questura/apps/client/src/features/articles/lib/paywallJsonLd.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/paywallJsonLd.ts
@@ -1,0 +1,98 @@
+import { PAYWALL_SELECTOR } from './gate'
+
+const ARTICLE_TYPES = new Set([
+  'Article',
+  'NewsArticle',
+  'BlogPosting',
+  'Report',
+  'ScholarlyArticle',
+  'TechArticle',
+])
+
+function isArticleNode(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const type = (value as { '@type'?: unknown })['@type']
+  return typeof type === 'string' && ARTICLE_TYPES.has(type)
+}
+
+/**
+ * The paywall properties Google reads to tell a lead-in sample apart from
+ * cloaking or thin content.
+ *
+ * `hasPart` names the element that stands in for the withheld body. Under
+ * ADR-0009 the locked content is absent from the response entirely, so the
+ * marked element is the notice that replaces it -- which is genuinely the
+ * paywalled part of this page, and is the only honest thing to point at.
+ */
+function paywallProperties(): Record<string, unknown> {
+  return {
+    isAccessibleForFree: false,
+    hasPart: {
+      '@type': 'WebPageElement',
+      isAccessibleForFree: false,
+      cssSelector: PAYWALL_SELECTOR,
+    },
+  }
+}
+
+type BuildPaywallJsonLdParams = {
+  headline: string
+  /** Editor-supplied structured data from the SEO tab, if any. */
+  existing?: unknown
+}
+
+/**
+ * Returns the JSON-LD to emit for a Gated item, or `null` when there is
+ * nothing to say.
+ *
+ * Merges into the editor's own structured data when that is already an Article
+ * node, rather than emitting a second one. Two Article nodes describing one
+ * page, one of them silent about the paywall, is exactly the ambiguity this
+ * markup exists to remove.
+ */
+export function buildPaywallJsonLd({
+  headline,
+  existing,
+}: BuildPaywallJsonLdParams): Record<string, unknown> | null {
+  if (isArticleNode(existing)) {
+    return { ...existing, ...paywallProperties() }
+  }
+
+  if (!headline) return null
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline,
+    ...paywallProperties(),
+  }
+}
+
+/**
+ * Every JSON-LD node a public article page should emit, in render order.
+ *
+ * One helper rather than the same three-way condition copied into each route
+ * renderer: the wrong branch either drops the editor's structured data or emits
+ * two Article nodes disagreeing about whether the page is paywalled, and both
+ * failures are invisible without viewing source.
+ */
+export function articleJsonLdNodes({
+  locked,
+  headline,
+  existing,
+}: {
+  locked: boolean
+  headline: string
+  existing?: unknown
+}): unknown[] {
+  if (!locked) return [existing]
+
+  const paywall = buildPaywallJsonLd({ headline, existing })
+  if (!paywall) return [existing]
+
+  // Merged into the editor's own node, so rendering that separately as well
+  // would put two conflicting descriptions of one page on it.
+  if (isArticleNode(existing)) return [paywall]
+
+  return [existing, paywall]
+}

--- a/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleByPath.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleByPath.tsx
@@ -3,6 +3,8 @@ import { JsonLd } from '@/components/seo/JsonLd'
 import { ArticlePage } from '@/features/articles/ArticlePage'
 import { isStandardArticle } from '@/features/articles/lib/articleGuards'
 import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
+import { articleJsonLdNodes } from '@/features/articles/lib/paywallJsonLd'
+import { isLocked } from '@/features/articles/lib/gate'
 import {
   fetchArticleByCanonicalPath,
   fetchRedirectByPath,
@@ -19,9 +21,15 @@ export async function renderStandardArticleByPath({ path, lang }: Params) {
   if (article && isStandardArticle(article)) {
     return (
       <>
-        <JsonLd data={article.seoSection?.structuredData} />
+        {articleJsonLdNodes({
+          locked: isLocked(article),
+          headline: article.title,
+          existing: article.seoSection?.structuredData,
+        }).map((node, index) => (
+          <JsonLd key={index} data={node} />
+        ))}
         <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
-        <ArticlePage article={article} />
+        <ArticlePage article={article} path={path} />
       </>
     )
   }

--- a/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleRoute.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderStandardArticleRoute.tsx
@@ -3,6 +3,8 @@ import { JsonLd } from '@/components/seo/JsonLd'
 import { ArticlePage } from '@/features/articles/ArticlePage'
 import { isStandardArticle } from '@/features/articles/lib/articleGuards'
 import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
+import { articleJsonLdNodes } from '@/features/articles/lib/paywallJsonLd'
+import { isLocked } from '@/features/articles/lib/gate'
 import { fetchArticle } from '@/features/articles/lib/fetchArticle'
 import { articleHrefForScope } from '@/features/articles/lib/articleScope'
 import type { ArticleScope } from '@/features/articles/lib/articleScope'
@@ -32,9 +34,15 @@ export async function renderStandardArticleRoute({
 
   return (
     <>
-      <JsonLd data={article.seoSection?.structuredData} />
+      {articleJsonLdNodes({
+        locked: isLocked(article),
+        headline: article.title,
+        existing: article.seoSection?.structuredData,
+      }).map((node, index) => (
+        <JsonLd key={index} data={node} />
+      ))}
       <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
-      <ArticlePage article={article} />
+      <ArticlePage article={article} path={path} />
     </>
   )
 }

--- a/apps/questura/apps/client/src/features/articles/types/index.ts
+++ b/apps/questura/apps/client/src/features/articles/types/index.ts
@@ -1,3 +1,5 @@
+import type { GateState } from '@/features/articles/lib/gate'
+
 export type MediaAsset = {
   id: number
   url: string
@@ -138,6 +140,8 @@ export type Article = {
   }
   contentBlocks: ContentBlock[]
   seoSection?: SeoSection
+  /** Access tier and lock state, always sent by the public routes (ADR-0009). */
+  gate?: GateState
 }
 
 export {


### PR DESCRIPTION
Sixth of the gating series, first client-side piece. **Inert** — no document is `member` yet, so nothing renders differently.

## What

- `lib/gate.ts` — reads the `gate` state the server now sends; `PAYWALL_SELECTOR`; `describeSample`
- `lib/paywallJsonLd.ts` — `isAccessibleForFree: false` plus `hasPart` / `cssSelector`
- `components/PaywallNotice.tsx` — the element that stands in for the withheld body
- Wired into both standard-article renderers

## Scope: standard articles only

Itineraries and maps render their bodies through different components. Emitting paywall JSON-LD there would point `cssSelector` at an element that does not exist — inaccurate markup is worse than an incomplete feature, so they land with their body work.

## The bug I wrote first, and why the helper exists

The obvious wiring is a ternary — paywall node *or* the editor's structured data. It is wrong two ways, and both are invisible without viewing source:

- editor data that is **not** an Article node gets **dropped**
- editor data that **is** an Article node yields **two Article nodes** disagreeing about whether the page is paywalled

`articleJsonLdNodes` merges when it can and emits both when it cannot, in one place instead of copied into four renderers.

## Why hasPart points at the notice

Under ADR-0009 the locked content is absent from the response entirely, so there is no withheld text in the DOM to mark. The notice **is** the paywalled part of the page. `data-paywalled` and `PAYWALL_SELECTOR` are a matched pair — renaming one silently breaks the structured data.

## Server-rendered, identity-free

The notice lives in the `force-static` shell, so it cannot depend on who is reading. **A member sees it too**, until the client swaps the full body in — that is the next PR, and until it lands a member has no way to read a gated article. Nothing is gated yet, so that is a sequencing detail, not a live gap.

## Verification

No CI job covers `apps/questura/apps/client`, so this was checked locally:

- `tsc --noEmit` — 0 errors
- `next lint` — clean (only pre-existing warnings in unrelated files)
- `check:global-css` — boundaries valid
- `next build` — compiles

Real rendering is unverifiable until deploy, by the nature of this app.
