### PR TITLE
Rate-limit payments per visitor and drop the plans cache

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/cancel-subscription/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/cancel-subscription/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { cancelUserSubscription } from '@/payments/lib/payment-service'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
-import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
+import { checkPaymentsRateLimit, checkPaymentsVisitorRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
@@ -25,6 +25,11 @@ export async function POST(req: NextRequest) {
     }
 
     const visitor = authResult.principal!
+    const visitorLimit = await checkPaymentsVisitorRateLimit(String(visitor.id), 'cancel')
+    if (!visitorLimit.allowed) {
+      return paymentsRateLimitResponse(corsHeaders, visitorLimit.retryAfterSeconds)
+    }
+
     const result = await cancelUserSubscription(String(visitor.id))
 
     if (!result.success) {

--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -5,7 +5,7 @@ import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
-import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
+import { checkPaymentsRateLimit, checkPaymentsVisitorRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 import { safeReturnPath } from '@/payments/lib/safe-return-path'
 import { checkoutIdempotencyKey } from '@/payments/lib/checkout-idempotency'
 import {
@@ -58,6 +58,11 @@ export async function POST(req: NextRequest) {
 
     const visitor = authResult.principal!
     const visitorAuthUserId = String(visitor.id)
+    const visitorLimit = await checkPaymentsVisitorRateLimit(visitorAuthUserId, 'checkout')
+    if (!visitorLimit.allowed) {
+      return paymentsRateLimitResponse(corsHeaders, visitorLimit.retryAfterSeconds)
+    }
+
     const profile = await findVisitorProfileByAuthUserId(visitorAuthUserId)
 
     // 2. Validate required user data

--- a/apps/questura/apps/server/src/app/api/payments/create-portal-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-portal-session/route.ts
@@ -4,7 +4,7 @@ import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
-import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
+import { checkPaymentsRateLimit, checkPaymentsVisitorRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 import { logger } from '@/shared/utils/logger'
 
 export async function POST(req: NextRequest) {
@@ -28,6 +28,11 @@ export async function POST(req: NextRequest) {
     }
 
     const visitor = authResult.principal!
+    const visitorLimit = await checkPaymentsVisitorRateLimit(String(visitor.id), 'portal')
+    if (!visitorLimit.allowed) {
+      return paymentsRateLimitResponse(corsHeaders, visitorLimit.retryAfterSeconds)
+    }
+
     const profile = await findVisitorProfileByAuthUserId(String(visitor.id))
 
     // 2. Validate user has a Stripe customer ID

--- a/apps/questura/apps/server/src/app/api/payments/reactivate-subscription/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/reactivate-subscription/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { reactivateUserSubscription } from '@/payments/lib/payment-service'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
-import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
+import { checkPaymentsRateLimit, checkPaymentsVisitorRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export async function POST(req: NextRequest) {
   const corsHeaders = getCorsHeaders(req)
@@ -25,6 +25,11 @@ export async function POST(req: NextRequest) {
     }
 
     const visitor = authResult.principal!
+    const visitorLimit = await checkPaymentsVisitorRateLimit(String(visitor.id), 'reactivate')
+    if (!visitorLimit.allowed) {
+      return paymentsRateLimitResponse(corsHeaders, visitorLimit.retryAfterSeconds)
+    }
+
     const result = await reactivateUserSubscription(String(visitor.id))
 
     if (!result.success) {

--- a/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/subscription-details/route.ts
@@ -3,7 +3,7 @@ import { getStripeSubscriptionDetails } from '@/payments/lib/payment-service'
 import { forbiddenOriginResponse, getPrivateCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
-import { checkPaymentsRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
+import { checkPaymentsRateLimit, checkPaymentsVisitorRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 
 export const dynamic = 'force-dynamic'
 
@@ -37,6 +37,11 @@ export async function GET(req: NextRequest) {
     }
 
     const visitor = authResult.principal!
+    const visitorLimit = await checkPaymentsVisitorRateLimit(String(visitor.id), 'details')
+    if (!visitorLimit.allowed) {
+      return paymentsRateLimitResponse(corsHeaders, visitorLimit.retryAfterSeconds)
+    }
+
     const profile = await findVisitorProfileByAuthUserId(String(visitor.id))
 
     if (!profile?.stripeSubscriptionId) {

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/payments/lib/stripe', () => ({
 
 vi.mock('@/payments/lib/payments-rate-limit', () => ({
   checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  checkPaymentsVisitorRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
   paymentsRateLimitResponse: vi.fn(),
 }))
 

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.promotion-codes.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.promotion-codes.test.ts
@@ -32,6 +32,7 @@ vi.mock('@/payments/lib/stripe', () => ({
 
 vi.mock('@/payments/lib/payments-rate-limit', () => ({
   checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  checkPaymentsVisitorRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
   paymentsRateLimitResponse: vi.fn(),
 }))
 

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/payments/lib/stripe', () => ({
 
 vi.mock('@/payments/lib/payments-rate-limit', () => ({
   checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  checkPaymentsVisitorRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
   paymentsRateLimitResponse: vi.fn(),
 }))
 

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/payments/lib/stripe', () => ({
 
 vi.mock('@/payments/lib/payments-rate-limit', () => ({
   checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  checkPaymentsVisitorRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
   paymentsRateLimitResponse: vi.fn(),
 }))
 

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
@@ -20,7 +20,7 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
-import { getMembershipPlans, resetMembershipPlansCache } from './membership-plans'
+import { getMembershipPlans } from './membership-plans'
 
 function givenMonthly(overrides: Record<string, unknown> = {}) {
   return {
@@ -59,7 +59,6 @@ function stubStripePrices(monthly: Record<string, unknown>, yearly: Record<strin
 describe('getMembershipPlans', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetMembershipPlansCache()
   })
 
   it('advertises the catalog even when Stripe charges a cheaper test amount', async () => {
@@ -162,13 +161,13 @@ describe('getMembershipPlans', () => {
     await expect(getMembershipPlans()).resolves.toEqual([])
   })
 
-  it('reuses a successful fetch within the TTL instead of hitting Stripe again', async () => {
+  it('hits Stripe on every call rather than serving a per-process cache', async () => {
     stubStripePrices(givenMonthly(), givenYearly())
 
     const first = await getMembershipPlans()
     const second = await getMembershipPlans()
 
     expect(second).toEqual(first)
-    expect(mocks.priceRetrieve).toHaveBeenCalledTimes(2)
+    expect(mocks.priceRetrieve).toHaveBeenCalledTimes(4)
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
@@ -121,28 +121,7 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
 }
 
 /** Every plan that is actually purchasable right now. */
-const PLAN_CACHE_TTL_MS = 5 * 60 * 1000
-
-let planCache: { storedAt: number; plans: MembershipPlan[] } | null = null
-
 export async function getMembershipPlans(): Promise<MembershipPlan[]> {
-  if (planCache && Date.now() - planCache.storedAt < PLAN_CACHE_TTL_MS) {
-    return planCache.plans
-  }
-
   const plans = await Promise.all([fetchPlan('monthly'), fetchPlan('yearly')])
-  const resolved = plans.filter((plan): plan is MembershipPlan => plan !== null)
-
-  // Do not cache an empty result: a Stripe blip would hide both plans for
-  // the whole TTL, and prices change ~never so a successful fetch is stable.
-  if (resolved.length > 0) {
-    planCache = { storedAt: Date.now(), plans: resolved }
-  }
-
-  return resolved
-}
-
-/** Test seam: drop the in-process cache between cases. */
-export function resetMembershipPlansCache(): void {
-  planCache = null
+  return plans.filter((plan): plan is MembershipPlan => plan !== null)
 }

--- a/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.test.ts
@@ -4,6 +4,7 @@ import { resetLocalCounters } from '@/shared/lib/rate-limit-counter'
 import {
   PAYMENTS_RATE_LIMITS,
   checkPaymentsRateLimit,
+  checkPaymentsVisitorRateLimit,
 } from './payments-rate-limit'
 
 function headersWithIp(ip: string) {
@@ -19,7 +20,7 @@ describe('payments rate limit', () => {
   it('allows checkout under the per-IP ceiling', async () => {
     const headers = headersWithIp('192.0.2.10')
 
-    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.ip; i += 1) {
       await expect(checkPaymentsRateLimit(headers, 'checkout')).resolves.toEqual({ allowed: true })
     }
   })
@@ -27,7 +28,7 @@ describe('payments rate limit', () => {
   it('rejects the next checkout over the ceiling', async () => {
     const headers = headersWithIp('192.0.2.11')
 
-    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.ip; i += 1) {
       await checkPaymentsRateLimit(headers, 'checkout')
     }
 
@@ -40,7 +41,7 @@ describe('payments rate limit', () => {
   it('does not share a budget across scopes', async () => {
     const headers = headersWithIp('192.0.2.12')
 
-    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.ip; i += 1) {
       await checkPaymentsRateLimit(headers, 'checkout')
     }
 
@@ -49,13 +50,64 @@ describe('payments rate limit', () => {
 
   it('does not share a budget across IPs', async () => {
     const first = headersWithIp('192.0.2.13')
-    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout; i += 1) {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.ip; i += 1) {
       await checkPaymentsRateLimit(first, 'checkout')
     }
 
     await expect(checkPaymentsRateLimit(headersWithIp('192.0.2.14'), 'checkout')).resolves.toEqual({
       allowed: true,
     })
+  })
+
+  it('rejects the next checkout after one visitor hits the ceiling, even from a fresh IP', async () => {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.visitor; i += 1) {
+      await expect(
+        checkPaymentsVisitorRateLimit('visitor_nat_a', 'checkout')
+      ).resolves.toEqual({ allowed: true })
+    }
+
+    await expect(checkPaymentsVisitorRateLimit('visitor_nat_a', 'checkout')).resolves.toEqual({
+      allowed: false,
+      retryAfterSeconds: expect.any(Number),
+    })
+  })
+
+  it('does not share a visitor budget across visitors', async () => {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.visitor; i += 1) {
+      await checkPaymentsVisitorRateLimit('visitor_a', 'checkout')
+    }
+
+    await expect(checkPaymentsVisitorRateLimit('visitor_b', 'checkout')).resolves.toEqual({
+      allowed: true,
+    })
+  })
+
+  it('does not share a visitor budget across scopes', async () => {
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.visitor; i += 1) {
+      await checkPaymentsVisitorRateLimit('visitor_scope', 'checkout')
+    }
+
+    await expect(checkPaymentsVisitorRateLimit('visitor_scope', 'portal')).resolves.toEqual({
+      allowed: true,
+    })
+  })
+
+  it('lets two visitors behind one NAT IP each spend a full checkout budget', async () => {
+    const nat = headersWithIp('192.0.2.50')
+
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.visitor; i += 1) {
+      await expect(checkPaymentsRateLimit(nat, 'checkout')).resolves.toEqual({ allowed: true })
+      await expect(checkPaymentsVisitorRateLimit('visitor_nat_1', 'checkout')).resolves.toEqual({
+        allowed: true,
+      })
+    }
+
+    for (let i = 0; i < PAYMENTS_RATE_LIMITS.checkout.visitor; i += 1) {
+      await expect(checkPaymentsRateLimit(nat, 'checkout')).resolves.toEqual({ allowed: true })
+      await expect(checkPaymentsVisitorRateLimit('visitor_nat_2', 'checkout')).resolves.toEqual({
+        allowed: true,
+      })
+    }
   })
 
   it('builds a 429 with Retry-After', async () => {

--- a/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payments-rate-limit.ts
@@ -14,34 +14,40 @@ import { logger } from '@/shared/utils/logger'
  * visitor can burn the shared Stripe rate budget that webhook processing
  * also uses. Plans is public and was two Stripe reads per unauthenticated
  * hit. Webhooks are excluded: Stripe retries must not 429.
+ *
+ * Two buckets, applied in order:
+ * 1. IP, before auth. Cheap flood bound so a NAT office is not one 8-slot
+ *    bucket, and unauthenticated hammering never reaches session lookup.
+ * 2. Visitor, after login. The Stripe-budget bound that used to live on IP.
+ *    Plans has no visitor bucket: it is public.
  */
 
 const WINDOW_SECONDS = 60
 
 export const PAYMENTS_RATE_LIMITS = {
-  checkout: 8,
-  portal: 8,
-  cancel: 8,
-  reactivate: 8,
-  details: 20,
-  plans: 30,
+  checkout: { ip: 40, visitor: 8 },
+  portal: { ip: 40, visitor: 8 },
+  cancel: { ip: 40, visitor: 8 },
+  reactivate: { ip: 40, visitor: 8 },
+  details: { ip: 60, visitor: 20 },
+  plans: { ip: 30 },
 } as const
 
 export type PaymentsRateLimitScope = keyof typeof PAYMENTS_RATE_LIMITS
+export type AuthenticatedPaymentsScope = Exclude<PaymentsRateLimitScope, 'plans'>
 
 export type PaymentsRateLimitResult =
   | { allowed: true }
   | { allowed: false; retryAfterSeconds: number }
 
-export async function checkPaymentsRateLimit(
-  headers: Headers,
+async function checkCounter(
+  key: string,
+  limit: number,
   scope: PaymentsRateLimitScope
 ): Promise<PaymentsRateLimitResult> {
-  const ipKey = `payments:rate-limit:${scope}:ip:${hashIdentifier(getClientIp(headers))}`
-
   let counter
   try {
-    counter = await incrementCounter(ipKey, WINDOW_SECONDS)
+    counter = await incrementCounter(key, WINDOW_SECONDS)
   } catch (error) {
     logger.error('Payments rate limit unavailable; denying', {
       scope,
@@ -50,11 +56,27 @@ export async function checkPaymentsRateLimit(
     return { allowed: false, retryAfterSeconds: WINDOW_SECONDS }
   }
 
-  if (counter.count > PAYMENTS_RATE_LIMITS[scope]) {
+  if (counter.count > limit) {
     return { allowed: false, retryAfterSeconds: counter.ttlSeconds }
   }
 
   return { allowed: true }
+}
+
+export async function checkPaymentsRateLimit(
+  headers: Headers,
+  scope: PaymentsRateLimitScope
+): Promise<PaymentsRateLimitResult> {
+  const ipKey = `payments:rate-limit:${scope}:ip:${hashIdentifier(getClientIp(headers))}`
+  return checkCounter(ipKey, PAYMENTS_RATE_LIMITS[scope].ip, scope)
+}
+
+export async function checkPaymentsVisitorRateLimit(
+  visitorId: string,
+  scope: AuthenticatedPaymentsScope
+): Promise<PaymentsRateLimitResult> {
+  const visitorKey = `payments:rate-limit:${scope}:visitor:${hashIdentifier(visitorId)}`
+  return checkCounter(visitorKey, PAYMENTS_RATE_LIMITS[scope].visitor, scope)
 }
 
 export function paymentsRateLimitResponse(

--- a/apps/questura/apps/server/src/features/payments/subscription-details.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/subscription-details.route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   findVisitorProfileByAuthUserId: vi.fn(),
   getStripeSubscriptionDetails: vi.fn(),
   checkPaymentsRateLimit: vi.fn(),
+  checkPaymentsVisitorRateLimit: vi.fn(),
 }))
 
 vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
@@ -19,10 +20,14 @@ vi.mock('@/payments/lib/payment-service', () => ({
   getStripeSubscriptionDetails: mocks.getStripeSubscriptionDetails,
 }))
 
-vi.mock('@/payments/lib/payments-rate-limit', () => ({
-  checkPaymentsRateLimit: mocks.checkPaymentsRateLimit,
-  paymentsRateLimitResponse: vi.fn(),
-}))
+vi.mock('@/payments/lib/payments-rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/payments/lib/payments-rate-limit')>()
+  return {
+    ...actual,
+    checkPaymentsRateLimit: mocks.checkPaymentsRateLimit,
+    checkPaymentsVisitorRateLimit: mocks.checkPaymentsVisitorRateLimit,
+  }
+})
 
 vi.mock('@/shared/config', () => ({
   APP_CONFIG: {
@@ -43,6 +48,7 @@ describe('subscription-details route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.checkPaymentsRateLimit.mockResolvedValue({ allowed: true })
+    mocks.checkPaymentsVisitorRateLimit.mockResolvedValue({ allowed: true })
     mocks.requireVisitorPrincipal.mockResolvedValue({ principal: { id: 'visitor_1' } })
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
       id: 10,
@@ -82,6 +88,41 @@ describe('subscription-details route', () => {
 
     expect(response.status).toBe(403)
     expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalled()
+  })
+
+  it('429s the IP bucket before resolving the visitor', async () => {
+    mocks.checkPaymentsRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 17 })
+
+    const response = await GET(
+      createRequest({
+        origin: 'http://localhost:3000',
+        cookie: 'questura_visitor.session_token=abc',
+      })
+    )
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('Retry-After')).toBe('17')
+    expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalled()
+    expect(mocks.checkPaymentsVisitorRateLimit).not.toHaveBeenCalled()
+  })
+
+  it('429s the visitor bucket after resolving the session', async () => {
+    mocks.checkPaymentsVisitorRateLimit.mockResolvedValue({
+      allowed: false,
+      retryAfterSeconds: 17,
+    })
+
+    const response = await GET(
+      createRequest({
+        origin: 'http://localhost:3000',
+        cookie: 'questura_visitor.session_token=abc',
+      })
+    )
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('Retry-After')).toBe('17')
+    expect(mocks.requireVisitorPrincipal).toHaveBeenCalled()
+    expect(mocks.getStripeSubscriptionDetails).not.toHaveBeenCalled()
   })
 
   it('serves the visitor their own subscription from an allowed origin', async () => {


### PR DESCRIPTION
## Summary
- Authenticated `/api/payments/*` routes keep a cheap IP flood bound (raised so a NAT office is not one 8-slot bucket) and add a per-visitor Stripe budget after login. `/api/payments/plans` stays IP-only.
- Drop the 5-minute in-process `getMembershipPlans` cache. Advertised amounts come from `MEMBERSHIP_CATALOG`; checkout uses env price IDs. The cache could disagree across processes and was not on the money path.

## Test plan
- [x] `payments-rate-limit.test.ts`: IP ceiling, visitor ceiling independent of IP, NAT case (two visitors behind one IP each get a full checkout budget)
- [x] `subscription-details.route.test.ts`: IP 429 before auth, visitor 429 after session resolve
- [x] `membership-plans.test.ts`: every call hits Stripe; catalog/compare-at/refusal cases still pass
- [ ] Live: health SHA matches main after deploy. Do not trigger Checkout (live Stripe, real money).


Made with [Cursor](https://cursor.com)