### PR TITLE
Hold the customer lock across the duplicate-checkout collapse

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
@@ -221,17 +221,35 @@ const { db, fakePayload } = D
 vi.mock('payload', () => ({ getPayload: async () => D.fakePayload }))
 vi.mock('@/payload.config', () => ({ default: {} }))
 
-// Per-key mutex, matching production's advisory-lock semantics.
+// Per-key mutex, matching production's advisory-lock semantics -- including
+// re-entrancy: nested calls share one connection (`AsyncLocalStorage`) and
+// Postgres counts advisory locks per session, so re-taking a key this async
+// context already holds returns immediately instead of waiting on itself.
+// Without that, the checkout handler's collapse lock would deadlock against the
+// resync lock nested inside it.
 const L = vi.hoisted(() => ({ locks: new Map<string, Promise<unknown>>() }))
 const locks = L.locks
-vi.mock('@/shared/utils/advisory-lock', () => ({
-  withAdvisoryLock: (_p: unknown, key: string, work: () => Promise<unknown>) => {
-    const prior = L.locks.get(key) ?? Promise.resolve()
-    const result = prior.then(work, work)
-    L.locks.set(key, result.then(() => undefined, () => undefined))
-    return result
-  },
-}))
+vi.mock('@/shared/utils/advisory-lock', async () => {
+  const { AsyncLocalStorage } = await import('node:async_hooks')
+  const held = new AsyncLocalStorage<Set<string>>()
+
+  return {
+    withAdvisoryLock: (_p: unknown, key: string, work: () => Promise<unknown>) => {
+      const owned = held.getStore()
+
+      if (owned?.has(key)) return work()
+
+      const next = new Set(owned ?? [])
+      next.add(key)
+      const run = () => held.run(next, work)
+
+      const prior = L.locks.get(key) ?? Promise.resolve()
+      const result = prior.then(run, run)
+      L.locks.set(key, result.then(() => undefined, () => undefined))
+      return result
+    },
+  }
+})
 
 const E = vi.hoisted(() => ({ emails: [] as string[] }))
 const emails = E.emails

