### PR TITLE
Capture the incomplete waiting state from a real Stripe run

### DIFF
--- a/apps/questura/apps/server/scripts/capture-membership-fixtures.ts
+++ b/apps/questura/apps/server/scripts/capture-membership-fixtures.ts
@@ -49,6 +49,11 @@ const FIXTURE_PATH = resolve(
   '../src/features/payments/__fixtures__/membership-lifecycle.events.json'
 )
 
+const INCOMPLETE_FIXTURE_PATH = resolve(
+  __dirname,
+  '../src/features/payments/__fixtures__/membership-incomplete.events.json'
+)
+
 /** Stripe test payment methods: one that always works, one that fails on charge. */
 const PM_GOOD = 'pm_card_visa'
 const PM_FAILING = 'pm_card_chargeCustomerFail'
@@ -191,6 +196,90 @@ async function drive(): Promise<{ subscriptionId: string; customerId: string; st
   return { subscriptionId: subscription.id, customerId: customer.id, startedAt }
 }
 
+/**
+ * Drive the waiting state: a subscription that exists but has not collected.
+ *
+ * This is the one path the tests covered without a single captured payload
+ * behind them. Production reaches it through Checkout with
+ * `request_three_d_secure: 'challenge'` -- the visitor is sent to their bank,
+ * and until they come back the subscription sits `incomplete` with an unpaid
+ * first invoice. `UNPAID_CURRENT_PERIOD` and `mapStripeStatusToInternal` both
+ * have branches for that status, and `resolveDunningGrace` deliberately refuses
+ * to open a grace window for it, all written against hand-built objects.
+ *
+ * `payment_behavior: 'default_incomplete'` reproduces the same state without a
+ * browser: Stripe creates the subscription, leaves it `incomplete`, and waits
+ * for the invoice to be paid. It is the *state* these fixtures are for, not the
+ * reason it was reached -- a 3DS challenge and a deferred confirmation leave the
+ * subscription in the same shape, and only the former needs a human at a bank's
+ * redirect page.
+ *
+ * No test clock here. Nothing needs time to pass: the subscription is born
+ * waiting, and paying the invoice ends the wait. That keeps this stage seconds
+ * long instead of minutes, so it can be re-run on its own.
+ */
+async function driveIncomplete(): Promise<{
+  subscriptionId: string
+  customerId: string
+  startedAt: number
+}> {
+  const startedAt = Math.floor(Date.now() / 1000)
+
+  const price = await stripe.prices.create({
+    currency: 'usd',
+    unit_amount: 50,
+    recurring: { interval: 'month' },
+    product_data: { name: 'Questura Membership (incomplete fixture)' },
+  })
+  log('incomplete', `price ${price.id}`)
+
+  const customer = await stripe.customers.create({
+    email: `fixture-incomplete+${startedAt}@questurian.test`,
+    name: 'Fixture Visitor (incomplete)',
+  })
+  log('incomplete', `customer ${customer.id}`)
+
+  await setDefaultPaymentMethod(customer.id, PM_GOOD)
+
+  const subscription = await stripe.subscriptions.create({
+    customer: customer.id,
+    items: [{ price: price.id }],
+    payment_behavior: 'default_incomplete',
+    metadata: { visitorAuthUserId: 'fixture-auth-user-incomplete' },
+  })
+  log('incomplete', `subscription ${subscription.id} status=${subscription.status}`)
+
+  if (subscription.status !== 'incomplete') {
+    throw new Error(
+      `Expected an incomplete subscription to capture; Stripe returned ${subscription.status}. ` +
+        'Without it this fixture would record the ordinary paid path under the wrong name.'
+    )
+  }
+
+  // The wait ends. Paying the open invoice is what a returning visitor's
+  // completed 3DS challenge amounts to on Stripe's side.
+  const invoiceId =
+    typeof subscription.latest_invoice === 'string'
+      ? subscription.latest_invoice
+      : subscription.latest_invoice?.id
+
+  if (!invoiceId) {
+    throw new Error('Incomplete subscription has no latest invoice to pay.')
+  }
+
+  await stripe.invoices.pay(invoiceId)
+  log('authenticated', `paid invoice ${invoiceId}`)
+
+  const settled = await stripe.subscriptions.retrieve(subscription.id)
+  log('authenticated', `subscription status=${settled.status}`)
+
+  if (settled.status !== 'active') {
+    log('authenticated', `WARNING: expected active after payment, got ${settled.status}`)
+  }
+
+  return { subscriptionId: subscription.id, customerId: customer.id, startedAt }
+}
+
 const CAPTURED_EVENT_TYPES = new Set([
   'customer.subscription.created',
   'customer.subscription.updated',
@@ -248,8 +337,110 @@ function reportPeriodEndShape(events: Stripe.Event[]) {
   }
 }
 
+/**
+ * Which capture to run. The lifecycle stage advances a test clock through three
+ * months and takes minutes; the incomplete stage takes seconds. Re-running the
+ * slow one to refresh the fast one wastes time and rewrites a fixture that did
+ * not need to change, so each can be asked for on its own.
+ */
+type CaptureStage = 'lifecycle' | 'incomplete' | 'all'
+
+function requestedStage(): CaptureStage {
+  const raw = (process.env.CAPTURE_STAGE ?? 'all').trim()
+
+  if (raw === 'lifecycle' || raw === 'incomplete' || raw === 'all') return raw
+
+  throw new Error(
+    `CAPTURE_STAGE must be lifecycle, incomplete or all; got ${JSON.stringify(raw)}.`
+  )
+}
+
+/**
+ * Wait for Stripe's event list to catch up with what already happened.
+ *
+ * `events.list` is eventually consistent. Reading it straight after paying the
+ * invoice returned only `customer.subscription.created` -- the transition out of
+ * the waiting state, which is the entire point of this capture, had not been
+ * listed yet. A fixture written from that read would have recorded a
+ * subscription that never leaves `incomplete` and looked, at a glance, like a
+ * successful capture.
+ *
+ * So the read is repeated until the event that proves the transition shows up.
+ * Failing loudly on timeout is deliberate: a short fixture that silently
+ * omits the interesting half is worse than no fixture.
+ */
+async function waitForEvents(
+  subscriptionId: string,
+  since: number,
+  required: string[],
+  stage: string
+): Promise<Stripe.Event[]> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const events = await collectEvents(subscriptionId, since)
+    const seen = new Set<string>(events.map((event) => event.type))
+
+    if (required.every((type) => seen.has(type))) return events
+
+    if (attempt === 0) {
+      log(stage, `waiting for ${required.filter((type) => !seen.has(type)).join(', ')}`)
+    }
+
+    await sleep(2000)
+  }
+
+  const events = await collectEvents(subscriptionId, since)
+  const seen = new Set<string>(events.map((event) => event.type))
+  const missing = required.filter((type) => !seen.has(type))
+
+  throw new Error(
+    `Stripe never listed ${missing.join(', ')} for ${subscriptionId}. ` +
+      `Captured only: ${[...seen].join(', ') || '(nothing)'}. Refusing to write a partial fixture.`
+  )
+}
+
+async function captureIncomplete() {
+  const { subscriptionId, customerId, startedAt } = await driveIncomplete()
+
+  // `subscription.updated` is the transition this fixture exists for; without it
+  // there is no evidence the waiting state ever ends.
+  const events = await waitForEvents(
+    subscriptionId,
+    startedAt,
+    ['customer.subscription.created', 'customer.subscription.updated', 'invoice.payment_succeeded'],
+    'capture'
+  )
+  log('capture', `${events.length} events for ${subscriptionId}`)
+
+  reportPeriodEndShape(events)
+
+  const fixture = {
+    capturedAt: new Date().toISOString(),
+    note: 'Captured from a real Stripe test-mode run of the incomplete (awaiting payment) path. Do not hand-edit; re-run the script.',
+    subscriptionId,
+    customerId,
+    events,
+  }
+
+  mkdirSync(dirname(INCOMPLETE_FIXTURE_PATH), { recursive: true })
+  writeFileSync(INCOMPLETE_FIXTURE_PATH, `${JSON.stringify(fixture, null, 2)}\n`)
+
+  console.log(`\nWrote ${events.length} events to ${INCOMPLETE_FIXTURE_PATH}`)
+}
+
 async function main() {
-  log('setup', 'test mode confirmed, driving the lifecycle')
+  const stage = requestedStage()
+  log('setup', `test mode confirmed, stage=${stage}`)
+
+  if (stage === 'incomplete') {
+    await captureIncomplete()
+    return
+  }
+
+  if (stage === 'all') {
+    await captureIncomplete()
+  }
+
+  log('setup', 'driving the lifecycle')
 
   const { subscriptionId, customerId, startedAt } = await drive()
 

--- a/apps/questura/apps/server/src/features/payments/__fixtures__/membership-incomplete.events.json
+++ b/apps/questura/apps/server/src/features/payments/__fixtures__/membership-incomplete.events.json
@@ -1,0 +1,641 @@
+{
+  "capturedAt": "2026-08-19T04:36:13.529Z",
+  "note": "Captured from a real Stripe test-mode run of the incomplete (awaiting payment) path. Do not hand-edit; re-run the script.",
+  "subscriptionId": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+  "customerId": "cus_V6DfbbhnhaPHqj",
+  "events": [
+    {
+      "id": "evt_1U61ESBUOUSxLiOZKK4MV0ki",
+      "object": "event",
+      "api_version": "2020-08-27",
+      "created": 1787114168,
+      "data": {
+        "object": {
+          "id": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1787114167,
+          "billing_cycle_anchor_config": null,
+          "billing_mode": {
+            "flexible": null,
+            "type": "classic"
+          },
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "feedback_option": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1787114167,
+          "currency": "usd",
+          "current_period_end": 1789792567,
+          "current_period_start": 1787114167,
+          "customer": "cus_V6DfbbhnhaPHqj",
+          "customer_account": null,
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "custom_fields": null,
+            "description": null,
+            "footer": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_V6Dfo0lTeX4SxY",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1787114167,
+                "current_period_end": 1789792567,
+                "current_period_start": 1787114167,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 50,
+                  "amount_decimal": "50",
+                  "billing_scheme": "per_unit",
+                  "created": 1787114165,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_V6Dfx5osoIcz80",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1787114165,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_V6Dfx5osoIcz80",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 50,
+                  "unit_amount_decimal": "50"
+                },
+                "quantity": 1,
+                "subscription": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1U61ERBUOUSxLiOZNT6lLnat"
+          },
+          "latest_invoice": "in_1U61ERBUOUSxLiOZQD8gZhDR",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "visitorAuthUserId": "fixture-auth-user-incomplete"
+          },
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "off"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": null,
+          "pending_update": null,
+          "plan": {
+            "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 50,
+            "amount_decimal": "50",
+            "billing_scheme": "per_unit",
+            "created": 1787114165,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_V6Dfx5osoIcz80",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1787114167,
+          "status": "incomplete",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": null,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "create_invoice"
+            }
+          },
+          "trial_start": null
+        }
+      },
+      "livemode": false,
+      "pending_webhooks": 0,
+      "request": {
+        "id": "req_gXyhoBQFTPwPAg",
+        "idempotency_key": "stripe-node-retry-be277a62-333f-41d7-9450-4fd8130866fd"
+      },
+      "type": "customer.subscription.created"
+    },
+    {
+      "id": "evt_1U61EVBUOUSxLiOZjKDRvVz5",
+      "object": "event",
+      "api_version": "2020-08-27",
+      "created": 1787114170,
+      "data": {
+        "object": {
+          "id": "in_1U61ERBUOUSxLiOZQD8gZhDR",
+          "object": "invoice",
+          "account_country": "US",
+          "account_name": "Ruben Malpartida",
+          "account_tax_ids": null,
+          "amount_due": 50,
+          "amount_overpaid": 0,
+          "amount_paid": 50,
+          "amount_remaining": 0,
+          "amount_shipping": 0,
+          "application": null,
+          "application_fee_amount": null,
+          "attempt_count": 1,
+          "attempted": true,
+          "auto_advance": false,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null,
+            "provider": null,
+            "status": null
+          },
+          "automatically_finalizes_at": null,
+          "billing_reason": "subscription_create",
+          "charge": "ch_3U61ERBUOUSxLiOZ29BhuBd6",
+          "collection_method": "charge_automatically",
+          "created": 1787114167,
+          "currency": "usd",
+          "custom_fields": null,
+          "customer": "cus_V6DfbbhnhaPHqj",
+          "customer_account": null,
+          "customer_address": null,
+          "customer_email": "fixture-incomplete+1787114165@questurian.test",
+          "customer_name": "Fixture Visitor (incomplete)",
+          "customer_phone": null,
+          "customer_shipping": null,
+          "customer_tax_exempt": "none",
+          "customer_tax_ids": [],
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "due_date": null,
+          "effective_at": 1787114167,
+          "ending_balance": 0,
+          "footer": null,
+          "from_invoice": null,
+          "hosted_invoice_url": "https://invoice.stripe.com/i/acct_1I5GsjBUOUSxLiOZ/test_YWNjdF8xSTVHc2pCVU9VU3hMaU9aLF9WNkRmNkxtSjM3NW9tbHpHUG1QcWkyMkp6aElKZVJwLDE3NzY1NDk3MQ0200T3aWBwam?s=ap",
+          "invoice_pdf": "https://pay.stripe.com/invoice/acct_1I5GsjBUOUSxLiOZ/test_YWNjdF8xSTVHc2pCVU9VU3hMaU9aLF9WNkRmNkxtSjM3NW9tbHpHUG1QcWkyMkp6aElKZVJwLDE3NzY1NDk3MQ0200T3aWBwam/pdf?s=ap",
+          "issuer": {
+            "type": "self"
+          },
+          "last_finalization_error": null,
+          "latest_revision": null,
+          "lines": {
+            "object": "list",
+            "data": [
+              {
+                "id": "il_1U61ERBUOUSxLiOZ3WgnpqN0",
+                "object": "line_item",
+                "amount": 50,
+                "amount_excluding_tax": 50,
+                "currency": "usd",
+                "description": "1 × Questura Membership (incomplete fixture) (at $0.50 / month)",
+                "discount_amounts": [],
+                "discountable": true,
+                "discounts": [],
+                "invoice": "in_1U61ERBUOUSxLiOZQD8gZhDR",
+                "livemode": false,
+                "metadata": {
+                  "visitorAuthUserId": "fixture-auth-user-incomplete"
+                },
+                "parent": {
+                  "invoice_item_details": null,
+                  "license_fee_subscription_details": null,
+                  "subscription_item_details": {
+                    "invoice_item": null,
+                    "proration": false,
+                    "proration_details": {
+                      "credited_items": null
+                    },
+                    "subscription": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+                    "subscription_item": "si_V6Dfo0lTeX4SxY"
+                  },
+                  "type": "subscription_item_details"
+                },
+                "period": {
+                  "end": 1789792567,
+                  "start": 1787114167
+                },
+                "plan": {
+                  "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 50,
+                  "amount_decimal": "50",
+                  "billing_scheme": "per_unit",
+                  "created": 1787114165,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_V6Dfx5osoIcz80",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "pretax_credit_amounts": [],
+                "price": {
+                  "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1787114165,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_V6Dfx5osoIcz80",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 50,
+                  "unit_amount_decimal": "50"
+                },
+                "pricing": {
+                  "price_details": {
+                    "price": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                    "product": "prod_V6Dfx5osoIcz80"
+                  },
+                  "type": "price_details",
+                  "unit_amount_decimal": "50"
+                },
+                "proration": false,
+                "proration_details": {
+                  "credited_items": null
+                },
+                "quantity": 1,
+                "quantity_decimal": "1",
+                "subscription": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+                "subscription_item": "si_V6Dfo0lTeX4SxY",
+                "subtotal": 50,
+                "tax_amounts": [],
+                "tax_rates": [],
+                "taxes": [],
+                "type": "subscription",
+                "unit_amount_excluding_tax": "50"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/invoices/in_1U61ERBUOUSxLiOZQD8gZhDR/lines"
+          },
+          "livemode": false,
+          "metadata": {},
+          "next_payment_attempt": null,
+          "number": "NOXQG6PT-0001",
+          "on_behalf_of": null,
+          "paid": true,
+          "paid_out_of_band": false,
+          "parent": {
+            "quote_details": null,
+            "subscription_details": {
+              "metadata": {
+                "visitorAuthUserId": "fixture-auth-user-incomplete"
+              },
+              "subscription": "sub_1U61ERBUOUSxLiOZNT6lLnat"
+            },
+            "type": "subscription_details"
+          },
+          "payment_intent": "pi_3U61ERBUOUSxLiOZ2eFQm9fk",
+          "payment_settings": {
+            "default_mandate": null,
+            "payment_method_options": null,
+            "payment_method_types": null
+          },
+          "period_end": 1787114167,
+          "period_start": 1787114167,
+          "post_payment_credit_notes_amount": 0,
+          "pre_payment_credit_notes_amount": 0,
+          "quote": null,
+          "receipt_number": null,
+          "rendering": null,
+          "rendering_options": null,
+          "shipping_cost": null,
+          "shipping_details": null,
+          "starting_balance": 0,
+          "statement_descriptor": null,
+          "status": "paid",
+          "status_transitions": {
+            "finalized_at": 1787114167,
+            "marked_uncollectible_at": null,
+            "paid_at": 1787114169,
+            "voided_at": null
+          },
+          "subscription": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+          "subscription_details": {
+            "metadata": {
+              "visitorAuthUserId": "fixture-auth-user-incomplete"
+            }
+          },
+          "subtotal": 50,
+          "subtotal_excluding_tax": 50,
+          "tax": null,
+          "test_clock": null,
+          "total": 50,
+          "total_discount_amounts": [],
+          "total_excluding_tax": 50,
+          "total_pretax_credit_amounts": [],
+          "total_tax_amounts": [],
+          "total_taxes": [],
+          "transfer_data": null,
+          "webhooks_delivered_at": 1787114167
+        }
+      },
+      "livemode": false,
+      "pending_webhooks": 0,
+      "request": {
+        "id": "req_tCnRyO4rQBDCie",
+        "idempotency_key": "stripe-node-retry-c2d59ccf-13b5-4409-9296-ff13fdbc8651"
+      },
+      "type": "invoice.payment_succeeded"
+    },
+    {
+      "id": "evt_1U61EVBUOUSxLiOZKFB0cKak",
+      "object": "event",
+      "api_version": "2020-08-27",
+      "created": 1787114170,
+      "data": {
+        "object": {
+          "id": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+          "object": "subscription",
+          "application": null,
+          "application_fee_percent": null,
+          "automatic_tax": {
+            "disabled_reason": null,
+            "enabled": false,
+            "liability": null
+          },
+          "billing_cycle_anchor": 1787114167,
+          "billing_cycle_anchor_config": null,
+          "billing_mode": {
+            "flexible": null,
+            "type": "classic"
+          },
+          "billing_thresholds": null,
+          "cancel_at": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "cancellation_details": {
+            "comment": null,
+            "feedback": null,
+            "feedback_option": null,
+            "reason": null
+          },
+          "collection_method": "charge_automatically",
+          "created": 1787114167,
+          "currency": "usd",
+          "current_period_end": 1789792567,
+          "current_period_start": 1787114167,
+          "customer": "cus_V6DfbbhnhaPHqj",
+          "customer_account": null,
+          "days_until_due": null,
+          "default_payment_method": null,
+          "default_source": null,
+          "default_tax_rates": [],
+          "description": null,
+          "discount": null,
+          "discounts": [],
+          "ended_at": null,
+          "invoice_settings": {
+            "account_tax_ids": null,
+            "custom_fields": null,
+            "description": null,
+            "footer": null,
+            "issuer": {
+              "type": "self"
+            }
+          },
+          "items": {
+            "object": "list",
+            "data": [
+              {
+                "id": "si_V6Dfo0lTeX4SxY",
+                "object": "subscription_item",
+                "billing_thresholds": null,
+                "created": 1787114167,
+                "current_period_end": 1789792567,
+                "current_period_start": 1787114167,
+                "discounts": [],
+                "metadata": {},
+                "plan": {
+                  "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                  "object": "plan",
+                  "active": true,
+                  "aggregate_usage": null,
+                  "amount": 50,
+                  "amount_decimal": "50",
+                  "billing_scheme": "per_unit",
+                  "created": 1787114165,
+                  "currency": "usd",
+                  "interval": "month",
+                  "interval_count": 1,
+                  "livemode": false,
+                  "metadata": {},
+                  "meter": null,
+                  "nickname": null,
+                  "product": "prod_V6Dfx5osoIcz80",
+                  "tiers_mode": null,
+                  "transform_usage": null,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "price": {
+                  "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+                  "object": "price",
+                  "active": true,
+                  "billing_scheme": "per_unit",
+                  "created": 1787114165,
+                  "currency": "usd",
+                  "custom_unit_amount": null,
+                  "livemode": false,
+                  "lookup_key": null,
+                  "metadata": {},
+                  "nickname": null,
+                  "product": "prod_V6Dfx5osoIcz80",
+                  "recurring": {
+                    "aggregate_usage": null,
+                    "interval": "month",
+                    "interval_count": 1,
+                    "meter": null,
+                    "trial_period_days": null,
+                    "usage_type": "licensed"
+                  },
+                  "tax_behavior": "unspecified",
+                  "tiers_mode": null,
+                  "transform_quantity": null,
+                  "type": "recurring",
+                  "unit_amount": 50,
+                  "unit_amount_decimal": "50"
+                },
+                "quantity": 1,
+                "subscription": "sub_1U61ERBUOUSxLiOZNT6lLnat",
+                "tax_rates": []
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/subscription_items?subscription=sub_1U61ERBUOUSxLiOZNT6lLnat"
+          },
+          "latest_invoice": "in_1U61ERBUOUSxLiOZQD8gZhDR",
+          "livemode": false,
+          "managed_payments": {
+            "enabled": false
+          },
+          "metadata": {
+            "visitorAuthUserId": "fixture-auth-user-incomplete"
+          },
+          "next_pending_invoice_item_invoice": null,
+          "on_behalf_of": null,
+          "pause_collection": null,
+          "payment_settings": {
+            "payment_method_options": null,
+            "payment_method_types": null,
+            "save_default_payment_method": "off"
+          },
+          "pending_invoice_item_interval": null,
+          "pending_setup_intent": null,
+          "pending_update": null,
+          "plan": {
+            "id": "price_1U61EPBUOUSxLiOZUI1ExuSF",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 50,
+            "amount_decimal": "50",
+            "billing_scheme": "per_unit",
+            "created": 1787114165,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "meter": null,
+            "nickname": null,
+            "product": "prod_V6Dfx5osoIcz80",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "schedule": null,
+          "start_date": 1787114167,
+          "status": "active",
+          "test_clock": null,
+          "transfer_data": null,
+          "trial_end": null,
+          "trial_settings": {
+            "end_behavior": {
+              "missing_payment_method": "create_invoice"
+            }
+          },
+          "trial_start": null
+        },
+        "previous_attributes": {
+          "status": "incomplete"
+        }
+      },
+      "livemode": false,
+      "pending_webhooks": 0,
+      "request": {
+        "id": "req_tCnRyO4rQBDCie",
+        "idempotency_key": "stripe-node-retry-c2d59ccf-13b5-4409-9296-ff13fdbc8651"
+      },
+      "type": "customer.subscription.updated"
+    }
+  ]
+}

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-state.incomplete.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-state.incomplete.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import type Stripe from 'stripe'
+
+import fixture from '../__fixtures__/membership-incomplete.events.json'
+import { DUNNING_GRACE_DAYS, deriveSubscriptionState } from './subscription-state'
+
+/**
+ * The waiting state, against payloads Stripe actually emitted.
+ *
+ * `incomplete` is what a subscription is between "the visitor pressed pay" and
+ * "the money arrived" — in production, the window while a 3DS challenge is
+ * open. Three separate pieces of logic have a branch for it (`UNPAID_CURRENT_PERIOD`,
+ * `mapStripeStatusToInternal`, and `resolveDunningGrace` refusing it a grace
+ * window), and until now every one of them was tested only against hand-built
+ * objects. Hand-built objects are exactly what hid the `current_period_end` bug
+ * that motivated the fixture capture in the first place.
+ *
+ * `__fixtures__/membership-incomplete.events.json` is a real run: a subscription
+ * created with `payment_behavior: 'default_incomplete'`, then its invoice paid.
+ * It records the shape of the wait and the shape of the wait ending.
+ */
+type CapturedEvent = {
+  type: string
+  data: { object: Record<string, unknown> }
+}
+
+const events = fixture.events as CapturedEvent[]
+
+function subscriptionEvents(): Stripe.Subscription[] {
+  return events
+    .filter((event) => event.data.object.object === 'subscription')
+    .map((event) => event.data.object as unknown as Stripe.Subscription)
+}
+
+function periodOf(subscription: Stripe.Subscription): { start: number; end: number } {
+  const item = subscription.items.data[0] as unknown as {
+    current_period_start: number
+    current_period_end: number
+  }
+  return { start: item.current_period_start, end: item.current_period_end }
+}
+
+function firstWithStatus(status: string): Stripe.Subscription {
+  const found = subscriptionEvents().find((subscription) => subscription.status === status)
+  if (!found) throw new Error(`Fixture has no subscription in ${status}`)
+  return found
+}
+
+describe('the incomplete waiting state, from captured payloads', () => {
+  // Guards the fixture itself. A capture that silently returned only
+  // `subscription.created` would leave every assertion below passing against a
+  // subscription that never leaves the waiting state — which is precisely what
+  // the first run of this capture produced before it learned to wait for
+  // Stripe's event list to catch up.
+  it('captured both halves: the wait, and the wait ending', () => {
+    const types = events.map((event) => event.type)
+
+    expect(types).toContain('customer.subscription.created')
+    expect(types).toContain('invoice.payment_succeeded')
+    expect(types).toContain('customer.subscription.updated')
+
+    const statuses = subscriptionEvents().map((subscription) => subscription.status)
+    expect(statuses).toContain('incomplete')
+    expect(statuses).toContain('active')
+  })
+
+  // The reason `incomplete` cannot be treated like any other status: Stripe has
+  // already rolled the period forward on a subscription that has collected
+  // nothing, so its period end describes time nobody has bought.
+  //
+  // Note the mechanism is not a null. `resolvePaidThrough` pins an unpaid
+  // current period to its *start* — the end of the last period actually paid
+  // for, which on a first subscription is the moment it was created. That is
+  // already in the past, so entitlement (`paidThroughAt > now`) is false, and
+  // the value still says something true rather than discarding the period.
+  it('pins entitlement to the period start while the first payment has not landed', () => {
+    const waiting = firstWithStatus('incomplete')
+    const item = periodOf(waiting)
+
+    const state = deriveSubscriptionState(waiting)
+
+    expect(state.paidThroughAt).toBe(new Date(item.start * 1000).toISOString())
+  })
+
+  it('never hands out the period end of a subscription that has not collected', () => {
+    const waiting = firstWithStatus('incomplete')
+    const item = periodOf(waiting)
+
+    // The trap: a real, future, plausible-looking timestamp sitting on an unpaid
+    // subscription. Reading it would grant a month of access for nothing.
+    expect(item.end).toBeGreaterThan(Math.floor(Date.now() / 1000))
+
+    const state = deriveSubscriptionState(waiting)
+
+    expect(state.paidThroughAt).not.toBe(new Date(item.end * 1000).toISOString())
+    // And what it does hand out buys no time at all.
+    expect(new Date(state.paidThroughAt!).getTime()).toBeLessThanOrEqual(Date.now())
+  })
+
+  // Grace exists to recover a payment that once worked. A subscription that has
+  // never collected has nothing to recover, so opening a window here would hand
+  // out free access to anyone who abandons a 3DS challenge.
+  it('opens no dunning grace for a subscription that never collected', () => {
+    const waiting = firstWithStatus('incomplete')
+
+    const state = deriveSubscriptionState(waiting, { graceDays: DUNNING_GRACE_DAYS })
+
+    expect(state.dunningGraceUntil).toBeNull()
+  })
+
+  it('surfaces the wait as past_due, the status the account page can explain', () => {
+    const waiting = firstWithStatus('incomplete')
+
+    expect(deriveSubscriptionState(waiting).subscriptionStatus).toBe('past_due')
+  })
+
+  // The half that matters to a visitor who completed their challenge: once the
+  // invoice is paid, entitlement has to appear.
+  it('grants entitlement once the payment lands', () => {
+    const settled = firstWithStatus('active')
+
+    const state = deriveSubscriptionState(settled)
+
+    expect(state.subscriptionStatus).toBe('active')
+    expect(state.paidThroughAt).not.toBeNull()
+    expect(state.dunningGraceUntil).toBeNull()
+  })
+
+  // Same subscription, same period, opposite entitlement — so the difference is
+  // the status and nothing else. This is the assertion that would fail if
+  // `UNPAID_CURRENT_PERIOD` ever stopped listing `incomplete`.
+  it('turns the same period from no access into access, on status alone', () => {
+    const waiting = firstWithStatus('incomplete')
+    const settled = firstWithStatus('active')
+
+    expect(periodOf(waiting).end).toBe(periodOf(settled).end)
+
+    const waitingThrough = new Date(deriveSubscriptionState(waiting).paidThroughAt!).getTime()
+    const settledThrough = new Date(deriveSubscriptionState(settled).paidThroughAt!).getTime()
+
+    expect(waitingThrough).toBeLessThanOrEqual(Date.now())
+    expect(settledThrough).toBeGreaterThan(Date.now())
+  })
+})


### PR DESCRIPTION
## The gap

`incomplete` is where a subscription sits between the visitor pressing pay and the money arriving — in production, the window while a 3DS challenge is open. Three separate pieces of logic branch on it:

- `UNPAID_CURRENT_PERIOD` lists it, so the period end is not treated as paid time
- `mapStripeStatusToInternal` maps it to `past_due`
- `resolveDunningGrace` deliberately refuses it a grace window

Every one of them was tested only against hand-built objects — which is exactly what hid the `current_period_end` bug that motivated the fixture capture in the first place. This was the last path covered by tests but never by a real payload.

## What this captures

`driveIncomplete()` creates a subscription with `payment_behavior: 'default_incomplete'`, then pays its invoice. A 3DS challenge and a deferred confirmation leave the subscription in the *same shape*; only the former needs a human at a bank's redirect page, so this reaches the state without one.

No test clock — nothing needs time to pass. The subscription is born waiting, and paying ends the wait, so this stage runs in seconds rather than the minutes the lifecycle capture needs.

Captured (test mode, `sk_test` enforced by the script, no money, no live data):

```
customer.subscription.created      status=incomplete   api=2020-08-27
invoice.payment_succeeded          paid=true
customer.subscription.updated      status=active       api=2020-08-27
```

## Two things the real payloads corrected

**1. The first run silently captured one event.** Stripe's `events.list` is eventually consistent, and reading it straight after paying returned only `subscription.created`. The transition out of the waiting state — the entire point of this capture — had not been listed yet. That fixture would have looked like a success and asserted nothing about the half that matters. `waitForEvents` now polls until the transition appears and **throws rather than write a partial fixture**.

**2. My assertions were wrong; the code was right.** The tests initially asserted `paidThroughAt` is `null` while incomplete. It isn't. `resolvePaidThrough` pins an unpaid current period to its *start* — the end of the last period actually paid for — which on a first subscription is its creation moment. That is already in the past, so entitlement (`paidThroughAt > now`) is still correctly denied, but by a different mechanism than I assumed. The assertions now pin what the code actually guarantees, including that the future-dated period end is never handed out.

That second one is the argument for capturing real payloads, made against this very change.

## Also

`CAPTURE_STAGE` (`lifecycle` | `incomplete` | `all`, default `all`) selects a stage, so refreshing this fixture does not re-run the three-month clock advance the lifecycle capture needs.

## Verification

`pnpm test:int` 1089 passed (121 files), 7 of them new. `pnpm typecheck` clean — it caught a real typing error in `waitForEvents` before commit. `pnpm lint` 0 errors (6 pre-existing warnings, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)