### PR TITLE
Accept only id-shaped characters in a referral id

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -19,12 +19,52 @@ import { logger } from '@/shared/utils/logger'
 // chars — bound well below that.
 const REFERRAL_ID_MAX_LENGTH = 100
 
+/**
+ * The characters an affiliate id can be made of. Anything else is not an id.
+ *
+ * Length alone was the only bound, so any 100 characters at all — newlines,
+ * quotes, control bytes, invisible Unicode — rode the request body into Stripe
+ * metadata and into the checkout idempotency hash. Nothing downstream
+ * interpolates the value, so this is not a live injection; it is an untrusted
+ * string being carried into places that are hard to clean up. Metadata surfaces
+ * in Dashboard exports, event payloads and webhook logs, and a value with an
+ * embedded newline is a forged line in a log a human will later read as truth.
+ *
+ * Endorsely does not publish the format, and the value is minted server-side —
+ * `assets.endorsely.com/endorsely.js` only copies whatever
+ * `app.endorsely.com/api/public/track` hands back into
+ * `window.endorsely_referral`. The one concrete sample in this repo is our own
+ * Endorsely org id, `fcadb40c-1e6f-45a3-b69f-709deae165c0` (client
+ * `.env.production.local`), so their ids are at least UUID-shaped. That is
+ * suggestive, not proof, so this set is drawn wider than a UUID on purpose: it
+ * also admits prefixed ids (`ref_abc123`), base64 and base64url tokens, and
+ * dotted or colon-namespaced slugs.
+ *
+ * Erring wide is the right direction here. Rejecting a real referral silently
+ * drops the metadata, the affiliate never gets the commission, and nobody finds
+ * out — there is no error anywhere. Accepting an odd-but-harmless id costs
+ * nothing.
+ *
+ * Two printable characters are still left out. `/` never appears in an id and
+ * is the one character that would matter if this value were ever put in a path.
+ * `@` is excluded so the "no email in metadata" guard below stays meaningful:
+ * with it allowed, a caller could plant an address-shaped string in the one
+ * field that assertion exists to keep addresses out of.
+ */
+const REFERRAL_ID_PATTERN = /^[A-Za-z0-9._:+=-]+$/
+
 function sanitizeReferralId(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null
   }
   const trimmed = value.trim()
   if (trimmed.length === 0 || trimmed.length > REFERRAL_ID_MAX_LENGTH) {
+    return null
+  }
+  // `null` is the existing "no referral" answer, so a malformed value is
+  // ignored rather than failing the checkout. A visitor must not lose a
+  // subscription because an affiliate script sent something odd.
+  if (!REFERRAL_ID_PATTERN.test(trimmed)) {
     return null
   }
   return trimmed

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -124,6 +124,58 @@ describe('create checkout session referral ID validation', () => {
     expect(metadata.endorsely_referral).toBe('ref_abc123')
   })
 
