### PR TITLE
Stop telling a revoked member their membership is active

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,25 @@ jobs:
       - name: Unit tests
         run: pnpm --dir apps/questura/apps/server run test:int
 
+  questura-client:
+    name: Questura client tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # Deliberately no `pnpm install`: these are node:test suites over pure
+      # modules, and node strips the TypeScript itself (needs >= 22.18, or the
+      # --experimental-strip-types the script passes). Nothing here imports a
+      # dependency, which is the constraint that keeps the job this cheap.
+      - name: Unit tests
+        run: pnpm --dir apps/questura/apps/client run test
+
   writer-web:
     name: Writer frontend
     runs-on: ubuntu-latest

--- a/apps/questura/apps/client/package.json
+++ b/apps/questura/apps/client/package.json
@@ -8,6 +8,7 @@
     "check:global-css": "node scripts/check-global-css-boundaries.mjs",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --experimental-strip-types --test \"src/**/*.test.mjs\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/questura/apps/client/src/features/AccountPage/components/Membership/MembershipSection.tsx
+++ b/apps/questura/apps/client/src/features/AccountPage/components/Membership/MembershipSection.tsx
@@ -30,9 +30,9 @@ export function MembershipSection({ user }: MembershipSectionProps) {
             membershipState={vm.membershipState}
           />
 
-          {vm.billingInfo && !vm.isRenewing && (
+          {vm.showActionLinks && !vm.isRenewing && (
             <>
-              <MembershipBillingInfo billingInfo={vm.billingInfo} />
+              {vm.billingInfo && <MembershipBillingInfo billingInfo={vm.billingInfo} />}
               <MembershipActionLinks
                 canUpdatePayment={vm.canUpdatePayment}
                 canCancel={vm.membershipState.showCancelButton}

--- a/apps/questura/apps/client/src/features/AccountPage/hooks/useMembershipSection.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/hooks/useMembershipSection.ts
@@ -45,8 +45,16 @@ export function useMembershipSection(user: User | null) {
     };
   })();
 
-  const membershipState = getMembershipState(effectiveUser);
-  const billingInfo = getBillingInfo(effectiveUser);
+  // One entitlement read for the whole card. `isActive` is `membership.active`
+  // from the server (dev override included), which is what actually gates paid
+  // articles -- so the card cannot claim a membership the paywall denies.
+  const membershipState = getMembershipState(effectiveUser, isActive);
+  const billingInfo = getBillingInfo(effectiveUser, isActive);
+
+  // A paused membership has no billing summary for the links to hang off, and it
+  // is the state that needs the portal most: the subscription is still charging
+  // while access is gone, and the portal is where that gets stopped.
+  const accessPaused = membershipState.type === 'access_paused';
 
   const [showCancellationModal, setShowCancellationModal] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -87,7 +95,8 @@ export function useMembershipSection(user: User | null) {
     isRenewing: renewMutation.isPending,
     showCancellationModal,
     successMessage,
-    canUpdatePayment: isActive || membershipState.showCancelButton,
+    canUpdatePayment: isActive || membershipState.showCancelButton || accessPaused,
+    showActionLinks: Boolean(billingInfo) || accessPaused,
     clearSuccess: () => setSuccessMessage(null),
     openCancelModal: () => setShowCancellationModal(true),
     handleCancelSubscription,

--- a/apps/questura/apps/client/src/features/AccountPage/services/membership.service.test.mjs
+++ b/apps/questura/apps/client/src/features/AccountPage/services/membership.service.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getBillingInfo, getMembershipState } from './membership.service.ts'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const inDays = (days) => new Date(Date.now() + days * DAY_MS).toISOString()
+
+function visitor(fields) {
+  return {
+    kind: 'visitor',
+    id: 'v_1',
+    email: 'member@example.com',
+    subscriptionStatus: 'active',
+    subscriptionRenewsAt: null,
+    membershipExpiration: null,
+    dunningGraceUntil: null,
+    cancelAtPeriodEnd: false,
+    ...fields,
+  }
+}
+
+// The reported bug: a disputed charge revokes entitlement without touching the
+// subscription, so the status enum still reads `active` and the paid-through
+// date is gone. The card used to answer that with "Premium Member".
+test('a live subscription with no entitlement is not shown as a premium member', () => {
+  const state = getMembershipState(visitor({ subscriptionStatus: 'active' }), false)
+
+  assert.equal(state.type, 'access_paused')
+  assert.notEqual(state.label, 'Premium Member')
+  assert.match(state.description, /paused/i)
+  // The subscription still exists and still bills; a second one is not the fix.
+  assert.equal(state.showUpgradeButton, false)
+})
+
+// The stuck class `audit-access-revocations.ts` looks for: entitlement is gone
+// but the profile still carries a period end, so the enum reads `active` and a
+// renewal date is still sitting there.
+test('a stuck profile is paused and advertises no billing date', () => {
+  const user = visitor({ subscriptionStatus: 'active', subscriptionRenewsAt: inDays(-3) })
+
+  assert.equal(getMembershipState(user, false).type, 'access_paused')
+  assert.equal(getBillingInfo(user, false), null)
+})
+
+test('an entitled active subscription still reads as a premium member', () => {
+  const user = visitor({ subscriptionStatus: 'active', subscriptionRenewsAt: inDays(20) })
+  const state = getMembershipState(user, true)
+
+  assert.equal(state.type, 'active')
+  assert.equal(state.label, 'Premium Member')
+  const billing = getBillingInfo(user, true)
+  assert.equal(billing?.billingPeriod, 'Monthly')
+  assert.ok(billing.nextBilling.length > 0)
+})
+
+test('an expiring membership with no entitlement stops promising a run-out date', () => {
+  const state = getMembershipState(
+    visitor({ cancelAtPeriodEnd: true, membershipExpiration: inDays(10) }),
+    false
+  )
+
+  assert.equal(state.type, 'access_paused')
+  assert.equal(state.showReactivateButton, false)
+})
+
+test('a cancelled membership with no entitlement stops saying "remains active until"', () => {
+  const state = getMembershipState(
+    visitor({ subscriptionStatus: 'cancelled', membershipExpiration: inDays(10) }),
+    false
+  )
+
+  assert.equal(state.type, 'access_paused')
+})
+
+// The other direction of the same rule: states that never claimed access are
+// left alone, so an ex-member keeps the button that sells them a membership.
+test('an expired membership keeps its upgrade path', () => {
+  const state = getMembershipState(
+    visitor({ subscriptionStatus: 'cancelled', membershipExpiration: inDays(-10) }),
+    false
+  )
+
+  assert.equal(state.type, 'expired')
+  assert.equal(state.showUpgradeButton, true)
+})
+
+test('a lapsed dunning failure keeps its upgrade path', () => {
+  const state = getMembershipState(
+    visitor({ subscriptionStatus: 'past_due', dunningGraceUntil: inDays(-1) }),
+    false
+  )
+
+  assert.equal(state.type, 'expired')
+  assert.equal(state.showUpgradeButton, true)
+})
+
+test('a covered dunning failure keeps its payment-issue copy while entitled', () => {
+  const state = getMembershipState(
+    visitor({ subscriptionStatus: 'past_due', dunningGraceUntil: inDays(3) }),
+    true
+  )
+
+  assert.equal(state.type, 'payment_issue')
+  assert.equal(state.showCancelButton, true)
+})
+
+test('a signed-out visitor is unchanged', () => {
+  assert.equal(getMembershipState(null, false).type, 'free')
+  assert.equal(getMembershipState(null, false).showUpgradeButton, true)
+  assert.equal(getBillingInfo(null, false), null)
+})
+
+test('a free visitor is offered an upgrade rather than a pause notice', () => {
+  const state = getMembershipState(visitor({ subscriptionStatus: 'none' }), false)
+
+  assert.equal(state.type, 'free')
+  assert.equal(state.showUpgradeButton, true)
+})
+
+// Pre-existing rule, kept: never sell a membership to someone who already has
+// access, whichever status produced the state.
+test('an entitled visitor is never offered an upgrade', () => {
+  const state = getMembershipState(
+    visitor({ subscriptionStatus: 'cancelled', membershipExpiration: inDays(-1) }),
+    true
+  )
+
+  assert.equal(state.showUpgradeButton, false)
+  assert.match(state.description, /rejoin once it ends/)
+})

--- a/apps/questura/apps/client/src/features/AccountPage/services/membership.service.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/services/membership.service.ts
@@ -1,7 +1,6 @@
 import type { User } from '@/lib/user/types';
 
-import { isActiveMember } from '../../Payments/lib/membership';
-import type { BillingInfo, MembershipState } from '../types/membership.types';
+import type { BillingInfo, MembershipState, MembershipType } from '../types/membership.types';
 
 function formatDate(dateString: string | null): string {
   if (!dateString) return '';
@@ -24,8 +23,15 @@ function formatDate(dateString: string | null): string {
   return formattedDate;
 }
 
-export function getBillingInfo(user: User | null): BillingInfo | null {
+/**
+ * `entitled` is the server's access decision (`membership.active`), passed in by
+ * the caller. A subscription can read `active` while entitlement has been taken
+ * away from it, and a "next billing" line under a membership that grants nothing
+ * is the same false claim as the badge above it.
+ */
+export function getBillingInfo(user: User | null, entitled: boolean): BillingInfo | null {
   if (!user || user.subscriptionStatus !== 'active') return null;
+  if (!entitled) return null;
   if (user.cancelAtPeriodEnd) return null;
 
   if (user.subscriptionRenewsAt) {
@@ -185,29 +191,80 @@ function membershipStateFromStatus(user: User | null): MembershipState {
   }
 }
 
+/** States whose copy tells the visitor they have paid access right now. */
+const STATES_CLAIMING_ACCESS: ReadonlySet<MembershipType> = new Set<MembershipType>([
+  'active',
+  'expiring',
+  'payment_issue',
+]);
+
+function claimsCurrentAccess(state: MembershipState, user: User): boolean {
+  if (STATES_CLAIMING_ACCESS.has(state.type)) return true;
+
+  // `cancelled` covers two branches above. The one that claims access is the
+  // "remains active until <date>" shape, and it is the only one reached with an
+  // unexpired `membershipExpiration`.
+  return state.type === 'cancelled' && Boolean(user.membershipExpiration);
+}
+
+/**
+ * What the card says when the subscription is alive but grants nothing.
+ *
+ * No Upgrade button: the subscription still exists and still bills, so selling a
+ * second one is the worst available answer. The portal is the next step instead
+ * -- it is where the visitor can stop the billing they are getting nothing for.
+ */
+function accessPausedState(): MembershipState {
+  return {
+    type: 'access_paused',
+    label: 'Access Paused',
+    badgeClass: 'bg-[#fff3e0] text-[#e65100] border border-[#ffe0b2]',
+    description:
+      'Your premium access is paused while a payment on this subscription is being resolved. ' +
+      'The subscription itself has not been cancelled, and access returns on its own if the ' +
+      'payment settles. Use "Update Payment Method" below to manage or cancel it.',
+    showCancelButton: false,
+    showUpgradeButton: false,
+    showReactivateButton: false,
+  };
+}
+
 /**
  * The membership as the account page should present it.
  *
- * The status enum alone produced a dead end: a subscription Stripe has already
- * deleted reports `canceled` while the period it was paid for is still running,
- * so the card said "cancelled -- Upgrade" to a visitor who was still entitled.
- * `/purchase` gates on the same entitlement (`MembershipGuard` -> `isActiveMember`
- * -> `membership.active`) and turned them away as an existing member. A button
- * that cannot work, in front of someone who might reasonably answer it by paying
- * a second time through another route.
+ * `entitled` is `membership.active` from `/api/me` -- the server's single access
+ * decision, and the same read `MembershipGuard` makes. It is passed in rather
+ * than read here so this module stays free of the dev-override store and can be
+ * exercised directly; `useMembershipSection` supplies it.
  *
- * Entitlement is the tie-breaker because it is the thing that actually gates
- * access, and it is derived once on the server. Offering to sell a membership to
- * someone who already has one is wrong regardless of which status produced it,
- * so this is applied to every branch rather than to the one that was reported.
+ * The status enum alone produced a dead end in both directions.
+ *
+ * Claiming too little: a subscription Stripe has already deleted reports
+ * `canceled` while the period it was paid for is still running, so the card said
+ * "cancelled -- Upgrade" to a visitor who was still entitled, and `/purchase`
+ * then turned them away as an existing member.
+ *
+ * Claiming too much: a refund or a dispute withdraws entitlement without
+ * touching the subscription -- `charge.dispute.created` deliberately leaves it
+ * alive, because a dispute can be won -- so `subscriptionStatus` stays `active`
+ * and the card said "Premium Member. Your premium membership is active." while
+ * every paid article returned 403. Profiles the webhooks left stuck, the class
+ * `audit-access-revocations.ts` exists to find, have the same shape.
+ *
+ * Entitlement decides both, because it is the thing that actually gates the
+ * articles: never sell to someone who already has access, never promise access
+ * to someone who has none.
  */
-export function getMembershipState(user: User | null): MembershipState {
+export function getMembershipState(user: User | null, entitled: boolean): MembershipState {
   const state = membershipStateFromStatus(user);
 
-  // `membership.active` is the server's entitlement decision; `isActiveMember`
-  // is the same read the purchase guard makes, dev override included, so the two
-  // screens cannot disagree about who is already a member.
-  if (!user || !state.showUpgradeButton || !isActiveMember(user)) return state;
+  if (!user) return state;
+
+  if (!entitled) {
+    return claimsCurrentAccess(state, user) ? accessPausedState() : state;
+  }
+
+  if (!state.showUpgradeButton) return state;
 
   return {
     ...state,

--- a/apps/questura/apps/client/src/features/AccountPage/types/membership.types.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/types/membership.types.ts
@@ -12,7 +12,14 @@ export type MembershipType =
   | 'cancelled'
   | 'inactive'
   /** Renewal charge failed; Stripe is retrying and access is still covered. */
-  | 'payment_issue';
+  | 'payment_issue'
+  /**
+   * The subscription is still live, but entitlement has been withdrawn from it
+   * -- a refunded or disputed charge, or a profile the webhooks left stuck.
+   * Access is gone while the subscription keeps billing, so the card has to say
+   * so rather than read the status enum's `active`.
+   */
+  | 'access_paused';
 
 export interface MembershipState {
   type: MembershipType;


### PR DESCRIPTION
## Why

`charge.dispute.created` deliberately does not cancel the subscription — a dispute may be won. Entitlement is withdrawn (`paidThroughAt` nulled), but `subscriptionStatus` stays `active`.

The account card read that enum, so a visitor whose access had been revoked saw:

> **Premium Member** — Your premium membership is active.

…while every gated article returned 403 for them. Same shape for the stuck class `scripts/audit-access-revocations.ts` exists to find. That is the state that generates refund requests: a customer who believes they are paying for access the paywall denies.

`getMembershipState` did apply entitlement as a tie-breaker, but only in the direction "don't offer Upgrade to someone who already has access". The opposite direction was uncovered.

## What

- `getMembershipState(user, entitled)` — entitlement (`membership.active`, the same read `MembershipGuard` makes) now decides both directions. Any state whose copy claims current access (`active`, `expiring`, `payment_issue`, and the "remains active until" shape of `cancelled`) is replaced by a new `access_paused` state when entitlement is absent.
- `access_paused` carries **no Upgrade button** on purpose — the subscription still exists and still bills, so selling a second one is the worst available answer. It points at the billing portal instead, which is where the visitor can stop paying for access they no longer have.
- `MembershipSection` renders the action links for that state; they previously hung off the billing summary, which a paused membership does not have.
- `getBillingInfo(user, entitled)` — a "next billing" date under a membership that grants nothing is the same false claim as the badge. This is what the stuck class showed (a renewal date in the past).
- Entitlement is passed in rather than read inside the module, which frees it of the dev-override store and makes it directly testable.

States that never claimed access are untouched: `expired`, lapsed `past_due`, cancelled-and-over and free visitors keep their Upgrade path.

## Verification

- `pnpm --dir apps/questura/apps/client run test` — 14 pass (11 new, covering both directions plus the states that must not be downgraded)
- `tsc --noEmit` on the client — clean
- New CI job `Questura client tests`. The client had no CI at all; this also picks up `ListicleMapNavigation.test.mjs`, which until now ran nowhere. No `pnpm install` needed — the suites are pure modules and node strips the types itself.

No server/`src` changes, so no migration. Nothing in this branch touches Stripe configuration.