### PR TITLE
Rename the price-tick enum members to GraphQL-safe digits

### DIFF
--- a/apps/questura/apps/server/src/migrations/20260816_010000_price_tier_graphql_safe_values.ts
+++ b/apps/questura/apps/server/src/migrations/20260816_010000_price_tier_graphql_safe_values.ts
@@ -1,0 +1,64 @@
+import type { MigrateDownArgs, MigrateUpArgs } from '@payloadcms/db-postgres'
+import { sql } from '@payloadcms/db-postgres'
+
+/**
+ * Renames the price-tick enum members to GraphQL-safe digits.
+ *
+ * Payload builds GraphQL enum *member* names from select option values, and
+ * `$` is not a legal GraphQL name -- these two enums were enough to abort the
+ * whole `/api/graphql` schema build, so every GraphQL query returned an empty
+ * 500. See `shared/content/priceTier.ts`.
+ *
+ * `ALTER TYPE ... RENAME VALUE` rewrites the label in place: no table is
+ * touched, no row is rewritten, and the 38 `accommodations.core_price` values
+ * carry their meaning across ('$$' becomes '2'). That is why this is a rename
+ * rather than a new type plus a backfill.
+ *
+ * Each rename is guarded on the old label still being present, so re-running
+ * the migration is a no-op instead of an error.
+ */
+
+const RENAMES: { type: string; from: string; to: string }[] = [
+  { type: 'enum_accommodations_core_price', from: '$', to: '1' },
+  { type: 'enum_accommodations_core_price', from: '$$', to: '2' },
+  { type: 'enum_accommodations_core_price', from: '$$$', to: '3' },
+  { type: 'enum_accommodations_core_price', from: '$$$$', to: '4' },
+  { type: 'lit_tour_price_tier', from: '$', to: '1' },
+  { type: 'lit_tour_price_tier', from: '$$', to: '2' },
+  { type: 'lit_tour_price_tier', from: '$$$', to: '3' },
+  { type: 'lit_tour_price_tier', from: '$$$$', to: '4' },
+]
+
+/**
+ * A plain `$$` dollar-quote tag would be terminated by the very labels being
+ * renamed, so every block below is tagged `$price_tier$` (same trick the
+ * migration that created these enums had to use).
+ */
+function renameStatements(renames: typeof RENAMES): string {
+  return renames
+    .map(
+      ({ type, from, to }) => `
+      DO $price_tier$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM pg_enum e
+          JOIN pg_type t ON t.oid = e.enumtypid
+          WHERE t.typname = '${type}' AND e.enumlabel = '${from}'
+        ) THEN
+          ALTER TYPE "${type}" RENAME VALUE '${from}' TO '${to}';
+        END IF;
+      END $price_tier$;`,
+    )
+    .join('\n')
+}
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql.raw(renameStatements(RENAMES)))
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(
+    sql.raw(renameStatements(RENAMES.map(({ type, from, to }) => ({ type, from: to, to: from })))),
+  )
+}

--- a/apps/questura/apps/server/src/migrations/index.ts
+++ b/apps/questura/apps/server/src/migrations/index.ts
@@ -30,6 +30,7 @@ import * as migration_20260814_010000_add_visitor_profile_paid_through from './2
 import * as migration_20260814_020000_drop_legacy_membership_columns from './20260814_020000_drop_legacy_membership_columns'
 import * as migration_20260814_030000_unique_visitor_profile_stripe_customer_id from './20260814_030000_unique_visitor_profile_stripe_customer_id'
 import * as migration_20260815_010000_add_access_tier from './20260815_010000_add_access_tier'
+import * as migration_20260816_010000_price_tier_graphql_safe_values from './20260816_010000_price_tier_graphql_safe_values'
 
 export const migrations = [
   {
@@ -191,5 +192,10 @@ export const migrations = [
     up: migration_20260815_010000_add_access_tier.up,
     down: migration_20260815_010000_add_access_tier.down,
     name: '20260815_010000_add_access_tier',
+  },
+  {
+    up: migration_20260816_010000_price_tier_graphql_safe_values.up,
+    down: migration_20260816_010000_price_tier_graphql_safe_values.down,
+    name: '20260816_010000_price_tier_graphql_safe_values',
   },
 ]


### PR DESCRIPTION
Follow-up to #322 (already merged and deployed), which moved both price fields to `'1'`–`'4'` in the config. This brings the two Postgres enums in line: `enum_accommodations_core_price` and `lit_tour_price_tier`.

## Why a rename, not a backfill
`ALTER TYPE ... RENAME VALUE` rewrites the label in place — no table touched, no row rewritten — so all 38 live `accommodations.core_price` values carry their meaning across (`$$` becomes `2`). Nothing here is destructive: no DROP, DELETE or TRUNCATE.

Each rename is guarded on the old label still existing, so re-running is a no-op. Every `DO` block is tagged `$price_tier$` because a plain `$$` tag would be terminated by the very labels being renamed (same trick the migration that created these enums needed).

## Rehearsal
Run on soft-prod inside a transaction ending in `ROLLBACK`:

```
enum_accommodations_core_price | 1,2,3,4
lit_tour_price_tier            | 1,2,3,4
core_price | count      (was  $:3  $$:15  $$$:11  $$$$:9)
 1 |  3
 2 | 15
 3 | 11
 4 |  9
```
After rollback the `$` spelling was intact.

## Deploy
Ships alone: `check-pending-migrations.mjs` flags `ALTER TYPE` as risky and blocks any deploy while it is pending. Applied by hand on the host after merge, then a normal deploy confirms preflight is clear.