### PR TITLE
Give the three image tests a timeout that fits the work they do

### DIFF
--- a/apps/questura/apps/server/src/features/media/pipeline/assemble-media-set.test.ts
+++ b/apps/questura/apps/server/src/features/media/pipeline/assemble-media-set.test.ts
@@ -17,6 +17,15 @@ const makeSource = async (): Promise<Buffer> =>
     .jpeg()
     .toBuffer()
 
+/**
+ * Real libvips work — see the note in `from-source.test.ts`. This test builds a
+ * 2400x1600 source and every variant off it, which makes it one of the three
+ * slowest tests in the suite and the only one in this file. vitest's 5s default
+ * flaked it on a loaded machine; raised here per test so the default still
+ * guards everything else.
+ */
+const IMAGE_WORK_TIMEOUT_MS = 30_000
+
 describe('assembleMediaSetFromSource', () => {
   it('skips legacy Bunny URL sync while creating source and variant media assets', async () => {
     const createCalls: Array<Record<string, unknown>> = []
@@ -52,5 +61,5 @@ describe('assembleMediaSetFromSource', () => {
         [BUNNY_ORIGINAL_URL_SYNC_CONTEXT_KEY]: true,
       })
     }
-  })
+  }, IMAGE_WORK_TIMEOUT_MS)
 })

--- a/apps/questura/apps/server/src/features/media/pipeline/from-source.test.ts
+++ b/apps/questura/apps/server/src/features/media/pipeline/from-source.test.ts
@@ -16,6 +16,27 @@ const makeSource = async (width: number, height: number): Promise<Buffer> =>
     .jpeg()
     .toBuffer()
 
+/**
+ * These are the only tests in the whole server suite that do real libvips work,
+ * and they are the slowest by a wide margin — ~1.4-2.2s for this file versus
+ * ~450ms for the next slowest file in the suite. Everything else finishes in
+ * milliseconds, so vitest's 5s default left them the least headroom of any test
+ * while needing the most.
+ *
+ * The result was a flake that looked like a regression: on a loaded machine
+ * (a parallel full-suite run, CI, a build in another terminal) these three
+ * tests — and only these three — would intermittently fail with
+ * `Test timed out`, on any branch including `main`.
+ *
+ * Confirmed by forcing `--testTimeout=400`, which reproduces exactly the same
+ * three test names. The failure is always the clock, never a wrong image: no
+ * assertion on width, height or format has ever been the thing that failed.
+ *
+ * So the timeout is raised here, per test, rather than globally — a hang in any
+ * other test should still trip the 5s default rather than sit for half a minute.
+ */
+const IMAGE_WORK_TIMEOUT_MS = 30_000
+
 describe('normalizeFocalPoint', () => {
   it('clamps out-of-range values', () => {
     expect(normalizeFocalPoint({ x: -1, y: 2 })).toEqual({ x: 0, y: 1 })
@@ -80,7 +101,7 @@ describe('generateVariantsFromSource', () => {
       expect(meta.height).toBe(spec.height)
       expect(meta.format).toBe('webp')
     }
-  })
+  }, IMAGE_WORK_TIMEOUT_MS)
 
   it('rejects when the source buffer cannot be parsed as an image', async () => {
     await expect(
@@ -103,5 +124,5 @@ describe('generateVariantsFromSource', () => {
     const meta = await sharp(square!.buffer).metadata()
     expect(meta.width).toBe(VARIANT_SPECS.square.width)
     expect(meta.height).toBe(VARIANT_SPECS.square.height)
-  })
+  }, IMAGE_WORK_TIMEOUT_MS)
 })


### PR DESCRIPTION
Fixes the intermittent `src/features/media/pipeline` failures that show up only in the full parallel run — on any branch, including `main`.

## It was the clock, not the image

The three tests that do real libvips work are the slowest in the suite by a wide margin:

| file | duration | note |
|---|---|---|
| `from-source.test.ts` | 1.4–2.2s | slowest in the suite |
| `assemble-media-set.test.ts` | 0.7–1.1s | 2nd slowest |
| *next slowest file in the suite* | ~455ms | everything else is milliseconds |

vitest's 5s default gave the heaviest tests the least headroom. On a loaded machine — parallel full-suite run, CI, a build in another terminal — they ran out of clock.

**Confirmed, not assumed.** Forcing `--testTimeout=400` reproduces *exactly* the same three test names that flake in the wild:

- `assembleMediaSetFromSource > skips legacy Bunny URL sync…`
- `generateVariantsFromSource > produces all 7 variants…`
- `generateVariantsFromSource > honors per-variant overrides…`

and the error is always `Test timed out`, **never** an assertion. Nothing has ever failed on a width, height or format. So this was never image corruption or a race in the pipeline — worth establishing given this repo has had genuine MediaSet byte corruption before.

Ruled out along the way: plain CPU contention (16 busy loops, then 6 real sharp processes with their own libvips pools at load-avg 18, still only pushed these to ~1s).

## The fix

An explicit `IMAGE_WORK_TIMEOUT_MS = 30_000` on those three tests only, with the reasoning written next to them.

Deliberately **not** a global `testTimeout` bump — a real hang anywhere else should still trip the 5s default rather than sit for half a minute.

## Verification

The whole suite passes with a global `--testTimeout=400` — **12.5× tighter than the real default**:

```
Test Files  122 passed (122)
     Tests  1117 passed (1117)
```

The same command failed these three before the change. Normal run also 122/122 · 1117 tests, `tsc` clean, lint 0 errors.