### PR TITLE
Advertise catalog prices while laptop Checkout charges $0.50

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
   - Verify loop: edit on Mac → push to `main` → `ssh linux-laptop '~/questura/deploy.sh'` → check the real domain. `apps/questura/infra/softprod/rollback.sh` reverts.
   - `~/questura/app` on the host is the deploy checkout and is **reset to `origin/main` on every deploy**. Never edit there; edits are destroyed.
   - The host runs **live Stripe** (`rk_live` + `pk_live`) against the owner's personal account. There are no test cards. Treat any checkout you trigger as a real charge and confirm before triggering one.
+  - **Membership pricing:** site always advertises **$12.99/month** and **$79.99/year**. Laptop Checkout currently charges **$0.50/month** on the same Stripe product. That mismatch is intentional until serverless launch — do not "fix" the UI to $0.50. One product (`Questurian Membership`). Switch and CLI rules: `apps/questura/docs/membership-pricing.md`. Live Stripe CLI: `apps/questura/scripts/stripe-live` (questura-linux-laptop key, never the Mac CLI device key) until serverless.
   - The Mac's local Postgres (`google-login` @5432) is stale scratch, not a source of truth. The live DB is `questura` @5433 on the host, inside the `questura-postgres` container.
 - When editing Payload collections or fields under `apps/questura/apps/server/src`, treat it as a database schema change:
   1. Run `pnpm db:migrate:create <descriptive-name> > /tmp/questura-migrate-create.log 2>&1` from `apps/questura/apps/server`.

