### PR TITLE
Validate the price against the catalog before charging it

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/create-checkout-session/route.ts
@@ -4,7 +4,7 @@ import { resolveStripeCustomerForVisitor, findLiveSubscription } from '@/payment
 import { APP_CONFIG, APP_URLS } from '@/shared/config'
 import { forbiddenOriginResponse, getCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { requireVisitorPrincipal } from '@/features/visitor-auth/lib/current-principal'
-import { isPlanId, priceIdForPlan, type PlanId } from '@/payments/lib/membership-plans'
+import { getPurchasablePlan, isPlanId, type PlanId } from '@/payments/lib/membership-plans'
 import { checkPaymentsRateLimit, checkPaymentsVisitorRateLimit, paymentsRateLimitResponse } from '@/payments/lib/payments-rate-limit'
 import { safeReturnPath } from '@/payments/lib/safe-return-path'
 import { checkoutIdempotencyKey } from '@/payments/lib/checkout-idempotency'
@@ -124,19 +124,43 @@ export async function POST(req: NextRequest) {
     }
 
     const plan: PlanId = isPlanId(body?.plan) ? body.plan : 'monthly'
-    const priceId = priceIdForPlan(plan)
 
     // Where to send the buyer once the success page has confirmed entitlement.
     // Attacker-controlled by definition and destined for a URL Stripe redirects
     // a browser to, so it is validated here rather than trusted from the client.
     const returnTo = safeReturnPath(body?.returnTo)
 
-    if (!priceId) {
+    // The price is resolved through the same validation the pricing page uses,
+    // not read straight out of host env.
+    //
+    // The two paths used to disagree. `/api/payments/plans` checked the
+    // configured Stripe price against `MEMBERSHIP_CATALOG` and dropped any plan
+    // whose interval, currency or amount did not match — so a yearly price that
+    // actually billed monthly, or billed in EUR, or billed $99.99, simply
+    // vanished from the pricing page with only a log line. This endpoint did
+    // none of that and charged it anyway. A buyer never has to see the pricing
+    // page to get here: `/purchase/yearly` posts `{"plan":"yearly"}` directly
+    // and the nav Subscribe copy is hardcoded, so the one check that existed
+    // could be bypassed just by taking the normal route through the site.
+    //
+    // The mismatch that is *not* an error is the laptop test charge: a price
+    // cheaper than the catalog is deliberate and stays purchasable. See
+    // `apps/questura/docs/membership-pricing.md`.
+    const purchasablePlan = await getPurchasablePlan(plan)
+
+    if (!purchasablePlan) {
+      // Also covers a plan with no configured price at all, which is how yearly
+      // behaved before an annual price existed in Stripe. Failing closed here
+      // costs a sale; the alternative charges a card an amount or an interval
+      // the site never advertised, which is a chargeback the customer wins.
+      logger.error('Refusing checkout for a plan that failed catalog validation', { plan })
       return NextResponse.json(
         { error: 'That plan is not available right now.' },
         { status: 400, headers: corsHeaders }
       )
     }
+
+    const priceId = purchasablePlan.priceId
 
     let referralId: string | null = null
     if (APP_CONFIG.features.endorselyAffiliates) {

--- a/apps/questura/apps/server/src/features/payments/__fixtures__/membership-prices.ts
+++ b/apps/questura/apps/server/src/features/payments/__fixtures__/membership-prices.ts
@@ -1,0 +1,48 @@
+import { MEMBERSHIP_CATALOG, type CatalogPlanId } from '@/payments/lib/membership-catalog'
+
+/**
+ * A Stripe price that passes catalog validation.
+ *
+ * Checkout no longer charges the raw `STRIPE_PRICE_ID_*` from host env — it
+ * resolves the price through `getPurchasablePlan`, which retrieves it from
+ * Stripe and refuses anything whose interval, currency or amount disagrees with
+ * `MEMBERSHIP_CATALOG`. So any test that expects a checkout session to be
+ * created has to stub a price Stripe would return, not just configure an id.
+ */
+export function catalogPrice(
+  plan: CatalogPlanId,
+  priceId: string,
+  /** Override a single field to build the price the catalog should reject. */
+  overrides: Record<string, unknown> = {}
+) {
+  const catalog = MEMBERSHIP_CATALOG[plan]
+
+  return {
+    id: priceId,
+    unit_amount: catalog.amount,
+    currency: catalog.currency,
+    recurring: { interval: catalog.interval, interval_count: 1 },
+    product: { name: 'Questurian Membership' },
+    metadata: {},
+    ...overrides,
+  }
+}
+
+/**
+ * Stub for `stripe.prices.retrieve` covering both plans the checkout route
+ * tests configure. Which plan an id maps to is decided by the id itself, so a
+ * test can keep asserting on the id it set in the `APP_CONFIG` mock.
+ */
+export function catalogPriceRetrieve(
+  ids: { monthly: string; yearly: string } = {
+    monthly: 'price_123',
+    yearly: 'price_yearly_123',
+  }
+) {
+  return async (priceId: string) => {
+    if (priceId === ids.yearly) return catalogPrice('yearly', priceId)
+    if (priceId === ids.monthly) return catalogPrice('monthly', priceId)
+    // Same shape as the real client: an unconfigured id is not a price.
+    throw new Error(`No such price: ${priceId}`)
+  }
+}

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.customer-reuse.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   stripeCustomerList: vi.fn(),
   stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
 }))
 
 vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