+  // Endorsely mints these server-side and publishes no format, so the charset
+  // is deliberately wider than any one guess. Each of these is a shape a real
+  // affiliate id plausibly takes, and dropping one costs a commission that
+  // nobody is ever told about.
+  it.each([
+    ['a UUID, the shape of our own Endorsely org id', 'fcadb40c-1e6f-45a3-b69f-709deae165c0'],
+    ['a prefixed id', 'ref_abc123'],
+    ['a base64url token', 'aGVsbG8td29ybGQ_dGVzdA'],
+    ['a padded base64 token', 'aGVsbG8gd29ybGQh+A=='],
+    ['a dotted slug', 'acme.partners.eu'],
+    ['a colon-namespaced id', 'endorsely:partner:42'],
+    ['a value at the length bound', 'a'.repeat(100)],
+  ])('accepts %s', async (_label, referralId) => {
+    const metadata = await metadataForBody({ referralId })
+
+    expect(metadata.endorsely_referral).toBe(referralId)
+  })
+
+  // The value arrives in the request body, so it is attacker-controlled by
+  // definition, and it lands in Stripe metadata and the checkout idempotency
+  // hash. A newline here is a forged line in a log a human later reads as
+  // truth; the invisible characters are there so a lookalike id cannot be
+  // planted next to a real one.
+  it.each([
+    ['a newline', 'ref_abc\nadmin: true'],
+    ['a carriage return', 'ref_abc\rref_def'],
+    ['a null byte', 'ref_abc\u0000'],
+    ['a tab in the middle', 'ref\tabc'],
+    ['an inner space', 'ref abc'],
+    ['a quote', 'ref_"abc"'],
+    ['angle brackets', '<script>alert(1)</script>'],
+    ['a backslash', 'ref\\abc'],
+    ['a slash', 'ref/../abc'],
+    ['an at sign, which would look like an address in metadata', 'visitor@example.com'],
+    ['a zero-width space', 'ref_a\u200bbc'],
+    ['a right-to-left override', 'ref_a\u202ebc'],
+    ['non-ASCII letters', 'réf_abc'],
+    ['an emoji', 'ref_abc🎟'],
+    ['a percent escape', 'ref%20abc'],
+    ['a JSON fragment', '{"$gt":""}'],
+  ])('drops a referral ID containing %s', async (_label, referralId) => {
+    const metadata = await metadataForBody({ referralId })
+
+    expect(metadata).not.toHaveProperty('endorsely_referral')
+  })
+
+  it('drops a referral ID that is only punctuation the set does not allow', async () => {
+    const metadata = await metadataForBody({ referralId: '!!!' })
+
+    expect(metadata).not.toHaveProperty('endorsely_referral')
+  })
+
   it('drops non-string referral IDs', async () => {
     const metadata = await metadataForBody({ referralId: { $gt: '' } })
 
@@ -134,6 +186,14 @@ describe('create checkout session referral ID validation', () => {
     const metadata = await metadataForBody({ referralId: 'x'.repeat(101) })
 
     expect(metadata).not.toHaveProperty('endorsely_referral')
+  })
+
+  // The length bound is measured after trimming, as it always was: surrounding
+  // whitespace must not be what pushes an otherwise-valid id over the edge.
+  it('still trims before measuring the length bound', async () => {
+    const metadata = await metadataForBody({ referralId: `   ${'y'.repeat(100)}   ` })
+
+    expect(metadata.endorsely_referral).toBe('y'.repeat(100))
   })
 
   it('drops empty referral IDs', async () => {


### PR DESCRIPTION
## Problem

`sanitizeReferralId` in `create-checkout-session/route.ts` did three things: reject non-strings, trim, and bound the length at 100. It accepted **any characters at all** — newlines, carriage returns, null bytes, quotes, backslashes, zero-width spaces, right-to-left overrides, arbitrary Unicode.

The value arrives in the POST body, so it is attacker-controlled by definition. From there it goes two places:

- Stripe metadata as `endorsely_referral` (route.ts, `metadata.endorsely_referral = referralId`)
- the checkout idempotency-key hash (`lib/checkout-idempotency.ts`)

Nothing downstream interpolates it, so this is not a live injection — it is an untrusted string being carried into places that are unpleasant to clean up. Stripe metadata surfaces in Dashboard exports, event payloads and webhook logs, and an id with an embedded newline is a forged line in a log a human later reads as fact. Invisible and bidirectional characters let a lookalike id sit beside a real one and read identically.

## Fix

```ts
const REFERRAL_ID_PATTERN = /^[A-Za-z0-9._:+=-]+$/
```

applied after the existing trim and length checks. A non-matching value returns `null` — the existing "no referral" answer — so a malformed id is ignored rather than failing the checkout. Nobody should lose a membership because an affiliate script sent something strange. Trimming and the 100-character bound are untouched.

## Evidence for the character set

I searched for the real format. What I found, and what I did not:

**Found (indirect):** `apps/questura/apps/client/.env.production.local:18` — `NEXT_PUBLIC_ENDORSELY_ORG_ID=fcadb40c-1e6f-45a3-b69f-709deae165c0`. Our own Endorsely org id is a lowercase UUID, so Endorsely's ids are at least UUID-shaped.

**Found (mechanism):** I fetched `https://assets.endorsely.com/endorsely.js`, the script `AffiliateTracking.tsx` loads. It does not generate the value. It POSTs to `app.endorsely.com/api/public/track` and assigns the response straight through: `window.endorsely_referral = e.referral`. It also seeds from URL params `ref`, `aff`, `via`, `by`, `_by`, `utm_source`, and `endorsely_referral` — affiliate-chosen strings, which is a reason not to assume UUID.

**Not found:** Endorsely publishes no documented format for `endorsely_referral`. Stripe's docs do not constrain it either (metadata values are free-form up to 500 chars). The `ref_abc123` in the existing tests is a fixture, not a captured value. **So I could not confirm the real format, and the set below is not a match to a known spec.**

Given that, I went wide rather than narrow. Alphanumerics plus `.` `_` `-` `:` `+` `=` covers:

| Shape | Example | Why plausible |
|---|---|---|
| UUID | `fcadb40c-1e6f-45a3-b69f-709deae165c0` | our own Endorsely org id |
| prefixed id | `ref_abc123` | common affiliate-tool convention |
| base64url token | `aGVsbG8td29ybGQ_dGVzdA` | needs `-` and `_` |
| padded base64 | `aGVsbG8gd29ybGQh+A==` | needs `+` and `=` |
| dotted slug | `acme.partners.eu` | affiliate-chosen `ref=` values |
| colon-namespaced | `endorsely:partner:42` | |

**Why err generous:** the two failure modes are wildly asymmetric. A rejected legitimate id produces no error anywhere — the metadata is simply absent, the affiliate never gets the commission, and nothing is logged that would ever connect the two. An odd-but-harmless id accepted costs nothing. So the set is drawn to make a false rejection implausible while still excluding every character class that made this worth changing: whitespace, control characters, quotes, brackets, backslashes, percent escapes, and all non-ASCII.

**Two printable characters deliberately left out:**

- `/` — never appears in an id, and is the one character that would matter if this value ever reached a path.
- `@` — excluded so the existing test `expect(JSON.stringify(metadata)).not.toContain('@')` keeps its meaning. That assertion exists to keep addresses out of metadata; allowing `@` would let a caller plant an address-shaped string in exactly the field it protects.

## Verification

From `apps/questura/apps/server`:

- `pnpm typecheck` — clean, no output.
- `pnpm lint` — **0 errors**, 6 warnings, all pre-existing (`FocalPointPickerField.tsx`, `lib/safe-return-path.ts`, 4 in `src/migrations/`). None in a file this PR touches.
- `pnpm test:int` — **118 files passed, 1068 tests passed**, 13.69s. Baseline on `main` is 1043; this PR adds 25.
- `create-checkout-session.referral.test.ts` alone: **30 passed** (was 5).

Tests added to the existing file, following its `createRequest()` / `metadataForBody()` / `mocks` patterns:

- 7 accepted shapes (the table above, plus a value sitting exactly at the 100-character bound), each asserted to reach `metadata.endorsely_referral` unchanged.
- 16 rejected values, each asserted to leave metadata without the key: newline, carriage return, null byte, tab, inner space, quote, `<script>` tags, backslash, slash, `@`, zero-width space, RTL override, non-ASCII letters, emoji, percent escape, and a `{"$gt":""}` JSON fragment.
- Punctuation-only (`!!!`) rejected.
- A new test pinning that trimming still happens **before** the length check, so 100 valid characters wrapped in spaces still passes — surrounding whitespace must not be what pushes a valid id over the bound.
- The four pre-existing tests (valid id trimmed and forwarded, non-string dropped, over-length dropped, empty dropped) are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)