### PR TITLE
Keep newer paid sub, prune webhook rows, lock nav copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
   - `~/questura/app` on the host is the deploy checkout and is **reset to `origin/main` on every deploy**. Never edit there; edits are destroyed.
   - The host runs **live Stripe** (`rk_live` + `pk_live`) against the owner's personal account. There are no test cards. Treat any checkout you trigger as a real charge and confirm before triggering one.
   - **Membership pricing:** site always advertises **$12.99/month** and **$79.99/year**. Laptop Checkout currently charges **$0.50/month** on the same Stripe product. That mismatch is intentional until serverless launch — do not "fix" the UI to $0.50. One product (`Questurian Membership`). Switch and CLI rules: `apps/questura/docs/membership-pricing.md`. Live Stripe CLI: `apps/questura/scripts/stripe-live` (questura-linux-laptop key, never the Mac CLI device key) until serverless.
+  - **Nav Subscribe button copy is hardcoded** (`Join: $1.54/wk` / `Subscribe: under $1.55/wk`). Not a bug. Do not dynamize it from Stripe or `/api/payments/plans`. Do not "fix" it to catalog or laptop prices.
   - The Mac's local Postgres (`google-login` @5432) is stale scratch, not a source of truth. The live DB is `questura` @5433 on the host, inside the `questura-postgres` container.
 - When editing Payload collections or fields under `apps/questura/apps/server/src`, treat it as a database schema change:
   1. Run `pnpm db:migrate:create <descriptive-name> > /tmp/questura-migrate-create.log 2>&1` from `apps/questura/apps/server`.

--- a/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
+++ b/apps/questura/apps/client/src/features/Navigation/shared/components/buttons/SubscribeButton.tsx
@@ -1,15 +1,5 @@
 "use client";
 
-import {
-  formatPerWeekEquivalent,
-  formatPlanAmount,
-  formatPlanInterval,
-  formatPlanPrice,
-  formatUnderWeeklyCeiling,
-  useMembershipPlans,
-  type MembershipPlan,
-} from '@/features/Payments/hooks/useMembershipPlan';
-
 /**
  * Breakpoints from globals.css:
  * --breakpoint-280: 280px
@@ -24,34 +14,7 @@ import {
  * --breakpoint-1536: 1536px
  */
 
-function shortBillingUnit(plan: MembershipPlan): string {
-  if (plan.intervalCount !== 1) return formatPlanInterval(plan);
-  if (plan.interval === 'month') return 'mo';
-  if (plan.interval === 'year') return 'yr';
-  if (plan.interval === 'week') return 'wk';
-  return plan.interval;
-}
-
 export default function SubscribeButton() {
-  const { monthly, yearly } = useMembershipPlans();
-
-  // Same source /join and /purchase use. Catalog $12.99 / $79.99, not the
-  // laptop $0.50 test charge. See docs/membership-pricing.md.
-  const weekly = yearly ? formatPerWeekEquivalent(yearly) : null;
-  const underWeekly = yearly ? formatUnderWeeklyCeiling(yearly) : null;
-  const billedPlan = yearly ?? monthly;
-
-  let mid = 'Join';
-  let wide = 'Subscribe';
-
-  if (weekly && underWeekly) {
-    mid = `Join: ${weekly}/wk`;
-    wide = `Subscribe: under ${underWeekly}/wk`;
-  } else if (billedPlan) {
-    mid = `Join: ${formatPlanAmount(billedPlan)}/${shortBillingUnit(billedPlan)}`;
-    wide = `Subscribe: ${formatPlanPrice(billedPlan)}`;
-  }
-
   return (
     <button
       className={`
@@ -74,9 +37,23 @@ export default function SubscribeButton() {
         550:h-[40px] 550:w-[234px] 550:px-1.5 550:text-[.850rem]
       `}
     >
+      {/*
+        HARDCODED. Leave it. This is not a bug, not stale, not a laptop/$0.50
+        mismatch, not a catalog-sync issue. Do not wire useMembershipPlans,
+        Stripe, or GET /api/payments/plans into this button. Do not replace
+        these strings with $12.99, $79.99, or $0.50. Owner locked this copy
+        2026-08-17.
+
+        Mid:  Join: $1.54/wk
+        Wide: Subscribe: under $1.55/wk
+
+        $79.99/yr ÷ 52 = $1.538/wk. Rounded up so "$1.54" slightly overstates
+        and "under $1.55" stays true. Weekly framing for an annual plan is
+        deliberate (2026-08-15).
+      */}
       <span className="380:hidden">Subscribe</span>
-      <span className="hidden 380:inline 550:hidden">{mid}</span>
-      <span className="hidden 550:inline">{wide}</span>
+      <span className="hidden 380:inline 550:hidden">Join: $1.54/wk</span>
+      <span className="hidden 550:inline">Subscribe: under $1.55/wk</span>
     </button>
   );
 }

