### PR TITLE
Make the handled Stripe event set checkable against the live endpoint

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -18,6 +18,7 @@
     "db:migrate:status": "cross-env NODE_OPTIONS=--no-deprecation payload migrate:status",
     "reconcile:stripe-profiles": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/reconcile-stripe-visitor-profiles.ts",
     "audit:access-revocations": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/audit-access-revocations.ts",
+    "verify:stripe-webhook-events": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/verify-stripe-webhook-events.ts",
     "set:itinerary-access": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/set-itinerary-access.ts",
     "capture:membership-fixtures": "bun scripts/capture-membership-fixtures.ts",
     "inventory:tour-agency": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/inventory-tour-agency-stops.ts",

--- a/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
+++ b/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
@@ -1,0 +1,128 @@
+/**
+ * Verify: the live webhook endpoint sends everything this app handles
+ *
+ * Why this exists
+ * ---------------
+ * A webhook handler only runs if Stripe is configured to send its event, and
+ * nothing in the codebase can see that configuration. `charge.refunded` and
+ * `charge.dispute.*` were handled, tested and deployed for months while the
+ * live endpoint had never had them enabled: every refund and every chargeback
+ * silently left the visitor's access intact. No test could have caught it,
+ * because the code was correct — the gap was in the Dashboard.
+ *
+ * This closes the loop from the other side. It reads the enabled events off the
+ * live endpoint and diffs them against `HANDLED_STRIPE_EVENT_TYPES`, which is
+ * derived from the dispatch map itself rather than written down a second time.
+ *
+ * What it reports
+ * ---------------
+ *   MISSING    Handled in code, not enabled on the endpoint. The handler is
+ *              dead. This is the failure this script exists to find.
+ *   EXTRA      Enabled on the endpoint, not handled in code. Harmless — it hits
+ *              the "Unhandled Stripe event type" log — but usually means either
+ *              a deliberate decision worth recording in
+ *              DELIBERATELY_UNHANDLED_STRIPE_EVENTS, or a half-finished change.
+ *   DISABLED   An endpoint whose status is not `enabled`. Reported so a
+ *              correctly-configured but switched-off endpoint cannot look like
+ *              a pass.
+ *
+ * Safety
+ * ------
+ * Read-only. Issues GET requests to Stripe and writes nothing, anywhere. Safe
+ * against a live key.
+ *
+ * Usage:
+ *   STRIPE_SECRET_KEY=... pnpm tsx scripts/verify-stripe-webhook-events.ts
+ *
+ * Exits non-zero if any enabled endpoint is missing a handled event, so it can
+ * gate a deploy.
+ */
+
+import Stripe from 'stripe'
+import {
+  DELIBERATELY_UNHANDLED_STRIPE_EVENTS,
+  HANDLED_STRIPE_EVENT_TYPES,
+} from '../src/features/payments/webhooks/handled-events'
+
+function requireKey(): string {
+  const key = process.env.STRIPE_SECRET_KEY
+  if (!key) {
+    throw new Error('STRIPE_SECRET_KEY is not set.')
+  }
+  return key
+}
+
+/**
+ * Which endpoint is ours. An account can hold endpoints for other integrations,
+ * and failing the run because someone else's Zapier hook does not send
+ * `charge.refunded` would make the check noise.
+ */
+const OUR_ENDPOINT_PATH = '/api/payments/webhooks/stripe'
+
+async function main() {
+  const stripe = new Stripe(requireKey(), { typescript: true })
+  const endpoints = await stripe.webhookEndpoints.list({ limit: 100 })
+
+  const ours = endpoints.data.filter((endpoint) => endpoint.url.includes(OUR_ENDPOINT_PATH))
+
+  if (ours.length === 0) {
+    console.error(`FAIL: no webhook endpoint on this account points at ${OUR_ENDPOINT_PATH}`)
+    process.exit(1)
+  }
+
+  let failed = false
+
+  for (const endpoint of ours) {
+    const enabled = new Set(endpoint.enabled_events)
+    // `*` is Stripe's "send everything", which satisfies any handled event.
+    const sendsEverything = enabled.has('*')
+
+    const missing = sendsEverything
+      ? []
+      : HANDLED_STRIPE_EVENT_TYPES.filter((type) => !enabled.has(type))
+    const extra = endpoint.enabled_events.filter(
+      (type) => type !== '*' && !HANDLED_STRIPE_EVENT_TYPES.includes(type as never)
+    )
+
+    console.log(`\n${endpoint.url}`)
+    console.log(`  status: ${endpoint.status}`)
+
+    if (endpoint.status !== 'enabled') {
+      console.log('  DISABLED: this endpoint receives nothing regardless of its event list')
+    }
+
+    if (missing.length > 0) {
+      for (const type of missing) {
+        console.log(`  MISSING: ${type} — handled in code, never delivered`)
+      }
+      // Only an enabled endpoint missing events is a live failure. A disabled
+      // one is already reported above and may be an intentional spare.
+      if (endpoint.status === 'enabled') failed = true
+    }
+
+    for (const type of extra) {
+      const reason = DELIBERATELY_UNHANDLED_STRIPE_EVENTS[type]
+      console.log(
+        reason
+          ? `  EXTRA (by decision): ${type} — ${reason}`
+          : `  EXTRA: ${type} — delivered but not handled`
+      )
+    }
+
+    if (missing.length === 0 && endpoint.status === 'enabled') {
+      console.log(`  OK: all ${HANDLED_STRIPE_EVENT_TYPES.length} handled events are enabled`)
+    }
+  }
+
+  if (failed) {
+    console.error('\nFAIL: an enabled endpoint is missing events this app handles.')
+    process.exit(1)
+  }
+
+  console.log('\nPASS: every handled event is enabled on every enabled endpoint.')
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -8,21 +8,10 @@ import { APP_CONFIG } from '@/shared/config'
 import { logger } from '@/shared/utils/logger'
 import { withAdvisoryLock } from '@/shared/utils/advisory-lock'
 import { getSubscriptionIdFromEvent, recordProcessedEvent } from '@/payments/webhooks/event-log'
-import { handleCheckoutSessionCompleted } from '@/payments/webhooks/handlers/checkout-session'
 import {
-  handleSubscriptionCreated,
-  handleSubscriptionUpdated,
-  handleSubscriptionDeleted,
-} from '@/payments/webhooks/handlers/subscription-lifecycle'
-import {
-  handleInvoicePaymentSucceeded,
-  handleInvoicePaymentFailed,
-} from '@/payments/webhooks/handlers/invoice-payment'
-import {
-  handleChargeRefunded,
-  handleDisputeCreated,
-  handleDisputeClosed,
-} from '@/payments/webhooks/handlers/charge-revocation'
+  STRIPE_WEBHOOK_HANDLERS,
+  isHandledStripeEventType,
+} from '@/payments/webhooks/handled-events'
 
 export async function POST(req: NextRequest) {
   const body = await req.text()
@@ -126,45 +115,10 @@ export async function POST(req: NextRequest) {
         }
       }
 
