### PR TITLE
Add magazine sidebar to standard articles

### DIFF
--- a/apps/questura/apps/client/src/app/styles/global/article-prose-and-media.css
+++ b/apps/questura/apps/client/src/app/styles/global/article-prose-and-media.css
@@ -618,6 +618,13 @@
   }
 }
 
+@media print {
+  [data-article-sidebar],
+  [data-article-share] {
+    display: none !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .shimmer-image::before,
   .shimmer-image > img,

--- a/apps/questura/apps/client/src/features/articles/ArticlePage.tsx
+++ b/apps/questura/apps/client/src/features/articles/ArticlePage.tsx
@@ -1,12 +1,17 @@
-import { Bookmark, Share2 } from 'lucide-react'
+import Link from 'next/link'
 import { PublicImage } from '@/components/media/PublicImage'
 import { GatedArticleBody } from '@/features/articles/components/GatedArticleBody'
+import { ArticleShareBar } from '@/features/articles/components/ArticleShareBar'
+import { ArticleSidebar } from '@/features/articles/components/ArticleSidebar'
 import { readGate } from '@/features/articles/lib/gate'
+import { articleCrumbsFromPath } from '@/features/articles/lib/articleCrumbs'
+import { fetchStandardArticleSidebar } from '@/features/articles/lib/fetchArticleSidebar'
 import { BlockRenderer } from '@/features/articles/components/BlockRenderer'
 import { AuthorLink } from '@/features/authors/components/AuthorLink'
+import { getPublicBaseUrl } from '@/lib/seo/publicBaseUrl'
 import { Article } from './types'
 
-function formatArticleDate(iso: string | undefined): string | null {
+function formatMagazineDate(iso: string | undefined): string | null {
   if (!iso) return null
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return null
@@ -15,149 +20,149 @@ function formatArticleDate(iso: string | undefined): string | null {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
     timeZone: 'America/New_York',
-  })
-    .format(date)
-    .replace(' at ', ', ')
+  }).format(date)
 }
 