@@ -33,6 +34,9 @@ vi.mock('@/payments/lib/stripe', () => ({
         create: mocks.stripeCheckoutCreate,
       },
     },
+    prices: {
+      retrieve: mocks.stripePriceRetrieve,
+    },
   },
 }))
 
@@ -54,6 +58,8 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
+import { catalogPriceRetrieve } from './__fixtures__/membership-prices'
+
 import { POST } from '@/app/api/payments/create-checkout-session/route'
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
@@ -72,6 +78,10 @@ function createRequest() {
 describe('create checkout session duplicate Stripe customer guard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Checkout validates the configured price against the catalog before it
+    // charges anything, so a session is only created when Stripe returns a
+    // price that matches.
+    mocks.stripePriceRetrieve.mockImplementation(catalogPriceRetrieve())
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.requireVisitorPrincipal.mockResolvedValue({
       result: { authenticated: true },

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.payment-methods.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.payment-methods.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   stripeCustomerList: vi.fn(),
   stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
   // Mutable so a single suite can exercise both sides of the flag; the config
   // module is read at request time, not captured at import.
   features: { endorselyAffiliates: false, stripePromotionCodes: false },
@@ -27,6 +28,7 @@ vi.mock('@/payments/lib/stripe', () => ({
     customers: { create: mocks.stripeCustomerCreate, list: mocks.stripeCustomerList },
     subscriptions: { list: mocks.stripeSubscriptionList },
     checkout: { sessions: { create: mocks.stripeCheckoutCreate } },
+    prices: { retrieve: mocks.stripePriceRetrieve },
   },
 }))
 
@@ -52,6 +54,8 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
+import { catalogPriceRetrieve } from './__fixtures__/membership-prices'
+
 import { POST } from '@/app/api/payments/create-checkout-session/route'
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
@@ -73,6 +77,10 @@ async function sessionParams() {
 describe('create checkout session payment methods', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Checkout validates the configured price against the catalog before it
+    // charges anything, so a session is only created when Stripe returns a
+    // price that matches.
+    mocks.stripePriceRetrieve.mockImplementation(catalogPriceRetrieve())
     mocks.features.stripePromotionCodes = false
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.promotion-codes.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.promotion-codes.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   stripeCustomerList: vi.fn(),
   stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
   // Mutable so a single suite can exercise both sides of the flag; the config
   // module is read at request time, not captured at import.
   features: { endorselyAffiliates: false, stripePromotionCodes: false },
@@ -27,6 +28,7 @@ vi.mock('@/payments/lib/stripe', () => ({
     customers: { create: mocks.stripeCustomerCreate, list: mocks.stripeCustomerList },
     subscriptions: { list: mocks.stripeSubscriptionList },
     checkout: { sessions: { create: mocks.stripeCheckoutCreate } },
+    prices: { retrieve: mocks.stripePriceRetrieve },
   },
 }))
 
@@ -52,6 +54,8 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
+import { catalogPriceRetrieve } from './__fixtures__/membership-prices'
+
 import { POST } from '@/app/api/payments/create-checkout-session/route'
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
@@ -73,6 +77,10 @@ async function sessionParams() {
 describe('create checkout session promotion codes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Checkout validates the configured price against the catalog before it
+    // charges anything, so a session is only created when Stripe returns a
+    // price that matches.
+    mocks.stripePriceRetrieve.mockImplementation(catalogPriceRetrieve())
     mocks.features.stripePromotionCodes = false
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.referral.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   stripeCustomerList: vi.fn(),
   stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
 }))
 
 vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
@@ -32,6 +33,9 @@ vi.mock('@/payments/lib/stripe', () => ({
       sessions: {
         create: mocks.stripeCheckoutCreate,
       },
+    },
+    prices: {
+      retrieve: mocks.stripePriceRetrieve,
     },
   },
 }))
@@ -60,6 +64,8 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
+import { catalogPriceRetrieve } from './__fixtures__/membership-prices'
+
 import { POST } from '@/app/api/payments/create-checkout-session/route'
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
@@ -78,6 +84,10 @@ function createRequest(body: unknown) {
 describe('create checkout session referral ID validation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Checkout validates the configured price against the catalog before it
+    // charges anything, so a session is only created when Stripe returns a
+    // price that matches.
+    mocks.stripePriceRetrieve.mockImplementation(catalogPriceRetrieve())
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.stripeCustomerList.mockResolvedValue({ data: [] })
     mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })

--- a/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
+++ b/apps/questura/apps/server/src/features/payments/create-checkout-session.route.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   stripeCustomerList: vi.fn(),
   stripeSubscriptionList: vi.fn(),
   stripeCheckoutCreate: vi.fn(),
+  stripePriceRetrieve: vi.fn(),
 }))
 
 vi.mock('@/features/visitor-auth/lib/current-principal', () => ({
@@ -32,6 +33,9 @@ vi.mock('@/payments/lib/stripe', () => ({
       sessions: {
         create: mocks.stripeCheckoutCreate,
       },
+    },
+    prices: {
+      retrieve: mocks.stripePriceRetrieve,
     },
   },
 }))
@@ -60,6 +64,8 @@ vi.mock('@/shared/config', () => ({
   },
 }))
 
