### PR TITLE
Make the Checkout promotion-code box opt-in

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -173,6 +173,11 @@ export async function POST(req: NextRequest) {
     )
     const cancelUrl = APP_URLS.frontendUrl('/subscription/cancel')
 
+    // Off unless deliberately enabled: `allow_promotion_codes` opens *every*
+    // active code in the Stripe account to anyone on any plan, so one
+    // unrestricted 100%-off code is a free membership for whoever learns it.
+    const allowPromotionCodes = APP_CONFIG.features.stripePromotionCodes
+
     // A double-clicked buy button otherwise creates two sessions on the same
     // customer. The key is derived from the request rather than the visitor
     // alone, because Stripe refuses a reused key whose parameters changed — see
@@ -184,6 +189,7 @@ export async function POST(req: NextRequest) {
       successUrl,
       cancelUrl,
       referralId,
+      allowPromotionCodes,
     })
 
     const session = await stripe.checkout.sessions.create({
@@ -196,7 +202,7 @@ export async function POST(req: NextRequest) {
       success_url: successUrl,
       cancel_url: cancelUrl,
       metadata,
-      allow_promotion_codes: true, // Optional: allow discount codes
+      allow_promotion_codes: allowPromotionCodes,
       billing_address_collection: 'auto', // Optional: collect billing address
       subscription_data: {
         metadata // Also add metadata to subscription object

--- a/apps/questura/apps/server/src/features/payments/checkout-idempotency.test.ts
+++ b/apps/questura/apps/server/src/features/payments/checkout-idempotency.test.ts
@@ -12,6 +12,7 @@ const BASE: CheckoutIdempotencyInput = {
   successUrl: 'https://questurian.com/subscription/success?returnTo=%2Fcity',
   cancelUrl: 'https://questurian.com/subscription/cancel',
   referralId: null,
+  allowPromotionCodes: false,
 }
 
 /**
@@ -50,6 +51,7 @@ describe('checkoutIdempotencyKey', () => {
     ['a different return path', { successUrl: 'https://questurian.com/subscription/success?returnTo=%2Fother' }],
     ['a different cancel URL', { cancelUrl: 'https://questurian.com/elsewhere' }],
     ['a referral appearing', { referralId: 'ref_abc' }],
+    ['promotion codes being enabled', { allowPromotionCodes: true }],
     ['a different customer', { customerId: 'cus_other' }],
     ['a different visitor', { visitorAuthUserId: 'visitor_999' }],
   ] as const)('produces a different key for %s', (_label, overrides) => {

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.promotion-codes.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.promotion-codes.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  requireVisitorPrincipal: vi.fn(),
+  findVisitorProfileByAuthUserId: vi.fn(),
+  updateVisitorProfileByAuthUserId: vi.fn(),
+  stripeCustomerCreate: vi.fn(),
+  stripeCustomerList: vi.fn(),
+  stripeSubscriptionList: vi.fn(),
+  stripeCheckoutCreate: vi.fn(),
+  // Mutable so a single suite can exercise both sides of the flag; the config
+  // module is read at request time, not captured at import.
+  features: { endorselyAffiliates: false, stripePromotionCodes: false },
+}))
+
+vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
+  requireVisitorPrincipal: mocks.requireVisitorPrincipal,
+}))
+
+vi.mock('@/features/visitor-auth/lib/visitor-profile', () => ({
+  findVisitorProfileByAuthUserId: mocks.findVisitorProfileByAuthUserId,
+  updateVisitorProfileByAuthUserId: mocks.updateVisitorProfileByAuthUserId,
+}))
+
+vi.mock('@/payments/lib/stripe', () => ({
+  stripe: {
+    customers: { create: mocks.stripeCustomerCreate, list: mocks.stripeCustomerList },
+    subscriptions: { list: mocks.stripeSubscriptionList },
+    checkout: { sessions: { create: mocks.stripeCheckoutCreate } },
+  },
+}))
+
+vi.mock('@/payments/lib/payments-rate-limit', () => ({
+  checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  paymentsRateLimitResponse: vi.fn(),
+}))
+
+vi.mock('@/shared/config', () => ({
+  APP_CONFIG: {
+    CORS_ORIGINS: ['http://localhost:3000'],
+    features: mocks.features,
+    stripe: {
+      priceId: 'price_123',
+      monthlyPriceId: 'price_123',
+      yearlyPriceId: 'price_yearly_123',
+    },
+  },
+  APP_URLS: {
+    frontend: 'http://localhost:3000',
+    frontendUrl: (path: string) => `http://localhost:3000${path}`,
+  },
+}))
+
+import { POST } from '@/app/api/payments/create-checkout-session/route'
+
+let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
+
+function createRequest() {
+  return new Request('http://localhost:4000/api/payments/create-checkout-session', {
+    method: 'POST',
+    headers: { origin: 'http://localhost:3000', 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  }) as any
+}
+
+async function sessionParams() {
+  const response = await POST(createRequest())
+  expect(response.status).toBe(200)
+  return mocks.stripeCheckoutCreate.mock.calls[0]
+}
+
+describe('create checkout session promotion codes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.features.stripePromotionCodes = false
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'none',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeCheckoutCreate.mockResolvedValue({
+      id: 'cs_123',
+      url: 'https://checkout.stripe.test/session',
+    })
+  })
+
+  afterEach(() => {
+    consoleLogSpy?.mockRestore()
+    consoleLogSpy = null
+  })
+
+  // The default matters more than the toggle: `allow_promotion_codes: true`
+  // exposes every active code in the account, so an unrestricted 100%-off code
+  // becomes a free membership for anyone who learns it.
+  it('does not offer the promotion code box by default', async () => {
+    const [params] = await sessionParams()
+
+    expect(params.allow_promotion_codes).toBe(false)
+  })
+
+  it('offers the promotion code box once the flag is enabled', async () => {
+    mocks.features.stripePromotionCodes = true
+
+    const [params] = await sessionParams()
+
+    expect(params.allow_promotion_codes).toBe(true)
+  })
+
+  // The flag changes the request body Stripe sees, and Stripe rejects a reused
+  // idempotency key whose parameters changed. A deploy that flips the flag
+  // inside one replay window would 500 the pay button if the key ignored it.
+  it('changes the idempotency key when the flag flips', async () => {
+    const [, offOptions] = await sessionParams()
+
+    vi.clearAllMocks()
+    mocks.stripeCheckoutCreate.mockResolvedValue({
+      id: 'cs_123',
+      url: 'https://checkout.stripe.test/session',
+    })
+    mocks.features.stripePromotionCodes = true
+
+    const [, onOptions] = await sessionParams()
+
+    expect(offOptions.idempotencyKey).not.toBe(onOptions.idempotencyKey)
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/checkout-idempotency.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/checkout-idempotency.ts
@@ -39,6 +39,7 @@ export type CheckoutIdempotencyInput = {
   successUrl: string
   cancelUrl: string
   referralId: string | null
+  allowPromotionCodes: boolean
 }
 
 /**
@@ -66,6 +67,7 @@ export function checkoutIdempotencyKey(
         input.successUrl,
         input.cancelUrl,
         input.referralId ?? '',
+        String(input.allowPromotionCodes),
         String(bucket),
       ].join('\u0000')
     )

--- a/apps/questura/apps/server/src/shared/config/index.ts
+++ b/apps/questura/apps/server/src/shared/config/index.ts
@@ -117,6 +117,13 @@ export const APP_CONFIG = {
     emailTracking: process.env.EMAIL_TRACKING !== 'false',
     enforcePasswordStrength: process.env.ENFORCE_PASSWORD_STRENGTH !== 'false',
     endorselyAffiliates: process.env.ENDORSELY_ENABLED === 'true',
+    // Whether Checkout shows the "add promotion code" box. Opt-in, because
+    // `allow_promotion_codes: true` makes *every* active code in the Stripe
+    // account redeemable by anyone on any plan — a single unrestricted 100%-off
+    // code is a permanent free membership for whoever learns it. Turn this on
+    // deliberately, once the live codes carry their own restrictions
+    // (`first_time_transaction`, an applies-to price, a redemption cap).
+    stripePromotionCodes: process.env.STRIPE_PROMOTION_CODES === 'true',
     homepageFeaturedAllowDrafts: process.env.HOMEPAGE_FEATURED_ALLOW_DRAFTS === 'true',
   },
 


### PR DESCRIPTION
## What

Puts `allow_promotion_codes` behind a feature flag, `STRIPE_PROMOTION_CODES`, **default off**.

## Why

`allow_promotion_codes: true` is not a per-session scoping mechanism — it opens *every active promotion code in the Stripe account* to whoever is at the Checkout page, on either plan. There is nothing in the session that limits which code applies. So the safety of the setting is entirely a property of how well every code in the account is restricted, and one unrestricted code undoes it.

A live audit of the account found exactly that shape: an active code with `percent_off: 100`, `duration: forever`, `first_time_transaction: false`, no minimum amount, 24 of 25 redemptions remaining. That is a permanent free membership for anyone who learns the code.

## ⚠️ Deploy note — this changes live behaviour

The account owner has confirmed the 100%-off code is a **deliberate test coupon** for the live-like environment and is staying active until testing finishes. Merging this PR with the default will therefore **remove the promo-code box from Checkout and make that coupon unusable** on the soft-prod host.

To keep testing it, set on the host before/with the deploy:

```
STRIPE_PROMOTION_CODES=true
```

Then drop the variable (or set it to `false`) at the serverless cutover, once live codes carry their own restrictions — `first_time_transaction`, an applies-to price, and a redemption cap.

## Interaction with the idempotency key (#316)

`allow_promotion_codes` is now a request parameter that varies, so it is folded into `CheckoutIdempotencyInput`. Stripe rejects a reused idempotency key whose parameters changed; without this, a deploy that flipped the flag inside one five-minute replay window would return a hard error on a live pay button. A test covers exactly that flip.

## Verification

- `pnpm vitest run src/features/payments` — 15 files, 193 tests pass (5 new)
- `pnpm tsc --noEmit` — clean
- New `create-checkout-session.promotion-codes.test.ts` asserts the box is off by default, on when the flag is set, and that the key changes when the flag flips
