### PR TITLE
Stop copying the visitor email into Stripe metadata

### DIFF
--- a/apps/questura/apps/server/scripts/capture-membership-fixtures.ts
+++ b/apps/questura/apps/server/scripts/capture-membership-fixtures.ts
@@ -138,7 +138,7 @@ async function drive(): Promise<{ subscriptionId: string; customerId: string; st
   const subscription = await stripe.subscriptions.create({
     customer: customer.id,
     items: [{ price: price.id }],
-    metadata: { visitorAuthUserId: 'fixture-auth-user', visitorEmail: customer.email ?? '' },
+    metadata: { visitorAuthUserId: 'fixture-auth-user' },
   })
   log('paid', `subscription ${subscription.id} status=${subscription.status}`)
 

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -149,10 +149,15 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // 6. Build metadata including optional affiliate referral
+    // 6. Build metadata including optional affiliate referral.
+    //
+    // `visitorAuthUserId` is the only identity Stripe needs: it is what
+    // ownership is resolved by everywhere (see `resolveStripeCustomerForVisitor`),
+    // and the address itself already lives on the Stripe customer. Carrying the
+    // email as well only copies PII into a field that surfaces in Dashboard
+    // exports, event payloads, and webhook logs.
     const metadata: Record<string, string> = {
       visitorAuthUserId,
-      visitorEmail: visitor.email,
     }
 
     if (referralId) {

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -140,4 +140,14 @@ describe('create checkout session referral ID validation', () => {
 
     expect(metadata).not.toHaveProperty('endorsely_referral')
   })
+
+  // Identity travels as the auth user ID alone. The address is on the Stripe
+  // customer already, and metadata is the copy that leaks into exports and logs.
+  it('keeps the visitor email out of Stripe metadata', async () => {
+    const metadata = await metadataForBody({})
+
+    expect(metadata.visitorAuthUserId).toBe('visitor_123')
+    expect(metadata).not.toHaveProperty('visitorEmail')
+    expect(JSON.stringify(metadata)).not.toContain('@')
+  })
 })


### PR DESCRIPTION
## What

Drops `visitorEmail` from the metadata sent on `checkout.sessions.create` (and the `subscription_data.metadata` that mirrors it).

## Why

`visitorAuthUserId` is the only identity Stripe needs — it is what ownership is resolved by everywhere (`resolveStripeCustomerForVisitor`, the revocation handlers, the customer-linkage audit). The email address already lives on the Stripe customer object. Sending it as metadata as well only copies PII into a field that shows up in Dashboard exports, raw event payloads, and webhook logs.

## Blast radius

Nothing reads `metadata.visitorEmail`. Grep across the repo found exactly three references:

- `create-checkout-session/route.ts` — the write, removed here
- `scripts/capture-membership-fixtures.ts` — updated
- `__fixtures__/membership-lifecycle.events.json` — **left intact on purpose.** That file is a recording of events Stripe actually sent; rewriting it to match code that did not exist at capture time would make it a worse fixture. The addresses in it are synthetic (`fixture+…@questurian.test`).

Only affects *new* sessions. Metadata already written to existing customers and subscriptions in Stripe is unchanged — scrubbing that back-catalogue is a separate decision.

## Verification

- `pnpm vitest run src/features/payments` — 13 files, 178 tests pass
- `pnpm tsc --noEmit` — clean
- New regression test asserts metadata carries `visitorAuthUserId`, has no `visitorEmail`, and contains no `@` at all