### PR TITLE
Store price tiers as digits so the GraphQL schema can build

### DIFF
--- a/apps/questura/apps/client/src/features/articles/ItineraryListicleArticlePage.tsx
+++ b/apps/questura/apps/client/src/features/articles/ItineraryListicleArticlePage.tsx
@@ -14,7 +14,10 @@ import {
   populatedVenueStops,
   venueRowFromBlock,
 } from "@/features/articles/lib/itineraryDays";
-import { isHttpUrl } from "@/features/articles/lib/listicleVenueFormatters";
+import {
+  formatPriceTier,
+  isHttpUrl,
+} from "@/features/articles/lib/listicleVenueFormatters";
 import type {
   ItineraryDay,
   ItineraryStopBlock,
@@ -82,6 +85,8 @@ function TourAgencyCard({
     .map(keyLocationLabel)
     .filter((label): label is string => Boolean(label));
   const href = block.url ? normalizedHref(block.url) : null;
+  // Tiers are stored as '1'-'4'; the ticks are rendered, never persisted.
+  const price = formatPriceTier(block.price);
 
   return (
     <li className="scroll-mt-4 border-t-[3px] border-double border-foreground/55 first:border-t-0 first:pt-0 pt-7 pb-7 last:pb-1 max-[379px]:pt-6 max-[379px]:pb-6 480:pt-9 480:pb-9 550:pt-11 550:pb-11 sm:pt-12 sm:pb-12 768:pt-14 768:pb-14">
@@ -115,10 +120,10 @@ function TourAgencyCard({
             <span className="maps-listicle-meta-item">
               <span className="maps-listicle-meta-value">{block.operator}</span>
             </span>
-            {block.price ? (
+            {price ? (
               <span className="maps-listicle-meta-item">
                 <span className="maps-listicle-meta-separator" aria-hidden />
-                <span className="maps-listicle-meta-value">{block.price}</span>
+                <span className="maps-listicle-meta-value">{price}</span>
               </span>
             ) : null}
           </p>

--- a/apps/questura/apps/client/src/features/articles/components/ItineraryStayDetails.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/ItineraryStayDetails.tsx
@@ -28,7 +28,7 @@ import {
   ItineraryDetailsModal,
   type ItineraryDetailRow,
 } from '@/features/articles/components/ItineraryDetailsModal'
-import { isHttpUrl } from '@/features/articles/lib/listicleVenueFormatters'
+import { formatPriceTier, isHttpUrl } from '@/features/articles/lib/listicleVenueFormatters'
 import type { GridCell } from '@/features/articles/components/ListicleVenueInfoGrid'
 import type { ListicleVenue } from '@/features/articles/types/mapsListicle'
 
@@ -103,7 +103,7 @@ function buildAmenityRows(item: ListicleVenue): ItineraryDetailRow[] {
     if (values.length > 0) push(key, icon, label, values.map(titleCase).join(', '))
   }
 
-  push('price', <CircleDollarSign className={accentClass} strokeWidth={1.75} aria-hidden />, 'Price', text(core.price))
+  push('price', <CircleDollarSign className={accentClass} strokeWidth={1.75} aria-hidden />, 'Price', formatPriceTier(core.price))
   const stayType = text(core.type) || text(item.type)
   if (stayType) push('stay-type', <Building2 className={accentClass} strokeWidth={1.75} aria-hidden />, 'Stay type', titleCase(stayType))
   push('district', <MapPin className={accentClass} strokeWidth={1.75} aria-hidden />, 'Neighborhood', text(core.district))

--- a/apps/questura/apps/client/src/features/articles/lib/listicleVenueFormatters.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/listicleVenueFormatters.ts
@@ -1,5 +1,24 @@
 /** Dining / venue fields for listicle detail UI */
 
+/**
+ * Renders a stored price tier as the dollar ticks readers expect.
+ *
+ * Tiers are stored as '1'-'4' because Payload builds GraphQL enum member names
+ * out of option values and '$' is not a legal GraphQL name. The ticks are
+ * presentation, so they are produced here rather than persisted.
+ *
+ * Tick input is accepted and passed through: accommodation profiles are synced
+ * from Location Manager, which sends ticks, and rows written before the
+ * encoding changed still hold them.
+ */
+export function formatPriceTier(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim()
+  if (/^\$+$/.test(trimmed)) return trimmed
+  if (!/^[1-4]$/.test(trimmed)) return ''
+  return '$'.repeat(Number(trimmed))
+}
+
 export function isHttpUrl(value: string): boolean {
   try {
     const u = new URL(value.trim())

--- a/apps/questura/apps/client/src/features/articles/types/itineraryListicle.ts
+++ b/apps/questura/apps/client/src/features/articles/types/itineraryListicle.ts
@@ -91,7 +91,8 @@ export type ItineraryTourAgencyBlock = {
   momentLabel?: string | null;
   title: string;
   operator: string;
-  price?: "$" | "$$" | "$$$" | "$$$$" | null;
+  /** Stored tier, rendered as ticks by `formatPriceTier`. Legacy rows may still hold ticks. */
+  price?: "1" | "2" | "3" | "4" | "$" | "$$" | "$$$" | "$$$$" | null;
   url: string;
   tourDuration: number;
   startingPoint?: {

--- a/apps/questura/apps/server/src/features/articles/listicle-itineraries/blocks/ItineraryTourAgencyBlock.ts
+++ b/apps/questura/apps/server/src/features/articles/listicle-itineraries/blocks/ItineraryTourAgencyBlock.ts
@@ -1,5 +1,6 @@
 import { Block } from 'payload'
 import { itineraryMomentFields } from './utils/momentFields'
+import { normalizePriceTier, priceTierOptions } from '@/shared/content/priceTier'
 
 const isValidAbsoluteUrl = (value: string | null | undefined): boolean => {
   if (!value) return true
@@ -22,12 +23,6 @@ const existingKeyLocationCollections = [
   'key-locations',
 ] as const
 
-const tourAgencyPriceOptions = [
-  { label: '$', value: '$' },
-  { label: '$$', value: '$$' },
-  { label: '$$$', value: '$$$' },
-  { label: '$$$$', value: '$$$$' },
-] as const
 
 export const ItineraryTourAgencyBlock: Block = {
   slug: 'itinerary-tour-agency',
@@ -59,9 +54,12 @@ export const ItineraryTourAgencyBlock: Block = {
       type: 'select',
       dbName: 'price_tier',
       enumName: 'lit_tour_price_tier',
-      options: [...tourAgencyPriceOptions],
+      options: priceTierOptions,
+      hooks: {
+        beforeValidate: [({ value }) => normalizePriceTier(value)],
+      },
       admin: {
-        description: 'Optional price tier for the tour.',
+        description: 'Optional price tier for the tour. Stored as 1-4; shown as $ to $$$$.',
       },
     },
     {

--- a/apps/questura/apps/server/src/features/articles/listicle-itineraries/collections/ListicleItineraries.test.ts
+++ b/apps/questura/apps/server/src/features/articles/listicle-itineraries/collections/ListicleItineraries.test.ts
@@ -43,7 +43,7 @@ function buildTourAgencyItem(overrides: Record<string, unknown> = {}) {
     blockType: 'itinerary-tour-agency',
     title: 'Sacred Valley Day Tour',
     operator: 'Andes Routes',
-    price: '$$',
+    price: '2',
     url: 'https://example.com/tours/sacred-valley',
     tourDuration: 8,
     startingPoint: {
@@ -153,6 +153,11 @@ describe('ListicleItineraries manual tour-agency validation', () => {
     await expect(runBeforeValidate(data)).rejects.toThrow(
       'Day 1 — Stop 1 price must be $, $$, $$$, or $$$$.',
     )
+  })
+
+  it('still accepts a tick price, which is what synced payloads send', async () => {
+    // Ticks are an input spelling; the field hook stores them as 1-4.
+    await expect(runBeforeValidate(buildData({ price: '$$$' }))).resolves.toBeDefined()
   })
 
   it('rejects tour durations outside 1 to 24 hours', async () => {

--- a/apps/questura/apps/server/src/features/articles/listicle-itineraries/collections/validateListicleItineraryBlockRows.ts
+++ b/apps/questura/apps/server/src/features/articles/listicle-itineraries/collections/validateListicleItineraryBlockRows.ts
@@ -15,13 +15,10 @@ import {
   getSourceCollectionForBlockType,
 } from '../../shared/utils/itemMedia/sourceItems'
 import { validateTourPicks } from '../../shared/utils/tourPicks'
+import { isPriceTier, normalizePriceTier } from '@/shared/content/priceTier'
 
-const tourAgencyPriceTiers = ['$', '$$', '$$$', '$$$$'] as const
-
-const isTourAgencyPriceTier = (value: unknown): value is (typeof tourAgencyPriceTiers)[number] => (
-  typeof value === 'string'
-  && tourAgencyPriceTiers.includes(value as (typeof tourAgencyPriceTiers)[number])
-)
+// Ticks are accepted as input and stored as 1-4; see shared/content/priceTier.
+const isTourAgencyPriceTier = (value: unknown): boolean => isPriceTier(normalizePriceTier(value))
 
 const isLatitude = (value: unknown): value is number => (
   typeof value === 'number' && Number.isFinite(value) && value >= -90 && value <= 90

--- a/apps/questura/apps/server/src/features/data/accommodations/collections/Accommodations.ts
+++ b/apps/questura/apps/server/src/features/data/accommodations/collections/Accommodations.ts
@@ -9,6 +9,7 @@ import type { CollectionConfig, Field } from 'payload'
 import { countryCodes } from '@/shared/constants/countryCodes'
 import { createLocationRefField } from '@/shared/location/server/fields'
 import { syncLocationFields } from '@/shared/location/server/syncLocationFields'
+import { normalizePriceTier, priceTierOptions } from '@/shared/content/priceTier'
 
 export const Accommodations: CollectionConfig = {
   slug: 'accommodations',
@@ -131,12 +132,13 @@ export const Accommodations: CollectionConfig = {
                         {
                           name: 'price',
                           type: 'select',
-                          options: [
-                            { label: '$', value: '$' },
-                            { label: '$$', value: '$$' },
-                            { label: '$$$', value: '$$$' },
-                            { label: '$$$$', value: '$$$$' },
-                          ],
+                          options: priceTierOptions,
+                          // Location Manager still sends '$'-'$$$$' in its
+                          // profile payload and deploys on its own cadence, so
+                          // the tick spelling stays a supported input.
+                          hooks: {
+                            beforeValidate: [({ value }) => normalizePriceTier(value)],
+                          },
                         },
                         { name: 'district', type: 'text' },
                         { name: 'type', type: 'text' },

--- a/apps/questura/apps/server/src/shared/content/graphqlSafeSelectValues.test.ts
+++ b/apps/questura/apps/server/src/shared/content/graphqlSafeSelectValues.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import config from '@/payload.config'
+
+/**
+ * Guards the whole config against the bug that killed `/api/graphql`.
+ *
+ * Payload derives GraphQL enum *member* names from a select option's `value`,
+ * running it through `formatName`, which patches leading digits, dots, dashes,
+ * slashes, plus signs, commas, parens, apostrophes, spaces and brackets -- and
+ * nothing else. A `$` survives it and is not a legal GraphQL name, so four
+ * price-tick options took the entire schema build down and every GraphQL query
+ * returned an empty 500. A unit test on one field would not have caught it;
+ * this walks every field in the real config.
+ */
+
+const NUMBERS = new Set('0123456789'.split(''))
+
+/** Mirrors @payloadcms/graphql's formatName (UTC-offset branch omitted: no such values here). */
+function formatName(input: string): string {
+  let sanitized = String(input)
+  if (NUMBERS.has(sanitized.substring(0, 1))) sanitized = `_${sanitized}`
+  return (
+    sanitized
+      .normalize('NFKD')
+      .replace(/[̀-ͯ]/g, '')
+      .replace(/\./g, '_')
+      .replace(/-|\//g, '_')
+      .replace(/\+/g, '_')
+      .replace(/,/g, '_')
+      .replace(/\(/g, '_')
+      .replace(/\)/g, '_')
+      .replace(/'/g, '_')
+      .replace(/ /g, '')
+      .replace(/\[|\]/g, '_') || '_'
+  )
+}
+
+const GRAPHQL_NAME = /^[_a-zA-Z][_a-zA-Z0-9]*$/
+
+type AnyField = Record<string, unknown>
+
+function collectSelectValues(fields: unknown, path: string, found: string[][]): void {
+  if (!Array.isArray(fields)) return
+
+  for (const raw of fields) {
+    if (!raw || typeof raw !== 'object') continue
+    const field = raw as AnyField
+    const name = typeof field.name === 'string' ? field.name : (field.label as string) ?? '?'
+    const here = `${path}.${name}`
+
+    if (field.type === 'select' && Array.isArray(field.options)) {
+      for (const option of field.options) {
+        const value =
+          typeof option === 'string'
+            ? option
+            : ((option as { value?: unknown })?.value as string | undefined)
+        if (typeof value === 'string') found.push([here, value])
+      }
+    }
+
+    collectSelectValues(field.fields, here, found)
+    for (const tab of (field.tabs as unknown[]) ?? []) {
+      const tabFields = (tab as AnyField)?.fields
+      collectSelectValues(tabFields, here, found)
+    }
+    for (const block of (field.blocks as unknown[]) ?? []) {
+      const blockFields = (block as AnyField)?.fields
+      collectSelectValues(blockFields, `${here}.${(block as AnyField)?.slug ?? '?'}`, found)
+    }
+  }
+}
+
+describe('select option values', () => {
+  it('are all legal GraphQL enum member names', async () => {
+    const resolved = await config
+    const found: string[][] = []
+
+    for (const collection of resolved.collections ?? []) {
+      collectSelectValues(collection.fields, collection.slug, found)
+    }
+    for (const global of resolved.globals ?? []) {
+      collectSelectValues(global.fields, global.slug, found)
+    }
+
+    expect(found.length).toBeGreaterThan(0)
+
+    const illegal = found
+      .filter(([, value]) => !GRAPHQL_NAME.test(formatName(value)))
+      .map(([where, value]) => `${where} = ${JSON.stringify(value)}`)
+
+    expect(illegal).toEqual([])
+  })
+})

--- a/apps/questura/apps/server/src/shared/content/priceTier.test.ts
+++ b/apps/questura/apps/server/src/shared/content/priceTier.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { isPriceTier, normalizePriceTier, priceTierOptions } from './priceTier'
+
+describe('priceTierOptions', () => {
+  it('stores GraphQL-safe values and shows ticks', () => {
+    // The reason this module exists: Payload builds GraphQL enum member names
+    // from option values, and a '$' value breaks the whole schema build.
+    expect(priceTierOptions.map((o) => o.value)).toEqual(['1', '2', '3', '4'])
+    expect(priceTierOptions.map((o) => o.label)).toEqual(['$', '$$', '$$$', '$$$$'])
+    for (const option of priceTierOptions) {
+      expect(option.value).toMatch(/^[_a-zA-Z0-9][_a-zA-Z0-9]*$/)
+    }
+  })
+})
+
+describe('normalizePriceTier', () => {
+  it('maps legacy ticks to the stored tier', () => {
+    expect(normalizePriceTier('$')).toBe('1')
+    expect(normalizePriceTier('$$')).toBe('2')
+    expect(normalizePriceTier('$$$')).toBe('3')
+    expect(normalizePriceTier('$$$$')).toBe('4')
+  })
+
+  it('tolerates surrounding whitespace from synced payloads', () => {
+    expect(normalizePriceTier(' $$$ ')).toBe('3')
+  })
+
+  it('leaves an already-stored tier alone', () => {
+    expect(normalizePriceTier('2')).toBe('2')
+  })
+
+  it('passes unknown values through so select validation still rejects them', () => {
+    // Silently blanking a bad value would turn an editor's mistake into a
+    // missing price nobody notices.
+    expect(normalizePriceTier('From $89')).toBe('From $89')
+    expect(normalizePriceTier('cheap')).toBe('cheap')
+  })
+
+  it('leaves empty and nullish values alone -- the field is optional', () => {
+    expect(normalizePriceTier('')).toBe('')
+    expect(normalizePriceTier(null)).toBeNull()
+    expect(normalizePriceTier(undefined)).toBeUndefined()
+  })
+})
+
+describe('isPriceTier', () => {
+  it('accepts only the stored encoding', () => {
+    expect(isPriceTier('1')).toBe(true)
+    expect(isPriceTier('4')).toBe(true)
+    expect(isPriceTier('$$')).toBe(false)
+    expect(isPriceTier('5')).toBe(false)
+    expect(isPriceTier(2)).toBe(false)
+  })
+})

--- a/apps/questura/apps/server/src/shared/content/priceTier.ts
+++ b/apps/questura/apps/server/src/shared/content/priceTier.ts
@@ -1,0 +1,61 @@
+/**
+ * Price tier: how expensive a venue or tour is, on a four-step scale.
+ *
+ * Values are `'1'`-`'4'` and are never the dollar ticks they render as. Payload
+ * derives GraphQL enum *member* names from an option's `value`, and `$` is not
+ * a legal GraphQL name -- four `$`-valued options were enough to take the
+ * entire `/api/graphql` schema build down with
+ * `Names must start with [_a-zA-Z] but "$" does not`, so every GraphQL query
+ * returned an empty 500 (diagnosed and fixed 2026-08-16). The ticks live in
+ * `label`, which is presentation and never reaches a type name.
+ *
+ * Digits rather than words (`budget`, `luxury`) because the sibling
+ * `priceLevel` selects on dining, nightlife, attractions and accommodations
+ * already use exactly this encoding, and the client already renders it as
+ * `'$'.repeat(n)`. One encoding per concept beats a second opinion.
+ */
+
+export const PRICE_TIER_VALUES = ['1', '2', '3', '4'] as const
+
+export type PriceTier = (typeof PRICE_TIER_VALUES)[number]
+
+export const priceTierOptions: { label: string; value: PriceTier }[] = [
+  { label: '$', value: '1' },
+  { label: '$$', value: '2' },
+  { label: '$$$', value: '3' },
+  { label: '$$$$', value: '4' },
+]
+
+/**
+ * The encoding this field used before the GraphQL fix.
+ *
+ * Location Manager still sends ticks in its accommodations profile payload and
+ * is a separate app on its own deploy cadence, so the tick spelling stays a
+ * supported *input* indefinitely -- it is the sync contract. It is simply not
+ * what we store.
+ */
+const LEGACY_TICKS: Record<string, PriceTier> = {
+  $: '1',
+  $$: '2',
+  $$$: '3',
+  $$$$: '4',
+}
+
+export function isPriceTier(value: unknown): value is PriceTier {
+  return typeof value === 'string' && (PRICE_TIER_VALUES as readonly string[]).includes(value)
+}
+
+/**
+ * Coerces an incoming price tier to the stored encoding.
+ *
+ * Returns the value untouched when it is neither a tier nor a legacy tick, so
+ * a bad value still fails select validation loudly rather than being silently
+ * swallowed into a wrong tier. Empty and nullish pass through as-is: the field
+ * is optional.
+ */
+export function normalizePriceTier(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  if (!trimmed) return value
+  return LEGACY_TICKS[trimmed] ?? value
+}


### PR DESCRIPTION
`/api/graphql` has never worked on this deployment: every query returns an empty 500, nothing reaches `server.log`, and `journalctl --user -u questura-server` shows

```
GraphQLError: Names must start with [_a-zA-Z] but "$" does not.
```

Payload builds GraphQL enum **member** names from select option `value`s. `formatName` patches leading digits, dots, dashes, slashes, `+`, commas, parens, apostrophes, spaces and brackets — but not `$`. Two fields used dollar ticks as values (accommodations `profile.core.price`, itinerary tour-agency block `price`), which aborted the whole schema build before any resolver ran.

## Change
Tiers store as `'1'`–`'4'`; ticks move to `label`. Digits because the sibling `priceLevel` selects (dining, nightlife, attractions, accommodations) already use that encoding and the client already renders `'$'.repeat(n)`.

- `shared/content/priceTier.ts` — options + `normalizePriceTier`.
- Both fields still **accept** ticks via a `beforeValidate` field hook. Location Manager syncs accommodation profiles with ticks on its own deploy cadence, so ticks remain the sync contract — just not the storage. Unknown values pass through unmapped so select validation still rejects them.
- Client renders through `formatPriceTier`, which also passes ticks through, so pre-migration rows keep displaying correctly during rollout.
- `graphqlSafeSelectValues.test.ts` walks every select option in the real config and fails on any illegal GraphQL name. Verified it catches all 3 sites when a `$` value is reintroduced.

## Deploy order
Code only. The enum rename migration ships as a **separate PR** because `check-pending-migrations.mjs` flags `ALTER TYPE` as risky and blocks any deploy while it is pending. Code-first also keeps readers correct: the client maps both encodings, so nothing reader-visible changes at any point.

Between this deploy and the migration, a write of a tier fails enum validation (the DB still holds `$`); reads are unaffected. That window is minutes and I apply the migration right after.

## Verification
- server: 862 tests pass, `tsc --noEmit` clean. client: `tsc --noEmit` clean.
- Migration rehearsed on soft-prod inside a transaction that rolled back: all 38 `accommodations.core_price` rows carried over 1:1 (3/15/11/9), then restored to `$` spelling.