### PR TITLE
Harden the gated-article full route

### DIFF
--- a/apps/questura/apps/server/src/app/api/public/articles/full/route.test.ts
+++ b/apps/questura/apps/server/src/app/api/public/articles/full/route.test.ts
@@ -10,6 +10,7 @@ import type { NextRequest } from 'next/server'
 const requireVisitorPrincipal = vi.fn()
 const find = vi.fn()
 const serializeArticleByCollection = vi.fn(async () => undefined)
+const checkArticlesFullRateLimit = vi.fn()
 
 vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
   get requireVisitorPrincipal() {
@@ -29,14 +30,28 @@ vi.mock('@/features/articles/public/serializeArticleBlocks', () => ({
   },
 }))
 
+vi.mock('@/shared/utils/logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+vi.mock('@/features/articles/public/articles-full-rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/articles/public/articles-full-rate-limit')>()
+  return {
+    ...actual,
+    get checkArticlesFullRateLimit() {
+      return checkArticlesFullRateLimit
+    },
+  }
+})
+
 const { GET } = await import('./route')
 
-function request(query: Record<string, string>): NextRequest {
+function request(query: Record<string, string>, headers: Record<string, string> = {}): NextRequest {
   const url = new URL('https://cms.example.test/api/public/articles/full')
   for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value)
 
   return {
-    headers: new Headers(),
+    headers: new Headers(headers),
     nextUrl: url,
   } as unknown as NextRequest
 }
@@ -55,6 +70,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   find.mockResolvedValue({ totalDocs: 1, docs: [{ ...GATED_DOC }] })
   requireVisitorPrincipal.mockResolvedValue(entitled(true))
