### PR TITLE
Gate itineraries: lodging stays, the day plan does not

### DIFF
--- a/apps/questura/apps/client/src/features/articles/ItineraryListicleArticlePage.tsx
+++ b/apps/questura/apps/client/src/features/articles/ItineraryListicleArticlePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import { Clock, ExternalLink, MapPin, Route } from "lucide-react";
 import { ShimmerImage } from "@/components/media/ShimmerImage";
 import { ArticlePageHeader } from "@/features/articles/components/ArticlePageHeader";
@@ -29,6 +29,11 @@ type ItineraryListicleArticlePageProps = {
   days: ItineraryDay[];
   selectedDayIndex: number;
   onSelectDay: (index: number) => void;
+  /**
+   * Rendered where the day-by-day plan would be when this itinerary is gated
+   * and the reader has not paid for it. Null once a member's full body loads.
+   */
+  lockedSlot?: ReactNode;
 };
 
 function formatDuration(hours: number): string {
@@ -247,6 +252,7 @@ export function ItineraryListicleArticlePage({
   days,
   selectedDayIndex,
   onSelectDay,
+  lockedSlot,
 }: ItineraryListicleArticlePageProps): JSX.Element {
   const dayIndex = Math.min(selectedDayIndex, Math.max(days.length - 1, 0));
   const selectedDay = days[dayIndex] ?? { whereStaying: [], items: [] };
@@ -324,6 +330,8 @@ export function ItineraryListicleArticlePage({
         ) : null}
 
         <StopList stops={stops} />
+
+        {lockedSlot}
       </div>
     </article>
   );

--- a/apps/questura/apps/client/src/features/articles/components/GatedArticleBody.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/GatedArticleBody.tsx
@@ -1,13 +1,11 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-
-import { get } from '@/lib/api'
 import { BlockRenderer } from '@/features/articles/components/BlockRenderer'
+import { GatedBodySkeleton, GatedLoadError } from '@/features/articles/components/GatedStates'
 import { PaywallNotice } from '@/features/articles/components/PaywallNotice'
 import type { GateState } from '@/features/articles/lib/gate'
+import { useGatedFullArticle } from '@/features/articles/lib/useGatedFullArticle'
 import type { ContentBlock } from '@/features/articles/types'
-import type { CurrentPrincipalResponse } from '@/lib/user/types'
 
 type GatedArticleBodyProps = {
   articleId: number
@@ -21,130 +19,42 @@ type FullArticleResponse = {
   contentBlocks?: ContentBlock[]
 }
 
-type Phase = 'identifying' | 'anonymous' | 'loading' | 'ready' | 'failed'
-
 /**
- * The locked region of a Gated item.
- *
- * Renders one of three things, and which one it must never get wrong is the
- * whole point: a paying member must not see a paywall for content they own,
- * and a non-member must not see the body.
+ * The locked region of a gated standard article.
  *
  * Client-side because the cached public shell is `force-static`, where
  * `cookies()` is empty by construction -- no page under it can know who is
  * reading (ADR-0009).
- *
- * Plain fetch rather than React Query, deliberately. The public shell has no
- * `QueryClientProvider`: ADR-0003 keeps React Query in the dynamic/private
- * route group and lazy islands, so calling a `useQuery` hook here throws during
- * render and 500s the page. This component is the one client island under the
- * public shell, and it has to stand on its own.
  */
 export function GatedArticleBody({ articleId, gate, path, lang }: GatedArticleBodyProps) {
-  const [phase, setPhase] = useState<Phase>('identifying')
-  const [blocks, setBlocks] = useState<ContentBlock[] | null>(null)
-  const [attempt, setAttempt] = useState(0)
-
-  const retry = useCallback(() => {
-    setPhase('identifying')
-    setAttempt((value) => value + 1)
-  }, [])
-
-  useEffect(() => {
-    let cancelled = false
-
-    const run = async () => {
-      let isMember = false
-
-      try {
-        const me = await get<CurrentPrincipalResponse>('/api/me')
-        isMember = me.principal?.membership.active === true
-      } catch {
-        // An anonymous reader is the overwhelmingly common case here, and
-        // /api/me answers 401 for them. Treat any failure to identify as
-        // "not a member" -- the paywall is the safe answer when we cannot
-        // tell, since the alternative is serving paid content on an error.
-        if (!cancelled) setPhase('anonymous')
-        return
-      }
-
-      if (cancelled) return
-
-      if (!isMember) {
-        setPhase('anonymous')
-        return
-      }
-
-      setPhase('loading')
-
-      try {
-        const full = await get<FullArticleResponse>(
-          `/api/public/articles/full?type=articles&id=${encodeURIComponent(String(articleId))}` +
-            `&lang=${encodeURIComponent(lang ?? 'en')}`,
-        )
-        if (cancelled) return
-
-        if (!full.contentBlocks) {
-          setPhase('failed')
-          return
-        }
-
-        setBlocks(full.contentBlocks)
-        setPhase('ready')
-      } catch {
-        // A member whose fetch failed is not a non-member. Falling through to
-        // the paywall would tell someone who paid that they had not.
-        if (!cancelled) setPhase('failed')
-      }
-    }
-
-    void run()
-
-    return () => {
-      cancelled = true
-    }
-  }, [articleId, lang, attempt])
+  const { phase, data, retry } = useGatedFullArticle<FullArticleResponse>({
+    articleId,
+    type: 'articles',
+    enabled: true,
+    lang,
+  })
 
   // The notice is what the server renders and what the browser renders first,
-  // so the two agree and hydration is stable.
-  //
-  // This costs a member a brief flash of the lock before the swap, which an
-  // earlier version avoided by showing a skeleton until identity was known.
-  // That was wrong: the skeleton is what would sit in the cached HTML, so a
-  // crawler and any reader without JS would get a loading placeholder instead
-  // of the sample's call to action -- and the page's paywall JSON-LD points at
-  // `[data-paywalled]`, which lives on this notice. No notice in the HTML means
-  // that selector matches nothing and the structured data describes a part of
-  // the page that is not there. Indexability is the constraint this whole
-  // design exists to protect; a flash is not.
+  // so the two agree and hydration is stable. A member sees it briefly before
+  // the swap; that is the correct trade, because the alternative puts a
+  // loading placeholder in the cached HTML where a crawler and any reader
+  // without JS would find the call to action -- and `[data-paywalled]`, which
+  // the page's paywall JSON-LD points at, lives on this notice.
   if (phase === 'identifying' || phase === 'anonymous') {
     return <PaywallNotice gate={gate} returnTo={path} />
   }
 
   if (phase === 'loading') {
-    return <BodySkeleton />
+    return <GatedBodySkeleton />
   }
 
-  if (phase === 'failed' || !blocks) {
-    return (
-      <div role="alert" className="rounded-lg border border-foreground/12 px-6 py-10 text-center">
-        <p className="text-sm text-foreground/70">
-          We couldn&rsquo;t load the rest of this article.
-        </p>
-        <button
-          type="button"
-          onClick={retry}
-          className="mt-4 rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium transition-colors hover:bg-foreground/5"
-        >
-          Try again
-        </button>
-      </div>
-    )
+  if (phase === 'failed' || !data?.contentBlocks) {
+    return <GatedLoadError onRetry={retry} />
   }
 
   // The full body includes the sample blocks the server already rendered, so
   // the sample is dropped here rather than duplicated above this component.
-  const remaining = blocks.slice(gate.shown)
+  const remaining = data.contentBlocks.slice(gate.shown)
 
   return (
     <>
@@ -152,19 +62,5 @@ export function GatedArticleBody({ articleId, gate, path, lang }: GatedArticleBo
         <BlockRenderer key={block.id} block={block} />
       ))}
     </>
-  )
-}
-
-function BodySkeleton() {
-  return (
-    <div aria-hidden className="space-y-4" data-testid="gated-body-skeleton">
-      {[0, 1, 2, 3, 4].map((row) => (
-        <div
-          key={row}
-          className="h-4 animate-pulse rounded bg-foreground/10"
-          style={{ width: `${[100, 96, 88, 98, 62][row]}%` }}
-        />
-      ))}
-    </div>
   )
 }

--- a/apps/questura/apps/client/src/features/articles/components/GatedStates.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/GatedStates.tsx
@@ -1,0 +1,38 @@
+/**
+ * Shared loading and failure states for gated content.
+ *
+ * Kept together so a standard article and an itinerary cannot drift into
+ * saying different things about the same situation.
+ */
+
+export function GatedBodySkeleton() {
+  return (
+    <div aria-hidden className="space-y-4" data-testid="gated-body-skeleton">
+      {[0, 1, 2, 3, 4].map((row) => (
+        <div
+          key={row}
+          className="h-4 animate-pulse rounded bg-foreground/10"
+          style={{ width: `${[100, 96, 88, 98, 62][row]}%` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function GatedLoadError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div role="alert" className="rounded-lg border border-foreground/12 px-6 py-10 text-center">
+      <p className="text-sm text-foreground/70">
+        We couldn&rsquo;t load the rest of this. Your membership is fine &mdash; this is a loading
+        problem.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-4 rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium transition-colors hover:bg-foreground/5"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/apps/questura/apps/client/src/features/articles/layouts/ItineraryArticleLayout.tsx
+++ b/apps/questura/apps/client/src/features/articles/layouts/ItineraryArticleLayout.tsx
@@ -13,6 +13,10 @@ import {
   populatedVenueStops,
   venueRowFromBlock,
 } from '@/features/articles/lib/itineraryDays'
+import { GatedBodySkeleton, GatedLoadError } from '@/features/articles/components/GatedStates'
+import { PaywallNotice } from '@/features/articles/components/PaywallNotice'
+import { readGate } from '@/features/articles/lib/gate'
+import { useGatedFullArticle } from '@/features/articles/lib/useGatedFullArticle'
 import type { RelatedMapsArticleTeaser } from '@/features/articles/lib/fetchRelatedMapsArticles'
 import type { ListicleItineraryArticle } from '@/features/articles/types/itineraryListicle'
 
@@ -21,6 +25,8 @@ interface ItineraryArticleLayoutProps {
   relatedArticles: RelatedMapsArticleTeaser[]
   country: string
   city?: string | null
+  /** Path the reader is on, so checkout can return them to it. */
+  path?: string
 }
 
 export function ItineraryArticleLayout({
@@ -28,8 +34,23 @@ export function ItineraryArticleLayout({
   relatedArticles,
   country,
   city,
+  path,
 }: ItineraryArticleLayoutProps): JSX.Element {
-  const days = useMemo(() => itineraryDaysForArticle(article), [article])
+  const gate = readGate(article)
+  const locked = gate?.locked === true
+
+  // The swap happens here rather than deeper down because this is where days
+  // are derived. A gated itinerary arrives with none, and a member's full body
+  // has to re-enter through the same derivation so the day tabs, map pins and
+  // scroll sync all agree.
+  const { phase, data, retry } = useGatedFullArticle<ListicleItineraryArticle>({
+    articleId: article.id,
+    type: 'itineraries',
+    enabled: locked,
+  })
+
+  const effectiveArticle = locked && phase === 'ready' && data ? data : article
+  const days = useMemo(() => itineraryDaysForArticle(effectiveArticle), [effectiveArticle])
   const [selectedDayIndex, setSelectedDayIndex] = useState(0)
   const dayIndex = Math.min(selectedDayIndex, Math.max(days.length - 1, 0))
 
@@ -69,10 +90,21 @@ export function ItineraryArticleLayout({
         city={city}
       >
         <ItineraryListicleArticlePage
-          article={article}
+          article={effectiveArticle}
           days={days}
           selectedDayIndex={dayIndex}
           onSelectDay={setSelectedDayIndex}
+          lockedSlot={
+            locked && gate ? (
+              phase === 'identifying' || phase === 'anonymous' ? (
+                <PaywallNotice gate={gate} returnTo={path ?? '/'} />
+              ) : phase === 'loading' ? (
+                <GatedBodySkeleton />
+              ) : phase === 'failed' ? (
+                <GatedLoadError onRetry={retry} />
+              ) : null
+            ) : null
+          }
         />
       </ListicleArticleLayout>
     </ListicleMapSyncProvider>

--- a/apps/questura/apps/client/src/features/articles/lib/useGatedFullArticle.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/useGatedFullArticle.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import { get } from '@/lib/api'
+import type { CurrentPrincipalResponse } from '@/lib/user/types'
+
+export type GatedPhase = 'identifying' | 'anonymous' | 'loading' | 'ready' | 'failed'
+
+/** `type` as the public routes name it, not the Payload collection slug. */
+export type GatedArticleType = 'articles' | 'itineraries' | 'maps'
+
+type UseGatedFullArticleOptions<T> = {
+  articleId: number
+  type: GatedArticleType
+  /** Skip everything when the item is not gated. */
+  enabled: boolean
+  lang?: string
+}
+
+type UseGatedFullArticleResult<T> = {
+  phase: GatedPhase
+  data: T | null
+  retry: () => void
+}
+
+/**
+ * Identifies the reader and, if they are entitled, fetches the full body of a
+ * Gated item (ADR-0009).
+ *
+ * Shared by every gated surface so the three-way decision -- notice, skeleton,
+ * body -- is made in one place. A paying member must not see a paywall for
+ * content they own, and a non-member must not see the body; that is not a
+ * judgement worth reimplementing per content type.
+ *
+ * Plain fetch rather than React Query on purpose. The public shell has no
+ * `QueryClientProvider` (ADR-0003 keeps React Query in the dynamic/private
+ * group), and calling a `useQuery` hook under it throws during render and 500s
+ * the page. That is not hypothetical -- it shipped, and it is why this hook
+ * exists as the single place that knows better.
+ */
+export function useGatedFullArticle<T>({
+  articleId,
+  type,
+  enabled,
+  lang,
+}: UseGatedFullArticleOptions<T>): UseGatedFullArticleResult<T> {
+  const [phase, setPhase] = useState<GatedPhase>('identifying')
+  const [data, setData] = useState<T | null>(null)
+  const [attempt, setAttempt] = useState(0)
+
+  const retry = useCallback(() => {
+    setPhase('identifying')
+    setAttempt((value) => value + 1)
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+
+    const run = async () => {
+      let isMember = false
+
+      try {
+        const me = await get<CurrentPrincipalResponse>('/api/me')
+        isMember = me.principal?.membership.active === true
+      } catch {
+        // Anonymous is the common case and /api/me answers 401 for it. Any
+        // failure to identify reads as "not a member": the notice is the safe
+        // answer when we cannot tell, since the alternative is serving paid
+        // content on an error.
+        if (!cancelled) setPhase('anonymous')
+        return
+      }
+
+      if (cancelled) return
+
+      if (!isMember) {
+        setPhase('anonymous')
+        return
+      }
+
+      setPhase('loading')
+
+      try {
+        const full = await get<T>(
+          `/api/public/articles/full?type=${type}&id=${encodeURIComponent(String(articleId))}` +
+            `&lang=${encodeURIComponent(lang ?? 'en')}`,
+        )
+        if (cancelled) return
+
+        setData(full)
+        setPhase('ready')
+      } catch {
+        // A member whose fetch failed is not a non-member. Falling through to
+        // the notice would tell someone who paid that they had not.
+        if (!cancelled) setPhase('failed')
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [articleId, type, lang, enabled, attempt])
+
+  return { phase, data, retry }
+}

--- a/apps/questura/apps/client/src/features/articles/routes/renderItineraryArticleRoute.tsx
+++ b/apps/questura/apps/client/src/features/articles/routes/renderItineraryArticleRoute.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { buildArticleBreadcrumbJsonLd } from '@/features/articles/lib/articleBreadcrumbJsonLd'
+import { articleJsonLdNodes } from '@/features/articles/lib/paywallJsonLd'
+import { isLocked } from '@/features/articles/lib/gate'
 import { articleHrefForScope } from '@/features/articles/lib/articleScope'
 import { fetchArticle } from '@/features/articles/lib/fetchArticle'
 import { fetchRelatedMapsArticles } from '@/features/articles/lib/fetchRelatedMapsArticles'
@@ -32,13 +34,20 @@ export async function renderItineraryArticleRoute({
 
   return (
     <>
-      <JsonLd data={article.seoSection?.structuredData} />
+      {articleJsonLdNodes({
+        locked: isLocked(article),
+        headline: article.title,
+        existing: article.seoSection?.structuredData,
+      }).map((node, index) => (
+        <JsonLd key={index} data={node} />
+      ))}
       <JsonLd data={buildArticleBreadcrumbJsonLd({ path, articleTitle: article.title })} />
       <ItineraryArticleLayout
         article={article}
         relatedArticles={relatedArticles}
         country={scope.country}
         city={scope.city}
+        path={path}
       />
     </>
   )

--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -18,6 +18,7 @@
     "db:migrate:status": "cross-env NODE_OPTIONS=--no-deprecation payload migrate:status",
     "reconcile:stripe-profiles": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/reconcile-stripe-visitor-profiles.ts",
     "audit:access-revocations": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/audit-access-revocations.ts",
+    "set:itinerary-access": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/set-itinerary-access.ts",
     "capture:membership-fixtures": "bun scripts/capture-membership-fixtures.ts",
     "inventory:tour-agency": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/inventory-tour-agency-stops.ts",
     "migrate:media-sets": "bun scripts/finish-media-set-migration.ts",

--- a/apps/questura/apps/server/scripts/set-itinerary-access.ts
+++ b/apps/questura/apps/server/scripts/set-itinerary-access.ts
@@ -1,0 +1,117 @@
+/**
+ * Bulk-set the Access tier on listicle itineraries.
+ *
+ * Why this is a script and not a migration
+ * ----------------------------------------
+ * It rewrites rows. The deploy preflight blocks `UPDATE` in a migration as a
+ * data rewrite, and that guard is worth keeping: migrations add shape, and
+ * changing what content costs is an editorial act that should be run
+ * deliberately, read its own report, and be reversible in one command.
+ *
+ * What it does
+ * ------------
+ * Sets `access` to `member` (or back to `free`) on every published listicle
+ * itinerary. Dry by default: it prints what it would change and exits without
+ * writing. Pass `--apply` to commit.
+ *
+ *   pnpm tsx scripts/set-itinerary-access.ts                 # report only
+ *   pnpm tsx scripts/set-itinerary-access.ts --apply         # lock them
+ *   pnpm tsx scripts/set-itinerary-access.ts --tier free --apply   # undo
+ *
+ * Reversal is the same command with `--tier free`. Nothing here is one-way.
+ *
+ * Drafts are deliberately included: an unpublished itinerary that is later
+ * published should already carry its tier, rather than going live free because
+ * this ran before it existed as a published row.
+ */
+import { getPayload } from 'payload'
+
+import config from '../src/payload.config'
+import { ACCESS_TIERS, type AccessTier } from '../src/shared/content/accessTier'
+
+type Args = { tier: AccessTier; apply: boolean }
+
+function parseArgs(argv: string[]): Args {
+  const apply = argv.includes('--apply')
+
+  const tierIndex = argv.indexOf('--tier')
+  const raw = tierIndex >= 0 ? argv[tierIndex + 1] : 'member'
+
+  if (!(ACCESS_TIERS as readonly string[]).includes(raw ?? '')) {
+    throw new Error(`--tier must be one of: ${ACCESS_TIERS.join(', ')}`)
+  }
+
+  return { tier: raw as AccessTier, apply }
+}
+
+async function main() {
+  const { tier, apply } = parseArgs(process.argv.slice(2))
+  const payload = await getPayload({ config })
+
+  const all = await payload.find({
+    collection: 'listicle-itineraries',
+    limit: 0,
+    depth: 0,
+    pagination: false,
+    overrideAccess: true,
+  })
+
+  const docs = all.docs as unknown as Array<{
+    id: number | string
+    title?: string
+    status?: string
+    access?: string
+  }>
+
+  const changing = docs.filter((doc) => doc.access !== tier)
+
+  console.log(`listicle itineraries: ${docs.length}`)
+  console.log(`already ${tier}:       ${docs.length - changing.length}`)
+  console.log(`to change:            ${changing.length}`)
+  console.log('')
+
+  for (const doc of changing) {
+    console.log(`  ${doc.status ?? '?'}  ${String(doc.id).padStart(5)}  ${doc.access ?? '?'} -> ${tier}  ${doc.title ?? ''}`)
+  }
+
+  if (!apply) {
+    console.log('')
+    console.log('Dry run. Nothing was written. Re-run with --apply to commit.')
+    return
+  }
+
+  let updated = 0
+  let failed = 0
+
+  for (const doc of changing) {
+    try {
+      await payload.update({
+        collection: 'listicle-itineraries',
+        id: doc.id,
+        data: { access: tier },
+        overrideAccess: true,
+        // Collection hooks revalidate public paths and enforce reference locks.
+        // Both are wanted here: a tier change must reach the cached pages, and
+        // nothing about this should bypass a guard that protects content.
+      })
+      updated += 1
+    } catch (error) {
+      failed += 1
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`  FAILED ${doc.id}: ${message}`)
+    }
+  }
+
+  console.log('')
+  console.log(`updated: ${updated}`)
+  console.log(`failed:  ${failed}`)
+
+  if (failed > 0) process.exitCode = 1
+}
+
+main()
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })


### PR DESCRIPTION
Makes itineraries safe to set to `Members only`. Until now, gating one would have stripped every day with nothing on the page explaining why.

## Much less new UI than expected

`itineraryDaysForArticle` already falls back to a synthetic single day built from the top-level `whereStaying` when `itineraryDays` is empty:

```ts
if (days.length > 0) return days
return [{ id: 'legacy-single-day', whereStaying: article.whereStaying ?? [], items: article.items ?? [] }]
```

So a stripped itinerary renders **header + lodging, no day tabs** (tabs require `length > 1`), no stops. The existing layout already does the right thing. What was missing: the notice, the member swap, and the paywall structured data.

## Why the swap is in the layout

That is where `days` is derived. A member's full body has to re-enter through the **same** derivation so day tabs, map pins and scroll-sync all agree. Swapping further down would leave the map showing a day the list no longer has.

## Shared hook, not a copy

`useGatedFullArticle` is extracted from `GatedArticleBody` rather than duplicated. The three-way decision — notice / skeleton / body — is the one piece of this feature that must never be wrong in either direction, so it should exist once.

It also carries the reason it uses plain `fetch`: the public shell has no `QueryClientProvider`, and a `useQuery` hook under it 500s the page. That already happened (#307); the comment is there so it does not happen twice.

## Also

- Loading/failure states move to `GatedStates` so an article and an itinerary cannot drift into describing the same situation differently.
- Failure copy now says **the membership is fine, this is a loading problem** — the reading a paying member actually needs.
- Single-type listicles untouched: never gated, they earn from ads.

## Verification

`tsc` 0 errors, `next lint` clean, `next build` compiles.

Rendering is unverifiable until deploy, as always with this app — and there is still **no gated itinerary in the data**, so the first real test is the bulk lock that follows this.
