### PR TITLE
Unify account security controls

### DIFF
--- a/apps/questura/apps/client/src/features/AccountPage/components/ConnectedAccounts/ConnectedAccountsSection.tsx
+++ b/apps/questura/apps/client/src/features/AccountPage/components/ConnectedAccounts/ConnectedAccountsSection.tsx
@@ -1,4 +1,5 @@
 import { User } from '@/lib/user/types';
+import { accountActionLinkClassName, accountGuidanceClassName } from '../account.styles';
 
 interface ConnectedAccountsSectionProps {
   user: User | null;
@@ -43,19 +44,13 @@ export function ConnectedAccountsSection({ user, onLinkGoogle, onUnlinkGoogle, s
               <button
                 onClick={onUnlinkGoogle}
                 disabled={!canUnlinkGoogle}
-                className="
-                  text-[0.82rem] text-[#c62828] hover:text-[#b71c1c]
-                  underline underline-offset-2 cursor-pointer
-                  transition-colors 480:ml-4 flex-shrink-0
-                  mt-2 480:mt-0 self-start 480:self-auto
-                  disabled:text-[#c4c2be] disabled:cursor-not-allowed
-                "
+                className={`${accountActionLinkClassName} 480:ml-4 flex-shrink-0 mt-2 480:mt-0 self-start 480:self-auto`}
               >
                 Disconnect
               </button>
             </div>
             {!canUnlinkGoogle && (
-              <p className="mb-4 text-[0.78rem] text-[#C65D3B]">
+              <p className={`${accountGuidanceClassName} mb-4`}>
                 Add a password before disconnecting Google.
               </p>
             )}

--- a/apps/questura/apps/client/src/features/AccountPage/components/Email/EmailSection.tsx
+++ b/apps/questura/apps/client/src/features/AccountPage/components/Email/EmailSection.tsx
@@ -1,5 +1,6 @@
 import { User } from '@/lib/user/types';
 import { useRouter } from 'next/navigation';
+import { accountActionLinkClassName, accountGuidanceClassName } from '../account.styles';
 
 interface EmailSectionProps {
   user: User | null;
@@ -11,7 +12,7 @@ export function EmailSection({ user }: EmailSectionProps) {
   const canChangeEmail = hasPassword && !user?.hasGoogleOAuth;
 
   return (
-    <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-4 480:p-6 768:p-8">
+    <div>
       <div className="flex flex-col 480:flex-row 480:justify-between 480:items-start">
         <div className="flex-1 min-w-0">
           <h3 className="font-display text-[1rem] 480:text-[1.1rem] text-[#1A1A1A] mb-1.5 768:text-[1.2rem]">
@@ -24,12 +25,12 @@ export function EmailSection({ user }: EmailSectionProps) {
             {user?.email}
           </div>
           {!hasPassword && (
-            <p className="text-[0.75rem] 480:text-[0.78rem] text-[#C65D3B]">
+            <p className={accountGuidanceClassName}>
               You must add a password to your account before changing your email.
             </p>
           )}
           {hasPassword && user?.hasGoogleOAuth && (
-            <p className="text-[0.75rem] 480:text-[0.78rem] text-[#C65D3B]">
+            <p className={accountGuidanceClassName}>
               Disconnect Google before changing your email.
             </p>
           )}
@@ -37,18 +38,18 @@ export function EmailSection({ user }: EmailSectionProps) {
         {canChangeEmail ? (
           <button
             onClick={() => router.push('/account/change-email')}
-            className="
-              text-[0.82rem] text-[#6b6a68] hover:text-[#1A1A1A]
-              underline underline-offset-2 480:ml-4 cursor-pointer
-              transition-colors mt-3 480:mt-0 self-start
-            "
+            className={`${accountActionLinkClassName} 480:ml-4 mt-3 480:mt-0 self-start`}
           >
             Edit
           </button>
         ) : (
-          <span className="text-[0.82rem] text-[#c4c2be] 480:ml-4 cursor-not-allowed mt-3 480:mt-0 self-start">
+          <button
+            type="button"
+            disabled
+            className={`${accountActionLinkClassName} 480:ml-4 mt-3 480:mt-0 self-start`}
+          >
             Edit
-          </span>
+          </button>
         )}
       </div>
     </div>

--- a/apps/questura/apps/client/src/features/AccountPage/components/Password/PasswordSection.tsx
+++ b/apps/questura/apps/client/src/features/AccountPage/components/Password/PasswordSection.tsx
@@ -7,6 +7,7 @@ import { useAddPasswordMutation } from '@/features/AccountPage/hooks/useAccountM
 import PasswordStrengthIndicator from '@/features/Auth/components/PasswordStrengthIndicator';
 import { validatePasswordRequirements, isPasswordValid } from '@/features/Auth/lib/auth-utils';
 import { isServiceUnavailableError } from '@/lib/api';
+import { accountActionLinkClassName } from '../account.styles';
 
 function AccountPasswordInput({
   label,
@@ -143,7 +144,7 @@ export function PasswordSection({ user, passwordSuccess, passwordError, onClearP
   const isOAuthOnly = user?.authProvider !== 'local' && user?.authProvider !== 'dual';
 
   return (
-    <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-4 480:p-6 768:p-8">
+    <div className="mt-5 pt-5 border-t border-[#d7d4ce] 480:mt-6 480:pt-6 768:mt-8 768:pt-8">
       <div className="flex flex-col 480:flex-row 480:justify-between 480:items-start">
         <div className="flex-1 min-w-0">
           <h3 className="font-display text-[1rem] 480:text-[1.1rem] text-[#1A1A1A] mb-1.5 768:text-[1.2rem]">
@@ -206,11 +207,7 @@ export function PasswordSection({ user, passwordSuccess, passwordError, onClearP
                 setShowForm(true);
               }
             }}
-            className="
-              text-[0.82rem] text-[#6b6a68] hover:text-[#1A1A1A]
-              underline underline-offset-2 480:ml-4 cursor-pointer
-              transition-colors whitespace-nowrap mt-3 480:mt-0 self-start
-            "
+            className={`${accountActionLinkClassName} 480:ml-4 whitespace-nowrap mt-3 480:mt-0 self-start`}
           >
             {!isOAuthOnly ? 'Change password' : 'Set password'}
           </button>

--- a/apps/questura/apps/client/src/features/AccountPage/components/account.styles.ts
+++ b/apps/questura/apps/client/src/features/AccountPage/components/account.styles.ts
@@ -1,0 +1,9 @@
+export const accountActionLinkClassName = `
+  text-[0.82rem] text-[#6b6a68] hover:text-[#1A1A1A]
+  underline underline-offset-2 cursor-pointer transition-colors
+  disabled:text-[#c4c2be] disabled:hover:text-[#c4c2be]
+  disabled:cursor-not-allowed
+`;
+
+export const accountGuidanceClassName =
+  'text-[0.75rem] 480:text-[0.78rem] text-[#2563EB] leading-[1.5]';

--- a/apps/questura/apps/client/src/features/AccountPage/pages/AccountPage.tsx
+++ b/apps/questura/apps/client/src/features/AccountPage/pages/AccountPage.tsx
@@ -76,14 +76,16 @@ function AccountContent() {
       {/* ── Sections ── */}
       <section className="px-4 480:px-6 pt-6 480:pt-10 pb-16 768:pt-12 768:pb-20">
         <div className="max-w-2xl mx-auto space-y-4 480:space-y-5 768:space-y-6">
-          <EmailSection user={user} />
+          <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-4 480:p-6 768:p-8">
+            <EmailSection user={user} />
 
-          <PasswordSection
-            user={user}
-            passwordSuccess={passwordSuccess}
-            passwordError={passwordError}
-            onClearPasswordMessages={clearPasswordMessages}
-          />
+            <PasswordSection
+              user={user}
+              passwordSuccess={passwordSuccess}
+              passwordError={passwordError}
+              onClearPasswordMessages={clearPasswordMessages}
+            />
+          </div>
 
           <ConnectedAccountsSection
             user={user}


### PR DESCRIPTION
## Why
Account credential controls looked like unrelated cards and used conflicting colors/styles across account states.

## What
- group Email and Password into one credential card
- use blue for prerequisite guidance
- centralize styling for Edit, Set/Change password, and Disconnect
- preserve disabled semantics

## Verification
- `pnpm typecheck`
- `pnpm test` (27 passed)
- `git diff --check`