### PR TITLE
Give checkout.sessions.create an idempotency key

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -7,6 +7,7 @@ import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-pri
 import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
 import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 import { safeReturnPath } from '@/payments/lib/safe-return-path'
+import { checkoutIdempotencyKey } from '@/payments/lib/checkout-idempotency'
 import {
   findVisitorProfileByAuthUserId,
   updateVisitorProfileByAuthUserId,
@@ -162,6 +163,24 @@ export async function POST(req: NextRequest) {
     // 7. Create checkout session for subscription
     logger.info('Creating checkout session', { plan })
 
+    const successUrl = APP_URLS.frontendUrl(
+      `/subscription/success?session_id={CHECKOUT_SESSION_ID}&returnTo=${encodeURIComponent(returnTo)}`,
+    )
+    const cancelUrl = APP_URLS.frontendUrl('/subscription/cancel')
+
+    // A double-clicked buy button otherwise creates two sessions on the same
+    // customer. The key is derived from the request rather than the visitor
+    // alone, because Stripe refuses a reused key whose parameters changed — see
+    // `checkout-idempotency.ts` for why it is also time-bucketed.
+    const idempotencyKey = checkoutIdempotencyKey({
+      visitorAuthUserId,
+      customerId: stripeCustomerId,
+      priceId,
+      successUrl,
+      cancelUrl,
+      referralId,
+    })
+
     const session = await stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: 'subscription', // KEY: subscription mode, not payment
@@ -169,17 +188,15 @@ export async function POST(req: NextRequest) {
         price: priceId,
         quantity: 1
       }],
-      success_url: APP_URLS.frontendUrl(
-        `/subscription/success?session_id={CHECKOUT_SESSION_ID}&returnTo=${encodeURIComponent(returnTo)}`,
-      ),
-      cancel_url: APP_URLS.frontendUrl('/subscription/cancel'),
+      success_url: successUrl,
+      cancel_url: cancelUrl,
       metadata,
       allow_promotion_codes: true, // Optional: allow discount codes
       billing_address_collection: 'auto', // Optional: collect billing address
       subscription_data: {
         metadata // Also add metadata to subscription object
       }
-    })
+    }, { idempotencyKey })
 
     logger.info('Created checkout session')
 

