### PR TITLE
Prove Stripe customer ownership before reconciling a profile

### DIFF
--- a/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
+++ b/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
@@ -15,8 +15,9 @@
  *
  * What it reports
  * ---------------
- *   RELINKABLE  A Stripe customer whose email matches a profile that has no
- *               `stripeCustomerId`. Repairable here.
+ *   RELINKABLE  A Stripe customer that names its owner in
+ *               `metadata.visitorAuthUserId`, whose profile still exists but
+ *               has lost its `stripeCustomerId`. Repairable here.
  *   DRIFTED     Linked profile whose subscription state disagrees with Stripe.
  *               Repairable here.
  *   ORPHANED    A Stripe customer with a LIVE subscription and no profile at
@@ -28,12 +29,24 @@
  *   DUPLICATE   Several Stripe customers share one email -- the second-customer
  *               bug. Reported so billing can be merged in Stripe by hand;
  *               merging customers is not something to automate.
+ *   UNPROVEN    A Stripe customer whose email matches profiles, but which does
+ *               not name any of them as its owner. NOT repairable here: email
+ *               alone never proves ownership (see `customer-linkage.ts`), and
+ *               adopting on an email match would hand a stranger the payer's
+ *               billing portal and membership. Reported for hand resolution.
+ *   MISMATCHED  A profile already carries this `stripeCustomerId`, but Stripe
+ *               names a different owner. A bad link already exists; it is
+ *               reported and skipped rather than written to.
  *
  * Safety
  * ------
  * Dry-run by default: prints the plan and writes nothing. Pass `--apply` to
  * write. It only ever fills in or corrects linkage on existing profiles; it
  * never creates, deletes, or reassigns a profile, and never writes to Stripe.
+ *
+ * Ownership is proven by `metadata.visitorAuthUserId` — never by email. The
+ * rule itself lives in `src/features/payments/lib/reconcile-ownership.ts` so it
+ * is shared with its tests and cannot drift from the checkout path.
  *
  * `--max-apply N` caps the blast radius. If the plan is larger than the cap the
  * plan is printed and nothing is written, because mass drift means something
@@ -61,6 +74,10 @@ import {
   exceedsApplyCap,
   type ReconcileStepResult,
 } from '../src/features/payments/lib/reconcile-report'
+import {
+  normalizeAuthUserId,
+  resolveReconcileTarget,
+} from '../src/features/payments/lib/reconcile-ownership'
 
 type PlannedUpdate = {
   profileId: string | number
@@ -135,6 +152,9 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
 
   const byEmail = new Map<string, (typeof profiles.docs)[number][]>()
   const byCustomerId = new Map<string, (typeof profiles.docs)[number]>()
+  // The ownership index. `metadata.visitorAuthUserId` on the Stripe customer is
+  // matched against this, and nothing else decides who a customer belongs to.
+  const byAuthUserId = new Map<string, (typeof profiles.docs)[number]>()
 
   for (const profile of profiles.docs) {
     const email = normalizeEmail(profile.email as string)
@@ -145,6 +165,8 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     }
     const customerId = profile.stripeCustomerId as string | null
     if (customerId) byCustomerId.set(customerId, profile)
+    const authUserId = normalizeAuthUserId(profile.authUserId as string | null)
+    if (authUserId) byAuthUserId.set(authUserId, profile)
   }
 
   emit(`Loaded ${profiles.docs.length} visitor profile(s)\n`)
@@ -156,8 +178,15 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
   const duplicates = new Map<string, string[]>()
   const seenEmails = new Map<string, string[]>()
 
+  const unproven: Array<{ customerId: string; email: string; status: string | null }> = []
+  const mismatched: Array<{
+    customerId: string
+    email: string
+    profileId: string | number
+    owner: string
+  }> = []
+
   let scanned = 0
-  let ambiguous = 0
 
   for await (const customer of stripe.customers.list({ limit: 100 })) {
     if (limit && scanned >= limit) break
@@ -184,10 +213,35 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     })
     const subscription = subscriptions.data[0] ?? null
 
-    const linked = byCustomerId.get(customer.id)
+    const owner = normalizeAuthUserId(customer.metadata?.visitorAuthUserId)
     const candidates = byEmail.get(email) ?? []
 