+  checkArticlesFullRateLimit.mockResolvedValue({ allowed: true })
 })
 
 describe('GET /api/public/articles/full — refusals', () => {
@@ -124,6 +140,49 @@ describe('GET /api/public/articles/full — refusals', () => {
     const res = await GET(request({ type: 'articles', id: '999' }))
     expect(res.status).toBe(404)
   })
+
+  it('rejects a cookie session from an untrusted origin before resolving the visitor', async () => {
+    const res = await GET(
+      request(
+        { type: 'articles', id: '42' },
+        { origin: 'https://evil.example', cookie: 'questura_visitor.session_token=abc' },
+      ),
+    )
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Origin not allowed.' })
+    expect(requireVisitorPrincipal).not.toHaveBeenCalled()
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('rejects a cookie session carrying no origin at all', async () => {
+    const res = await GET(
+      request({ type: 'articles', id: '42' }, { cookie: 'questura_visitor.session_token=abc' }),
+    )
+
+    expect(res.status).toBe(403)
+    expect(requireVisitorPrincipal).not.toHaveBeenCalled()
+  })
+
+  it('429s before touching auth when the caller is over the rate limit', async () => {
+    checkArticlesFullRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 17 })
+
+    const res = await GET(request({ type: 'articles', id: '42' }))
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('retry-after')).toBe('17')
+    expect(requireVisitorPrincipal).not.toHaveBeenCalled()
+    expect(find).not.toHaveBeenCalled()
+  })
+
+  it('does not leak internal error text on a 500', async () => {
+    find.mockRejectedValue(new Error('relation "articles" does not exist'))
+
+    const res = await GET(request({ type: 'articles', id: '42' }))
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ message: 'Failed to load article.' })
+  })
 })
 
 describe('GET /api/public/articles/full — success', () => {
@@ -140,6 +199,19 @@ describe('GET /api/public/articles/full — success', () => {
     const res = await GET(request({ type: 'itineraries', id: '42' }))
 
     expect(res.headers.get('cache-control')).toContain('no-store')
+    expect(res.headers.get('vary')).toContain('Cookie')
+  })
+
+  it('serves the unlocked body from an allowed origin with a cookie', async () => {
+    const res = await GET(
+      request(
+        { type: 'articles', id: '42' },
+        { origin: 'http://localhost:3000', cookie: 'questura_visitor.session_token=abc' },
+      ),
+    )
+
+    expect(res.status).toBe(200)
+    expect(requireVisitorPrincipal).toHaveBeenCalled()
   })
 
   it('sends no-store on refusals too', async () => {

--- a/apps/questura/apps/server/src/app/api/public/articles/full/route.ts
+++ b/apps/questura/apps/server/src/app/api/public/articles/full/route.ts
@@ -3,8 +3,13 @@ import { getPayload } from 'payload'
 
 import config from '@/payload.config'
 import { DEFAULT_LANG, isSupportedLang } from '@/shared/i18n/languageField'
-import { getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getPrivateCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { logger } from '@/shared/utils/logger'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
+import {
+  articlesFullRateLimitResponse,
+  checkArticlesFullRateLimit,
+} from '@/features/articles/public/articles-full-rate-limit'
 import { serializeArticleByCollection } from '@/features/articles/public/serializeArticleBlocks'
 import { isArticleTypeKey, TYPE_TO_COLLECTION } from '@/features/articles/public/scope'
 import { isGatedItem } from '@/shared/content/accessTier'
@@ -20,46 +25,51 @@ import { isGatedItem } from '@/shared/content/accessTier'
  */
 export const dynamic = 'force-dynamic'
 
-/**
- * `no-store` rather than `private`. A shared cache honouring `private` is the
- * failure this design exists to make impossible, and there is nothing here
- * worth caching anyway.
- */
-const NO_STORE = { 'Cache-Control': 'no-store, no-cache, must-revalidate' }
-
-function fail(req: NextRequest, message: string, status: number) {
-  return NextResponse.json(
-    { message },
-    { status, headers: { ...getCorsHeaders(req), ...NO_STORE } },
-  )
+function fail(corsHeaders: Record<string, string>, message: string, status: number) {
+  return NextResponse.json({ message }, { status, headers: corsHeaders })
 }
 
 // GET /api/public/articles/full?type=itineraries&id=42&lang=en
 export async function GET(req: NextRequest) {
+  const corsHeaders = getPrivateCorsHeaders(req)
+
+  // Cookie-authenticated and answers with the unlocked paid body. Being a GET
+  // with no reflected CORS header for untrusted origins makes it hard to read
+  // cross-origin, but "hard to exploit" is not the bar the payments routes
+  // give: a cookie session from an untrusted origin is refused, not merely
+  // CORS-blocked.
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
+
+  const rateLimit = await checkArticlesFullRateLimit(req.headers)
+  if (!rateLimit.allowed) {
+    return articlesFullRateLimitResponse(corsHeaders, rateLimit.retryAfterSeconds)
+  }
+
   try {
     const params = req.nextUrl.searchParams
 
     const type = params.get('type')
-    if (!isArticleTypeKey(type)) return fail(req, 'type must be articles, maps or itineraries', 400)
+    if (!isArticleTypeKey(type)) return fail(corsHeaders, 'type must be articles, maps or itineraries', 400)
 
     const id = params.get('id')
-    if (!id) return fail(req, 'id required', 400)
+    if (!id) return fail(corsHeaders, 'id required', 400)
 
     const lang = params.get('lang') ?? DEFAULT_LANG
-    if (!isSupportedLang(lang)) return fail(req, `unsupported lang: ${lang}`, 400)
+    if (!isSupportedLang(lang)) return fail(corsHeaders, `unsupported lang: ${lang}`, 400)
 
     // Verification is deliberately not required. Checkout does not require it
     // either, so demanding it here would let a visitor complete a real charge
     // and then be refused the content they just bought.
     const auth = await requireVisitorPrincipal(req.headers)
     if (auth.error || !auth.principal) {
-      return fail(req, auth.error ?? 'Authentication required', auth.status)
+      return fail(corsHeaders, auth.error ?? 'Authentication required', auth.status)
     }
 
     // Entitlement is the paid-through date plus any dunning grace (ADR-0008),
     // never the mirrored subscription status.
     if (!auth.principal.membership.active) {
-      return fail(req, 'Membership required', 403)
+      return fail(corsHeaders, 'Membership required', 403)
     }
 
     const collection = TYPE_TO_COLLECTION[type]
@@ -79,7 +89,7 @@ export async function GET(req: NextRequest) {
       overrideAccess: true,
     })
 
-    if (result.totalDocs === 0) return fail(req, 'Article not found.', 404)
+    if (result.totalDocs === 0) return fail(corsHeaders, 'Article not found.', 404)
 
     const article = result.docs[0] as unknown as Record<string, unknown>
 
@@ -87,18 +97,19 @@ export async function GET(req: NextRequest) {
     // their whole body -- so a request for one is a client bug rather than a
     // thing to satisfy quietly. Refusing keeps this route's contract to exactly
     // one sentence: paid content, for someone who paid.
-    if (!isGatedItem(article)) return fail(req, 'Article is not gated.', 404)
+    if (!isGatedItem(article)) return fail(corsHeaders, 'Article is not gated.', 404)
 
     await serializeArticleByCollection(collection, article, payload)
 
     // No gate state attached on purpose. This response is the unlocked view by
     // definition, and a `locked: false` here would be a second, contradictable
     // source of truth for a question the status code already answers.
-    return NextResponse.json(article, { headers: { ...getCorsHeaders(req), ...NO_STORE } })
+    return NextResponse.json(article, { headers: corsHeaders })
   } catch (error) {
-    const message =
-      error instanceof Error && error.message ? error.message : 'Failed to load article.'
-    return fail(req, message, 500)
+    logger.error('Failed to load gated article', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return fail(corsHeaders, 'Failed to load article.', 500)
   }
 }
 

--- a/apps/questura/apps/server/src/features/articles/public/articles-full-rate-limit.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/articles-full-rate-limit.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetLocalCounters } from '@/shared/lib/rate-limit-counter'
+import {
+  ARTICLES_FULL_RATE_LIMIT,
+  checkArticlesFullRateLimit,
+  articlesFullRateLimitResponse,
+} from './articles-full-rate-limit'
+
+function headersWithIp(ip: string) {
+  return new Headers({ 'x-forwarded-for': ip })
+}
+
+describe('articles full rate limit', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    resetLocalCounters()
+  })
+
+  it('allows reads under the per-IP ceiling', async () => {
+    const headers = headersWithIp('192.0.2.10')
+
+    for (let i = 0; i < ARTICLES_FULL_RATE_LIMIT; i += 1) {
+      await expect(checkArticlesFullRateLimit(headers)).resolves.toEqual({ allowed: true })
+    }
+  })
+
+  it('rejects the next read over the ceiling', async () => {
+    const headers = headersWithIp('192.0.2.11')
+
+    for (let i = 0; i < ARTICLES_FULL_RATE_LIMIT; i += 1) {
+      await checkArticlesFullRateLimit(headers)
+    }
+
+    await expect(checkArticlesFullRateLimit(headers)).resolves.toEqual({
+      allowed: false,
+      retryAfterSeconds: expect.any(Number),
+    })
+  })
+
+  it('does not share a budget across IPs', async () => {
+    const first = headersWithIp('192.0.2.13')
+    for (let i = 0; i < ARTICLES_FULL_RATE_LIMIT; i += 1) {
+      await checkArticlesFullRateLimit(first)
+    }
+
+    await expect(checkArticlesFullRateLimit(headersWithIp('192.0.2.14'))).resolves.toEqual({
+      allowed: true,
+    })
+  })
+
+  it('builds a 429 with Retry-After', async () => {
+    const response = articlesFullRateLimitResponse(
+      { 'Access-Control-Allow-Origin': 'http://localhost:3000' },
+      17
+    )
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('Retry-After')).toBe('17')
+    await expect(response.json()).resolves.toEqual({
+      error: 'Too many attempts. Please try again shortly.',
+    })
+  })
+})

--- a/apps/questura/apps/server/src/features/articles/public/articles-full-rate-limit.ts
+++ b/apps/questura/apps/server/src/features/articles/public/articles-full-rate-limit.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+
+import {
+  getClientIp,
+  hashIdentifier,
+  incrementCounter,
+} from '@/shared/lib/rate-limit-counter'
+import { logger } from '@/shared/utils/logger'
+
+/**
+ * Throttle for `GET /api/public/articles/full`.
+ *
+ * This is the only public article route that authenticates from a cookie and
+ * returns the unlocked paid body. The cached `/api/public/articles/*` routes
+ * are ISR and shared; this one is per-caller and hits Payload at depth 2.
+ * Unbounded callers can scrape every gated article or burn that read budget.
+ *
+ * Keyed by IP alone. Keying by account would mean resolving the session first,
+ * which is the database work the throttle exists to bound.
+ */
+
+const WINDOW_SECONDS = 60
+export const ARTICLES_FULL_RATE_LIMIT = 30
+
+export type ArticlesFullRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number }
+
+export async function checkArticlesFullRateLimit(
+  headers: Headers
+): Promise<ArticlesFullRateLimitResult> {
+  const ipKey = `articles:rate-limit:full:ip:${hashIdentifier(getClientIp(headers))}`
+
+  let counter
+  try {
+    counter = await incrementCounter(ipKey, WINDOW_SECONDS)
+  } catch (error) {
+    logger.error('Articles full rate limit unavailable; denying', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { allowed: false, retryAfterSeconds: WINDOW_SECONDS }
+  }
+
+  if (counter.count > ARTICLES_FULL_RATE_LIMIT) {
+    return { allowed: false, retryAfterSeconds: counter.ttlSeconds }
+  }
+
+  return { allowed: true }
+}
+
+export function articlesFullRateLimitResponse(
+  corsHeaders: HeadersInit,
+  retryAfterSeconds: number
+) {
+  const response = NextResponse.json(
+    { error: 'Too many attempts. Please try again shortly.' },
+    { status: 429, headers: corsHeaders }
+  )
+  response.headers.set('Retry-After', String(retryAfterSeconds))
+  return response
+}


### PR DESCRIPTION
## Summary
- Stop `/api/public/articles/full` from returning raw 500 error text to callers.
- Rate-limit the cookie-authenticated paid-body route (30/IP/min), matching the payments-route bar.
- Reject cookie sessions from untrusted or missing origins before auth, same rule as subscription-details.

## Test plan
- [x] `pnpm exec vitest run` on `articles/full/route.test.ts` and `articles-full-rate-limit.test.ts` (21 passed)
- [ ] Confirm a member on questurian.com can still load a gated article after deploy (not deploying in this PR)


Made with [Cursor](https://cursor.com)