### PR TITLE
Fail the checkout webhook when a duplicate refund fails

### DIFF
--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -743,6 +743,30 @@ describe('Stripe webhook route', () => {
     expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
   })
 
+  it('leaves the duplicate subscription alive when its refund fails', async () => {
+    givenEvent('checkout.session.completed', {
+      id: 'cs_refund_fail',
+      customer: 'cus_1',
+      subscription: 'sub_new',
+    })
+    mocks.subscriptionList.mockResolvedValue({
+      data: [
+        { id: 'sub_old', status: 'active', created: 100, latest_invoice: 'in_old' },
+        { id: 'sub_new', status: 'active', created: 200, latest_invoice: 'in_new' },
+      ],
+    })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_new', payment_intent: 'pi_new' })
+    mocks.refundCreate.mockRejectedValueOnce(new Error('Stripe unavailable'))
+
+    const response = await POST(createRequest())
+
+    // Cancelling anyway would leave the customer charged, cancelled and
+    // un-refunded. Fail the delivery so Stripe retries the refund instead.
+    expect(response.status).toBe(500)
+    expect(mocks.subscriptionCancel).not.toHaveBeenCalled()
+    expect(mocks.resyncSubscription).not.toHaveBeenCalled()
+  })
+
   it('keeps the paid subscription when an older one was abandoned at 3DS', async () => {
     givenEvent('checkout.session.completed', {
       id: 'cs_3',

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -76,7 +76,11 @@ async function refundDuplicateSubscription(subscription: Stripe.Subscription) {
       invoiceId,
       error: error instanceof Error ? error.message : String(error),
     })
-    return
+    // Swallowing this would let the caller cancel the subscription anyway,
+    // leaving the customer charged, cancelled and un-refunded. The refund is
+    // keyed idempotently, so throwing lets Stripe redeliver the event and retry
+    // the whole collapse without double-refunding.
+    throw error
   }
 
   logger.error('Duplicate subscription cancelled but no charge was found to refund', {


### PR DESCRIPTION
## Why

`refundDuplicateSubscription` caught a `refunds.create` failure, logged it and returned. `collapseDuplicateSubscriptions` then cancelled the subscription anyway. A customer whose refund call failed came out charged, cancelled and un-refunded — recorded only in a log line.

## What

Rethrow after logging. The extras loop aborts before `subscriptions.cancel`, the webhook 500s, and Stripe redelivers the event. The refund uses idempotency key `dup-sub-refund-<subId>`, so the retry replays the cached refund instead of issuing a second one.

The separate "no charge found to refund" path is unchanged — nothing was collected there, so cancelling is still correct.

## Trade-off

A permanently failing refund (e.g. the charge was refunded out-of-band under a different key) now blocks the whole collapse until Stripe exhausts retries: the extra subscription stays live and the kept one is never resynced. Deliberate — loud failure over silent money loss. Worth watching in webhook failure alerts.

## Verification

`pnpm vitest run src/features/payments/stripe-webhook.route.test.ts` — 42 passed (41 before).

New regression test: *leaves the duplicate subscription alive when its refund fails* — asserts 500, no `subscriptions.cancel`, no resync.

No database change: the diff is a webhook handler and its test, no Payload collections or fields.