-      switch (event.type) {
-        case 'checkout.session.completed':
-          await handleCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session)
-          break
-
-        case 'customer.subscription.created':
-          await handleSubscriptionCreated(event.data.object as Stripe.Subscription)
-          break
-
-        case 'customer.subscription.updated':
-          await handleSubscriptionUpdated(event.data.object as Stripe.Subscription)
-          break
-
-        case 'customer.subscription.deleted':
-          await handleSubscriptionDeleted(event.data.object as Stripe.Subscription)
-          break
-
-        case 'invoice.payment_succeeded':
-          await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice)
-          break
-
-        case 'invoice.payment_failed':
-          await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice)
-          break
-
-        case 'charge.refunded':
-          await handleChargeRefunded(event.data.object as Stripe.Charge)
-          break
-
-        case 'charge.dispute.created':
-          await handleDisputeCreated(event.data.object as Stripe.Dispute)
-          break
-
-        case 'charge.dispute.closed':
-          await handleDisputeClosed(event.data.object as Stripe.Dispute)
-          break
-
-        default:
-          logger.info('Unhandled Stripe event type', { eventId: event.id, eventType: event.type })
+      if (isHandledStripeEventType(event.type)) {
+        await STRIPE_WEBHOOK_HANDLERS[event.type](event)
+      } else {
+        logger.info('Unhandled Stripe event type', { eventId: event.id, eventType: event.type })
       }
 
       // Recording is part of successful processing. If storage fails, throw so

