### PR TITLE
Write down what is left before real customers, and what was decided against

### DIFF
--- a/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
+++ b/apps/questura/apps/server/src/app/api/payments/webhooks/stripe/route.ts
@@ -182,9 +182,17 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ received: true, duplicate: true })
       }
 
-      // Ordering guard: Stripe does not guarantee delivery order. If we've
-      // already processed a newer event for this subscription, don't let this
-      // older event overwrite that state.
+      // Ordering guard: Stripe does not guarantee delivery order. If we have
+      // already processed a newer event for this subscription, do not let this
+      // older one overwrite that state.
+      //
+      // Its resolution is one second, and the comparison is strict, so two
+      // events for one subscription in the same second get no protection from
+      // it at all. That is survivable only because of ADR-0008: every handler
+      // refetches the subscription from Stripe rather than reading the event
+      // payload, so the loser of a same-second race still writes current state.
+      // This guard saves the refetch and the write; it is not what makes the
+      // outcome correct, and it must not be relied on as if it were.
       const subscriptionId = getSubscriptionIdFromEvent(event)
 
       if (subscriptionId) {

--- a/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
+++ b/apps/questura/apps/server/src/features/payments/lib/membership-plans.test.ts
@@ -162,6 +162,14 @@ describe('getMembershipPlans', () => {
   })
 
   it('hits Stripe on every call rather than serving a per-process cache', async () => {
+    // A per-process cache was here and was removed on purpose (e8a69d1d): it
+    // disagreed across instances, and checkout never used it, so it protected
+    // the display path only. Re-adding it has been proposed since on the
+    // grounds that two `prices.retrieve` per pricing-page view share Stripe's
+    // rate budget with webhook processing. That budget is already defended the
+    // way that commit chose -- a per-visitor limit alongside the per-IP one --
+    // and nothing has been observed throttling a webhook. Reverse this only
+    // with a measurement, not an argument.
     stubStripePrices(givenMonthly(), givenYearly())
 
     const first = await getMembershipPlans()

--- a/apps/questura/apps/server/src/features/payments/webhooks/event-retention.ts
+++ b/apps/questura/apps/server/src/features/payments/webhooks/event-retention.ts
@@ -8,6 +8,17 @@ import type { getPayload } from 'payload'
  * state. Stripe stops retrying after about three days. After that the row is
  * only taking space. 30 days keeps dashboard "resend this event" replays
  * deduped without letting the table grow forever.
+ *
+ * Past 30 days a Dashboard resend runs its handler again, since the row that
+ * would have deduped it is gone. Every handler refetches from Stripe and
+ * mirrors what it finds, so they converge on a second run — with two
+ * exceptions that mutate Stripe rather than mirror it: `charge.refunded`
+ * rewrites the revocation flag and re-attempts a cancel, and `charge.dispute.*`
+ * does the same. Both are effectively idempotent — the flag is rewritten to the
+ * same values and `cancelRefundedSubscription` tolerates an already-cancelled
+ * subscription — so this is a thing to know before resending an old event, not
+ * a defect. Raising the window would trade table growth for a guarantee we do
+ * not currently need.
  */
 
 export const WEBHOOK_EVENT_RETENTION_DAYS = 30

--- a/apps/questura/docs/serverless-launch-checklist.md
+++ b/apps/questura/docs/serverless-launch-checklist.md
@@ -1,0 +1,122 @@
+# Serverless launch checklist
+
+What has to be true before the site takes money from someone who is not the
+owner. The Linux laptop is a live-like test environment with an expiry date
+(`infra/softprod/README.md`); this is the list of things that do not travel
+with the repository and must be redone on the real platform.
+
+**Nothing here is a code change.** The payments code is audited and the known
+correctness gaps are closed. Every item below is configuration, and every item
+below is a real blocker — the site is not launchable with any of them open.
+
+## 0. Choose the platform first
+
+Six of the seven items resolve from one decision, so make it before starting.
+`TRUSTED_PROXY` (item 2) only recognises `cloudflare`, `vercel`, `netlify` and
+`fly` (`src/shared/config/trusted-proxy.ts`); anything else needs its header
+added there, deliberately, with the reasoning that file already sets out.
+
+## 1. Charge the catalog price
+
+**Blocker. The site advertises $12.99/month and $79.99/year and Checkout
+currently takes $0.50/month.** That mismatch is deliberate while the laptop is
+the test runtime, and it stops being defensible the moment a stranger can buy.
+
+Point the price env at the catalog IDs and restart:
+
+```
+STRIPE_PRICE_ID=price_1U4P3aBUOUSxLiOZfKskTKeO
+STRIPE_PRICE_ID_MONTHLY=price_1U4P3aBUOUSxLiOZfKskTKeO
+STRIPE_PRICE_ID_YEARLY=price_1U4P3bBUOUSxLiOZMGh7ZrJL
+```
+
+`getPurchasablePlan` verifies each against `MEMBERSHIP_CATALOG` at request time
+and refuses a price that bills on the wrong interval, in the wrong currency, or
+above the catalog amount. A refused plan is a 400 on Checkout and a missing
+entry on `/api/payments/plans`, with the reason in the server log.
+
+Full rule and the switch both ways: `docs/membership-pricing.md`.
+
+Note that the nav Subscribe button copy (`Join: $1.54/wk`) is hardcoded and is
+not driven by any of this. Check it still reads correctly against the catalog
+price; do not wire it to Stripe.
+
+## 2. Set `TRUSTED_PROXY` before the first deploy, not after
+
+**Blocker, and order-sensitive.** Production refuses to boot without it
+(`assertProductionConfig`), which is the good failure. The bad one is setting it
+to the wrong platform: the rate limiters then identify callers from a header
+the caller writes, and every limit is bypassable. Reading `X-Forwarded-For`
+first was a *verified live* rate-limit bypass, not a theoretical one.
+
+Set it to the platform actually terminating the request, and keep the origin
+unreachable except through that proxy — the header says nothing about a caller
+who reaches the origin directly.
+
+## 3. Rotate `PAYLOAD_SECRET` and `BETTER_AUTH_SECRET`
+
+The laptop's secrets have lived on a machine that is deliberately slept, closed
+and eventually retired. Generate new ones for the real platform. Rotating
+invalidates existing sessions — do it at cutover, not after visitors have
+signed in.
+
+## 4. Move the database
+
+The live DB is `questura` on port 5433 inside the `questura-postgres` container
+on the laptop. The Mac's local Postgres is stale scratch and is not a source of
+truth for anything.
+
+- Provision managed Postgres on the chosen platform
+- Dump and restore, then run `pnpm db:migrate` and confirm `db:migrate:status`
+- Check row counts on `locations`, `articles`, `media_assets`, `media_sets`,
+  `users`, `visitor_profiles` and the `visitor_auth_*` tables against the source
+- **Set up real backups.** What exists today is one 1.8 MB `pg_dump -Fc` sitting
+  on the same disk as the database it came from, taken by hand. That is not a
+  backup, and after launch it is customer data.
+
+Media is on Bunny and does not move with the database.
+
+## 5. Repoint the Stripe webhook endpoint
+
+New origin means a new endpoint, a new signing secret, and the event list has
+to be set explicitly.
+
+- Create the endpoint on the new domain, set `STRIPE_WEBHOOK_SECRET`
+- Enable every event in `handled-events.ts`
+- Run `pnpm verify:stripe-webhook-events` and read the output
+
+The `charge.*` events were never enabled on the current endpoint, so refund and
+dispute revocation was dead code in live Stripe until 2026-08-16. It was
+invisible because a webhook that is never delivered looks exactly like a webhook
+with nothing to do. Verify rather than assume.
+
+## 6. Schedule the nightly reconcile
+
+`pnpm reconcile:nightly` has no home on a serverless platform — there is no
+long-lived machine to run the timer. Pick the platform's scheduler.
+
+It runs with apply on and a blast cap of 25 profiles. Confirm it is scheduled,
+that it holds the same per-customer advisory lock the webhooks take, and that
+its output goes somewhere a person will read.
+
+## 7. Narrow the live Stripe key
+
+The current `rk_live` was widened deliberately for the build phase, with the
+owner's approval, on the understanding that it would be narrowed at this
+cutover. Issue a key scoped to what the app actually calls and replace it.
+Do not ship the build-phase key.
+
+---
+
+## Not blockers — decided, do not re-open
+
+Audits keep re-proposing these. Each was looked at and settled; reverse one only
+with new evidence, not a fresh argument.
+
+| Item | Where | Decision |
+|---|---|---|
+| Cache `/api/payments/plans` | `membership-plans.test.ts` | Removed on purpose in `e8a69d1d` — disagreed across instances, checkout never used it. The rate-budget concern was answered in that same commit with per-visitor limits. |
+| One-second ordering guard | `webhooks/stripe/route.ts` | Real, and survivable: every handler refetches from Stripe (ADR-0008), so a same-second loser still writes current state. Comment now says so. |
+| Webhook resend past 30 days | `event-retention.ts` | Handlers converge on a second run; the two that mutate Stripe are idempotent in effect. Know it before resending an old event. |
+| Nav Subscribe button copy | `SubscribeButton.tsx` | Hardcoded on purpose. Not driven from Stripe or `/api/payments/plans`. |
+| Advertised price vs laptop charge | `docs/membership-pricing.md` | Intentional until item 1 above. Never sync the UI down to $0.50. |


### PR DESCRIPTION
## Why

The payments audit is closed on the code side (#359, #360, #361, #362, #363). What remains between here and taking money from someone who is not the owner is **all configuration**, none of which travels with the repository — so it was living in one person's head.

## `docs/serverless-launch-checklist.md`

Seven items, each a real blocker:

1. **Charge the catalog price** — the site advertises $12.99/$79.99, Checkout takes $0.50/month. Deliberate while the laptop is the test runtime; indefensible the moment a stranger can buy.
2. **Set `TRUSTED_PROXY` before the first deploy** — order-sensitive. Boot fails without it (good). The bad failure is the wrong value: reading `X-Forwarded-For` first was a *verified live* rate-limit bypass.
3. **Rotate `PAYLOAD_SECRET` / `BETTER_AUTH_SECRET`** — at cutover, since it invalidates sessions.
4. **Move the database, and give it a real backup** — what exists is one hand-taken `pg_dump -Fc` on the same disk as the database it came from. After launch that is customer data.
5. **Repoint and verify the Stripe webhook endpoint** — the `charge.*` events were never enabled on the current one, so refund and dispute revocation was dead in live Stripe until 2026-08-16. Verify, don't assume.
6. **Schedule the nightly reconcile** — no long-lived machine on serverless.
7. **Narrow the live Stripe key** — widened deliberately for the build phase, on the understanding it gets narrowed here.

## The half that saves the most time

A "decided, do not re-open" table. Audits keep re-proposing settled things — the plans cache most of all, removed deliberately in `e8a69d1d` and proposed again since on grounds that commit had already answered.

## Three inline corrections

Recording decisions, no behaviour change:

- **Ordering guard comment** (`webhooks/stripe/route.ts`) — reads stronger than the guard is. One-second resolution, strict comparison, so two events in the same second get nothing from it. Survivable only because every handler refetches from Stripe (ADR-0008). The comment now says that instead of implying the guard is what makes the outcome correct.
- **`membership-plans.test.ts`** — the "no per-process cache" test now carries *why*, so the next reader sees a decision rather than an oversight.
- **`event-retention.ts`** — what a Dashboard resend past 30 days actually does.

## Verification

- `vitest run src/features/payments src/app` — 430 passed, 31 files
- `tsc --noEmit` — clean