### PR TITLE
Cap the Stripe webhook body before buffering it

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -13,8 +13,114 @@ import {
   isHandledStripeEventType,
 } from '@/payments/webhooks/handled-events'
 
+/**
+ * Refuse to buffer more than this from an unauthenticated caller.
+ *
+ * This route's URL is public and the signature is the only thing that
+ * authenticates a caller — but the signature cannot be checked until the whole
+ * payload is in memory, so an uncapped `req.text()` lets anyone who knows the
+ * URL hold as much server memory as they care to send, in parallel, and never
+ * reach the check that would have rejected them.
+ *
+ * 1 MiB is deliberately far above anything Stripe sends. Stripe publishes no
+ * maximum event size, so the number comes from two bounds instead. Real events
+ * captured from this account (`payments/__fixtures__/membership-lifecycle.events.json`)
+ * run 3.8-5.6 KB, averaging 4.6 KB. The pathological upper bound is metadata:
+ * Stripe allows 50 keys of 500 characters per object, about 27 KB, and an event
+ * can carry the object plus `previous_attributes`, so even a deliberately
+ * stuffed invoice with its inline line items lands well under 100 KB. 1 MiB is
+ * ~180x the largest event we have ever received and ~10x that worst case.
+ *
+ * The asymmetry justifies the generosity: a rejected legitimate event is a
+ * refund that never revokes access or a payment that never grants membership,
+ * discovered days later. Accepting a 900 KB request costs 900 KB.
+ */
+const MAX_WEBHOOK_BODY_BYTES = 1_048_576
+
+type BodyRead =
+  | { ok: true; body: string }
+  | { ok: false; observedBytes: number; declaredBytes: number | null }
+
+/**
+ * Read the raw payload, refusing to buffer past the cap.
+ *
+ * `content-length` is checked first so an honest oversized request costs
+ * nothing, but it is only a hint: it is absent under chunked encoding and a
+ * hostile caller can simply understate it. So the stream is also metered as it
+ * arrives and abandoned the moment the budget is gone — a cap that trusts only
+ * the header is not a cap.
+ *
+ * The bytes are concatenated and decoded once, rather than decoded per chunk,
+ * because signature verification is byte-exact: a multi-byte character split
+ * across a chunk boundary would decode to two replacement characters and every
+ * event containing an accented name or an emoji would fail to verify. Decoding
+ * the joined buffer with `TextDecoder` also strips a leading BOM exactly as the
+ * `Request.text()` this replaces does, so the string handed to
+ * `constructEvent` is identical to the one it received before.
+ */
+async function readBodyWithinCap(req: NextRequest): Promise<BodyRead> {
+  const contentLength = req.headers.get('content-length')
+  const declaredBytes = contentLength === null ? null : Number(contentLength)
+
+  if (declaredBytes !== null && Number.isFinite(declaredBytes) && declaredBytes > MAX_WEBHOOK_BODY_BYTES) {
+    return { ok: false, observedBytes: declaredBytes, declaredBytes }
+  }
+
+  // No stream to meter (an empty body, or a runtime that already materialised
+  // it). `content-length` has been checked, so fall back to the plain read.
+  if (!req.body) {
+    return { ok: true, body: await req.text() }
+  }
+
+  const reader = req.body.getReader()
+  const chunks: Uint8Array[] = []
+  let observedBytes = 0
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value) continue
+
+      observedBytes += value.byteLength
+
+      if (observedBytes > MAX_WEBHOOK_BODY_BYTES) {
+        // Drop what we have and stop pulling: holding the chunks while the
+        // sender keeps writing is the exact cost this guard exists to avoid.
+        chunks.length = 0
+        await reader.cancel()
+        return { ok: false, observedBytes, declaredBytes }
+      }
+
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const joined = new Uint8Array(observedBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    joined.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return { ok: true, body: new TextDecoder().decode(joined) }
+}
+
 export async function POST(req: NextRequest) {
-  const body = await req.text()
+  const read = await readBodyWithinCap(req)
+
+  if (!read.ok) {
+    logger.warn('Stripe webhook rejected: body exceeds size cap', {
+      observedBytes: read.observedBytes,
+      declaredBytes: read.declaredBytes,
+      maxBytes: MAX_WEBHOOK_BODY_BYTES,
+    })
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+  }
+
+  const body = read.body
   const headersList = await headers()
   const sig = headersList.get('stripe-signature')
 

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -122,11 +122,45 @@ const PAST_TS = Math.floor(Date.now() / 1000) - 24 * 60 * 60
 
 let consoleSpies: Array<ReturnType<typeof vi.spyOn>> = []
 
-function createRequest() {
+function createRequest(
+  options: { body?: string | ReadableStream<Uint8Array>; contentLength?: string } = {},
+) {
+  const { body = '{}', contentLength } = options
+
   return new Request('http://localhost:4000/api/payments/webhooks/stripe', {
     method: 'POST',
-    body: '{}',
-  }) as any
+    body,
+    headers: contentLength === undefined ? undefined : { 'content-length': contentLength },
+    // Required by undici before it will accept a stream as a request body.
+    duplex: 'half',
+  } as any) as any
+}
+
+/** The structured log line the logger emitted for `message`, parsed back. */
+function loggedWarning(message: string): Record<string, unknown> | undefined {
+  for (const [line] of vi.mocked(console.log).mock.calls as unknown as Array<[unknown]>) {
+    if (typeof line !== 'string' || !line.includes(message)) continue
+    try {
+      return JSON.parse(line)
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+/** A body delivered in chunks, the way a real chunked upload arrives. */
+function streamOf(...chunks: Array<string | Uint8Array>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(typeof chunk === 'string' ? encoder.encode(chunk) : chunk)
+      }
+      controller.close()
+    },
+  })
 }
 
 function givenEvent(type: string, object: Record<string, unknown>, extra: Partial<{ id: string; created: number }> = {}) {
@@ -1080,5 +1114,117 @@ describe('Stripe webhook route', () => {
 
     expect(mocks.subscriptionRetrieve).not.toHaveBeenCalled()
     expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+  })
+  /**
+   * The URL is public and the signature is the only thing authenticating the
+   * caller — but it cannot be checked until the payload is buffered. Without a
+   * cap, anyone who knows the URL can make the server hold whatever they send.
+   */
+  describe('body size cap', () => {
+    const OVER_CAP_BYTES = 1_048_577
+
+    it('rejects an oversized body that declares its size, without buffering it', async () => {
+      const response = await POST(
+        createRequest({ body: '{}', contentLength: String(OVER_CAP_BYTES) }),
+      )
+
+      expect(response.status).toBe(413)
+      await expect(response.json()).resolves.toEqual({ error: 'Payload too large' })
+      // The whole point: the caller never reaches the verification step, so it
+      // never costs us the payload it claimed to be sending.
+      expect(mocks.constructEvent).not.toHaveBeenCalled()
+
+      // A silent 413 makes a real misconfiguration indistinguishable from an
+      // attack, so the size that triggered it has to be in the log.
+      expect(loggedWarning('Stripe webhook rejected: body exceeds size cap')).toMatchObject({
+        level: 'warn',
+        observedBytes: OVER_CAP_BYTES,
+        declaredBytes: OVER_CAP_BYTES,
+        maxBytes: 1_048_576,
+      })
+    })
+
+    it('rejects an oversized body that declares no size at all', async () => {
+      // Chunked encoding carries no `content-length`, and a hostile caller can
+      // simply omit it. A cap that only reads the header is not a cap.
+      const megabyteChunk = new Uint8Array(1_048_576)
+      const response = await POST(
+        createRequest({ body: streamOf(megabyteChunk, megabyteChunk) }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(mocks.constructEvent).not.toHaveBeenCalled()
+    })
+
+    it('rejects an oversized body that understates its size', async () => {
+      // `content-length` is a claim by the sender, not a fact. Believing a
+      // small one would hand an attacker the uncapped read straight back.
+      const megabyteChunk = new Uint8Array(1_048_576)
+      const response = await POST(
+        createRequest({ body: streamOf(megabyteChunk, megabyteChunk), contentLength: '2' }),
+      )
+
+      expect(response.status).toBe(413)
+      expect(mocks.constructEvent).not.toHaveBeenCalled()
+    })
+
+    it('passes an ordinary event through untouched', async () => {
+      // Real events from this account run 3.8-5.6 KB; nothing near the cap.
+      const payload = JSON.stringify({ id: 'evt_1', type: 'customer.subscription.deleted' })
+      givenEvent('customer.subscription.deleted', { id: 'sub_1', customer: 'cus_1' })
+
+      const response = await POST(createRequest({ body: payload }))
+
+      expect(response.status).toBe(200)
+      expect(mocks.constructEvent).toHaveBeenCalledWith(payload, 't=1,v1=sig', 'whsec_test')
+      expect(mocks.resyncSubscription).toHaveBeenCalledWith('sub_1')
+    })
+
+    it('accepts a body that sits just under the cap', async () => {
+      const payload = 'x'.repeat(1_048_576)
+      givenEvent('customer.subscription.deleted', { id: 'sub_1', customer: 'cus_1' })
+
+      const response = await POST(createRequest({ body: payload }))
+
+      expect(response.status).toBe(200)
+      expect(mocks.constructEvent).toHaveBeenCalledWith(payload, 't=1,v1=sig', 'whsec_test')
+    })
+
+    it('reassembles a multi-byte character split across chunks', async () => {
+      // Signature verification is byte-exact. Decoding each chunk on its own
+      // would turn a character straddling the boundary into replacement
+      // characters, and every event naming a customer with an accent or an
+      // emoji would fail to verify — a silent, total outage of the webhook.
+      const payload = JSON.stringify({ name: 'Renée 🎟 Grüßen', city: '東京' })
+      const bytes = new TextEncoder().encode(payload)
+      // Cut one byte into the four-byte emoji, so neither half is valid UTF-8
+      // on its own.
+      const cut = new TextEncoder().encode(payload.slice(0, payload.indexOf('🎟'))).byteLength + 1
+      const chunks = [bytes.slice(0, cut), bytes.slice(cut)]
+
+      // Guard the guard: if the cut had landed on a character boundary this
+      // test would pass without exercising anything.
+      expect(chunks.map((chunk) => new TextDecoder().decode(chunk)).join('')).not.toBe(payload)
+
+      givenEvent('customer.subscription.deleted', { id: 'sub_1', customer: 'cus_1' })
+
+      const response = await POST(createRequest({ body: streamOf(...chunks) }))
+
+      expect(response.status).toBe(200)
+      expect(mocks.constructEvent).toHaveBeenCalledWith(payload, 't=1,v1=sig', 'whsec_test')
+    })
+
+    it('is byte-identical to reading the request whole', async () => {
+      // The regression this locks down: any change to how the body is read
+      // must produce exactly what `req.text()` would have, or every signature
+      // fails and no membership is ever granted again.
+      const payload = JSON.stringify({ accents: 'Ångström', emoji: '💳', cjk: '東京都' })
+      givenEvent('customer.subscription.deleted', { id: 'sub_1', customer: 'cus_1' })
+
+      await POST(createRequest({ body: payload }))
+
+      const [received] = mocks.constructEvent.mock.calls[0]
+      expect(received).toBe(await createRequest({ body: payload }).text())
+    })
   })
 })


### PR DESCRIPTION
## Problem

`src/app/api/payments/webhooks/stripe/route.ts` began with:

```ts
export async function POST(req: NextRequest) {
  const body = await req.text()
```

Two things are wrong with that line together:

1. It buffers the whole body into memory with no ceiling.
2. It happens **before** `stripe.webhooks.constructEvent`, which is the only thing that authenticates the caller.

The endpoint URL is public. Anyone who knows it can POST an arbitrarily large body, in parallel, and the server holds every byte in memory before it reaches the check that would have rejected the request in microseconds. Signature verification cannot help, because verification is what needs the buffer.

## Fix

A `readBodyWithinCap(req)` helper in the same file, returning a discriminated result. The route rejects with `413` and a `warn` log before any of the existing logic runs. Nothing else in the handler changed.

**Enforced twice, on purpose:**

- `content-length` is checked first, so an honest oversized request is refused without reading a byte.
- The header is then treated as a hint, not a fact. It is absent under chunked transfer encoding, and a hostile sender can simply understate it. So the stream is metered as it arrives (`reader.read()` with a running byte budget) and `reader.cancel()`ed the moment the budget is gone, with the accumulated chunks dropped. A cap that only reads the header is not a cap — it is a suggestion.

**Byte-exactness:** Stripe's signature covers the raw payload, so the string handed to `constructEvent` must be identical to what `req.text()` produced. Chunks are accumulated as `Uint8Array`s, concatenated, and decoded **once** with `TextDecoder`. Decoding per chunk would corrupt any multi-byte character straddling a chunk boundary into replacement characters, and every event naming a customer with an accent or containing an emoji would fail verification — a silent, total webhook outage. `TextDecoder` on the joined buffer also strips a leading BOM exactly as the Fetch spec's `text()` does, so the behaviour matches in that corner too.

There is still a `req.body === null` fallback to `await req.text()` (an empty body, or a runtime that already materialised it); `content-length` has been checked by that point.

## Why 1 MiB

Stripe publishes no maximum event size — I looked, and neither the webhooks docs nor the rate-limit docs state one. So the number is bracketed from two directions rather than picked by taste:

- **Observed:** real events captured from this account, `src/features/payments/__fixtures__/membership-lifecycle.events.json` — 9 events, 3,803 to **5,634 bytes**, mean 4,585. Largest is an `invoice.payment_succeeded`.
- **Pathological:** the thing that actually inflates a Stripe event is metadata, which Stripe caps at 50 keys x 500 characters ≈ 27 KB per object. An event can carry the object plus `previous_attributes`, and an invoice carries its inline line items, so a deliberately stuffed event still lands well under 100 KB.

1 MiB is ~180x the largest event ever received here and ~10x that worst case.

I erred generous deliberately. The two failure modes are not symmetric: a legitimate event rejected is a refund that never revokes access or a payment that never grants membership, discovered days later by hand. A 900 KB request accepted costs 900 KB. The win is bounding the unbounded, and 1 MiB does that just as completely as 64 KB would while carrying none of the false-rejection risk.

## Verification

From `apps/questura/apps/server`:

- `pnpm typecheck` — clean, no output.
- `pnpm lint` — **0 errors**, 6 warnings, all pre-existing (`FocalPointPickerField.tsx`, `lib/safe-return-path.ts`, 4 in `src/migrations/`). None in a file this PR touches.
- `pnpm test:int` — **118 files passed, 1050 tests passed**, 13.64s. Baseline on `main` is 1043; this PR adds 7.

New tests in `stripe-webhook.route.test.ts`, using the existing `createRequest()` / `givenEvent()` / `mocks` patterns (`createRequest` gained optional `body` and `contentLength`, defaulting to exactly what it did before, so all 49 existing tests are unchanged):

1. Oversized body **with** a declaring `content-length` → 413, `constructEvent` never called, and the `warn` line carries `observedBytes` / `declaredBytes` / `maxBytes`.
2. Oversized body with **no** `content-length` (2 MiB delivered as a stream) → still 413.
3. Oversized body that **understates** `content-length` as `2` → still 413, proving the header is not trusted.
4. An ordinary event passes through: 200, `constructEvent` called with the exact payload string, handler reached.
5. A body sitting exactly **at** the cap is accepted, pinning the boundary.
6. A payload split mid-emoji across two chunks still verifies byte-identically. The test asserts first that naive per-chunk decoding would *not* reproduce the payload, so it cannot pass vacuously.
7. The result is byte-identical to `await request.text()` on the same payload, over accents, an emoji, and CJK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)