### PR TITLE
Make the webhook verification script actually runnable

### DIFF
--- a/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
+++ b/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
@@ -32,17 +32,28 @@
  * against a live key.
  *
  * Usage:
- *   STRIPE_SECRET_KEY=... pnpm tsx scripts/verify-stripe-webhook-events.ts
+ *   pnpm verify:stripe-webhook-events            # dev machine, via tsx
+ *
+ * On the deploy host there are no dev dependencies, so `tsx` does not exist.
+ * Node strips the types itself there:
+ *
+ *   set -a; . ~/questura/config/server.env; set +a
+ *   node --experimental-strip-types scripts/verify-stripe-webhook-events.ts
  *
  * Exits non-zero if any enabled endpoint is missing a handled event, so it can
  * gate a deploy.
  */
 
 import Stripe from 'stripe'
+// The dependency-free half of the contract, imported with an explicit extension
+// so this runs under plain `node --experimental-strip-types` on a host that has
+// no dev dependencies. Importing the handler map instead would pull in Payload
+// and every handler, which is what made the first version of this script
+// unrunnable anywhere it mattered.
 import {
   DELIBERATELY_UNHANDLED_STRIPE_EVENTS,
   HANDLED_STRIPE_EVENT_TYPES,
-} from '../src/features/payments/webhooks/handled-events'
+} from '../src/features/payments/webhooks/event-contract.ts'
 
 function requireKey(): string {
   const key = process.env.STRIPE_SECRET_KEY

--- a/apps/questura/apps/server/src/features/payments/handled-events.test.ts
+++ b/apps/questura/apps/server/src/features/payments/handled-events.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   DELIBERATELY_UNHANDLED_STRIPE_EVENTS,
   HANDLED_STRIPE_EVENT_TYPES,
-  STRIPE_WEBHOOK_HANDLERS,
   isHandledStripeEventType,
-} from '@/payments/webhooks/handled-events'
+} from '@/payments/webhooks/event-contract'
+import { STRIPE_WEBHOOK_HANDLERS } from '@/payments/webhooks/handled-events'
 
 describe('stripe webhook event contract', () => {
   // This list is what `verify-stripe-webhook-events.ts` diffs the live endpoint
@@ -37,8 +37,11 @@ describe('stripe webhook event contract', () => {
     expect(isHandledStripeEventType('')).toBe(false)
   })
 
-  it('derives the verified list from the dispatch itself', () => {
-    expect(HANDLED_STRIPE_EVENT_TYPES).toHaveLength(Object.keys(STRIPE_WEBHOOK_HANDLERS).length)
+  // The Record<HandledStripeEventType, ...> annotation makes this a compile-time
+  // guarantee; asserted at runtime too so the pairing survives a later loosening
+  // of the type.
+  it('has a handler for every event in the contract, and no others', () => {
+    expect(Object.keys(STRIPE_WEBHOOK_HANDLERS).sort()).toEqual([...HANDLED_STRIPE_EVENT_TYPES].sort())
     for (const type of HANDLED_STRIPE_EVENT_TYPES) {
       expect(typeof STRIPE_WEBHOOK_HANDLERS[type]).toBe('function')
     }
@@ -58,9 +61,25 @@ describe('stripe webhook event contract', () => {
     }
   })
 
-  // Inherited from the object literal, not an event Stripe would ever send.
+  // Inherited object keys are not events Stripe would ever send.
   it('does not treat inherited object keys as handled events', () => {
     expect(isHandledStripeEventType('toString')).toBe(false)
     expect(isHandledStripeEventType('constructor')).toBe(false)
+  })
+
+  // The reason the contract lives in its own module: the verification script has
+  // to run on the deploy host, which has no dev dependencies. A single import
+  // reaching a handler pulls in Payload and the whole server, and the script
+  // stops being runnable exactly where it is needed. Cheap to assert, easy to
+  // break by accident.
+  it('keeps the contract module free of imports', async () => {
+    const { readFile } = await import('node:fs/promises')
+    const { resolve } = await import('node:path')
+    const source = await readFile(
+      resolve(process.cwd(), 'src/features/payments/webhooks/event-contract.ts'),
+      'utf-8'
+    )
+
+    expect(source).not.toMatch(/^\s*import\s/m)
   })
 })

--- a/apps/questura/apps/server/src/features/payments/webhooks/event-contract.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/event-contract.ts
@@ -1,0 +1,48 @@
+/**
+ * The contract between this app and the Stripe webhook endpoint.
+ *
+ * Deliberately dependency-free — no handlers, no Payload, no config. It is
+ * imported both by the running app and by
+ * `scripts/verify-stripe-webhook-events.ts`, which has to be runnable on the
+ * deploy host where dev dependencies are not installed and importing a handler
+ * would drag in the entire server.
+ *
+ * Drift is prevented from the other direction: `handled-events.ts` types its
+ * dispatch map as `Record<HandledStripeEventType, …>`, so a name added here
+ * without a handler, or a handler added without a name here, fails to compile.
+ */
+
+/** Exactly the events the live webhook endpoint must have enabled. */
+export const HANDLED_STRIPE_EVENT_TYPES = [
+  'checkout.session.completed',
+  'customer.subscription.created',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+  'invoice.payment_succeeded',
+  'invoice.payment_failed',
+  'charge.refunded',
+  'charge.dispute.created',
+  'charge.dispute.closed',
+] as const
+
+export type HandledStripeEventType = (typeof HANDLED_STRIPE_EVENT_TYPES)[number]
+
+const HANDLED_LOOKUP: ReadonlySet<string> = new Set(HANDLED_STRIPE_EVENT_TYPES)
+
+export function isHandledStripeEventType(type: string): type is HandledStripeEventType {
+  return HANDLED_LOOKUP.has(type)
+}
+
+/**
+ * Events considered and deliberately left unhandled, so a future reader does
+ * not have to re-derive the reasoning — and so the verification script can tell
+ * "we decided against this" apart from "nobody looked".
+ */
+export const DELIBERATELY_UNHANDLED_STRIPE_EVENTS: Readonly<Record<string, string>> = {
+  'checkout.session.async_payment_failed':
+    'Only fires for delayed-notification payment methods (bank debits, vouchers). Checkout is card-only, so it cannot fire; revisit if a delayed method is ever enabled.',
+  'checkout.session.expired':
+    'An abandoned Checkout Session grants nothing, so there is no entitlement to correct.',
+  'invoice.payment_action_required':
+    'SCA step-up on a renewal. Stripe emails the visitor and retries on its own, and a genuine failure arrives as invoice.payment_failed, which is handled. Adding it would only duplicate the dunning signal.',
+}

--- a/apps/questura/apps/server/src/features/payments/webhooks/handled-events.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handled-events.ts
@@ -11,12 +11,20 @@ import {
   handleDisputeCreated,
   handleDisputeClosed,
 } from './handlers/charge-revocation'
+import type { HandledStripeEventType } from './event-contract'
+
+export {
+  DELIBERATELY_UNHANDLED_STRIPE_EVENTS,
+  HANDLED_STRIPE_EVENT_TYPES,
+  isHandledStripeEventType,
+} from './event-contract'
+export type { HandledStripeEventType } from './event-contract'
 
 /**
- * The Stripe events this app acts on, and the handler for each.
+ * The handler for each event named in the contract.
  *
- * Why this is a map and not a `switch`
- * ------------------------------------
+ * Why a map and not a `switch`
+ * ----------------------------
  * A handler only ever runs if Stripe is configured to *send* its event, and
  * nothing in the code can see that configuration. `charge.refunded` and
  * `charge.dispute.*` were handled here for months while the live endpoint had
@@ -24,12 +32,16 @@ import {
  * the visitor's access, and no test could have caught it because the code was
  * correct. The gap was in the Dashboard.
  *
- * Deriving the expected event list from the dispatch itself means
- * `scripts/verify-stripe-webhook-events.ts` can diff *this* against the live
- * endpoint and name the difference. A `switch` would have needed the list
- * written down twice, which is how the two drift apart again.
+ * The `Record<HandledStripeEventType, …>` annotation is what keeps the two
+ * halves honest: an event named in `event-contract.ts` with no handler here, or
+ * a handler here for an event not named there, fails to compile. That lets the
+ * verification script import the names alone — without dragging in Payload and
+ * every handler — while still describing exactly what this dispatch does.
  */
-export const STRIPE_WEBHOOK_HANDLERS = {
+export const STRIPE_WEBHOOK_HANDLERS: Record<
+  HandledStripeEventType,
+  (event: Stripe.Event) => Promise<unknown>
+> = {
   'checkout.session.completed': (event) =>
     handleCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session),
 
@@ -53,29 +65,4 @@ export const STRIPE_WEBHOOK_HANDLERS = {
   'charge.dispute.created': (event) => handleDisputeCreated(event.data.object as Stripe.Dispute),
 
   'charge.dispute.closed': (event) => handleDisputeClosed(event.data.object as Stripe.Dispute),
-} satisfies Record<string, (event: Stripe.Event) => Promise<unknown>>
-
-export type HandledStripeEventType = keyof typeof STRIPE_WEBHOOK_HANDLERS
-
-/** Exactly the events the live webhook endpoint must have enabled. */
-export const HANDLED_STRIPE_EVENT_TYPES = Object.keys(
-  STRIPE_WEBHOOK_HANDLERS
-) as HandledStripeEventType[]
-
-export function isHandledStripeEventType(type: string): type is HandledStripeEventType {
-  return Object.hasOwn(STRIPE_WEBHOOK_HANDLERS, type)
-}
-
-/**
- * Events considered and deliberately left unhandled, so a future reader does
- * not have to re-derive the reasoning — and so the verification script can tell
- * "we decided against this" apart from "nobody looked".
- */
-export const DELIBERATELY_UNHANDLED_STRIPE_EVENTS: Record<string, string> = {
-  'checkout.session.async_payment_failed':
-    'Only fires for delayed-notification payment methods (bank debits, vouchers). Checkout is card-only, so it cannot fire; revisit if a delayed method is ever enabled.',
-  'checkout.session.expired':
-    'An abandoned Checkout Session grants nothing, so there is no entitlement to correct.',
-  'invoice.payment_action_required':
-    'SCA step-up on a renewal. Stripe emails the visitor and retries on its own, and a genuine failure arrives as invoice.payment_failed, which is handled. Adding it would only duplicate the dunning signal.',
 }

--- a/apps/questura/apps/server/tsconfig.json
+++ b/apps/questura/apps/server/tsconfig.json
@@ -10,6 +10,12 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    // Lets an operational script import a `.ts` path explicitly, which is what
+    // makes `scripts/verify-stripe-webhook-events.ts` runnable under plain
+    // `node --experimental-strip-types` on the deploy host, where dev
+    // dependencies (and so `tsx`) are absent. Safe with `noEmit`: nothing is
+    // emitted, and Next builds the app through its own pipeline.
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Why

Follow-up to #318. That PR claimed the verification script would be runnable on the host once merged. It is not — I found this by deploying and trying to run it. Two defects:

**1. It dragged in the whole server.** The script imported `HANDLED_STRIPE_EVENT_TYPES` from `handled-events.ts`, which derives it from the dispatch map — and the map imports every handler, which reach Payload and app config. Resolving nine strings pulled in the entire application.

**2. It needed `tsx`.** A dev dependency. The deploy checkout installs production dependencies only, so the npm script fails with `spawn tsx ENOENT`.

Observed on the host after deploying `c73f3ea4`:

```
Error: spawn tsx ENOENT
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../webhooks/handled-events'
```

A drift-detection tool that cannot run in the environment it checks is worth nothing, so this is a real fix, not polish.

## What

**`webhooks/event-contract.ts`** — new, and deliberately **imports nothing**. Holds the nine event names, the `HandledStripeEventType` type, the `isHandledStripeEventType` guard, and the deliberately-unhandled notes.

**`handled-events.ts`** keeps the dispatch map and re-exports the contract, so no call site changes. The map is now annotated `Record<HandledStripeEventType, (event) => Promise<unknown>>`.

**Drift is still impossible, just enforced the other way round.** #318 derived the list from the map. This derives nothing — instead the type annotation makes both directions a compile error: an event named in the contract with no handler, or a handler for an event not in the contract, fails the build. That is the same guarantee, and it lets the script import the names without the handlers.

**The script** imports only `event-contract.ts`, with an explicit `.ts` path, enabled by `allowImportingTsExtensions` in tsconfig (safe under the existing `noEmit: true`; Next builds the app through its own pipeline). It now runs under plain `node --experimental-strip-types` with no dev dependencies present. The header documents both invocations.

## Verification

- Ran the script under plain Node with no `tsx` involved: it loads and reports `STRIPE_SECRET_KEY is not set.` — a clean argument error rather than a module-resolution failure. That was the actual bug.
- `pnpm vitest run src/features/payments` — 16 files, 201 tests pass
- `pnpm tsc --noEmit` — clean
- New test asserts `event-contract.ts` contains no `import` statement at all, since that is the single property the script's runnability depends on and it is easy to break by accident
- Existing test tightened to assert the handler map and the contract cover exactly the same events, in both directions

A live run against the Stripe endpoint follows once this deploys.
