### PR TITLE
Mirror the billing subscription when reconciling, not the newest

### DIFF
--- a/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
+++ b/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
@@ -48,6 +48,11 @@
  * rule itself lives in `src/features/payments/lib/reconcile-ownership.ts` so it
  * is shared with its tests and cannot drift from the checkout path.
  *
+ * Which of a customer's subscriptions a profile mirrors is decided by
+ * `selectProfileSubscription` (`customer-linkage.ts`) — the billing one, and
+ * only the newest when none is billing — the same rule `ownsProfileRow` applies
+ * on the webhook path.
+ *
  * `--max-apply N` caps the blast radius. If the plan is larger than the cap the
  * plan is printed and nothing is written, because mass drift means something
  * systemic — wrong Stripe key, wrong account, a bad deploy — rather than N
@@ -69,6 +74,7 @@ import { getPayload } from 'payload'
 import Stripe from 'stripe'
 
 import config from '../src/payload.config'
+import { selectProfileSubscription } from '../src/features/payments/lib/customer-linkage'
 import { deriveSubscriptionState } from '../src/features/payments/lib/subscription-state'
 import {
   exceedsApplyCap,
@@ -202,16 +208,21 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     seenEmails.set(email, emailBucket)
     if (emailBucket.length > 1) duplicates.set(email, emailBucket)
 
-    // Newest subscription wins; Stripe returns most recent first.
+    // Every subscription, not just the newest: which one owns the profile row
+    // is an ownership question, and `selectProfileSubscription` answers it with
+    // the same rule the webhook path enforces (`ownsProfileRow`). Reading only
+    // the newest made a ~23h `incomplete` from an abandoned 3DS attempt
+    // outrank the membership actually billing, and this script writes what it
+    // reads.
     const subscriptions = await stripe.subscriptions.list({
       customer: customer.id,
       status: 'all',
-      limit: 1,
+      limit: 100,
       // The dunning grace is derived from Stripe's own next retry time, which
       // lives on the invoice.
       expand: ['data.latest_invoice'],
     })
-    const subscription = subscriptions.data[0] ?? null
+    const subscription = selectProfileSubscription(subscriptions.data)
 
     const owner = normalizeAuthUserId(customer.metadata?.visitorAuthUserId)
     const candidates = byEmail.get(email) ?? []
@@ -242,13 +253,22 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     }
 
     if (target.kind === 'none') {
-      if (subscription) {
+      if (subscriptions.data.length > 0) {
         // Only a subscription that could still grant access is a problem. A
         // customer whose subscription ended and whose profile is gone is
         // history: there is nothing to repair and nothing to grant, so warning
         // about it every run trains people to ignore the warning.
-        if (LIVE_SUBSCRIPTION_STATUSES.has(subscription.status)) {
-          orphaned.push({ customerId: customer.id, email, status: subscription.status })
+        //
+        // Asked of the whole list rather than of the selected one: the question
+        // here is "is anyone paying with no account to grant it to", which any
+        // grantable subscription answers, not just the one that would own a row
+        // that does not exist.
+        const grantable = subscriptions.data.find((candidate) =>
+          LIVE_SUBSCRIPTION_STATUSES.has(candidate.status)
+        )
+
+        if (grantable) {
+          orphaned.push({ customerId: customer.id, email, status: grantable.status })
         } else {
           historicalOrphans += 1
         }

--- a/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
+++ b/apps/questura/apps/server/src/features/payments/customer-linkage.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/payments/lib/stripe', () => ({
 import {
   findLiveSubscription,
   listBillableSubscriptions,
+  selectProfileSubscription,
   selectSubscriptionToKeep,
   syncStripeCustomerEmail,
 } from '@/payments/lib/customer-linkage'
@@ -172,5 +173,60 @@ describe('selectSubscriptionToKeep', () => {
     ])
 
     expect(kept).toEqual(expect.objectContaining({ id: 'sub_newer' }))
+  })
+})
+
+describe('selectProfileSubscription', () => {
+  const subscription = (
+    id: string,
+    status: string,
+    created: number,
+  ) => ({ id, status, created }) as never
+
+  it('returns null for a customer with no subscriptions', () => {
+    expect(selectProfileSubscription([])).toBeNull()
+  })
+
+  // The reconciler bug: an abandoned 3DS attempt sits `incomplete` for ~23
+  // hours, so it is the newest thing on the customer while the membership that
+  // is actually billing runs on. Mirroring the attempt onto the profile writes
+  // `past_due` over remaining paid time and points the cancel button at a dead
+  // subscription.
+  it('keeps the billing subscription over a newer abandoned attempt', () => {
+    const selected = selectProfileSubscription([
+      subscription('sub_abandoned', 'incomplete', 200),
+      subscription('sub_paid', 'active', 100),
+    ])
+
+    expect(selected).toEqual(expect.objectContaining({ id: 'sub_paid' }))
+  })
+
+  it('keeps a subscription Stripe is still retrying over a newer dead one', () => {
+    const selected = selectProfileSubscription([
+      subscription('sub_dead', 'canceled', 300),
+      subscription('sub_retrying', 'past_due', 100),
+    ])
+
+    expect(selected).toEqual(expect.objectContaining({ id: 'sub_retrying' }))
+  })
+
+  it('keeps the newest when several are live', () => {
+    const selected = selectProfileSubscription([
+      subscription('sub_old', 'active', 100),
+      subscription('sub_new', 'active', 200),
+    ])
+
+    expect(selected).toEqual(expect.objectContaining({ id: 'sub_new' }))
+  })
+
+  // With nothing billing, the newest closed record is the profile's final
+  // state, so an older cancellation cannot overwrite a newer one.
+  it('falls back to the newest when nothing is live', () => {
+    const selected = selectProfileSubscription([
+      subscription('sub_older', 'canceled', 100),
+      subscription('sub_newer', 'incomplete_expired', 200),
+    ])
+
+    expect(selected).toEqual(expect.objectContaining({ id: 'sub_newer' }))
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/customer-linkage.ts
@@ -197,6 +197,34 @@ export async function findLiveSubscription(
   return listed.find(isLiveSubscription) ?? null
 }
 
+/**
+ * The one subscription a profile row should mirror, given everything Stripe
+ * holds for the customer.
+ *
+ * This is the same ownership rule `ownsProfileRow` enforces on the webhook path
+ * (`subscription-resync.ts`): the subscription that is billing owns the row,
+ * and only when none is does the newest one own it. Newest-wins on its own is
+ * the bug PR #324 fixed — a visitor who abandons 3DS leaves an `incomplete`
+ * subscription sitting on the customer for ~23 hours, so a dead attempt is the
+ * newest thing there while a paid membership is still running. Mirroring the
+ * attempt stamps `past_due` and its period start over the live membership's
+ * remaining paid time, and points `/account`'s cancel button at a dead id.
+ *
+ * Ties among live subscriptions keep the newest, matching the order Stripe
+ * lists them in, so the batch path and the webhook path cannot disagree.
+ */
+export function selectProfileSubscription(
+  subscriptions: Stripe.Subscription[]
+): Stripe.Subscription | null {
+  const live = subscriptions.filter(isLiveSubscription)
+  const candidates = live.length > 0 ? live : subscriptions
+
+  return candidates.reduce<Stripe.Subscription | null>(
+    (best, subscription) => (!best || subscription.created > best.created ? subscription : best),
+    null
+  )
+}
+
 export async function listBillableSubscriptions(
   customerId: string
 ): Promise<Stripe.Subscription[]> {


### PR DESCRIPTION
## Why

The nightly reconciler took `subscriptions.list({ limit: 1 })` — Stripe's **most recently created** subscription — as the one a visitor profile should mirror. The webhook path decides that differently: `ownsProfileRow` (`subscription-resync.ts`) keeps the subscription that is **billing**, and falls back to newest only when none is. That rule exists because of PR #324, where a refunded duplicate revoked a live paid membership.

Ordinary visitor behaviour triggers the split:

1. Member is billing monthly.
2. They open a second Checkout and abandon 3DS → an `incomplete` subscription sits on the customer for ~23h, newer than the live one.
3. Nightly run reads only that dead attempt and writes it: `subscriptionStatus: past_due`, `paidThroughAt` reset to the attempt's period, `stripeSubscriptionId` repointed.

Result: remaining paid time is gone and `/account`'s cancel button points at a subscription that cannot stop the real charge. It counts as **one** DRIFTED row, so it stays inside the 25 `--max-apply` cap and is applied unattended.

## What

- `customer-linkage.ts`: new pure `selectProfileSubscription(subscriptions)` — live one wins, newest only when none is live. Lives beside `isLiveSubscription`/`findLiveSubscription` so the batch and webhook paths share one rule.
- `reconcile-stripe-visitor-profiles.ts`: lists the customer's subscriptions (`limit: 100`, invoice still expanded for the dunning grace) and selects through it.
- ORPHANED detection now asks the whole list instead of the selected subscription — "is someone paying with no account to grant it to" is answered by any grantable subscription, not only by the one that would own a profile row that does not exist. Without that, a newer `canceled` subscription could hide an `incomplete` one and downgrade a real orphan to a historical count.
- No behaviour change to `ownsProfileRow` itself; the proven webhook path is untouched.

## Verification

- `pnpm vitest run src/features/payments` → 20 files, 288 tests passed.
- 5 new tests for `selectProfileSubscription`, including the exact break case (newer `incomplete` vs older `active`) and the no-live fallback.
- `pnpm exec tsc --noEmit` → clean.
- No schema change: script + payments lib + test only. No Stripe writes; the script still never writes to Stripe and remains dry-run by default.