--- a/apps/questura/apps/server/src/features/payments/checkout-idempotency.test.ts
+++ b/apps/questura/apps/server/src/features/payments/checkout-idempotency.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHECKOUT_IDEMPOTENCY_WINDOW_MS,
+  checkoutIdempotencyKey,
+  type CheckoutIdempotencyInput,
+} from '@/payments/lib/checkout-idempotency'
+
+const BASE: CheckoutIdempotencyInput = {
+  visitorAuthUserId: 'visitor_123',
+  customerId: 'cus_123',
+  priceId: 'price_monthly',
+  successUrl: 'https://questurian.com/subscription/success?returnTo=%2Fcity',
+  cancelUrl: 'https://questurian.com/subscription/cancel',
+  referralId: null,
+}
+
+/**
+ * Anchored to the start of a bucket, not to an arbitrary instant. A mid-bucket
+ * anchor makes "now + window - 1ms" straddle the boundary, which would make the
+ * replay assertions depend on where in the bucket the constant happened to land.
+ */
+const BUCKET_START =
+  Math.floor(1_760_000_000_000 / CHECKOUT_IDEMPOTENCY_WINDOW_MS) * CHECKOUT_IDEMPOTENCY_WINDOW_MS
+
+function keyAt(overrides: Partial<CheckoutIdempotencyInput>, now = BUCKET_START) {
+  return checkoutIdempotencyKey({ ...BASE, ...overrides }, now)
+}
+
+describe('checkoutIdempotencyKey', () => {
+  // The whole point of bucketing: Stripe replays a key for 24h and a Checkout
+  // Session expires in about the same time, so an unbucketed key could hand a
+  // returning visitor a session that is already dead.
+  it('replays for the whole window and no longer', () => {
+    const first = keyAt({})
+
+    expect(keyAt({}, BUCKET_START + 1)).toBe(first)
+    expect(keyAt({}, BUCKET_START + CHECKOUT_IDEMPOTENCY_WINDOW_MS - 1)).toBe(first)
+    expect(keyAt({}, BUCKET_START + CHECKOUT_IDEMPOTENCY_WINDOW_MS)).not.toBe(first)
+  })
+
+  it('keeps the replay window far shorter than a session’s ~24h expiry', () => {
+    expect(CHECKOUT_IDEMPOTENCY_WINDOW_MS).toBeLessThan(60 * 60 * 1000)
+  })
+
+  // Stripe rejects a reused key whose request body changed, so anything the
+  // caller can vary has to move the key. Each of these would be a hard 500
+  // otherwise.
+  it.each([
+    ['a different plan', { priceId: 'price_yearly' }],
+    ['a different return path', { successUrl: 'https://questurian.com/subscription/success?returnTo=%2Fother' }],
+    ['a different cancel URL', { cancelUrl: 'https://questurian.com/elsewhere' }],
+    ['a referral appearing', { referralId: 'ref_abc' }],
+    ['a different customer', { customerId: 'cus_other' }],
+    ['a different visitor', { visitorAuthUserId: 'visitor_999' }],
+  ] as const)('produces a different key for %s', (_label, overrides) => {
+    expect(keyAt(overrides)).not.toBe(keyAt({}))
+  })
+
+  it('does not collide when a field value straddles the separator', () => {
+    expect(keyAt({ visitorAuthUserId: 'a', customerId: 'b' })).not.toBe(
+      keyAt({ visitorAuthUserId: 'ab', customerId: '' })
+    )
+  })
+
+  it('stays inside Stripe’s 255-character key limit', () => {
+    const key = keyAt({ referralId: 'x'.repeat(100) })
+
+    expect(key.length).toBeLessThanOrEqual(255)
+    expect(key.startsWith('checkout:')).toBe(true)
+  })
+
+  it('leaks no identifiers into the key itself', () => {
+    const key = keyAt({ referralId: 'ref_abc' })
+
+    expect(key).not.toContain('visitor_123')
+    expect(key).not.toContain('cus_123')
+    expect(key).not.toContain('ref_abc')
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -120,7 +120,8 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     })
     expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_existing' })
+      expect.objectContaining({ customer: 'cus_existing' }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 
@@ -148,7 +149,8 @@ describe('create checkout session duplicate Stripe customer guard', () => {
 
     expect(mocks.stripeCustomerCreate).toHaveBeenCalledTimes(1)
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_new' })
+      expect.objectContaining({ customer: 'cus_new' }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
     expect(mocks.updateVisitorProfileByAuthUserId).toHaveBeenCalledWith('visitor_123', {
       stripeCustomerId: 'cus_new',
@@ -166,7 +168,8 @@ describe('create checkout session duplicate Stripe customer guard', () => {
 
     expect(mocks.stripeCustomerCreate).toHaveBeenCalledTimes(1)
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_new' })
+      expect.objectContaining({ customer: 'cus_new' }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 
@@ -185,7 +188,8 @@ describe('create checkout session duplicate Stripe customer guard', () => {
 
     expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_mine' })
+      expect.objectContaining({ customer: 'cus_mine' }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 
@@ -219,7 +223,8 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     expect(response.status).toBe(200)
     expect(mocks.stripeCustomerCreate).toHaveBeenCalledTimes(1)
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_new' })
+      expect.objectContaining({ customer: 'cus_new' }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
     expect(mocks.updateVisitorProfileByAuthUserId).toHaveBeenCalledWith('visitor_123', {
       stripeCustomerId: 'cus_new',
@@ -238,7 +243,8 @@ describe('create checkout session duplicate Stripe customer guard', () => {
     expect(mocks.stripeCustomerList).not.toHaveBeenCalled()
     expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_linked' })
+      expect.objectContaining({ customer: 'cus_linked' }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 })

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -175,6 +175,7 @@ describe('create checkout session route auth guard', () => {
         mode: 'subscription',
         line_items: [{ price: 'price_123', quantity: 1 }],
       }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 
@@ -189,6 +190,7 @@ describe('create checkout session route auth guard', () => {
 
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({ line_items: [{ price: 'price_123', quantity: 1 }] }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 
@@ -205,6 +207,7 @@ describe('create checkout session route auth guard', () => {
 
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({ line_items: [{ price: 'price_yearly_123', quantity: 1 }] }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 
@@ -219,6 +222,7 @@ describe('create checkout session route auth guard', () => {
 
     expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
       expect.objectContaining({ line_items: [{ price: 'price_123', quantity: 1 }] }),
+      expect.objectContaining({ idempotencyKey: expect.stringMatching(/^checkout:[0-9a-f]{64}$/) }),
     )
   })
 

--- a/apps/questura/apps/server/src/features/payments/lib/checkout-idempotency.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/checkout-idempotency.ts
@@ -1,0 +1,76 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Idempotency keys for `checkout.sessions.create`.
+ *
+ * Without a key, a double-clicked buy button creates two Checkout Sessions on
+ * the same customer. Only one can be paid — `findLiveSubscription` blocks the
+ * second — but the stray session still lands in the Dashboard and still has to
+ * be reasoned about. A key collapses the retry at Stripe instead.
+ *
+ * Two properties matter, and they pull against each other:
+ *
+ *  1. **The key must cover every parameter that varies.** Stripe rejects a
+ *     reused key whose request body differs from the first ("Keys for
+ *     idempotent requests can only be used with the same parameters"). `plan`,
+ *     `returnTo` (which lands in `success_url`) and the affiliate referral are
+ *     all caller-influenced, so a key built from the visitor alone would turn a
+ *     visitor who opened checkout from two different pages into a hard 500.
+ *     Hashing the request itself makes a genuinely different request a
+ *     genuinely different key.
+ *
+ *  2. **The key must expire well before the session does.** Stripe replays a
+ *     key for 24h and returns *the original object*. A Checkout Session also
+ *     expires after ~24h, so a visitor who abandoned checkout and came back
+ *     later could be handed back a session that is already expired — a pay
+ *     button that goes nowhere, with nothing in the logs to say why. The time
+ *     bucket keeps the replay window far shorter than the session lifetime.
+ *
+ * Five minutes is comfortably longer than any double-click or retry storm and
+ * far shorter than the session's own expiry.
+ */
+export const CHECKOUT_IDEMPOTENCY_WINDOW_MS = 5 * 60 * 1000
+
+/** The request fields that must produce a different session when they differ. */
+export type CheckoutIdempotencyInput = {
+  visitorAuthUserId: string
+  customerId: string
+  priceId: string
+  successUrl: string
+  cancelUrl: string
+  referralId: string | null
+}
+
+/**
+ * A stable key for one logical checkout attempt.
+ *
+ * `now` is injectable so tests can sit on a bucket boundary rather than sleep
+ * through one.
+ */
+export function checkoutIdempotencyKey(
+  input: CheckoutIdempotencyInput,
+  now: number = Date.now()
+): string {
+  const bucket = Math.floor(now / CHECKOUT_IDEMPOTENCY_WINDOW_MS)
+
+  // Field order is fixed here rather than left to JSON key order so the digest
+  // cannot drift if the input type is later reordered. NUL joins the fields
+  // because it is the one byte none of them can contain — a printable separator
+  // would let two different inputs collide by straddling it.
+  const fingerprint = createHash('sha256')
+    .update(
+      [
+        input.visitorAuthUserId,
+        input.customerId,
+        input.priceId,
+        input.successUrl,
+        input.cancelUrl,
+        input.referralId ?? '',
+        String(bucket),
+      ].join('\u0000')
+    )
+    .digest('hex')
+
+  // Stripe caps idempotency keys at 255 chars; this is a fixed 73.
+  return `checkout:${fingerprint}`
+}


### PR DESCRIPTION
## What

Adds an idempotency key to `stripe.checkout.sessions.create`, derived in a new `payments/lib/checkout-idempotency.ts`.

## Why

A double-clicked buy button creates two Checkout Sessions on the same customer. Only one can ever be paid — the `findLiveSubscription` guard blocks the second — but the stray session still lands in the Dashboard and still has to be reasoned about later.

## Two design points worth reviewing

**The key hashes the request, not the visitor.** Stripe rejects a reused key whose request body differs ("Keys for idempotent requests can only be used with the same parameters they were first used with"). `plan`, `returnTo` (which lands in `success_url`) and the affiliate referral are all caller-influenced. A key like `checkout:{visitorAuthUserId}:{plan}` would therefore turn *"visitor opened checkout from two different pages within the window"* into a hard 500 on a live pay button. Hashing the parameters makes a genuinely different request a genuinely different key.

**The key is time-bucketed to 5 minutes.** Stripe replays a key for 24h and returns *the original object*. A Checkout Session also expires after ~24h. An unbucketed key could hand a returning visitor back a session that has already expired — a pay button that goes nowhere, with nothing in the logs to say why. Five minutes is far longer than any double-click and far shorter than the session's own lifetime.

The digest joins fields on a NUL byte so two different inputs cannot collide by straddling the separator, and the key carries no identifiers in the clear.

## Blast radius

Behaviour is unchanged for every non-duplicate request. The one visible change is that ten existing assertions on `stripeCheckoutCreate` had to learn about the second argument — `toHaveBeenCalledWith` matches the full argument list, so they would have failed otherwise. Those are mechanical additions of `expect.objectContaining({ idempotencyKey: … })`.

## Verification

- `pnpm vitest run src/features/payments` — 14 files, 188 tests pass (10 new)
- `pnpm tsc --noEmit` — clean
- New tests cover: replay across the whole window and not past it, a different key for each of the six varying inputs, separator-straddling collision, the 255-char Stripe limit, and that no identifier leaks into the key
