### PR TITLE
Swap in the full body for members, with no paywall flash

### DIFF
--- a/apps/questura/apps/client/src/features/articles/ArticlePage.tsx
+++ b/apps/questura/apps/client/src/features/articles/ArticlePage.tsx
@@ -1,6 +1,6 @@
 import { Bookmark, Share2 } from 'lucide-react'
 import { PublicImage } from '@/components/media/PublicImage'
-import { PaywallNotice } from '@/features/articles/components/PaywallNotice'
+import { GatedArticleBody } from '@/features/articles/components/GatedArticleBody'
 import { readGate } from '@/features/articles/lib/gate'
 import { BlockRenderer } from '@/features/articles/components/BlockRenderer'
 import { AuthorLink } from '@/features/authors/components/AuthorLink'
@@ -152,7 +152,9 @@ export function ArticlePage({ article, path }: { article: Article; path?: string
               <BlockRenderer key={block.id} block={block} />
             ))}
 
-            {gate?.locked ? <PaywallNotice gate={gate} returnTo={path ?? '/'} /> : null}
+            {gate?.locked ? (
+              <GatedArticleBody articleId={article.id} gate={gate} path={path ?? '/'} />
+            ) : null}
           </div>
         </div>
 

--- a/apps/questura/apps/client/src/features/articles/components/GatedArticleBody.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/GatedArticleBody.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { APIError, get } from '@/lib/api'
+import { useUserQuery } from '@/lib/user/hooks/useUserQuery'
+import { BlockRenderer } from '@/features/articles/components/BlockRenderer'
+import { PaywallNotice } from '@/features/articles/components/PaywallNotice'
+import type { GateState } from '@/features/articles/lib/gate'
+import type { ContentBlock } from '@/features/articles/types'
+
+type GatedArticleBodyProps = {
+  articleId: number
+  gate: GateState
+  /** Path the reader is on, so checkout can return them to it. */
+  path: string
+  lang?: string
+}
+
+type FullArticleResponse = {
+  contentBlocks?: ContentBlock[]
+}
+
+/**
+ * The locked region of a Gated item.
+ *
+ * Renders one of three things, and which one it must never get wrong is the
+ * whole point: a paying member must not see a paywall for content they own,
+ * and a non-member must not see the body.
+ *
+ * Client-side because the cached public shell is `force-static`, where
+ * `cookies()` is empty by construction -- no page under it can know who is
+ * reading (ADR-0009).
+ */
+export function GatedArticleBody({ articleId, gate, path, lang }: GatedArticleBodyProps) {
+  const { data: user, isPending: identityPending } = useUserQuery()
+  const isMember = user?.membership?.active === true
+
+  const body = useQuery({
+    queryKey: ['article-full', articleId, lang ?? 'en'],
+    // Only a member may ask. Firing this for anonymous readers would turn every
+    // cached article page into a guaranteed 401 against the dynamic route.
+    enabled: isMember,
+    staleTime: 5 * 60 * 1000,
+    retry: (failureCount, error) => {
+      if (error instanceof APIError && error.status >= 400 && error.status < 500) return false
+      return failureCount < 2
+    },
+    queryFn: () =>
+      get<FullArticleResponse>(
+        `/api/public/articles/full?type=articles&id=${encodeURIComponent(String(articleId))}` +
+          `&lang=${encodeURIComponent(lang ?? 'en')}`,
+      ),
+  })
+
+  // Identity unknown. Showing the paywall here would flash a lock at a member
+  // who has already paid, on every single page load -- the cached HTML is
+  // identical for everyone, so this branch is what every reader hits first.
+  if (identityPending || (isMember && body.isPending)) {
+    return <BodySkeleton />
+  }
+
+  if (!isMember) {
+    return <PaywallNotice gate={gate} returnTo={path} />
+  }
+
+  // A member whose fetch failed is not a non-member. Falling through to the
+  // paywall would tell someone who paid that they had not, which is worse than
+  // admitting the load failed.
+  if (body.isError || !body.data?.contentBlocks) {
+    return (
+      <div
+        role="alert"
+        className="rounded-lg border border-foreground/12 px-6 py-10 text-center"
+      >
+        <p className="text-sm text-foreground/70">
+          We couldn&rsquo;t load the rest of this article.
+        </p>
+        <button
+          type="button"
+          onClick={() => body.refetch()}
+          className="mt-4 rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium transition-colors hover:bg-foreground/5"
+        >
+          Try again
+        </button>
+      </div>
+    )
+  }
+
+  // The full body includes the sample blocks the server already rendered, so
+  // the sample is dropped here rather than duplicated above this component.
+  const remaining = body.data.contentBlocks.slice(gate.shown)
+
+  return (
+    <>
+      {remaining.map((block) => (
+        <BlockRenderer key={block.id} block={block} />
+      ))}
+    </>
+  )
+}
+
+function BodySkeleton() {
+  return (
+    <div aria-hidden className="space-y-4" data-testid="gated-body-skeleton">
+      {[0, 1, 2, 3, 4].map((row) => (
+        <div
+          key={row}
+          className="h-4 animate-pulse rounded bg-foreground/10"
+          style={{ width: `${[100, 96, 88, 98, 62][row]}%` }}
+        />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
Eighth of the gating series. Closes the gap #303 deliberately left: the paywall notice is server-rendered in the `force-static` shell, so until now **a member saw the lock too**.

Stacked on #304 (the mechanical `BlockRenderer` extraction) — will retarget to `main` once that merges.

## Three states, and getting them wrong is the whole risk

| Reader | Sees |
|---|---|
| identity still loading | **skeleton** — never the paywall |
| not a member | paywall notice |
| member, body loading | skeleton |
| member, body loaded | the rest of the article |
| member, fetch failed | retry — **not** the paywall |

**Why the skeleton matters.** The cached HTML is byte-identical for everyone, so the "identity unknown" branch is what *every* reader hits first. Rendering the lock there would flash a paywall at paying members on every single page load.

**Why a failed fetch is not a paywall.** Falling through would tell someone who paid that they had not. A retry admits the truth; the paywall lies.

## Two details worth checking

- The fetch is `enabled: isMember`, so anonymous traffic never turns a cached article page into a guaranteed 401 against the dynamic route.
- 4xx is not retried — there is no point re-asking whether someone is entitled.
- The full response contains the sample blocks the server already rendered, so `gate.shown` is sliced off here rather than the sample being duplicated on screen.

## Not in this PR

The checkout `returnTo` leg. It needs the **server** to accept a return path, validate it as same-origin-relative, and append it to `success_url` — the auth leg already works via the existing `getSafeRedirectPath`. That is its own change.

## Verification

No CI job covers this app, so: `tsc --noEmit` 0 errors, `next lint` clean, `next build` compiles. Real behaviour is unverifiable until deploy — and this is the PR where your two test accounts finally make that a real check.
