### PR TITLE
Survive Stripe refusing the revocation flag on a cancelled subscription

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/access-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/access-revocation.ts
@@ -1,0 +1,85 @@
+import { logger } from '@/shared/utils/logger'
+import { stripe } from './stripe'
+import {
+  ACCESS_REVOKED_METADATA_KEY,
+  ACCESS_REVOKED_METADATA_VALUE,
+  ACCESS_REVOKED_PERIOD_END_METADATA_KEY,
+  ACCESS_REVOKED_REASON_METADATA_KEY,
+  type AccessRevocation,
+} from './subscription-state'
+
+/**
+ * Whether Stripe rejected this write because the subscription is already over.
+ *
+ * Stripe refuses most updates to a `canceled` subscription — "a canceled
+ * subscription can only update its cancellation_details" — and it is not
+ * documented whether a metadata-only update is exempt. Rather than guess, the
+ * error path asks Stripe for the status: if the subscription really is
+ * cancelled, the rejection is the expected one and the caller falls back;
+ * anything else (bad key, wrong account, an outage) still propagates so the
+ * webhook retries instead of quietly writing the wrong entitlement.
+ *
+ * The status check runs only after a failure, so the happy path costs nothing.
+ * If Stripe does allow the write, this branch is simply never taken.
+ */
+async function rejectedForCancelledSubscription(
+  subscriptionId: string,
+  error: unknown
+): Promise<boolean> {
+  if ((error as { type?: string }).type !== 'invalid_request_error') return false
+
+  try {
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+    return subscription.status === 'canceled'
+  } catch {
+    // The status is unknowable, so the original rejection stands unexplained.
+    return false
+  }
+}
+
+/**
+ * Write — or, with `null`, clear — the revocation flag on a Stripe subscription.
+ *
+ * Returns whether the flag actually landed. `false` means the subscription was
+ * already cancelled and Stripe refused the write; the profile still has to be
+ * brought in line, so the caller must pass the same revocation to
+ * `resyncSubscription` as `accessRevoked` rather than letting it re-read the
+ * metadata that was never updated.
+ *
+ * This is the common shape of a refund, not an edge case: support cancels the
+ * subscription and *then* refunds the charge, so `charge.refunded` routinely
+ * arrives against a cancelled subscription. Throwing there would 500 the
+ * webhook, Stripe would retry for three days and never succeed, and the
+ * refunded visitor would keep their access with `paidThroughAt` still sitting
+ * at the period end they were given their money back for.
+ */
+export async function writeAccessRevocation(
+  subscriptionId: string,
+  revocation: AccessRevocation | null
+): Promise<boolean> {
+  try {
+    // Stripe deletes a metadata key when its value is the empty string, so a
+    // restore clears all three in one update.
+    await stripe.subscriptions.update(subscriptionId, {
+      metadata: {
+        [ACCESS_REVOKED_METADATA_KEY]: revocation ? ACCESS_REVOKED_METADATA_VALUE : '',
+        [ACCESS_REVOKED_REASON_METADATA_KEY]: revocation ? revocation.reason : '',
+        [ACCESS_REVOKED_PERIOD_END_METADATA_KEY]:
+          revocation && revocation.periodEnd ? String(revocation.periodEnd) : '',
+      },
+    })
+
+    return true
+  } catch (error) {
+    if (!(await rejectedForCancelledSubscription(subscriptionId, error))) throw error
+
+    logger.warn('Stripe refused the revocation flag on a cancelled subscription', {
+      subscriptionId,
+      revoking: Boolean(revocation),
+      reason: revocation?.reason ?? null,
+      error: error instanceof Error ? error.message : String(error),
+    })
+
+    return false
+  }
+}

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
@@ -12,7 +12,11 @@ import {
 import { stripe } from './stripe'
 import { findLiveSubscription, isLiveSubscription } from './customer-linkage'
 import { getSubscriptionProductName } from './payment-helpers'
-import { deriveSubscriptionState, type DerivedSubscriptionState } from './subscription-state'
+import {
+  deriveSubscriptionState,
+  type AccessRevocation,
+  type DerivedSubscriptionState,
+} from './subscription-state'
 import { resolveMembershipTransitions, type MembershipTransition } from './membership-transitions'
 
 /**
@@ -29,6 +33,15 @@ type ResyncResult = {
   profileId: string | number | null
   state: DerivedSubscriptionState | null
   transitions: MembershipTransition[]
+}
+
+export type ResyncOptions = {
+  /**
+   * Revocation to trust over the subscription's own metadata, for callers that
+   * know the metadata write was refused (a cancelled subscription). `null`
+   * asserts "not revoked"; omit the key entirely to read Stripe as usual.
+   */
+  accessRevoked?: AccessRevocation | null
 }
 
 /** `next_payment_attempt` lives on the invoice, so the grace needs it expanded. */
