### PR TITLE
Recognise Stripe's rejection by rawType, not by the class name

### DIFF
--- a/apps/questura/apps/server/src/features/payments/__fixtures__/stripe-errors.ts
+++ b/apps/questura/apps/server/src/features/payments/__fixtures__/stripe-errors.ts
@@ -1,0 +1,35 @@
+import Stripe from 'stripe'
+
+/**
+ * Stripe rejections for tests, built by the SDK's own error classes.
+ *
+ * Hand-shaped rejections are why the cancelled-subscription refund path was
+ * broken in production while its tests passed. Every fixture asserted
+ * `Object.assign(new Error(...), { type: 'invalid_request_error' })`, but a
+ * real client sets `type` to the *class name* and puts the API's spelling on
+ * `rawType`. The fixtures described an error Stripe has never thrown, so the
+ * guard reading `type` looked correct in every test and matched nothing live.
+ *
+ * Constructing through `Stripe.errors` is the fix: the shape comes from the
+ * pinned SDK, so a fixture cannot drift from what the SDK actually throws, and
+ * an SDK upgrade that changes the shape breaks these tests rather than
+ * production.
+ */
+export function stripeInvalidRequestError(message: string): Stripe.errors.StripeInvalidRequestError {
+  return new Stripe.errors.StripeInvalidRequestError({
+    type: 'invalid_request_error',
+    message,
+  })
+}
+
+/** Stripe's rejection when a subscription is already `canceled`. */
+export function cancelledSubscriptionError(): Stripe.errors.StripeInvalidRequestError {
+  return stripeInvalidRequestError(
+    'A canceled subscription can only update its cancellation_details.'
+  )
+}
+
+/** An `invalid_request_error` that has nothing to do with cancellation. */
+export function badApiKeyError(): Stripe.errors.StripeInvalidRequestError {
+  return stripeInvalidRequestError('Invalid API Key provided')
+}

