### PR TITLE
Sell through cards only, instead of whatever the Dashboard allows

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -246,6 +246,28 @@ export async function POST(req: NextRequest) {
         price: priceId,
         quantity: 1
       }],
+      // Pinned here rather than left to the Dashboard, because the rest of this
+      // system is written against cards and says so out loud:
+      // `DELIBERATELY_UNHANDLED_STRIPE_EVENTS` leaves
+      // `checkout.session.async_payment_failed` unhandled on the stated grounds
+      // that "Checkout is card-only, so it cannot fire".
+      //
+      // That was not true. The account's default payment method configuration
+      // (`pmc_1RdDUl…`, checked 2026-08-19) enables affirm, amazon_pay,
+      // bancontact, blik, cashapp, eps, giropay and klarna alongside card and
+      // link. `mode: 'subscription'` filters that list to methods supporting
+      // recurring payments, which is why nothing has broken yet — but bancontact
+      // reaches recurring through a SEPA mandate, and SEPA is a
+      // delayed-notification method: the session completes `unpaid`, money
+      // arrives later, and the failure case is the event we do not handle.
+      //
+      // Naming the methods here means an enabled Dashboard toggle can no longer
+      // silently widen what this endpoint sells, and the contract's reasoning
+      // becomes true again. Apple Pay and Google Pay are unaffected — they ride
+      // in as card wallets. Link is the one thing this drops; add `'link'` to
+      // the array to bring it back, since it is card-backed and settles
+      // immediately.
+      payment_method_types: ['card'],
       success_url: successUrl,
       cancel_url: cancelUrl,
       metadata,

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.payment-methods.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.payment-methods.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  requireVisitorPrincipal: vi.fn(),
+  findVisitorProfileByAuthUserId: vi.fn(),
+  updateVisitorProfileByAuthUserId: vi.fn(),
+  stripeCustomerCreate: vi.fn(),
+  stripeCustomerList: vi.fn(),
+  stripeSubscriptionList: vi.fn(),
+  stripeCheckoutCreate: vi.fn(),
+  // Mutable so a single suite can exercise both sides of the flag; the config
+  // module is read at request time, not captured at import.
+  features: { endorselyAffiliates: false, stripePromotionCodes: false },
+}))
+
+vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
+  requireVisitorPrincipal: mocks.requireVisitorPrincipal,
+}))
+
+vi.mock('@/features/visitor-auth/lib/visitor-profile', () => ({
+  findVisitorProfileByAuthUserId: mocks.findVisitorProfileByAuthUserId,
+  updateVisitorProfileByAuthUserId: mocks.updateVisitorProfileByAuthUserId,
+}))
+
+vi.mock('@/payments/lib/stripe', () => ({
+  stripe: {
+    customers: { create: mocks.stripeCustomerCreate, list: mocks.stripeCustomerList },
+    subscriptions: { list: mocks.stripeSubscriptionList },
+    checkout: { sessions: { create: mocks.stripeCheckoutCreate } },
+  },
+}))
+
+vi.mock('@/payments/lib/payments-rate-limit', () => ({
+  checkPaymentsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  checkPaymentsVisitorRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  paymentsRateLimitResponse: vi.fn(),
+}))
+
+vi.mock('@/shared/config', () => ({
+  APP_CONFIG: {
+    CORS_ORIGINS: ['http://localhost:3000'],
+    features: mocks.features,
+    stripe: {
+      priceId: 'price_123',
+      monthlyPriceId: 'price_123',
+      yearlyPriceId: 'price_yearly_123',
+    },
+  },
+  APP_URLS: {
+    frontend: 'http://localhost:3000',
+    frontendUrl: (path: string) => `http://localhost:3000${path}`,
+  },
+}))
+
+import { POST } from '@/app/api/payments/create-checkout-session/route'
+
+let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
+
+function createRequest() {
+  return new Request('http://localhost:4000/api/payments/create-checkout-session', {
+    method: 'POST',
+    headers: { origin: 'http://localhost:3000', 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  }) as any
+}
+
+async function sessionParams() {
+  const response = await POST(createRequest())
+  expect(response.status).toBe(200)
+  return mocks.stripeCheckoutCreate.mock.calls[0]
+}
+
+describe('create checkout session payment methods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.features.stripePromotionCodes = false
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'none',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeCheckoutCreate.mockResolvedValue({
+      id: 'cs_123',
+      url: 'https://checkout.stripe.test/session',
+    })
+  })
+
+  afterEach(() => {
+    consoleLogSpy?.mockRestore()
+    consoleLogSpy = null
+  })
+
+  // `DELIBERATELY_UNHANDLED_STRIPE_EVENTS` leaves
+  // `checkout.session.async_payment_failed` unhandled because "Checkout is
+  // card-only, so it cannot fire". Nothing in the code enforced that: the list
+  // came from the Stripe Dashboard, where this account has bancontact, klarna,
+  // cashapp and others switched on. This is the assertion that makes the
+  // contract's claim true, so enabling a delayed-notification method in the
+  // Dashboard can no longer quietly invalidate it.
+  it('sells through cards only, whatever the Dashboard has enabled', async () => {
+    const [params] = await sessionParams()
+
+    expect(params.payment_method_types).toEqual(['card'])
+  })
+
+  // Omitting the field is the failure this guards: Stripe then falls back to the
+  // account's default payment method configuration, which is exactly the
+  // Dashboard-controlled list the handlers are not written for.
+  it('never leaves the method list to the account default', async () => {
+    const [params] = await sessionParams()
+
+    expect(params.payment_method_types).toBeDefined()
+  })
+
+  // A delayed method would let a session complete before the money settles, so
+  // the mode that decides entitlement has to keep travelling with it.
+  it('still creates a subscription, not a one-off payment', async () => {
+    const [params] = await sessionParams()
+
+    expect(params.mode).toBe('subscription')
+    expect(params.line_items).toEqual([{ price: 'price_123', quantity: 1 }])
+  })
+})


