### PR TITLE
Add STRIPE_FORCE_3DS, an opt-in card authentication lever for testing

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -182,6 +182,7 @@ export async function POST(req: NextRequest) {
     // active code in the Stripe account to anyone on any plan, so one
     // unrestricted 100%-off code is a free membership for whoever learns it.
     const allowPromotionCodes = APP_CONFIG.features.stripePromotionCodes
+    const forceThreeDSecure = APP_CONFIG.features.stripeForceThreeDSecure
 
     // A double-clicked buy button otherwise creates two sessions on the same
     // customer. The key is derived from the request rather than the visitor
@@ -195,6 +196,7 @@ export async function POST(req: NextRequest) {
       cancelUrl,
       referralId,
       allowPromotionCodes,
+      forceThreeDSecure,
     })
 
     const session = await stripe.checkout.sessions.create({
@@ -211,7 +213,14 @@ export async function POST(req: NextRequest) {
       billing_address_collection: 'auto', // Optional: collect billing address
       subscription_data: {
         metadata // Also add metadata to subscription object
-      }
+      },
+      // Off unless the host asks for it. A US-issued card never triggers SCA on
+      // its own, so without this the subscription never passes through
+      // `incomplete` and the 3DS branch of the membership emails cannot be
+      // exercised against a real Stripe at all. See `stripeForceThreeDSecure`.
+      ...(forceThreeDSecure
+        ? { payment_method_options: { card: { request_three_d_secure: 'any' as const } } }
+        : {}),
     }, { idempotencyKey })
 
     logger.info('Created checkout session')

--- a/apps/questura/apps/server/src/features/payments/checkout-idempotency.test.ts
+++ b/apps/questura/apps/server/src/features/payments/checkout-idempotency.test.ts
@@ -13,6 +13,7 @@ const BASE: CheckoutIdempotencyInput = {
   cancelUrl: 'https://questurian.com/subscription/cancel',
   referralId: null,
   allowPromotionCodes: false,
+  forceThreeDSecure: false,
 }
 
 /**
@@ -52,6 +53,7 @@ describe('checkoutIdempotencyKey', () => {
     ['a different cancel URL', { cancelUrl: 'https://questurian.com/elsewhere' }],
     ['a referral appearing', { referralId: 'ref_abc' }],
     ['promotion codes being enabled', { allowPromotionCodes: true }],
+    ['forced card authentication being enabled', { forceThreeDSecure: true }],
     ['a different customer', { customerId: 'cus_other' }],
     ['a different visitor', { visitorAuthUserId: 'visitor_999' }],
   ] as const)('produces a different key for %s', (_label, overrides) => {

--- a/apps/questura/apps/server/src/features/payments/lib/checkout-idempotency.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/checkout-idempotency.ts
@@ -40,6 +40,7 @@ export type CheckoutIdempotencyInput = {
   cancelUrl: string
   referralId: string | null
   allowPromotionCodes: boolean
+  forceThreeDSecure: boolean
 }
 
 /**
@@ -68,6 +69,7 @@ export function checkoutIdempotencyKey(
         input.cancelUrl,
         input.referralId ?? '',
         String(input.allowPromotionCodes),
+        String(input.forceThreeDSecure),
         String(bucket),
       ].join('\u0000')
     )

--- a/apps/questura/apps/server/src/shared/config/index.ts
+++ b/apps/questura/apps/server/src/shared/config/index.ts
@@ -124,6 +124,20 @@ export const APP_CONFIG = {
     // (`first_time_transaction`, an applies-to price, a redemption cap).
     stripePromotionCodes: process.env.STRIPE_PROMOTION_CODES === 'true',
     homepageFeaturedAllowDrafts: process.env.HOMEPAGE_FEATURED_ALLOW_DRAFTS === 'true',
+    /**
+     * Ask the issuer to authenticate every Checkout card, even where it would
+     * not otherwise be required.
+     *
+     * Purely a testing lever, and off by default. SCA is an EU/UK rule, so a
+     * US-issued card never challenges on its own — which leaves the whole
+     * `incomplete → active` path (and the emails that hang off it) impossible
+     * to exercise from here. Forcing the request is the only way to make a real
+     * subscription pass through `incomplete` on this account.
+     *
+     * Never turn this on where real buyers can reach it: it adds a challenge
+     * step to every purchase and issuers decline some of them outright.
+     */
+    stripeForceThreeDSecure: process.env.STRIPE_FORCE_3DS === 'true',
   },
 
   // Backend URL - localhost for Phase 1


### PR DESCRIPTION
## Why

SCA is an EU/UK regulatory requirement, so a **US-issued card never triggers 3DS on its own**. That makes the entire `incomplete → active` path unreachable on this account — no subscription ever passes through `incomplete`, so the membership emails hanging off that transition cannot be exercised against a real Stripe.

That is exactly why the bug in #336 survived. Checked against live Stripe, read-only:

```
incomplete subscriptions:          0
incomplete_expired subscriptions:  0
```

Zero, ever. Nothing on this account has ever taken the path.

`STRIPE_FORCE_3DS=true` asks the issuer to authenticate every Checkout card, making that path reachable with an ordinary card and a $0.50 charge.

## Safety

- **Off by default** (`=== 'true'`), like every other flag in `features`.
- **Must stay off wherever real buyers can reach it** — it adds a challenge to every purchase and some issuers decline outright.
- A **host env flag rather than a code constant**, so switching it off is a restart rather than a deploy, and so it cannot follow the code to serverless production.

## Idempotency

The flag also joins the Checkout idempotency fingerprint. It changes the session body, and that file's stated contract is that every parameter which can vary must move the key. Without it:

- flipping the flag inside the 5-minute window reuses a key whose parameters changed → Stripe rejects the request outright;
- a second test purchase (needed for the abandoned-challenge case) would be handed back the **first** session instead of a new one.

## Testing plan this unblocks

1. `STRIPE_FORCE_3DS=true` on the host, restart, buy monthly ($0.50) → challenge appears → **welcome email**.
2. Buy again, close the window at the challenge → subscription sticks at `incomplete` → Stripe expires it ~23h later → **no email at all**.
3. Unset the flag, restart.

Both halves of #336, against the real deployed server, real webhooks, real database, real email.

Full server suite: 1040 tests passing, `tsc --noEmit` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)