### PR TITLE
Sell through Link as well as cards

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -264,10 +264,14 @@ export async function POST(req: NextRequest) {
       // Naming the methods here means an enabled Dashboard toggle can no longer
       // silently widen what this endpoint sells, and the contract's reasoning
       // becomes true again. Apple Pay and Google Pay are unaffected — they ride
-      // in as card wallets. Link is the one thing this drops; add `'link'` to
-      // the array to bring it back, since it is card-backed and settles
-      // immediately.
-      payment_method_types: ['card'],
+      // in as card wallets.
+      //
+      // `link` is named alongside `card` deliberately. Link is card-backed and
+      // settles immediately, so it is not a delayed-notification method and does
+      // not reopen the `checkout.session.async_payment_failed` hole this list
+      // exists to close. Listing it explicitly keeps the guarantee intact while
+      // still offering returning customers one-click checkout.
+      payment_method_types: ['card', 'link'],
       success_url: successUrl,
       cancel_url: cancelUrl,
       metadata,

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.payment-methods.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.payment-methods.test.ts
@@ -106,10 +106,31 @@ describe('create checkout session payment methods', () => {
   // cashapp and others switched on. This is the assertion that makes the
   // contract's claim true, so enabling a delayed-notification method in the
   // Dashboard can no longer quietly invalidate it.
-  it('sells through cards only, whatever the Dashboard has enabled', async () => {
+  it('sells through card and Link only, whatever the Dashboard has enabled', async () => {
     const [params] = await sessionParams()
 
-    expect(params.payment_method_types).toEqual(['card'])
+    expect(params.payment_method_types).toEqual(['card', 'link'])
+  })
+
+  // The point of the list is not the count, it is that nothing on it can
+  // complete a session before the money settles. Link is card-backed and
+  // settles immediately, so it belongs; anything that reaches recurring through
+  // a SEPA-style mandate does not. This assertion is what should fail if a
+  // future edit adds a delayed-notification method to the array.
+  it('never sells through a delayed-notification method', async () => {
+    const [params] = await sessionParams()
+
+    const delayedNotification = [
+      'acss_debit', 'au_becs_debit', 'bacs_debit', 'bancontact', 'boleto',
+      'ideal', 'sepa_debit', 'sofort', 'us_bank_account',
+    ]
+
+    expect(params.payment_method_types).not.toEqual(
+      expect.arrayContaining(delayedNotification),
+    )
+    for (const method of params.payment_method_types ?? []) {
+      expect(delayedNotification).not.toContain(method)
+    }
   })
 
   // Omitting the field is the failure this guards: Stripe then falls back to the


### PR DESCRIPTION
## Why

#346 narrowed Checkout to `payment_method_types: ['card']`. That was the right fix for the right reason — the account's default payment method configuration has bancontact, klarna, cashapp and others switched on, and `DELIBERATELY_UNHANDLED_STRIPE_EVENTS` leaves `checkout.session.async_payment_failed` unhandled on the grounds that Checkout is card-only. Bancontact reaches recurring through a SEPA mandate, SEPA is delayed-notification, and that is exactly the event we do not handle.

Link was collateral damage. It is card-backed and settles immediately, so it was never part of that problem — it got dropped because naming one method was the simplest way to close the hole.

## What

- `payment_method_types: ['card', 'link']`.
- The comment now explains why Link is safe to name rather than telling a future reader how to add it back.
- New assertion: **no delayed-notification method may ever appear in the list**. That is the property the unhandled-events contract actually depends on, and until now it was only implied by the array being one element long. The existing test is updated to the new list; the new one is what should fail if someone adds `sepa_debit` in a year.

## Verification

`pnpm test` on the server — full suite green locally (exit 0).

Apple Pay and Google Pay are unaffected either way; they ride in as card wallets on hosted Checkout and are not entries in this array.