### PR TITLE
Fix 500 on gated articles: no React Query in the public shell

### DIFF
--- a/apps/questura/apps/client/src/features/articles/components/GatedArticleBody.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/GatedArticleBody.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { useCallback, useEffect, useState } from 'react'
 
-import { APIError, get } from '@/lib/api'
-import { useUserQuery } from '@/lib/user/hooks/useUserQuery'
+import { get } from '@/lib/api'
 import { BlockRenderer } from '@/features/articles/components/BlockRenderer'
 import { PaywallNotice } from '@/features/articles/components/PaywallNotice'
 import type { GateState } from '@/features/articles/lib/gate'
 import type { ContentBlock } from '@/features/articles/types'
+import type { CurrentPrincipalResponse } from '@/lib/user/types'
 
 type GatedArticleBodyProps = {
   articleId: number
@@ -21,6 +21,8 @@ type FullArticleResponse = {
   contentBlocks?: ContentBlock[]
 }
 
+type Phase = 'identifying' | 'anonymous' | 'loading' | 'ready' | 'failed'
+
 /**
  * The locked region of a Gated item.
  *
@@ -31,54 +33,107 @@ type FullArticleResponse = {
  * Client-side because the cached public shell is `force-static`, where
  * `cookies()` is empty by construction -- no page under it can know who is
  * reading (ADR-0009).
+ *
+ * Plain fetch rather than React Query, deliberately. The public shell has no
+ * `QueryClientProvider`: ADR-0003 keeps React Query in the dynamic/private
+ * route group and lazy islands, so calling a `useQuery` hook here throws during
+ * render and 500s the page. This component is the one client island under the
+ * public shell, and it has to stand on its own.
  */
 export function GatedArticleBody({ articleId, gate, path, lang }: GatedArticleBodyProps) {
-  const { data: user, isPending: identityPending } = useUserQuery()
-  const isMember = user?.membership?.active === true
+  const [phase, setPhase] = useState<Phase>('identifying')
+  const [blocks, setBlocks] = useState<ContentBlock[] | null>(null)
+  const [attempt, setAttempt] = useState(0)
 
-  const body = useQuery({
-    queryKey: ['article-full', articleId, lang ?? 'en'],
-    // Only a member may ask. Firing this for anonymous readers would turn every
-    // cached article page into a guaranteed 401 against the dynamic route.
-    enabled: isMember,
-    staleTime: 5 * 60 * 1000,
-    retry: (failureCount, error) => {
-      if (error instanceof APIError && error.status >= 400 && error.status < 500) return false
-      return failureCount < 2
-    },
-    queryFn: () =>
-      get<FullArticleResponse>(
-        `/api/public/articles/full?type=articles&id=${encodeURIComponent(String(articleId))}` +
-          `&lang=${encodeURIComponent(lang ?? 'en')}`,
-      ),
-  })
+  const retry = useCallback(() => {
+    setPhase('identifying')
+    setAttempt((value) => value + 1)
+  }, [])
 
-  // Identity unknown. Showing the paywall here would flash a lock at a member
-  // who has already paid, on every single page load -- the cached HTML is
-  // identical for everyone, so this branch is what every reader hits first.
-  if (identityPending || (isMember && body.isPending)) {
-    return <BodySkeleton />
-  }
+  useEffect(() => {
+    let cancelled = false
 
-  if (!isMember) {
+    const run = async () => {
+      let isMember = false
+
+      try {
+        const me = await get<CurrentPrincipalResponse>('/api/me')
+        isMember = me.principal?.membership.active === true
+      } catch {
+        // An anonymous reader is the overwhelmingly common case here, and
+        // /api/me answers 401 for them. Treat any failure to identify as
+        // "not a member" -- the paywall is the safe answer when we cannot
+        // tell, since the alternative is serving paid content on an error.
+        if (!cancelled) setPhase('anonymous')
+        return
+      }
+
+      if (cancelled) return
+
+      if (!isMember) {
+        setPhase('anonymous')
+        return
+      }
+
+      setPhase('loading')
+
+      try {
+        const full = await get<FullArticleResponse>(
+          `/api/public/articles/full?type=articles&id=${encodeURIComponent(String(articleId))}` +
+            `&lang=${encodeURIComponent(lang ?? 'en')}`,
+        )
+        if (cancelled) return
+
+        if (!full.contentBlocks) {
+          setPhase('failed')
+          return
+        }
+
+        setBlocks(full.contentBlocks)
+        setPhase('ready')
+      } catch {
+        // A member whose fetch failed is not a non-member. Falling through to
+        // the paywall would tell someone who paid that they had not.
+        if (!cancelled) setPhase('failed')
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [articleId, lang, attempt])
+
+  // The notice is what the server renders and what the browser renders first,
+  // so the two agree and hydration is stable.
+  //
+  // This costs a member a brief flash of the lock before the swap, which an
+  // earlier version avoided by showing a skeleton until identity was known.
+  // That was wrong: the skeleton is what would sit in the cached HTML, so a
+  // crawler and any reader without JS would get a loading placeholder instead
+  // of the sample's call to action -- and the page's paywall JSON-LD points at
+  // `[data-paywalled]`, which lives on this notice. No notice in the HTML means
+  // that selector matches nothing and the structured data describes a part of
+  // the page that is not there. Indexability is the constraint this whole
+  // design exists to protect; a flash is not.
+  if (phase === 'identifying' || phase === 'anonymous') {
     return <PaywallNotice gate={gate} returnTo={path} />
   }
 
-  // A member whose fetch failed is not a non-member. Falling through to the
-  // paywall would tell someone who paid that they had not, which is worse than
-  // admitting the load failed.
-  if (body.isError || !body.data?.contentBlocks) {
+  if (phase === 'loading') {
+    return <BodySkeleton />
+  }
+
+  if (phase === 'failed' || !blocks) {
     return (
-      <div
-        role="alert"
-        className="rounded-lg border border-foreground/12 px-6 py-10 text-center"
-      >
+      <div role="alert" className="rounded-lg border border-foreground/12 px-6 py-10 text-center">
         <p className="text-sm text-foreground/70">
           We couldn&rsquo;t load the rest of this article.
         </p>
         <button
           type="button"
-          onClick={() => body.refetch()}
+          onClick={retry}
           className="mt-4 rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium transition-colors hover:bg-foreground/5"
         >
           Try again
@@ -89,7 +144,7 @@ export function GatedArticleBody({ articleId, gate, path, lang }: GatedArticleBo
 
   // The full body includes the sample blocks the server already rendered, so
   // the sample is dropped here rather than duplicated above this component.
-  const remaining = body.data.contentBlocks.slice(gate.shown)
+  const remaining = blocks.slice(gate.shown)
 
   return (
     <>


### PR DESCRIPTION
**Live bug fix.** Setting an article to `Members only` returned 500 on its public page.

## Root cause

`GatedArticleBody` called `useUserQuery()` — React Query. The `(public)` layout has **no** `QueryClientProvider`; ADR-0003 deliberately keeps React Query in the dynamic/private route group and lazy islands. `useQuery` runs during render, so it threw while the page was being generated.

It only reproduced once an article was gated, because that is the only condition under which the component mounts — which is why every check before this passed.

## Fix

Plain `fetch` in an effect. This component is the one client island under the public shell and has to stand on its own; adding a provider to that shell would pull React Query into every cached public page to serve one component.

## The design error the crash exposed

The first version showed a **skeleton** until identity was known, to spare members a flash of the lock. I argued for that in #305. It was wrong.

An effect does not run during server rendering, so the skeleton is what would sit in the **cached HTML**. A crawler — and any reader without JS — would get a loading placeholder instead of the sample's call to action. Worse, the page's paywall JSON-LD points at `[data-paywalled]`, which lives on the notice. With no notice in the HTML, that selector matches nothing and the structured data describes a part of the page that is not there.

The notice is now what the server renders and what the browser renders first, so hydration is stable and the markup is honest.

**Members now see a brief flash of the lock before the swap.** That is the correct trade: indexability is the constraint this design exists to protect; a flash is not.

## Also

A failure to identify the reader is treated as *not a member*. The paywall is the safe answer when we cannot tell — the alternative is serving paid content on an error.

## Verification

`tsc` 0 errors, `next lint` clean, `next build` compiles, and zero `@tanstack` imports remain in the file — the throwing call is gone, not worked around.

The real proof is the live page after deploy, which is what I'll check next.
