### PR TITLE
Key the subscription resync lock on the customer, not the subscription

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.test.ts
@@ -134,7 +134,10 @@ describe('applyPlannedUpdate', () => {
 
     await applyPlannedUpdate(plan(), d)
 
-    expect(locked).toEqual(['stripe:subscription:sub_1'])
+    // The customer, not the subscription: that is what the profile row belongs
+    // to, and a subscription-keyed lock excludes nothing when the same customer
+    // has a second subscription writing the same row.
+    expect(locked).toEqual(['stripe:customer:cus_1'])
   })
 
   it('writes what Stripe says now, not what the scan planned', async () => {
@@ -209,7 +212,7 @@ describe('applyPlannedUpdate', () => {
     })
   })
 
-  it('runs a linkage-only row unlocked, guarded by the timestamp alone', async () => {
+  it('locks a linkage-only row too, on its customer', async () => {
     const { deps: d, writeProfile, locked } = deps({
       readProfile: async () => profile({ stripeCustomerId: null, stripeSubscriptionId: null }),
       readDesired: async () => ({ customerId: 'cus_1', subscriptionId: null, state: null }),
@@ -221,7 +224,7 @@ describe('applyPlannedUpdate', () => {
     )
 
     expect(outcome).toBe('applied')
-    expect(locked).toEqual([])
+    expect(locked).toEqual(['stripe:customer:cus_1'])
     expect(writeProfile).toHaveBeenCalledWith('p1', { stripeCustomerId: 'cus_1' })
   })
 

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-apply.ts
@@ -23,11 +23,11 @@
  * values to write. Every write re-derives from scratch:
  *
  *   1. Under the same advisory lock the webhook path uses
- *      (`stripe:subscription:${id}`, see `subscription-resync.ts`), so a resync
- *      cannot interleave with this at all.
+ *      (`customerLockKey`, see `subscription-lock.ts`), so a resync cannot
+ *      interleave with this at all. The key is the customer, so it also covers
+ *      linkage-only rows, which have no subscription to name.
  *   2. Re-reading the profile, and abandoning the row if it changed since the
- *      scan saw it -- a compare-and-swap on `updatedAt`. This is what covers
- *      the rows with no subscription to lock on.
+ *      scan saw it -- a compare-and-swap on `updatedAt`.
  *   3. Re-reading Stripe, including which subscription owns the row. The
  *      revocation flag lives in subscription metadata, so a fresh read is the
  *      only thing that can see a refund the scan snapshot predates.
@@ -40,6 +40,7 @@
  * `vitest`, which only collects `src/`.
  */
 
+import { customerLockKey } from './subscription-lock'
 import type { DerivedSubscriptionState } from './subscription-state'
 
 /** The profile fields reconciliation reads and writes. */
@@ -70,8 +71,9 @@ export type PlannedUpdate = {
   reason: 'RELINKABLE' | 'DRIFTED'
   customerId: string
   /**
-   * Lock key, and the subscription the scan decided owns this row. Null when
-   * the plan is customer linkage only.
+   * The subscription the scan decided owns this row, re-checked under the lock.
+   * Null when the plan is customer linkage only. Not the lock key -- that is
+   * the customer, because that is what the profile row belongs to.
    */
   subscriptionId: string | null
   /** Compare-and-swap token, captured when the scan read the profile. */
@@ -218,12 +220,10 @@ export async function applyPlannedUpdate(
   }
 
   try {
-    // No subscription means no key the webhook path would ever contend on, so
-    // there is nothing to serialise against and the `updatedAt` check above is
-    // the whole guard for those rows.
-    return update.subscriptionId
-      ? await deps.withLock(`stripe:subscription:${update.subscriptionId}`, work)
-      : await work()
+    // Every planned row has a customer, so every row is serialised against the
+    // webhook path -- including linkage-only rows, which a subscription-keyed
+    // lock left running with the `updatedAt` check as their only guard.
+    return await deps.withLock(customerLockKey(update.customerId), work)
   } catch (error) {
     // One unwritable row must not hide the rest of the plan from the report.
     deps.emit(

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-lock.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-lock.ts
@@ -1,0 +1,24 @@
+/**
+ * The advisory-lock key that guards a Visitor profile's subscription state.
+ *
+ * Keyed on the *customer*, not the subscription, because the row being written
+ * is keyed on neither: a profile holds one subscription, a customer accumulates
+ * many, and every one of them writes the same `visitor-profiles` row. Two
+ * subscriptions of one customer used to take two different keys, so a delayed
+ * `customer.subscription.updated` for the old one could run concurrently with
+ * the checkout collapse that replaced it, read-decide-write against a snapshot
+ * the collapse had already invalidated, and leave the profile pointing at a
+ * cancelled, refunded subscription while the live one billed silently.
+ *
+ * `ownsProfileRow` (see `subscription-resync.ts`) decides *whether* a
+ * subscription may write the row; this key is what makes that decision atomic
+ * with the write that follows it. Both need the same scope to be worth
+ * anything, and the row's scope is the customer.
+ *
+ * Shared by every writer of that row — the webhook resync and the nightly
+ * reconcile apply pass — so the two cannot drift onto keys that fail to
+ * exclude each other.
+ */
+export function customerLockKey(customerId: string): string {
+  return `stripe:customer:${customerId}`
+}

--- a/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/subscription-resync.ts
@@ -3,6 +3,7 @@ import type Stripe from 'stripe'
 import config from '@/payload.config'
 import { logger } from '@/shared/utils/logger'
 import { withAdvisoryLock } from '@/shared/utils/advisory-lock'
+import { customerLockKey } from './subscription-lock'
 import { resolveProfileForStripeCustomer } from './subscription-profile'
 import {
   sendMembershipConfirmationEmail,
@@ -42,6 +43,28 @@ export type ResyncOptions = {
    * asserts "not revoked"; omit the key entirely to read Stripe as usual.
    */
   accessRevoked?: AccessRevocation | null
+}
+
+/**
+ * The customer a subscription belongs to, read before the lock because the lock
+ * key depends on it.
+ *
+ * Reading this outside the lock is safe precisely because it is the one field
+ * that cannot change: Stripe never moves a subscription between customers.
+ * Nothing else from this response is used — every value the write derives from
+ * is refetched inside the lock, so a snapshot taken here cannot become the
+ * thing that gets written.
+ */
+async function fetchCustomerId(subscriptionId: string): Promise<string> {
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+  const customerId =
+    typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
+
+  if (!customerId) {
+    throw new Error(`Subscription ${subscriptionId} has no customer; cannot resync`)
+  }
+
+  return customerId
 }
 
 /** `next_payment_attempt` lives on the invoice, so the grace needs it expanded. */
@@ -180,24 +203,22 @@ async function sendTransitionEmails(
  * Refetch a subscription from Stripe and write everything it implies onto the
  * matching Visitor profile, emitting emails for whatever actually changed.
  *
- * Serialised per subscription: the read, the Stripe call and the write are not
+ * Serialised per *customer*: the read, the Stripe call and the write are not
  * atomic, so without the lock two parallel deliveries would each observe the
- * same before-state and each decide the same transition occurred.
+ * same before-state and each decide the same transition occurred. The key is
+ * the customer rather than the subscription because the row this writes is the
+ * profile, and every one of a customer's subscriptions writes that same row —
+ * see `subscription-lock.ts`.
  */
 export async function resyncSubscription(
   subscriptionId: string,
   options: ResyncOptions = {}
 ): Promise<ResyncResult> {
   const payload = await getPayload({ config })
+  const customerId = await fetchCustomerId(subscriptionId)
 
-  return withAdvisoryLock(payload, `stripe:subscription:${subscriptionId}`, async () => {
+  return withAdvisoryLock(payload, customerLockKey(customerId), async () => {
     const subscription = await fetchSubscription(subscriptionId)
-    const customerId =
-      typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
-
-    if (!customerId) {
-      throw new Error(`Subscription ${subscriptionId} has no customer; cannot resync`)
-    }
 
     // Checkout copies its metadata onto the subscription, so even a renewal
     // years later still carries the visitor it belongs to. That is what makes a

--- a/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
@@ -844,6 +844,39 @@ describe('adversarial', () => {
     expect(profile().stripeSubscriptionId).toBe('sub_NEW')
     expect(entitled()).toBe(true)
   })
+
+  it('N13: a delayed event for the old subscription cannot outrun the collapse onto the new one', async () => {
+    // The lock has to be keyed on what the *row* belongs to. Keyed per
+    // subscription, these two deliveries take different keys and run straight
+    // through each other: the sub_A resync decides it owns the row while sub_A
+    // is still live, the checkout collapse then refunds and cancels sub_A and
+    // writes sub_B, and the sub_A write lands last -- leaving the profile on a
+    // cancelled, refunded subscription while sub_B quietly bills.
+    const a = makeSub('sub_A', { created: now() - 100, latest_invoice: 'in_A' })
+    const b = makeSub('sub_B', { created: now() - 50, latest_invoice: 'in_B' })
+    store.subs.set(a.id, a)
+    store.subs.set(b.id, b)
+    store.invoices.set('in_A', makeInvoice('in_A', { subscription: 'sub_A' }))
+    store.invoices.set('in_B', makeInvoice('in_B', { subscription: 'sub_B' }))
+    store.charges.set('ch_in_A', { id: 'ch_in_A', invoice: 'in_A', refunded: false, payment_intent: 'pi_in_A' })
+    db['visitor-profiles'][0].stripeSubscriptionId = 'sub_A'
+    db['visitor-profiles'][0].subscriptionStatus = 'active'
+    db['visitor-profiles'][0].paidThroughAt = new Date(Date.now() + 20 * DAY * 1000).toISOString()
+
+    await Promise.all([
+      deliver('customer.subscription.updated', a, { id: 'evt_A' }),
+      deliver('checkout.session.completed', {
+        id: 'cs_B', customer: 'cus_1', subscription: 'sub_B',
+        metadata: { visitorAuthUserId: 'auth_1' }, customer_details: {},
+      }, { id: 'evt_B' }),
+    ])
+
+    // The row must name the subscription that is actually billing, so /account
+    // can cancel it and entitlement is derived from something alive.
+    expect(profile().stripeSubscriptionId).toBe('sub_B')
+    expect(store.subs.get(profile().stripeSubscriptionId as string)!.status).not.toBe('canceled')
+    expect(entitled()).toBe(true)
+  })
 })
 
 describe('resync ownership when the profile points at the dead subscription', () => {

--- a/apps/questura/apps/server/src/shared/utils/advisory-lock.ts
+++ b/apps/questura/apps/server/src/shared/utils/advisory-lock.ts
@@ -12,19 +12,20 @@ import { logger } from './logger'
  * Payload has no way to express "hold a row against a concurrent handler while
  * I go and ask Stripe something", and the operation is not a single statement,
  * so ordinary row locks do not help. Stripe delivers webhooks in parallel, so
- * two events for the same subscription can otherwise interleave: both read the
+ * two events for the same customer can otherwise interleave: both read the
  * same before-state, both write, and both conclude the same transition
  * happened and send the same email twice.
  *
  * This is the only raw SQL in runtime server code. It is deliberate and narrow:
- * one lock, keyed per subscription, so unrelated visitors never contend.
+ * one lock, keyed per Stripe customer (`customerLockKey`) or per event, so
+ * unrelated visitors never contend.
  *
  * Connection ownership, and why it is not Payload's pool
  * ------------------------------------------------------
  * A session-level lock holds its connection for the whole of `work` — every
  * Stripe call and email send inside it. Taken from Payload's pool that is a
  * mutual wait, not contention: the Stripe webhook handler locks per event, then
- * `resyncSubscription` locks per subscription inside it, and the queries those
+ * `resyncSubscription` locks per customer inside it, and the queries those
  * locks exist to protect need connections from the same pool. Enough concurrent
  * deliveries (measured 2026-08-15: roughly 7-9 against `pool.max: 20`) and every
  * connection is held by a lock holder that cannot progress without a connection


### PR DESCRIPTION
## Why

The advisory lock that serialises subscription resyncs was keyed on the subscription; the row it writes is keyed on the profile. One customer can hold several subscriptions (that is the premise of `collapseDuplicateSubscriptions`), and all of them write the same `visitor-profiles` row — under different lock keys, so concurrently.

`ownsProfileRow` reads the incumbent inside the lock to decide whether a subscription may write the row, but the lock did not cover the other writer, so that decision could be invalidated before the write landed:

1. delayed `customer.subscription.updated` for A begins a resync; A is still live → owns the row
2. concurrently `checkout.session.completed` for B collapses duplicates: refunds and cancels A, resyncs B, writes `stripeSubscriptionId = B`
3. A's resync writes A plus A's now-dead state — last write wins
4. A's own `customer.subscription.deleted` then correctly skips (B is live), so nothing repairs it

Result: the profile permanently names a cancelled, refunded subscription while B bills. Entitlement is derived from a dead subscription and `/account`'s cancel button targets an id that can no longer be cancelled. The nightly reconcile was not a repair path either — it locked on the same wrong key.

## What

- new `lib/subscription-lock.ts`: one `customerLockKey()`, imported by both writers so they cannot drift onto keys that fail to exclude each other
- `subscription-resync.ts`: resolves the customer id before taking the lock (the one field that cannot change — Stripe never moves a subscription between customers), then locks `stripe:customer:<id>` and refetches everything the write derives from inside it
- `reconcile-apply.ts`: same key; linkage-only rows are now locked too, instead of relying on the `updatedAt` compare-and-swap alone
- `advisory-lock.ts`: doc comments updated; the nested-lock deadlock analysis is unchanged — one connection per async context, lock order still event → customer

## Verification

- `lifecycle-simulation.test.ts` N13: a delayed `customer.subscription.updated` for the old subscription racing the checkout collapse onto the new one. The harness's lock mock is a per-key mutex, so under the old key the two deliveries genuinely interleave. Asserts the row names the subscription that is actually billing, that it is not cancelled, and that the buyer stays entitled.
- `reconcile-apply.test.ts`: lock-key assertions moved to the customer key, including the linkage-only row that used to run unlocked.
- No Payload collection or field touched — no migration.