### PR TITLE
Load dotenv in the itinerary access script

### DIFF
--- a/apps/questura/apps/server/scripts/set-itinerary-access.ts
+++ b/apps/questura/apps/server/scripts/set-itinerary-access.ts
@@ -24,6 +24,9 @@
  * published should already carry its tier, rather than going live free because
  * this ran before it existed as a published row.
  */
+// A bare tsx script does not load `.env` the way Next does, and Payload
+// refuses to boot without its secret. Same first line as the other scripts.
+import 'dotenv/config'
 import { getPayload } from 'payload'
 
 import config from '../src/payload.config'


### PR DESCRIPTION
One-line fix. `import 'dotenv/config'` — the first line every other script in `scripts/` already has.

A bare `tsx` script does not read `.env` the way Next does, so Payload refused to boot with `missing secret key` when I ran it on the host.

Caught by the **dry run**, which is exactly why the script defaults to dry rather than writing.