### PR TITLE
Put the price back on the nav subscribe button

### DIFF
--- a/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
+++ b/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
@@ -37,13 +37,24 @@ export default function SubscribeButton() {
       `}
     >
       {/*
-       * No price in this label: it is static chrome on every page and cannot
-       * know the Stripe price, so it used to advertise $1.50/wk against a real
-       * $0.50/month. /join states the price it reads from Stripe.
+       * HARDCODED PRICE -- verify against Stripe before changing plan pricing.
+       *
+       * Derived from the annual plan: $79.99/yr ÷ 52 = $1.538/wk. Rounded up,
+       * so "$1.54" slightly overstates and "under $1.55" stays true; rounding
+       * down would understate the price, which is the direction that gets
+       * argued in a dispute.
+       *
+       * This is static chrome on every page and cannot read Stripe, so it goes
+       * stale the moment plan pricing changes. `GET /api/payments/plans` is the
+       * source of truth, and /join renders from it. If you change the price in
+       * Stripe, change this line in the same breath.
+       *
+       * Weekly framing for a plan billed annually is a deliberate choice, made
+       * 2026-08-15 with the trade-off understood.
        */}
       <span className="380:hidden">Subscribe</span>
-      <span className="hidden 380:inline 550:hidden">Join</span>
-      <span className="hidden 550:inline">Become a member</span>
+      <span className="hidden 380:inline 550:hidden">Join: $1.54/wk</span>
+      <span className="hidden 550:inline">Subscribe: under $1.55/wk</span>
 
     </button>
   );


### PR DESCRIPTION
Restores the price-bearing nav label, and incidentally unblocks the deploy.

## Copy

```diff
- <span className="hidden 380:inline 550:hidden">Join</span>
- <span className="hidden 550:inline">Become a member</span>
+ <span className="hidden 380:inline 550:hidden">Join: $1.54/wk</span>
+ <span className="hidden 550:inline">Subscribe: under $1.55/wk</span>
```

#296 removed the price because the old label advertised `$1.50/wk` against a real **$0.50/month**. That mismatch is gone — live Stripe now reports **$12.99/mo** and **$79.99/yr** — so the reason for dropping it no longer holds.

## The arithmetic

$79.99/yr ÷ 52 = **$1.538/wk**. Rounded **up**, so `$1.54` slightly overstates and `under $1.55` is true. Rounding down would understate the price, which is the direction that gets argued in a dispute.

Restoring `less than $1.50/wk` verbatim would have been false by four cents.

## Stated trade-off

Weekly framing for a plan billed **annually** is a deliberate choice, made with the risk on the table: it is the smallest honest number and closest to the previous copy, but anyone doing the arithmetic finds a yearly commitment behind a weekly figure. `/join` states the real terms.

The price is **hardcoded and will go stale.** `GET /api/payments/plans` is the source of truth and `/join` renders from it; the comment says so at the exact line that has to change.

## Why this also unblocks deploys

The `6740ac5a` release directory on the host holds a `server-ready` marker that no longer matches its own tree — `db:migrate` regenerated the gitignored `payload-types.ts` **after** the marker was written, and that file is inside the hashed tree. The deploy refuses to reuse or rebuild that SHA, so both attempts failed identically.

"Create a new commit" is the script's own documented remedy. This is a real change rather than an empty one.

Both failures reconciled cleanly back to `450d36a6` with all four health checks passing — live was never touched, and never split.

## Verification

`tsc` 0 errors, `next lint` clean, `next build` compiles.
