### PR TITLE
Wait for Postgres before starting the server

### DIFF
--- a/apps/questura/apps/server/package.json
+++ b/apps/questura/apps/server/package.json
@@ -37,7 +37,7 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:deploy && pnpm run test:softprod",
     "test:deploy": "node --test scripts/deploy/*.test.mjs",
-    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh && bash ../../infra/softprod/adopt-host-release.test.sh && bash ../../infra/softprod/healthcheck.test.sh && bash ../../infra/softprod/reconcile.test.sh",
+    "test:softprod": "bash ../../infra/softprod/deploy.test.sh && bash ../../infra/softprod/release-lib.test.sh && bash ../../infra/softprod/stage-host-config.test.sh && bash ../../infra/softprod/prepare-host-release.test.sh && bash ../../infra/softprod/adopt-host-release.test.sh && bash ../../infra/softprod/healthcheck.test.sh && bash ../../infra/softprod/reconcile.test.sh && bash ../../infra/softprod/wait-for-postgres.test.sh",
     "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/questura/infra/softprod/host/systemd/questura-server.service.in
+++ b/apps/questura/infra/softprod/host/systemd/questura-server.service.in
@@ -12,6 +12,12 @@ Environment=NODE_ENV=production
 Environment=NODE_OPTIONS=--no-deprecation
 EnvironmentFile=%h/questura/config/server.env
 EnvironmentFile=%h/questura/current-server/.env.release
+# Postgres is a Docker container owned by the system daemon, so this user
+# unit has nothing to order itself after. Without the wait, a reboot starts
+# the server before the database is listening: it logs a connection failure,
+# throws an unhandledRejection, and is restarted into health about a minute
+# later. See host/wait-for-postgres.sh.
+ExecStartPre=%h/questura/infra/wait-for-postgres.sh
 ExecStart=@PNPM_BIN@ exec next start -H 127.0.0.1 -p 4000
 Restart=always
 RestartSec=5

