### PR TITLE
Pin the Stripe API version in the batch scripts

### DIFF
--- a/apps/questura/apps/server/scripts/audit-access-revocations.ts
+++ b/apps/questura/apps/server/scripts/audit-access-revocations.ts
@@ -54,6 +54,7 @@ import { fileURLToPath } from 'node:url'
 import { getPayload } from 'payload'
 import Stripe from 'stripe'
 
+import { STRIPE_API_VERSION } from '../src/features/payments/lib/stripe-api-version'
 import config from '../src/payload.config'
 import type { ReconcileStepResult } from '../src/features/payments/lib/reconcile-report'
 import {
@@ -129,7 +130,7 @@ export async function run(
     throw new Error('STRIPE_SECRET_KEY is required to audit revocations against Stripe')
   }
 
-  const stripe = new Stripe(secretKey)
+  const stripe = new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION, typescript: true })
   const payload = await getPayload({ config })
 
   emit('🔍 Read-only audit — nothing will be written to Stripe or Payload\n')

--- a/apps/questura/apps/server/scripts/capture-membership-fixtures.ts
+++ b/apps/questura/apps/server/scripts/capture-membership-fixtures.ts
@@ -43,6 +43,7 @@
 import { writeFileSync, mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import Stripe from 'stripe'
+import { STRIPE_API_VERSION } from '../src/features/payments/lib/stripe-api-version'
 
 const FIXTURE_PATH = resolve(
   __dirname,
@@ -72,7 +73,7 @@ function requireTestKey(): string {
   return key
 }
 
-const stripe = new Stripe(requireTestKey(), { typescript: true })
+const stripe = new Stripe(requireTestKey(), { apiVersion: STRIPE_API_VERSION, typescript: true })
 
 function log(stage: string, message: string) {
   console.log(`[${stage}] ${message}`)

--- a/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
+++ b/apps/questura/apps/server/scripts/reconcile-stripe-visitor-profiles.ts
@@ -80,6 +80,7 @@ import { fileURLToPath } from 'node:url'
 import { getPayload } from 'payload'
 import Stripe from 'stripe'
 
+import { STRIPE_API_VERSION } from '../src/features/payments/lib/stripe-api-version'
 import config from '../src/payload.config'
 import { selectProfileSubscription } from '../src/features/payments/lib/customer-linkage'
 import { deriveSubscriptionState } from '../src/features/payments/lib/subscription-state'
@@ -162,7 +163,7 @@ export async function run(options: ReconcileProfilesOptions = {}): Promise<Recon
     throw new Error('STRIPE_SECRET_KEY is required to reconcile against Stripe')
   }
 
-  const stripe = new Stripe(secretKey)
+  const stripe = new Stripe(secretKey, { apiVersion: STRIPE_API_VERSION, typescript: true })
   const payload = await getPayload({ config })
 
   emit(apply ? '⚠️  APPLY mode — profiles will be written' : '🔍 Dry run — nothing will be written')

--- a/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
+++ b/apps/questura/apps/server/scripts/verify-stripe-webhook-events.ts
@@ -66,6 +66,7 @@ import {
 } from '../src/features/payments/webhooks/event-contract.ts'
 // Type-only, so it is erased before Node sees the file and adds no runtime
 // dependency. That property is load-bearing here — see the header.
+import { STRIPE_API_VERSION } from '../src/features/payments/lib/stripe-api-version.ts'
 import type { ReconcileStepResult } from '../src/features/payments/lib/reconcile-report.ts'
 
 function requireKey(): string {
@@ -97,7 +98,7 @@ export async function run(
     options.onLine?.(line)
   }
 
-  const stripe = new Stripe(requireKey(), { typescript: true })
+  const stripe = new Stripe(requireKey(), { apiVersion: STRIPE_API_VERSION, typescript: true })
   const endpoints = await stripe.webhookEndpoints.list({ limit: 100 })
 
   const ours = endpoints.data.filter((endpoint) => endpoint.url.includes(OUR_ENDPOINT_PATH))

--- a/apps/questura/apps/server/src/features/payments/lib/stripe-api-version.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/stripe-api-version.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+import { STRIPE_API_VERSION } from './stripe-api-version'
+
+const SERVER_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..')
+const SCANNED_DIRS = ['src', 'scripts']
+const SKIPPED_DIRS = new Set(['node_modules', '.next', 'migrations'])
+
+/**
+ * How much text after `new Stripe(` still counts as the same call. The options
+ * object is always the second argument, so anything further away belongs to
+ * different code.
+ */
+const OPTIONS_WINDOW = 400
+
+function walk(dir: string): string[] {
+  const found: string[] = []
+
+  for (const entry of readdirSync(dir)) {
+    if (SKIPPED_DIRS.has(entry)) continue
+
+    const full = path.join(dir, entry)
+
+    if (statSync(full).isDirectory()) {
+      found.push(...walk(full))
+      continue
+    }
+
+    if (!/\.(ts|tsx|mts|cts)$/.test(entry)) continue
+    if (/\.test\.(ts|tsx)$/.test(entry)) continue
+
+    found.push(full)
+  }
+
+  return found
+}
+
+/**
+ * Drop block comments and whole-line `//` comments, so prose *about* a Stripe
+ * client — this file's own doc comment included — is not read as one.
+ */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n')
+}
+
+function clientsWithoutApiVersion(): string[] {
+  const offenders: string[] = []
+
+  for (const dir of SCANNED_DIRS) {
+    for (const file of walk(path.join(SERVER_ROOT, dir))) {
+      const source = withoutComments(readFileSync(file, 'utf8'))
+      const chunks = source.split('new Stripe(').slice(1)
+
+      for (const chunk of chunks) {
+        if (chunk.slice(0, OPTIONS_WINDOW).includes('apiVersion')) continue
+        offenders.push(path.relative(SERVER_ROOT, file))
+      }
+    }
+  }
+
+  return offenders
+}
+
+describe('Stripe API version', () => {
+  it('is the version the installed SDK is typed against', () => {
+    // The type already refuses a version the SDK does not know, so this only
+    // documents which one that is when someone reads a failure here.
+    expect(STRIPE_API_VERSION).toBe('2025-08-27.basil')
+  })
+
+  /**
+   * The app client is pinned; the batch scripts were not, and one of them is
+   * the nightly apply-on reconcile. An SDK bump would have moved the scripts'
+   * API version and left the app's, so `current_period_end` would read as null
+   * inside an unattended job that then writes `paidThroughAt: null` over live
+   * members. Pinning is one line, and this test is what keeps the next script
+   * from skipping it.
+   */
+  it('is passed by every Stripe client in src/ and scripts/', () => {
+    expect(clientsWithoutApiVersion()).toEqual([])
+  })
+})

--- a/apps/questura/apps/server/src/features/payments/lib/stripe-api-version.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/stripe-api-version.ts
@@ -1,0 +1,19 @@
+import type Stripe from 'stripe'
+
+/**
+ * The Stripe API version every client in this repo talks.
+ *
+ * `current_period_end` lives on the subscription item in this version
+ * (ADR-0008). An unpinned client follows whatever the installed SDK defaults
+ * to after an upgrade, `getSubscriptionPeriodSeconds` starts returning nulls,
+ * and every member loses access. Bumping this is a deliberate, reviewed change.
+ *
+ * It lives in its own module, apart from `stripe.ts`, because the batch scripts
+ * need it and `stripe.ts` pulls in `APP_CONFIG` — importing that from a script
+ * would drag boot-time env validation into a process that supplies its own key.
+ * A leaf with a single type-only import can be shared by anything.
+ *
+ * Every Stripe client must pass it. `stripe-api-version.test.ts` fails the
+ * build if a new `new Stripe(...)` appears without one.
+ */
+export const STRIPE_API_VERSION: Stripe.LatestApiVersion = '2025-08-27.basil'

--- a/apps/questura/apps/server/src/features/payments/lib/stripe.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/stripe.ts
@@ -2,14 +2,13 @@ import Stripe from 'stripe'
 import { APP_CONFIG } from '@/shared/config'
 
 /**
- * Pin the Stripe API version the SDK was typed against.
- *
- * `current_period_end` lives on the subscription item in this version
- * (ADR-0008). An unpinned client follows whatever the installed SDK defaults
- * to after an upgrade, and `getPeriod` starts returning nulls — every member
- * loses access. Bumping this is a deliberate, reviewed change.
+ * The pinned API version, defined in `stripe-api-version.ts` and re-exported
+ * here so existing importers keep working. The batch scripts import the leaf
+ * directly rather than this module, which would pull `APP_CONFIG` in with it.
  */
-export const STRIPE_API_VERSION: Stripe.LatestApiVersion = '2025-08-27.basil'
+import { STRIPE_API_VERSION } from './stripe-api-version'
+
+export { STRIPE_API_VERSION }
 
 /**
  * Bound a single Stripe request so one hung call cannot hold a whole request.


### PR DESCRIPTION
## What

Four scripts built a Stripe client with no `apiVersion`:

- `scripts/reconcile-stripe-visitor-profiles.ts`
- `scripts/audit-access-revocations.ts`
- `scripts/verify-stripe-webhook-events.ts`
- `scripts/capture-membership-fixtures.ts`

The app client pins `2025-08-27.basil` (`stripe.ts`) because `current_period_end` moved onto the subscription item in that version (ADR-0008).

## Why it matters

The first of those is what `pnpm reconcile:nightly` runs — unattended, with apply on. A `pnpm up stripe` moves the scripts' API version and leaves the app's pinned. `getSubscriptionPeriodSeconds` then returns `{null, null}` and the job writes `paidThroughAt: null` over live members, capped at 25 a night by the blast radius guard, with nothing to notice it.

Latent today: `node_modules/stripe/cjs/apiVersion.js` currently exports the same string.

## How

- New leaf `src/features/payments/lib/stripe-api-version.ts` holds the constant. Separate from `stripe.ts` so a script can import it without pulling in `APP_CONFIG` and its boot-time env validation.
- `stripe.ts` re-exports it — no importer changes.
- All four scripts pass `{ apiVersion: STRIPE_API_VERSION, typescript: true }`.
- `stripe-api-version.test.ts` scans `src/` and `scripts/` and fails on any `new Stripe(` without an `apiVersion`.

## Verification

- `vitest run src/features/payments` — 391 passed, 27 files
- `tsc --noEmit` — clean
- Guard test confirmed failing before the fix (it caught this file's own doc comment, which is why it strips comments first)

No runtime behaviour change; the scripts now send the version the app already sends.