--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -20,6 +20,7 @@
     "reconcile:nightly": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/nightly-stripe-reconcile.ts",
     "audit:access-revocations": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/audit-access-revocations.ts",
     "verify:stripe-webhook-events": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/verify-stripe-webhook-events.ts",
+    "prune:stripe-webhook-events": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/prune-stripe-webhook-events.ts",
     "set:itinerary-access": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/set-itinerary-access.ts",
     "capture:membership-fixtures": "bun scripts/capture-membership-fixtures.ts",
     "inventory:tour-agency": "cross-env NODE_OPTIONS=--no-deprecation tsx scripts/inventory-tour-agency-stops.ts",

--- a/apps/questura/apps/server/scripts/nightly-stripe-reconcile.ts
+++ b/apps/questura/apps/server/scripts/nightly-stripe-reconcile.ts
@@ -27,8 +27,11 @@
  * 2. `reconcile-stripe-visitor-profiles` — with apply and a blast-radius cap.
  * 3. `audit-access-revocations` — read-only. Each row is a decision about
  *    somebody's money and stays manual by design; do not add an apply mode.
+ * 4. `prune-stripe-webhook-events` — drop processed webhook rows older than
+ *    30 days. Last so a prune failure cannot hide billing drift. Respects
+ *    `QUESTURA_RECONCILE_APPLY`: dry-run counts, apply deletes.
  *
- * All three run even if an earlier one fails, because the value is in the whole
+ * All four run even if an earlier one fails, because the value is in the whole
  * picture and a Stripe outage in step one should not hide drift in step two.
  * The exit code is aggregated by `reconcile-report.ts`.
  *
@@ -55,6 +58,7 @@ import {
   type ReconcileStepReport,
 } from '../src/features/payments/lib/reconcile-report'
 import { run as runAuditRevocations } from './audit-access-revocations'
+import { run as runPruneWebhookEvents } from './prune-stripe-webhook-events'
 import { run as runReconcileProfiles } from './reconcile-stripe-visitor-profiles'
 import { run as runVerifyWebhookEvents } from './verify-stripe-webhook-events'
 
