### PR TITLE
State the allowed origins on /api/me like every other cookie route

### DIFF
--- a/apps/questura/apps/server/src/app/api/cookie-auth-origin-guard.test.ts
+++ b/apps/questura/apps/server/src/app/api/cookie-auth-origin-guard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+/**
+ * Every route that identifies its caller from the session cookie must state its
+ * allowed origins.
+ *
+ * The rule is written down in `payments/subscription-details/route.ts`, and it
+ * was written down because the alternative — arguing each route separately on
+ * how hard it would be to read cross-origin — is how `/api/me` ended up being
+ * the one identity route without the guard. "Hard to exploit" is not the
+ * guarantee the others give.
+ *
+ * A route is cookie-authenticated if it imports `current-principal`. That is
+ * the module that turns a cookie into a visitor, so importing it is the honest
+ * signal, and a new route cannot opt out of this test without also opting out
+ * of knowing who the caller is.
+ */
+const API_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)))
+
+function routeFiles(dir: string): string[] {
+  const found: string[] = []
+
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+
+    if (statSync(full).isDirectory()) {
+      found.push(...routeFiles(full))
+      continue
+    }
+
+    if (entry === 'route.ts' || entry === 'route.tsx') found.push(full)
+  }
+
+  return found
+}
+
+function cookieAuthRoutesWithoutOriginGuard(): string[] {
+  return routeFiles(API_ROOT)
+    .filter((file) => {
+      const source = readFileSync(file, 'utf8')
+      return source.includes('current-principal') && !source.includes('forbiddenOriginResponse')
+    })
+    .map((file) => path.relative(API_ROOT, file))
+}
+
+describe('cookie-authenticated API routes', () => {
+  it('all call forbiddenOriginResponse', () => {
+    expect(cookieAuthRoutesWithoutOriginGuard()).toEqual([])
+  })
+
+  it('finds the routes it claims to scan', () => {
+    // Without this the test above passes just as happily when the walk is
+    // pointed at the wrong directory and finds nothing at all.
+    const scanned = routeFiles(API_ROOT).filter((file) =>
+      readFileSync(file, 'utf8').includes('current-principal')
+    )
+
+    expect(scanned.length).toBeGreaterThanOrEqual(7)
+  })
+})

--- a/apps/questura/apps/server/src/app/api/me/route.ts
+++ b/apps/questura/apps/server/src/app/api/me/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { getPrivateCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
+import { forbiddenOriginResponse, getPrivateCorsHeaders, handleCorsOptions } from '@/shared/utils/cors'
 import { getCurrentPrincipal } from '@/features/visitor-auth/lib/current-principal'
 
 /**
@@ -14,11 +14,21 @@ import { getCurrentPrincipal } from '@/features/visitor-auth/lib/current-princip
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
+  const corsHeaders = getPrivateCorsHeaders(req)
+
+  // The last cookie-authenticated identity route that skipped this.
+  // `subscription-details` states the rule it was added under: a route that
+  // authenticates from an ambient cookie and answers with one visitor's state
+  // declares its allowed origins, rather than each route being argued about
+  // separately. Cross-origin reads are already blocked here by the unreflected
+  // `Access-Control-Allow-Origin`, so this closes a gap in the rule rather than
+  // a live hole — which is the point: the rule is what survives the next route.
+  const blocked = forbiddenOriginResponse(req, corsHeaders)
+  if (blocked) return blocked
+
   const principal = await getCurrentPrincipal(req.headers)
 
-  return NextResponse.json(principal, {
-    headers: getPrivateCorsHeaders(req),
-  })
+  return NextResponse.json(principal, { headers: corsHeaders })
 }
 
 export async function OPTIONS(req: NextRequest) {


### PR DESCRIPTION
## What

`/api/me` was the only cookie-authenticated identity route without `forbiddenOriginResponse`.

The rule it now follows is written down in `payments/subscription-details/route.ts`: a route that authenticates from an ambient cookie and answers with one visitor's own state declares its allowed origins, rather than each route being argued about separately.

## Is it a live hole?

No. Cross-origin reads are already blocked by the unreflected `Access-Control-Allow-Origin`. This is consistency — but "hard to exploit" is not the guarantee the other six routes give, and arguing each route separately is exactly how this one got missed.

## The durable half

`src/app/api/cookie-auth-origin-guard.test.ts` walks every `route.ts` under `src/app/api`, treats importing `current-principal` as the signal that a route identifies its caller from the cookie, and fails on any such route missing the guard. A new route cannot opt out without also opting out of knowing who is calling.

A second case asserts the walk finds at least 7 routes, so the first cannot pass by scanning nothing.

Current cookie-authenticated routes (all now guarded):

- `payments/create-checkout-session`
- `payments/create-portal-session`
- `payments/cancel-subscription`
- `payments/reactivate-subscription`
- `payments/subscription-details`
- `public/articles/full`
- `me`

## Verification

- `vitest run src/app` — 38 passed, 4 files
- `tsc --noEmit` — clean