@@ -163,7 +176,10 @@ async function sendTransitionEmails(
  * atomic, so without the lock two parallel deliveries would each observe the
  * same before-state and each decide the same transition occurred.
  */
-export async function resyncSubscription(subscriptionId: string): Promise<ResyncResult> {
+export async function resyncSubscription(
+  subscriptionId: string,
+  options: ResyncOptions = {}
+): Promise<ResyncResult> {
   const payload = await getPayload({ config })
 
   return withAdvisoryLock(payload, `stripe:subscription:${subscriptionId}`, async () => {
@@ -209,6 +225,9 @@ export async function resyncSubscription(subscriptionId: string): Promise<Resync
     const state = deriveSubscriptionState(subscription, {
       previousDunningGraceUntil: profile.dunningGraceUntil,
       nextPaymentAttempt: nextPaymentAttemptOf(subscription),
+      // Spread so an absent option stays absent: `accessRevoked: undefined`
+      // and `accessRevoked: null` mean different things to the deriver.
+      ...('accessRevoked' in options ? { accessRevoked: options.accessRevoked } : {}),
     })
 
     const transitions = resolveMembershipTransitions(profile, state)

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.test.ts
@@ -262,4 +262,25 @@ describe('deriveSubscriptionState', () => {
       dunningGraceUntil: null,
     })
   })
+
+  // A cancelled subscription will not take the metadata write, so the handler
+  // hands the revocation to the deriver directly instead.
+  it('honours a caller-supplied revocation the subscription never recorded', () => {
+    const active = firstWhere((s) => s.status === 'active' && !s.cancel_at_period_end)
+
+    expect(
+      deriveSubscriptionState(active, {
+        accessRevoked: { reason: 'refund', periodEnd: 2_000 },
+      })
+    ).toMatchObject({ paidThroughAt: null, dunningGraceUntil: null })
+  })
+
+  it('lets an explicit null override a flag still stuck on the subscription', () => {
+    const active = firstWhere((s) => s.status === 'active' && !s.cancel_at_period_end)
+    const revoked = { ...active, metadata: { access_revoked: 'true' } } as Stripe.Subscription
+
+    expect(deriveSubscriptionState(revoked, { accessRevoked: null }).paidThroughAt).toEqual(
+      deriveSubscriptionState(active).paidThroughAt
+    )
+  })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.ts
@@ -44,6 +44,38 @@ export type AccessRevokedReason =
   | typeof ACCESS_REVOKED_REASON_REFUND
   | typeof ACCESS_REVOKED_REASON_DISPUTE
 
+/** A revocation as the rest of the system passes it around, metadata aside. */
+export type AccessRevocation = {
+  reason: AccessRevokedReason
+  periodEnd: number | null
+}
+
+/**
+ * Read the revocation a subscription is carrying, if any.
+ *
+ * A flag written before the reason and period-end keys existed carries neither;
+ * it is read as a refund, matching how `clearRefundRevocationOnNewPeriod`
+ * treats it — a wrongly cleared dispute is corrected by its own `closed` event,
+ * whereas a wrongly kept refund locks a paying visitor out permanently.
+ */
+export function readAccessRevocation(
+  subscription: Stripe.Subscription
+): AccessRevocation | null {
+  const metadata = subscription.metadata ?? {}
+
+  if (metadata[ACCESS_REVOKED_METADATA_KEY] !== ACCESS_REVOKED_METADATA_VALUE) return null
+
+  const periodEnd = Number(metadata[ACCESS_REVOKED_PERIOD_END_METADATA_KEY])
+
+  return {
+    reason:
+      metadata[ACCESS_REVOKED_REASON_METADATA_KEY] === ACCESS_REVOKED_REASON_DISPUTE
+        ? ACCESS_REVOKED_REASON_DISPUTE
+        : ACCESS_REVOKED_REASON_REFUND,
+    periodEnd: Number.isFinite(periodEnd) && periodEnd > 0 ? periodEnd : null,
+  }
+}
+
 const DAY_MS = 24 * 60 * 60 * 1000
 
 /**
@@ -79,6 +111,13 @@ export type DeriveContext = {
    * rather than assuming the fixed window outlasts it.
    */
   nextPaymentAttempt?: number | null
+  /**
+   * Revocation to apply *instead of* the subscription's own metadata, for the
+   * case where Stripe refused the metadata write. `null` asserts "not revoked"
+   * and overrides a flag still sitting on the subscription; omitting the key
+   * reads the metadata as usual. See `payments/lib/access-revocation.ts`.
+   */
+  accessRevoked?: AccessRevocation | null
 }
 
 /**
@@ -233,7 +272,12 @@ export function deriveSubscriptionState(
 ): DerivedSubscriptionState {
   const subscriptionStatus = mapStripeStatusToInternal(subscription.status)
 
-  if (subscription.metadata?.[ACCESS_REVOKED_METADATA_KEY] === ACCESS_REVOKED_METADATA_VALUE) {
+  const revocation =
+    context.accessRevoked !== undefined
+      ? context.accessRevoked
+      : readAccessRevocation(subscription)
+
+  if (revocation) {
     return {
       subscriptionStatus,
       cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -626,6 +626,81 @@ describe('Stripe webhook route', () => {
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
   })
 
+  // Cancel-then-refund is the ordinary refund flow, and Stripe refuses most
+  // updates to a cancelled subscription. Throwing here used to 500 the webhook
+  // forever, leaving the refunded visitor's access and paidThroughAt intact.
+  it('revokes membership even when Stripe refuses the flag on a cancelled subscription', async () => {
+    givenEvent('charge.refunded', {
+      id: 'ch_1',
+      refunded: true,
+      invoice: 'in_1',
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({
+      id: 'in_1',
+      subscription: 'sub_1',
+      lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
+    })
+    mocks.subscriptionUpdate.mockRejectedValue(
+      Object.assign(
+        new Error('A canceled subscription can only update its cancellation_details.'),
+        { type: 'invalid_request_error' },
+      ),
+    )
+    mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'canceled', metadata: {} })
+
+    const response = await POST(createRequest())
+
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1', {
+      accessRevoked: { reason: 'refund', periodEnd: 2_000 },
+    })
+  })
+
+  it('restores membership on a won dispute the cancelled subscription will not record', async () => {
+    givenEvent('charge.dispute.closed', {
+      id: 'dp_1',
+      status: 'won',
+      charge: { id: 'ch_1', invoice: 'in_1' },
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
+    mocks.subscriptionUpdate.mockRejectedValue(
+      Object.assign(
+        new Error('A canceled subscription can only update its cancellation_details.'),
+        { type: 'invalid_request_error' },
+      ),
+    )
+    mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'canceled', metadata: {} })
+
+    const response = await POST(createRequest())
+
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1', { accessRevoked: null })
+  })
+
+  // Only the cancelled-subscription rejection is tolerated. A bad key or a
+  // Stripe outage must still retry rather than write entitlement from a guess.
+  it('fails the webhook when the revocation write is rejected for another reason', async () => {
+    givenEvent('charge.refunded', {
+      id: 'ch_1',
+      refunded: true,
+      invoice: 'in_1',
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({
+      id: 'in_1',
+      subscription: 'sub_1',
+      lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
+    })
+    mocks.subscriptionUpdate.mockRejectedValue(
+      Object.assign(new Error('Invalid API Key provided'), { type: 'invalid_request_error' }),
+    )
+    mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'active', metadata: {} })
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(500)
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
+  })
+
   it('does not resync a refunded charge that is not tied to a subscription', async () => {
     givenEvent('charge.refunded', {
       id: 'ch_1',

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
@@ -1,13 +1,11 @@
 import type Stripe from 'stripe'
+import { writeAccessRevocation } from '@/payments/lib/access-revocation'
 import { stripe } from '@/payments/lib/stripe'
 import { resyncSubscription } from '@/payments/lib/subscription-resync'
 import {
-  ACCESS_REVOKED_METADATA_KEY,
-  ACCESS_REVOKED_METADATA_VALUE,
-  ACCESS_REVOKED_PERIOD_END_METADATA_KEY,
   ACCESS_REVOKED_REASON_DISPUTE,
-  ACCESS_REVOKED_REASON_METADATA_KEY,
   ACCESS_REVOKED_REASON_REFUND,
+  type AccessRevocation,
   type AccessRevokedReason,
 } from '@/payments/lib/subscription-state'
 import { logger } from '@/shared/utils/logger'
@@ -45,22 +43,25 @@ async function chargeFromDispute(dispute: Stripe.Dispute): Promise<Stripe.Charge
   return stripe.charges.retrieve(dispute.charge)
 }
 
-async function markAccessRevoked(
-  subscriptionId: string,
-  revocation: { reason: AccessRevokedReason; periodEnd: number | null } | null
-) {
-  // Stripe deletes a metadata key when its value is the empty string, so a
-  // restore clears all three in one update.
-  await stripe.subscriptions.update(subscriptionId, {
-    metadata: {
-      [ACCESS_REVOKED_METADATA_KEY]: revocation ? ACCESS_REVOKED_METADATA_VALUE : '',
-      [ACCESS_REVOKED_REASON_METADATA_KEY]: revocation ? revocation.reason : '',
-      [ACCESS_REVOKED_PERIOD_END_METADATA_KEY]:
-        revocation && revocation.periodEnd ? String(revocation.periodEnd) : '',
-    },
-  })
+/**
+ * Record the revocation on Stripe, then bring the profile in line with it.
+ *
+ * Stripe is the preferred home for the flag because every later resync refetches
+ * the subscription and would otherwise re-derive access from a period the
+ * visitor was refunded for. But a cancelled subscription will not take the
+ * write, and cancel-then-refund is the ordinary refund flow — so when the write
+ * is refused the revocation is handed straight to the resync instead. The
+ * profile is what gates access, so it ends up correct either way.
+ */
+async function markAccessRevoked(subscriptionId: string, revocation: AccessRevocation | null) {
+  const flagged = await writeAccessRevocation(subscriptionId, revocation)
 
-  await resyncSubscription(subscriptionId)
+  if (flagged) {
+    await resyncSubscription(subscriptionId)
+    return
+  }
+
+  await resyncSubscription(subscriptionId, { accessRevoked: revocation })
 }
 
 async function revokeForCharge(

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/invoice-payment.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/invoice-payment.ts
@@ -1,7 +1,8 @@
 import type Stripe from 'stripe'
 import { logger } from '@/shared/utils/logger'
+import { writeAccessRevocation } from '@/payments/lib/access-revocation'
 import { stripe } from '@/payments/lib/stripe'
-import { resyncSubscription } from '@/payments/lib/subscription-resync'
+import { resyncSubscription, type ResyncOptions } from '@/payments/lib/subscription-resync'
 import {
   ACCESS_REVOKED_METADATA_KEY,
   ACCESS_REVOKED_METADATA_VALUE,
@@ -53,21 +54,26 @@ const NEW_PERIOD_BILLING_REASONS = new Set<Stripe.Invoice.BillingReason>([
  * period end. Those are treated as refunds and cleared: a wrongly cleared
  * dispute is corrected by its own `closed` event, whereas a wrongly kept
  * refund locks a paying visitor out permanently.
+ *
+ * Returns the options the following resync must run with: the clear normally
+ * lands on Stripe and nothing needs overriding, but a subscription cancelled
+ * between the payment and this delivery will not take the write, and the resync
+ * would then re-read the flag this call just decided to lift.
  */
 async function clearRefundRevocationOnNewPeriod(
   invoice: Stripe.Invoice,
   subscriptionId: string
-): Promise<void> {
+): Promise<ResyncOptions> {
   const billingReason = invoice.billing_reason
-  if (!billingReason || !NEW_PERIOD_BILLING_REASONS.has(billingReason)) return
+  if (!billingReason || !NEW_PERIOD_BILLING_REASONS.has(billingReason)) return {}
 
   const subscription = await stripe.subscriptions.retrieve(subscriptionId)
   const metadata = subscription.metadata ?? {}
 
-  if (metadata[ACCESS_REVOKED_METADATA_KEY] !== ACCESS_REVOKED_METADATA_VALUE) return
+  if (metadata[ACCESS_REVOKED_METADATA_KEY] !== ACCESS_REVOKED_METADATA_VALUE) return {}
 
   const reason = metadata[ACCESS_REVOKED_REASON_METADATA_KEY]
-  if (reason && reason !== ACCESS_REVOKED_REASON_REFUND) return
+  if (reason && reason !== ACCESS_REVOKED_REASON_REFUND) return {}
 
   const revokedPeriodEnd = Number(metadata[ACCESS_REVOKED_PERIOD_END_METADATA_KEY])
   const { start: paidPeriodStart } = getSubscriptionPeriodSeconds(subscription)
@@ -78,7 +84,7 @@ async function clearRefundRevocationOnNewPeriod(
     paidPeriodStart !== null &&
     paidPeriodStart < revokedPeriodEnd
   ) {
-    return
+    return {}
   }
 
   logger.warn('Restoring membership: a period after the refunded one was paid', {
@@ -88,13 +94,9 @@ async function clearRefundRevocationOnNewPeriod(
     paidPeriodStart,
   })
 
-  await stripe.subscriptions.update(subscriptionId, {
-    metadata: {
-      [ACCESS_REVOKED_METADATA_KEY]: '',
-      [ACCESS_REVOKED_REASON_METADATA_KEY]: '',
-      [ACCESS_REVOKED_PERIOD_END_METADATA_KEY]: '',
-    },
-  })
+  const cleared = await writeAccessRevocation(subscriptionId, null)
+
+  return cleared ? {} : { accessRevoked: null }
 }
 
 export async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
@@ -108,7 +110,12 @@ export async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
   }
 
   // Before the resync, so the state it derives already reflects the cleared flag.
-  await clearRefundRevocationOnNewPeriod(invoice, subscriptionId)
+  const resyncOptions = await clearRefundRevocationOnNewPeriod(invoice, subscriptionId)
+
+  if ('accessRevoked' in resyncOptions) {
+    await resyncSubscription(subscriptionId, resyncOptions)
+    return
+  }
 
   await resyncSubscription(subscriptionId)
 }


### PR DESCRIPTION
## Why

Revocation records itself by writing `access_revoked` onto the Stripe subscription, so every later resync re-derives entitlement from the flag rather than from a period the visitor was refunded for.

Stripe refuses most updates to a **cancelled** subscription — *"a canceled subscription can only update its cancellation_details"* — and cancel-then-refund is the ordinary refund flow. Support cancels the subscription, *then* refunds the charge, so `charge.refunded` routinely arrives against a subscription that will not take the write.

`markAccessRevoked` threw there. The webhook 500s, Stripe retries for ~3 days and never succeeds, and the refunded visitor keeps their access with `paidThroughAt` still sitting at the period end they were given their money back for.

The update endpoint's docs do not state whether a metadata-only update is exempt, and every test mocked the call, so it was untested against the real API.

## What

**`payments/lib/access-revocation.ts` (new)** — `writeAccessRevocation(subId, revocation) -> boolean`. Rather than guessing whether metadata-only updates are exempt, it finds out at runtime: on an `invalid_request_error` it retrieves the subscription and checks `status === 'canceled'`.

- cancelled → tolerate, warn, return `false`
- anything else (bad key, wrong account, outage) → rethrow, so the webhook still retries instead of writing entitlement from a guess

The status check runs only on the error path, so the happy path costs nothing. **If Stripe does allow the write, this branch is never taken and behaviour is unchanged.**

**Carrying the revocation past Stripe.** `DeriveContext.accessRevoked` and `ResyncOptions.accessRevoked` let a caller that knows the write was refused hand the revocation to `deriveSubscriptionState` directly, so the profile — which is what actually gates access — ends up correct either way. `undefined` reads the metadata as before; `null` asserts *not revoked*, which the won-dispute restore needs in order to override a flag stuck on the subscription. The option is only passed when the write was refused, so existing `resyncSubscription(id)` call sites are untouched.

**`invoice-payment.ts` had the same exposure.** `clearRefundRevocationOnNewPeriod` also called `subscriptions.update`, and the duplicate-checkout collapse deliberately cancels and refunds the extra subscriptions it creates — so a late `invoice.payment_succeeded` can hit a cancelled one. It now returns `ResyncOptions` instead of `void`.

Also extracted `readAccessRevocation()` (pure) into `subscription-state.ts`; the deriver reads through it instead of poking `metadata` inline.

## Known gap, deliberately not closed here

The override is **one-shot**. The revocation lives only in Stripe metadata, so when that write is refused nothing durable records it. A later resync of the same cancelled subscription — realistically a retried earlier `invoice.payment_succeeded` delivery landing after the refund — re-derives from flagless metadata and restores `paidThroughAt`.

Narrow (cancelled subs emit nothing new; only the ~3-day retry window replays), but the cancelled path is the *common* refund flow, so it is not exotic either. Closing it means revocation columns on `visitor_profiles` read by the deriver, plus moving the lift logic out of `clearRefundRevocationOnNewPeriod` — a schema change, kept out of a fix whose job is to stop the retry loop.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm vitest run` — **815 passed / 104 files**, 5 new tests
- No migrations, no Payload collections or fields touched

New coverage: revocation survives the cancelled-subscription rejection; won-dispute restore works when the clear is refused; a *non*-cancellation rejection still 500s the webhook; deriver honours a caller-supplied revocation and an explicit `null` override.