-    if (!linked && candidates.length === 0) {
+    const target = resolveReconcileTarget({
+      customerOwnerAuthUserId: owner,
+      linkedProfile: byCustomerId.get(customer.id),
+      ownedProfile: owner ? byAuthUserId.get(owner) : null,
+      emailCandidateCount: candidates.length,
+    })
+
+    if (target.kind === 'mismatched') {
+      mismatched.push({
+        customerId: customer.id,
+        email,
+        profileId: target.profile.id,
+        owner: owner ?? '',
+      })
+      continue
+    }
+
+    if (target.kind === 'unproven') {
+      // The old code adopted this case on the strength of the shared email.
+      // It is reported instead: an email match is a lead for a human, never a
+      // licence to hand over someone's billing portal and membership.
+      unproven.push({ customerId: customer.id, email, status: subscription?.status ?? null })
+      continue
+    }
+
+    if (target.kind === 'none') {
       if (subscription) {
         // Only a subscription that could still grant access is a problem. A
         // customer whose subscription ended and whose profile is gone is
@@ -202,15 +256,7 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
       continue
     }
 
-    // Prefer the already-linked profile; otherwise adopt the sole email match.
-    // Ambiguous email matches are left alone rather than guessed at.
-    const profile = linked ?? (candidates.length === 1 ? candidates[0] : null)
-
-    if (!profile) {
-      ambiguous += 1
-      emit(`⚠️  ${email}: ${candidates.length} profiles share this email — skipping, resolve by hand`)
-      continue
-    }
+    const profile = target.profile
 
     const desired: Record<string, unknown> = {}
 
@@ -268,6 +314,8 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
   emit(`DRIFTED    : ${drifted.length}`)
   emit(`ORPHANED   : ${orphaned.length}`)
   emit(`DUPLICATE  : ${duplicates.size}`)
+  emit(`UNPROVEN   : ${unproven.length}`)
+  emit(`MISMATCHED : ${mismatched.length}`)
   if (historicalOrphans > 0) {
     // Counted, not warned about: closed records with no profile need no action.
     emit(`(${historicalOrphans} ended subscription(s) with no profile — historical, no action)`)
@@ -282,10 +330,35 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
   if (orphaned.length > 0) {
     emit(`\n⚠️  ${orphaned.length} Stripe customer(s) have a subscription but NO visitor profile.`)
     emit('   This is what destroyed profile rows look like. Resolve by hand:')
-    emit('   the visitor must sign in (creating an auth user + profile), then re-run')
-    emit('   this script to re-link them.\n')
+    emit('   the visitor signs in (creating an auth user + profile), then set')
+    emit('   metadata.visitorAuthUserId on the customer in Stripe to that auth user')
+    emit('   — signing in alone does not prove who paid — and re-run this script.\n')
     for (const row of orphaned) {
       emit(`  [ORPHANED] ${row.customerId} <${row.email}> subscription=${row.status}`)
+    }
+  }
+
+  if (unproven.length > 0) {
+    emit(`\n⚠️  ${unproven.length} Stripe customer(s) match a profile by email only.`)
+    emit('   Email is not ownership: a customer keeps the address it was created')
+    emit('   with, and this account also holds customers made by hand. Nothing was')
+    emit('   written. Confirm the payer by hand, then set')
+    emit('   metadata.visitorAuthUserId on the customer in Stripe and re-run.\n')
+    for (const row of unproven) {
+      emit(
+        `  [UNPROVEN] ${row.customerId} <${row.email}> subscription=${row.status ?? 'none'}`
+      )
+    }
+  }
+
+  if (mismatched.length > 0) {
+    emit(`\n⛔ ${mismatched.length} profile(s) hold a Stripe customer that names another owner.`)
+    emit('   A wrong linkage already exists. Nothing was written to these profiles;')
+    emit('   resolve the ownership by hand before this run can heal them.\n')
+    for (const row of mismatched) {
+      emit(
+        `  [MISMATCHED] ${row.customerId} <${row.email}> profile=${row.profileId} stripe_owner=${row.owner}`
+      )
     }
   }
 
@@ -304,7 +377,8 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     drifted: drifted.length,
     orphaned: orphaned.length,
     duplicate: duplicates.size,
-    ambiguous,
+    unproven: unproven.length,
+    mismatched: mismatched.length,
     historical: historicalOrphans,
   }
 

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-ownership.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-ownership.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeAuthUserId, resolveReconcileTarget } from './reconcile-ownership'
+
+/**
+ * These tests exist because the nightly reconciliation used to link a Stripe
+ * customer to a profile on a shared email alone — unattended, apply on by
+ * default — and the same write copied the payer's subscription onto whoever
+ * happened to hold that address. The rule below is what stops that, so the case
+ * that used to be adopted is the one asserted hardest.
+ */
+
+const PAYER = { id: 1, authUserId: 'auth-payer' }
+const STRANGER = { id: 2, authUserId: 'auth-stranger' }
+
+describe('resolveReconcileTarget', () => {
+  it('repairs lost linkage when the customer names an owner that still exists', () => {
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: 'auth-payer',
+        linkedProfile: null,
+        ownedProfile: PAYER,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'update', profile: PAYER })
+  })
+
+  it('refuses an email-only match, however unambiguous', () => {
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: null,
+        linkedProfile: null,
+        ownedProfile: null,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'unproven' })
+  })
+
+  it('refuses an email match even when the customer names some other owner', () => {
+    // The destroyed-profile case: the payer's account is gone, and a stranger
+    // now holds the address the customer was created with.
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: 'auth-payer',
+        linkedProfile: null,
+        ownedProfile: null,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'unproven' })
+  })
+
+  it('treats blank metadata as no claim of ownership', () => {
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: '   ',
+        linkedProfile: null,
+        ownedProfile: PAYER,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'unproven' })
+  })
+
+  it('reports nothing to do when no profile carries the email either', () => {
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: null,
+        linkedProfile: null,
+        ownedProfile: null,
+        emailCandidateCount: 0,
+      })
+    ).toEqual({ kind: 'none' })
+  })
+
+  it('keeps healing drift on an existing linkage', () => {
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: 'auth-payer',
+        linkedProfile: PAYER,
+        ownedProfile: PAYER,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'update', profile: PAYER })
+  })
+
+  it('still heals drift on a legacy customer that names nobody', () => {
+    // Ownership was proven once, at checkout, by whatever wrote the linkage.
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: null,
+        linkedProfile: PAYER,
+        ownedProfile: null,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'update', profile: PAYER })
+  })
+
+  it('will not write to a linked profile Stripe says belongs to someone else', () => {
+    expect(
+      resolveReconcileTarget({
+        customerOwnerAuthUserId: 'auth-payer',
+        linkedProfile: STRANGER,
+        ownedProfile: PAYER,
+        emailCandidateCount: 1,
+      })
+    ).toEqual({ kind: 'mismatched', profile: STRANGER })
+  })
+})
+
+describe('normalizeAuthUserId', () => {
+  it('collapses absent, empty and whitespace ids to null', () => {
+    expect(normalizeAuthUserId(undefined)).toBeNull()
+    expect(normalizeAuthUserId(null)).toBeNull()
+    expect(normalizeAuthUserId('')).toBeNull()
+    expect(normalizeAuthUserId('  ')).toBeNull()
+  })
+
+  it('trims a real id rather than rejecting it', () => {
+    expect(normalizeAuthUserId(' auth-payer ')).toBe('auth-payer')
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-ownership.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-ownership.ts
@@ -1,0 +1,86 @@
+/**
+ * Who does this Stripe customer belong to?
+ *
+ * The checkout path already answers this: `customer-linkage.ts` refuses to
+ * adopt a Stripe customer on an email match, because a customer's email is
+ * written once at creation and nothing syncs it afterwards — so an address a
+ * visitor has since abandoned sits on their customer, free for the next signup
+ * to claim. This account also predates the site and holds hand-made customers.
+ * `metadata.visitorAuthUserId` is stamped by us at creation and is the only
+ * claim of ownership either path trusts.
+ *
+ * The nightly reconciliation used to disagree with that: an unlinked profile
+ * that merely shared the customer's email was adopted, and the same write that
+ * stamped `stripeCustomerId` also copied `paidThroughAt` and
+ * `subscriptionStatus` off that customer's subscription. Nightly, unattended,
+ * apply-on-by-default. One hit hands a stranger the payer's billing portal —
+ * card last four, invoices, cancel button — plus a free membership.
+ *
+ * So the rule lives here, once, as a pure function both the script and its
+ * tests can use, and email is demoted to what it always was: a hint worth
+ * reporting, never a proof worth writing.
+ */
+
+/** The parts of a visitor profile this rule reads. */
+export type OwnableProfile = {
+  id: string | number
+  authUserId?: string | null
+}
+
+export type ReconcileTarget<P extends OwnableProfile> =
+  /** Ownership is proven; linkage and subscription state may be written. */
+  | { kind: 'update'; profile: P }
+  /**
+   * The profile already carrying this `stripeCustomerId` is not the one Stripe
+   * says owns the customer. Something linked it wrongly before; writing money
+   * state to it now would compound that, so it is reported and skipped.
+   */
+  | { kind: 'mismatched'; profile: P }
+  /**
+   * No proof of ownership, but profiles carry the customer's email. This is
+   * exactly the case the old code auto-applied. Report only.
+   */
+  | { kind: 'unproven' }
+  /** Nothing on this side at all — the caller's ORPHANED/historical bucket. */
+  | { kind: 'none' }
+
+export function normalizeAuthUserId(value: string | null | undefined): string | null {
+  const trimmed = (value ?? '').trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Decide which profile — if any — a Stripe customer may be reconciled onto.
+ *
+ * `linkedProfile` is the profile already holding this `stripeCustomerId`;
+ * `ownedProfile` is the profile whose `authUserId` equals the customer's
+ * `metadata.visitorAuthUserId`. `emailCandidateCount` is only ever used to tell
+ * "unproven" apart from "nothing there".
+ */
+export function resolveReconcileTarget<P extends OwnableProfile>(input: {
+  customerOwnerAuthUserId: string | null | undefined
+  linkedProfile: P | null | undefined
+  ownedProfile: P | null | undefined
+  emailCandidateCount: number
+}): ReconcileTarget<P> {
+  const owner = normalizeAuthUserId(input.customerOwnerAuthUserId)
+
+  // An existing linkage is itself the proof: it was written by a checkout that
+  // resolved ownership, or by a previous proven repair. Only Stripe explicitly
+  // naming a different owner overrides it.
+  if (input.linkedProfile) {
+    if (owner && normalizeAuthUserId(input.linkedProfile.authUserId) !== owner) {
+      return { kind: 'mismatched', profile: input.linkedProfile }
+    }
+    return { kind: 'update', profile: input.linkedProfile }
+  }
+
+  // Lost linkage, repairable: the customer names its owner and that account
+  // still exists. This is the case the script was written for, and it survives
+  // the ownership rule intact.
+  if (owner && input.ownedProfile) {
+    return { kind: 'update', profile: input.ownedProfile }
+  }
+
+  return input.emailCandidateCount > 0 ? { kind: 'unproven' } : { kind: 'none' }
+}

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-report.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-report.test.ts
@@ -24,7 +24,8 @@ const CLEAN_PROFILES = {
   planned: 0,
   orphaned: 0,
   duplicate: 0,
-  ambiguous: 0,
+  unproven: 0,
+  mismatched: 0,
   historical: 0,
 }
 const CLEAN_AUDIT = {
@@ -245,5 +246,20 @@ describe('exceedsApplyCap', () => {
 
   it('has no cap when none is given, which is the manual CLI default', () => {
     expect(exceedsApplyCap(10_000, null)).toBe(false)
+  })
+})
+
+describe('ownership findings escalate', () => {
+  // An email-only match is not something the apply pass may repair, so finding
+  // one has to reach a human the same way ORPHANED and DUPLICATE do.
+  it.each(['unproven', 'mismatched'])('treats %s as needing attention', (key) => {
+    const classified = classifyStep({
+      step: 'profiles',
+      counts: { ...CLEAN_PROFILES, [key]: 1 },
+      lines: [],
+    })
+
+    expect(classified.status).toBe('attention')
+    expect(classified.escalations).toContain(key)
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-report.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-report.ts
@@ -58,7 +58,10 @@ export type StepStatus = 'ok' | 'attention' | 'error'
  */
 export const ESCALATING_COUNTS: Readonly<Record<ReconcileStepName, readonly string[]>> = {
   verify: ['missing', 'disabled'],
-  profiles: ['orphaned', 'duplicate'],
+  // `unproven` and `mismatched` are ownership questions only a human can
+  // answer: an email match is not proof, so the script reports them instead of
+  // adopting them, and the nightly must not let that report go unread.
+  profiles: ['orphaned', 'duplicate', 'unproven', 'mismatched'],
   audit: ['stuck', 'unknown'],
   // Pruning old webhook rows is the job working. A throw still escalates.
   retention: [],
@@ -70,7 +73,7 @@ export const ESCALATING_COUNTS: Readonly<Record<ReconcileStepName, readonly stri
  */
 const SUMMARY_COUNTS: Readonly<Record<ReconcileStepName, readonly string[]>> = {
   verify: ['missing', 'disabled', 'extra'],
-  profiles: ['relinkable', 'drifted', 'applied', 'orphaned', 'duplicate'],
+  profiles: ['relinkable', 'drifted', 'applied', 'orphaned', 'duplicate', 'unproven', 'mismatched'],
   audit: ['stuck', 'unknown', 'in_period', 'contested', 'closed'],
   retention: ['expired', 'deleted'],
 }


### PR DESCRIPTION
## Why

`scripts/reconcile-stripe-visitor-profiles.ts` linked a Stripe customer to a visitor profile **on a shared email alone**, and the same write copied `paidThroughAt` / `subscriptionStatus` off that customer's subscription:

```ts
const candidates = byEmail.get(email) ?? []
const profile = linked ?? (candidates.length === 1 ? candidates[0] : null)
if (!profile.stripeCustomerId) desired.stripeCustomerId = customer.id
```

No ownership check. It runs unattended — `infra/softprod/reconcile.sh:31` defaults `QUESTURA_RECONCILE_APPLY` to `1`, nightly at 04:20.

Stripe writes a customer's email once, at creation, and nothing syncs it afterwards, so an address a visitor has since abandoned sits on their customer waiting for the next signup to claim. The account also predates the site and holds hand-made customers. A hit hands the victim's billing portal — card last four, invoices, cancel button — plus a free membership, to a signup that never verified its email.

`payments/lib/customer-linkage.ts:18-37` already states the invariant this violated: *"Email alone never proves ownership… Matching on email alone would hand a stranger's card, invoices and portal to whoever registers that address next."* The script's own header even said `authUserId` is not derivable from Stripe, then derived it from email anyway.

The ORPHANED remediation text made it worse: *"the visitor must sign in… then re-run this script to re-link them"* — nothing proved the person who signed in was the payer.

## What

- New `src/features/payments/lib/reconcile-ownership.ts` — one pure function deciding who a customer may be reconciled onto, shared with its tests so it cannot drift from the checkout path.
- Ownership is `customer.metadata.visitorAuthUserId` matched against `profile.authUserId`. `resolveStripeCustomerForVisitor` stamps every customer we create, so genuine lost-linkage repair is unaffected.
- Email-only matches become **UNPROVEN**: reported, never written. Previously auto-applied.
- A profile already holding a customer that names a different owner becomes **MISMATCHED**: reported and skipped rather than written to.
- Both escalate the nightly to exit 1 alongside ORPHANED / DUPLICATE (`ESCALATING_COUNTS`), and appear on the summary line.
- ORPHANED remediation text now says to stamp `metadata.visitorAuthUserId` in Stripe first, because signing in does not prove who paid.

Behaviour deliberately kept: an existing linkage is still proof enough to heal drift, including on legacy customers carrying no metadata.

## Verification

- 8 new tests in `reconcile-ownership.test.ts`, including the exact case that used to be adopted.
- `pnpm vitest run src/features/payments` — 283 passed, 20 files.
- `pnpm exec tsc --noEmit` — clean.
- No schema change: touches `payments/lib` and `scripts/` only. Nothing ran against live Stripe.