### PR TITLE
Cut locked prose out of a gated item's JSON-LD

### DIFF
--- a/apps/questura/apps/server/src/features/articles/public/freeSample.ts
+++ b/apps/questura/apps/server/src/features/articles/public/freeSample.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/shared/utils/logger'
 import type { ArticleCollectionSlug } from './serializeArticleBlocks'
 
 /**
@@ -77,13 +78,101 @@ function blockTypeOf(block: unknown): string {
  * Callers must have already decided that this reader gets a sample. Calling it
  * for an entitled member would truncate content they are allowed to read.
  */
+/**
+ * The longest string a Gated item's JSON-LD may carry.
+ *
+ * Legitimate structured data on these items is metadata: a headline, a
+ * description, URLs, names, a `cssSelector`. None of that runs long. Locked
+ * prose does, and the only way it reaches JSON-LD is a pipeline or an editor
+ * putting it there. 1000 characters is several times the longest honest field
+ * and a small fraction of any real body.
+ */
+const MAX_STRUCTURED_DATA_STRING = 1000
+
+/**
+ * Keys that are body text by definition, dropped at any length.
+ *
+ * `articleBody` is schema.org's own name for the whole article; `text` is the
+ * generic equivalent. A short one is a truncated body, not a safe one.
+ */
+const STRUCTURED_DATA_BODY_KEYS = new Set(['articleBody', 'text'])
+
+/**
+ * Remove locked prose from a Gated item's JSON-LD, in place.
+ *
+ * `seoSection.structuredData` is a free-form `json` field emitted whole by
+ * `by-id` and `by-canonical-path`, and the Sample rule did not touch it. It is
+ * the one part of a Gated response carrying arbitrary editor-supplied text past
+ * the enforcement point — so the day a pipeline or an editor writes
+ * `articleBody` into JSON-LD, the paywall is bypassed with no code change and
+ * nothing to notice.
+ *
+ * It lives inside `applySampleRule` rather than in `gatePublicArticle` because
+ * there are two enforcement surfaces, not one: the public reader routes and
+ * Payload's own REST/GraphQL mounts via `gateExternalApiRead`. Anonymous
+ * `GET /api/articles` handing over complete paid bodies (fixed 2026-08-16) is
+ * what that second surface costs when a rule lands on only one caller. Both go
+ * through here, and so does anything added later.
+ *
+ * Stripping the field wholesale would be wrong: ADR-0009 requires the
+ * paywalled-content markup (`isAccessibleForFree: false` plus `hasPart` with a
+ * `cssSelector`) to survive, and it is what keeps a short sample from reading
+ * as thin content to Search. The shape is kept; only the long strings go.
+ */
+function stripLockedProseFromStructuredData(doc: Record<string, unknown>): string[] {
+  const seo = doc.seoSection
+  if (!seo || typeof seo !== 'object') return []
+
+  const structuredData = (seo as Record<string, unknown>).structuredData
+  if (!structuredData || typeof structuredData !== 'object') return []
+
+  const removed: string[] = []
+
+  const walk = (node: unknown, path: string) => {
+    if (Array.isArray(node)) {
+      node.forEach((entry, index) => walk(entry, `${path}[${index}]`))
+      return
+    }
+
+    if (!node || typeof node !== 'object') return
+
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      const here = path ? `${path}.${key}` : key
+
+      if (typeof value === 'string') {
+        if (STRUCTURED_DATA_BODY_KEYS.has(key) || value.length > MAX_STRUCTURED_DATA_STRING) {
+          delete (node as Record<string, unknown>)[key]
+          removed.push(here)
+        }
+        continue
+      }
+
+      walk(value, here)
+    }
+  }
+
+  walk(structuredData, '')
+
+  return removed
+}
+
 export function applySampleRule(
   collection: ArticleCollectionSlug,
   doc: Record<string, unknown>,
   limits: SampleLimits = DEFAULT_SAMPLE_LIMITS,
 ): SampleOutcome {
-  if (collection === 'articles') return sampleArticle(doc, limits)
-  if (collection === 'listicle-itineraries') return sampleItinerary(doc)
+  if (collection === 'articles' || collection === 'listicle-itineraries') {
+    const removed = stripLockedProseFromStructuredData(doc)
+    if (removed.length > 0) {
+      logger.warn("Removed body-length text from a gated item's structured data", {
+        collection,
+        id: doc.id,
+        keys: removed,
+      })
+    }
+
+    return collection === 'articles' ? sampleArticle(doc, limits) : sampleItinerary(doc)
+  }
 
   // Single-type listicles are never gated. Reached only if a caller ignores
   // that, so it removes nothing rather than inventing a rule for a collection

--- a/apps/questura/apps/server/src/features/articles/public/gateExternalApiRead.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/gateExternalApiRead.test.ts
@@ -106,4 +106,32 @@ describe('gateExternalApiRead', () => {
 
     expect(doc.gate).toBeUndefined()
   })
+  it("strips locked prose from a gated item's structured data over REST", () => {
+    // Surface parity. `seoSection.structuredData` is free-form JSON emitted
+    // whole, and a rule that lands on only one of the two enforcement surfaces
+    // is what let anonymous `GET /api/articles` hand over paid bodies until
+    // 2026-08-16. The strip lives in `applySampleRule`, so both callers get it.
+    const doc: Record<string, unknown> = {
+      access: 'member',
+      contentBlocks: blocks(9),
+      seoSection: {
+        structuredData: {
+          '@type': 'Article',
+          headline: 'Three days in Lima',
+          isAccessibleForFree: false,
+          articleBody: 'z'.repeat(5000),
+        },
+      },
+    }
+
+    read(hook, doc, { payloadAPI: 'REST' })
+
+    const jsonLd = (doc.seoSection as Record<string, unknown>).structuredData as Record<
+      string,
+      unknown
+    >
+    expect(jsonLd.articleBody).toBeUndefined()
+    expect(jsonLd.headline).toBe('Three days in Lima')
+    expect(jsonLd.isAccessibleForFree).toBe(false)
+  })
 })