--- a/apps/questura/apps/server/src/features/payments/handled-events.test.ts
+++ b/apps/questura/apps/server/src/features/payments/handled-events.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DELIBERATELY_UNHANDLED_STRIPE_EVENTS,
+  HANDLED_STRIPE_EVENT_TYPES,
+  STRIPE_WEBHOOK_HANDLERS,
+  isHandledStripeEventType,
+} from '@/payments/webhooks/handled-events'
+
+describe('stripe webhook event contract', () => {
+  // This list is what `verify-stripe-webhook-events.ts` diffs the live endpoint
+  // against, so a silent change here would quietly widen or narrow what the
+  // deploy check considers correct. Pinned deliberately.
+  it('handles exactly the events the endpoint is verified against', () => {
+    expect([...HANDLED_STRIPE_EVENT_TYPES].sort()).toEqual([
+      'charge.dispute.closed',
+      'charge.dispute.created',
+      'charge.refunded',
+      'checkout.session.completed',
+      'customer.subscription.created',
+      'customer.subscription.deleted',
+      'customer.subscription.updated',
+      'invoice.payment_failed',
+      'invoice.payment_succeeded',
+    ])
+  })
+
+  // The revocation path is the one that was dead in production. If any of these
+  // three ever leaves the dispatch, refunds and chargebacks stop revoking.
+  it('routes the revocation events', () => {
+    expect(isHandledStripeEventType('charge.refunded')).toBe(true)
+    expect(isHandledStripeEventType('charge.dispute.created')).toBe(true)
+    expect(isHandledStripeEventType('charge.dispute.closed')).toBe(true)
+  })
+
+  it('rejects an event type it does not dispatch', () => {
+    expect(isHandledStripeEventType('customer.updated')).toBe(false)
+    expect(isHandledStripeEventType('')).toBe(false)
+  })
+
+  it('derives the verified list from the dispatch itself', () => {
+    expect(HANDLED_STRIPE_EVENT_TYPES).toHaveLength(Object.keys(STRIPE_WEBHOOK_HANDLERS).length)
+    for (const type of HANDLED_STRIPE_EVENT_TYPES) {
+      expect(typeof STRIPE_WEBHOOK_HANDLERS[type]).toBe('function')
+    }
+  })
+
+  // "Decided against" and "handled" must stay disjoint, or the script would
+  // report an event as both missing and deliberately skipped.
+  it('does not record a handled event as deliberately unhandled', () => {
+    for (const type of Object.keys(DELIBERATELY_UNHANDLED_STRIPE_EVENTS)) {
+      expect(isHandledStripeEventType(type)).toBe(false)
+    }
+  })
+
+  it('gives a reason for every event it decided against', () => {
+    for (const [type, reason] of Object.entries(DELIBERATELY_UNHANDLED_STRIPE_EVENTS)) {
+      expect(reason.length, `${type} needs a reason`).toBeGreaterThan(20)
+    }
+  })
+
+  // Inherited from the object literal, not an event Stripe would ever send.
+  it('does not treat inherited object keys as handled events', () => {
+    expect(isHandledStripeEventType('toString')).toBe(false)
+    expect(isHandledStripeEventType('constructor')).toBe(false)
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/webhooks/handled-events.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handled-events.ts
@@ -1,0 +1,81 @@
+import type Stripe from 'stripe'
+import { handleCheckoutSessionCompleted } from './handlers/checkout-session'
+import {
+  handleSubscriptionCreated,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+} from './handlers/subscription-lifecycle'
+import { handleInvoicePaymentSucceeded, handleInvoicePaymentFailed } from './handlers/invoice-payment'
+import {
+  handleChargeRefunded,
+  handleDisputeCreated,
+  handleDisputeClosed,
+} from './handlers/charge-revocation'
+
+/**
+ * The Stripe events this app acts on, and the handler for each.
+ *
+ * Why this is a map and not a `switch`
+ * ------------------------------------
+ * A handler only ever runs if Stripe is configured to *send* its event, and
+ * nothing in the code can see that configuration. `charge.refunded` and
+ * `charge.dispute.*` were handled here for months while the live endpoint had
+ * never had them enabled — so every refund and every chargeback silently kept
+ * the visitor's access, and no test could have caught it because the code was
+ * correct. The gap was in the Dashboard.
+ *
+ * Deriving the expected event list from the dispatch itself means
+ * `scripts/verify-stripe-webhook-events.ts` can diff *this* against the live
+ * endpoint and name the difference. A `switch` would have needed the list
+ * written down twice, which is how the two drift apart again.
+ */
+export const STRIPE_WEBHOOK_HANDLERS = {
+  'checkout.session.completed': (event) =>
+    handleCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session),
+
+  'customer.subscription.created': (event) =>
+    handleSubscriptionCreated(event.data.object as Stripe.Subscription),
+
+  'customer.subscription.updated': (event) =>
+    handleSubscriptionUpdated(event.data.object as Stripe.Subscription),
+
+  'customer.subscription.deleted': (event) =>
+    handleSubscriptionDeleted(event.data.object as Stripe.Subscription),
+
+  'invoice.payment_succeeded': (event) =>
+    handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice),
+
+  'invoice.payment_failed': (event) =>
+    handleInvoicePaymentFailed(event.data.object as Stripe.Invoice),
+
+  'charge.refunded': (event) => handleChargeRefunded(event.data.object as Stripe.Charge),
+
+  'charge.dispute.created': (event) => handleDisputeCreated(event.data.object as Stripe.Dispute),
+
+  'charge.dispute.closed': (event) => handleDisputeClosed(event.data.object as Stripe.Dispute),
+} satisfies Record<string, (event: Stripe.Event) => Promise<unknown>>
+
+export type HandledStripeEventType = keyof typeof STRIPE_WEBHOOK_HANDLERS
+
+/** Exactly the events the live webhook endpoint must have enabled. */
+export const HANDLED_STRIPE_EVENT_TYPES = Object.keys(
+  STRIPE_WEBHOOK_HANDLERS
+) as HandledStripeEventType[]
+
+export function isHandledStripeEventType(type: string): type is HandledStripeEventType {
+  return Object.hasOwn(STRIPE_WEBHOOK_HANDLERS, type)
+}
+
+/**
+ * Events considered and deliberately left unhandled, so a future reader does
+ * not have to re-derive the reasoning — and so the verification script can tell
+ * "we decided against this" apart from "nobody looked".
+ */
+export const DELIBERATELY_UNHANDLED_STRIPE_EVENTS: Record<string, string> = {
+  'checkout.session.async_payment_failed':
+    'Only fires for delayed-notification payment methods (bank debits, vouchers). Checkout is card-only, so it cannot fire; revisit if a delayed method is ever enabled.',
+  'checkout.session.expired':
+    'An abandoned Checkout Session grants nothing, so there is no entitlement to correct.',
+  'invoice.payment_action_required':
+    'SCA step-up on a renewal. Stripe emails the visitor and retries on its own, and a genuine failure arrives as invoice.payment_failed, which is handled. Adding it would only duplicate the dunning signal.',
+}


### PR DESCRIPTION
## Why

This is the fix for the *class* of bug the audit found, not another instance of it.

A webhook handler only ever runs if Stripe is configured to **send** its event, and nothing in the codebase could see that configuration. `charge.refunded`, `charge.dispute.created` and `charge.dispute.closed` were handled, unit-tested, reviewed and deployed — while the live endpoint had never had them enabled. Every refund and every chargeback silently left the visitor's access intact. No test could have caught it, because the code was correct; the gap was in the Dashboard, on the other side of a boundary the repo had no way to look across.

(The three events have since been added to the live endpoint, which is what makes `charge-revocation.ts` live code. This PR is about making sure the next such gap is visible.)

## What

**1. The dispatch becomes a map.** `src/features/payments/webhooks/handled-events.ts` holds `STRIPE_WEBHOOK_HANDLERS`, and the route does a lookup instead of a nine-arm `switch`. Same nine events, same handlers, same "Unhandled Stripe event type" log for anything else.

**2. The expected event list is derived from that map**, not written down a second time — `HANDLED_STRIPE_EVENT_TYPES = Object.keys(STRIPE_WEBHOOK_HANDLERS)`. Writing it twice is exactly how the two copies drift.

**3. A read-only verification script**, `pnpm verify:stripe-webhook-events`, diffs that list against the live endpoint and reports:

- `MISSING` — handled in code, not enabled on the endpoint. The handler is dead. **Exits non-zero**, so it can gate a deploy.
- `EXTRA` — delivered but not handled. Harmless, but usually a decision worth recording or a half-finished change.
- `DISABLED` — a correctly-configured endpoint that is switched off, so it cannot look like a pass.

It filters to endpoints whose URL contains `/api/payments/webhooks/stripe`, so an unrelated integration on the same account cannot fail the run. It issues only GETs and is safe against the live key.

**4. Decisions are recorded.** `DELIBERATELY_UNHANDLED_STRIPE_EVENTS` documents the two events raised in review plus one more, each with its reasoning, so `EXTRA` can distinguish "we decided against this" from "nobody looked":

| Event | Why not handled |
|---|---|
| `checkout.session.async_payment_failed` | Only fires for delayed-notification methods (bank debits, vouchers). Checkout is card-only, so it cannot fire. |
| `invoice.payment_action_required` | SCA step-up on renewal; Stripe emails and retries on its own, and a real failure arrives as `invoice.payment_failed`, which is handled. |
| `checkout.session.expired` | An abandoned session grants nothing, so there is no entitlement to correct. |

## Verification

- `pnpm vitest run src/features/payments` — 15 files, 196 tests pass (7 new)
- `pnpm tsc --noEmit` — clean
- New tests pin the nine-event list, assert the revocation events are routed, assert handled and deliberately-unhandled stay disjoint, and check that inherited keys like `toString` are not treated as events

The script itself has **not** yet been run against live from this branch — the deploy checkout is reset to `origin/main`, so it only becomes runnable on the host once this merges. Running it there is the first post-merge step.
