### PR TITLE
Keep a refund revocation when an unrelated dispute is won

### DIFF
--- a/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lifecycle-simulation.test.ts
@@ -598,6 +598,32 @@ describe('refunds and disputes', () => {
     expect(entitled()).toBe(false)
   })
 
+  it('S14: a won dispute does not lift a later period\'s refund revocation', async () => {
+    // Two periods on one subscription: January is disputed, February is refunded
+    // in full. A revocation is three scalar metadata keys, so February's
+    // overwrites January's -- and clearing on the won January dispute used to
+    // take February's with it, handing back access to a refunded period.
+    const januaryEnd = now() - 2 * DAY
+    const sub = makeSub('sub_A', { latest_invoice: 'in_2' })
+    store.subs.set(sub.id, sub)
+    store.invoices.set('in_1', makeInvoice('in_1', { lines: { data: [{ period: { end: januaryEnd } }] } }))
+    store.invoices.set('in_2', makeInvoice('in_2', { billing_reason: 'subscription_cycle' }))
+    store.charges.set('ch_in_1', { id: 'ch_in_1', invoice: 'in_1', refunded: false, payment_intent: 'pi_in_1' })
+    store.charges.set('ch_in_2', { id: 'ch_in_2', invoice: 'in_2', refunded: true, payment_intent: 'pi_in_2' })
+    db['visitor-profiles'][0].stripeSubscriptionId = 'sub_A'
+    db['visitor-profiles'][0].subscriptionStatus = 'active'
+
+    await deliver('charge.dispute.created', { id: 'dp_1', charge: 'ch_in_1', status: 'needs_response' })
+    await deliver('charge.refunded', store.charges.get('ch_in_2'))
+    expect(entitled()).toBe(false)
+
+    await deliver('charge.dispute.closed', { id: 'dp_1', charge: 'ch_in_1', status: 'won' })
+
+    expect(store.subs.get('sub_A')!.metadata.access_revoked).toBe('true')
+    expect(store.subs.get('sub_A')!.metadata.access_revoked_reason).toBe('refund')
+    expect(entitled()).toBe(false)
+  })
+
   it('S13: a paid period after a refunded one lifts the revocation', async () => {
     const start = now() - 60
     const sub = makeSub('sub_A', {

--- a/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/handlers/charge-revocation.ts
@@ -5,6 +5,7 @@ import { resyncSubscription } from '@/payments/lib/subscription-resync'
 import {
   ACCESS_REVOKED_REASON_DISPUTE,
   ACCESS_REVOKED_REASON_REFUND,
+  readAccessRevocation,
   type AccessRevocation,
   type AccessRevokedReason,
 } from '@/payments/lib/subscription-state'
@@ -154,6 +155,41 @@ export async function handleDisputeCreated(dispute: Stripe.Dispute) {
 }
 
 /**
+ * The revocation on the subscription right now, when it is not the one this
+ * dispute wrote.
+ *
+ * A revocation is three scalar metadata keys, so a subscription only ever holds
+ * the most recent one. Clearing on a won dispute therefore clears whatever is
+ * there — including a revocation some *later* event wrote for a different
+ * period. The order that does damage: a dispute opens on January's charge, then
+ * February's charge is refunded in full and overwrites the flag, then the
+ * January dispute is won and lifts the refund's revocation with it. The visitor
+ * keeps access to a period they were given their money back for, and
+ * `clearRefundRevocationOnNewPeriod` cannot help — it only ever clears.
+ *
+ * The dispute's own revocation is recognised by reason *and* period end, so a
+ * second dispute still open on another period is held onto too. Anything that
+ * is not this dispute's stays, and the resync re-reads it rather than being
+ * handed a null.
+ *
+ * One extra retrieve, only on the restoring path.
+ */
+async function revocationOutlivingThisDispute(
+  subscriptionId: string,
+  disputedPeriodEnd: number | null
+): Promise<AccessRevocation | null> {
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+  const current = readAccessRevocation(subscription)
+
+  if (!current) return null
+  if (current.reason === ACCESS_REVOKED_REASON_DISPUTE && current.periodEnd === disputedPeriodEnd) {
+    return null
+  }
+
+  return current
+}
+
+/**
  * Resolve a dispute: restore the membership, or end the arrangement with it.
  *
  * A won dispute clears the flag and leaves the subscription alone — that is why
@@ -195,6 +231,26 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute) {
 
   const restore = RESTORE_ON_DISPUTE_STATUS.has(dispute.status)
   const lost = dispute.status === DISPUTE_STATUS_LOST
+  const disputedPeriodEnd = invoicePeriod(invoice).end
+
+  const outliving = restore
+    ? await revocationOutlivingThisDispute(subscriptionId, disputedPeriodEnd)
+    : null
+
+  if (outliving) {
+    logger.warn('Won dispute left the membership revoked; a later event revoked it again', {
+      disputeId: dispute.id,
+      subscriptionId,
+      status: dispute.status,
+      heldReason: outliving.reason,
+      heldPeriodEnd: outliving.periodEnd,
+    })
+
+    // The flag on Stripe is already the one to keep, so the resync re-reads it
+    // rather than being handed anything.
+    await resyncSubscription(subscriptionId)
+    return
+  }
 
   logger.info(
     restore
@@ -211,9 +267,7 @@ export async function handleDisputeClosed(dispute: Stripe.Dispute) {
 
   await markAccessRevoked(
     subscriptionId,
-    restore
-      ? null
-      : { reason: ACCESS_REVOKED_REASON_DISPUTE, periodEnd: invoicePeriod(invoice).end },
+    restore ? null : { reason: ACCESS_REVOKED_REASON_DISPUTE, periodEnd: disputedPeriodEnd },
     // The money is gone for good, so the subscription must stop charging for it.
     { cancelSubscription: lost }
   )


### PR DESCRIPTION
## The bug

A revocation is three scalar metadata keys on the Stripe subscription — `access_revoked`, `_reason`, `_period_end`. A subscription only ever holds the most recent one.

`handleDisputeClosed` cleared all three on `won` / `warning_closed`, so a won dispute lifted whatever revocation happened to be there — including one a **later, unrelated** event wrote.

Damaging order:

1. Dispute opens on January's charge → flag = `dispute`, periodEnd = Jan
2. February's charge is refunded in full → flag overwritten = `refund`, periodEnd = Feb, subscription cancelled
3. January dispute closes `won` → flag cleared entirely → **access restored to a period the visitor was refunded for**

`clearRefundRevocationOnNewPeriod` cannot correct this; it only ever clears.

## The fix

The restoring path reads the subscription first and recognises *its own* revocation by reason **and** period end. Anything else stays put, and the resync re-reads the flag rather than being handed a `null`.

A second dispute still open on a different period is held onto for the same reason.

Cost: one `subscriptions.retrieve`, only on the restoring path.

## Verification

`S14` added to `lifecycle-simulation.test.ts` — the end-to-end harness that drives the real webhook route, real handlers, real resync, real state derivation (per the file's own docstring, and the harness that caught the ownership-guard bug in #324).

Confirmed non-vacuous: with the handler change stashed, S14 fails with `expected true to be false` — `entitled()` returns true on the refunded period.

- `vitest run src/features/payments` — 390 passed, 26 files
- `tsc --noEmit` — clean

## Note on the general shape

The durable fix is keying revocations by charge/invoice (a JSON list) instead of three scalars. That is a bigger change with a metadata migration; this scopes the clear correctly without one.