### PR DESCRIPTION
## The invariant the code already claims

`webhooks/event-contract.ts` leaves an event unhandled and gives its reason:

> `'checkout.session.async_payment_failed'`: *"Only fires for delayed-notification payment methods (bank debits, vouchers). **Checkout is card-only**, so it cannot fire; revisit if a delayed method is ever enabled."*

Nothing in the code made that true. `checkout.sessions.create` passed no `payment_method_types`, so the list came from the Stripe Dashboard.

## What the account actually has enabled

Checked against live Stripe on 2026-08-19. The account has two payment method configurations; `pmc_1SVLJw…` belongs to a connected application (it has a `parent` and an `application`), so the one that applies here is the account's own default:

```
pmc_1RdDUlBUOUSxLiOZsn6Z6eic  (no parent, no application, is_default)
  enabled: affirm, amazon_pay, apple_pay, bancontact, blik, card,
           cashapp, eps, giropay, klarna, link
```

So the premise is false, and has been for as long as those toggles have been on. Nobody "revisited" it because enabling a method in the Dashboard produces no diff for anyone to review.

## How bad is it, honestly

Not currently broken, and I want to be accurate about that. `mode: 'subscription'` filters the offered list to methods that support recurring payments, which excludes most of the above. That is why nothing has gone wrong yet.

It is not a guarantee, though:

- **bancontact** reaches recurring through a **SEPA Direct Debit mandate**, and SEPA is a delayed-notification method.
- Such a session completes with `payment_status: 'unpaid'` and settles later.
- `handleCheckoutSessionCompleted` never inspects `payment_status`.
- The event that reports the money never arriving is the one deliberately left unhandled.

`invoice.payment_failed` **is** handled and would eventually pull entitlement through dunning, so this is a second line of defence covering for an invariant the code believes it already holds. That is a fragile place to leave it — the safety net is load-bearing and undocumented as such.

## The change

`payment_method_types: ['card']` at the call site. 22 added lines, nothing removed — the diff is purely additive.

- **Apple Pay / Google Pay are unaffected.** They are card wallets and still appear under `card`.
- **Link is dropped.** It is card-backed and settles immediately, so it is safe to keep — adding `'link'` to the array brings it back. Called out because it is a conversion decision, not a safety one, and it is yours to make.

## Verification

- New `create-checkout-session.payment-methods.test.ts` (3 tests). **Removing the one added line fails 2 of them** — the assertion bites.
- `pnpm test:int`: 1082 passed (120 files). `pnpm typecheck` clean. `pnpm lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)