### PR TITLE
Heal the cancel path, and escalate double-billed customers nightly

### DIFF
--- a/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
+++ b/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
@@ -99,6 +99,7 @@ import {
   normalizeAuthUserId,
   resolveReconcileTarget,
 } from '../src/features/payments/lib/reconcile-ownership'
+import { isLiveSubscription } from '../src/features/payments/lib/customer-linkage'
 
 export type ReconcileProfilesOptions = {
   apply?: boolean
@@ -203,6 +204,19 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
   const duplicates = new Map<string, string[]>()
   const seenEmails = new Map<string, string[]>()
 
+  /**
+   * Customers Stripe is billing more than once.
+   *
+   * `collapseDuplicateSubscriptions` (checkout webhook) refunds and cancels the
+   * extras the moment a duplicate checkout completes, and logs an error when it
+   * does — but a log line on one host is not a thing anyone reads, and the
+   * collapse only runs if that webhook arrived at all. This is the standing
+   * check: whatever the cause, a customer holding two live subscriptions is
+   * being charged twice, so it escalates the nightly rather than waiting to be
+   * noticed on a statement.
+   */
+  const multiLive: Array<{ customerId: string; email: string; subscriptionIds: string[] }> = []
+
   const unproven: Array<{ customerId: string; email: string; status: string | null }> = []
   const mismatched: Array<{
     customerId: string
@@ -242,6 +256,15 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
       expand: ['data.latest_invoice'],
     })
     const subscription = selectProfileSubscription(subscriptions.data)
+
+    const live = subscriptions.data.filter(isLiveSubscription)
+    if (live.length > 1) {
+      multiLive.push({
+        customerId: customer.id,
+        email,
+        subscriptionIds: live.map((candidate) => candidate.id),
+      })
+    }
 
     const owner = normalizeAuthUserId(customer.metadata?.visitorAuthUserId)
     const candidates = byEmail.get(email) ?? []
@@ -345,6 +368,7 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
   emit(`DUPLICATE  : ${duplicates.size}`)
   emit(`UNPROVEN   : ${unproven.length}`)
   emit(`MISMATCHED : ${mismatched.length}`)
+  emit(`MULTI_LIVE : ${multiLive.length}`)
   if (historicalOrphans > 0) {
     // Counted, not warned about: closed records with no profile need no action.
     emit(`(${historicalOrphans} ended subscription(s) with no profile — historical, no action)`)
@@ -391,6 +415,16 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     }
   }
 
