### PR TITLE
Re-derive the nightly reconcile plan before writing it

### DIFF
--- a/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
+++ b/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
@@ -44,6 +44,13 @@
  * write. It only ever fills in or corrects linkage on existing profiles; it
  * never creates, deletes, or reassigns a profile, and never writes to Stripe.
  *
+ * The plan is never written as read. The scan takes minutes, webhooks keep
+ * arriving during it, and a plan applied verbatim makes the older reading win
+ * purely by writing last — restoring access to a visitor refunded mid-scan, or
+ * burying a membership bought mid-scan. So `--apply` treats the plan as a list
+ * of rows worth revisiting and re-derives each one under the webhook's own
+ * advisory lock. `src/features/payments/lib/reconcile-apply.ts` owns that pass.
+ *
  * Ownership is proven by `metadata.visitorAuthUserId` — never by email. The
  * rule itself lives in `src/features/payments/lib/reconcile-ownership.ts` so it
  * is shared with its tests and cannot drift from the checkout path.
@@ -81,16 +88,17 @@ import {
   type ReconcileStepResult,
 } from '../src/features/payments/lib/reconcile-report'
 import {
+  applyPlan,
+  diffProfileAgainst,
+  type ApplyDeps,
+  type PlannedUpdate,
+  type ProfileSnapshot,
+} from '../src/features/payments/lib/reconcile-apply'
+import { withAdvisoryLock } from '../src/shared/utils/advisory-lock'
+import {
   normalizeAuthUserId,
   resolveReconcileTarget,
 } from '../src/features/payments/lib/reconcile-ownership'
-
-type PlannedUpdate = {
-  profileId: string | number
-  email: string
-  changes: Record<string, unknown>
-  reason: 'RELINKABLE' | 'DRIFTED'
-}
 
 export type ReconcileProfilesOptions = {
   apply?: boolean
@@ -124,6 +132,17 @@ const LIVE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
 
 function normalizeEmail(email: string | null | undefined): string {
   return (email ?? '').trim().toLowerCase()
+}
+
+/**
+ * Stripe's own next retry time, which the dunning grace is derived from. It
+ * lives on the latest invoice, so both the scan and the apply pass have to
+ * expand it -- an unexpanded id yields no retry time and a shorter grace.
+ */
+function nextPaymentAttemptOf(subscription: Stripe.Subscription): number | null {
+  const invoice = subscription.latest_invoice
+
+  return invoice && typeof invoice !== 'string' ? (invoice.next_payment_attempt ?? null) : null
 }
 
 export async function run(options: ReconcileProfilesOptions = {}): Promise<ReconcileStepResult> {
@@ -278,48 +297,38 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
 
     const profile = target.profile
 
-    const desired: Record<string, unknown> = {}
+    // Reuse the webhook's own derivation rather than restating it, so a
+    // reconciliation run and a live resync cannot disagree about what a
+    // Stripe subscription means. This previously read `current_period_end`
+    // off the subscription root, which the SDK's API version does not
+    // populate, and restated the paid-access rule by hand.
+    const state = subscription
+      ? deriveSubscriptionState(subscription, {
+          previousDunningGraceUntil: profile.dunningGraceUntil,
+          nextPaymentAttempt: nextPaymentAttemptOf(subscription),
+        })
+      : null
 
-    if (!profile.stripeCustomerId) {
-      desired.stripeCustomerId = customer.id
-    }
+    // What the scan saw, for the report and for deciding which rows are worth
+    // revisiting. It is NOT what gets written: by the time the apply pass runs
+    // this reading is minutes old, so it re-derives under a lock instead. See
+    // `reconcile-apply.ts`.
+    const changes = diffProfileAgainst(profile as ProfileSnapshot, {
+      customerId: customer.id,
+      subscriptionId: subscription?.id ?? null,
+      state,
+    })
 
-    if (subscription) {
-      // Reuse the webhook's own derivation rather than restating it, so a
-      // reconciliation run and a live resync cannot disagree about what a
-      // Stripe subscription means. This previously read `current_period_end`
-      // off the subscription root, which the SDK's API version does not
-      // populate, and restated the paid-access rule by hand.
-      const invoice = subscription.latest_invoice
-      const state = deriveSubscriptionState(subscription, {
-        previousDunningGraceUntil: profile.dunningGraceUntil,
-        nextPaymentAttempt:
-          invoice && typeof invoice !== 'string' ? (invoice.next_payment_attempt ?? null) : null,
-      })
-
-      if (profile.stripeSubscriptionId !== subscription.id) {
-        desired.stripeSubscriptionId = subscription.id
-      }
-      if (profile.subscriptionStatus !== state.subscriptionStatus) {
-        desired.subscriptionStatus = state.subscriptionStatus
-      }
-      if (Boolean(profile.cancelAtPeriodEnd) !== state.cancelAtPeriodEnd) {
-        desired.cancelAtPeriodEnd = state.cancelAtPeriodEnd
-      }
-      if ((profile.paidThroughAt ?? null) !== state.paidThroughAt) {
-        desired.paidThroughAt = state.paidThroughAt
-      }
-      if ((profile.dunningGraceUntil ?? null) !== state.dunningGraceUntil) {
-        desired.dunningGraceUntil = state.dunningGraceUntil
-      }
-    }
-
-    if (Object.keys(desired).length > 0) {
+    if (Object.keys(changes).length > 0) {
       updates.push({
         profileId: profile.id,
         email,
-        changes: desired,
+        changes,
         reason: profile.stripeCustomerId ? 'DRIFTED' : 'RELINKABLE',
+        customerId: customer.id,
+        subscriptionId: subscription?.id ?? null,
+        // Compare-and-swap token: the apply pass abandons the row if this moved.
+        updatedAt: (profile.updatedAt as string | null) ?? null,
       })
     }
   }
@@ -434,35 +443,96 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     }
   }
 