--- a/apps/questura/apps/client/src/app/join/layout.tsx
+++ b/apps/questura/apps/client/src/app/join/layout.tsx
@@ -31,8 +31,9 @@ export default function JoinLayout({
       />
       <JoinNavbar />
       {/*
-       * The plan cards read their prices from /api/payments/plans rather than
-       * hardcoding them, so this static route still needs a query client.
+       * Plan cards read advertised catalog prices ($12.99 / $79.99) from
+       * /api/payments/plans, so this static route still needs a query client.
+       * Laptop may charge $0.50. See docs/membership-pricing.md.
        */}
       <QueryProvider>
         <main className="flex-1">{children}</main>

--- a/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
+++ b/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
@@ -1,5 +1,15 @@
 "use client";
 
+import {
+  formatPerWeekEquivalent,
+  formatPlanAmount,
+  formatPlanInterval,
+  formatPlanPrice,
+  formatUnderWeeklyCeiling,
+  useMembershipPlans,
+  type MembershipPlan,
+} from '@/features/Payments/hooks/useMembershipPlan';
+
 /**
  * Breakpoints from globals.css:
  * --breakpoint-280: 280px
@@ -13,7 +23,35 @@
  * --breakpoint-1280: 1280px
  * --breakpoint-1536: 1536px
  */
+
+function shortBillingUnit(plan: MembershipPlan): string {
+  if (plan.intervalCount !== 1) return formatPlanInterval(plan);
+  if (plan.interval === 'month') return 'mo';
+  if (plan.interval === 'year') return 'yr';
+  if (plan.interval === 'week') return 'wk';
+  return plan.interval;
+}
+
 export default function SubscribeButton() {
+  const { monthly, yearly } = useMembershipPlans();
+
+  // Same source /join and /purchase use. Catalog $12.99 / $79.99, not the
+  // laptop $0.50 test charge. See docs/membership-pricing.md.
+  const weekly = yearly ? formatPerWeekEquivalent(yearly) : null;
+  const underWeekly = yearly ? formatUnderWeeklyCeiling(yearly) : null;
+  const billedPlan = yearly ?? monthly;
+
+  let mid = 'Join';
+  let wide = 'Subscribe';
+
+  if (weekly && underWeekly) {
+    mid = `Join: ${weekly}/wk`;
+    wide = `Subscribe: under ${underWeekly}/wk`;
+  } else if (billedPlan) {
+    mid = `Join: ${formatPlanAmount(billedPlan)}/${shortBillingUnit(billedPlan)}`;
+    wide = `Subscribe: ${formatPlanPrice(billedPlan)}`;
+  }
+
   return (
     <button
       className={`
@@ -36,26 +74,9 @@ export default function SubscribeButton() {
         550:h-[40px] 550:w-[234px] 550:px-1.5 550:text-[.850rem]
       `}
     >
-      {/*
-       * HARDCODED PRICE -- verify against Stripe before changing plan pricing.
-       *
-       * Derived from the annual plan: $79.99/yr ÷ 52 = $1.538/wk. Rounded up,
-       * so "$1.54" slightly overstates and "under $1.55" stays true; rounding
-       * down would understate the price, which is the direction that gets
-       * argued in a dispute.
-       *
-       * This is static chrome on every page and cannot read Stripe, so it goes
-       * stale the moment plan pricing changes. `GET /api/payments/plans` is the
-       * source of truth, and /join renders from it. If you change the price in
-       * Stripe, change this line in the same breath.
-       *
-       * Weekly framing for a plan billed annually is a deliberate choice, made
-       * 2026-08-15 with the trade-off understood.
-       */}
       <span className="380:hidden">Subscribe</span>
-      <span className="hidden 380:inline 550:hidden">Join: $1.54/wk</span>
-      <span className="hidden 550:inline">Subscribe: under $1.55/wk</span>
-
+      <span className="hidden 380:inline 550:hidden">{mid}</span>
+      <span className="hidden 550:inline">{wide}</span>
     </button>
   );
 }

--- a/apps/questura/apps/client/src/features/Payments/components/PricingDisplay.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/PricingDisplay.tsx
@@ -89,13 +89,8 @@ function PlanArrowLink({ href, label }: { href: string; label: string }) {
 }
 
 /**
- * The annual card, priced from Stripe.
- *
- * Every figure here — the price, the crossed-out "full price", the discount
- * badge, the per-month equivalent — is derived from the two prices the checkout
- * charges. This page used to hardcode $79.99 / $155.88 / $6.67 / "Save 49%"
- * against a real price of $0.50 a month, which is the drift /purchase was fixed
- * for. See `useMembershipPlan`.
+ * The annual card, priced from the catalog ($79.99/year).
+ * Laptop Checkout may still charge $0.50. See docs/membership-pricing.md.
  */
 function AnnualPlanCard({
   plan,

--- a/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
+++ b/apps/questura/apps/client/src/features/Payments/hooks/useMembershipPlan.ts
@@ -3,20 +3,16 @@ import { useQuery } from '@tanstack/react-query';
 import { get } from '@/lib/api';
 
 /**
- * The real price of a plan, as Stripe reports it.
- *
- * Purchase pages used to hardcode their own numbers while checkout charged
- * whatever the server had configured. They drifted immediately: the pages
- * advertised $12.99 and $79.99 against a single $0.50/month price, and the
- * "Annual Plan" billed monthly. A page cannot be trusted to state a price it
- * does not control, so it asks for the same price the checkout will use.
+ * What membership costs to advertise. Catalog $12.99 / $79.99, not the laptop
+ * $0.50 test charge. Mismatch is intentional until serverless.
+ * See apps/questura/docs/membership-pricing.md.
  */
 export type PlanId = 'monthly' | 'yearly';
 
 export type MembershipPlan = {
   id: PlanId;
   priceId: string;
-  /** Minor units, as Stripe reports them. */
+  /** Catalog amount in minor units ($12.99 or $79.99). Not the laptop test charge. */
   amount: number;
   currency: string;
   interval: string;
@@ -64,13 +60,57 @@ function billingMonths(plan: MembershipPlan): number | null {
  * A multi-month plan's price expressed per month, or null when the plan is
  * already billed monthly (or in a unit months cannot express).
  *
- * Rounded up: a derived figure must never undercut what Stripe will charge.
+ * Rounded up: a derived figure must never undercut the catalog price.
  */
 export function formatPerMonthEquivalent(plan: MembershipPlan): string | null {
   const months = billingMonths(plan);
   if (!months || months <= 1) return null;
 
   return formatMinorUnits(Math.ceil(plan.amount / months), plan.currency);
+}
+
+/**
+ * How many weeks one billing period covers, or null when Stripe bills in a
+ * unit that does not divide into weeks (`day`, `month`).
+ *
+ * Month is excluded on purpose: a month is not a fixed number of weeks, and
+ * weekly framing was chosen for a plan billed annually.
+ */
+function billingWeeks(plan: MembershipPlan): number | null {
+  if (plan.interval === 'year') return 52 * plan.intervalCount;
+  if (plan.interval === 'week') return plan.intervalCount;
+  return null;
+}
+
+function weeklyCeilingMinorUnits(plan: MembershipPlan): number | null {
+  const weeks = billingWeeks(plan);
+  if (!weeks || weeks <= 1) return null;
+
+  return Math.ceil(plan.amount / weeks);
+}
+
+/**
+ * A multi-week plan's price expressed per week, or null when the billing unit
+ * cannot be divided into weeks without inventing a figure.
+ *
+ * Rounded up: a derived figure must never undercut the catalog price.
+ */
+export function formatPerWeekEquivalent(plan: MembershipPlan): string | null {
+  const weekly = weeklyCeilingMinorUnits(plan);
+  if (weekly == null) return null;
+
+  return formatMinorUnits(weekly, plan.currency);
+}
+
+/**
+ * One cent above the rounded-up weekly equivalent, for "under $X/wk" copy.
+ * Null when there is no honest weekly figure.
+ */
+export function formatUnderWeeklyCeiling(plan: MembershipPlan): string | null {
+  const weekly = weeklyCeilingMinorUnits(plan);
+  if (weekly == null) return null;
+
+  return formatMinorUnits(weekly + 1, plan.currency);
 }
 
 export type PlanSaving = {
@@ -82,9 +122,8 @@ export type PlanSaving = {
 /**
  * The saving a plan advertises, or null when it advertises none.
  *
- * Derived from the same Stripe price the checkout charges, so the crossed-out
- * figure cannot drift away from the real one the way the old hardcoded prices
- * did.
+ * Derived from catalog amounts, so the crossed-out figure is "full price at
+ * the monthly catalog rate", not a leftover laptop test charge.
  */
 export function getPlanSaving(plan: MembershipPlan): PlanSaving | null {
   if (!plan.compareAtAmount || plan.compareAtAmount <= plan.amount) return null;
@@ -101,11 +140,10 @@ export function getPlanSaving(plan: MembershipPlan): PlanSaving | null {
 /**
  * The saving an annual plan can honestly advertise.
  *
- * Preferred form is the real cross-plan comparison: what the same span of
- * months costs at the monthly price the checkout actually charges. That is what
- * the crossed-out "full price" on /join claims to be, so it is derived rather
- * than written down. Falls back to the price's own `compare_at_amount` when the
- * monthly plan is not offered.
+ * Preferred form is the cross-plan comparison: what the same span of months
+ * costs at the monthly catalog price. That is what the crossed-out "full
+ * price" on /join claims to be. Falls back to the price's own
+ * `compare_at_amount` when the monthly plan is not offered.
  */
 export type AnnualSaving = {
   compareAt: string;

--- a/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
@@ -13,7 +13,7 @@ import { queryKeys } from '@/lib/react-query';
 
 interface PurchasePageProps {
   planName?: string;
-  /** Which Stripe price to sell. The amount comes from Stripe, never from here. */
+  /** Which plan to sell. Advertised amount is the catalog via /api/payments/plans. */
   plan?: PlanId;
   planDescription?: string;
 }

--- a/apps/questura/apps/server/src/app/api/payments/plans/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/plans/route.ts
@@ -5,11 +5,8 @@ import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/li
 import { logger } from '@/shared/utils/logger'
 
 /**
- * What the membership actually costs, straight from Stripe.
- *
- * Public and unauthenticated on purpose: a visitor has to see the price before
- * deciding to sign in, and prices are already public information. It exposes
- * only what a pricing page needs -- no keys, no customer data.
+ * Catalog amounts ($12.99 / $79.99), not the laptop $0.50 test charge.
+ * Checkout uses the host Stripe price ID. See docs/membership-pricing.md.
  */
 export async function GET(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)

--- a/apps/questura/apps/server/src/features/payments/lib/membership-catalog.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-catalog.ts
@@ -1,0 +1,48 @@
+/**
+ * Questurian membership catalog — the product prices.
+ *
+ * Full rule: apps/questura/docs/membership-pricing.md
+ *
+ * One Stripe product: Questurian Membership. Monthly, yearly, and the $0.50
+ * laptop test charge are prices on that product — not a second product.
+ *
+ * Site always advertises these catalog amounts. Laptop Checkout may charge
+ * $0.50. That mismatch is intentional until serverless launch. Do not "fix"
+ * the UI down to $0.50. To charge the real $12.99 / $79.99 for one test,
+ * point host STRIPE_PRICE_ID_* at `STRIPE_MEMBERSHIP_PRICES.catalog` and
+ * restart questura-server. See the doc.
+ */
+export const MEMBERSHIP_CATALOG = {
+  monthly: {
+    amount: 1299,
+    currency: 'usd',
+    interval: 'month',
+  },
+  yearly: {
+    amount: 7999,
+    currency: 'usd',
+    interval: 'year',
+  },
+} as const
+
+export type CatalogPlanId = keyof typeof MEMBERSHIP_CATALOG
+
+/** The only membership product. Do not add another for testing. */
+export const STRIPE_MEMBERSHIP_PRODUCT_ID = 'prod_V4XBrsC0ai3ZOY'
+
+/**
+ * Prices on Questurian Membership.
+ *
+ * Checkout uses whichever ID is in host `STRIPE_PRICE_ID_MONTHLY` /
+ * `STRIPE_PRICE_ID_YEARLY`. These constants are the switch, not runtime
+ * config — do not import them to bypass the env.
+ */
+export const STRIPE_MEMBERSHIP_PRICES = {
+  catalog: {
+    monthly: 'price_1U4P3aBUOUSxLiOZfKskTKeO',
+    yearly: 'price_1U4P3bBUOUSxLiOZMGh7ZrJL',
+  },
+  laptopTestCharge: {
+    monthly: 'price_1U5aq5BUOUSxLiOZMnZHT1eS',
+  },
+} as const

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { MEMBERSHIP_CATALOG } from './membership-catalog'
+
 const mocks = vi.hoisted(() => ({
   priceRetrieve: vi.fn(),
 }))
@@ -20,10 +22,10 @@ vi.mock('@/shared/config', () => ({
 
 import { getMembershipPlans, resetMembershipPlansCache } from './membership-plans'
 
-function givenPrice(overrides: Record<string, unknown> = {}) {
+function givenMonthly(overrides: Record<string, unknown> = {}) {
   return {
     id: 'price_monthly',
-    unit_amount: 1299,
+    unit_amount: MEMBERSHIP_CATALOG.monthly.amount,
     currency: 'usd',
     recurring: { interval: 'month', interval_count: 1 },
     product: { name: 'Questurian Membership' },
@@ -32,18 +34,61 @@ function givenPrice(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function givenYearly(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'price_yearly',
+    unit_amount: MEMBERSHIP_CATALOG.yearly.amount,
+    currency: 'usd',
+    recurring: { interval: 'year', interval_count: 1 },
+    product: { name: 'Questurian Membership' },
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function stubStripePrices(monthly: Record<string, unknown>, yearly: Record<string, unknown> | null) {
+  mocks.priceRetrieve.mockImplementation(async (id: string) => {
+    if (id === 'price_yearly') {
+      if (!yearly) throw new Error('no such price')
+      return yearly
+    }
+    return monthly
+  })
+}
+
 describe('getMembershipPlans', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetMembershipPlansCache()
   })
 
-  it('reports the price and interval Stripe actually holds', async () => {
-    mocks.priceRetrieve.mockResolvedValue(givenPrice())
+  it('advertises the catalog even when Stripe charges a cheaper test amount', async () => {
+    stubStripePrices(givenMonthly({ unit_amount: 50 }), givenYearly({ unit_amount: 50 }))
 
-    const [plan] = await getMembershipPlans()
+    const plans = await getMembershipPlans()
 
-    expect(plan).toMatchObject({
+    expect(plans).toEqual([
+      expect.objectContaining({
+        id: 'monthly',
+        amount: 1299,
+        currency: 'usd',
+        interval: 'month',
+      }),
+      expect.objectContaining({
+        id: 'yearly',
+        amount: 7999,
+        currency: 'usd',
+        interval: 'year',
+      }),
+    ])
+  })
+
+  it('advertises the catalog when Stripe already matches it', async () => {
+    stubStripePrices(givenMonthly(), givenYearly())
+
+    const [monthly] = await getMembershipPlans()
+
+    expect(monthly).toMatchObject({
       amount: 1299,
       currency: 'usd',
       interval: 'month',
@@ -52,45 +97,61 @@ describe('getMembershipPlans', () => {
     })
   })
 
-  it('carries a compare-at price from metadata', async () => {
-    mocks.priceRetrieve.mockResolvedValue(
-      givenPrice({
-        unit_amount: 7999,
-        recurring: { interval: 'year', interval_count: 1 },
-        metadata: { compare_at_amount: '15588' },
-      })
-    )
+  it('omits a plan Stripe would charge more than the catalog', async () => {
+    stubStripePrices(givenMonthly({ unit_amount: 2000 }), givenYearly())
 
-    const [plan] = await getMembershipPlans()
+    const plans = await getMembershipPlans()
 
-    expect(plan.compareAtAmount).toBe(15588)
-    expect(plan.interval).toBe('year')
+    expect(plans.map((plan) => plan.id)).toEqual(['yearly'])
   })
 
-  it('ignores a compare-at price that is not above the real price', async () => {
-    // A "was" price at or below what is charged advertises a saving that does
-    // not exist, which is worse than showing none.
-    mocks.priceRetrieve.mockResolvedValue(
-      givenPrice({ unit_amount: 7999, metadata: { compare_at_amount: '7999' } })
+  it('omits a yearly price that actually bills monthly', async () => {
+    stubStripePrices(
+      givenMonthly(),
+      givenYearly({ recurring: { interval: 'month', interval_count: 1 } }),
     )
 
-    const [plan] = await getMembershipPlans()
+    const plans = await getMembershipPlans()
 
-    expect(plan.compareAtAmount).toBeNull()
+    expect(plans.map((plan) => plan.id)).toEqual(['monthly'])
+  })
+
+  it('carries a compare-at price from metadata', async () => {
+    stubStripePrices(
+      givenMonthly(),
+      givenYearly({ metadata: { compare_at_amount: '15588' } }),
+    )
+
+    const yearly = (await getMembershipPlans()).find((plan) => plan.id === 'yearly')
+
+    expect(yearly?.compareAtAmount).toBe(15588)
+    expect(yearly?.interval).toBe('year')
+  })
+
+  it('ignores a compare-at price that is not above the catalog', async () => {
+    stubStripePrices(
+      givenMonthly({ metadata: { compare_at_amount: '1299' } }),
+      givenYearly(),
+    )
+
+    const monthly = (await getMembershipPlans()).find((plan) => plan.id === 'monthly')
+
+    expect(monthly?.compareAtAmount).toBeNull()
   })
 
   it('ignores compare-at metadata that is not a number', async () => {
-    mocks.priceRetrieve.mockResolvedValue(
-      givenPrice({ metadata: { compare_at_amount: 'one hundred' } })
+    stubStripePrices(
+      givenMonthly({ metadata: { compare_at_amount: 'one hundred' } }),
+      givenYearly(),
     )
 
-    const [plan] = await getMembershipPlans()
+    const monthly = (await getMembershipPlans()).find((plan) => plan.id === 'monthly')
 
-    expect(plan.compareAtAmount).toBeNull()
+    expect(monthly?.compareAtAmount).toBeNull()
   })
 
   it('omits a plan whose price is not recurring rather than selling it', async () => {
-    mocks.priceRetrieve.mockResolvedValue(givenPrice({ recurring: null }))
+    stubStripePrices(givenMonthly({ recurring: null }), null)
 
     await expect(getMembershipPlans()).resolves.toEqual([])
   })
@@ -102,7 +163,7 @@ describe('getMembershipPlans', () => {
   })
 
   it('reuses a successful fetch within the TTL instead of hitting Stripe again', async () => {
-    mocks.priceRetrieve.mockResolvedValue(givenPrice())
+    stubStripePrices(givenMonthly(), givenYearly())
 
     const first = await getMembershipPlans()
     const second = await getMembershipPlans()

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
@@ -1,26 +1,26 @@
 import { APP_CONFIG } from '@/shared/config'
 import { logger } from '@/shared/utils/logger'
+import { MEMBERSHIP_CATALOG } from './membership-catalog'
 import { stripe } from './stripe'
 
 /**
- * The membership plans Questura sells, resolved from Stripe.
+ * The membership plans Questura sells.
  *
- * Prices used to be hardcoded in the purchase pages while checkout charged
- * whatever `STRIPE_PRICE_ID` pointed at. The two drifted immediately: the pages
- * advertised $12.99 and $79.99 against a single $0.50/month price, and the
- * "Annual Plan" billed monthly. A page that states a price it does not control
- * will eventually lie, so the amount shown is read from the same price the
- * checkout session uses.
+ * Advertised amounts come from `MEMBERSHIP_CATALOG` ($12.99/month, $79.99/year).
+ * Checkout charges whichever Stripe price ID is in host env. On the laptop that
+ * is usually $0.50/month on the same product. Intentional until serverless.
+ * Do not copy Stripe `unit_amount` onto the page.
+ * See `apps/questura/docs/membership-pricing.md`.
  */
 export type PlanId = 'monthly' | 'yearly'
 
 export type MembershipPlan = {
   id: PlanId
   priceId: string
-  /** Minor units, as Stripe reports them. */
+  /** Catalog amount in minor units ($12.99 or $79.99). Not the laptop test charge. */
   amount: number
   currency: string
-  /** Stripe's own billing interval, so the page never has to assume "month". */
+  /** Catalog billing interval, verified against Stripe so yearly cannot bill monthly. */
   interval: string
   intervalCount: number
   productName: string | null
@@ -60,9 +60,39 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
       return null
     }
 
+    const catalog = MEMBERSHIP_CATALOG[plan]
+    const stripeAmount = price.unit_amount ?? 0
+
+    if (
+      price.recurring.interval !== catalog.interval ||
+      price.recurring.interval_count !== 1 ||
+      price.currency !== catalog.currency
+    ) {
+      logger.error('Configured membership price does not match the catalog', {
+        plan,
+        priceId,
+        stripeInterval: price.recurring.interval,
+        stripeIntervalCount: price.recurring.interval_count,
+        stripeCurrency: price.currency,
+      })
+      return null
+    }
+
+    // Cheaper than catalog = laptop test charge. More than catalog = we would
+    // advertise $12.99 and charge more, which is the dispute. Refuse that plan.
+    if (stripeAmount > catalog.amount) {
+      logger.error('Stripe would charge more than the catalog price; refusing to advertise', {
+        plan,
+        priceId,
+        stripeAmount,
+        catalogAmount: catalog.amount,
+      })
+      return null
+    }
+
     const compareAtRaw = Number.parseInt(price.metadata?.compare_at_amount ?? '', 10)
     const compareAtAmount =
-      Number.isFinite(compareAtRaw) && compareAtRaw > (price.unit_amount ?? 0) ? compareAtRaw : null
+      Number.isFinite(compareAtRaw) && compareAtRaw > catalog.amount ? compareAtRaw : null
 
     const product = price.product
     const productName =
@@ -73,10 +103,10 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
     return {
       id: plan,
       priceId,
-      amount: price.unit_amount ?? 0,
-      currency: price.currency,
-      interval: price.recurring.interval,
-      intervalCount: price.recurring.interval_count,
+      amount: catalog.amount,
+      currency: catalog.currency,
+      interval: catalog.interval,
+      intervalCount: 1,
       productName,
       compareAtAmount,
     }

--- a/apps/questura/apps/server/src/shared/config/index.ts
+++ b/apps/questura/apps/server/src/shared/config/index.ts
@@ -71,9 +71,8 @@ export const APP_CONFIG = {
   stripe: {
     secretKey: process.env.STRIPE_SECRET_KEY || '',
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
-    // One price per billing interval. `STRIPE_PRICE_ID` is the pre-plan name and
-    // is kept as the monthly fallback so a host missing the new vars still sells
-    // the monthly plan rather than failing checkout outright.
+    // `STRIPE_PRICE_ID` is the pre-plan monthly fallback. Laptop $0.50 vs
+    // catalog $12.99 / $79.99 is a host env switch — docs/membership-pricing.md.
     priceId: process.env.STRIPE_PRICE_ID || '',
     monthlyPriceId: process.env.STRIPE_PRICE_ID_MONTHLY || process.env.STRIPE_PRICE_ID || '',
     yearlyPriceId: process.env.STRIPE_PRICE_ID_YEARLY || '',

--- a/apps/questura/docs/membership-pricing.md
+++ b/apps/questura/docs/membership-pricing.md
@@ -1,0 +1,81 @@
+# Membership pricing (laptop vs launch)
+
+This is the rule. Reviews that "fix" advertised prices to match Checkout are
+wrong until serverless launch.
+
+## One product
+
+Stripe product **Questurian Membership** (`prod_V4XBrsC0ai3ZOY`) is the only
+membership product. Monthly, yearly, and the cheap laptop test charge are
+**prices on that product**. Do not create another product for testing.
+
+## Two numbers, on purpose
+
+| What | Amount | Where it lives |
+|---|---|---|
+| **Catalog** (what the site says) | **$12.99 / month**, **$79.99 / year** | `membership-catalog.ts` → `/api/payments/plans` → `/join`, `/purchase`, Subscribe button |
+| **Laptop test charge** (what Checkout takes now) | **$0.50 / month** | Host `STRIPE_PRICE_ID_MONTHLY` → Stripe Checkout |
+
+The site advertises the catalog. The laptop charges $0.50 so live Checkout can
+be proven without a $12.99 hit every test. **That mismatch is intentional.**
+Ignore it in reviews. Do not sync the UI down to $0.50. Do not treat $0.50 as
+the product.
+
+The only forbidden mismatch: advertising **less** than Stripe will charge.
+
+## This is not launch
+
+The Linux laptop is a live-like test environment, not production. Production
+is serverless, later. **Catalog Stripe prices become what Checkout charges at
+serverless deploy**, not before, unless someone deliberately switches (below)
+for one real-price test.
+
+## Switch: $0.50 test charge ↔ real catalog charge
+
+Price IDs are also in `apps/questura/apps/server/src/features/payments/lib/membership-catalog.ts`.
+
+Host file: `~/questura/config/server.env`. Then restart the server (env is
+read at process start):
+
+```bash
+systemctl --user restart questura-server
+```
+
+**Laptop testing (current default) — charge $0.50/month:**
+
+```
+STRIPE_PRICE_ID=price_1U5aq5BUOUSxLiOZMnZHT1eS
+STRIPE_PRICE_ID_MONTHLY=price_1U5aq5BUOUSxLiOZMnZHT1eS
+```
+
+**One real-price test — charge $12.99 / $79.99:**
+
+```
+STRIPE_PRICE_ID=price_1U4P3aBUOUSxLiOZfKskTKeO
+STRIPE_PRICE_ID_MONTHLY=price_1U4P3aBUOUSxLiOZfKskTKeO
+STRIPE_PRICE_ID_YEARLY=price_1U4P3bBUOUSxLiOZMGh7ZrJL
+```
+
+That is a real charge on the owner's live Stripe account. Confirm before
+switching.
+
+**Yearly while monthly is $0.50:** `STRIPE_PRICE_ID_YEARLY` is still the
+catalog yearly price. Buying yearly on the laptop **charges $79.99**. Do not
+click yearly unless that is intended.
+
+**Serverless launch:** point both monthly and yearly at the catalog price IDs
+and leave them there. Then advertised = charged.
+
+## Stripe CLI (until serverless)
+
+Use the **`questura-linux-laptop`** restricted key (host `STRIPE_SECRET_KEY`,
+suffix `…1dDj`). Never the Mac `CLI key for Rubens-iMac-2.local` (`…qnwG`).
+
+Stripe CLI ignores live keys in `~/.config/stripe/config.toml`. From the Mac:
+
+```bash
+apps/questura/scripts/stripe-live <stripe args>
+```
+
+That wrapper pulls the laptop key over ssh and passes `--api-key`. Do not copy
+the secret onto the Mac.

--- a/apps/questura/infra/softprod/README.md
+++ b/apps/questura/infra/softprod/README.md
@@ -12,6 +12,11 @@ So this is a **live-like test environment that happens to be publicly
 reachable**. The only transactions on it are the owner's own tests. It is not
 serving customers, and nobody but the owner depends on it being up.
 
+**Catalog vs laptop test charge.** One Stripe product, catalog **$12.99/month**
+and **$79.99/year** on the site, **$0.50/month** in Checkout while this machine
+is the test runtime. Intentional until serverless. Do not sync the UI to $0.50.
+How to switch to a real-price test, and Stripe CLI: `docs/membership-pricing.md`.
+
 **It has an expiry date.** Once the site is proven end to end here, this
 machine is switched off and production moves to a serverless deployment. That
 is the plan of record, not a vague intention.

--- a/apps/questura/scripts/stripe-live
+++ b/apps/questura/scripts/stripe-live
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Live Stripe CLI with the questura-linux-laptop key (host STRIPE_SECRET_KEY).
+# Never the Mac `CLI key for Rubens-iMac-2.local`. See docs/membership-pricing.md.
+set -euo pipefail
+
+key="$(
+  ssh -o BatchMode=yes linux-laptop \
+    'python3 -c "import pathlib,re; t=pathlib.Path.home().joinpath(\"questura/config/server.env\").read_text(); m=re.search(r\"^STRIPE_SECRET_KEY=(.*)$\", t, re.M); print(m.group(1).strip().strip(chr(34)).strip(chr(39)) if m else \"\")"'
+)"
+
+suffix="${key: -4}"
+if [[ $key != rk_live_* || $suffix != 1dDj ]]; then
+  echo "stripe-live: refusing unexpected key suffix …${suffix}" >&2
+  exit 1
+fi
+
+# Stripe CLI 1.29 rejects `--live` before the resource command. Key via env;
+# `--live` last so this never uses the Mac device key.
+exec env STRIPE_API_KEY="$key" stripe "$@" --live


### PR DESCRIPTION
## Why
Laptop Checkout charges a $0.50 test price on Questurian Membership. The site was copying Stripe's unit_amount onto /join, /purchase, and the subscribe button, so reviews kept treating $0.50 as the product. Catalog is $12.99/month and $79.99/year until serverless launch.

## What
- Plans API advertises catalog amounts; Stripe only proves the plan is buyable and supplies the price ID Checkout charges
- Subscribe button reads the same plans API (no hardcoded $1.54/wk)
- `docs/membership-pricing.md` is the switch: $0.50 test vs real catalog price IDs
- `scripts/stripe-live` uses the questura-linux-laptop key, not the Mac CLI device key

## Verification
- `pnpm exec vitest run src/features/payments/lib/membership-plans.test.ts` (10 passed)
- Host monthly price ID already pointed at the $0.50 test price; this deploy makes the UI keep saying $12.99 / $79.99


Made with [Cursor](https://cursor.com)