### PR TITLE
Drop stale dark: variants so OS dark mode cannot restyle Questura

### DIFF
--- a/apps/questura/apps/client/src/app/(private)/(auth)/auth-callback-close/page.tsx
+++ b/apps/questura/apps/client/src/app/(private)/(auth)/auth-callback-close/page.tsx
@@ -73,28 +73,30 @@ function AuthCallbackCloseContent() {
   }, [searchParams]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-md w-full text-center space-y-4 p-6">
-        <div className="mx-auto h-12 w-12 bg-green-100 rounded-full flex items-center justify-center">
-          {closing ? (
-            <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
-          ) : (
-            <div className="animate-spin h-6 w-6 border-2 border-green-600 border-t-transparent rounded-full"></div>
-          )}
+    <div className="min-h-screen flex items-center justify-center px-5">
+      <div className="w-full max-w-md">
+        <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-8 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-[#e8f5e9] rounded-full mb-4">
+            {closing ? (
+              <svg className="w-6 h-6 text-[#2e7d32]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <div className="w-6 h-6 border-2 border-[#2e7d32] border-t-transparent rounded-full animate-spin" />
+            )}
+          </div>
+          <h2 className="font-display text-[1.35rem] text-[#1A1A1A] mb-2">
+            {closing ? 'Success!' : 'Processing...'}
+          </h2>
+          <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65]">
+            {closing
+              ? 'Authentication complete. This window will close automatically.'
+              : 'Please wait while we complete your authentication.'}
+          </p>
+          <p className="mt-3 text-[0.78rem] text-[#9a9894]">
+            You can close this window if it doesn&apos;t close automatically.
+          </p>
         </div>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-          {closing ? 'Success!' : 'Processing...'}
-        </h2>
-        <p className="text-gray-600 dark:text-gray-400">
-          {closing
-            ? 'Authentication complete. This window will close automatically.'
-            : 'Please wait while we complete your authentication.'}
-        </p>
-        <p className="text-sm text-gray-500 dark:text-gray-500">
-          You can close this window if it doesn&apos;t close automatically.
-        </p>
       </div>
     </div>
   );

--- a/apps/questura/apps/client/src/app/error.tsx
+++ b/apps/questura/apps/client/src/app/error.tsx
@@ -18,50 +18,54 @@ export default function Error({
   }, [error]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
-      <div className="max-w-md w-full text-center space-y-4">
-        <div className="mx-auto h-12 w-12 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center">
-          <svg
-            className="h-6 w-6 text-red-600 dark:text-red-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 9v2m0 4v2m0 0a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-        </div>
+    <div className="min-h-screen flex items-center justify-center px-5">
+      <div className="w-full max-w-md">
+        <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-8 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-[#fce4ec] rounded-full mb-4">
+            <svg
+              className="w-6 h-6 text-[#c62828]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4v2m0 0a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
 
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          <h1 className="font-display text-[1.35rem] text-[#1A1A1A]">
             Something went wrong
           </h1>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          <p className="mt-2 text-[0.88rem] text-[#6b6a68] leading-[1.65]">
             We encountered an unexpected error. Please try again.
           </p>
+
+          {process.env.NODE_ENV === 'development' && error.message && (
+            <details className="mt-4 text-left">
+              <summary className="cursor-pointer text-[0.82rem] text-[#9a9894] hover:text-[#1A1A1A]">
+                Error details (development only)
+              </summary>
+              <pre className="mt-2 p-3 bg-white border border-[#e5e2dc] rounded-sm text-xs overflow-auto text-[#c62828]">
+                {error.message}
+              </pre>
+            </details>
+          )}
+
+          <button
+            onClick={() => reset()}
+            className="
+              mt-6 w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+              text-white text-center py-3.5 rounded
+              text-[0.88rem] font-medium transition-colors
+            "
+          >
+            Try again
+          </button>
         </div>
-
-        {process.env.NODE_ENV === 'development' && error.message && (
-          <details className="mt-4 text-left">
-            <summary className="cursor-pointer text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300">
-              Error details (development only)
-            </summary>
-            <pre className="mt-2 p-3 bg-gray-100 dark:bg-gray-800 rounded text-xs overflow-auto text-red-600 dark:text-red-400">
-              {error.message}
-            </pre>
-          </details>
-        )}
-
-        <button
-          onClick={() => reset()}
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:ring-offset-gray-900"
-        >
-          Try again
-        </button>
       </div>
     </div>
   );

--- a/apps/questura/apps/client/src/app/not-found.tsx
+++ b/apps/questura/apps/client/src/app/not-found.tsx
@@ -2,26 +2,30 @@ import Link from 'next/link';
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
-      <div className="max-w-md w-full text-center space-y-4">
-        <div className="space-y-2">
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
+    <div className="min-h-screen flex items-center justify-center px-5">
+      <div className="w-full max-w-md">
+        <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-8 text-center">
+          <h1 className="font-display text-[2.1rem] text-[#1A1A1A]">
             404
           </h1>
-          <p className="text-xl font-semibold text-gray-700 dark:text-gray-300">
+          <p className="mt-2 font-display text-[1.15rem] text-[#1A1A1A]">
             Page Not Found
           </p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="mt-2 text-[0.88rem] text-[#6b6a68] leading-[1.65] mb-6">
             The page you&apos;re looking for doesn&apos;t exist or has been moved.
           </p>
-        </div>
 
-        <Link
-          href="/"
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:ring-offset-gray-900"
-        >
-          Return to Home
-        </Link>
+          <Link
+            href="/"
+            className="
+              inline-block w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+              text-white text-center py-3.5 rounded
+              text-[0.88rem] font-medium transition-colors
+            "
+          >
+            Return to Home
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/apps/questura/apps/client/src/components/layout/PasswordResetModal.tsx
+++ b/apps/questura/apps/client/src/components/layout/PasswordResetModal.tsx
@@ -34,77 +34,80 @@ export default function PasswordResetModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[60] overflow-y-auto">
-      {/* Background overlay */}
-      <div
-        className="fixed inset-0 bg-black/30 transition-opacity"
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-5">
+      <button
+        type="button"
+        className="absolute inset-0 bg-[#1A1A1A]/60"
         onClick={onClose}
-        aria-hidden="true"
-      ></div>
+        aria-label="Close password reset"
+      />
 
-      {/* Modal container */}
-      <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center 640:block 640:p-0">
-        <span className="hidden 640:inline-block 640:align-middle 640:h-screen" aria-hidden="true">&#8203;</span>
+      <div
+        className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm max-w-md w-full p-6 480:p-8 relative"
+        role="dialog"
+      >
+        <button
+          type="button"
+          className="absolute top-4 right-4 text-[#9a9894] hover:text-[#1A1A1A] transition-colors cursor-pointer"
+          onClick={onClose}
+        >
+          <span className="sr-only">Close</span>
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
 
-        {/* Modal content */}
-        <div className="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all 640:my-8 640:align-middle 640:max-w-md 640:w-full 640:p-6 relative z-[60] pointer-events-auto" role="dialog">
-          <div className="absolute top-0 right-0 pt-4 pr-4 z-10">
-            <button
-              type="button"
-              className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
-              onClick={onClose}
-            >
-              <span className="sr-only">Close</span>
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
+        <h3 className="font-display text-[1.15rem] text-[#1A1A1A] mb-2 768:text-[1.25rem]">
+          Reset Password
+        </h3>
+        <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65] mb-6">
+          {sent
+            ? "Check your email for a password reset link."
+            : "We'll email you a secure link to choose a new password."}
+        </p>
 