-  let applied = 0
-  let applyFailed = 0
-  for (const update of updates) {
-    try {
+  // Every write re-reads the profile and re-reads Stripe, under the same lock
+  // the webhook path takes. The plan above is a list of rows worth revisiting,
+  // never the values to write -- see the header of `reconcile-apply.ts` for the
+  // two ways writing it verbatim corrupts live membership state.
+  const deps: ApplyDeps = {
+    emit,
+
+    readProfile: async (profileId) => {
+      const doc = await payload.findByID({
+        collection: 'visitor-profiles',
+        id: profileId,
+        depth: 0,
+        overrideAccess: true,
+        // A row deleted between the scan and now is a skip, not a throw.
+        disableErrors: true,
+      })
+
+      return (doc as ProfileSnapshot | null) ?? null
+    },
+
+    readDesired: async (customerId, profile) => {
+      const customer = await stripe.customers.retrieve(customerId)
+      if (customer.deleted) return null
+
+      // Ownership is re-proven, not assumed to have survived the scan. It is
+      // the same rule the scan applied: `metadata.visitorAuthUserId`, never
+      // email.
+      const owner = normalizeAuthUserId(customer.metadata?.visitorAuthUserId)
+      if (!owner || owner !== normalizeAuthUserId(profile.authUserId ?? null)) return null
+
+      const subscriptions = await stripe.subscriptions.list({
+        customer: customerId,
+        status: 'all',
+        limit: 100,
+        expand: ['data.latest_invoice'],
+      })
+
+      // Re-selected, not refetched by id: a checkout during the scan can make a
+      // different subscription the one this row mirrors.
+      const subscription = selectProfileSubscription(subscriptions.data)
+
+      return {
+        customerId,
+        subscriptionId: subscription?.id ?? null,
+        state: subscription
+          ? deriveSubscriptionState(subscription, {
+              previousDunningGraceUntil: profile.dunningGraceUntil,
+              nextPaymentAttempt: nextPaymentAttemptOf(subscription),
+            })
+          : null,
+      }
+    },
+
+    writeProfile: async (profileId, changes) => {
       await payload.update({
         collection: 'visitor-profiles',
-        id: update.profileId,
-        data: update.changes,
+        id: profileId,
+        data: changes,
         overrideAccess: true,
       })
-      applied += 1
-    } catch (error) {
-      // One unwritable row must not hide the rest of the plan from the report.
-      applyFailed += 1
-      emit(
-        `  ⛔ FAILED profile ${update.profileId} <${update.email}>: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      )
-    }
+    },
+
+    withLock: (key, work) => withAdvisoryLock(payload, key, work),
   }
 
-  emit(`\n✅ Applied ${applied} profile update(s).`)
-  if (applyFailed > 0) emit(`⛔ ${applyFailed} update(s) could not be written.`)
+  const summary = await applyPlan(updates, deps)
+  const skipped = summary.stale + summary.noop + summary.missing
+
+  emit(`\n✅ Applied ${summary.applied} profile update(s).`)
+  if (skipped > 0) {
+    emit(
+      `↷ ${skipped} planned update(s) skipped as out of date (${summary.stale} changed under the scan, ${summary.noop} already in sync, ${summary.missing} no longer resolvable).`
+    )
+  }
+  if (summary.failed > 0) emit(`⛔ ${summary.failed} update(s) could not be written.`)
 
   return {
-    ok: applyFailed === 0,
-    reason: applyFailed > 0 ? 'apply-failed' : undefined,
-    counts: { ...baseCounts, applied, planned: updates.length, apply_failed: applyFailed },
+    ok: summary.failed === 0,
+    reason: summary.failed > 0 ? 'apply-failed' : undefined,
+    counts: {
+      ...baseCounts,
+      applied: summary.applied,
+      planned: updates.length,
+      apply_failed: summary.failed,
+      // Skips are the guard working, not a finding: `ESCALATING_COUNTS` does
+      // not list them, so they inform the report without paging anyone.
+      skipped_stale: summary.stale,
+      skipped_noop: summary.noop,
+      skipped_missing: summary.missing,
+    },
     lines,
   }
 }

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  applyPlan,
+  applyPlannedUpdate,
+  diffProfileAgainst,
+  type ApplyDeps,
+  type PlannedUpdate,
+  type ProfileSnapshot,
+} from './reconcile-apply'
+
+/**
+ * These tests exist for one property: the nightly plan must never be written as
+ * read. The scan takes minutes and webhooks keep arriving during it, so a plan
+ * applied verbatim is the *older* reading winning by writing last — which is
+ * how a refunded visitor gets access back and a fresh member gets locked out.
+ *
+ * So the scenarios below are written as timelines: the plan says one thing, the
+ * world moved, and the assertion is about what actually reaches the database.
+ */
+
+const PAID_STATE = {
+  subscriptionStatus: 'active' as const,
+  cancelAtPeriodEnd: false,
+  paidThroughAt: '2026-03-01T00:00:00.000Z',
+  dunningGraceUntil: null,
+}
+
+const REVOKED_STATE = {
+  subscriptionStatus: 'active' as const,
+  cancelAtPeriodEnd: false,
+  paidThroughAt: null,
+  dunningGraceUntil: null,
+}
+
+function profile(overrides: Partial<ProfileSnapshot> = {}): ProfileSnapshot {
+  return {
+    id: 'p1',
+    updatedAt: '2026-02-19T04:22:00.000Z',
+    authUserId: 'auth-1',
+    stripeCustomerId: 'cus_1',
+    stripeSubscriptionId: 'sub_1',
+    subscriptionStatus: 'active',
+    cancelAtPeriodEnd: false,
+    paidThroughAt: '2026-03-01T00:00:00.000Z',
+    dunningGraceUntil: null,
+    ...overrides,
+  }
+}
+
+function plan(overrides: Partial<PlannedUpdate> = {}): PlannedUpdate {
+  return {
+    profileId: 'p1',
+    email: 'visitor@example.com',
+    changes: { paidThroughAt: '2026-03-01T00:00:00.000Z' },
+    reason: 'DRIFTED',
+    customerId: 'cus_1',
+    subscriptionId: 'sub_1',
+    updatedAt: '2026-02-19T04:22:00.000Z',
+    ...overrides,
+  }
+}
+
+function deps(overrides: Partial<ApplyDeps> = {}) {
+  const writeProfile = vi.fn(async () => {})
+  const locked: string[] = []
+
+  const base: ApplyDeps = {
+    readProfile: async () => profile(),
+    readDesired: async () => ({
+      customerId: 'cus_1',
+      subscriptionId: 'sub_1',
+      state: PAID_STATE,
+    }),
+    writeProfile,
+    withLock: async (key, work) => {
+      locked.push(key)
+      return work()
+    },
+    emit: () => {},
+    ...overrides,
+  }
+
+  return { deps: base, writeProfile: base.writeProfile as typeof writeProfile, locked }
+}
+
+describe('diffProfileAgainst', () => {
+  it('returns only the fields that actually differ', () => {
+    const changes = diffProfileAgainst(profile({ paidThroughAt: null }), {
+      customerId: 'cus_1',
+      subscriptionId: 'sub_1',
+      state: PAID_STATE,
+    })
+
+    expect(changes).toEqual({ paidThroughAt: '2026-03-01T00:00:00.000Z' })
+  })
+
+  it('fills a lost customer linkage without touching subscription state', () => {
+    const changes = diffProfileAgainst(profile({ stripeCustomerId: null }), {
+      customerId: 'cus_1',
+      subscriptionId: 'sub_1',
+      state: PAID_STATE,
+    })
+
+    expect(changes).toEqual({ stripeCustomerId: 'cus_1' })
+  })
+
+  it('writes nothing when the profile already matches Stripe', () => {
+    expect(
+      diffProfileAgainst(profile(), {
+        customerId: 'cus_1',
+        subscriptionId: 'sub_1',
+        state: PAID_STATE,
+      })
+    ).toEqual({})
+  })
+
+  it('leaves subscription fields alone when the customer has no subscription', () => {
+    const changes = diffProfileAgainst(profile({ stripeCustomerId: null }), {
+      customerId: 'cus_1',
+      subscriptionId: null,
+      state: null,
+    })
+
+    expect(changes).toEqual({ stripeCustomerId: 'cus_1' })
+  })
+})
+
+describe('applyPlannedUpdate', () => {
+  it('serialises on the same key the webhook resync uses', async () => {
+    const { deps: d, locked } = deps({
+      readProfile: async () => profile({ paidThroughAt: null }),
+    })
+
+    await applyPlannedUpdate(plan(), d)
+
+    expect(locked).toEqual(['stripe:subscription:sub_1'])
+  })
+
+  it('writes what Stripe says now, not what the scan planned', async () => {
+    // 04:22 scan saw paid-through Mar 1. 04:31 a refund revoked access. The
+    // plan still says Mar 1; only the fresh read may decide.
+    const { deps: d, writeProfile } = deps({
+      readProfile: async () => profile({ paidThroughAt: null }),
+      readDesired: async () => ({
+        customerId: 'cus_1',
+        subscriptionId: 'sub_1',
+        state: REVOKED_STATE,
+      }),
+    })
+
+    const outcome = await applyPlannedUpdate(
+      plan({ changes: { paidThroughAt: '2026-03-01T00:00:00.000Z' } }),
+      d
+    )
+
+    expect(outcome).toBe('noop')
+    expect(writeProfile).not.toHaveBeenCalled()
+  })
+
+  it('abandons a row the refund webhook already rewrote', async () => {
+    const { deps: d, writeProfile } = deps({
+      // The revocation handler wrote at 04:31, moving `updatedAt`.
+      readProfile: async () =>
+        profile({ paidThroughAt: null, updatedAt: '2026-02-19T04:31:00.000Z' }),
+    })
+
+    const outcome = await applyPlannedUpdate(plan(), d)
+
+    expect(outcome).toBe('stale')
+    expect(writeProfile).not.toHaveBeenCalled()
+  })
+
+  it('abandons a row whose owning subscription changed mid-scan', async () => {
+    // Visitor checked out at 04:25; the new subscription owns the row now, and
+    // the webhook has already written it.
+    const { deps: d, writeProfile } = deps({
+      readProfile: async () => profile({ stripeSubscriptionId: 'sub_2' }),
+      readDesired: async () => ({
+        customerId: 'cus_1',
+        subscriptionId: 'sub_2',
+        state: PAID_STATE,
+      }),
+    })
+
+    const outcome = await applyPlannedUpdate(plan({ subscriptionId: 'sub_1' }), d)
+
+    expect(outcome).toBe('stale')
+    expect(writeProfile).not.toHaveBeenCalled()
+  })
+
+  it('treats an unknown updatedAt as movement rather than as agreement', async () => {
+    const { deps: d, writeProfile } = deps({
+      readProfile: async () => profile({ updatedAt: null }),
+    })
+
+    expect(await applyPlannedUpdate(plan(), d)).toBe('stale')
+    expect(writeProfile).not.toHaveBeenCalled()
+  })
+
+  it('applies a genuine divergence that survived both re-reads', async () => {
+    const { deps: d, writeProfile } = deps({
+      readProfile: async () => profile({ paidThroughAt: null }),
+    })
+
+    expect(await applyPlannedUpdate(plan(), d)).toBe('applied')
+    expect(writeProfile).toHaveBeenCalledWith('p1', {
+      paidThroughAt: '2026-03-01T00:00:00.000Z',
+    })
+  })
+
+  it('runs a linkage-only row unlocked, guarded by the timestamp alone', async () => {
+    const { deps: d, writeProfile, locked } = deps({
+      readProfile: async () => profile({ stripeCustomerId: null, stripeSubscriptionId: null }),
+      readDesired: async () => ({ customerId: 'cus_1', subscriptionId: null, state: null }),
+    })
+
+    const outcome = await applyPlannedUpdate(
+      plan({ reason: 'RELINKABLE', subscriptionId: null, changes: { stripeCustomerId: 'cus_1' } }),
+      d
+    )
+
+    expect(outcome).toBe('applied')
+    expect(locked).toEqual([])
+    expect(writeProfile).toHaveBeenCalledWith('p1', { stripeCustomerId: 'cus_1' })
+  })
+
+  it('skips a profile deleted between the scan and the write', async () => {
+    const { deps: d, writeProfile } = deps({ readProfile: async () => null })
+
+    expect(await applyPlannedUpdate(plan(), d)).toBe('missing')
+    expect(writeProfile).not.toHaveBeenCalled()
+  })
+
+  it('skips a customer that no longer resolves to this profile', async () => {
+    const { deps: d, writeProfile } = deps({ readDesired: async () => null })
+
+    expect(await applyPlannedUpdate(plan(), d)).toBe('missing')
+    expect(writeProfile).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed row instead of throwing out of the pass', async () => {
+    const emit = vi.fn()
+    const { deps: d } = deps({
+      readProfile: async () => profile({ paidThroughAt: null }),
+      writeProfile: async () => {
+        throw new Error('connection terminated')
+      },
+      emit,
+    })
+
+    expect(await applyPlannedUpdate(plan(), d)).toBe('failed')
+    expect(emit.mock.calls.flat().join('\n')).toContain('connection terminated')
+  })
+})
+
+describe('applyPlan', () => {
+  it('keeps going after a failure and tallies every outcome', async () => {
+    const seen: Array<string | number> = []
+    const { deps: d } = deps({
+      readProfile: async (id) => {
+        seen.push(id)
+        if (id === 'gone') return null
+        if (id === 'moved') return profile({ id, updatedAt: '2026-02-19T04:31:00.000Z' })
+        return profile({ id, paidThroughAt: null })
+      },
+      writeProfile: async (id) => {
+        if (id === 'bad') throw new Error('nope')
+      },
+    })
+
+    const summary = await applyPlan(
+      [
+        plan({ profileId: 'ok' }),
+        plan({ profileId: 'gone' }),
+        plan({ profileId: 'moved' }),
+        plan({ profileId: 'bad' }),
+      ],
+      d
+    )
+
+    expect(summary).toEqual({ applied: 1, stale: 1, noop: 0, missing: 1, failed: 1 })
+    expect(seen).toEqual(['ok', 'gone', 'moved', 'bad'])
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.ts
@@ -1,0 +1,250 @@
+/**
+ * Nightly reconciliation: the write half
+ *
+ * Why this exists
+ * ---------------
+ * `scripts/reconcile-stripe-visitor-profiles.ts` works in two phases. It reads
+ * every Stripe customer and builds a plan (minutes of network walk), then it
+ * writes that plan. Between the two, webhooks keep arriving.
+ *
+ * Applying the plan as-read makes the *older* reading win, because it is simply
+ * the one that writes last:
+ *
+ *   04:22 scan reads subscription: clean, paid through Mar 1
+ *   04:31 charge.refunded lands, revokes access, sets paidThroughAt = null
+ *   04:40 plan is applied: paidThroughAt = Mar 1 -- refunded visitor has access
+ *
+ * and the mirror image, where a visitor who checks out at 04:25 gets their old
+ * cancelled subscription written back over a live membership. `--max-apply`
+ * bounds how many rows that can hit; it says nothing about whether they are
+ * right.
+ *
+ * So the plan is treated as a *list of rows worth revisiting*, never as the
+ * values to write. Every write re-derives from scratch:
+ *
+ *   1. Under the same advisory lock the webhook path uses
+ *      (`stripe:subscription:${id}`, see `subscription-resync.ts`), so a resync
+ *      cannot interleave with this at all.
+ *   2. Re-reading the profile, and abandoning the row if it changed since the
+ *      scan saw it -- a compare-and-swap on `updatedAt`. This is what covers
+ *      the rows with no subscription to lock on.
+ *   3. Re-reading Stripe, including which subscription owns the row. The
+ *      revocation flag lives in subscription metadata, so a fresh read is the
+ *      only thing that can see a refund the scan snapshot predates.
+ *
+ * The diff itself is shared with the scan phase (`diffProfileAgainst`) so the
+ * plan and the write cannot disagree about what a divergence is.
+ *
+ * Dependencies are injected rather than imported: the script owns the Stripe
+ * client and the Payload instance, and this file has to stay testable under
+ * `vitest`, which only collects `src/`.
+ */
+
+import type { DerivedSubscriptionState } from './subscription-state'
+
+/** The profile fields reconciliation reads and writes. */
+export type ProfileSnapshot = {
+  id: string | number
+  updatedAt?: string | null
+  authUserId?: string | null
+  stripeCustomerId?: string | null
+  stripeSubscriptionId?: string | null
+  subscriptionStatus?: string | null
+  cancelAtPeriodEnd?: boolean | null
+  paidThroughAt?: string | null
+  dunningGraceUntil?: string | null
+}
+
+/** What a fresh Stripe read says a profile should mirror. */
+export type DesiredProfileState = {
+  customerId: string
+  /** Null when the customer has no subscription to mirror at all. */
+  subscriptionId: string | null
+  state: DerivedSubscriptionState | null
+}
+
+export type PlannedUpdate = {
+  profileId: string | number
+  email: string
+  changes: Record<string, unknown>
+  reason: 'RELINKABLE' | 'DRIFTED'
+  customerId: string
+  /**
+   * Lock key, and the subscription the scan decided owns this row. Null when
+   * the plan is customer linkage only.
+   */
+  subscriptionId: string | null
+  /** Compare-and-swap token, captured when the scan read the profile. */
+  updatedAt: string | null
+}
+
+export type ApplyOutcome =
+  | 'applied'
+  /** The profile moved under us, or a different subscription now owns it. */
+  | 'stale'
+  /** Nothing left to write: something else already healed it. */
+  | 'noop'
+  /** The profile is gone, or the Stripe customer is gone or no longer owned. */
+  | 'missing'
+  | 'failed'
+
+export type ApplyDeps = {
+  /** Re-read the profile inside the lock. Null when the row is gone. */
+  readProfile: (profileId: string | number) => Promise<ProfileSnapshot | null>
+  /**
+   * Re-read Stripe for this customer and re-derive. Must re-select which
+   * subscription owns the row (`selectProfileSubscription`), not just refetch
+   * the one the scan picked. Null when the customer is gone.
+   */
+  readDesired: (customerId: string, profile: ProfileSnapshot) => Promise<DesiredProfileState | null>
+  writeProfile: (profileId: string | number, changes: Record<string, unknown>) => Promise<void>
+  /** Runs `work` under the given advisory lock key. */
+  withLock: <T>(key: string, work: () => Promise<T>) => Promise<T>
+  emit: (line: string) => void
+}
+
+export type ApplySummary = {
+  applied: number
+  stale: number
+  noop: number
+  missing: number
+  failed: number
+}
+
+/**
+ * The one definition of "this profile disagrees with Stripe", used by the scan
+ * to plan and by the apply pass to write. Returns only the fields that differ,
+ * so a row healed between the two phases writes nothing.
+ */
+export function diffProfileAgainst(
+  profile: ProfileSnapshot,
+  desired: DesiredProfileState
+): Record<string, unknown> {
+  const changes: Record<string, unknown> = {}
+
+  if (!profile.stripeCustomerId) {
+    changes.stripeCustomerId = desired.customerId
+  }
+
+  const { state, subscriptionId } = desired
+
+  if (state && subscriptionId) {
+    if (profile.stripeSubscriptionId !== subscriptionId) {
+      changes.stripeSubscriptionId = subscriptionId
+    }
+    if (profile.subscriptionStatus !== state.subscriptionStatus) {
+      changes.subscriptionStatus = state.subscriptionStatus
+    }
+    if (Boolean(profile.cancelAtPeriodEnd) !== state.cancelAtPeriodEnd) {
+      changes.cancelAtPeriodEnd = state.cancelAtPeriodEnd
+    }
+    if ((profile.paidThroughAt ?? null) !== state.paidThroughAt) {
+      changes.paidThroughAt = state.paidThroughAt
+    }
+    if ((profile.dunningGraceUntil ?? null) !== state.dunningGraceUntil) {
+      changes.dunningGraceUntil = state.dunningGraceUntil
+    }
+  }
+
+  return changes
+}
+
+/**
+ * Whether the profile changed since the scan read it.
+ *
+ * A missing token on either side is treated as movement: without a timestamp
+ * to compare there is no evidence the row is unchanged, and the safe reading of
+ * "unknown" is to leave the row for the next run rather than overwrite it.
+ */
+function movedSinceScan(scanned: string | null, current: string | null | undefined): boolean {
+  if (!scanned || !current) return true
+
+  return scanned !== current
+}
+
+/**
+ * Apply one planned row, re-deriving everything inside the lock.
+ *
+ * The plan's own `changes` are deliberately never written: they are a snapshot
+ * of a Stripe read that is minutes old by the time this runs.
+ */
+export async function applyPlannedUpdate(
+  update: PlannedUpdate,
+  deps: ApplyDeps
+): Promise<ApplyOutcome> {
+  const work = async (): Promise<ApplyOutcome> => {
+    const profile = await deps.readProfile(update.profileId)
+
+    if (!profile) {
+      deps.emit(`  ↷ SKIPPED profile ${update.profileId} <${update.email}>: profile no longer exists`)
+      return 'missing'
+    }
+
+    if (movedSinceScan(update.updatedAt, profile.updatedAt)) {
+      deps.emit(
+        `  ↷ SKIPPED profile ${update.profileId} <${update.email}>: changed since the scan read it`
+      )
+      return 'stale'
+    }
+
+    const desired = await deps.readDesired(update.customerId, profile)
+
+    if (!desired) {
+      deps.emit(
+        `  ↷ SKIPPED profile ${update.profileId} <${update.email}>: Stripe customer ${update.customerId} is gone or no longer names this profile as its owner`
+      )
+      return 'missing'
+    }
+
+    // Which subscription owns the row is itself a thing that can change under
+    // us -- a checkout mid-scan makes a new one the owner. If the fresh read
+    // disagrees with the plan, a webhook has already handled this row.
+    if (desired.subscriptionId !== update.subscriptionId) {
+      deps.emit(
+        `  ↷ SKIPPED profile ${update.profileId} <${update.email}>: owning subscription changed since the scan (${update.subscriptionId ?? 'none'} → ${desired.subscriptionId ?? 'none'})`
+      )
+      return 'stale'
+    }
+
+    const changes = diffProfileAgainst(profile, desired)
+
+    if (Object.keys(changes).length === 0) {
+      deps.emit(`  ↷ SKIPPED profile ${update.profileId} <${update.email}>: already in sync`)
+      return 'noop'
+    }
+
+    await deps.writeProfile(update.profileId, changes)
+    return 'applied'
+  }
+
+  try {
+    // No subscription means no key the webhook path would ever contend on, so
+    // there is nothing to serialise against and the `updatedAt` check above is
+    // the whole guard for those rows.
+    return update.subscriptionId
+      ? await deps.withLock(`stripe:subscription:${update.subscriptionId}`, work)
+      : await work()
+  } catch (error) {
+    // One unwritable row must not hide the rest of the plan from the report.
+    deps.emit(
+      `  ⛔ FAILED profile ${update.profileId} <${update.email}>: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+    return 'failed'
+  }
+}
+
+/** Apply every planned row, one at a time, and tally the outcomes. */
+export async function applyPlan(
+  updates: PlannedUpdate[],
+  deps: ApplyDeps
+): Promise<ApplySummary> {
+  const summary: ApplySummary = { applied: 0, stale: 0, noop: 0, missing: 0, failed: 0 }
+
+  for (const update of updates) {
+    summary[await applyPlannedUpdate(update, deps)] += 1
+  }
+
+  return summary
+}


### PR DESCRIPTION
## Why

`reconcile-stripe-visitor-profiles.ts` reads every Stripe customer into a plan (minutes of network walk), then writes the whole plan at the end. Webhooks keep arriving in between, so the plan applied verbatim makes the **older** reading win — purely by writing last.

Access wrongly restored:

```
04:20  questura-reconcile.timer fires (APPLY=1, MAX_APPLY=25)
04:22  scan reads customer C's subscription: clean, paidThroughAt = Mar 1
04:31  charge.refunded writes the revocation flag, profile -> paidThroughAt: null
04:40  the 04:22 plan is applied: paidThroughAt = Mar 1
       -> refunded visitor has access back
```

Paying member locked out:

```
04:22  scan reads Stripe: profile's subscription is expired, nothing live
04:25  visitor checks out; checkout.session.completed resyncs, membership live
04:40  plan writes the old cancelled subscription's state back
       -> member locked out until the next nightly, up to 24h
```

Three omissions compounded: **no advisory lock** (`resyncSubscription` serialises on `stripe:subscription:${id}`; this path took nothing), **no re-read**, **no compare-and-swap**. `deriveSubscriptionState` is shared with the webhook path, so both compute correctly — from snapshots taken at different times. `exceedsApplyCap` bounds how many rows are wrong, not whether they are.

## What

New `src/features/payments/lib/reconcile-apply.ts` owns the write half. The plan becomes a list of rows worth revisiting; every write re-derives from scratch:

1. Under `withAdvisoryLock(payload, 'stripe:subscription:${id}')` — the same key the webhook path takes, so a resync cannot interleave.
2. Re-reads the profile and abandons the row if `updatedAt` moved since the scan. An absent timestamp on either side counts as movement — without evidence the row is unchanged, the safe reading is to leave it for the next run.
3. Re-reads Stripe. This is what makes the refund case work at all: the revocation flag lives in subscription metadata, so only a fresh read can see a refund the 04:22 snapshot predates. Ownership (`metadata.visitorAuthUserId`, never email) is re-proven too.
4. Re-selects which subscription owns the row via `selectProfileSubscription`, rather than refetching the one the scan picked — a checkout mid-scan changes the answer.
5. Diffs against the fresh profile. Nothing left to write means something else already healed it.

The script's scan phase now shares `diffProfileAgainst` with the apply pass, so the plan and the write cannot disagree about what a divergence is. Dependencies are injected because `vitest.config.ts` only collects `src/`.

Rows with no subscription (linkage-only) run unlocked — there is no key the webhook path would ever contend on — with the `updatedAt` compare-and-swap as the whole guard. Documented as such rather than papered over with a lock key nothing else takes.

New counts `skipped_stale` / `skipped_noop` / `skipped_missing` are reported but deliberately absent from `ESCALATING_COUNTS`: a skipped row is the guard working, not something to page a human about.

## Verification

- `src/features/payments/lib/reconcile-apply.test.ts` — 15 new tests, both scenarios above written as timelines, plus the lock-key assertion, failure isolation, and the outcome tally
- Full server suite: **1105 pass / 122 files**
- `pnpm exec tsc --noEmit`: clean
- eslint on all three files: clean

No schema surface touched — `scripts/` and `payments/lib/` only, no collection, field, or migration. Cost is two extra Stripe reads per applied row, bounded by `MAX_APPLY=25`.