### PR TITLE
Make membership and Stripe fields admin-only on visitor profiles

### DIFF
--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Field } from 'payload'
+
+import { logger } from '@/shared/utils/logger'
 
 import { VisitorProfiles } from './VisitorProfiles'
+import { logMembershipFieldEdits } from './hooks/logMembershipFieldEdits'
 import { preventVisitorProfileDelete } from './hooks/preventDelete'
 
 const access = VisitorProfiles.access as Record<
@@ -30,5 +35,165 @@ describe('VisitorProfiles deletion', () => {
         req: {},
       }),
     ).toThrow('Visitor profiles cannot be deleted independently.')
+  })
+})
+
+/** Every named field, flattened out of rows and collapsibles. */
+function namedFields(fields: Field[]): Map<string, Field> {
+  const found = new Map<string, Field>()
+
+  for (const field of fields) {
+    if ('name' in field && field.name) found.set(field.name, field)
+    if ('fields' in field && Array.isArray(field.fields)) {
+      for (const [name, nested] of namedFields(field.fields)) found.set(name, nested)
+    }
+  }
+
+  return found
+}
+
+const fields = namedFields(VisitorProfiles.fields)
+
+/** `UIField` carries no `access`, and none of these fields is one. */
+const fieldAccess = (field: Field | undefined) =>
+  (field as { access?: { update?: unknown } } | undefined)?.access
+
+const fieldUpdate = (name: string) => {
+  const field = fields.get(name)
+  if (!field) throw new Error(`No field named ${name} on visitor-profiles`)
+  const update = fieldAccess(field)?.update
+  if (!update) throw new Error(`Field ${name} has no update access rule`)
+  return (user: unknown) =>
+    Boolean((update as (args: { req: { user: unknown } }) => unknown)({ req: { user } }))
+}
+
+describe('VisitorProfiles membership fields', () => {
+  const MEMBERSHIP_FIELDS = [
+    'authUserId',
+    'billingEmail',
+    'subscriptionStatus',
+    'paidThroughAt',
+    'dunningGraceUntil',
+    'cancelAtPeriodEnd',
+    'stripeCustomerId',
+    'stripeSubscriptionId',
+    'affiliateReferralId',
+    'affiliateReferredAt',
+  ]
+
+  // Entitlement is a future `paidThroughAt` and nothing else, so write access
+  // to these fields is write access to the paywall.
+  it.each(MEMBERSHIP_FIELDS)('refuses %s to an editor', (name) => {
+    expect(fieldUpdate(name)({ id: 2, collection: 'users', role: 'editor', status: 'active' })).toBe(
+      false,
+    )
+  })
+
+  it.each(MEMBERSHIP_FIELDS)('refuses %s to a writer', (name) => {
+    expect(fieldUpdate(name)({ id: 3, collection: 'users', role: 'writer', status: 'active' })).toBe(
+      false,
+    )
+  })
+
+  it.each(MEMBERSHIP_FIELDS)('refuses %s to a disabled admin', (name) => {
+    expect(
+      fieldUpdate(name)({ id: 4, collection: 'users', role: 'admin', status: 'disabled' }),
+    ).toBe(false)
+  })
+
+  it.each(MEMBERSHIP_FIELDS)('allows %s to an active admin', (name) => {
+    expect(fieldUpdate(name)({ id: 1, collection: 'users', role: 'admin', status: 'active' })).toBe(
+      true,
+    )
+  })
+
+  // Editors keep the collection so support corrections do not need an admin.
+  it('still lets an editor update the profile itself', () => {
+    expect(access.update({ req: { user: { id: 2, collection: 'users', role: 'editor' } } })).toBe(
+      true,
+    )
+  })
+
+  it('leaves support fields editable', () => {
+    for (const name of ['email', 'firstName', 'lastName']) {
+      expect(fieldAccess(fields.get(name))?.update).toBeUndefined()
+    }
+  })
+})
+
+describe('membership edit audit trail', () => {
+  const run = (args: Record<string, unknown>) =>
+    (logMembershipFieldEdits as (a: unknown) => unknown)(args)
+
+  it('is wired into the collection lifecycle', () => {
+    expect(VisitorProfiles.hooks?.afterChange).toContain(logMembershipFieldEdits)
+  })
+
+  it('logs a hand-granted membership', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined as never)
+
+    run({
+      operation: 'update',
+      doc: { id: 7, paidThroughAt: '2030-01-01T00:00:00.000Z', subscriptionStatus: 'active' },
+      previousDoc: { id: 7, paidThroughAt: null, subscriptionStatus: 'none' },
+      req: { user: { id: 2, collection: 'users', role: 'editor' } },
+    })
+
+    expect(warn).toHaveBeenCalledWith(
+      'Membership fields changed by a staff account',
+      expect.objectContaining({
+        profileId: 7,
+        actorId: 2,
+        changedFields: ['subscriptionStatus', 'paidThroughAt'],
+      }),
+    )
+
+    warn.mockRestore()
+  })
+
+  it('stays quiet for support edits that touch no membership field', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined as never)
+
+    run({
+      operation: 'update',
+      doc: { id: 7, firstName: 'Ada', paidThroughAt: '2030-01-01T00:00:00.000Z' },
+      previousDoc: { id: 7, firstName: 'A', paidThroughAt: '2030-01-01T00:00:00.000Z' },
+      req: { user: { id: 2, collection: 'users' } },
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  // Stripe resync, checkout and the reconciler all write through the Local API
+  // with no `req.user`, and log their own writes.
+  it('stays quiet for machine writes', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined as never)
+
+    run({
+      operation: 'update',
+      doc: { id: 7, paidThroughAt: '2030-01-01T00:00:00.000Z' },
+      previousDoc: { id: 7, paidThroughAt: null },
+      req: {},
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  // A `Date` from one write path and an ISO string from another are the same
+  // instant; a false positive every renewal makes the log unreadable.
+  it('does not report an unchanged date written in a different shape', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined as never)
+
+    run({
+      operation: 'update',
+      doc: { id: 7, paidThroughAt: '2030-01-01T00:00:00.000Z' },
+      previousDoc: { id: 7, paidThroughAt: new Date('2030-01-01T00:00:00.000Z') },
+      req: { user: { id: 1, collection: 'users' } },
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/VisitorProfiles.ts
@@ -1,6 +1,28 @@
+import { isAdminFieldLevel } from '@/features/auth/collections/access'
 import { staffUser } from '@/features/auth/lib/staff-user'
 import type { CollectionConfig } from 'payload'
+import { logMembershipFieldEdits } from './hooks/logMembershipFieldEdits'
 import { preventVisitorProfileDelete } from './hooks/preventDelete'
+
+/**
+ * Membership and billing linkage are admin-only, field by field.
+ *
+ * Collection `update` is deliberately wider than that: editors work profiles
+ * for support (a mistyped address, a name), and losing that would push every
+ * correction onto an admin. But entitlement is nothing more than a future
+ * `paidThroughAt`, so a plain date field on this collection *is* the paywall —
+ * an editor who can write it can hand themselves, or anyone, a free
+ * membership, and one who can clear `stripeCustomerId` can strand a paying
+ * visitor's subscription with no way back to their profile.
+ *
+ * Field access is the right seam rather than narrowing the collection: it
+ * refuses the write at the API as well as greying the input out in the admin
+ * panel, and it is bypassed by trusted Local API calls — so Stripe resync,
+ * checkout and the nightly reconciler, which all write through the Local API
+ * with `overrideAccess`, are unaffected. Stripe stays the only thing that
+ * grants access; an admin doing it by hand stays possible and is logged.
+ */
+const membershipFieldAccess = { update: isAdminFieldLevel } as const
 
 export const VisitorProfiles: CollectionConfig = {
   slug: 'visitor-profiles',
@@ -33,6 +55,9 @@ export const VisitorProfiles: CollectionConfig = {
     // Access control is bypassable by trusted Local API calls. Preserve the
     // invariant there too; future erasure must be one coordinated workflow.
     beforeDelete: [preventVisitorProfileDelete],
+    // The collection keeps no history, so a hand-granted membership would
+    // otherwise be indistinguishable from one Stripe paid for.
+    afterChange: [logMembershipFieldEdits],
   },
   fields: [
     {
@@ -41,6 +66,10 @@ export const VisitorProfiles: CollectionConfig = {
       required: true,
       unique: true,
       index: true,
+      // The key every membership lookup runs through. `readOnly` only greys
+      // the input out; without field access an editor could repoint a profile
+      // at another visitor's auth user over the API.
+      access: membershipFieldAccess,
       admin: {
         readOnly: true,
         description: 'BetterAuth user ID for this Visitor account.',
@@ -59,6 +88,7 @@ export const VisitorProfiles: CollectionConfig = {
       name: 'billingEmail',
       type: 'email',
       index: true,
+      access: membershipFieldAccess,
       admin: {
         readOnly: true,
         description:
@@ -89,6 +119,7 @@ export const VisitorProfiles: CollectionConfig = {
         { label: 'Cancelled', value: 'cancelled' },
         { label: 'Past Due', value: 'past_due' },
       ],
+      access: membershipFieldAccess,
       admin: {
         description: 'Visitor membership status from Stripe.',
       },
@@ -99,6 +130,9 @@ export const VisitorProfiles: CollectionConfig = {
         {
           name: 'paidThroughAt',
           type: 'date',
+          // The paywall itself: access is `isFuture(paidThroughAt)` and
+          // nothing else.
+          access: membershipFieldAccess,
           admin: {
             description:
               'End of the last billing period actually paid for. Never advances on an unpaid period, so it is not the same as Stripe current_period_end, which moves at renewal before the charge clears.',
@@ -107,6 +141,7 @@ export const VisitorProfiles: CollectionConfig = {
         {
           name: 'dunningGraceUntil',
           type: 'date',
+          access: membershipFieldAccess,
           admin: {
             description:
               'Bounded extension of access while Stripe retries a failed renewal. Set when the subscription enters past_due, cleared on recovery.',
@@ -118,6 +153,7 @@ export const VisitorProfiles: CollectionConfig = {
       name: 'cancelAtPeriodEnd',
       type: 'checkbox',
       defaultValue: false,
+      access: membershipFieldAccess,
       admin: {
         description: 'Whether the subscription stops at the paid-through date instead of renewing.',
       },
@@ -142,10 +178,12 @@ export const VisitorProfiles: CollectionConfig = {
               type: 'text',
               index: true,
               unique: true,
+              access: membershipFieldAccess,
             },
             {
               name: 'stripeSubscriptionId',
               type: 'text',
+              access: membershipFieldAccess,
             },
           ],
         },
@@ -162,12 +200,16 @@ export const VisitorProfiles: CollectionConfig = {
           type: 'row',
           fields: [
             {
+              // Referral attribution decides who gets paid for this member,
+              // so it is money the same way the fields above are.
               name: 'affiliateReferralId',
               type: 'text',
+              access: membershipFieldAccess,
             },
             {
               name: 'affiliateReferredAt',
               type: 'date',
+              access: membershipFieldAccess,
             },
           ],
         },

--- a/apps/questura/apps/server/src/features/visitor-auth/collections/hooks/logMembershipFieldEdits.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/collections/hooks/logMembershipFieldEdits.ts
@@ -1,0 +1,80 @@
+import type { CollectionAfterChangeHook } from 'payload'
+
+import { logger } from '@/shared/utils/logger'
+
+/**
+ * Fields that decide whether someone is a paying member, or where their money
+ * goes. Everything else on the profile is support data.
+ */
+const MEMBERSHIP_FIELDS = [
+  'authUserId',
+  'billingEmail',
+  'subscriptionStatus',
+  'paidThroughAt',
+  'dunningGraceUntil',
+  'cancelAtPeriodEnd',
+  'stripeCustomerId',
+  'stripeSubscriptionId',
+  'affiliateReferralId',
+  'affiliateReferredAt',
+] as const
+
+function changedMembershipFields(
+  doc: Record<string, unknown>,
+  previous: Record<string, unknown> | undefined
+): string[] {
+  if (!previous) return []
+
+  return MEMBERSHIP_FIELDS.filter((field) => {
+    const before = previous[field] ?? null
+    const after = doc[field] ?? null
+
+    // Dates arrive as `Date` from one path and as an ISO string from another,
+    // so compare their serialised form rather than their identity.
+    const normalise = (value: unknown) => (value instanceof Date ? value.toISOString() : value)
+
+    return normalise(before) !== normalise(after)
+  })
+}
+
+/**
+ * Record membership and billing changes made by a person.
+ *
+ * Granting a membership by hand is still allowed — an admin refunding, or
+ * fixing a Stripe outage, needs it — but the collection keeps no history, so
+ * without this a hand-written `paidThroughAt` is indistinguishable from one
+ * Stripe paid for. Field access already limits who can do it; this records
+ * that they did.
+ *
+ * Only writes carrying an authenticated principal are logged. Stripe resync,
+ * checkout and the reconciler run through the Local API with no `req.user`,
+ * and they already log their own writes; logging them here would bury the
+ * hand edits in machine noise, which is the opposite of an audit trail.
+ */
+export const logMembershipFieldEdits: CollectionAfterChangeHook = ({
+  doc,
+  previousDoc,
+  operation,
+  req,
+}) => {
+  if (operation !== 'update') return doc
+  if (!req?.user) return doc
+
+  const changed = changedMembershipFields(
+    doc as Record<string, unknown>,
+    previousDoc as Record<string, unknown> | undefined
+  )
+
+  if (changed.length === 0) return doc
+
+  logger.warn('Membership fields changed by a staff account', {
+    profileId: (doc as { id?: unknown }).id,
+    actorId: req.user.id,
+    actorCollection: req.user.collection,
+    changedFields: changed,
+    subscriptionStatus: (doc as { subscriptionStatus?: unknown }).subscriptionStatus,
+    paidThroughAt: (doc as { paidThroughAt?: unknown }).paidThroughAt,
+  })
+
+  return doc
+}


### PR DESCRIPTION
## Why

`visitor-profiles` grants collection `update` to **admin and editor**, and every membership field was writable by both. Entitlement is `isFuture(paidThroughAt)` and nothing else — so that plain date field *is* the paywall.

An editor (content role) could therefore:

- write `paidThroughAt` into the future and hand themselves, or anyone, a free membership;
- clear `stripeCustomerId`, stranding a paying visitor's subscription with no profile for its webhooks to resolve;
- repoint `authUserId` at another visitor's auth user.

The collection keeps no history, so none of it left a trace.

## What

Field-level `access.update: isAdminFieldLevel` on the money and identity surface:

`authUserId`, `billingEmail`, `subscriptionStatus`, `paidThroughAt`, `dunningGraceUntil`, `cancelAtPeriodEnd`, `stripeCustomerId`, `stripeSubscriptionId`, `affiliateReferralId`, `affiliateReferredAt`.

The last two are beyond the reported set on purpose: referral attribution decides who gets paid for a member, which is the same money surface.

Collection `update` stays as it was. Editors keep the profile for support work — `email`, `firstName`, `lastName` — which is why they have it; pushing every mistyped address onto an admin is the wrong trade.

**Field access rather than `admin.readOnly`:** `readOnly` only disables the input and leaves the REST write open. Field access refuses the write *and* greys the input. It is bypassed by trusted Local API calls, so checkout, `subscription-resync`, `payment-service` and the nightly reconciler — all of which write with `overrideAccess` — are unaffected. Verified each call site. Stripe stays the only thing that grants access.

**Audit trail:** granting by hand stays possible for an admin handling a refund or a Stripe outage, so an `afterChange` hook records which membership fields a staff account changed and to what. Machine writes carry no `req.user` and log themselves already, so they stay out of the trail rather than burying the hand edits.

## Verification

- `VisitorProfiles.test.ts` — 54 tests: every gated field refused to an editor, to a writer, and to a *disabled* admin; allowed to an active admin; support fields asserted still ungated; collection-level editor update asserted unchanged. Hook tests cover the hand-grant log, silence for support-only edits, silence for machine writes, and no false positive when a date arrives as `Date` on one side and an ISO string on the other.
- `pnpm exec tsc --noEmit` clean.
- Full server suite: 1014/1016. The two failures are `media/pipeline` sharp timeouts under parallel load and pass in isolation — untouched by this change.
- No schema change: access rules and a hook, no field storage shape touched, so no migration.