### PR TITLE
Set the Sample rule from editorial policy

### DIFF
--- a/apps/questura/apps/client/src/features/articles/components/PaywallNotice.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/PaywallNotice.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { Lock } from 'lucide-react'
 
-import { describeSample, type GateState } from '@/features/articles/lib/gate'
+import { describeLock, type GateState } from '@/features/articles/lib/gate'
 
 type PaywallNoticeProps = {
   gate: GateState
@@ -20,7 +20,7 @@ type PaywallNoticeProps = {
  * is reading. A member sees this too, until the client swaps the full body in.
  */
 export function PaywallNotice({ gate, returnTo }: PaywallNoticeProps) {
-  const summary = describeSample(gate)
+  const { headline, cta } = describeLock(gate)
   const href = `/join?returnTo=${encodeURIComponent(returnTo)}`
 
   return (
@@ -35,7 +35,7 @@ export function PaywallNotice({ gate, returnTo }: PaywallNoticeProps) {
       </span>
 
       <p className="mx-auto mt-4 max-w-[34ch] text-balance text-xl font-medium leading-snug">
-        {summary ? `You're reading ${summary}.` : 'The rest of this is for members.'}
+        {headline ?? 'The rest of this is for members.'}
       </p>
 
       <p className="mx-auto mt-3 max-w-[46ch] text-sm leading-relaxed text-foreground/60">
@@ -46,7 +46,7 @@ export function PaywallNotice({ gate, returnTo }: PaywallNoticeProps) {
         href={href}
         className="mt-7 inline-flex items-center justify-center rounded-md bg-foreground px-6 py-3 text-sm font-medium text-background transition-opacity hover:opacity-90"
       >
-        Unlock the full guide
+        {cta}
       </Link>
 
       <p className="mt-4 font-mono text-[11px] text-foreground/45">

--- a/apps/questura/apps/client/src/features/articles/lib/gate.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/gate.ts
@@ -37,19 +37,35 @@ export function isLocked(article: unknown): boolean {
   return readGate(article)?.locked === true
 }
 
+export type LockCopy = {
+  /** What the reader is looking at, or null when there is nothing useful to say. */
+  headline: string | null
+  cta: string
+}
+
 /**
- * How much is being withheld, phrased in the unit the server cut on: "Day 1 of
- * 5" reads as a sample, where "part of this article" reads as an error.
+ * Names what is being withheld, in the unit the server actually cut on.
+ *
+ * Itineraries keep no day at all, so the old "Day 1 of 5" phrasing would read
+ * as "Day 0 of 5" -- which sounds like a bug rather than an offer. The pitch
+ * for an itinerary is the trip length being unlocked, not the fraction shown.
  */
-export function describeSample(gate: GateState): string | null {
-  if (!gate.locked || gate.total <= 0) return null
+export function describeLock(gate: GateState): LockCopy {
+  if (!gate.locked) return { headline: null, cta: 'Unlock the full guide' }
 
   if (gate.unit === 'days') {
-    return gate.total > gate.shown
-      ? `Day ${gate.shown} of ${gate.total}`
-      : `${gate.total} day${gate.total === 1 ? '' : 's'}`
+    return {
+      headline: 'Your stay is above. The day-by-day plan is for members.',
+      cta: gate.total > 0 ? `Unlock all ${gate.total} days` : 'Unlock the full itinerary',
+    }
   }
 
-  const noun = gate.unit === 'items' ? 'stop' : 'section'
-  return `${gate.shown} of ${gate.total} ${noun}${gate.total === 1 ? '' : 's'}`
+  if (gate.total > gate.shown && gate.shown > 0) {
+    return {
+      headline: `You're reading the first ${gate.shown} of ${gate.total} sections.`,
+      cta: 'Unlock the full guide',
+    }
+  }
+
+  return { headline: null, cta: 'Unlock the full guide' }
 }

--- a/apps/questura/apps/server/src/features/articles/public/freeSample.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/freeSample.test.ts
@@ -2,44 +2,149 @@ import { describe, expect, it } from 'vitest'
 
 import { DEFAULT_SAMPLE_LIMITS, applySampleRule } from './freeSample'
 
-const blocks = (n: number) =>
-  Array.from({ length: n }, (_, i) => ({ blockType: 'text', content: `block ${i}` }))
-
-const items = (n: number) =>
-  Array.from({ length: n }, (_, i) => ({ blockType: 'dining', blurb: `stop ${i}` }))
-
-const days = (n: number) =>
-  Array.from({ length: n }, (_, i) => ({
-    items: items(3),
-    whereStaying: [{ blockType: 'itinerary-where-staying', blurb: `hotel ${i}` }],
-  }))
+const text = (i: number) => ({ blockType: 'text', content: `para ${i}` })
 
 describe('applySampleRule — standard articles', () => {
-  it('keeps the leading blocks and drops the rest', () => {
-    const doc: Record<string, unknown> = { contentBlocks: blocks(9) }
+  it('keeps the opening prose and nothing else', () => {
+    const doc: Record<string, unknown> = {
+      contentBlocks: [text(0), text(1), text(2), text(3)],
+    }
 
     const outcome = applySampleRule('articles', doc)
 
-    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 3, total: 9 })
-    expect(doc.contentBlocks).toHaveLength(3)
-    expect((doc.contentBlocks as { content: string }[])[0].content).toBe('block 0')
-  })
-
-  it('reports nothing applied when the body is already at or under the limit', () => {
-    const doc: Record<string, unknown> = { contentBlocks: blocks(2) }
-
-    const outcome = applySampleRule('articles', doc)
-
-    expect(outcome).toEqual({ applied: false, unit: 'blocks', shown: 2, total: 2 })
+    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 2, total: 4 })
     expect(doc.contentBlocks).toHaveLength(2)
+    expect((doc.contentBlocks as { content: string }[]).map((b) => b.content)).toEqual([
+      'para 0',
+      'para 1',
+    ])
   })
 
-  it('survives a document with no body at all', () => {
-    const doc: Record<string, unknown> = {}
+  it('withholds editorial blocks even when they come first', () => {
+    // These carry standalone value, so an early key-takeaway must not become
+    // the free part of a paid article.
+    const doc: Record<string, unknown> = {
+      contentBlocks: [
+        { blockType: 'key-takeaway' },
+        { blockType: 'pull-quote' },
+        text(0),
+        { blockType: 'in-the-know' },
+        text(1),
+        { blockType: 'faq' },
+      ],
+    }
 
-    expect(applySampleRule('articles', doc)).toEqual({
+    applySampleRule('articles', doc)
+
+    expect((doc.contentBlocks as { blockType: string }[]).map((b) => b.blockType)).toEqual([
+      'text',
+      'text',
+    ])
+  })
+
+  it('withholds images', () => {
+    const doc: Record<string, unknown> = {
+      contentBlocks: [text(0), { blockType: 'image' }, { blockType: 'img-trio' }, text(1)],
+    }
+
+    applySampleRule('articles', doc)
+
+    expect((doc.contentBlocks as { blockType: string }[]).map((b) => b.blockType)).toEqual([
+      'text',
+      'text',
+    ])
+  })
+
+  it('withholds an unknown future block type by default', () => {
+    // Allowlist, not blocklist: a block type added later must not leak just
+    // because nobody remembered this file.
+    const doc: Record<string, unknown> = {
+      contentBlocks: [{ blockType: 'brand-new-editorial-thing' }, text(0), text(1)],
+    }
+
+    applySampleRule('articles', doc)
+
+    expect((doc.contentBlocks as { blockType: string }[]).map((b) => b.blockType)).toEqual([
+      'text',
+      'text',
+    ])
+  })
+
+  it('reports applied when non-text blocks were removed but every text block survived', () => {
+    const doc: Record<string, unknown> = {
+      contentBlocks: [text(0), { blockType: 'faq' }],
+    }
+
+    const outcome = applySampleRule('articles', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 1, total: 2 })
+  })
+
+  it('handles an article with no prose at all', () => {
+    const doc: Record<string, unknown> = { contentBlocks: [{ blockType: 'image' }] }
+
+    const outcome = applySampleRule('articles', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 0, total: 1 })
+    expect(doc.contentBlocks).toEqual([])
+  })
+
+  it('honours a caller-supplied limit', () => {
+    const doc: Record<string, unknown> = { contentBlocks: [text(0), text(1), text(2)] }
+
+    applySampleRule('articles', doc, { ...DEFAULT_SAMPLE_LIMITS, articleTextBlocks: 1 })
+
+    expect(doc.contentBlocks).toHaveLength(1)
+  })
+})
+
+describe('applySampleRule — listicle itineraries', () => {
+  const day = (n: number) => ({
+    items: [{ blockType: 'dining', blurb: `stop ${n}` }],
+    whereStaying: [{ blockType: 'itinerary-where-staying', blurb: `hotel ${n}` }],
+  })
+
+  it('removes every day and keeps only the top-level lodging', () => {
+    const doc: Record<string, unknown> = {
+      whereStaying: [{ blockType: 'itinerary-where-staying', blurb: 'Hotel B' }],
+      itineraryDays: [day(1), day(2), day(3)],
+    }
+
+    const outcome = applySampleRule('listicle-itineraries', doc)
+
+    expect(outcome).toEqual({ applied: true, unit: 'days', shown: 0, total: 3 })
+    expect(doc.itineraryDays).toEqual([])
+    expect(doc.whereStaying).toHaveLength(1)
+  })
+
+  it('takes per-day lodging with the day it belongs to', () => {
+    // Day lodging is nested inside the day rows, and no day survives.
+    const doc: Record<string, unknown> = { itineraryDays: [day(1), day(2)] }
+
+    applySampleRule('listicle-itineraries', doc)
+
+    expect(JSON.stringify(doc.itineraryDays)).not.toContain('hotel')
+  })
+
+  it('strips the legacy top-level stop list too', () => {
+    const doc: Record<string, unknown> = {
+      items: [{ blockType: 'dining' }, { blockType: 'attractions' }],
+      whereStaying: [{ blockType: 'itinerary-where-staying' }],
+    }
+
+    const outcome = applySampleRule('listicle-itineraries', doc)
+
+    expect(outcome.applied).toBe(true)
+    expect(doc.items).toEqual([])
+    expect(doc.whereStaying).toHaveLength(1)
+  })
+
+  it('reports nothing applied for an itinerary with no body', () => {
+    const doc: Record<string, unknown> = { whereStaying: [] }
+
+    expect(applySampleRule('listicle-itineraries', doc)).toEqual({
       applied: false,
-      unit: 'blocks',
+      unit: 'days',
       shown: 0,
       total: 0,
     })
@@ -47,97 +152,12 @@ describe('applySampleRule — standard articles', () => {
 })
 
 describe('applySampleRule — single-type listicles', () => {
-  it('keeps the leading ranked items', () => {
-    const doc: Record<string, unknown> = { items: items(12) }
+  it('removes nothing, because they are never gated', () => {
+    const doc: Record<string, unknown> = { items: [{ blockType: 'dining' }, { blockType: 'bar' }] }
 
     const outcome = applySampleRule('single-type-listicles', doc)
 
-    expect(outcome).toEqual({ applied: true, unit: 'items', shown: 3, total: 12 })
-    expect(doc.items).toHaveLength(3)
-  })
-})
-
-describe('applySampleRule — listicle itineraries', () => {
-  it('keeps Day 1 whole, including its lodging', () => {
-    const doc: Record<string, unknown> = { itineraryDays: days(5) }
-
-    const outcome = applySampleRule('listicle-itineraries', doc)
-
-    expect(outcome).toEqual({ applied: true, unit: 'days', shown: 1, total: 5 })
-    expect(doc.itineraryDays).toHaveLength(1)
-
-    const dayOne = (doc.itineraryDays as { items: unknown[]; whereStaying: unknown[] }[])[0]
-    expect(dayOne.items).toHaveLength(3)
-    expect(dayOne.whereStaying).toHaveLength(1)
-  })
-
-  it('strips the legacy top-level body on a day-shaped itinerary', () => {
-    // Both shapes can be populated at once. Truncating days while leaving the
-    // legacy arrays would hand back the very stops the day cut removed.
-    const doc: Record<string, unknown> = {
-      itineraryDays: days(4),
-      items: items(20),
-      whereStaying: [{ blockType: 'itinerary-where-staying' }],
-    }
-
-    const outcome = applySampleRule('listicle-itineraries', doc)
-
-    expect(outcome.applied).toBe(true)
-    expect(doc.itineraryDays).toHaveLength(1)
-    expect(doc.items).toEqual([])
-    expect(doc.whereStaying).toEqual([])
-  })
-
-  it('falls back to the item rule for a legacy itinerary with no days', () => {
-    const doc: Record<string, unknown> = {
-      itineraryDays: [],
-      items: items(10),
-      whereStaying: [{ blockType: 'itinerary-where-staying' }],
-    }
-
-    const outcome = applySampleRule('listicle-itineraries', doc)
-
-    expect(outcome).toEqual({ applied: true, unit: 'items', shown: 3, total: 10 })
-    expect(doc.items).toHaveLength(3)
-    expect(doc.whereStaying).toEqual([])
-  })
-
-  it('reports applied when only lodging had to be removed', () => {
-    const doc: Record<string, unknown> = {
-      items: items(2),
-      whereStaying: [{ blockType: 'itinerary-where-staying' }],
-    }
-
-    const outcome = applySampleRule('listicle-itineraries', doc)
-
-    expect(outcome.applied).toBe(true)
+    expect(outcome.applied).toBe(false)
     expect(doc.items).toHaveLength(2)
-    expect(doc.whereStaying).toEqual([])
-  })
-})
-
-describe('applySampleRule — limits', () => {
-  it('honours caller-supplied limits over the defaults', () => {
-    const doc: Record<string, unknown> = { contentBlocks: blocks(9) }
-
-    const outcome = applySampleRule('articles', doc, {
-      ...DEFAULT_SAMPLE_LIMITS,
-      articleBlocks: 5,
-    })
-
-    expect(outcome.shown).toBe(5)
-    expect(doc.contentBlocks).toHaveLength(5)
-  })
-
-  it('treats a zero limit as a full lock rather than as no limit', () => {
-    const doc: Record<string, unknown> = { contentBlocks: blocks(4) }
-
-    const outcome = applySampleRule('articles', doc, {
-      ...DEFAULT_SAMPLE_LIMITS,
-      articleBlocks: 0,
-    })
-
-    expect(outcome).toEqual({ applied: true, unit: 'blocks', shown: 0, total: 4 })
-    expect(doc.contentBlocks).toEqual([])
   })
 })

--- a/apps/questura/apps/server/src/features/articles/public/freeSample.ts
+++ b/apps/questura/apps/server/src/features/articles/public/freeSample.ts
@@ -9,9 +9,16 @@ import type { ArticleCollectionSlug } from './serializeArticleBlocks'
  * entirely locked, and nobody finds out from the code. These rules have no
  * unset state.
  *
- * The cut also lands on each shape's natural seam. An itinerary keeps Day 1
- * whole, which is both a clean boundary and the best pitch available: "see
- * Day 1 free, unlock all five days". A block count would have cut mid-day.
+ * The rules are editorial policy, set 2026-08-15:
+ *
+ * - A standard article shows its opening prose and nothing else. Images and
+ *   the editorial blocks -- key takeaways, pull quotes, in-the-know, highlight
+ *   callouts, FAQ -- are held back even when they appear early, because each
+ *   carries standalone value and is a reason to subscribe on its own.
+ * - An itinerary never shows a day. Only its top-level lodging section
+ *   survives; the day-by-day plan is the product.
+ * - A single-type listicle is never gated at all. Those earn from ads, and ad
+ *   revenue needs the whole page reachable.
  *
  * This module only derives; it does not decide who gets the sample. Callers
  * pair it with the Access tier and the reader's Membership entitlement.
@@ -20,23 +27,26 @@ import type { ArticleCollectionSlug } from './serializeArticleBlocks'
 export type SampleUnit = 'blocks' | 'items' | 'days'
 
 export type SampleLimits = {
-  /** Leading `contentBlocks` kept on a standard article. */
-  articleBlocks: number
-  /** Leading `items` kept on a single-type listicle. */
-  listicleItems: number
-  /** Leading `itineraryDays` kept whole on a listicle itinerary. */
-  itineraryDays: number
+  /** Leading `text` blocks kept on a standard article. */
+  articleTextBlocks: number
 }
 
 /**
- * Guesses, deliberately centralised so they can move on conversion evidence
- * rather than being scattered across call sites.
+ * Centralised so the number can move on conversion evidence rather than being
+ * scattered across call sites.
  */
 export const DEFAULT_SAMPLE_LIMITS: SampleLimits = {
-  articleBlocks: 3,
-  listicleItems: 3,
-  itineraryDays: 1,
+  articleTextBlocks: 2,
 }
+
+/**
+ * Block types that may appear in a standard article's Free sample.
+ *
+ * An allowlist, not a blocklist. A new editorial block type added later is
+ * withheld by default, which is the safe direction: the alternative leaks paid
+ * content the moment someone adds a block and forgets this file.
+ */
+const SAMPLEABLE_ARTICLE_BLOCKS = new Set(['text'])
 
 export type SampleOutcome = {
   /** Whether anything was actually removed. */
@@ -51,92 +61,73 @@ function asArray(value: unknown): unknown[] | null {
   return Array.isArray(value) ? value : null
 }
 
-/**
- * Truncates `doc[key]` to `limit` entries in place.
- *
- * In-place because `serializeArticleByCollection` already mutates the document
- * it is handed and the routes serialize that same object; returning a copy here
- * would leave two divergent notions of the response body.
- */
-function truncate(
-  doc: Record<string, unknown>,
-  key: string,
-  limit: number,
-): { shown: number; total: number; applied: boolean } {
-  const list = asArray(doc[key])
-  if (!list) return { shown: 0, total: 0, applied: false }
-
-  const total = list.length
-  const shown = Math.max(0, Math.min(limit, total))
-  if (shown >= total) return { shown: total, total, applied: false }
-
-  doc[key] = list.slice(0, shown)
-  return { shown, total, applied: true }
+function blockTypeOf(block: unknown): string {
+  if (!block || typeof block !== 'object') return ''
+  const type = (block as { blockType?: unknown }).blockType
+  return typeof type === 'string' ? type : ''
 }
 
 /**
  * Applies the Sample rule for `collection` to `doc`, mutating it.
  *
+ * In-place because `serializeArticleByCollection` already mutates the document
+ * the routes serialize; returning a copy would leave two divergent notions of
+ * the response body.
+ *
  * Callers must have already decided that this reader gets a sample. Calling it
- * on a free item or for an entitled member would silently truncate content
- * they are allowed to read.
+ * for an entitled member would truncate content they are allowed to read.
  */
 export function applySampleRule(
   collection: ArticleCollectionSlug,
   doc: Record<string, unknown>,
   limits: SampleLimits = DEFAULT_SAMPLE_LIMITS,
 ): SampleOutcome {
-  if (collection === 'articles') {
-    const r = truncate(doc, 'contentBlocks', limits.articleBlocks)
-    return { applied: r.applied, unit: 'blocks', shown: r.shown, total: r.total }
-  }
+  if (collection === 'articles') return sampleArticle(doc, limits)
+  if (collection === 'listicle-itineraries') return sampleItinerary(doc)
 
-  if (collection === 'single-type-listicles') {
-    const r = truncate(doc, 'items', limits.listicleItems)
-    return { applied: r.applied, unit: 'items', shown: r.shown, total: r.total }
-  }
-
-  // Listicle itineraries carry two body shapes. `itineraryDays` is current;
-  // top-level `items`/`whereStaying` are the legacy pre-days layout that
-  // beforeValidate still normalises. Cut whichever one this document uses.
-  const days = asArray(doc.itineraryDays)
-  if (days && days.length > 0) {
-    const r = truncate(doc, 'itineraryDays', limits.itineraryDays)
-    // Legacy top-level body is not part of a day-shaped itinerary's sample.
-    // Leaving it would hand back the very stops the day cut removed.
-    const hadLegacy = stripLegacyItineraryBody(doc)
-    return {
-      applied: r.applied || hadLegacy,
-      unit: 'days',
-      shown: r.shown,
-      total: r.total,
-    }
-  }
-
-  // Legacy itinerary: no days to cut on, so fall back to the listicle rule and
-  // drop lodging, which is the part worth paying for.
-  const r = truncate(doc, 'items', limits.listicleItems)
-  const hadLodging = stripWhereStaying(doc)
-  return { applied: r.applied || hadLodging, unit: 'items', shown: r.shown, total: r.total }
+  // Single-type listicles are never gated. Reached only if a caller ignores
+  // that, so it removes nothing rather than inventing a rule for a collection
+  // that has no paid tier.
+  return { applied: false, unit: 'items', shown: 0, total: 0 }
 }
 
-function stripWhereStaying(doc: Record<string, unknown>): boolean {
-  const lodging = asArray(doc.whereStaying)
-  if (!lodging || lodging.length === 0) return false
-  doc.whereStaying = []
-  return true
-}
+function sampleArticle(doc: Record<string, unknown>, limits: SampleLimits): SampleOutcome {
+  const blocks = asArray(doc.contentBlocks)
+  if (!blocks) return { applied: false, unit: 'blocks', shown: 0, total: 0 }
 
-function stripLegacyItineraryBody(doc: Record<string, unknown>): boolean {
-  let stripped = false
+  const total = blocks.length
+  const kept: unknown[] = []
 
-  const legacyItems = asArray(doc.items)
-  if (legacyItems && legacyItems.length > 0) {
-    doc.items = []
-    stripped = true
+  for (const block of blocks) {
+    if (kept.length >= limits.articleTextBlocks) break
+    if (SAMPLEABLE_ARTICLE_BLOCKS.has(blockTypeOf(block))) kept.push(block)
   }
 
-  if (stripWhereStaying(doc)) stripped = true
+  doc.contentBlocks = kept
 
-  return stripped
+  return {
+    applied: kept.length < total,
+    unit: 'blocks',
+    shown: kept.length,
+    total,
+  }
+}
+
+function sampleItinerary(doc: Record<string, unknown>): SampleOutcome {
+  const days = asArray(doc.itineraryDays) ?? []
+  const legacyItems = asArray(doc.items) ?? []
+
+  // Every day goes, including each day's own lodging -- per-day lodging lives
+  // inside the day rows, and the policy is that no day survives. Only the
+  // itinerary's top-level `whereStaying` is left untouched.
+  const applied = days.length > 0 || legacyItems.length > 0
+  doc.itineraryDays = []
+  doc.items = []
+
+  return {
+    applied,
+    unit: 'days',
+    shown: 0,
+    total: days.length,
+  }
 }

--- a/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.test.ts
@@ -17,13 +17,13 @@ describe('gatePublicArticle', () => {
     expect(doc.gate).toEqual(state)
   })
 
-  it('reduces a gated article to its Free sample', () => {
+  it('reduces a gated article to its opening prose', () => {
     const doc: Record<string, unknown> = { access: 'member', contentBlocks: blocks(9) }
 
     const state = gatePublicArticle('articles', doc)
 
-    expect(state).toEqual({ access: 'member', locked: true, unit: 'blocks', shown: 3, total: 9 })
-    expect(doc.contentBlocks).toHaveLength(3)
+    expect(state).toEqual({ access: 'member', locked: true, unit: 'blocks', shown: 2, total: 9 })
+    expect(doc.contentBlocks).toHaveLength(2)
   })
 
   it('treats a document with no tier as free rather than locking it', () => {
@@ -59,16 +59,33 @@ describe('gatePublicArticle', () => {
     expect(state).toMatchObject({ shown: 2, total: 2 })
   })
 
-  it('locks an itinerary down to Day 1 and counts in days', () => {
+  it('removes every day from an itinerary and counts in days', () => {
     const doc: Record<string, unknown> = {
       access: 'member',
+      whereStaying: [{ blockType: 'itinerary-where-staying' }],
       itineraryDays: Array.from({ length: 5 }, () => ({ items: [], whereStaying: [] })),
     }
 
     const state = gatePublicArticle('listicle-itineraries', doc)
 
-    expect(state).toEqual({ access: 'member', locked: true, unit: 'days', shown: 1, total: 5 })
-    expect(doc.itineraryDays).toHaveLength(1)
+    expect(state).toEqual({ access: 'member', locked: true, unit: 'days', shown: 0, total: 5 })
+    expect(doc.itineraryDays).toEqual([])
+    expect(doc.whereStaying).toHaveLength(1)
+  })
+
+  it('never locks a single-type listicle, even with a stale member tier', () => {
+    // The field is removed from that collection, but the column can still hold
+    // a value set before removal. Ad revenue needs the whole page reachable.
+    const doc: Record<string, unknown> = {
+      access: 'member',
+      items: [{ blockType: 'dining' }, { blockType: 'bar' }],
+    }
+
+    const state = gatePublicArticle('single-type-listicles', doc)
+
+    expect(state.locked).toBe(false)
+    expect(state.access).toBe('free')
+    expect(doc.items).toHaveLength(2)
   })
 
   it('always attaches gate state, so the client never infers lock from absence', () => {

--- a/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.ts
+++ b/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.ts
@@ -41,6 +41,22 @@ export function gatePublicArticle(
 ): GateState {
   const access = isAccessTier(doc.access) ? doc.access : DEFAULT_ACCESS_TIER
 
+  // Single-type listicles are never gated: they earn from ads, which needs the
+  // whole page reachable. The Access tier field is removed from that collection,
+  // so this only fires on a stale `member` value left in the column from before
+  // the removal -- which must not lock a page that is supposed to pay its way.
+  if (collection === 'single-type-listicles') {
+    const listicleState: GateState = {
+      access: 'free',
+      locked: false,
+      unit: 'items',
+      shown: 0,
+      total: 0,
+    }
+    doc.gate = listicleState
+    return listicleState
+  }
+
   if (!isGatedItem(doc)) {
     const state: GateState = { access, locked: false, unit: 'blocks', shown: 0, total: 0 }
     doc.gate = state

--- a/apps/questura/apps/server/src/features/articles/single-type-listicles/collections/SingleTypeListicles.ts
+++ b/apps/questura/apps/server/src/features/articles/single-type-listicles/collections/SingleTypeListicles.ts
@@ -1,6 +1,5 @@
 import type { CollectionConfig } from 'payload'
 import { languageField } from '@/shared/i18n/languageField'
-import { accessTierField } from '@/shared/content/accessTier'
 import { singleTypeListicleAccess } from './access'
 import {
   articleType,
@@ -54,9 +53,11 @@ export const SingleTypeListicles: CollectionConfig = {
     items,
     seo,
 
+    // No Access tier: single-type listicles earn from ads and are never
+    // gated. The column is dropped separately -- destructive SQL cannot ride
+    // along in a feature change (infra/softprod/README.md).
     status,
     languageField,
-    accessTierField,
     author,
     publishedAt,
     articleType,


### PR DESCRIPTION
Replaces the placeholder cut sizes with editorial policy, decided 2026-08-15.

## The three rules

| Collection | Free sample | Was |
|---|---|---|
| `articles` | first **2 text blocks** only | first 3 blocks of any kind |
| `listicle-itineraries` | **top-level lodging only**, no days | Day 1 whole |
| `single-type-listicles` | **never gated** | gateable |

## What each change fixes

**Articles.** The old rule took the first three blocks of *any* type, so an article opening on a key takeaway gave that away free. Images and every editorial block — key takeaway, pull quote, in-the-know, highlight callout, FAQ — are now withheld even when they appear first, because each carries standalone value and is a reason to subscribe on its own.

Sampleable types are an **allowlist**, not a blocklist. A block type added later is withheld by default; a blocklist leaks paid content the moment someone adds a block and forgets this file.

**Itineraries.** No day survives, including each day's own nested lodging — only the itinerary's top-level "Where you're staying" remains. The day-by-day plan is the product.

Reader copy changes with it. `Day 1 of 5` would now render `Day 0 of 5`, which reads as a bug rather than an offer, so an itinerary pitches the trip length being unlocked: *"Unlock all 5 days."*

**Listicles.** They earn from ads, which needs the whole page reachable. The field is removed from the collection, **and** the gate refuses to lock one even if the column still holds a stale `member` from before removal — a value nobody can now see or change must not be able to take a page off ads.

## What is deliberately not here

The listicle **column drop**. Dropping a column is destructive SQL and the deploy preflight blocks it, which forces the documented code-first/migration-second split. Removing the field is what makes the behaviour correct; removing the column is cleanup that needs its own reviewed, approved migration.

## Live impact

One article is currently gated (`barranco-vs-miraflores`). It goes from 3 mixed blocks to 2 text blocks — a slightly smaller sample, no other change.

## Verification

- server `test:int` — **810 pass**
- `test:deploy` migration guard — 8 pass
- client `tsc` 0 errors, `next lint` clean, `next build` compiles
