### PR TITLE
Stop offering Upgrade to a member who still has access

### DIFF
--- a/apps/questura/apps/client/src/features/AccountPage/services/membership.service.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/services/membership.service.ts
@@ -1,5 +1,6 @@
 import type { User } from '@/lib/user/types';
 
+import { isActiveMember } from '../../Payments/lib/membership';
 import type { BillingInfo, MembershipState } from '../types/membership.types';
 
 function formatDate(dateString: string | null): string {
@@ -37,7 +38,15 @@ export function getBillingInfo(user: User | null): BillingInfo | null {
   return null;
 }
 
-export function getMembershipState(user: User | null): MembershipState {
+/**
+ * The status enum's reading of the membership, before entitlement is consulted.
+ *
+ * `subscriptionStatus` and `membershipExpiration` describe the *subscription*.
+ * Whether the visitor may actually read paid content is a separate, server-side
+ * decision (`membership.active`, derived from `paidThroughAt`). Where the two
+ * disagree, entitlement wins -- see `getMembershipState`.
+ */
+function membershipStateFromStatus(user: User | null): MembershipState {
   if (!user) {
     return {
       type: 'free',
@@ -174,4 +183,37 @@ export function getMembershipState(user: User | null): MembershipState {
         showReactivateButton: false,
       };
   }
+}
+
+/**
+ * The membership as the account page should present it.
+ *
+ * The status enum alone produced a dead end: a subscription Stripe has already
+ * deleted reports `canceled` while the period it was paid for is still running,
+ * so the card said "cancelled -- Upgrade" to a visitor who was still entitled.
+ * `/purchase` gates on the same entitlement (`MembershipGuard` -> `isActiveMember`
+ * -> `membership.active`) and turned them away as an existing member. A button
+ * that cannot work, in front of someone who might reasonably answer it by paying
+ * a second time through another route.
+ *
+ * Entitlement is the tie-breaker because it is the thing that actually gates
+ * access, and it is derived once on the server. Offering to sell a membership to
+ * someone who already has one is wrong regardless of which status produced it,
+ * so this is applied to every branch rather than to the one that was reported.
+ */
+export function getMembershipState(user: User | null): MembershipState {
+  const state = membershipStateFromStatus(user);
+
+  // `membership.active` is the server's entitlement decision; `isActiveMember`
+  // is the same read the purchase guard makes, dev override included, so the two
+  // screens cannot disagree about who is already a member.
+  if (!user || !state.showUpgradeButton || !isActiveMember(user)) return state;
+
+  return {
+    ...state,
+    showUpgradeButton: false,
+    // Without a next step this is just a card with nothing to do on it. The
+    // visitor still has access; what they need is when it ends and what then.
+    description: `${state.description} You can rejoin once it ends.`,
+  };
 }


### PR DESCRIPTION
## The dead end

The account card and `/purchase` answer "is this person a member?" from two different sources, and they disagree in an ordinary case.

- The card reads the **status enum**: `membership.service.ts` `case 'canceled'` with a future `membershipExpiration` returns `showUpgradeButton: true`.
- `/purchase` reads **entitlement**: `MembershipGuard` → `isActiveMember` → `user.membership.active`, derived server-side from `paidThroughAt`.

A subscription Stripe has already deleted reports `canceled` while the period it was paid for is still running. So the card says "Membership Cancelled — Upgrade", and following that button lands on "You're Already a Member!". A button that cannot work — in front of someone who might reasonably answer it by paying a second time through another route.

## The fix

`getMembershipState` now applies entitlement as the tie-breaker after the status switch: while `isActiveMember(user)` is true, no Upgrade button. It calls the *same* function the purchase guard calls, dev override included, so the two screens can no longer disagree.

Applied to every branch rather than to the one that was reported. Offering to sell a membership to someone who already holds one is wrong whichever status produced it, and `canceled`-with-no-expiry, `inactive` and `default` can each reach it the same way. Cheaper to close the class than to fix the instance and wait for the next one.

The removed button is replaced with a next step ("You can rejoin once it ends") — otherwise the card is a status with nothing to act on, which is a milder version of the same problem. `showCancelButton` and `showReactivateButton` are untouched, so `canUpdatePayment` is unaffected.

## Scope

Presentation only. No API, no schema, no payment path. `getMembershipState` has exactly one consumer (`useMembershipSection`).

## Verification

`pnpm typecheck` and `pnpm lint` clean on the client (0 errors; pre-existing warnings only, none in touched files).

⚠️ **No automated test covers this.** The Questura client has no test runner configured (`package.json` has only `lint`, `build`, `typecheck`) and no CI job in `.github/workflows/ci.yml` — the server, softprod scripts and the writer app are covered, the client is not. `getMembershipState` is a pure function and would be straightforward to test; adding a runner is a bigger change than this fix and is deliberately left out. Flagging it rather than quietly shipping untested UI logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)