### PR TITLE
Correct the revocation comments against what Stripe actually did

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/access-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/access-revocation.ts
@@ -62,12 +62,23 @@ async function rejectedForCancelledSubscription(
  * `resyncSubscription` as `accessRevoked` rather than letting it re-read the
  * metadata that was never updated.
  *
- * This is the common shape of a refund, not an edge case: support cancels the
+ * In practice Stripe has been observed accepting this write on an
+ * already-cancelled subscription (2026-08-19, `sub_1U5yA8`), so `false` is the
+ * rare answer rather than the usual one. It is still handled, because Stripe
+ * documents no guarantee that a metadata-only update stays exempt from the
+ * "a canceled subscription can only update its cancellation_details" rule, and
+ * the failure mode if that changed unnoticed is a refunded visitor keeping
+ * access.
+ *
+ * What *is* the common shape of a refund is the order: support cancels the
  * subscription and *then* refunds the charge, so `charge.refunded` routinely
- * arrives against a cancelled subscription. Throwing there would 500 the
- * webhook, Stripe would retry for three days and never succeed, and the
- * refunded visitor would keep their access with `paidThroughAt` still sitting
- * at the period end they were given their money back for.
+ * arrives against a cancelled subscription — which is why
+ * `cancelRefundedSubscription` below, not this write, is where that ordinary
+ * flow actually met Stripe's rejection. Rethrowing an expected rejection from
+ * either call 500s the webhook, Stripe retries for three days and never
+ * succeeds, and the refunded visitor keeps their access with `paidThroughAt`
+ * still sitting at the period end they were given their money back for. That is
+ * not hypothetical: it is what `evt_3U5yA4` did until 2026-08-19.
  */
 export async function writeAccessRevocation(
   subscriptionId: string,

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
@@ -51,10 +51,16 @@ async function chargeFromDispute(dispute: Stripe.Dispute): Promise<Stripe.Charge
  *
  * Stripe is the preferred home for the flag because every later resync refetches
  * the subscription and would otherwise re-derive access from a period the
- * visitor was refunded for. But a cancelled subscription will not take the
- * write, and cancel-then-refund is the ordinary refund flow — so when the write
- * is refused the revocation is handed straight to the resync instead. The
- * profile is what gates access, so it ends up correct either way.
+ * visitor was refunded for.
+ *
+ * A cancelled subscription *does* take a metadata-only write — observed on this
+ * account 2026-08-19, where `sub_1U5yA8` carried all three revocation keys
+ * despite having been cancelled 42 minutes before the refund that wrote them.
+ * The `flagged === false` fallback below is therefore defensive, not the usual
+ * path: it exists because Stripe documents no guarantee either way, so a future
+ * tightening would otherwise silently leave the profile un-revoked. When the
+ * write is refused the revocation is handed straight to the resync instead, and
+ * the profile is what gates access, so it ends up correct either way.
  */
 async function markAccessRevoked(
   subscriptionId: string,


### PR DESCRIPTION
## Why

While verifying #340 against live Stripe, the subscription behind the stuck refund event turned out to contradict two comments in the code.

`sub_1U5yA8BUOUSxLiOZmpqJrblk`:

```
status:   canceled     (ended_at 1787105038 = 02:03:58Z)
metadata: access_revoked=true, access_revoked_reason=refund,
          access_revoked_period_end=1789780764
```

The refund event that writes those keys was created at 02:45:57Z — **42 minutes after the subscription was cancelled**. Nothing else writes them. So Stripe accepted a metadata-only update on an already-cancelled subscription, which is exactly what both comments said it would not do:

> But a cancelled subscription will not take the write…
> `false` means the subscription was already cancelled and Stripe refused the write

## Why it's worth a PR

This isn't pedantry about a comment. Someone tracing the three-day webhook stall through these comments would look at `writeAccessRevocation` and find it working fine. The rejection that actually stalled `evt_3U5yA4BUOUSxLiOZ1x75PwjG` came one line later, from `cancelRefundedSubscription` cancelling a subscription Stripe had already cancelled. The comments pointed at the wrong call.

## What changes

Comments only — no behaviour change, no test changes needed.

- `writeAccessRevocation` now says `false` is the rare answer, records the observation, and points at `cancelRefundedSubscription` as where the ordinary cancel-then-refund order actually meets a rejection.
- `markAccessRevoked` likewise, and now explains why the `flagged === false` branch is kept anyway.

The fallback stays. Stripe documents no guarantee that metadata-only updates remain exempt from "a canceled subscription can only update its cancellation_details", and if that changed unnoticed the cost is a refunded visitor keeping access. It's now labelled as the defensive branch it is.

## Verification

`pnpm typecheck` clean; `pnpm test:int` payments suite 351 passed (23 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)