--- a/apps/questura/infra/softprod/host/wait-for-postgres.sh
+++ b/apps/questura/infra/softprod/host/wait-for-postgres.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Block until Postgres accepts TCP connections, or give up loudly.
+#
+# Postgres runs as a Docker container (`questura-postgres`), started by the
+# system Docker daemon. `questura-server` is a *user* unit, so it has no unit to
+# order itself after -- systemd starts it as soon as the network is up, which
+# after a reboot is well before the container is listening. The server then logs
+# `Database connection failed`, raises an unhandledRejection, and dies; systemd
+# restarts it and it eventually comes up healthy. That is roughly a minute of
+# 502s after every reboot, and a pair of alarming log lines that mean nothing.
+#
+# Waiting here turns that into a quiet pause before the process ever starts.
+set -Eeuo pipefail
+
+timeout_seconds=${QUESTURA_PG_WAIT_TIMEOUT:-90}
+
+# The unit loads server.env, so DATABASE_URI is already in the environment.
+# Parse rather than hardcode 5433: the port lives in compose.yml and has moved
+# before.
+uri=${DATABASE_URI:-}
+hostport=${uri##*@}
+hostport=${hostport%%/*}
+hostport=${hostport%%\?*}
+host=${hostport%%:*}
+port=${hostport##*:}
+
+# No colon in the authority means no explicit port; and an unparseable URI must
+# not silently become a connection test against nothing.
+if [[ $port == "$host" ]]; then
+  port=5432
+fi
+if [[ -z $host || -z $port || ! $port =~ ^[0-9]+$ ]]; then
+  echo "wait-for-postgres: cannot read host:port from DATABASE_URI" >&2
+  exit 1
+fi
+
+for ((i = 0; i < timeout_seconds; i++)); do
+  if (exec 3<>"/dev/tcp/$host/$port") 2>/dev/null; then
+    exec 3>&- 2>/dev/null || true
+    [[ $i -gt 0 ]] && echo "wait-for-postgres: $host:$port ready after ${i}s"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "wait-for-postgres: $host:$port refused connections for ${timeout_seconds}s" >&2
+exit 1

--- a/apps/questura/infra/softprod/stage-host-config.sh
+++ b/apps/questura/infra/softprod/stage-host-config.sh
@@ -45,6 +45,7 @@ require_regular_file "$SERVER_ENV_SOURCE"
 require_regular_file "$CLIENT_ENV_SOURCE"
 require_regular_file "$HOST_SOURCE/compose.yml"
 require_regular_file "$HOST_SOURCE/tunnel-config.yml"
+require_regular_file "$HOST_SOURCE/wait-for-postgres.sh"
 
 PNPM_BIN=${QUESTURA_PNPM_BIN:-}
 if [[ -z $PNPM_BIN ]]; then
@@ -72,6 +73,7 @@ install -m 0600 "$SERVER_ENV_SOURCE" "$stage_directory/config/server.env"
 install -m 0600 "$CLIENT_ENV_SOURCE" "$stage_directory/config/client.env"
 install -m 0644 "$HOST_SOURCE/compose.yml" "$stage_directory/infra/compose.yml"
 install -m 0644 "$HOST_SOURCE/tunnel-config.yml" "$stage_directory/infra/tunnel-config.yml"
+install -m 0755 "$HOST_SOURCE/wait-for-postgres.sh" "$stage_directory/infra/wait-for-postgres.sh"
 
 expected_compose_json="$stage_directory/expected-compose.json"
 if [[ -f $INFRA_ROOT/.env ]]; then
@@ -192,6 +194,7 @@ for path in \
   "$INFRA_ROOT/.env" \
   "$INFRA_ROOT/compose.yml" \
   "$INFRA_ROOT/tunnel-config.yml" \
+  "$INFRA_ROOT/wait-for-postgres.sh" \
   "$RENDERED_ROOT"; do
   if [[ -e $path ]]; then cp -a "$path" "$backup_directory/"; fi
 done
@@ -203,6 +206,7 @@ install -m 0600 "$stage_directory/config/client.env" "$CONFIG_ROOT/client.env"
 install -m 0600 "$stage_directory/infra/.env" "$INFRA_ROOT/.env"
 install -m 0644 "$stage_directory/infra/compose.yml" "$INFRA_ROOT/compose.yml"
 install -m 0644 "$stage_directory/infra/tunnel-config.yml" "$INFRA_ROOT/tunnel-config.yml"
+install -m 0755 "$stage_directory/infra/wait-for-postgres.sh" "$INFRA_ROOT/wait-for-postgres.sh"
 for unit in "$stage_directory/infra/systemd"/*.service "$stage_directory/infra/systemd"/*.timer; do
   install -m 0644 "$unit" "$RENDERED_ROOT/$(basename -- "$unit")"
 done

--- a/apps/questura/infra/softprod/wait-for-postgres.test.sh
+++ b/apps/questura/infra/softprod/wait-for-postgres.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests for wait-for-postgres.sh -- the pre-start gate on questura-server.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="$SCRIPT_DIR/host/wait-for-postgres.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# A listener the script should find immediately. Any free port will do; the
+# script only ever opens a TCP connection and closes it.
+listener_port=''
+listener_pid=''
+start_listener() {
+  listener_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+  python3 -c "
+import socket, sys, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', $listener_port))
+s.listen(16)
+time.sleep(30)
+" &
+  listener_pid=$!
+  # Give the listener a moment to bind before anything connects.
+  for _ in $(seq 1 50); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/$listener_port") 2>/dev/null; then
+      exec 3>&- 2>/dev/null || true
+      return 0
+    fi
+    sleep 0.1
+  done
+  fail "test listener never came up"
+}
+
+cleanup() {
+  [[ -n $listener_pid ]] && kill "$listener_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- succeeds against a listening port -------------------------------------
+start_listener
+DATABASE_URI="postgres://user:pw@127.0.0.1:$listener_port/questura" \
+  bash "$SCRIPT" >/dev/null 2>&1 ||
+  fail "should exit 0 when the port is already accepting connections"
+
+# --- a query string must not be read as part of the port -------------------
+DATABASE_URI="postgres://user:pw@127.0.0.1:$listener_port/questura?sslmode=disable" \
+  bash "$SCRIPT" >/dev/null 2>&1 ||
+  fail "should tolerate query parameters on the URI"
+
+# --- gives up rather than hanging forever ----------------------------------
+closed_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+start=$(date +%s)
+if DATABASE_URI="postgres://user:pw@127.0.0.1:$closed_port/questura" \
+  QUESTURA_PG_WAIT_TIMEOUT=2 bash "$SCRIPT" >/dev/null 2>&1; then
+  fail "should exit non-zero when nothing ever listens"
+fi
+elapsed=$(( $(date +%s) - start ))
+(( elapsed < 15 )) || fail "timeout was not honoured (took ${elapsed}s)"
+
+# --- an unreadable URI must fail loudly, not connect to nothing ------------
+# The failure mode this guards is a blank host silently becoming a successful
+# no-op, which would restore exactly the race the script exists to remove.
+if DATABASE_URI="" QUESTURA_PG_WAIT_TIMEOUT=2 bash "$SCRIPT" >/dev/null 2>&1; then
+  fail "should exit non-zero when DATABASE_URI is empty"
+fi
+
+if DATABASE_URI="postgres://user:pw@127.0.0.1:not-a-port/questura" \
+  QUESTURA_PG_WAIT_TIMEOUT=2 bash "$SCRIPT" >/dev/null 2>&1; then
+  fail "should exit non-zero when the port is not numeric"
+fi
+
+# --- the unit actually calls it --------------------------------------------
+# The script is worthless if nothing invokes it, and the unit and the installer
+# are edited in different files.
+grep -q '^ExecStartPre=%h/questura/infra/wait-for-postgres.sh$' \
+  "$SCRIPT_DIR/host/systemd/questura-server.service.in" ||
+  fail "questura-server.service.in does not run wait-for-postgres.sh"
+
+grep -q 'install -m 0755 "\$stage_directory/infra/wait-for-postgres.sh" "\$INFRA_ROOT/wait-for-postgres.sh"' \
+  "$SCRIPT_DIR/stage-host-config.sh" ||
+  fail "stage-host-config.sh does not install wait-for-postgres.sh"
+
+echo "wait-for-postgres tests passed"


### PR DESCRIPTION
## Why

From the live user journal, 2026-08-19 ~08:47 EDT, after the laptop rebooted:

```
Database connection failed
unhandledRejection
<process dies, systemd restarts it, comes up healthy>
```

Self-healing, but it costs roughly a minute of 502s after every reboot and prints two alarming lines that mean nothing.

Postgres runs as a Docker container (`questura-postgres`) owned by the **system** daemon. `questura-server` is a **user** unit, so there is no unit for it to order itself after — `After=network-online.target` is satisfied long before the container is listening. An `ExecStartPre` gate is the fix that is actually available here.

## What

- `host/wait-for-postgres.sh` — polls TCP until Postgres answers, then exits.
- `questura-server.service.in` gains `ExecStartPre=%h/questura/infra/wait-for-postgres.sh`.
- `stage-host-config.sh` requires, stages, backs up and installs it alongside the other host files.
- `wait-for-postgres.test.sh`, wired into `test:softprod` so CI runs it.

Host and port are parsed from `DATABASE_URI`, not hardcoded to 5433 — the port lives in `compose.yml` and has moved before. An unreadable URI exits **non-zero** rather than quietly succeeding: a blank host silently passing would restore exactly the race this removes. That is the case the tests pin down, along with the timeout actually being honoured, and the unit and installer really referencing the script (they live in three different files).

## Verification

`pnpm run test:softprod` — all seven suites green, including the new one.

## ⚠️ This does not take effect on merge

Deploying does not install units. `stage-host-config.sh` stages them and prints *"Active services and unit files were not changed."* Activating this needs an explicit host step — stage the config, copy the rendered unit into `~/.config/systemd/user/`, `daemon-reload`, restart `questura-server` — and that restart is a brief live outage.

Merging is safe and inert. Activation should be a deliberate, separately-confirmed action.