### PR TITLE
Stop the Google button submitting the form it sits in

### DIFF
--- a/apps/questura/apps/client/src/features/Auth/components/google/GoogleSignInButton.tsx
+++ b/apps/questura/apps/client/src/features/Auth/components/google/GoogleSignInButton.tsx
@@ -24,28 +24,43 @@ export default function GoogleSignInButton({
     const callbackURL = new URL(redirectPath, window.location.origin).toString();
     const errorCallbackURL = new URL('/auth-error', window.location.origin).toString();
 
-    const response = await fetch(`${backendUrl}/api/visitor-auth/sign-in/social`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({
-        provider: 'google',
-        callbackURL,
-        errorCallbackURL,
-      }),
-    });
+    try {
+      const response = await fetch(`${backendUrl}/api/visitor-auth/sign-in/social`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          provider: 'google',
+          callbackURL,
+          errorCallbackURL,
+        }),
+      });
 
-    if (!response.ok) {
-      window.location.href = `/auth-error?error=oauth_failed`;
-      return;
+      if (!response.ok) {
+        window.location.href = `/auth-error?error=oauth_failed`;
+        return;
+      }
+
+      const data = await response.json() as { url?: string };
+      window.location.href = data.url || '/auth-error?error=oauth_failed';
+    } catch {
+      // `fetch` rejects rather than resolving when the request never reaches the
+      // backend at all -- a refused origin, a DNS failure, an offline browser.
+      // Unhandled, that rejection is invisible: the click appears to do nothing
+      // at all, which is indistinguishable from a dead button and sends people
+      // to support saying "the Google button doesn't work".
+      window.location.href = `/auth-error?error=oauth_unreachable`;
     }
-
-    const data = await response.json() as { url?: string };
-    window.location.href = data.url || '/auth-error?error=oauth_failed';
   };
 
   return (
     <button
+      // Both sign-in steps render this inside their `<form>`, and a button with
+      // no type submits the form it sits in. Clicking Google therefore ran the
+      // form's own validation and stopped on the required email field instead
+      // of ever reaching `handleSignIn` -- OAuth was unreachable for anyone who
+      // had not already filled the form in.
+      type="button"
       onClick={handleSignIn}
       className={`flex items-center justify-center gap-3 bg-white border border-gray-300 hover:bg-gray-50 text-black px-6 py-3 rounded-lg transition-colors shadow-sm cursor-pointer ${className}`}
     >

--- a/apps/questura/apps/client/src/features/Auth/pages/AuthErrorPage.tsx
+++ b/apps/questura/apps/client/src/features/Auth/pages/AuthErrorPage.tsx
@@ -32,6 +32,12 @@ function AuthErrorContent() {
         case 'oauth_failed':
           setError('Google sign-in failed. Please try again or use email/password login.');
           break;
+        // The request never reached the server, so "sign-in failed" would be
+        // misleading -- nothing was attempted and retrying the same way fails
+        // the same way.
+        case 'oauth_unreachable':
+          setError('We could not reach the sign-in service. Check your connection and try again.');
+          break;
         case 'invalid_credentials':
           setError('Invalid credentials provided. Please check your email and password.');
           break;

--- a/apps/questura/apps/client/src/features/CityDashboard/lib/oauthErrorMessages.ts
+++ b/apps/questura/apps/client/src/features/CityDashboard/lib/oauthErrorMessages.ts
@@ -2,6 +2,7 @@ const oauthErrorMessages: Record<string, string> = {
   account_exists_local: 'This email has a password. You can link Google in account page.',
   oauth_failed: 'Google sign-in failed. Please try again or use password login.',
   oauth_cancelled: 'Google sign-in was cancelled.',
+  oauth_unreachable: 'We could not reach the sign-in service. Check your connection and try again.',
 }
 
 export function getOAuthErrorMessage(error: string | null): string {


### PR DESCRIPTION
## The bug

A `<button>` with no `type` **submits the form it is inside**. `GoogleSignInButton` renders inside both sign-in forms:

| File | Button | Enclosing `<form>` | Has `required` email |
|---|---|---|---|
| `EmailStep.tsx` | line 85 | line 20 | ✅ line 31 |
| `PasswordStep.tsx` | line 148 | line 33 | ✅ line 46 |

So clicking **Sign in with Google** ran the form's own validation, stopped on the required email field with *"fill out email field"*, and **never reached `handleSignIn`**. Google sign-in was unreachable for anyone who hadn't already filled the form in.

`type="button"` is the whole fix.

## Second, quieter bug

The handler had no `catch`. `fetch` **rejects** rather than resolving when the request never reaches the backend — a refused origin, a DNS failure, an offline browser. Unhandled, that rejection is invisible: the click does *nothing at all*, indistinguishable from a dead button.

Observed live today from `https://questurian.com`, which was missing from the server's CORS allowlist (fixed separately in host config). The button was silently dead, with nothing shown to the visitor.

It now lands on `/auth-error?error=oauth_unreachable` with its own message — *"We could not reach the sign-in service"* — because "Google sign-in failed" is wrong when nothing was ever attempted. Added to both error maps; both already had safe fallbacks, so this is a wording improvement rather than a crash fix.

Client typecheck clean. The one eslint warning in `AuthErrorPage.tsx` is pre-existing (line 8, `searchParams` deps) and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)