+import { catalogPrice, catalogPriceRetrieve } from './__fixtures__/membership-prices'
+
 import { POST } from '@/app/api/payments/create-checkout-session/route'
 
 let consoleLogSpy: ReturnType<typeof vi.spyOn> | null = null
@@ -78,6 +84,10 @@ function createRequest(body: Record<string, unknown> = {}) {
 describe('create checkout session route auth guard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Checkout validates the configured price against the catalog before it
+    // charges anything, so a session is only created when Stripe returns a
+    // price that matches.
+    mocks.stripePriceRetrieve.mockImplementation(catalogPriceRetrieve())
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
       id: 10,
@@ -310,5 +320,146 @@ describe('create checkout session route auth guard', () => {
     await expect(response.json()).resolves.toEqual({ error: 'Origin not allowed.' })
     expect(mocks.requireVisitorPrincipal).not.toHaveBeenCalled()
     expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Checkout used to charge `STRIPE_PRICE_ID_*` straight out of host env.
+ *
+ * Every check on what that price actually is lived on `/api/payments/plans`,
+ * the display path — so a yearly price that really billed monthly, or billed in
+ * EUR, or billed $99.99, was dropped from the pricing page with nothing but a
+ * log line while this endpoint went on charging it. `/purchase/yearly` posts
+ * `{"plan":"yearly"}` without ever loading the pricing page, and the nav
+ * Subscribe copy is hardcoded, so a buyer could reach the charge without
+ * passing the one check that existed.
+ */
+describe('create checkout session price validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    mocks.stripePriceRetrieve.mockImplementation(catalogPriceRetrieve())
+    mocks.requireVisitorPrincipal.mockResolvedValue({
+      principal: { id: 'visitor_123', email: 'visitor@example.com', profileId: 10 },
+      error: null,
+      status: 200,
+    })
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'none',
+      stripeCustomerId: 'cus_123',
+    })
+    mocks.stripeCustomerCreate.mockResolvedValue({ id: 'cus_123' })
+    mocks.stripeCustomerList.mockResolvedValue({ data: [] })
+    mocks.stripeSubscriptionList.mockResolvedValue({ data: [] })
+    mocks.updateVisitorProfileByAuthUserId.mockResolvedValue({ id: 10 })
+    mocks.stripeCheckoutCreate.mockResolvedValue({
+      id: 'cs_123',
+      url: 'https://checkout.stripe.test/session',
+    })
+  })
+
+  afterEach(() => {
+    consoleLogSpy?.mockRestore()
+    consoleLogSpy = null
+  })
+
+  async function expectRefused(body: Record<string, unknown> = {}) {
+    const response = await POST(createRequest(body))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'That plan is not available right now.',
+    })
+    expect(mocks.stripeCheckoutCreate).not.toHaveBeenCalled()
+    return response
+  }
+
+  it('refuses to charge a yearly price that actually bills monthly', async () => {
+    mocks.stripePriceRetrieve.mockResolvedValue(
+      catalogPrice('yearly', 'price_yearly_123', {
+        recurring: { interval: 'month', interval_count: 1 },
+      })
+    )
+
+    await expectRefused({ plan: 'yearly' })
+  })
+
+  it('refuses to charge a price billed in another currency', async () => {
+    mocks.stripePriceRetrieve.mockResolvedValue(
+      catalogPrice('monthly', 'price_123', { currency: 'eur' })
+    )
+
+    await expectRefused()
+  })
+
+  it('refuses to charge more than the advertised catalog amount', async () => {
+    mocks.stripePriceRetrieve.mockResolvedValue(
+      catalogPrice('yearly', 'price_yearly_123', { unit_amount: 9999 })
+    )
+
+    await expectRefused({ plan: 'yearly' })
+  })
+
+  it('refuses to charge a price that is not recurring at all', async () => {
+    mocks.stripePriceRetrieve.mockResolvedValue(
+      catalogPrice('monthly', 'price_123', { recurring: null })
+    )
+
+    await expectRefused()
+  })
+
+  it('fails closed when Stripe cannot resolve the configured price', async () => {
+    mocks.stripePriceRetrieve.mockRejectedValue(new Error('No such price: price_123'))
+
+    await expectRefused()
+  })
+
+  // The refusal has to land before anything is created on the Stripe side.
+  // A customer minted for a checkout that is then refused is an orphan row
+  // nothing points at.
+  it('refuses before creating a Stripe customer', async () => {
+    mocks.findVisitorProfileByAuthUserId.mockResolvedValue({
+      id: 10,
+      subscriptionStatus: 'none',
+      stripeCustomerId: null,
+    })
+    mocks.stripePriceRetrieve.mockResolvedValue(
+      catalogPrice('monthly', 'price_123', { unit_amount: 9999 })
+    )
+
+    await expectRefused()
+
+    expect(mocks.stripeCustomerCreate).not.toHaveBeenCalled()
+    expect(mocks.stripeCustomerList).not.toHaveBeenCalled()
+  })
+
+  // The one mismatch that is deliberate: the laptop bills $0.50/month on the
+  // same product while the site advertises $12.99. Validation must not break
+  // that. See apps/questura/docs/membership-pricing.md.
+  it('still sells the cheaper laptop test charge', async () => {
+    mocks.stripePriceRetrieve.mockResolvedValue(
+      catalogPrice('monthly', 'price_123', { unit_amount: 50 })
+    )
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(200)
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ line_items: [{ price: 'price_123', quantity: 1 }] }),
+      expect.anything(),
+    )
+  })
+
+  // The id charged is the validated plan's, not whatever the body asked for a
+  // price of — the two must not be able to drift apart.
+  it('charges the price id the validated plan carries', async () => {
+    await POST(createRequest({ plan: 'yearly' }))
+
+    expect(mocks.stripePriceRetrieve).toHaveBeenCalledWith('price_yearly_123', expect.anything())
+    expect(mocks.stripeCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ line_items: [{ price: 'price_yearly_123', quantity: 1 }] }),
+      expect.anything(),
+    )
   })
 })

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.ts
@@ -37,7 +37,16 @@ export type MembershipPlan = {
   compareAtAmount: number | null
 }
 