--- a/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.test.ts
+++ b/apps/questura/apps/server/src/features/articles/public/gatePublicArticle.test.ts
@@ -98,4 +98,93 @@ describe('gatePublicArticle', () => {
     expect(free.gate).toBeDefined()
     expect(gated.gate).toBeDefined()
   })
+  describe("a gated item's structured data", () => {
+    const gatedWithJsonLd = (structuredData: unknown): Record<string, unknown> => ({
+      access: 'member',
+      contentBlocks: blocks(9),
+      seoSection: { structuredData },
+    })
+
+    const jsonLdOf = (doc: Record<string, unknown>) =>
+      (doc.seoSection as Record<string, unknown>).structuredData as Record<string, unknown>
+
+    it('drops articleBody at any length', () => {
+      // Body text by definition. A short one is a truncated body, not a safe one.
+      const doc = gatedWithJsonLd({ '@type': 'Article', articleBody: 'the whole piece' })
+
+      gatePublicArticle('articles', doc)
+
+      expect(jsonLdOf(doc).articleBody).toBeUndefined()
+      expect(jsonLdOf(doc)['@type']).toBe('Article')
+    })
+
+    it('drops a body-length string under any key', () => {
+      const doc = gatedWithJsonLd({ '@type': 'Article', notes: 'x'.repeat(1001) })
+
+      gatePublicArticle('articles', doc)
+
+      expect(jsonLdOf(doc).notes).toBeUndefined()
+    })
+
+    it('keeps the paywall markup ADR-0009 needs for indexability', () => {
+      // Stripping the field wholesale would cost the `isAccessibleForFree` /
+      // `hasPart` markup that keeps a short sample from reading as thin content.
+      const doc = gatedWithJsonLd({
+        '@type': 'Article',
+        headline: 'Three days in Lima',
+        isAccessibleForFree: false,
+        hasPart: {
+          '@type': 'WebPageElement',
+          isAccessibleForFree: false,
+          cssSelector: '.paywalled',
+        },
+        articleBody: 'y'.repeat(5000),
+      })
+
+      gatePublicArticle('articles', doc)
+
+      expect(jsonLdOf(doc)).toEqual({
+        '@type': 'Article',
+        headline: 'Three days in Lima',
+        isAccessibleForFree: false,
+        hasPart: {
+          '@type': 'WebPageElement',
+          isAccessibleForFree: false,
+          cssSelector: '.paywalled',
+        },
+      })
+    })
+
+    it('reaches prose nested in arrays', () => {
+      const doc = gatedWithJsonLd({
+        '@type': 'ItemList',
+        itemListElement: [{ '@type': 'ListItem', name: 'Day 1', text: 'the locked day' }],
+      })
+
+      gatePublicArticle('listicle-itineraries', doc)
+
+      const list = jsonLdOf(doc).itemListElement as Array<Record<string, unknown>>
+      expect(list[0].text).toBeUndefined()
+      expect(list[0].name).toBe('Day 1')
+    })
+
+    it('leaves a free item alone', () => {
+      // Free items are not sampled, so nothing about them is locked.
+      const doc: Record<string, unknown> = {
+        access: 'free',
+        contentBlocks: blocks(3),
+        seoSection: { structuredData: { articleBody: 'all of it, deliberately' } },
+      }
+
+      gatePublicArticle('articles', doc)
+
+      expect(jsonLdOf(doc).articleBody).toBe('all of it, deliberately')
+    })
+
+    it('tolerates a gated item with no structured data at all', () => {
+      const doc: Record<string, unknown> = { access: 'member', contentBlocks: blocks(9) }
+
+      expect(() => gatePublicArticle('articles', doc)).not.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
## The gap

`seoSection.structuredData` is a free-form `json` field on both paid collections. It is emitted whole by `articles/by-id` and `articles/by-canonical-path`, and `applySampleRule` never touched it.

Nothing writes `articleBody` there **today** — I checked. The exposure is that nothing has to change in this repo for it to become a full paywall bypass: one pipeline or one editor putting body text into JSON-LD, and the locked remainder ships to every anonymous caller with no code change and nothing to notice it.

## Where the fix lives, and why

Inside `applySampleRule`, not `gatePublicArticle`.

ADR-0009 says there are **two** enforcement surfaces: this app's public reader routes, and Payload's own REST/GraphQL mounts via `gateExternalApiRead`. A rule that lands on one caller is exactly what let anonymous `GET /api/articles?where[access][equals]=member` hand over complete paid bodies until 2026-08-16. Both surfaces go through the sample rule, so both get this, and so does anything added later.

## Not a wholesale strip

ADR-0009 requires the paywalled-content markup to survive — `isAccessibleForFree: false` plus `hasPart` with a `cssSelector` — because it is what keeps a short sample from reading as thin content to Search, and what makes the paywall legible rather than accidental.

So the shape is kept and only long strings go:

| Rule | Removed |
|---|---|
| `articleBody`, `text` | any length — a short one is a truncated body, not a safe one |
| any other key | over 1000 chars — several times the longest honest field (headline, description, cssSelector, URLs) |

Arrays are walked, so prose nested in an `itemListElement` goes too. Each removal logs its key path. Free items are untouched.

## Verification

- `vitest run src/features/articles/public` — 60 passed, 10 files
- `tsc --noEmit` — clean
- 7 new tests, including one asserting the ADR-0009 markup survives intact, and one on the REST surface for parity