@@ -107,6 +111,7 @@ async function main(): Promise<number> {
   reports.push(await runStep('verify', () => runVerifyWebhookEvents()))
   reports.push(await runStep('profiles', () => runReconcileProfiles({ apply, maxApply })))
   reports.push(await runStep('audit', () => runAuditRevocations()))
+  reports.push(await runStep('retention', () => runPruneWebhookEvents({ apply })))
 
   const report = buildReconcileReport(reports, { apply, maxApply })
   for (const line of report.lines) console.log(line)
@@ -117,7 +122,7 @@ async function main(): Promise<number> {
 main()
   .then((exitCode) => process.exit(exitCode))
   .catch((error) => {
-    // Only a failure outside the three steps reaches here — a bad env knob, or
+    // Only a failure outside the steps reaches here — a bad env knob, or
     // the report builder itself. A step that throws is reported, not fatal.
     console.error(
       'RECONCILE result=error exit=1 reason=orchestrator-failed',

--- a/apps/questura/apps/server/scripts/prune-stripe-webhook-events.ts
+++ b/apps/questura/apps/server/scripts/prune-stripe-webhook-events.ts
@@ -1,0 +1,65 @@
+/**
+ * Prune processed Stripe webhook rows older than the retention window
+ *
+ * Why this exists
+ * ---------------
+ * Every delivered event is recorded in `stripe-webhook-events` so Stripe
+ * retries are skipped and a stale subscription event cannot overwrite newer
+ * state. Nothing used to delete those rows. Stripe stops retrying after about
+ * three days; after that the row is only taking space.
+ *
+ * Safety
+ * ------
+ * Dry-run by default: prints the expired count and writes nothing. Pass
+ * `--apply` to delete. Honours `QUESTURA_RECONCILE_APPLY` when the nightly
+ * orchestrator calls `run({ apply })`.
+ *
+ * Usage:
+ *   pnpm prune:stripe-webhook-events
+ *   pnpm prune:stripe-webhook-events -- --apply
+ *
+ * Also callable as `run(options)` by `scripts/nightly-stripe-reconcile.ts`.
+ */
+
+import 'dotenv/config'
+import { fileURLToPath } from 'node:url'
+
+import { getPayload } from 'payload'
+
+import {
+  createPayloadWebhookEventStore,
+  pruneExpiredWebhookEvents,
+} from '../src/features/payments/webhooks/event-retention'
+import type { ReconcileStepResult } from '../src/features/payments/lib/reconcile-report'
+import config from '../src/payload.config'
+
+export type PruneWebhookEventsOptions = {
+  apply?: boolean
+  onLine?: (line: string) => void
+}
+
+export async function run(
+  options: PruneWebhookEventsOptions = {}
+): Promise<ReconcileStepResult> {
+  const payload = await getPayload({ config })
+  const result = await pruneExpiredWebhookEvents({
+    apply: options.apply ?? false,
+    store: createPayloadWebhookEventStore(payload),
+  })
+
+  for (const line of result.lines) options.onLine?.(line)
+
+  return result
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run({
+    apply: process.argv.includes('--apply'),
+    onLine: (line) => console.log(line),
+  })
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('Webhook event prune failed:', error)
+      process.exit(1)
+    })
+}

--- a/apps/questura/apps/server/src/features/payments/collections/StripeWebhookEvents.ts
+++ b/apps/questura/apps/server/src/features/payments/collections/StripeWebhookEvents.ts
@@ -4,6 +4,7 @@ import type { CollectionConfig } from 'payload'
  * Records every Stripe webhook event we have processed.
  * Used by the webhook route to skip duplicate deliveries (Stripe retries)
  * and to ignore out-of-order subscription events that would overwrite newer state.
+ * Nightly prune drops rows older than 30 days (`event-retention.ts`).
  */
 export const StripeWebhookEvents: CollectionConfig = {
   slug: 'stripe-webhook-events',

--- a/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
+++ b/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
@@ -147,13 +147,13 @@ describe('selectSubscriptionToKeep', () => {
     expect(kept).toEqual(expect.objectContaining({ id: 'sub_paid' }))
   })
 
-  it('keeps the oldest when both subscriptions actually collected', () => {
+  it('keeps the newer when both subscriptions actually collected', () => {
     const kept = selectSubscriptionToKeep([
       subscription('sub_old', 'active', 100),
       subscription('sub_new', 'active', 200),
     ])
 
-    expect(kept).toEqual(expect.objectContaining({ id: 'sub_old' }))
+    expect(kept).toEqual(expect.objectContaining({ id: 'sub_new' }))
   })
 
   it('prefers a subscription Stripe is still retrying over one that never confirmed', () => {
@@ -165,12 +165,12 @@ describe('selectSubscriptionToKeep', () => {
     expect(kept).toEqual(expect.objectContaining({ id: 'sub_retrying' }))
   })
 
-  it('falls back to age when every candidate is equally unpaid', () => {
+  it('falls back to newer when every candidate is equally unpaid', () => {
     const kept = selectSubscriptionToKeep([
       subscription('sub_newer', 'incomplete', 200),
       subscription('sub_older', 'incomplete', 100),
     ])
 
-    expect(kept).toEqual(expect.objectContaining({ id: 'sub_older' }))
+    expect(kept).toEqual(expect.objectContaining({ id: 'sub_newer' }))
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -148,8 +148,9 @@ const LOWEST_KEEP_PRIORITY = 3
  * derives entitlement from one that never collected — the visitor pays, is
  * refunded, and gets nothing.
  *
- * Paid-ness is therefore ranked first and `created` only breaks ties, which is
- * what the genuine duplicate case (two Checkouts both confirming) needs.
+ * Paid-ness is therefore ranked first. Equal-priority ties keep the newer
+ * subscription: two Checkouts that both collected (monthly then yearly) should
+ * keep the later choice, not refund the one the buyer just paid for.
  */
 export function selectSubscriptionToKeep(
   billable: Stripe.Subscription[]
@@ -162,7 +163,7 @@ export function selectSubscriptionToKeep(
 
     if (candidate !== incumbent) return candidate < incumbent ? subscription : best
 
-    return subscription.created < best.created ? subscription : best
+    return subscription.created > best.created ? subscription : best
   }, null)
 }
 

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-report.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-report.test.ts
@@ -37,18 +37,23 @@ const CLEAN_AUDIT = {
   closed: 0,
 }
 
-function reports(overrides: Partial<Record<'verify' | 'profiles' | 'audit', ReconcileStepReport>> = {}) {
+const CLEAN_RETENTION = { expired: 0, deleted: 0 }
+
+function reports(
+  overrides: Partial<Record<'verify' | 'profiles' | 'audit' | 'retention', ReconcileStepReport>> = {}
+) {
   return [
     overrides.verify ?? { step: 'verify' as const, counts: CLEAN_VERIFY, lines: [] },
     overrides.profiles ?? { step: 'profiles' as const, counts: CLEAN_PROFILES, lines: [] },
     overrides.audit ?? { step: 'audit' as const, counts: CLEAN_AUDIT, lines: [] },
+    overrides.retention ?? { step: 'retention' as const, counts: CLEAN_RETENTION, lines: [] },
   ]
 }
 
 const OPTIONS = { apply: true, maxApply: 25 }
 
 describe('buildReconcileReport exit code', () => {
-  it('exits 0 when all three steps are clean', () => {
+  it('exits 0 when all steps are clean', () => {
     const report = buildReconcileReport(reports(), OPTIONS)
     expect(report.exitCode).toBe(0)
     expect(report.summaryLine).toContain('result=ok')
@@ -141,6 +146,7 @@ describe('buildReconcileReport exit code', () => {
     // The other two ran anyway: a Stripe blip in step one must not hide drift.
     expect(report.summaryLine).toContain('profiles=ok')
     expect(report.summaryLine).toContain('audit=ok')
+    expect(report.summaryLine).toContain('retention=ok')
     expect(report.lines.join('\n')).toContain('socket hang up')
   })
 
@@ -183,6 +189,21 @@ describe('buildReconcileReport exit code', () => {
       OPTIONS
     )
     expect(report.exitCode).toBe(0)
+  })
+
+  it('does not escalate pruned webhook rows — that is the retention job working', () => {
+    const report = buildReconcileReport(
+      reports({
+        retention: {
+          step: 'retention',
+          counts: { expired: 40, deleted: 40 },
+          lines: [],
+        },
+      }),
+      OPTIONS
+    )
+    expect(report.exitCode).toBe(0)
+    expect(report.summaryLine).toContain('expired=40 deleted=40')
   })
 
   it('reports missing counts as zero rather than failing to render them', () => {

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-report.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-report.ts
@@ -3,13 +3,13 @@
  *
  * Why this exists
  * ---------------
- * The nightly job runs three scripts and then has to answer one question: does
+ * The nightly job runs four scripts and then has to answer one question: does
  * a human need to look at this tonight? That answer is the whole value of the
  * job — get it wrong in the lenient direction and divergence stays silent; get
  * it wrong in the noisy direction and the report joins the pile of output
  * nobody reads.
  *
- * So the answer is computed here, as a pure function over the three result
+ * So the answer is computed here, as a pure function over the step result
  * objects, and nowhere else. It lives in `src/` rather than `scripts/` because
  * `vitest.config.ts` only collects tests under `src/shared`, `src/features`,
  * and `src/app`: putting it here makes the rule testable with no config change.
@@ -24,7 +24,7 @@
  *           exceeded, or a step that threw.
  */
 
-export type ReconcileStepName = 'verify' | 'profiles' | 'audit'
+export type ReconcileStepName = 'verify' | 'profiles' | 'audit' | 'retention'
 
 /**
  * What each script's `run()` hands back. `lines` is the detail report the
@@ -60,6 +60,8 @@ export const ESCALATING_COUNTS: Readonly<Record<ReconcileStepName, readonly stri
   verify: ['missing', 'disabled'],
   profiles: ['orphaned', 'duplicate'],
   audit: ['stuck', 'unknown'],
+  // Pruning old webhook rows is the job working. A throw still escalates.
+  retention: [],
 }
 
 /**
@@ -70,6 +72,7 @@ const SUMMARY_COUNTS: Readonly<Record<ReconcileStepName, readonly string[]>> = {
   verify: ['missing', 'disabled', 'extra'],
   profiles: ['relinkable', 'drifted', 'applied', 'orphaned', 'duplicate'],
   audit: ['stuck', 'unknown', 'in_period', 'contested', 'closed'],
+  retention: ['expired', 'deleted'],
 }
 
 export type StepClassification = {
@@ -112,7 +115,7 @@ function formatCounts(step: ReconcileStepName, counts: Record<string, number> | 
   // Keyed even when there is nothing to report: every field on the summary line
   // has to be a `key=value` pair or the line stops being parseable.
   if (!counts) return `${step}_counts=unavailable`
-  // Count names are unique across the three steps, so they need no prefix.
+  // Count names are unique across steps, so they need no prefix.
   return SUMMARY_COUNTS[step].map((key) => `${key}=${counts[key] ?? 0}`).join(' ')
 }
 

--- a/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
@@ -576,9 +576,9 @@ describe('duplicate checkout collapse', () => {
     const newer = makeSub('sub_B', { created: now() - 50, latest_invoice: 'in_B' })
     store.subs.set(older.id, older)
     store.subs.set(newer.id, newer)
-    store.invoices.set('in_A', makeInvoice('in_A'))
+    store.invoices.set('in_A', makeInvoice('in_A', { subscription: 'sub_A' }))
     store.invoices.set('in_B', makeInvoice('in_B', { subscription: 'sub_B' }))
-    store.charges.set('ch_in_B', { id: 'ch_in_B', invoice: 'in_B', refunded: true, payment_intent: 'pi_in_B' })
+    store.charges.set('ch_in_A', { id: 'ch_in_A', invoice: 'in_A', refunded: true, payment_intent: 'pi_in_A' })
 
     await deliver('checkout.session.completed', {
       id: 'cs_2', customer: 'cus_1', subscription: 'sub_B',
@@ -586,15 +586,15 @@ describe('duplicate checkout collapse', () => {
       customer_details: {},
     })
 
-    expect(profile().stripeSubscriptionId).toBe('sub_A')
+    expect(profile().stripeSubscriptionId).toBe('sub_B')
     expect(entitled()).toBe(true)
     expect(store.refunds).toHaveLength(1)
-    expect(store.subs.get('sub_B')!.status).toBe('canceled')
+    expect(store.subs.get('sub_A')!.status).toBe('canceled')
 
     // Stripe now emits the refund we just made. It must not revoke the
     // membership that survived.
-    await deliver('charge.refunded', store.charges.get('ch_in_B'))
-    expect(profile().stripeSubscriptionId).toBe('sub_A')
+    await deliver('charge.refunded', store.charges.get('ch_in_A'))
+    expect(profile().stripeSubscriptionId).toBe('sub_B')
     expect(entitled()).toBe(true)
   })
 
@@ -679,19 +679,19 @@ describe('adversarial', () => {
     store.subs.set(b.id, b)
     store.invoices.set('in_A', makeInvoice('in_A', { subscription: 'sub_A' }))
     store.invoices.set('in_B', makeInvoice('in_B', { subscription: 'sub_B' }))
-    store.charges.set('ch_in_B', { id: 'ch_in_B', invoice: 'in_B', refunded: true, payment_intent: 'pi_in_B' })
+    store.charges.set('ch_in_A', { id: 'ch_in_A', invoice: 'in_A', refunded: true, payment_intent: 'pi_in_A' })
 
-    // sub_B's checkout resynced first, so the profile points at the loser.
-    db['visitor-profiles'][0].stripeSubscriptionId = 'sub_B'
+    // sub_A's checkout resynced first, so the profile points at the loser.
+    db['visitor-profiles'][0].stripeSubscriptionId = 'sub_A'
     db['visitor-profiles'][0].subscriptionStatus = 'active'
     db['visitor-profiles'][0].paidThroughAt = new Date(Date.now() + 20 * DAY * 1000).toISOString()
 
-    // Stripe cancels + refunds B, and the refund event beats the collapse's resync.
-    b.status = 'canceled'
-    b.ended_at = now()
-    await deliver('charge.refunded', store.charges.get('ch_in_B'))
+    // Stripe cancels + refunds A, and the refund event beats the collapse's resync.
+    a.status = 'canceled'
+    a.ended_at = now()
+    await deliver('charge.refunded', store.charges.get('ch_in_A'))
 
-    // sub_A is live and paid for. The buyer must not be locked out.
+    // sub_B is live and paid for. The buyer must not be locked out.
     expect(entitled()).toBe(true)
   })
 

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -879,7 +879,7 @@ describe('Stripe webhook route', () => {
     expect(mocks.resyncSubscription).not.toHaveBeenCalled()
   })
 
-  it('cancels and refunds a newer duplicate subscription, then resyncs the oldest', async () => {
+  it('cancels and refunds an older duplicate subscription, then resyncs the newer', async () => {
     givenEvent('checkout.session.completed', {
       id: 'cs_2',
       customer: 'cus_1',
@@ -892,19 +892,19 @@ describe('Stripe webhook route', () => {
       ],
     })
     mocks.invoiceRetrieve.mockResolvedValue({
-      id: 'in_new',
-      payment_intent: 'pi_new',
+      id: 'in_old',
+      payment_intent: 'pi_old',
     })
 
     await POST(createRequest())
 
     expect(mocks.refundCreate).toHaveBeenCalledWith(
-      { payment_intent: 'pi_new' },
-      { idempotencyKey: 'dup-sub-refund-sub_new' },
+      { payment_intent: 'pi_old' },
+      { idempotencyKey: 'dup-sub-refund-sub_old' },
     )
-    expect(mocks.subscriptionCancel).toHaveBeenCalledWith('sub_new')
-    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_old')
-    expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
+    expect(mocks.subscriptionCancel).toHaveBeenCalledWith('sub_old')
+    expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_new')
+    expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_old')
   })
 
   it('leaves the duplicate subscription alive when its refund fails', async () => {
@@ -919,7 +919,7 @@ describe('Stripe webhook route', () => {
         { id: 'sub_new', status: 'active', created: 200, latest_invoice: 'in_new' },
       ],
     })
-    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_new', payment_intent: 'pi_new' })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_old', payment_intent: 'pi_old' })
     mocks.refundCreate.mockRejectedValueOnce(new Error('Stripe unavailable'))
 
     const response = await POST(createRequest())
@@ -957,7 +957,7 @@ describe('Stripe webhook route', () => {
     givenEvent('checkout.session.completed', {
       id: 'cs_4',
       customer: 'cus_1',
-      subscription: 'sub_new',
+      subscription: 'sub_old',
     })
     mocks.subscriptionList.mockResolvedValueOnce({
       data: [
@@ -965,7 +965,7 @@ describe('Stripe webhook route', () => {
         { id: 'sub_new', status: 'active', created: 200, latest_invoice: 'in_new' },
       ],
     })
-    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_new', payment_intent: 'pi_new' })
+    mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_old', payment_intent: 'pi_old' })
     mocks.resyncSubscription.mockRejectedValueOnce(new Error('Stripe unavailable'))
 
     const failed = await POST(createRequest())
@@ -974,13 +974,13 @@ describe('Stripe webhook route', () => {
     // Stripe retries. The extras this handler already cancelled are no longer
     // billable, so the session's own subscription is the cancelled, refunded one.
     mocks.subscriptionList.mockResolvedValue({
-      data: [{ id: 'sub_old', status: 'active', created: 100, latest_invoice: 'in_old' }],
+      data: [{ id: 'sub_new', status: 'active', created: 200, latest_invoice: 'in_new' }],
     })
 
     await POST(createRequest())
 
-    expect(mocks.resyncSubscription).toHaveBeenLastCalledWith('sub_old')
-    expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_new')
+    expect(mocks.resyncSubscription).toHaveBeenLastCalledWith('sub_new')
+    expect(mocks.resyncSubscription).not.toHaveBeenCalledWith('sub_old')
   })
 
   const CLEARED_REVOCATION_METADATA = {

--- a/apps/questura/apps/server/src/features/payments/webhooks/event-retention.test.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/event-retention.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  WEBHOOK_EVENT_RETENTION_DAYS,
+  createPayloadWebhookEventStore,
+  pruneExpiredWebhookEvents,
+  webhookEventRetentionCutoff,
+} from './event-retention'
+
+describe('webhookEventRetentionCutoff', () => {
+  it('is 30 days before now, which is past Stripe retry and short of forever', () => {
+    const now = new Date('2026-08-17T00:00:00.000Z')
+    const cutoff = webhookEventRetentionCutoff(now)
+
+    expect(WEBHOOK_EVENT_RETENTION_DAYS).toBe(30)
+    expect(cutoff.toISOString()).toBe('2026-07-18T00:00:00.000Z')
+  })
+})
+
+describe('pruneExpiredWebhookEvents', () => {
+  it('counts expired rows and deletes nothing on a dry run', async () => {
+    const deleteExpired = vi.fn()
+
+    const result = await pruneExpiredWebhookEvents({
+      apply: false,
+      now: new Date('2026-08-17T00:00:00.000Z'),
+      store: {
+        countExpired: async () => 12,
+        deleteExpired,
+      },
+    })
+
+    expect(result.counts).toEqual({ expired: 12, deleted: 0 })
+    expect(deleteExpired).not.toHaveBeenCalled()
+    expect(result.ok).toBe(true)
+  })
+
+  it('deletes the expired rows when apply is on', async () => {
+    const deleteExpired = vi.fn(async () => 12)
+
+    const result = await pruneExpiredWebhookEvents({
+      apply: true,
+      now: new Date('2026-08-17T00:00:00.000Z'),
+      store: {
+        countExpired: async () => 12,
+        deleteExpired,
+      },
+    })
+
+    expect(deleteExpired).toHaveBeenCalledWith('2026-07-18T00:00:00.000Z')
+    expect(result.counts).toEqual({ expired: 12, deleted: 12 })
+  })
+})
+
+describe('createPayloadWebhookEventStore', () => {
+  it('counts and deletes by our createdAt, not Stripe eventCreated', async () => {
+    let remaining = [{ id: 3 }, { id: 4 }]
+    const payload = {
+      find: vi.fn(async () => ({
+        docs: remaining.slice(0, 100),
+        totalDocs: remaining.length,
+      })),
+      delete: vi.fn(async ({ id }: { id: number }) => {
+        remaining = remaining.filter((doc) => doc.id !== id)
+        return {}
+      }),
+    }
+
+    const store = createPayloadWebhookEventStore(payload as never)
+    const cutoff = '2026-07-18T00:00:00.000Z'
+
+    await expect(store.countExpired(cutoff)).resolves.toBe(2)
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'stripe-webhook-events',
+        where: { createdAt: { less_than: cutoff } },
+        overrideAccess: true,
+      })
+    )
+
+    await expect(store.deleteExpired(cutoff)).resolves.toBe(2)
+    expect(payload.delete).toHaveBeenCalledWith({
+      collection: 'stripe-webhook-events',
+      id: 3,
+      overrideAccess: true,
+    })
+    expect(payload.delete).toHaveBeenCalledWith({
+      collection: 'stripe-webhook-events',
+      id: 4,
+      overrideAccess: true,
+    })
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/webhooks/event-retention.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/event-retention.ts
@@ -1,0 +1,107 @@
+import type { getPayload } from 'payload'
+
+/**
+ * Drop processed Stripe webhook rows once they can no longer be retried.
+ *
+ * `stripe-webhook-events` exists so a Stripe retry of the same event id is a
+ * no-op, and so an out-of-order subscription event cannot overwrite newer
+ * state. Stripe stops retrying after about three days. After that the row is
+ * only taking space. 30 days keeps dashboard "resend this event" replays
+ * deduped without letting the table grow forever.
+ */
+
+export const WEBHOOK_EVENT_RETENTION_DAYS = 30
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export type WebhookEventRetentionStore = {
+  countExpired: (cutoffIso: string) => Promise<number>
+  deleteExpired: (cutoffIso: string) => Promise<number>
+}
+
+type PayloadApi = Pick<Awaited<ReturnType<typeof getPayload>>, 'find' | 'delete'>
+
+const BATCH = 100
+const expiredWhere = (cutoffIso: string) => ({ createdAt: { less_than: cutoffIso } })
+
+/**
+ * Payload adapter. Collection access is closed (`delete: () => false`), so
+ * every call has to `overrideAccess`. `createdAt` is when we recorded the
+ * event — pruning by Stripe `eventCreated` would drop a dashboard resend
+ * of an old event before Stripe finished retrying that delivery.
+ */
+export function createPayloadWebhookEventStore(payload: PayloadApi): WebhookEventRetentionStore {
+  return {
+    async countExpired(cutoffIso) {
+      const result = await payload.find({
+        collection: 'stripe-webhook-events',
+        where: expiredWhere(cutoffIso),
+        limit: 1,
+        depth: 0,
+        overrideAccess: true,
+      })
+      return result.totalDocs
+    },
+
+    async deleteExpired(cutoffIso) {
+      let deleted = 0
+
+      for (;;) {
+        const batch = await payload.find({
+          collection: 'stripe-webhook-events',
+          where: expiredWhere(cutoffIso),
+          limit: BATCH,
+          depth: 0,
+          overrideAccess: true,
+        })
+
+        if (batch.docs.length === 0) return deleted
+
+        const before = deleted
+        for (const doc of batch.docs) {
+          await payload.delete({
+            collection: 'stripe-webhook-events',
+            id: doc.id,
+            overrideAccess: true,
+          })
+          deleted += 1
+        }
+
+        if (deleted === before) {
+          throw new Error('Webhook event prune deleted nothing from a non-empty batch')
+        }
+      }
+    },
+  }
+}
+
+export function webhookEventRetentionCutoff(now: Date): Date {
+  return new Date(now.getTime() - WEBHOOK_EVENT_RETENTION_DAYS * MS_PER_DAY)
+}
+
+export async function pruneExpiredWebhookEvents(options: {
+  apply: boolean
+  now?: Date
+  store: WebhookEventRetentionStore
+}): Promise<{
+  ok: boolean
+  counts: { expired: number; deleted: number }
+  lines: string[]
+}> {
+  const now = options.now ?? new Date()
+  const cutoff = webhookEventRetentionCutoff(now)
+  const cutoffIso = cutoff.toISOString()
+  const expired = await options.store.countExpired(cutoffIso)
+  const deleted = options.apply ? await options.store.deleteExpired(cutoffIso) : 0
+
+  const lines = [
+    `retention: ${WEBHOOK_EVENT_RETENTION_DAYS}d cutoff=${cutoffIso}`,
+    `expired=${expired} deleted=${deleted} apply=${options.apply ? 1 : 0}`,
+  ]
+
+  return {
+    ok: true,
+    counts: { expired, deleted },
+    lines,
+  }
+}

--- a/apps/questura/docs/membership-pricing.md
+++ b/apps/questura/docs/membership-pricing.md
@@ -13,7 +13,8 @@ membership product. Monthly, yearly, and the cheap laptop test charge are
 
 | What | Amount | Where it lives |
 |---|---|---|
-| **Catalog** (what the site says) | **$12.99 / month**, **$79.99 / year** | `membership-catalog.ts` → `/api/payments/plans` → `/join`, `/purchase`, Subscribe button |
+| **Catalog** (what the site says) | **$12.99 / month**, **$79.99 / year** | `membership-catalog.ts` → `/api/payments/plans` → `/join`, `/purchase` |
+| **Nav Subscribe button** | **`Join: $1.54/wk` / `Subscribe: under $1.55/wk`** | Hardcoded in `SubscribeButton.tsx`. Not a bug. Do not wire plans/Stripe into it. |
 | **Laptop test charge** (what Checkout takes now) | **$0.50 / month** | Host `STRIPE_PRICE_ID_MONTHLY` → Stripe Checkout |
 
 The site advertises the catalog. The laptop charges $0.50 so live Checkout can


### PR DESCRIPTION
## Summary
- Duplicate checkouts that both collected now keep the newer subscription (monthly-then-yearly keeps yearly) instead of refunding the later one.
- Nightly Stripe reconcile prunes `stripe-webhook-events` older than 30 days; `QUESTURA_RECONCILE_APPLY=0` still only counts.
- Nav Subscribe button copy is hardcoded again (`Join: $1.54/wk` / `Subscribe: under $1.55/wk`) and marked as not a bug.

## Test plan
- [ ] Payments unit tests: `customer-linkage`, webhook route collapse, lifecycle S11/N2, event-retention, reconcile-report
- [ ] After merge+deploy, nav button still shows `Join: $1.54/wk` / `Subscribe: under $1.55/wk` (no plans fetch)
- [ ] Do not trigger a live Checkout to verify the tiebreak


Made with [Cursor](https://cursor.com)