+  if (multiLive.length > 0) {
+    emit(`\n⛔ ${multiLive.length} Stripe customer(s) hold more than one live subscription.`)
+    emit('   They are being billed twice. Nothing is cancelled here: which one to')
+    emit('   keep decides who gets refunded, so it is a human call. Keep the one')
+    emit('   that collected, refund and cancel the rest in Stripe, then re-run.\n')
+    for (const row of multiLive) {
+      emit(`  [MULTI_LIVE] ${row.customerId} <${row.email}> ${row.subscriptionIds.join(', ')}`)
+    }
+  }
+
   if (duplicates.size > 0) {
     emit(`\n⚠️  ${duplicates.size} email(s) map to multiple Stripe customers:`)
     for (const [email, ids] of duplicates) {
@@ -408,6 +442,7 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     duplicate: duplicates.size,
     unproven: unproven.length,
     mismatched: mismatched.length,
+    multi_live: multiLive.length,
     historical: historicalOrphans,
   }
 

--- a/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/payment-service.ts
@@ -8,6 +8,7 @@ import type { StripeSubscriptionExpanded, UserSubscriptionUpdate } from '../type
 import { resyncSubscription } from './subscription-resync'
 import { findVisitorProfileByAuthUserId } from '@/features/visitor-auth/lib/visitor-profile'
 import { resolveProfileForStripeCustomer } from './subscription-profile'
+import { findLiveSubscription } from './customer-linkage'
 
 /**
  * Stripe states in which a subscription is still live enough to cancel or
@@ -136,26 +137,52 @@ export async function cancelUserSubscription(authUserId: string): Promise<{
     // local `active` status locked visitors in dunning out of cancelling, which
     // is exactly when someone most wants to stop the retries (ADR-0008).
     const current = await stripe.subscriptions.retrieve(profile.stripeSubscriptionId)
+    let target: Stripe.Subscription = current
 
     if (!CANCELLABLE_STRIPE_STATUSES.has(current.status)) {
-      return { success: false, message: 'This subscription can no longer be cancelled.' }
+      // The row names a subscription Stripe will not cancel, but the button
+      // that got us here was offered off the *mirror*, which said the visitor
+      // has a membership. Refusing here is the worst answer available: if a
+      // different subscription is the one actually billing, the visitor is
+      // being charged with no way to stop it — exactly the dead end a stale
+      // `stripeSubscriptionId` used to produce.
+      //
+      // So ask Stripe who is billing, repoint the row onto it, and cancel that
+      // one. The resync is what repairs the row, and it runs before anything is
+      // cancelled so the profile is correct even if the cancel then fails.
+      const live = profile.stripeCustomerId
+        ? await findLiveSubscription(profile.stripeCustomerId)
+        : null
+
+      if (!live || live.id === profile.stripeSubscriptionId) {
+        return { success: false, message: 'This subscription can no longer be cancelled.' }
+      }
+
+      logger.warn('Profile named an uncancellable subscription; healing onto the live one', {
+        storedSubscriptionId: profile.stripeSubscriptionId,
+        liveSubscriptionId: live.id,
+        profileId: profile.id,
+      })
+
+      await resyncSubscription(live.id)
+      target = live
     }
 
-    if (current.cancel_at_period_end) {
+    if (target.cancel_at_period_end) {
       return { success: false, message: 'Subscription is already scheduled to cancel.' }
     }
 
-    await stripe.subscriptions.update(profile.stripeSubscriptionId, {
+    await stripe.subscriptions.update(target.id, {
       cancel_at_period_end: true,
     })
 
     // Writing state is resync's job; this returns what resync actually wrote so
     // the response is derived truth rather than a local guess.
-    const { state } = await resyncSubscription(profile.stripeSubscriptionId)
+    const { state } = await resyncSubscription(target.id)
     const endsAt = state?.paidThroughAt ?? null
 
     logger.info('Cancelled subscription', {
-      subscriptionId: profile.stripeSubscriptionId,
+      subscriptionId: target.id,
       endsAt,
     })
 

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-report.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-report.test.ts
@@ -26,6 +26,7 @@ const CLEAN_PROFILES = {
   duplicate: 0,
   unproven: 0,
   mismatched: 0,
+  multi_live: 0,
   historical: 0,
 }
 const CLEAN_AUDIT = {
@@ -251,8 +252,10 @@ describe('exceedsApplyCap', () => {
 
 describe('ownership findings escalate', () => {
   // An email-only match is not something the apply pass may repair, so finding
-  // one has to reach a human the same way ORPHANED and DUPLICATE do.
-  it.each(['unproven', 'mismatched'])('treats %s as needing attention', (key) => {
+  // one has to reach a human the same way ORPHANED and DUPLICATE do. Nor is a
+  // customer billed twice: which subscription to keep decides who gets
+  // refunded, so `multi_live` escalates rather than being auto-applied.
+  it.each(['unproven', 'mismatched', 'multi_live'])('treats %s as needing attention', (key) => {
     const classified = classifyStep({
       step: 'profiles',
       counts: { ...CLEAN_PROFILES, [key]: 1 },

--- a/apps/questura/apps/server/src/features/payments/lib/reconcile-report.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/reconcile-report.ts
@@ -61,7 +61,11 @@ export const ESCALATING_COUNTS: Readonly<Record<ReconcileStepName, readonly stri
   // `unproven` and `mismatched` are ownership questions only a human can
   // answer: an email match is not proof, so the script reports them instead of
   // adopting them, and the nightly must not let that report go unread.
-  profiles: ['orphaned', 'duplicate', 'unproven', 'mismatched'],
+  // `multi_live` is a customer Stripe is billing twice. The checkout collapse
+  // repairs the case it can see; this count is what catches the rest, and
+  // deciding which subscription to keep — and therefore who gets refunded — is
+  // a human call, so it escalates.
+  profiles: ['orphaned', 'duplicate', 'unproven', 'mismatched', 'multi_live'],
   audit: ['stuck', 'unknown'],
   // Pruning old webhook rows is the job working. A throw still escalates.
   retention: [],
@@ -73,7 +77,16 @@ export const ESCALATING_COUNTS: Readonly<Record<ReconcileStepName, readonly stri
  */
 const SUMMARY_COUNTS: Readonly<Record<ReconcileStepName, readonly string[]>> = {
   verify: ['missing', 'disabled', 'extra'],
-  profiles: ['relinkable', 'drifted', 'applied', 'orphaned', 'duplicate', 'unproven', 'mismatched'],
+  profiles: [
+    'relinkable',
+    'drifted',
+    'applied',
+    'orphaned',
+    'duplicate',
+    'unproven',
+    'mismatched',
+    'multi_live',
+  ],
   audit: ['stuck', 'unknown', 'in_period', 'contested', 'closed'],
   retention: ['expired', 'deleted'],
 }

--- a/apps/questura/apps/server/src/features/payments/payment-service.test.ts
+++ b/apps/questura/apps/server/src/features/payments/payment-service.test.ts
@@ -9,12 +9,20 @@ const mocks = vi.hoisted(() => ({
   findVisitorProfileByStripeCustomerId: vi.fn(),
   payloadUpdate: vi.fn(),
   resyncSubscription: vi.fn(),
+  findLiveSubscription: vi.fn(),
 }))
 
 // cancel/reactivate call Stripe then hand the write to resync, so these tests
 // assert delegation rather than re-checking what resync derives.
 vi.mock('@/payments/lib/subscription-resync', () => ({
   resyncSubscription: mocks.resyncSubscription,
+}))
+
+// The cancel path asks Stripe who is actually billing when the stored id turns
+// out to be uncancellable, so this is a seam these tests drive rather than the
+// real customer walk.
+vi.mock('@/payments/lib/customer-linkage', () => ({
+  findLiveSubscription: mocks.findLiveSubscription,
 }))
 
 vi.mock('@/payments/lib/stripe', () => ({
@@ -66,6 +74,7 @@ const activeProfile = {
   email: 'visitor@example.com',
   firstName: 'Ada',
   lastName: 'Lovelace',
+  stripeCustomerId: 'cus_1',
   stripeSubscriptionId: 'sub_1',
   subscriptionStatus: 'active',
   cancelAtPeriodEnd: false,
@@ -206,17 +215,71 @@ describe('cancelUserSubscription', () => {
     })
   })
 
-  it('refuses when Stripe reports the subscription already gone', async () => {
+  it('refuses when Stripe reports the subscription already gone and nothing else is billing', async () => {
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
     mocks.stripeSubscriptionRetrieve.mockResolvedValue({
       id: 'sub_1',
       status: 'canceled',
       cancel_at_period_end: false,
     })
+    mocks.findLiveSubscription.mockResolvedValue(null)
 
     await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
       success: false,
       message: 'This subscription can no longer be cancelled.',
+    })
+    expect(mocks.stripeSubscriptionUpdate).not.toHaveBeenCalled()
+  })
+
+  // The dead end this replaces: the card offered Cancel off the mirrored
+  // status, the stored id was uncancellable, and the visitor kept being charged
+  // by a subscription the button could not reach.
+  it('cancels the subscription that is really billing when the stored id is dead', async () => {
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'canceled',
+      cancel_at_period_end: false,
+    })
+    mocks.findLiveSubscription.mockResolvedValue({
+      id: 'sub_2',
+      status: 'active',
+      cancel_at_period_end: false,
+    })
+    mocks.resyncSubscription.mockResolvedValue({
+      profileId: 10,
+      state: { paidThroughAt: new Date(FUTURE_TS * 1000).toISOString() },
+      transitions: [],
+    })
+
+    const result = await cancelUserSubscription('auth_1')
+
+    expect(result.success).toBe(true)
+    expect(mocks.stripeSubscriptionUpdate).toHaveBeenCalledWith('sub_2', {
+      cancel_at_period_end: true,
+    })
+    // Repointed before anything was cancelled, so the row is right even if the
+    // cancel then fails.
+    expect(mocks.resyncSubscription).toHaveBeenNthCalledWith(1, 'sub_2')
+  })
+
+  it('does not cancel a live subscription that is already scheduled to end', async () => {
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue(activeProfile)
+    mocks.stripeSubscriptionRetrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'canceled',
+      cancel_at_period_end: false,
+    })
+    mocks.findLiveSubscription.mockResolvedValue({
+      id: 'sub_2',
+      status: 'active',
+      cancel_at_period_end: true,
+    })
+    mocks.resyncSubscription.mockResolvedValue({ profileId: 10, state: null, transitions: [] })
+
+    await expect(cancelUserSubscription('auth_1')).resolves.toEqual({
+      success: false,
+      message: 'Subscription is already scheduled to cancel.',
     })
     expect(mocks.stripeSubscriptionUpdate).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
The two loose ends left after #353 and #354.

## 1. Cancel could refuse and leave the visitor paying

`/account` offers Cancel off the mirrored status, but `cancelUserSubscription` cancels whatever id the profile row holds. If that id is uncancellable while a *different* subscription is the one actually billing, the old answer was "This subscription can no longer be cancelled." — the charge continues and the only control the visitor has says no.

Now: ask Stripe who is billing (`findLiveSubscription`), resync onto it — which repoints the row — and cancel that one. The resync runs *before* the cancel, so the profile is correct even if the cancel then fails. When nothing live exists, the refusal stands exactly as before.

Tests: the dead-id heal, the refusal when nothing else is billing, and a live subscription already scheduled to end (must not double-cancel).

## 2. Nothing watched for double billing

`collapseDuplicateSubscriptions` refunds and cancels extras and logs an error when it fires — but a log line on one host is not something anyone reads, and the collapse only runs if that webhook arrived at all.

The nightly profile scan already lists every customer's subscriptions for `selectProfileSubscription`, so it now counts customers holding more than one live subscription: `MULTI_LIVE` in the summary, a detail block naming the customer and subscription ids, and `multi_live` added to the profiles step's escalating counts (exit 1, human needed).

Reports rather than repairs, deliberately: which subscription survives decides who gets refunded, and that is not a decision to make unattended. This also keeps the check portable — it lives in the reconcile job, not in anything tied to the current host.

## Deliberately not changed

The account UI still offers Cancel based on the mirrored status. Hiding the button on a stale row takes the control away from the visitor rather than making it work; the server is where this can be decided against Stripe, and now is.