### PR TITLE
Force a 3DS challenge, not merely a request

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -218,8 +218,13 @@ export async function POST(req: NextRequest) {
       // its own, so without this the subscription never passes through
       // `incomplete` and the 3DS branch of the membership emails cannot be
       // exercised against a real Stripe at all. See `stripeForceThreeDSecure`.
+      // `challenge`, not `any`: `any` only asks the issuer to authenticate, and a
+      // US issuer answers that frictionlessly — authenticated invisibly, paid in
+      // three seconds, subscription `active` on arrival. Observed on this account
+      // 2026-08-18. `challenge` asks for an interactive step, which is what
+      // actually leaves the subscription sitting in `incomplete`.
       ...(forceThreeDSecure
-        ? { payment_method_options: { card: { request_three_d_secure: 'any' as const } } }
+        ? { payment_method_options: { card: { request_three_d_secure: 'challenge' as const } } }
         : {}),
     }, { idempotencyKey })
 


### PR DESCRIPTION
Follow-up to #337.

`request_three_d_secure: 'any'` asks the issuer to authenticate but leaves the *method* to them, and a US issuer answers frictionlessly. Observed live on this account, 2026-08-18:

```
21:19:24  payment_intent.created         status=requires_payment_method
21:19:27  payment_intent.succeeded       status=succeeded      ← 3s, no requires_action
21:19:29  customer.subscription.created  status=active         ← never `incomplete`
```

No challenge was ever presented, the subscription never passed through `incomplete`, and so the path the flag exists to reach was not reached.

`'challenge'` requests an *interactive* authentication step, which is what leaves the subscription in `incomplete` while the buyer answers it.

Still gated behind `STRIPE_FORCE_3DS`, still off by default.

### Worth noting

That purchase was not wasted — it proved the live pipeline end to end, including deduplication under a real three-way webhook race:

```
resync → transitions: ["membership_started"]   → email sent once
resync → transitions: []                       → no duplicate
resync → transitions: []                       → no duplicate
```

Server suite: 1040 passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)