### PR TITLE
Return the buyer to the article they were reading after checkout

### DIFF
--- a/apps/questura/apps/client/src/features/Payments/pages/SubscriptionSuccessPage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/SubscriptionSuccessPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -8,6 +8,7 @@ import { SuspenseBoundary } from '@/components/shared/SuspenseBoundary';
 import { get } from '@/lib/api';
 import { queryKeys } from '@/lib/react-query';
 import type { CurrentPrincipalResponse } from '@/lib/user/types';
+import { getSafeRedirectPath } from '@/lib/validations';
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 8000;
@@ -18,6 +19,10 @@ function SubscriptionSuccessContent() {
   const searchParams = useSearchParams() ?? new URLSearchParams();
   const sessionId = searchParams?.get('session_id');
   const queryClient = useQueryClient();
+  const router = useRouter();
+  // Validated server-side before it reached the success_url, and validated
+  // again here because a query parameter is editable in the address bar.
+  const returnTo = getSafeRedirectPath(searchParams?.get('returnTo') ?? null);
   const [mounted, setMounted] = useState(false);
   const [confirmation, setConfirmation] = useState<Confirmation>('checking');
 
@@ -39,6 +44,14 @@ function SubscriptionSuccessContent() {
             if (!cancelled) {
               setConfirmation('active');
               await queryClient.invalidateQueries({ queryKey: queryKeys.userMe() });
+
+              // Only once entitlement is genuinely live. Forwarding on the
+              // Stripe redirect alone would land the buyer on the article
+              // while the webhook is still in flight, and show them the very
+              // paywall they just paid to remove.
+              if (returnTo && returnTo !== '/') {
+                router.replace(returnTo);
+              }
             }
             return;
           }
@@ -56,7 +69,7 @@ function SubscriptionSuccessContent() {
     return () => {
       cancelled = true;
     };
-  }, [mounted, queryClient]);
+  }, [mounted, queryClient, returnTo, router]);
 
   if (!mounted) {
     return (

--- a/apps/questura/apps/client/src/features/Payments/services/subscription-mutations.service.ts
+++ b/apps/questura/apps/client/src/features/Payments/services/subscription-mutations.service.ts
@@ -58,12 +58,18 @@ export async function createPortalSessionRequest(): Promise<string | null> {
 
 export async function createCheckoutSessionRequest(
   referralId: string | null,
-  plan: 'monthly' | 'yearly' = 'monthly'
+  plan: 'monthly' | 'yearly' = 'monthly',
+  /**
+   * Where to send the buyer after the success page confirms entitlement. The
+   * server validates this; it is never trusted as sent.
+   */
+  returnTo?: string | null
 ): Promise<CheckoutSessionResponse> {
   try {
     return await post<CheckoutSessionResponse>('/api/payments/create-checkout-session', {
       referralId: referralId || null,
       plan,
+      returnTo: returnTo || null,
     });
   } catch (error) {
     throw mapSubscriptionError(error);

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -6,6 +6,7 @@ import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/sh
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
 import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
+import { safeReturnPath } from '@/payments/lib/safe-return-path'
 import {
   findVisitorProfileByAuthUserId,
   updateVisitorProfileByAuthUserId,
@@ -69,7 +70,7 @@ export async function POST(req: NextRequest) {
     // 3. Parse the request body once: it carries the chosen plan, and the
     // affiliate referral when that feature is on. Reading it only for referrals
     // would silently drop the plan whenever the flag is off.
-    let body: { plan?: unknown; referralId?: unknown } = {}
+    let body: { plan?: unknown; referralId?: unknown; returnTo?: unknown } = {}
     try {
       body = await req.json()
     } catch {
@@ -78,6 +79,11 @@ export async function POST(req: NextRequest) {
 
     const plan: PlanId = isPlanId(body?.plan) ? body.plan : 'monthly'
     const priceId = priceIdForPlan(plan)
+
+    // Where to send the buyer once the success page has confirmed entitlement.
+    // Attacker-controlled by definition and destined for a URL Stripe redirects
+    // a browser to, so it is validated here rather than trusted from the client.
+    const returnTo = safeReturnPath(body?.returnTo)
 
     if (!priceId) {
       return NextResponse.json(
@@ -163,7 +169,9 @@ export async function POST(req: NextRequest) {
         price: priceId,
         quantity: 1
       }],
-      success_url: APP_URLS.frontendUrl('/subscription/success?session_id={CHECKOUT_SESSION_ID}'),
+      success_url: APP_URLS.frontendUrl(
+        `/subscription/success?session_id={CHECKOUT_SESSION_ID}&returnTo=${encodeURIComponent(returnTo)}`,
+      ),
       cancel_url: APP_URLS.frontendUrl('/subscription/cancel'),
       metadata,
       allow_promotion_codes: true, // Optional: allow discount codes

--- a/apps/questura/apps/server/src/features/payments/lib/safe-return-path.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/safe-return-path.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_RETURN_PATH, isSafeReturnPath, safeReturnPath } from './safe-return-path'
+
+describe('safeReturnPath — accepts', () => {
+  it('keeps an ordinary article path', () => {
+    expect(safeReturnPath('/peru/lima/itineraries/5-days-in-lima')).toBe(
+      '/peru/lima/itineraries/5-days-in-lima',
+    )
+  })
+
+  it('accepts an encoded path', () => {
+    expect(safeReturnPath(encodeURIComponent('/peru/lima/guides/safety'))).toBe(
+      '/peru/lima/guides/safety',
+    )
+  })
+
+  it('keeps a query string and fragment', () => {
+    expect(safeReturnPath('/articles?page=2#top')).toBe('/articles?page=2#top')
+  })
+})
+
+describe('safeReturnPath — refuses', () => {
+  const hostile = [
+    ['absolute url', 'https://evil.test/steal'],
+    ['protocol-relative', '//evil.test'],
+    ['backslash separator', '/\\evil.test'],
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['data scheme', 'data:text/html,x'],
+    ['not rooted', 'peru/lima'],
+    ['empty', ''],
+    ['newline injection', '/articles\nSet-Cookie: a=b'],
+    ['null byte', '/articles\u0000'],
+  ] as const
+
+  for (const [name, value] of hostile) {
+    it(`refuses ${name}`, () => {
+      expect(safeReturnPath(value)).toBe(DEFAULT_RETURN_PATH)
+      expect(isSafeReturnPath(value)).toBe(false)
+    })
+  }
+
+  it('refuses a double-encoded absolute url', () => {
+    // One decode happens in safeReturnPath; the value must not survive by being
+    // decoded again somewhere later.
+    expect(safeReturnPath(encodeURIComponent('https://evil.test'))).toBe(DEFAULT_RETURN_PATH)
+  })
+
+  it('refuses an encoded protocol-relative url', () => {
+    expect(safeReturnPath('%2F%2Fevil.test')).toBe(DEFAULT_RETURN_PATH)
+  })
+
+  it('refuses malformed percent-encoding rather than repairing it', () => {
+    expect(safeReturnPath('%E0%A4%A')).toBe(DEFAULT_RETURN_PATH)
+  })
+
+  it('refuses a non-string', () => {
+    expect(safeReturnPath(undefined)).toBe(DEFAULT_RETURN_PATH)
+    expect(safeReturnPath(null)).toBe(DEFAULT_RETURN_PATH)
+    expect(safeReturnPath({ toString: () => '/ok' })).toBe(DEFAULT_RETURN_PATH)
+  })
+
+  it('refuses an absurdly long path', () => {
+    expect(safeReturnPath(`/${'a'.repeat(600)}`)).toBe(DEFAULT_RETURN_PATH)
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/safe-return-path.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/safe-return-path.ts
@@ -1,0 +1,55 @@
+/**
+ * Validates a caller-supplied post-checkout return path.
+ *
+ * The client has its own guard, which is irrelevant here: this value is
+ * attacker-controlled by definition and ends up in a URL Stripe redirects a
+ * browser to. An unvalidated one turns the checkout flow into an open redirect
+ * with a payment-shaped pretext in front of it.
+ *
+ * Relative paths only. Anything else -- absolute URLs, protocol-relative
+ * `//host`, `javascript:`, a decode that throws -- collapses to the account
+ * page rather than being repaired, because a return path we cannot read is a
+ * return path we should not honour.
+ */
+export const DEFAULT_RETURN_PATH = '/account'
+
+const MAX_RETURN_PATH_LENGTH = 512
+
+export function isSafeReturnPath(path: string): boolean {
+  if (!path || path.length > MAX_RETURN_PATH_LENGTH) return false
+
+  // Must be root-relative. `//evil.test` is protocol-relative, not relative.
+  if (!path.startsWith('/')) return false
+  if (path.startsWith('//')) return false
+
+  // A backslash is treated as a path separator by some browsers, so `/\evil.test`
+  // can navigate off-origin even though it starts with a single slash.
+  if (path.includes('\\')) return false
+
+  if (path.includes('://')) return false
+
+  const lowered = path.toLowerCase()
+  if (lowered.includes('javascript:') || lowered.includes('data:')) return false
+
+  // Control characters, including the newline that would let this value inject
+  // a second query parameter or header downstream.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(path)) return false
+
+  return true
+}
+
+export function safeReturnPath(value: unknown): string {
+  if (typeof value !== 'string') return DEFAULT_RETURN_PATH
+
+  let candidate = value
+  try {
+    // Accept either an encoded or a plain path; a double-encoded hostile value
+    // must not survive by being decoded later than it is checked.
+    candidate = decodeURIComponent(value)
+  } catch {
+    return DEFAULT_RETURN_PATH
+  }
+
+  return isSafeReturnPath(candidate) ? candidate : DEFAULT_RETURN_PATH
+}


### PR DESCRIPTION
Ninth of the gating series. Completes the unlock flow: the paywall CTA already carried the article path to `/join`; this carries it through Stripe and back.

## Server-side validation is the point of this PR

`returnTo` is attacker-controlled by definition and ends up in a URL **Stripe redirects a browser to**. Unvalidated, it turns checkout into an open redirect with a payment-shaped pretext in front of it. The client has its own guard; that is irrelevant here.

`safeReturnPath` decodes **once**, then refuses anything not root-relative. Rejected input collapses to `/account` rather than being repaired — a return path we cannot read is one we should not honour.

| Input | Result |
|---|---|
| `/peru/lima/itineraries/5-days` | kept |
| `https://evil.test/steal` | `/account` |
| `//evil.test` | `/account` |
| `/\evil.test` | `/account` — some browsers treat `\` as a path separator |
| `javascript:` / `data:` | `/account` |
| `%2F%2Fevil.test`, double-encoded absolute | `/account` |
| newline / NUL | `/account` — would inject a second parameter downstream |
| malformed `%E0%A4%A` | `/account` — refused, not repaired |
| >512 chars, non-string | `/account` |

Validated **again** on the success page, because by then it is a query parameter and those are editable in the address bar.

## The forward is hung off entitlement, not off the Stripe redirect

The success page already polled `/api/me` for up to 8s to absorb the webhook race. This attaches the redirect to that confirmation.

Forwarding on the Stripe redirect alone would land the buyer on the article **while the webhook is still in flight**, showing them the exact paywall they just paid to remove. If confirmation times out, the page stays put and says so — existing behaviour, unchanged.

## Verification

- Server: **807 tests** (17 new in `safe-return-path.test.ts`)
- Client: `tsc` 0 errors, `next lint` clean, `next build` compiles

No live checkout was triggered. This path is verifiable end-to-end only with a real charge, so it stays unproven until you decide to run one.
