### PR TITLE
Do not 500 a member because two of their requests raced

### DIFF
--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.test.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.test.ts
@@ -84,6 +84,33 @@ describe('Visitor profile system helpers', () => {
     })
   })
 
+  it('returns the winner\'s profile when a concurrent request created it first', async () => {
+    // `authUserId` is unique, so the losing create is refused. The row it wanted
+    // exists, so this is not an error to hand back to `/api/me` -- a 500 there
+    // reads as anonymous on the client and shows a member the paywall.
+    payload.find
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [{ id: 7, authUserId: 'auth_123' }] })
+    payload.create.mockRejectedValue(new Error('duplicate key value violates unique constraint'))
+
+    const profile = await ensureVisitorProfileForAuthUser({
+      id: 'auth_123',
+      email: 'visitor@example.com',
+      name: 'Ada Lovelace',
+    })
+
+    expect(profile).toEqual({ id: 7, authUserId: 'auth_123' })
+  })
+
+  it('rethrows a create failure that is not a lost race', async () => {
+    payload.find.mockResolvedValue({ docs: [] })
+    payload.create.mockRejectedValue(new Error('connection terminated'))
+
+    await expect(
+      ensureVisitorProfileForAuthUser({ id: 'auth_123', email: 'visitor@example.com', name: '' })
+    ).rejects.toThrow('connection terminated')
+  })
+
   it('updates existing VisitorProfiles with system access', async () => {
     payload.find.mockResolvedValue({
       docs: [{ id: 42, authUserId: 'auth_123' }],

--- a/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.ts
+++ b/apps/questura/apps/server/src/features/visitor-auth/lib/visitor-profile.ts
@@ -65,6 +65,31 @@ export async function updateVisitorProfileByAuthUserId(
   })
 }
 
+/**
+ * Find the visitor's profile, creating it if this is the first time we see them.
+ *
+ * Find-then-create is not atomic, and nothing serialises it: two authenticated
+ * requests landing together on a visitor who has no profile yet both read
+ * nothing and both create. `authUserId` is `unique`, so the second create is
+ * refused — correctly, and that is the constraint doing its job.
+ *
+ * What was wrong is that the refusal propagated. `resolveVisitorPrincipal` calls
+ * this on every authenticated request that finds no profile, and a throw there
+ * 500s the payments routes; on the client, `useGatedFullArticle` reads any
+ * `/api/me` failure as anonymous, so a paying member gets the paywall because
+ * two of their own requests raced.
+ *
+ * The losing create is not an error to report — the row it wanted exists. So a
+ * failed create re-reads, and returns the winner's row if one appeared. Any
+ * failure that is *not* a lost race leaves the re-read empty and the original
+ * error is rethrown unchanged, because the error shape is not sniffed: Payload
+ * raises its own `ValidationError` for a duplicate it catches itself and a
+ * Postgres `23505` for one the database catches, and guessing which is how
+ * `isInvalidRequestError` came to match nothing a real client throws.
+ *
+ * The window is narrow — sign-up and the OAuth callback already create the
+ * profile in an after hook, so this only fires when it is genuinely missing.
+ */
 export async function ensureVisitorProfileForAuthUser(user: BetterAuthUser) {
   const existing = await findVisitorProfileByAuthUserId(user.id)
   if (existing) return existing
@@ -72,16 +97,23 @@ export async function ensureVisitorProfileForAuthUser(user: BetterAuthUser) {
   const payload = await getPayload({ config })
   const { firstName, lastName } = splitDisplayName(user.name)
 
-  return payload.create({
-    collection: 'visitor-profiles',
-    data: {
-      authUserId: user.id,
-      email: normalizeEmail(user.email),
-      firstName,
-      lastName,
-      subscriptionStatus: 'none',
-      cancelAtPeriodEnd: false,
-    },
-    overrideAccess: true,
-  })
+  try {
+    return await payload.create({
+      collection: 'visitor-profiles',
+      data: {
+        authUserId: user.id,
+        email: normalizeEmail(user.email),
+        firstName,
+        lastName,
+        subscriptionStatus: 'none',
+        cancelAtPeriodEnd: false,
+      },
+      overrideAccess: true,
+    })
+  } catch (error) {
+    const winner = await findVisitorProfileByAuthUserId(user.id)
+    if (winner) return winner
+
+    throw error
+  }
 }


### PR DESCRIPTION
## The bug

`ensureVisitorProfileForAuthUser` (`features/visitor-auth/lib/visitor-profile.ts`) is find-then-create with nothing serialising it. Two authenticated requests arriving together for a visitor who has no profile yet both read nothing and both create. `authUserId` is `unique: true`, so the database refuses the second — correctly.

The refusal propagated. `resolveVisitorPrincipal` calls this on every authenticated request that finds no profile, `/api/me` has no try/catch, and `requireVisitorPrincipal` is called outside the try on some payments paths.

The visible outcome is worse than a 500: `useGatedFullArticle` reads *any* `/api/me` failure as anonymous, so a paying member gets shown the paywall because two of their own requests raced.

## The fix

A failed create re-reads and returns the winner's row.

The error shape is deliberately **not** sniffed. Payload raises its own `ValidationError` for a duplicate it catches, Postgres raises `23505` for one the database catches — and guessing which is exactly how `isInvalidRequestError` in `access-revocation.ts` came to match nothing a real client throws. If the re-read finds nothing, the original error is rethrown unchanged, so a connection failure still fails.

## Scope

Narrow trigger: sign-up and the OAuth callback already create the profile in an after hook, so this only fires when the profile is genuinely missing.

`/api/me`'s own error handling is not touched here — that goes with the origin-guard change in the next PR.

## Verification

- `vitest run src/features/visitor-auth` — 144 passed, 14 files
- `tsc --noEmit` — clean
- Two new tests: the lost race returns the winner's row; a non-race failure rethrows