### PR TITLE
Decide membership emails by entitlement, not the status enum

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/membership-transitions.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-transitions.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit coverage for the transition resolver.
+ *
+ * The end-to-end simulation drives whole webhook sequences; this file pins the
+ * decision itself, including the before-states that are awkward to reach
+ * through the route — above all the `past_due` fork, where one internal status
+ * covers both a failed renewal and a first charge that never cleared.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  resolveMembershipTransitions,
+  type MembershipSnapshot,
+} from './membership-transitions'
+import type { DerivedSubscriptionState } from './subscription-state'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const future = (days = 20) => new Date(Date.now() + days * DAY_MS).toISOString()
+const past = (days = 20) => new Date(Date.now() - days * DAY_MS).toISOString()
+
+function state(over: Partial<DerivedSubscriptionState> = {}): DerivedSubscriptionState {
+  return {
+    subscriptionStatus: 'active',
+    cancelAtPeriodEnd: false,
+    paidThroughAt: future(),
+    dunningGraceUntil: null,
+    ...over,
+  }
+}
+
+function kinds(before: MembershipSnapshot, after: DerivedSubscriptionState) {
+  return resolveMembershipTransitions(before, after).map((t) => t.kind)
+}
+
+const NEW_VISITOR: MembershipSnapshot = {
+  subscriptionStatus: 'none',
+  cancelAtPeriodEnd: false,
+  paidThroughAt: null,
+  dunningGraceUntil: null,
+}
+
+/**
+ * What `customer.subscription.created` writes for a subscription still waiting
+ * on 3DS: `incomplete` maps to internal `past_due`, and `paidThroughAt` is the
+ * start of a period nobody has paid for yet, so it is already in the past. No
+ * grace opens, because nothing ever collected.
+ */
+const AWAITING_3DS: MembershipSnapshot = {
+  subscriptionStatus: 'past_due',
+  cancelAtPeriodEnd: false,
+  paidThroughAt: past(0.001),
+  dunningGraceUntil: null,
+}
+
+/** A member whose renewal charge failed: paid time behind them, grace running. */
+const DUNNING: MembershipSnapshot = {
+  subscriptionStatus: 'past_due',
+  cancelAtPeriodEnd: false,
+  paidThroughAt: past(0.001),
+  dunningGraceUntil: future(5),
+}
+
+const ACTIVE_MEMBER: MembershipSnapshot = {
+  subscriptionStatus: 'active',
+  cancelAtPeriodEnd: false,
+  paidThroughAt: future(),
+  dunningGraceUntil: null,
+}
+
+describe('membership_started', () => {
+  it('welcomes a first-time buyer', () => {
+    expect(kinds(NEW_VISITOR, state())).toEqual(['membership_started'])
+  })
+
+  it('welcomes a 3DS buyer whose first charge only cleared on the second event', () => {
+    // The bug: `incomplete` and a failed renewal share one internal status, so
+    // this read as dunning recovery and the buyer heard nothing at all.
+    expect(kinds(AWAITING_3DS, state())).toEqual(['membership_started'])
+  })
+
+  it('stays silent when a failed renewal recovers', () => {
+    expect(kinds(DUNNING, state())).toEqual([])
+  })
+
+  it('stays silent when dunning recovers after the grace already lapsed', () => {
+    // Access may have blinked out, but the membership itself never restarted.
+    expect(kinds({ ...DUNNING, dunningGraceUntil: past(1) }, state())).toEqual([])
+  })
+
+  it('does not re-welcome an active member on a redelivered event', () => {
+    expect(kinds(ACTIVE_MEMBER, state())).toEqual([])
+  })
+
+  it('does not welcome a revoked member whose subscription is still active', () => {
+    // A refund nulls `paidThroughAt` while Stripe still reports `active`; the
+    // next update must not read as a fresh signup.
+    expect(kinds({ ...ACTIVE_MEMBER, paidThroughAt: null }, state({ paidThroughAt: null })))
+      .toEqual([])
+  })
+
+  it('welcomes someone who subscribes again after their membership ended', () => {
+    const ended: MembershipSnapshot = {
+      subscriptionStatus: 'cancelled',
+      cancelAtPeriodEnd: false,
+      paidThroughAt: past(3),
+      dunningGraceUntil: null,
+    }
+    expect(kinds(ended, state())).toEqual(['membership_started'])
+  })
+
+  it('says nothing while the payment is still outstanding', () => {
+    expect(kinds(NEW_VISITOR, state({ subscriptionStatus: 'past_due', paidThroughAt: past(0.001) })))
+      .toEqual([])
+  })
+})
+
+describe('cancellation and reactivation', () => {
+  it('announces a scheduled cancellation once', () => {
+    const after = state({ cancelAtPeriodEnd: true })
+    expect(kinds(ACTIVE_MEMBER, after)).toEqual(['cancellation_scheduled'])
+
+    const [transition] = resolveMembershipTransitions(ACTIVE_MEMBER, after)
+    expect(transition).toEqual({ kind: 'cancellation_scheduled', endsAt: after.paidThroughAt })
+
+    const cancelling = { ...ACTIVE_MEMBER, cancelAtPeriodEnd: true }
+    expect(kinds(cancelling, after)).toEqual([])
+  })
+
+  it('announces a reactivation once', () => {
+    const cancelling = { ...ACTIVE_MEMBER, cancelAtPeriodEnd: true }
+    expect(kinds(cancelling, state())).toEqual(['reactivated'])
+    expect(kinds(ACTIVE_MEMBER, state())).toEqual([])
+  })
+
+  it('welcomes and schedules together when a signup arrives already cancelling', () => {
+    expect(kinds(NEW_VISITOR, state({ cancelAtPeriodEnd: true })))
+      .toEqual(['membership_started', 'cancellation_scheduled'])
+  })
+})
+
+describe('membership_ended', () => {
+  it('announces an unannounced ending', () => {
+    const after = state({ subscriptionStatus: 'cancelled', paidThroughAt: past(0.001) })
+    expect(resolveMembershipTransitions(ACTIVE_MEMBER, after))
+      .toEqual([{ kind: 'membership_ended', wasImmediate: true }])
+  })
+
+  it('stays silent when an abandoned 3DS attempt expires', () => {
+    // `incomplete_expired` maps to `cancelled` just like a real ending does.
+    // Nobody was ever let in, so there is nothing to say goodbye to.
+    expect(kinds(AWAITING_3DS, state({ subscriptionStatus: 'cancelled', paidThroughAt: past(0.001) })))
+      .toEqual([])
+  })
+
+  it('announces the ending of a dunning subscription Stripe gave up on', () => {
+    // The grace is long expired by the time Stripe stops retrying, but it is
+    // still on the profile, and it is the proof this membership was real.
+    const exhausted = { ...DUNNING, dunningGraceUntil: past(20) }
+    expect(kinds(exhausted, state({ subscriptionStatus: 'cancelled', paidThroughAt: past(0.001) })))
+      .toEqual(['membership_ended'])
+  })
+
+  it('announces the ending of a refunded member whose access is already revoked', () => {
+    // A refund nulls `paidThroughAt` and then cancels the subscription, so the
+    // ending arrives against a member with no paid time left. They were a
+    // member, and the cancellation is still theirs to hear about.
+    const refunded = { ...ACTIVE_MEMBER, paidThroughAt: null }
+    expect(kinds(refunded, state({ subscriptionStatus: 'cancelled', paidThroughAt: null })))
+      .toEqual(['membership_ended'])
+  })
+
+  it('announces an ending for paid-up access even where the status lags', () => {
+    const paidUp: MembershipSnapshot = {
+      subscriptionStatus: 'none',
+      cancelAtPeriodEnd: false,
+      paidThroughAt: future(),
+      dunningGraceUntil: null,
+    }
+    expect(kinds(paidUp, state({ subscriptionStatus: 'cancelled', paidThroughAt: null })))
+      .toEqual(['membership_ended'])
+  })
+
+  it('stays silent when a visitor who never subscribed sees a cancelled subscription', () => {
+    expect(kinds(NEW_VISITOR, state({ subscriptionStatus: 'cancelled', paidThroughAt: null })))
+      .toEqual([])
+  })
+
+  it('reports an ending with paid time left as not immediate', () => {
+    const after = state({ subscriptionStatus: 'cancelled', paidThroughAt: future(5) })
+    expect(resolveMembershipTransitions(ACTIVE_MEMBER, after))
+      .toEqual([{ kind: 'membership_ended', wasImmediate: false }])
+  })
+
+  it('stays silent when the visitor already scheduled the ending', () => {
+    const cancelling = { ...ACTIVE_MEMBER, cancelAtPeriodEnd: true }
+    expect(kinds(cancelling, state({ subscriptionStatus: 'cancelled', paidThroughAt: past(0.001) })))
+      .toEqual([])
+  })
+
+  it('stays silent on a redelivered ending', () => {
+    const ended: MembershipSnapshot = {
+      subscriptionStatus: 'cancelled',
+      cancelAtPeriodEnd: false,
+      paidThroughAt: past(0.001),
+      dunningGraceUntil: null,
+    }
+    expect(kinds(ended, state({ subscriptionStatus: 'cancelled', paidThroughAt: past(0.001) })))
+      .toEqual([])
+  })
+})
+
+describe('missing fields', () => {
+  it('treats an empty snapshot as a visitor who has never subscribed', () => {
+    expect(kinds({}, state())).toEqual(['membership_started'])
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/membership-transitions.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-transitions.ts
@@ -14,6 +14,7 @@ export type MembershipSnapshot = {
   subscriptionStatus?: string | null
   cancelAtPeriodEnd?: boolean | null
   paidThroughAt?: string | null
+  dunningGraceUntil?: string | null
 }
 
 export type MembershipTransition =
@@ -26,6 +27,40 @@ function isFuture(value: string | null | undefined): boolean {
   if (!value) return false
   const at = new Date(value)
   return !Number.isNaN(at.getTime()) && at > new Date()
+}
+
+/**
+ * Whether the profile already had a membership before this event.
+ *
+ * Both a beginning and an ending hang on this one question, and the internal
+ * status cannot answer it alone. `mapStripeStatusToInternal` folds Stripe's
+ * `incomplete` into `past_due`, so one label covers both a member whose
+ * renewal charge failed and a buyer whose very first charge has not cleared
+ * yet — the 3DS/SCA case, where the card is authorised seconds later, or
+ * abandoned and expired. Reading that label as dunning got both ends wrong:
+ * the buyer's `incomplete → active` looked like a recovery, which is
+ * deliberately silent, so nothing welcomed them; and their
+ * `incomplete_expired → cancelled` looked like a membership ending, so an
+ * expired attempt mailed a farewell for a membership that never existed.
+ *
+ * Entitlement answers it directly. A real member has paid time behind them:
+ * an `active` status, a `paidThroughAt` still in the future, or a dunning
+ * grace — which `deriveSubscriptionState` opens only for Stripe's own
+ * `past_due`/`unpaid` and never for `incomplete`, and which stays on the
+ * profile, expired, for as long as the dunning lasts. A subscription that has
+ * never collected a payment has none of the three.
+ *
+ * `cancelled` is terminal regardless of leftover paid time: the subscription
+ * is gone, so the next `active` is a new membership rather than the
+ * continuation of one, and a redelivered ending announces nothing.
+ */
+function hadMembership(before: MembershipSnapshot): boolean {
+  const previousStatus = before.subscriptionStatus ?? 'none'
+
+  if (previousStatus === 'cancelled') return false
+  if (previousStatus === 'active') return true
+
+  return isFuture(before.paidThroughAt) || Boolean(before.dunningGraceUntil)
 }
 
 /**
@@ -42,10 +77,9 @@ export function resolveMembershipTransitions(
   const transitions: MembershipTransition[] = []
 
   const wasCancelling = Boolean(before.cancelAtPeriodEnd)
-  const previousStatus = before.subscriptionStatus ?? 'none'
+  const wasMember = hadMembership(before)
 
-  const startedFrom = previousStatus === 'none' || previousStatus === 'cancelled'
-  if (startedFrom && after.subscriptionStatus === 'active') {
+  if (!wasMember && after.subscriptionStatus === 'active') {
     transitions.push({ kind: 'membership_started' })
   }
 
@@ -59,7 +93,11 @@ export function resolveMembershipTransitions(
 
   // A subscription that ends after the visitor scheduled it was already
   // announced when they cancelled; only an unannounced ending needs an email.
-  if (previousStatus !== 'cancelled' && after.subscriptionStatus === 'cancelled' && !wasCancelling) {
+  // An ending is also only news to someone who had a membership to lose, which
+  // is what keeps an abandoned first charge — `incomplete_expired`, and so
+  // internally `cancelled` — from mailing a farewell to a visitor who never
+  // got in.
+  if (wasMember && after.subscriptionStatus === 'cancelled' && !wasCancelling) {
     transitions.push({ kind: 'membership_ended', wasImmediate: !isFuture(after.paidThroughAt) })
   }
 

--- a/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
@@ -367,6 +367,67 @@ describe('purchase', () => {
     expect(entitled()).toBe(true)
     expect(emails).toEqual(['confirmation'])
   })
+
+  it('S1b: a 3DS buyer is welcomed once the delayed first charge clears', async () => {
+    // Stripe reports `incomplete` until the cardholder finishes the challenge,
+    // and `mapStripeStatusToInternal` folds that into `past_due` — the same
+    // internal status a failed renewal produces. The welcome email has to
+    // survive that collision.
+    const start = now() - 60
+    const sub = makeSub('sub_A', {
+      status: 'incomplete',
+      items: { data: [{ current_period_start: start, current_period_end: start + 30 * DAY, price: {} }] },
+      latest_invoice: 'in_1',
+    })
+    store.subs.set(sub.id, sub)
+    store.invoices.set('in_1', makeInvoice('in_1', { status: 'open', paid: false }))
+
+    await deliver('customer.subscription.created', sub)
+
+    expect(profile().subscriptionStatus).toBe('past_due')
+    // An unpaid first period must not open a dunning window or grant access.
+    expect(profile().dunningGraceUntil).toBeNull()
+    expect(entitled()).toBe(false)
+    expect(emails).toEqual([])
+
+    // The challenge succeeds.
+    const s = store.subs.get('sub_A')!
+    s.status = 'active'
+    store.invoices.set('in_1', makeInvoice('in_1'))
+
+    await deliver('invoice.payment_succeeded', store.invoices.get('in_1'))
+
+    expect(profile().subscriptionStatus).toBe('active')
+    expect(entitled()).toBe(true)
+    expect(emails).toEqual(['confirmation'])
+  })
+
+  it('S1c: an abandoned 3DS attempt expires without mailing anything', async () => {
+    // `incomplete_expired` maps to `cancelled`, the same internal status a real
+    // ending produces. Nobody was ever let in, so there is no goodbye to send.
+    const start = now() - 60
+    const sub = makeSub('sub_A', {
+      status: 'incomplete',
+      items: { data: [{ current_period_start: start, current_period_end: start + 30 * DAY, price: {} }] },
+      latest_invoice: 'in_1',
+    })
+    store.subs.set(sub.id, sub)
+    store.invoices.set('in_1', makeInvoice('in_1', { status: 'open', paid: false }))
+
+    await deliver('customer.subscription.created', sub)
+    expect(emails).toEqual([])
+
+    // The cardholder never finishes; Stripe expires the attempt ~23h later.
+    const s = store.subs.get('sub_A')!
+    s.status = 'incomplete_expired'
+    s.ended_at = now()
+
+    await deliver('customer.subscription.deleted', s)
+
+    expect(profile().subscriptionStatus).toBe('cancelled')
+    expect(entitled()).toBe(false)
+    expect(emails).toEqual([])
+  })
 })
 
 describe('renewal and dunning', () => {
@@ -422,11 +483,17 @@ describe('renewal and dunning', () => {
     store.invoices.set('in_2', makeInvoice('in_2', { status: 'open', paid: false }))
     db['visitor-profiles'][0].stripeSubscriptionId = 'sub_A'
     db['visitor-profiles'][0].subscriptionStatus = 'past_due'
+    // What the failed renewal left behind: paid through the last period it
+    // collected, and a grace that has long since run out.
+    db['visitor-profiles'][0].paidThroughAt = new Date(start * 1000).toISOString()
+    db['visitor-profiles'][0].dunningGraceUntil = new Date(Date.now() - 10 * DAY * 1000).toISOString()
 
     await deliver('customer.subscription.deleted', sub)
 
     expect(profile().subscriptionStatus).toBe('cancelled')
     expect(entitled()).toBe(false)
+    // This membership was real, so its ending is still announced.
+    expect(emails).toEqual(['cancelled'])
   })
 })
 


### PR DESCRIPTION
## The problem

`mapStripeStatusToInternal` folds Stripe's `incomplete` into `past_due`, so one internal status covers two unrelated situations:

- a member whose **renewal charge failed** (real dunning), and
- a buyer whose **very first charge has not cleared yet** — the ordinary 3DS/SCA path, where the card is authorised seconds later, or abandoned and expired.

`resolveMembershipTransitions` inferred "was this person already a member?" from that status, and so got **both ends** of the lifecycle wrong for 3DS buyers:

| Sequence | Was read as | Result |
|---|---|---|
| `incomplete → active` | dunning recovery | recovery is deliberately silent → **paying member got no welcome email** |
| `incomplete_expired → cancelled` | a membership ending | **an abandoned attempt was mailed a farewell** for a membership it never had |

Both failed silently — no error, no log.

## The fix

`hadMembership(before)` asks the question directly instead of guessing from the enum. A real member has one of three pieces of evidence:

- an `active` status,
- a `paidThroughAt` still in the future, or
- a **dunning grace** — which `deriveSubscriptionState` opens only for Stripe's own `past_due`/`unpaid`, never for `incomplete`, and which stays on the profile for as long as the dunning lasts.

A subscription that has never collected a payment has none of the three. `cancelled` stays terminal regardless of leftover paid time, so a resubscribe is a new membership and a redelivered ending still announces nothing.

Both the `membership_started` and `membership_ended` decisions now hang on that one predicate.

## Behaviour preserved

Deliberately unchanged, and each pinned by a test:

- dunning recovery is still silent
- a dunning subscription Stripe gives up on **is** still announced (the expired grace is the proof the membership was real)
- a refunded member — `paidThroughAt` already nulled — still hears about the cancellation that follows
- redelivered and duplicate events still mail nothing
- cancel-at-period-end is still announced exactly once

## Tests

- **`lib/membership-transitions.test.ts`** — new file; the resolver had no unit coverage at all. 22 cases across the 3DS fork, dunning, refund-revoked state, resubscribe, and every transition kind.
- **`lifecycle-simulation.test.ts`** — **S1b**: a 3DS buyer is welcomed when the delayed charge clears. **S1c**: an abandoned attempt expires quietly. **S3**'s fixture now carries the grace and paid-through date a real failed renewal leaves behind, and asserts its ending is still announced.

Each new assertion was verified to **fail against the previous logic** and pass against this one.

Full server suite: 1039 tests passing, `tsc --noEmit` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)