### PR TITLE
Document the Node version the verification script needs

### DIFF
--- a/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
+++ b/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
@@ -35,10 +35,15 @@
  *   pnpm verify:stripe-webhook-events            # dev machine, via tsx
  *
  * On the deploy host there are no dev dependencies, so `tsx` does not exist.
- * Node strips the types itself there:
+ * Node strips the types itself there — but only from 22.6, and the host's
+ * `/usr/bin/node` is 18, which rejects the flag outright. Use the nvm build:
  *
+ *   cd ~/questura/app/apps/questura/apps/server
  *   set -a; . ~/questura/config/server.env; set +a
- *   node --experimental-strip-types scripts/verify-stripe-webhook-events.ts
+ *   ~/.nvm/versions/node/v22.23.2/bin/node \
+ *     --experimental-strip-types scripts/verify-stripe-webhook-events.ts
+ *
+ * Confirmed working against the live account on 2026-08-16.
  *
  * Exits non-zero if any enabled endpoint is missing a handled event, so it can
  * gate a deploy.


### PR DESCRIPTION
Docs-only follow-up to #319.

The usage note said to run the script with `node --experimental-strip-types`. On the deploy host that fails:

```
node: bad option: --experimental-strip-types
```

`/usr/bin/node` there is v18; type stripping needs 22.6+. The nvm build (v22.23.2) is present and works. Header now records the full working invocation, and that it was confirmed against the live account.

For the record, that live run passed:

```
https://cms.questurian.com/api/payments/webhooks/stripe
  status: enabled
  OK: all 9 handled events are enabled

PASS: every handled event is enabled on every enabled endpoint.
```

The disabled `api.questurian.com` endpoint is reported as `DISABLED` with its missing events listed, and correctly does not fail the run.

No code change — comment only.