-function formatLocationLabel(location: string | undefined): string {
-  const parts = (location ?? '')
-    .split('|')
-    .map((part) => part.trim())
-    .filter(Boolean)
-
-  if (parts.length === 0) return 'Questurian'
-
-  return parts
-    .map((part) =>
-      part
-        .split('-')
-        .map((word) => (word ? `${word[0].toUpperCase()}${word.slice(1)}` : word))
-        .join(' '),
-    )
-    .join(' / ')
-}
-
-function StandardArticleHeader({ article }: { article: Article }) {
-  const { title, author, publishedAt, updatedAt, seoSection, location } = article
+function StandardArticleHeader({
+  article,
+  path,
+  shareUrl,
+}: {
+  article: Article
+  path?: string
+  shareUrl: string
+}) {
+  const { title, author, publishedAt, updatedAt, seoSection, headerSection } = article
   const description = seoSection?.metaDescription
-  const label = formatLocationLabel(location)
   const displayName = author?.displayName
-  const dateLine = formatArticleDate(publishedAt ?? updatedAt)
+  const dateLine = formatMagazineDate(publishedAt ?? updatedAt)
+  const crumbs = articleCrumbsFromPath(path)
 
   return (
-    <header className="mx-auto w-full max-w-[840px] px-4 pt-8 pb-8 sm:px-0 sm:pt-12 sm:pb-10 lg:pt-16">
-      <p className="mb-7 font-mono text-[12px] uppercase tracking-[0.18em] text-foreground">
-        {label}
-      </p>
-      <h1 className="font-display text-[36px] font-normal leading-[1.05] text-foreground sm:text-[46px] lg:text-[52px]">
+    <header className="px-4 pt-8 pb-6 1024:px-0 1024:pt-10 1024:pb-8">
+      <div className="mb-5 flex flex-col gap-2 1024:mb-6 1024:flex-row 1024:items-baseline 1024:justify-between 1024:gap-6">
+        {crumbs.length > 0 ? (
+          <nav aria-label="Breadcrumb">
+            <ol className="flex flex-wrap items-center gap-x-1.5 font-[family-name:var(--font-dm-sans)] text-[11px] font-semibold uppercase tracking-[0.14em] text-terracotta">
+              {crumbs.map((crumb, index) => (
+                <li key={`${crumb.label}-${index}`} className="flex items-center gap-x-1.5">
+                  {index > 0 ? <span aria-hidden className="text-terracotta/60">›</span> : null}
+                  {crumb.href ? (
+                    <Link href={crumb.href} className="hover:underline">
+                      {crumb.label}
+                    </Link>
+                  ) : (
+                    <span>{crumb.label}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+        ) : (
+          <span />
+        )}
+        {displayName || dateLine ? (
+          <p className="font-display text-[15px] italic leading-snug text-foreground 1024:text-right">
+            {displayName ? (
+              <>
+                By{' '}
+                <AuthorLink
+                  authorSlug={author?.slug}
+                  authorId={author?.id}
+                  className="hover:underline"
+                >
+                  {displayName}
+                </AuthorLink>
+              </>
+            ) : null}
+            {displayName && dateLine ? ' • ' : null}
+            {dateLine}
+          </p>
+        ) : null}
+      </div>
+
+      <h1 className="font-display text-[32px] font-normal leading-[1.08] text-foreground sm:text-[40px] 1024:text-[44px]">
         {title}
       </h1>
+
       {description ? (
-        <p className="mt-6 max-w-[680px] font-display text-[20px] leading-[1.32] text-foreground sm:text-[22px] lg:text-[23px]">
-          {description}
-        </p>
-      ) : null}
-      {displayName ? (
-        <p className="mt-7 font-display text-[20px] leading-snug text-foreground sm:text-[22px]">
-          By <AuthorLink authorSlug={author?.slug} authorId={author?.id} className="hover:underline">{displayName}</AuthorLink>
-        </p>
-      ) : null}
-      {dateLine ? (
-        <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.14em] text-foreground/55 sm:hidden">
-          {dateLine}
-        </p>
-      ) : null}
+        <>
+          <div className="mt-5 h-px w-full bg-foreground/18" aria-hidden />
+          <p className="mt-5 max-w-[40rem] font-display text-[18px] italic leading-[1.4] text-foreground/80 sm:text-[20px]">
+            {description}
+          </p>
+        </>
+      ) : (
+        <div className="mt-5 h-px w-full bg-foreground/18" aria-hidden />
+      )}
+
+      <div className="mt-6">
+        <ArticleShareBar
+          url={shareUrl}
+          title={title}
+          imageUrl={headerSection?.featuredImage?.url}
+        />
+      </div>
     </header>
   )
 }
 
-function ArticleMetaRow({
-  publishedAt,
-  updatedAt,
-}: {
-  publishedAt?: string
-  updatedAt?: string
-}) {
-  const dateLine = formatArticleDate(publishedAt ?? updatedAt)
-
-  return (
-    <div className="mx-auto max-w-[700px] border-b border-t border-foreground/18 px-4 py-5 sm:px-0">
-      <div className="flex items-center justify-between gap-5">
-        <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-foreground">
-          {dateLine}
-        </p>
-        <div className="flex shrink-0 items-center gap-6 font-mono text-[11px] uppercase tracking-[0.14em] text-foreground">
-          <button type="button" className="inline-flex items-center gap-1.5 hover:text-terracotta">
-            Share <Share2 size={16} strokeWidth={1.6} aria-hidden />
-          </button>
-          <button type="button" className="inline-flex items-center gap-1.5 hover:text-terracotta">
-            Save <Bookmark size={16} strokeWidth={1.6} aria-hidden />
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-
-// ── Main component ───────────────────────────────────────────────────────────
-
-export function ArticlePage({ article, path }: { article: Article; path?: string }) {
-  const { publishedAt, updatedAt, headerSection, contentBlocks } = article
+export async function ArticlePage({ article, path }: { article: Article; path?: string }) {
+  const { headerSection, contentBlocks } = article
   const featuredImage = headerSection?.featuredImage
   const gate = readGate(article)
+  const sidebar = await fetchStandardArticleSidebar(article, path)
+  const sharePath = path && path.startsWith('/') ? path : `/${article.slug}`
+  const shareUrl = `${getPublicBaseUrl()}${sharePath}`
 
   return (
-    <article
-      data-article-layout="standard"
-      className="min-h-screen bg-background"
-    >
-      <div className="mx-auto w-full max-w-[960px]">
+    <article data-article-layout="standard" className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-6xl px-0 1024:px-8">
+        <div className="1024:grid 1024:grid-cols-[1fr_300px] 1024:gap-x-12">
+          <div className="1024:col-start-1 1024:row-start-1">
+            <StandardArticleHeader article={article} path={path} shareUrl={shareUrl} />
+          </div>
 
-        <StandardArticleHeader article={article} />
+          <div className="min-w-0 1024:col-start-1 1024:row-start-2">
+            {featuredImage?.url ? (
+              <figure className="px-0">
+                <div className="aspect-[16/10] w-full overflow-hidden">
+                  <PublicImage
+                    src={featuredImage.url}
+                    alt={featuredImage.alt_text ?? ''}
+                    width={1600}
+                    height={1000}
+                    sizes="(min-width: 1024px) 780px, 100vw"
+                    className="h-full w-full object-cover"
+                    priority
+                  />
+                </div>
+                {featuredImage.alt_text ? (
+                  <figcaption className="px-4 pt-2 font-mono text-[11px] text-foreground/45 1024:px-0">
+                    {featuredImage.alt_text}
+                  </figcaption>
+                ) : null}
+              </figure>
+            ) : null}
 
-        {/* ── Featured image ───────────────────────────────────────── */}
-        {featuredImage?.url && (
-          <figure className="px-0">
-            <div className="aspect-[16/10] w-full overflow-hidden">
-              <PublicImage
-                src={featuredImage.url}
-                alt={featuredImage.alt_text ?? ''}
-                width={1600}
-                height={1000}
-                sizes="(min-width: 1024px) 880px, (min-width: 768px) 760px, 100vw"
-                className="w-full h-full object-cover"
-                priority
-              />
+            <div className="px-4 pt-8 pb-16 1024:px-0 1024:pt-10 1024:pb-20">
+              <div className="space-y-8 sm:space-y-10">
+                {contentBlocks?.map((block) => (
+                  <BlockRenderer key={block.id} block={block} />
+                ))}
+
+                {gate?.locked ? (
+                  <GatedArticleBody articleId={article.id} gate={gate} path={path ?? '/'} />
+                ) : null}
+              </div>
             </div>
-            {featuredImage.alt_text ? (
-              <figcaption className="pt-2 font-mono text-[11px] text-foreground/45">
-                {featuredImage.alt_text}
-              </figcaption>
-            ) : null}
-          </figure>
-        )}
+          </div>
 
-        <ArticleMetaRow publishedAt={publishedAt} updatedAt={updatedAt} />
-
-        {/* ── Content blocks ───────────────────────────────────────── */}
-        <div className="px-4 pt-10 pb-20 sm:px-0 sm:pt-12">
-          <div className="mx-auto max-w-[700px] space-y-8 sm:space-y-10">
-            {contentBlocks?.map((block) => (
-              <BlockRenderer key={block.id} block={block} />
-            ))}
-
-            {gate?.locked ? (
-              <GatedArticleBody articleId={article.id} gate={gate} path={path ?? '/'} />
-            ) : null}
+          <div className="px-4 1024:col-start-2 1024:row-start-2 1024:px-0">
+            <ArticleSidebar trending={sidebar.trending} partners={sidebar.partners} />
           </div>
         </div>
-
       </div>
     </article>
   )

--- a/apps/questura/apps/client/src/features/articles/components/ArticleShareBar.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/ArticleShareBar.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { Link2, Printer } from 'lucide-react'
+
+type ArticleShareBarProps = {
+  url: string
+  title: string
+  imageUrl?: string | null
+}
+
+function ShareCircle({
+  label,
+  onClick,
+  href,
+  children,
+}: {
+  label: string
+  onClick?: () => void
+  href?: string
+  children: ReactNode
+}) {
+  const className =
+    'inline-flex size-8 items-center justify-center rounded-full border border-foreground/80 text-foreground transition-colors hover:bg-foreground hover:text-background'
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={label}
+        className={className}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  return (
+    <button type="button" aria-label={label} className={className} onClick={onClick}>
+      {children}
+    </button>
+  )
+}
+
+export function ArticleShareBar({ url, title, imageUrl }: ArticleShareBarProps) {
+  const [copied, setCopied] = useState(false)
+  const encodedUrl = encodeURIComponent(url)
+  const encodedTitle = encodeURIComponent(title)
+  const encodedImage = imageUrl ? encodeURIComponent(imageUrl) : ''
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1600)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2.5" data-article-share>
+      <ShareCircle label={copied ? 'Link copied' : 'Copy link'} onClick={copyLink}>
+        <Link2 size={13} strokeWidth={2} aria-hidden />
+      </ShareCircle>
+      <ShareCircle
+        label="Share on Facebook"
+        href={`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`}
+      >
+        <svg viewBox="0 0 24 24" className="size-3.5 fill-current" aria-hidden>
+          <path d="M14 8h3V4h-3c-2.8 0-5 2.2-5 5v3H6v4h3v8h4v-8h3.2l.8-4H13V9c0-.6.4-1 1-1Z" />
+        </svg>
+      </ShareCircle>
+      <ShareCircle
+        label="Share on Pinterest"
+        href={`https://www.pinterest.com/pin/create/button/?url=${encodedUrl}&description=${encodedTitle}${encodedImage ? `&media=${encodedImage}` : ''}`}
+      >
+        <svg viewBox="0 0 24 24" className="size-3.5 fill-current" aria-hidden>
+          <path d="M12 2C6.5 2 2 6.3 2 11.6c0 4 2.5 7.4 6.1 8.6-.1-.7-.2-1.8 0-2.6.2-.7 1.4-6 1.4-6s-.4-.7-.4-1.8c0-1.7 1-3 2.2-3 1 0 1.5.8 1.5 1.7 0 1-.7 2.6-1 4-.3 1.2.6 2.2 1.8 2.2 2.1 0 3.6-2.7 3.6-5.9 0-2.4-1.6-4.2-4.6-4.2-3.3 0-5.4 2.5-5.4 5.2 0 1 .5 2.1 1 2.7.1.1.1.2.1.3l-.4 1.6c0 .2-.1.3-.4.2-1.5-.6-2.2-2.3-2.2-4.2 0-3.1 2.6-6.9 7.8-6.9 4.2 0 6.9 3 6.9 6.3 0 4.3-2.4 7.5-5.9 7.5-1.2 0-2.3-.6-2.7-1.4l-.7 2.8c-.3 1-1 2.2-1.5 3 .1 0 .2.1.4.1 3.6 0 7-1.5 9.4-4.1C20.7 17.4 22 14.7 22 11.6 22 6.3 17.5 2 12 2Z" />
+        </svg>
+      </ShareCircle>
+      <ShareCircle
+        label="Share on X"
+        href={`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`}
+      >
+        <svg viewBox="0 0 24 24" className="size-3 fill-current" aria-hidden>
+          <path d="M14.7 10.3 22.4 2h-1.8l-6.7 7.2L8.5 2H2.1l8.1 11.4L2.1 22h1.8l7-7.6L15.5 22h6.4l-7.2-11.7Zm-2.5 2.7-.8-1.1L4.6 3.3h2.8l5.2 7.2.8 1.1 6.8 9.4h-2.8l-5.2-7Z" />
+        </svg>
+      </ShareCircle>
+      <ShareCircle label="Print article" onClick={() => window.print()}>
+        <Printer size={13} strokeWidth={2} aria-hidden />
+      </ShareCircle>
+    </div>
+  )
+}

--- a/apps/questura/apps/client/src/features/articles/components/ArticleSidebar.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/ArticleSidebar.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link'
+import { PublicImage } from '@/components/media/PublicImage'
+import type { ArticleIndexItem } from '@/features/articles/lib/fetchArticleIndex'
+
+type ArticleSidebarProps = {
+  trending: ArticleIndexItem[]
+  partners: ArticleIndexItem[]
+}
+
+function AdSlot({ size }: { size: 'half-page' | 'rectangle' }) {
+  const height = size === 'half-page' ? 'h-[250px] 1024:h-[600px]' : 'h-[250px]'
+
+  return (
+    <div className="w-full">
+      <p className="mb-1.5 text-center font-[family-name:var(--font-dm-sans)] text-[9px] uppercase tracking-[0.2em] text-foreground/40">
+        Advertisement
+      </p>
+      <div
+        className={`flex ${height} w-full items-center justify-center border border-foreground/12 bg-foreground/[0.04]`}
+        aria-hidden
+      >
+        <span className="font-[family-name:var(--font-dm-sans)] text-[10px] uppercase tracking-[0.16em] text-foreground/25">
+          Ad space
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function SidebarHeading({ id, children }: { id: string; children: string }) {
+  return (
+    <h2
+      id={id}
+      className="border-b border-foreground/20 pb-2 font-[family-name:var(--font-dm-sans)] text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground"
+    >
+      {children}
+    </h2>
+  )
+}
+
+function SidebarArticleRow({ item, size }: { item: ArticleIndexItem; size: 'trending' | 'partner' }) {
+  const thumb = size === 'trending' ? 'size-[72px]' : 'size-[56px]'
+
+  return (
+    <li>
+      <Link href={item.href} className="group flex gap-3 py-3">
+        <div className={`relative ${thumb} shrink-0 overflow-hidden bg-foreground/8`}>
+          {item.thumbnail ? (
+            <PublicImage
+              src={item.thumbnail.url}
+              alt={item.thumbnail.alt ?? ''}
+              width={144}
+              height={144}
+              sizes="72px"
+              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            />
+          ) : null}
+        </div>
+        <p
+          className={`min-w-0 font-display leading-snug text-foreground group-hover:underline ${
+            size === 'trending' ? 'text-[15px]' : 'text-[14px]'
+          }`}
+        >
+          {item.title}
+        </p>
+      </Link>
+    </li>
+  )
+}
+
+export function ArticleSidebar({ trending, partners }: ArticleSidebarProps) {
+  return (
+    <aside
+      data-article-sidebar
+      className="flex flex-col gap-8 pt-10 1024:pt-0"
+      aria-label="Article sidebar"
+    >
+      <AdSlot size="half-page" />
+
+      {trending.length > 0 ? (
+        <section aria-labelledby="article-trending-heading">
+          <SidebarHeading id="article-trending-heading">Trending News</SidebarHeading>
+          <ul className="divide-y divide-foreground/12">
+            {trending.map((item) => (
+              <SidebarArticleRow key={item.id} item={item} size="trending" />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <AdSlot size="rectangle" />
+
+      {partners.length > 0 ? (
+        <section aria-labelledby="article-partners-heading">
+          <SidebarHeading id="article-partners-heading">From Our Partners</SidebarHeading>
+          <ul className="divide-y divide-foreground/12">
+            {partners.map((item) => (
+              <SidebarArticleRow key={item.id} item={item} size="partner" />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </aside>
+  )
+}

--- a/apps/questura/apps/client/src/features/articles/components/BlockRenderer.tsx
+++ b/apps/questura/apps/client/src/features/articles/components/BlockRenderer.tsx
@@ -31,7 +31,7 @@ function TextBlockRenderer({ block }: { block: TextBlock }) {
 
 function ImageBlockRenderer({ block }: { block: ImageBlock }) {
   return (
-    <figure className="-mx-4 sm:mx-0 lg:-mx-10">
+    <figure className="-mx-4 1024:mx-0">
       <PublicImage
         src={block.image.url}
         alt={block.altText ?? block.image.alt_text ?? ''}
@@ -41,7 +41,7 @@ function ImageBlockRenderer({ block }: { block: ImageBlock }) {
         className="w-full object-cover"
       />
       {block.caption && (
-        <figcaption className="px-4 pt-2 text-[11px] text-foreground/50 italic sm:px-0 sm:text-[12px]">
+        <figcaption className="px-4 pt-2 text-[11px] italic text-foreground/50 1024:px-0 sm:text-[12px]">
           {block.caption}
         </figcaption>
       )}
@@ -54,7 +54,7 @@ function ImgPairBlockRenderer({ block }: { block: ImgPairBlock }) {
   const alt2 = block.imageTwo.mediaSet?.alt_text ?? block.imageTwo.alt_text ?? ''
 
   return (
-    <figure className="-mx-4 sm:mx-0 lg:-mx-10">
+    <figure className="-mx-4 1024:mx-0">
       <div className="flex gap-1 sm:gap-2">
         <PublicImage
           src={block.imageOne.url}
@@ -74,7 +74,7 @@ function ImgPairBlockRenderer({ block }: { block: ImgPairBlock }) {
         />
       </div>
       {block.caption && (
-        <figcaption className="px-4 pt-2 text-[11px] text-foreground/50 italic sm:px-0 sm:text-[12px]">
+        <figcaption className="px-4 pt-2 text-[11px] italic text-foreground/50 1024:px-0 sm:text-[12px]">
           {block.caption}
         </figcaption>
       )}
@@ -88,7 +88,7 @@ function ImgTrioBlockRenderer({ block }: { block: ImgTrioBlock }) {
   const imageClassName = isLandscape ? 'aspect-[16/10]' : 'aspect-square'
 
   return (
-    <figure className="-mx-4 sm:mx-0 lg:-mx-10">
+    <figure className="-mx-4 1024:mx-0">
       <div className="grid grid-cols-1 gap-1 sm:grid-cols-3 sm:gap-2">
         {images.map((image, index) => (
           <PublicImage
@@ -103,7 +103,7 @@ function ImgTrioBlockRenderer({ block }: { block: ImgTrioBlock }) {
         ))}
       </div>
       {block.caption && (
-        <figcaption className="px-4 pt-2 text-[11px] text-foreground/50 italic sm:px-0 sm:text-[12px]">
+        <figcaption className="px-4 pt-2 text-[11px] italic text-foreground/50 1024:px-0 sm:text-[12px]">
           {block.caption}
         </figcaption>
       )}

--- a/apps/questura/apps/client/src/features/articles/lib/articleCrumbs.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/articleCrumbs.ts
@@ -1,0 +1,43 @@
+import { ARTICLE_TYPE_SEGMENTS } from '@/lib/reservedSlugs'
+
+export type ArticleCrumb = {
+  label: string
+  href: string | null
+}
+
+function humanizeSegment(segment: string): string {
+  return segment
+    .split('-')
+    .map((word) => (word ? `${word[0].toUpperCase()}${word.slice(1)}` : word))
+    .join(' ')
+}
+
+/**
+ * Visible trail from the public URL, minus the article slug.
+ * `/peru/safety/slug` -> Peru > Safety
+ * `/peru/lima/safety/slug` -> Peru > Lima > Safety
+ */
+export function articleCrumbsFromPath(path: string | undefined): ArticleCrumb[] {
+  if (!path) return []
+
+  const segments = path.split('/').filter(Boolean)
+  if (segments.length < 2) return []
+
+  const intermediates = segments.slice(0, -1)
+  const crumbs: ArticleCrumb[] = []
+  let cumulative = ''
+
+  intermediates.forEach((segment, index) => {
+    cumulative += `/${segment}`
+    const isType = ARTICLE_TYPE_SEGMENTS.has(segment.toLowerCase())
+    const isLast = index === intermediates.length - 1
+    const isCity = intermediates.length >= 3 && index === 1 && !isType
+
+    crumbs.push({
+      label: humanizeSegment(segment),
+      href: isLast && !isType ? null : isType || index === 0 || isCity ? cumulative : null,
+    })
+  })
+
+  return crumbs
+}

--- a/apps/questura/apps/client/src/features/articles/lib/fetchArticleSidebar.ts
+++ b/apps/questura/apps/client/src/features/articles/lib/fetchArticleSidebar.ts
@@ -1,0 +1,82 @@
+import type { Article } from '../types'
+import type { ArticleScope } from './articleScope'
+import { fetchArticleIndex, type ArticleIndexItem } from './fetchArticleIndex'
+
+const TRENDING_COUNT = 5
+const PARTNERS_COUNT = 5
+
+function scopesFromLocation(location: string | undefined): ArticleScope[] {
+  const parts = (location ?? '')
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  const scopes: ArticleScope[] = []
+  if (parts.length >= 2) scopes.push({ kind: 'city', country: parts[0], city: parts[1] })
+  if (parts.length >= 1) scopes.push({ kind: 'country', country: parts[0] })
+  scopes.push({ kind: 'global' })
+  return scopes
+}
+
+async function indexForScope(scope: ArticleScope): Promise<ArticleIndexItem[]> {
+  try {
+    const data = await fetchArticleIndex({ scope, type: 'articles', page: 1, pageSize: 20 })
+    return data?.items ?? []
+  } catch {
+    return []
+  }
+}
+
+async function firstNonEmptyIndex(
+  scopes: ArticleScope[],
+  article: Article,
+  path?: string,
+): Promise<ArticleIndexItem[]> {
+  for (const scope of scopes) {
+    const items = excludeCurrent(await indexForScope(scope), article, path)
+    if (items.length > 0) return items
+  }
+  return []
+}
+
+function excludeCurrent(
+  items: ArticleIndexItem[],
+  article: Article,
+  path?: string,
+): ArticleIndexItem[] {
+  return items.filter((item) => {
+    if (item.slug === article.slug) return false
+    if (path && item.href === path) return false
+    return true
+  })
+}
+
+export type ArticleSidebarLists = {
+  trending: ArticleIndexItem[]
+  partners: ArticleIndexItem[]
+}
+
+export async function fetchStandardArticleSidebar(
+  article: Article,
+  path?: string,
+): Promise<ArticleSidebarLists> {
+  const scopes = scopesFromLocation(article.location)
+  const localItems = await firstNonEmptyIndex(scopes, article, path)
+  const trending = localItems.slice(0, TRENDING_COUNT)
+  const trendingIds = new Set(trending.map((item) => String(item.id)))
+
+  let partnerPool: ArticleIndexItem[]
+  if (scopes[0]?.kind === 'global') {
+    partnerPool = localItems.slice(TRENDING_COUNT)
+  } else {
+    const globalItems = excludeCurrent(await indexForScope({ kind: 'global' }), article, path).filter(
+      (item) => !trendingIds.has(String(item.id)),
+    )
+    partnerPool = globalItems.length > 0 ? globalItems : localItems.slice(TRENDING_COUNT)
+  }
+
+  return {
+    trending,
+    partners: partnerPool.slice(0, PARTNERS_COUNT),
+  }
+}


### PR DESCRIPTION
## Why
Standard articles still read as a single centered column. Editorial pages (and the Peru safety URL) need a right rail for ads and more of our stories.

## What
- Two-column magazine chrome on every standard article path: crumbs, byline, dek, share icons, hero + body on the left
- Sidebar: ad slot, Trending News, second ad slot, From Our Partners
- Trending pulls same-country/city articles; partners pull a broader set and skip the current story
- Ad slots are labeled placeholders until a network is wired

## Verification
- [ ] Open https://www.questurian.com/peru/safety/a-practical-guide-to-staying-safe-in-peru-for-2026
- [ ] Desktop: sidebar starts at the hero, not beside the title
- [ ] Trending / partners show other live articles, not this one
- [ ] Mobile: sidebar stacks under the body
- [ ] Auth form files were left uncommitted on purpose


Made with [Cursor](https://cursor.com)