-          <div className="640:flex 640:items-start">
-            <div className="w-full mt-3 text-center 640:mt-0 640:text-left">
-              <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-2">
-                Reset Password
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-                {sent
-                  ? "Check your email for a password reset link."
-                  : "We'll email you a secure link to choose a new password."}
+        {sent ? (
+          <button
+            type="button"
+            className="
+              w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+              text-white text-center py-3 rounded
+              text-[0.88rem] font-medium transition-colors
+            "
+            onClick={onClose}
+          >
+            Done
+          </button>
+        ) : (
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <input
+              type="email"
+              value={email}
+              readOnly
+              className="
+                w-full px-3.5 py-2.5 border border-[#e5e2dc] rounded-sm
+                text-[0.88rem] text-[#1A1A1A] bg-white
+              "
+            />
+            {resetRequest.error && (
+              <p className="text-[0.84rem] text-[#c62828]">
+                {resetRequest.error.message}
               </p>
-
-              {sent ? (
-                <button
-                  type="button"
-                  className="w-full rounded-lg bg-[#468BE6] px-4 py-3 text-sm font-medium text-white hover:bg-[#1A5799]"
-                  onClick={onClose}
-                >
-                  Done
-                </button>
-              ) : (
-                <form className="space-y-4" onSubmit={handleSubmit}>
-                  <input
-                    type="email"
-                    value={email}
-                    readOnly
-                    className="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-3 text-sm text-black"
-                  />
-                  {resetRequest.error && (
-                    <p className="text-sm text-red-600">
-                      {resetRequest.error.message}
-                    </p>
-                  )}
-                  <button
-                    type="submit"
-                    disabled={resetRequest.isPending}
-                    className="w-full rounded-lg bg-[#468BE6] px-4 py-3 text-sm font-medium text-white hover:bg-[#1A5799] disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {resetRequest.isPending ? 'Sending...' : 'Send reset link'}
-                  </button>
-                </form>
-              )}
-            </div>
-          </div>
-        </div>
+            )}
+            <button
+              type="submit"
+              disabled={resetRequest.isPending}
+              className="
+                w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+                text-white text-center py-3 rounded
+                text-[0.88rem] font-medium transition-colors
+                disabled:opacity-50 disabled:cursor-not-allowed
+              "
+            >
+              {resetRequest.isPending ? 'Sending...' : 'Send reset link'}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/apps/questura/apps/client/src/components/shared/ui/LoadingSpinner.tsx
+++ b/apps/questura/apps/client/src/components/shared/ui/LoadingSpinner.tsx
@@ -24,17 +24,17 @@ export default function LoadingSpinner({
 
   if (variant === 'fullscreen') {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen flex items-center justify-center px-5">
         <div className="max-w-md w-full text-center space-y-4">
-          <LoaderCircle 
-            className="animate-spin mx-auto text-blue-500" 
+          <LoaderCircle
+            className="animate-spin mx-auto text-[#2C2C2C]"
             size={sizeMap[size]}
           />
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          <h2 className="font-display text-[1.35rem] text-[#1A1A1A]">
             {message}
           </h2>
           {subMessage && (
-            <p className="text-gray-600 dark:text-gray-400">
+            <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65]">
               {subMessage}
             </p>
           )}
@@ -45,8 +45,8 @@ export default function LoadingSpinner({
 
   if (variant === 'inline') {
     return (
-      <LoaderCircle 
-        className={`animate-spin text-blue-600 ${className}`}
+      <LoaderCircle
+        className={`animate-spin text-[#2C2C2C] ${className}`}
         size={sizeMap[size]}
       />
     );
@@ -54,13 +54,13 @@ export default function LoadingSpinner({
 
   return (
     <div className={`text-center ${className}`}>
-      <LoaderCircle 
-        className="animate-spin mx-auto text-blue-600" 
+      <LoaderCircle
+        className="animate-spin mx-auto text-[#2C2C2C]"
         size={sizeMap[size]}
       />
-      <p className="mt-4 text-gray-600 dark:text-gray-400">{message}</p>
+      <p className="mt-4 text-[0.88rem] text-[#6b6a68]">{message}</p>
       {subMessage && (
-        <p className="mt-2 text-sm text-gray-500 dark:text-gray-500">{subMessage}</p>
+        <p className="mt-2 text-[0.78rem] text-[#9a9894]">{subMessage}</p>
       )}
     </div>
   );

--- a/apps/questura/apps/client/src/components/shared/ui/PasswordInput.tsx
+++ b/apps/questura/apps/client/src/components/shared/ui/PasswordInput.tsx
@@ -1,6 +1,6 @@
 /**
- * Reusable password input component with show/hide toggle
- * Matches the design from Auth forms
+ * Reusable password input with show/hide toggle.
+ * Matches the account / email-change form fields.
  */
 
 import { useState, type ChangeEvent } from 'react';
@@ -41,7 +41,7 @@ export default function PasswordInput({
       {label && (
         <label
           htmlFor={id || name}
-          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          className="block text-[0.82rem] font-medium text-[#4f4e4b] mb-1.5"
         >
           {label}
         </label>
@@ -53,11 +53,15 @@ export default function PasswordInput({
           type={showPassword ? "text" : "password"}
           autoComplete={autoComplete}
           required={required}
-          className={`appearance-none rounded-lg relative block w-full px-3 py-3 pr-16 border ${
-            error
-              ? 'border-red-300 dark:border-red-600'
-              : 'border-gray-300 dark:border-gray-600'
-          } placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white bg-white dark:bg-gray-800 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 640:text-sm ${className || ''}`}
+          className={`
+            w-full px-3.5 py-2.5 pr-14 border rounded-sm
+            text-[0.88rem] text-[#1A1A1A] placeholder-[#c4c2be]
+            bg-white transition-colors
+            focus:outline-none focus:border-[#1A1A1A]
+            disabled:opacity-50
+            ${error ? 'border-[#f8bbd0]' : 'border-[#d7d4ce]'}
+            ${className || ''}
+          `}
           placeholder={placeholder}
           value={value}
           onChange={onChange}
@@ -67,14 +71,14 @@ export default function PasswordInput({
         <button
           type="button"
           onClick={() => setShowPassword(!showPassword)}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-sm font-medium text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 cursor-pointer z-20"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-[0.78rem] text-[#6b6a68] hover:text-[#1A1A1A] transition-colors cursor-pointer z-20"
           tabIndex={-1}
         >
           {showPassword ? 'Hide' : 'Show'}
         </button>
       </div>
       {error && (
-        <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+        <p className="mt-1.5 text-[0.84rem] text-[#c62828]">
           {error}
         </p>
       )}

--- a/apps/questura/apps/client/src/features/Auth/components/form/PasswordStep.tsx
+++ b/apps/questura/apps/client/src/features/Auth/components/form/PasswordStep.tsx
@@ -149,15 +149,15 @@ export default function PasswordStep({
         </div>
 
         {errorMessage && (
-          <div className="mt-4 rounded-md bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 p-4">
+          <div className="mt-4 rounded-sm bg-[#fff3e0] border border-[#ffe0b2] p-4">
             <div className="flex">
               <div className="flex-shrink-0">
-                <svg className="h-5 w-5 text-orange-400" viewBox="0 0 20 20" fill="currentColor">
+                <svg className="h-5 w-5 text-[#e65100]" viewBox="0 0 20 20" fill="currentColor">
                   <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
                 </svg>
               </div>
               <div className="ml-3">
-                <p className="text-sm text-orange-800 dark:text-orange-200">
+                <p className="text-[0.84rem] text-[#e65100]">
                   {errorMessage}
                 </p>
               </div>

--- a/apps/questura/apps/client/src/features/Auth/pages/AuthErrorPage.tsx
+++ b/apps/questura/apps/client/src/features/Auth/pages/AuthErrorPage.tsx
@@ -62,12 +62,12 @@ function AuthErrorContent() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 640:px-6 1024:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div className="text-center">
-          <div className="mx-auto flex items-center justify-center h-16 w-16 rounded-full bg-red-100 dark:bg-red-900/20">
+    <div className="min-h-screen flex items-center justify-center px-5 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-8 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-[#fce4ec] rounded-full mb-4">
             <svg
-              className="h-8 w-8 text-red-600 dark:text-red-400"
+              className="w-6 h-6 text-[#c62828]"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -80,43 +80,53 @@ function AuthErrorContent() {
               />
             </svg>
           </div>
-          
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white">
+
+          <h2 className="font-display text-[1.35rem] text-[#1A1A1A] mb-4">
             Authentication Error
           </h2>
-          
-          <div className="mt-4 p-4 rounded-md bg-red-50 dark:bg-red-900/20">
-            <p className="text-sm text-red-800 dark:text-red-200">
+
+          <div className="mb-6 p-3 bg-[#fce4ec] border border-[#f8bbd0] rounded-sm text-left">
+            <p className="text-[0.84rem] text-[#c62828] leading-[1.65]">
               {error}
             </p>
           </div>
-        </div>
 
-        <div className="mt-8 space-y-4">
-          <button
-            onClick={handleGoToLogin}
-            className="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors cursor-pointer"
-          >
-            Go to Sign In
-          </button>
-          
-          <button
-            onClick={handleGoToSignup}
-            className="w-full flex justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors cursor-pointer"
-          >
-            Create New Account
-          </button>
-          
-          <button
-            onClick={handleGoHome}
-            className="w-full flex justify-center py-3 px-4 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors cursor-pointer"
-          >
-            Go to Homepage
-          </button>
-        </div>
+          <div className="space-y-3">
+            <button
+              onClick={handleGoToLogin}
+              className="
+                w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+                text-white text-center py-3 rounded
+                text-[0.88rem] font-medium transition-colors cursor-pointer
+              "
+            >
+              Go to Sign In
+            </button>
 
-        <div className="mt-6 text-center">
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+            <button
+              onClick={handleGoToSignup}
+              className="
+                w-full bg-white border border-[#d7d4ce]
+                text-[#4f4e4b] text-center py-3 rounded
+                text-[0.88rem] font-medium transition-colors
+                hover:bg-[#f0efeb] cursor-pointer
+              "
+            >
+              Create New Account
+            </button>
+
+            <button
+              onClick={handleGoHome}
+              className="
+                w-full text-[0.82rem] text-[#6b6a68] hover:text-[#1A1A1A]
+                underline underline-offset-2 cursor-pointer transition-colors py-2
+              "
+            >
+              Go to Homepage
+            </button>
+          </div>
+
+          <p className="mt-6 text-[0.78rem] text-[#9a9894]">
             If you continue to experience issues, please contact support.
           </p>
         </div>
@@ -128,10 +138,10 @@ function AuthErrorContent() {
 export default function AuthErrorPage() {
   return (
     <SuspenseBoundary fallback={
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-screen flex items-center justify-center px-5">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading...</p>
+          <div className="w-8 h-8 border-2 border-[#9a9894] border-t-transparent rounded-full animate-spin mx-auto" />
+          <p className="mt-4 text-[0.88rem] text-[#6b6a68]">Loading...</p>
         </div>
       </div>
     }>

--- a/apps/questura/apps/client/src/features/Auth/pages/AuthPage.tsx
+++ b/apps/questura/apps/client/src/features/Auth/pages/AuthPage.tsx
@@ -8,6 +8,64 @@ import { queryKeys } from '@/lib/react-query';
 import { isPopupWindow } from '@/features/Auth/lib/auth-utils';
 import { getSafeRedirectPath, parseSafeUserData } from '@/lib/validations';
 
+function AuthStatusCard({
+  tone,
+  title,
+  body,
+  hint,
+}: {
+  tone: 'success' | 'loading' | 'error';
+  title: string;
+  body: string;
+  hint?: string;
+}) {
+  const iconWrap =
+    tone === 'success'
+      ? 'bg-[#e8f5e9]'
+      : tone === 'error'
+        ? 'bg-[#fce4ec]'
+        : 'bg-white border border-[#e5e2dc]';
+  const iconColor =
+    tone === 'success'
+      ? 'text-[#2e7d32]'
+      : tone === 'error'
+        ? 'text-[#c62828]'
+        : 'text-[#6b6a68]';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-5">
+      <div className="w-full max-w-md">
+        <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-8 text-center">
+          <div className={`inline-flex items-center justify-center w-12 h-12 rounded-full mb-4 ${iconWrap}`}>
+            {tone === 'loading' ? (
+              <div className="w-6 h-6 border-2 border-[#9a9894] border-t-transparent rounded-full animate-spin" />
+            ) : tone === 'success' ? (
+              <svg className={`w-6 h-6 ${iconColor}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg className={`w-6 h-6 ${iconColor}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            )}
+          </div>
+          <h2 className="font-display text-[1.35rem] text-[#1A1A1A] mb-2">
+            {title}
+          </h2>
+          <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65]">
+            {body}
+          </p>
+          {hint ? (
+            <p className="mt-3 text-[0.78rem] text-[#9a9894]">
+              {hint}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function AuthPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams() ?? new URLSearchParams();
@@ -125,63 +183,33 @@ function AuthPageContent() {
   // Show popup closing message (prevents showing /account page in popup)
   if (isPopupClosing) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="max-w-md w-full text-center space-y-4">
-          <div className="mx-auto h-12 w-12 bg-green-100 rounded-full flex items-center justify-center">
-            <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
-          </div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Success!
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            Authentication complete. This window will close automatically.
-          </p>
-          <p className="text-sm text-gray-500 dark:text-gray-500">
-            You can close this window if it doesn&apos;t close automatically.
-          </p>
-        </div>
-      </div>
+      <AuthStatusCard
+        tone="success"
+        title="Success!"
+        body="Authentication complete. This window will close automatically."
+        hint="You can close this window if it doesn't close automatically."
+      />
     );
   }
 
   if (isProcessing) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="max-w-md w-full text-center space-y-4">
-          <div className="animate-spin mx-auto h-12 w-12 border-4 border-blue-500 border-t-transparent rounded-full"></div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Processing authentication...
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            Please wait while we complete your sign-in.
-          </p>
-        </div>
-      </div>
+      <AuthStatusCard
+        tone="loading"
+        title="Processing authentication..."
+        body="Please wait while we complete your sign-in."
+      />
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="max-w-md w-full text-center space-y-4">
-          <div className="mx-auto h-12 w-12 bg-red-100 rounded-full flex items-center justify-center">
-            <svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </div>
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            Authentication Failed
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            {error}
-          </p>
-          <p className="text-sm text-gray-500 dark:text-gray-500">
-            Redirecting to login page...
-          </p>
-        </div>
-      </div>
+      <AuthStatusCard
+        tone="error"
+        title="Authentication Failed"
+        body={error}
+        hint="Redirecting to login page..."
+      />
     );
   }
 
@@ -192,12 +220,11 @@ function AuthPageContent() {
 export default function AuthPage() {
   return (
     <SuspenseBoundary fallback={
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading...</p>
-        </div>
-      </div>
+      <AuthStatusCard
+        tone="loading"
+        title="Loading..."
+        body="Please wait."
+      />
     }>
       <AuthPageContent />
     </SuspenseBoundary>

--- a/apps/questura/apps/client/src/features/Payments/components/MembershipGuard.tsx
+++ b/apps/questura/apps/client/src/features/Payments/components/MembershipGuard.tsx
@@ -23,20 +23,28 @@ export default function MembershipGuard({ user, children, fallback }: Membership
   }
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-8">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-          You&apos;re Already a Member!
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400 mb-6">
-          You already have an active membership. Visit your account to manage your settings.
-        </p>
-        <Link
-          href="/account"
-          className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-        >
-          Go to Account
-        </Link>
+    <div className="min-h-screen">
+      <div className="px-6 pt-8 pb-16 480:pt-10 768:pt-12">
+        <div className="max-w-xl mx-auto">
+          <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-6 480:p-8 text-center">
+            <h1 className="font-display text-[1.35rem] text-[#1A1A1A] mb-2 480:text-[1.55rem]">
+              You&apos;re Already a Member!
+            </h1>
+            <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65] mb-6">
+              You already have an active membership. Visit your account to manage your settings.
+            </p>
+            <Link
+              href="/account"
+              className="
+                inline-block w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+                text-white text-center py-3.5 rounded
+                text-[0.88rem] font-medium transition-colors
+              "
+            >
+              Go to Account
+            </Link>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/PurchasePage.tsx
@@ -43,7 +43,7 @@ export default function PurchasePage({
   if (loading) {
     return (
       <div className="flex justify-center items-center min-h-screen">
-        <div className="text-lg">Loading...</div>
+        <div className="text-[0.88rem] text-[#6b6a68]">Loading...</div>
       </div>
     );
   }
@@ -81,121 +81,136 @@ export default function PurchasePage({
 
   return (
     <MembershipGuard user={user}>
-      <div className="max-w-2xl mx-auto px-4 py-8">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
-          <div className="text-center mb-8">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-              Complete Your Purchase
-            </h1>
-            <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg mb-6">
-              <h2 className="text-xl font-semibold text-blue-900 dark:text-blue-100 mb-2">
-                {planName}
-              </h2>
-              <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">
+      <div className="min-h-screen">
+        <div className="px-6 pt-8 pb-16 480:pt-10 768:pt-12">
+          <div className="max-w-xl mx-auto">
+            <div className="mb-8">
+              <h1 className="font-display text-[1.35rem] text-[#1A1A1A] 480:text-[1.55rem] 768:text-[1.75rem]">
+                Complete Your Purchase
+              </h1>
+            </div>
+
+            <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-6 480:p-8">
+              <div className="bg-white border border-[#e5e2dc] rounded-sm p-4 mb-6">
+                <h2 className="font-display text-[1.1rem] text-[#1A1A1A] mb-1">
+                  {planName}
+                </h2>
+                <p className="font-display text-[1.35rem] text-[#1A1A1A]">
+                  {saving ? (
+                    <span className="mr-2 text-[1rem] font-normal text-[#9a9894] line-through">
+                      {saving.compareAt}
+                    </span>
+                  ) : null}
+                  {priceLabel ?? (pricingLoading ? 'Loading price…' : 'Price unavailable')}
+                </p>
                 {saving ? (
-                  <span className="mr-2 text-lg font-normal text-blue-700/70 line-through dark:text-blue-300/70">
-                    {saving.compareAt}
-                  </span>
-                ) : null}
-                {priceLabel ?? (pricingLoading ? 'Loading price…' : 'Price unavailable')}
-              </p>
-              {saving ? (
-                <p className="text-sm font-medium text-green-700 dark:text-green-400">
-                  Save {saving.saved} ({saving.percentOff}% off)
-                </p>
-              ) : null}
-              <p className="text-blue-700 dark:text-blue-300 text-sm">
-                {planDescription}
-              </p>
-            </div>
-          </div>
-
-          {!isAuthenticated ? (
-            <div>
-              <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4 text-center">
-                {authFormState.showPasswordStep
-                  ? (authFormState.isSignUp ? 'Create Account To Complete Purchase' : 'Log In To Complete Purchase')
-                  : 'Sign In To Complete Your Purchase'}
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6 text-center">
-                {authFormState.showPasswordStep
-                  ? (authFormState.isSignUp
-                      ? 'Set up your password to create your account and proceed to checkout.'
-                      : 'Enter your password to sign in and proceed to checkout.')
-                  : 'If you have an account, you will be asked to sign in with your password. If not, the provided email address will be used to create a new account.'}
-              </p>
-
-              <EnhancedAuthForm inModal={true} onSuccess={handleAuthSuccess} onModeChange={handleAuthFormStateChange} />
-            </div>
-          ) : (
-            <div>
-              <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-6 text-center">
-                Complete Your Payment
-              </h3>
-
-              <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg mb-6">
-                <h4 className="font-medium text-gray-900 dark:text-white mb-2">Account Details</h4>
-                <p className="text-gray-700 dark:text-gray-300">
-                  <span className="font-medium">Email:</span> {user?.email}
-                </p>
-                {user?.kind === 'visitor' && user.firstName && user.lastName && (
-                  <p className="text-gray-700 dark:text-gray-300">
-                    <span className="font-medium">Name:</span> {user.firstName} {user.lastName}
+                  <p className="mt-1 text-[0.84rem] font-medium text-[#2e7d32]">
+                    Save {saving.saved} ({saving.percentOff}% off)
                   </p>
-                )}
+                ) : null}
+                <p className="mt-1 text-[0.82rem] text-[#6b6a68]">
+                  {planDescription}
+                </p>
               </div>
 
-              {checkoutMutation.error ? (
-                <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
-                  <p className="text-red-700 dark:text-red-300 text-sm">
-                    {isServiceUnavailableError(checkoutMutation.error)
-                      ? 'Service is unavailable. Please try again later.'
-                      : checkoutMutation.error instanceof Error
-                      ? checkoutMutation.error.message
-                      : 'Failed to create checkout session'}
+              {!isAuthenticated ? (
+                <div>
+                  <h3 className="font-display text-[1.1rem] text-[#1A1A1A] mb-2 text-center">
+                    {authFormState.showPasswordStep
+                      ? (authFormState.isSignUp ? 'Create Account To Complete Purchase' : 'Log In To Complete Purchase')
+                      : 'Sign In To Complete Your Purchase'}
+                  </h3>
+                  <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65] mb-6 text-center">
+                    {authFormState.showPasswordStep
+                      ? (authFormState.isSignUp
+                          ? 'Set up your password to create your account and proceed to checkout.'
+                          : 'Enter your password to sign in and proceed to checkout.')
+                      : 'If you have an account, you will be asked to sign in with your password. If not, the provided email address will be used to create a new account.'}
                   </p>
+
+                  <EnhancedAuthForm inModal={true} onSuccess={handleAuthSuccess} onModeChange={handleAuthFormStateChange} />
                 </div>
-              ) : null}
+              ) : (
+                <div>
+                  <h3 className="font-display text-[1.1rem] text-[#1A1A1A] mb-5 text-center">
+                    Complete Your Payment
+                  </h3>
 
-              <button
-                onClick={handleSubscribe}
-                disabled={checkoutMutation.isPending || pricingLoading || pricingUnavailable}
-                className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-              >
-                {checkoutMutation.isPending
-                  ? 'Creating session...'
-                  : priceLabel
-                    ? `Subscribe Now - ${priceLabel}`
-                    : 'Subscribe Now'}
-              </button>
-
-              {!user?.emailVerified && (
-                <div className="mt-4 space-y-2 text-center">
-                  <p className="text-sm text-gray-600 dark:text-gray-300">
-                    Your email isn&apos;t verified yet. You can subscribe now and verify later.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={handleResendVerificationEmail}
-                    disabled={sendingVerificationEmail}
-                    className="text-sm font-medium text-blue-600 underline underline-offset-2 hover:text-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {sendingVerificationEmail ? 'Sending...' : 'Resend verification email'}
-                  </button>
-                  {verificationEmailStatus && (
-                    <p className="text-sm text-gray-600 dark:text-gray-300">
-                      {verificationEmailStatus}
+                  <div className="bg-white border border-[#e5e2dc] rounded-sm p-4 mb-6">
+                    <h4 className="text-[0.84rem] font-medium text-[#1A1A1A] mb-1">Account Details</h4>
+                    <p className="text-[0.88rem] text-[#6b6a68]">
+                      <span className="font-medium text-[#4f4e4b]">Email:</span> {user?.email}
                     </p>
+                    {user?.kind === 'visitor' && user.firstName && user.lastName && (
+                      <p className="text-[0.88rem] text-[#6b6a68]">
+                        <span className="font-medium text-[#4f4e4b]">Name:</span> {user.firstName} {user.lastName}
+                      </p>
+                    )}
+                  </div>
+
+                  {checkoutMutation.error ? (
+                    <div className="bg-[#fce4ec] border border-[#f8bbd0] rounded-sm p-3.5 mb-6">
+                      <p className="text-[0.84rem] text-[#c62828]">
+                        {isServiceUnavailableError(checkoutMutation.error)
+                          ? 'Service is unavailable. Please try again later.'
+                          : checkoutMutation.error instanceof Error
+                          ? checkoutMutation.error.message
+                          : 'Failed to create checkout session'}
+                      </p>
+                    </div>
+                  ) : null}
+
+                  <button
+                    onClick={handleSubscribe}
+                    disabled={checkoutMutation.isPending || pricingLoading || pricingUnavailable}
+                    className="
+                      w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+                      text-white text-center py-3 rounded
+                      text-[0.88rem] font-medium transition-colors
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                    "
+                  >
+                    {checkoutMutation.isPending
+                      ? 'Creating session...'
+                      : priceLabel
+                        ? `Subscribe Now - ${priceLabel}`
+                        : 'Subscribe Now'}
+                  </button>
+
+                  {!user?.emailVerified && (
+                    <div className="mt-4 space-y-2 text-center">
+                      <p className="text-[0.82rem] text-[#6b6a68] leading-[1.65]">
+                        Your email isn&apos;t verified yet. You can subscribe now and verify later.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={handleResendVerificationEmail}
+                        disabled={sendingVerificationEmail}
+                        className="
+                          text-[0.82rem] text-[#6b6a68] hover:text-[#1A1A1A]
+                          underline underline-offset-2 cursor-pointer transition-colors
+                          disabled:text-[#c4c2be] disabled:hover:text-[#c4c2be]
+                          disabled:cursor-not-allowed
+                        "
+                      >
+                        {sendingVerificationEmail ? 'Sending...' : 'Resend verification email'}
+                      </button>
+                      {verificationEmailStatus && (
+                        <p className="text-[0.82rem] text-[#6b6a68]">
+                          {verificationEmailStatus}
+                        </p>
+                      )}
+                    </div>
                   )}
                 </div>
               )}
-            </div>
-          )}
 
-          <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-600">
-            <p className="text-center text-sm text-gray-500 dark:text-gray-400">
-              Secure payment powered by Stripe
-            </p>
+              <div className="mt-8 pt-5 border-t border-[#e5e2dc]">
+                <p className="text-center text-[0.78rem] text-[#9a9894]">
+                  Secure payment powered by Stripe
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/questura/apps/client/src/features/Payments/pages/SubscriptionCancelPage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/SubscriptionCancelPage.tsx
@@ -4,53 +4,70 @@ import Link from 'next/link';
 
 export default function SubscriptionCancelPage() {
   return (
-    <div className="max-w-2xl mx-auto px-4 py-8">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">
-        <div className="mb-6">
-          <div className="w-16 h-16 bg-yellow-100 dark:bg-yellow-900/20 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg className="w-8 h-8 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-            </svg>
+    <div className="min-h-screen">
+      <div className="px-6 pt-8 pb-16 480:pt-10 768:pt-12">
+        <div className="max-w-xl mx-auto">
+          <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-6 480:p-8 text-center">
+            <div className="flex justify-center mb-6">
+              <div className="flex items-center justify-center h-12 w-12 rounded-full bg-[#fff3e0]">
+                <svg className="h-6 w-6 text-[#e65100]" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+              </div>
+            </div>
+
+            <h1 className="font-display text-[1.35rem] text-[#1A1A1A] mb-2 480:text-[1.55rem]">
+              Subscription Cancelled
+            </h1>
+            <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65] mb-6">
+              No worries! You can try again anytime when you&apos;re ready.
+            </p>
+
+            <div className="bg-white border border-[#e5e2dc] rounded-sm p-4 mb-6 text-left">
+              <h3 className="text-[0.84rem] font-medium text-[#1A1A1A] mb-2">
+                What happens next?
+              </h3>
+              <ul className="text-[0.82rem] text-[#6b6a68] space-y-1 list-disc list-inside leading-[1.65]">
+                <li>No charges have been made to your account</li>
+                <li>You can subscribe anytime with no penalties</li>
+                <li>Your account remains active for free features</li>
+              </ul>
+            </div>
+
+            <div className="space-y-3">
+              <Link
+                href="/join"
+                className="
+                  block w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+                  text-white text-center py-3.5 rounded
+                  text-[0.88rem] font-medium transition-colors
+                "
+              >
+                Try Again
+              </Link>
+
+              <Link
+                href="/"
+                className="
+                  block w-full bg-white border border-[#d7d4ce]
+                  text-[#4f4e4b] text-center py-3 rounded
+                  text-[0.88rem] font-medium transition-colors
+                  hover:bg-[#f0efeb]
+                "
+              >
+                Return to Home
+              </Link>
+            </div>
+
+            <div className="mt-8 pt-5 border-t border-[#e5e2dc]">
+              <p className="text-[0.78rem] text-[#9a9894]">
+                Need help?{' '}
+                <Link href="/contact" className="text-[#2563EB] hover:text-[#1A1A1A] underline underline-offset-2">
+                  Contact our support team
+                </Link>
+              </p>
+            </div>
           </div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-            Subscription Cancelled
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-300 mb-6">
-            No worries! You can try again anytime when you&apos;re ready.
-          </p>
-        </div>
-
-        <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg mb-6">
-          <h3 className="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-2">
-            What happens next?
-          </h3>
-          <ul className="text-sm text-blue-800 dark:text-blue-200 space-y-1 text-left">
-            <li>• No charges have been made to your account</li>
-            <li>• You can subscribe anytime with no penalties</li>
-            <li>• Your account remains active for free features</li>
-          </ul>
-        </div>
-
-        <div className="space-y-4">
-          <Link
-            href="/join"
-            className="inline-block w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-          >
-            Try Again
-          </Link>
-
-          <Link
-            href="/"
-            className="inline-block w-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-          >
-            Return to Home
-          </Link>
-        </div>
-
-        <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-600">
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Need help? <Link href="/contact" className="text-blue-600 dark:text-blue-400 hover:underline">Contact our support team</Link>
-          </p>
         </div>
       </div>
     </div>

--- a/apps/questura/apps/client/src/features/Payments/pages/SubscriptionSuccessPage.tsx
+++ b/apps/questura/apps/client/src/features/Payments/pages/SubscriptionSuccessPage.tsx
@@ -74,7 +74,7 @@ function SubscriptionSuccessContent() {
   if (!mounted) {
     return (
       <div className="flex justify-center items-center min-h-screen">
-        <div className="text-lg">Loading...</div>
+        <div className="text-[0.88rem] text-[#6b6a68]">Loading...</div>
       </div>
     );
   }
@@ -94,65 +94,79 @@ function SubscriptionSuccessContent() {
         : 'Your payment went through. Membership may take a moment to appear on your account — refresh or check back shortly.';
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-8">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">
-        <div className="mb-6">
-          <div className={`w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 ${
-            confirmation === 'active'
-              ? 'bg-green-100 dark:bg-green-900/20'
-              : 'bg-gray-100 dark:bg-gray-700'
-          }`}>
-            {confirmation === 'active' ? (
-              <svg className="w-8 h-8 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-            ) : confirmation === 'checking' ? (
-              <div className="w-8 h-8 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
-            ) : (
-              <svg className="w-8 h-8 text-gray-500 dark:text-gray-300" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
-              </svg>
+    <div className="min-h-screen">
+      <div className="px-6 pt-8 pb-16 480:pt-10 768:pt-12">
+        <div className="max-w-xl mx-auto">
+          <div className="bg-[#f7f6f2] border border-[#d7d4ce] rounded-sm p-6 480:p-8 text-center">
+            <div className="flex justify-center mb-6">
+              <div className={`flex items-center justify-center h-12 w-12 rounded-full ${
+                confirmation === 'active'
+                  ? 'bg-[#e8f5e9]'
+                  : 'bg-white border border-[#e5e2dc]'
+              }`}>
+                {confirmation === 'active' ? (
+                  <svg className="h-6 w-6 text-[#2e7d32]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : confirmation === 'checking' ? (
+                  <div className="w-6 h-6 border-2 border-[#9a9894] border-t-transparent rounded-full animate-spin" />
+                ) : (
+                  <svg className="h-6 w-6 text-[#6b6a68]" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
+                  </svg>
+                )}
+              </div>
+            </div>
+
+            <h1 className="font-display text-[1.35rem] text-[#1A1A1A] mb-2 480:text-[1.55rem]">
+              {headline}
+            </h1>
+            <p className="text-[0.88rem] text-[#6b6a68] leading-[1.65] mb-6">
+              {body}
+            </p>
+
+            {sessionId && (
+              <div className="bg-white border border-[#e5e2dc] rounded-sm p-4 mb-6 text-left">
+                <p className="text-[0.82rem] text-[#6b6a68]">
+                  <span className="font-medium text-[#4f4e4b]">Session ID:</span> {sessionId}
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <Link
+                href="/account"
+                className="
+                  block w-full bg-[#2C2C2C] hover:bg-[#1A1A1A]
+                  text-white text-center py-3.5 rounded
+                  text-[0.88rem] font-medium transition-colors
+                "
+              >
+                Go to Account Dashboard
+              </Link>
+
+              <Link
+                href="/"
+                className="
+                  block w-full bg-white border border-[#d7d4ce]
+                  text-[#4f4e4b] text-center py-3 rounded
+                  text-[0.88rem] font-medium transition-colors
+                  hover:bg-[#f0efeb]
+                "
+              >
+                Return to Home
+              </Link>
+            </div>
+
+            {confirmation === 'active' && (
+              <div className="mt-8 pt-5 border-t border-[#e5e2dc]">
+                <p className="text-[0.78rem] text-[#9a9894] leading-[1.65]">
+                  Thank you for your subscription! You now have access to all premium features.
+                </p>
+              </div>
             )}
           </div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-            {confirmation === 'active' ? '🎉 ' : ''}{headline}
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-300 mb-6">
-            {body}
-          </p>
         </div>
-
-        {sessionId && (
-          <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg mb-6">
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              <span className="font-medium">Session ID:</span> {sessionId}
-            </p>
-          </div>
-        )}
-
-        <div className="space-y-4">
-          <Link
-            href="/account"
-            className="inline-block w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-          >
-            Go to Account Dashboard
-          </Link>
-
-          <Link
-            href="/"
-            className="inline-block w-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white font-semibold py-3 px-6 rounded-lg transition-colors"
-          >
-            Return to Home
-          </Link>
-        </div>
-
-        {confirmation === 'active' && (
-          <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-600">
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              Thank you for your subscription! You now have access to all premium features.
-            </p>
-          </div>
-        )}
       </div>
     </div>
   );
@@ -162,7 +176,7 @@ export default function SubscriptionSuccessPage() {
   return (
     <SuspenseBoundary fallback={
       <div className="flex justify-center items-center min-h-screen">
-        <div className="text-lg">Loading...</div>
+        <div className="text-[0.88rem] text-[#6b6a68]">Loading...</div>
       </div>
     }>
       <SubscriptionSuccessContent />


### PR DESCRIPTION
## Summary
- OS dark mode was activating leftover Tailwind `dark:` classes on account, purchase, auth, and global states while Questura stayed light.
- Removed those variants and restyled the affected surfaces to the `/account` tokens (beige cards, charcoal buttons, warm type).
- Client-only CSS. No schema, no Stripe, no deploy-host edits.

## Test plan
- [ ] `/account/change-email` and `/account/change-password` inputs stay light with OS dark mode on
- [ ] `/purchase/monthly` and `/purchase/yearly` match account cards/buttons
- [ ] `/subscription/success` and `/subscription/cancel` match account
- [ ] Password-reset modal, auth callback/error/close, 404, and error pages stay light


Made with [Cursor](https://cursor.com)