### PR TITLE
Fix blank /purchase page for active members

### DIFF
--- a/apps/questura/apps/client/src/features/Payments/components/MembershipGuard.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/MembershipGuard.tsx
@@ -5,11 +5,16 @@ import { isActiveMember } from '../lib/membership';
 import { useDevStore } from '@/lib/stores/devStore';
 import type { MembershipGuardProps } from '../types';
 
+/**
+ * Hides purchase UI from active members.
+ * Active membership → fallback, or the "already a member" screen.
+ * Otherwise → children.
+ */
 export default function MembershipGuard({ user, children, fallback }: MembershipGuardProps) {
   useDevStore((s) => s.membershipOverride);
   const hasActiveMembership = user ? isActiveMember(user) : false;
 
-  if (hasActiveMembership) {
+  if (!hasActiveMembership) {
     return <>{children}</>;
   }
 

--- a/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
@@ -6,7 +6,6 @@ import { useAuth } from '@/lib/user/hooks';
 import { EnhancedAuthForm } from '@/features/Auth';
 import { isServiceUnavailableError, post } from '@/lib/api';
 import MembershipGuard from '../components/MembershipGuard';
-import { useMembership } from '../hooks/useMembership';
 import { useCreateCheckoutSessionMutation } from '../hooks/useSubscriptionMutations';
 import { formatPlanPrice, getPlanSaving, useMembershipPlan, type PlanId } from '../hooks/useMembershipPlan';
 import { queryKeys } from '@/lib/react-query';
@@ -25,7 +24,6 @@ export default function PurchasePage({
 }: PurchasePageProps) {
   const { user, loading, isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
-  const { hasValidMembership } = useMembership(user);
 
   const checkoutMutation = useCreateCheckoutSessionMutation();
   const { plan: pricing, isLoading: pricingLoading, isUnavailable: pricingUnavailable } = useMembershipPlan(plan);
@@ -81,16 +79,9 @@ export default function PurchasePage({
     }
   };
 
-  if (hasValidMembership) {
-    return (
-      <MembershipGuard user={user}>
-        <div />
-      </MembershipGuard>
-    );
-  }
-
   return (
-    <div className="max-w-2xl mx-auto px-4 py-8">
+    <MembershipGuard user={user}>
+      <div className="max-w-2xl mx-auto px-4 py-8">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
@@ -208,5 +199,6 @@ export default function PurchasePage({
           </div>
         </div>
       </div>
-    );
+    </MembershipGuard>
+  );
 }

--- a/apps/questura/apps/client/src/features/Payments/types/index.ts
+++ b/apps/questura/apps/client/src/features/Payments/types/index.ts
@@ -36,7 +36,8 @@ export interface UserWithMembership {
 // Component Props
 // ============================================================================
 /**
- * Props for MembershipGuard component
+ * Props for MembershipGuard. Children render only when the user is not an
+ * active member. `fallback` replaces the default "already a member" screen.
  */
 export interface MembershipGuardProps {
   user?: UserWithMembership | null;


### PR DESCRIPTION
## Summary
- Active members hitting `/purchase` saw a blank page because `MembershipGuard` rendered children when membership was valid.
- Guard polarity now matches its default copy: members see the already-a-member screen; everyone else sees the purchase form.

## Test plan
- [ ] Signed-in member visits `/purchase` and sees "You're Already a Member!" with an account link
- [ ] Signed-out visitor still sees the purchase/sign-in form
- [ ] Non-member signed-in user still sees checkout


Made with [Cursor](https://cursor.com)