### PR TITLE
Forbid caching on cookie-authenticated API responses

### DIFF
--- a/apps/questura/apps/server/src/app/api/me/route.ts
+++ b/apps/questura/apps/server/src/app/api/me/route.ts
@@ -1,13 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { getPrivateCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { getCurrentPrincipal } from '@/features/visitor-auth/lib/current-principal'
+
+/**
+ * Who the caller is, plus their membership state. Derived from the session
+ * cookie, so the answer differs for every caller and must never be stored by
+ * anything sitting between this route and the browser that asked.
+ *
+ * Next already treats a route that reads headers as dynamic; the marker is
+ * declared rather than inferred so the property survives a refactor.
+ */
+export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
   const principal = await getCurrentPrincipal(req.headers)
 
   return NextResponse.json(principal, {
-    headers: getCorsHeaders(req),
+    headers: getPrivateCorsHeaders(req),
   })
 }
 

--- a/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getStripeSubscriptionDetails } from '@/payments/lib/payment-service'
-import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getPrivateCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
 import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(req: NextRequest) {
-  const corsHeaders = getCorsHeaders(req)
+  // Every response below carries these, the 404 included: "no subscription
+  // found" is itself a fact about one visitor's billing, not a shared answer.
+  const corsHeaders = getPrivateCorsHeaders(req)
 
   // The only payments route that skipped this. Being a GET with no reflected
   // CORS header makes it hard to read cross-origin, but "hard to exploit" is

--- a/apps/questura/apps/server/src/shared/utils/cors.test.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.test.ts
@@ -7,7 +7,12 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
-import { forbiddenOriginResponse, getCorsHeaders, isForbiddenOrigin } from './cors'
+import {
+  forbiddenOriginResponse,
+  getCorsHeaders,
+  getPrivateCorsHeaders,
+  isForbiddenOrigin,
+} from './cors'
 
 function requestWithOrigin(origin?: string) {
   return new NextRequest('http://localhost:4000/api/health', {
@@ -36,6 +41,38 @@ describe('getCorsHeaders', () => {
 
     expect(headers).not.toHaveProperty('Access-Control-Allow-Origin')
     expect(headers).not.toHaveProperty('Access-Control-Allow-Credentials')
+  })
+})
+
+describe('getPrivateCorsHeaders', () => {
+  it('forbids storing a per-caller response', () => {
+    const headers = getPrivateCorsHeaders(requestWithOrigin('https://app.example.com'))
+
+    expect(headers['Cache-Control']).toBe('no-store, no-cache, must-revalidate')
+  })
+
+  // `private` would be honoured by the browser and ignored by exactly the
+  // shared cache this is defending against.
+  it('never downgrades to a directive a shared cache may store', () => {
+    const headers = getPrivateCorsHeaders(requestWithOrigin('https://app.example.com'))
+
+    expect(headers['Cache-Control']).not.toMatch(/(^|[\s,])(private|public|max-age)/)
+  })
+
+  it('varies by cookie as well as origin, so a stored copy is keyed by session', () => {
+    const headers = getPrivateCorsHeaders(requestWithOrigin('https://app.example.com'))
+
+    expect(headers['Vary']).toBe('Origin, Cookie')
+  })
+
+  it('keeps the CORS contract of the headers it wraps', () => {
+    const allowed = getPrivateCorsHeaders(requestWithOrigin('https://app.example.com'))
+    const disallowed = getPrivateCorsHeaders(requestWithOrigin('https://evil.example.com'))
+
+    expect(allowed['Access-Control-Allow-Origin']).toBe('https://app.example.com')
+    expect(allowed['Access-Control-Allow-Credentials']).toBe('true')
+    expect(disallowed).not.toHaveProperty('Access-Control-Allow-Origin')
+    expect(disallowed['Cache-Control']).toBe('no-store, no-cache, must-revalidate')
   })
 })
 

--- a/apps/questura/apps/server/src/shared/utils/cors.ts
+++ b/apps/questura/apps/server/src/shared/utils/cors.ts
@@ -55,6 +55,34 @@ export function getCorsHeaders(req: NextRequest): Record<string, string> {
   return headers
 }
 
+/**
+ * `no-store` rather than `private`. A shared cache honouring `private` is the
+ * exact failure this exists to prevent, and a per-caller response is never
+ * worth caching anyway. `Vary: Cookie` is appended to the `Vary: Origin` that
+ * CORS already sets, so a cache that stores the response despite `no-store`
+ * still keys it by session rather than serving one visitor's copy to everyone.
+ */
+const NO_STORE = 'no-store, no-cache, must-revalidate'
+
+/**
+ * CORS headers for a route whose body depends on who is asking.
+ *
+ * Next treats a route that reads headers as dynamic on its own, but Cloudflare
+ * sits in front of this origin (TRUSTED_PROXY) and one cache rule matching
+ * `/api/*` is enough to hand one visitor's identity, membership or billing
+ * state to everyone. Every cookie-authenticated route states its own terms
+ * rather than relying on that rule never being written.
+ */
+export function getPrivateCorsHeaders(req: NextRequest): Record<string, string> {
+  const headers = getCorsHeaders(req)
+
+  return {
+    ...headers,
+    'Cache-Control': NO_STORE,
+    'Vary': [headers['Vary'], 'Cookie'].filter(Boolean).join(', '),
+  }
+}
+
 export function handleCorsOptions(req: NextRequest) {
   return new NextResponse('', {
     status: 200,


### PR DESCRIPTION
## Why

`/api/me` and `/api/payments/subscription-details` both authenticate from an ambient session cookie and return per-visitor data — identity + membership, and billing state. Neither sent a cache directive. The only caching-adjacent header was the `Vary: Origin` that `getCorsHeaders` already sets.

Next won't statically cache either route, so nothing is broken today. But Cloudflare fronts this origin (`TRUSTED_PROXY`), and one cache rule matching `/api/*` is enough to store one visitor's identity, membership or billing state and serve it to everyone. That property shouldn't depend on such a rule never being written.

`/api/public/articles/full` already gets this right; these two now match it.

## What

- New `getPrivateCorsHeaders()` in `shared/utils/cors.ts` — wraps `getCorsHeaders()` and adds:
  - `Cache-Control: no-store, no-cache, must-revalidate`. `no-store` rather than `private`, because a shared cache honouring `private` is the exact failure being defended against, and there is nothing here worth caching.
  - `Cookie` appended to the existing `Vary: Origin`, so a cache that stores the response despite `no-store` still keys it by session.
- Both routes declare `export const dynamic = 'force-dynamic'` — already inferred, now stated, so it survives a refactor.
- On `subscription-details`, swapping the one `corsHeaders` const covers every return path including the 404: "no subscription found" is itself a fact about one visitor's billing.

## Verification

- `pnpm typecheck` clean
- `pnpm test:int` — 113 files, 929 tests pass (4 new)
- 4 new cases in `cors.test.ts` cover the no-store directive, that it never downgrades to `private`/`public`/`max-age`, `Vary: Origin, Cookie`, and that the wrapped CORS contract still holds for allowed and disallowed origins

No Payload collection or field touched — no migration, and rollback stays a clean code-only revert.