-export function priceIdForPlan(plan: PlanId): string {
+/**
+ * The raw configured price ID, straight from host env, unvalidated.
+ *
+ * Deliberately not exported. Reading the env price and charging it was the
+ * whole bug: every guarantee about what this site sells — the interval, the
+ * currency, the ceiling on the amount — lives in `getPurchasablePlan` below,
+ * and a caller holding the bare ID has none of them. Charging paths go through
+ * `getPurchasablePlan`.
+ */
+function priceIdForPlan(plan: PlanId): string {
   return plan === 'yearly' ? APP_CONFIG.stripe.yearlyPriceId : APP_CONFIG.stripe.monthlyPriceId
 }
 
@@ -45,7 +54,19 @@ export function isPlanId(value: unknown): value is PlanId {
   return value === 'monthly' || value === 'yearly'
 }
 
-async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
+/**
+ * The plan as it may actually be sold, or `null` when it must not be sold at all.
+ *
+ * This is the single gate in front of the configured Stripe price, and both the
+ * pricing page and Checkout go through it. Everything it refuses is a case where
+ * the price in host env disagrees with what the site advertises: a different
+ * billing interval, a different currency, or an amount above the catalog.
+ *
+ * It fails closed, including when Stripe itself cannot be reached. Refusing to
+ * start a checkout is recoverable; charging a card an amount or an interval the
+ * buyer was never shown is a dispute the buyer wins.
+ */
+export async function getPurchasablePlan(plan: PlanId): Promise<MembershipPlan | null> {
   const priceId = priceIdForPlan(plan)
 
   // A plan with no configured price is not offered, rather than broken. That is
@@ -122,6 +143,6 @@ async function fetchPlan(plan: PlanId): Promise<MembershipPlan | null> {
 
 /** Every plan that is actually purchasable right now. */
 export async function getMembershipPlans(): Promise<MembershipPlan[]> {
-  const plans = await Promise.all([fetchPlan('monthly'), fetchPlan('yearly')])
+  const plans = await Promise.all([getPurchasablePlan('monthly'), getPurchasablePlan('yearly')])
   return plans.filter((plan): plan is MembershipPlan => plan !== null)
 }

--- a/apps/questura/docs/membership-pricing.md
+++ b/apps/questura/docs/membership-pricing.md
@@ -24,6 +24,32 @@ the product.
 
 The only forbidden mismatch: advertising **less** than Stripe will charge.
 
+## What enforces that
+
+`getPurchasablePlan()` in `membership-plans.ts`. It retrieves the configured
+price from Stripe and refuses the plan outright when the price disagrees with
+`MEMBERSHIP_CATALOG` on:
+
+- **billing interval** — a "yearly" price that actually bills monthly
+- **interval count** — anything other than every 1 interval
+- **currency** — anything other than the catalog currency
+- **amount** — *above* the catalog amount. Below is the laptop test charge and
+  is allowed; that is the whole point of the switch below.
+
+It also refuses when Stripe cannot be reached at all, rather than guessing.
+
+**Both the pricing page and Checkout go through it.** They did not always:
+`/api/payments/plans` validated and `POST /api/payments/create-checkout-session`
+did not, so a bad `STRIPE_PRICE_ID_*` dropped the plan from `/join` with only a
+log line while `/purchase/yearly` — which posts `{"plan":"yearly"}` without ever
+loading the pricing page — kept charging it.
+
+A refused plan is a **400 `That plan is not available right now.`** on Checkout
+and a missing entry on `/api/payments/plans`. If the buy button starts returning
+that, the price ID in `~/questura/config/server.env` is the thing to look at,
+and the reason is in the server log (`Configured membership price does not match
+the catalog`, or `Stripe would charge more than the catalog price`).
+
 ## This is not launch
 
 The Linux laptop is a live-like test environment, not production. Production


### PR DESCRIPTION
## The bug

`POST /api/payments/create-checkout-session` read `STRIPE_PRICE_ID_*` straight out of host env and handed it to Stripe:

```ts
const priceId = priceIdForPlan(plan)   // raw env, unvalidated
// ...straight into stripe.checkout.sessions.create
```

All the validation lived on `/api/payments/plans` — the **display** path. `fetchPlan` there refuses a price whose `recurring.interval`, `interval_count` or `currency` disagrees with `MEMBERSHIP_CATALOG`, or whose `unit_amount` is above the catalog amount.

So if `STRIPE_PRICE_ID_YEARLY` pointed at a price that is monthly, or in EUR, or $99.99:

- `/api/payments/plans` logged `Configured membership price does not match the catalog` and dropped the plan from the pricing page — **nobody notices**
- checkout charged it anyway

And a buyer never has to load the pricing page to get there: `/purchase/yearly` posts `{"plan":"yearly"}` directly, and the nav Subscribe copy is hardcoded. On live Stripe with real cards that is a chargeback with the customer in the right.

## The fix

Checkout resolves its price through the same gate and 400s when the plan is not purchasable — **before** any Stripe customer is created, so a refused checkout leaves no orphan row.

- `fetchPlan` → exported as `getPurchasablePlan(plan)`; `getMembershipPlans()` still calls it for both plans
- `priceIdForPlan` is **no longer exported** — a caller holding the bare env id has none of the guarantees, which was the whole bug
- fails closed when Stripe itself can't be reached, rather than guessing

The deliberate mismatch still works: a price *cheaper* than the catalog is the laptop test charge and stays purchasable (`docs/membership-pricing.md`).

## Verification

Live host config checked — both prices pass the new gate, so the live buy button is unaffected:

| env | price | Stripe | verdict |
|---|---|---|---|
| `STRIPE_PRICE_ID_MONTHLY` | `price_1U5aq5…` | $0.50 usd month/1 | ≤ $12.99 catalog → sold |
| `STRIPE_PRICE_ID_YEARLY` | `price_1U4P3b…` | $79.99 usd year/1 | == catalog → sold |

8 new regression tests. Reverting the route fix while keeping them fails 7 of the 8 (the 8th is the "still sells the $0.50 laptop charge" guard, which correctly passes either way).

- `pnpm vitest run src/features/payments` → 389 passed
- `pnpm exec tsc --noEmit` → clean
- `pnpm lint` → 0 errors (7 pre-existing warnings, none in these files)

Full suite has 1–3 flaky `src/features/media/pipeline` failures under parallel load; reproduced on a clean tree without these changes.

Also documents the guard in `docs/membership-pricing.md` so an operator who sets a bad price knows why the buy button started 400ing.