--- a/apps/questura/apps/server/src/features/payments/lib/access-revocation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/access-revocation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import Stripe from 'stripe'
+import { stripeInvalidRequestError } from '../__fixtures__/stripe-errors'
+
+/**
+ * The assumption `rejectedForCancelledSubscription` rests on, pinned.
+ *
+ * The cancel-then-refund fallback read `error.type` and compared it to
+ * `invalid_request_error`. That is the API's spelling, but the SDK puts the
+ * API's spelling on `rawType` and sets `type` to the error's *class name*, so
+ * the comparison matched nothing a real client throws. Every refund against an
+ * already-cancelled subscription — the ordinary refund order — rethrew, 500'd
+ * the webhook, and left the refunded visitor's access intact while Stripe
+ * retried for three days.
+ *
+ * The behavioural tests in `stripe-webhook.route.test.ts` cover what the
+ * handlers then do. These assert the shape those tests depend on, straight from
+ * the pinned SDK, so an upgrade that moves either field fails here — loudly and
+ * in one place — rather than silently in production.
+ */
+describe('the Stripe SDK error shape the revocation fallback depends on', () => {
+  it('puts the API error type on rawType, not on type', () => {
+    const error = stripeInvalidRequestError('A canceled subscription can only update its cancellation_details.')
+
+    expect(error.rawType).toBe('invalid_request_error')
+    expect(error.type).toBe('StripeInvalidRequestError')
+  })
+
+  it('never spells type as the API error type, which is what the old guard looked for', () => {
+    const error = stripeInvalidRequestError('anything')
+
+    expect(error.type).not.toBe('invalid_request_error')
+  })
+
+  it('is a real Error, so an unrecognised rejection still propagates as one', () => {
+    const error = stripeInvalidRequestError('Invalid API Key provided')
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(Stripe.errors.StripeInvalidRequestError)
+    expect(error.message).toBe('Invalid API Key provided')
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/access-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/access-revocation.ts
@@ -9,6 +9,22 @@ import {
 } from './subscription-state'
 
 /**
+ * Whether this is the SDK's "Stripe rejected the request itself" error.
+ *
+ * `rawType` carries the API's own error type (`invalid_request_error`); `type`
+ * carries the SDK's *class name* (`StripeInvalidRequestError`). Reading `type`
+ * and comparing it to the API spelling matches nothing a real client ever
+ * throws, which is exactly how this guard came to reject every error it was
+ * written to recognise. Both spellings are accepted so neither reading can
+ * silently fail again.
+ */
+function isInvalidRequestError(error: unknown): boolean {
+  const { type, rawType } = (error ?? {}) as { type?: string; rawType?: string }
+
+  return rawType === 'invalid_request_error' || type === 'StripeInvalidRequestError'
+}
+
+/**
  * Whether Stripe rejected this write because the subscription is already over.
  *
  * Stripe refuses most updates to a `canceled` subscription — "a canceled
@@ -26,7 +42,7 @@ async function rejectedForCancelledSubscription(
   subscriptionId: string,
   error: unknown
 ): Promise<boolean> {
-  if ((error as { type?: string }).type !== 'invalid_request_error') return false
+  if (!isInvalidRequestError(error)) return false
 
   try {
     const subscription = await stripe.subscriptions.retrieve(subscriptionId)

--- a/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
@@ -23,6 +23,7 @@
  * sandbox test clock.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { stripeInvalidRequestError } from './__fixtures__/stripe-errors'
 
 // ---------------------------------------------------------------------------
 // Fake Stripe
@@ -68,10 +69,13 @@ const store = {
   cancelCalls: [] as string[],
 }
 
+// Built by the SDK's own error class so the fake rejects exactly as a real
+// client does -- `type` is the class name, `rawType` the API's spelling. A
+// hand-shaped error here is what let the cancelled-subscription refund bug pass
+// its tests. Called during tests, never while this factory is hoisted, so the
+// top-level import is initialised by the time it runs.
 function stripeError(message: string) {
-  const err = new Error(message) as Error & { type: string; code?: string }
-  err.type = 'invalid_request_error'
-  return err
+  return stripeInvalidRequestError(message) as Error & { type: string; code?: string }
 }
 
 function clone<T>(value: T): T {

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { headers } from 'next/headers'
+import {
+  badApiKeyError,
+  cancelledSubscriptionError,
+  stripeInvalidRequestError,
+} from './__fixtures__/stripe-errors'
 
 const mocks = vi.hoisted(() => ({
   constructEvent: vi.fn(),
@@ -585,9 +590,7 @@ describe('Stripe webhook route', () => {
       lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
     })
     mocks.subscriptionCancel.mockRejectedValue(
-      Object.assign(new Error('No such subscription to cancel'), {
-        type: 'invalid_request_error',
-      }),
+      stripeInvalidRequestError('No such subscription to cancel'),
     )
     mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'canceled', metadata: {} })
 
@@ -611,7 +614,7 @@ describe('Stripe webhook route', () => {
       lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
     })
     mocks.subscriptionCancel.mockRejectedValue(
-      Object.assign(new Error('Invalid API Key provided'), { type: 'invalid_request_error' }),
+      badApiKeyError(),
     )
     mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'active', metadata: {} })
 
@@ -778,9 +781,7 @@ describe('Stripe webhook route', () => {
       lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
     })
     mocks.subscriptionCancel.mockRejectedValue(
-      Object.assign(new Error('No such subscription to cancel'), {
-        type: 'invalid_request_error',
-      }),
+      stripeInvalidRequestError('No such subscription to cancel'),
     )
     mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'canceled', metadata: {} })
 
@@ -805,10 +806,7 @@ describe('Stripe webhook route', () => {
       lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
     })
     mocks.subscriptionUpdate.mockRejectedValue(
-      Object.assign(
-        new Error('A canceled subscription can only update its cancellation_details.'),
-        { type: 'invalid_request_error' },
-      ),
+      cancelledSubscriptionError(),
     )
     mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'canceled', metadata: {} })
 
@@ -828,10 +826,7 @@ describe('Stripe webhook route', () => {
     })
     mocks.invoiceRetrieve.mockResolvedValue({ id: 'in_1', subscription: 'sub_1' })
     mocks.subscriptionUpdate.mockRejectedValue(
-      Object.assign(
-        new Error('A canceled subscription can only update its cancellation_details.'),
-        { type: 'invalid_request_error' },
-      ),
+      cancelledSubscriptionError(),
     )
     mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'canceled', metadata: {} })
 
@@ -855,7 +850,7 @@ describe('Stripe webhook route', () => {
       lines: { data: [{ period: { start: 1_000, end: 2_000 } }] },
     })
     mocks.subscriptionUpdate.mockRejectedValue(
-      Object.assign(new Error('Invalid API Key provided'), { type: 'invalid_request_error' }),
+      badApiKeyError(),
     )
     mocks.subscriptionRetrieve.mockResolvedValue({ id: 'sub_1', status: 'active', metadata: {} })
 


### PR DESCRIPTION
## The bug

Refunds against an already-cancelled subscription have never worked in production.

`rejectedForCancelledSubscription` tested `error.type !== 'invalid_request_error'`. That is the API's spelling of the error type, but the Node SDK puts the API's spelling on `rawType` and sets `type` to the error's **class name**:

```
readonly type: 'StripeError' | 'StripeCardError' | 'StripeInvalidRequestError' | …
readonly rawType: RawErrorType   // 'invalid_request_error' | 'card_error' | …
```

(`stripe@18.5.0`, `types/Errors.d.ts`; `Error.js:52-54` sets `this.type = type || this.constructor.name`.)

So the comparison matched nothing a real client throws. The fallback this file documents as the ordinary refund flow — support cancels the subscription, *then* refunds the charge — never once ran. The error rethrew, the webhook 500'd, Stripe retried for three days and never succeeded, and the refunded visitor kept their access with `paidThroughAt` still sitting at the period they were given their money back for.

Both call sites are affected (`writeAccessRevocation` and `cancelRefundedSubscription`), so a refund on a cancelled subscription fails at the first Stripe call it makes.

## Why the tests didn't catch it

Every fixture built the rejection by hand:

```ts
Object.assign(new Error('...'), { type: 'invalid_request_error' })
```

That describes an error Stripe has never emitted. The tests asserted the bug was correct.

## The fix

- Accept `rawType === 'invalid_request_error'`, keeping `type === 'StripeInvalidRequestError'` as a second signal so neither reading can silently fail again.
- Fixtures construct through `Stripe.errors.StripeInvalidRequestError` (`__fixtures__/stripe-errors.ts`), so their shape comes from the pinned SDK and cannot drift from what it actually throws.
- `lib/access-revocation.test.ts` pins the shape assumption itself, so an SDK upgrade that moves either field fails in one obvious place rather than in production.

## Verification

- `pnpm test:int` — 315 pass (22 files).
- **Reverting only the production line fails 5 tests**, exactly the cancelled-subscription refund and dispute paths. That is the proof the fixtures now bite:
  - `S6: a refund on an already-cancelled subscription still revokes (metadata write refused)`
  - `tolerates a refunded subscription that was already cancelled`
  - `tolerates a lost dispute on a subscription that was already cancelled`
  - `revokes membership even when Stripe refuses the flag on a cancelled subscription`
  - `restores membership on a won dispute the cancelled subscription will not record`
- `pnpm typecheck` clean; `pnpm lint` 0 errors (6 pre-existing warnings, none in touched files).

## Follow-up needed after deploy

There is a live `charge.refunded` event still retrying against the host and failing every time; Stripe gives up 3 days after the first attempt. Once this is deployed, that event needs resending from the Stripe Dashboard, and the affected profile checked (`pnpm audit:access-revocations`). Behaviour change is confined to the error path — no schema, no API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)