--- a/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/stripe-webhook.route.test.ts
@@ -28,18 +28,32 @@ const mocks = vi.hoisted(() => ({
 
 const eventLock = vi.hoisted(() => ({ tail: Promise.resolve() as Promise<unknown> }))
 
-vi.mock('@/shared/utils/advisory-lock', () => ({
-  withAdvisoryLock: vi.fn(
-    (_payload: unknown, _key: string, work: () => Promise<unknown>) => {
-      const result = eventLock.tail.then(work, work)
-      eventLock.tail = result.then(
-        () => undefined,
-        () => undefined,
-      )
-      return result
-    },
-  ),
-}))
+// One tail for every key, so any two deliveries serialise -- stricter than
+// production, which is what makes the ordering assertions here deterministic.
+// A lock taken *inside* another one runs straight through instead: the handler
+// path nests (event lock, then the checkout collapse's customer lock), and
+// queueing a nested take behind the tail its own caller holds would deadlock
+// the test rather than model anything real.
+vi.mock('@/shared/utils/advisory-lock', async () => {
+  const { AsyncLocalStorage } = await import('node:async_hooks')
+  const nested = new AsyncLocalStorage<true>()
+
+  return {
+    withAdvisoryLock: vi.fn(
+      (_payload: unknown, _key: string, work: () => Promise<unknown>) => {
+        if (nested.getStore()) return work()
+
+        const run = () => nested.run(true, work)
+        const result = eventLock.tail.then(run, run)
+        eventLock.tail = result.then(
+          () => undefined,
+          () => undefined,
+        )
+        return result
+      },
+    ),
+  }
+})
 
 // Subscription state is written by resync alone (ADR-0008); these tests assert
 // that each event reaches it, and subscription-state.test.ts covers what it

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/checkout-session.ts
@@ -1,4 +1,6 @@
+import { getPayload } from 'payload'
 import type Stripe from 'stripe'
+import config from '@/payload.config'
 import { updateUserSubscription } from '@/payments/lib/payment-service'
 import { resyncSubscription } from '@/payments/lib/subscription-resync'
 import type { UserSubscriptionUpdate } from '@/payments/types'
@@ -7,6 +9,8 @@ import { splitDisplayName } from '@/features/visitor-auth/lib/visitor-profile'
 import { resolveProfileForStripeCustomer } from '@/payments/lib/subscription-profile'
 import { listBillableSubscriptions, selectSubscriptionToKeep } from '@/payments/lib/customer-linkage'
 import { stripe } from '@/payments/lib/stripe'
+import { customerLockKey } from '@/payments/lib/subscription-lock'
+import { withAdvisoryLock } from '@/shared/utils/advisory-lock'
 import { logger } from '@/shared/utils/logger'
 
 type InvoiceWithPayment = Stripe.Invoice & {
@@ -156,12 +160,35 @@ export async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Se
     )
   }
 
-  const keptSubscriptionId = await collapseDuplicateSubscriptions(customerId, subscriptionId)
-  const { profileId } = await resyncSubscription(keptSubscriptionId)
+  const payload = await getPayload({ config })
 
-  if (!profileId) {
-    throw new Error(`Failed to resync subscription ${keptSubscriptionId} after checkout`)
-  }
+  // Collapsing and resyncing are one decision, so they take one lock.
+  //
+  // The collapse is itself a read-decide-write over the customer: it lists the
+  // subscriptions, picks the survivor, then refunds and cancels the rest.
+  // Unlocked, a second delivery can list the same set before this one has
+  // cancelled anything, and the two pick survivors against a state each is
+  // about to invalidate -- two collapses, two refund attempts, and a resync
+  // deciding ownership from a list that is already wrong.
+  //
+  // `resyncSubscription` takes this same key inside. That is a re-entry, not a
+  // second lock: nested calls share one connection (`AsyncLocalStorage`) and
+  // Postgres counts advisory locks per session, so the inner take returns
+  // immediately and the inner release only decrements.
+  const keptSubscriptionId = await withAdvisoryLock(
+    payload,
+    customerLockKey(customerId),
+    async () => {
+      const kept = await collapseDuplicateSubscriptions(customerId, subscriptionId)
+      const { profileId } = await resyncSubscription(kept)
+
+      if (!profileId) {
+        throw new Error(`Failed to resync subscription ${kept} after checkout`)
+      }
+
+      return kept
+    }
+  )
 
   const extras: UserSubscriptionUpdate = {}
 


### PR DESCRIPTION
Follow-up to #353, which keyed the profile-row lock on the customer.

## Why

`collapseDuplicateSubscriptions` is itself a read-decide-write over the customer: it lists the customer's subscriptions, picks the survivor, then refunds and cancels the rest. Only the `resyncSubscription` after it was locked, so the deciding half ran unserialised.

Two checkout completions landing together could both list the same set before either had cancelled anything, and each would pick a survivor against a state the other was about to invalidate — two collapses, two refund attempts, and a resync deciding ownership from a list that is already stale.

## What

- `handleCheckoutSessionCompleted` takes `customerLockKey(customerId)` around collapse + resync.
- The nested `resyncSubscription` takes the same key: a re-entry, not a second lock. Nested calls share one connection via `AsyncLocalStorage`, and Postgres counts advisory locks per session, so the inner take returns immediately and the inner release only decrements. Lock order is unchanged: event → customer.

## Test doubles

Both webhook test doubles had to learn that nesting, or they deadlock where production does not:

- `lifecycle-simulation.test.ts`: per-key mutex now runs a re-taken key straight through.
- `stripe-webhook.route.test.ts`: single-tail mock now runs any nested take straight through, keeping its deliberately-stricter serialisation for top-level takes.

## Deliberately not changed

Checkout *creation* stays unlocked. `create-checkout-session` already refuses a second session while `findLiveSubscription` returns anything, and the request is idempotency-keyed against double-clicks. Serialising that check would not close the remaining window, which is two sessions created while neither is paid yet — nothing at creation time can see a payment that has not happened. That case is exactly what the collapse exists to clean up, which is why the collapse is what got locked.