### PR TITLE
Give Prompt2Blog one definition of "ready to ship"

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/policies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/policies.py
@@ -8,11 +8,78 @@ what it replaced. They hold no I/O and no prompt construction.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Any
 
 from .config import P2B_AUGMENTATION_MIN_RETENTION_RATIO, P2B_REPAIR_MAX_ATTEMPTS
-from .quality import _should_run_repair
-from .support import _safe_dict, _safe_int, _safe_str, _tokenize_words
+from .quality import (
+    HARD_CONSTRAINT_CHECK_KEYS,
+    REPAIR_SCORE_THRESHOLD,
+    _should_run_repair,
+)
+from .support import _safe_bool, _safe_dict, _safe_int, _safe_str, _tokenize_words
+
+
+@dataclass(frozen=True)
+class ReadinessVerdict:
+    """Whether a finished run may be handed to staging, and why not if not."""
+
+    ready: bool
+    blockers: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"ready": self.ready, "blockers": list(self.blockers)}
+
+
+def evaluate_readiness(
+    *,
+    quality: dict[str, Any],
+    checks: dict[str, Any],
+    groundedness: dict[str, Any],
+) -> ReadinessVerdict:
+    """Decide whether a settled run is ready for staging.
+
+    Finalize used to ask three questions -- word count, primary keyword,
+    `groundedness["grounded"]` -- and shipped anything that answered yes. A
+    4/10 article whose repair attempts had all failed still came back
+    `ready_for_staging`, and so did a run whose grounding check had crashed,
+    because the unchecked result reports `grounded: True` so that a checker
+    outage degrades the run instead of blocking it.
+
+    The blocker set is deliberately the repair loop's own trigger conditions
+    plus the two failures repair cannot clear (an audit that produced no score,
+    and a grounding check that never ran). Blocking on anything repair does not
+    try to fix would mark runs `needs_revision` that the pipeline had no way of
+    rescuing.
+    """
+    quality = _safe_dict(quality)
+    checks = _safe_dict(checks)
+    groundedness = _safe_dict(groundedness)
+    blockers: list[str] = []
+
+    # Absent rather than present is the safe default here. `unchecked_groundedness`
+    # sets `checked: False, grounded: True`; reading `grounded` alone treats a
+    # crashed checker as a pass.
+    if not _safe_bool(groundedness.get("checked"), default=False):
+        blockers.append("groundedness_unchecked")
+    elif not _safe_bool(groundedness.get("grounded"), default=False):
+        blockers.append("claims_ungrounded")
+
+    if not _safe_bool(quality.get("audit_complete"), default=False):
+        blockers.append("audit_incomplete")
+    elif (
+        _safe_int(quality.get("overall_score"), default=0) < REPAIR_SCORE_THRESHOLD
+    ):
+        blockers.append("quality_score_below_threshold")
+
+    if _safe_bool(quality.get("too_close_to_source"), default=False):
+        blockers.append("too_close_to_source")
+
+    for key in HARD_CONSTRAINT_CHECK_KEYS:
+        if not _safe_bool(checks.get(key), default=True):
+            blockers.append(key)
+
+    return ReadinessVerdict(ready=not blockers, blockers=tuple(blockers))
 
 
 def _quality_rank(quality: dict[str, Any]) -> tuple[int, int]:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -27,6 +27,25 @@ REPAIR_SCORE_THRESHOLD = 7
 # threshold, so a gap in the response is never itself a repair trigger.
 NEUTRAL_QUALITY_SCORE = 7
 
+# The constraint checks an article must satisfy to ship. This is the single
+# list; `_should_run_repair` spends an attempt when one of these fails, and
+# `policies.evaluate_readiness` refuses to mark the run ready while one still
+# fails. Keeping both on the same tuple is what stops the gate that decides
+# "try again" and the gate that decides "ship it" from disagreeing -- finalize
+# used to check three of these and ignore the rest.
+#
+# `paragraph_length_met` is deliberately absent: it is a soft stylistic
+# preference, it never triggered repair, and promoting it to a blocker would
+# fail runs that nothing in the pipeline is able to fix.
+HARD_CONSTRAINT_CHECK_KEYS = (
+    "target_word_count_met",
+    "cta_present",
+    "primary_keyword_present",
+    "secondary_keywords_present",
+    "must_include_covered",
+    "claims_grounded",
+)
+
 
 def _extract_narrative_focus(writing_brief: dict[str, Any]) -> str:
     editorial = _safe_str(writing_brief.get("editorial_instructions"))
@@ -351,14 +370,7 @@ def _should_run_repair(quality: dict[str, Any], checks: dict[str, Any]) -> bool:
     if _safe_bool(quality.get("too_close_to_source"), default=False):
         return True
 
-    for key in (
-        "target_word_count_met",
-        "cta_present",
-        "primary_keyword_present",
-        "secondary_keywords_present",
-        "must_include_covered",
-        "claims_grounded",
-    ):
+    for key in HARD_CONSTRAINT_CHECK_KEYS:
         if not _safe_bool(checks.get(key), default=True):
             return True
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
@@ -5,6 +5,7 @@ from typing import Any
 from ..content.markdown import _build_markdown
 from ..dependencies import PipelineDependencies
 from ..graph.state import Prompt2BlogGraphState
+from ..policies import evaluate_readiness
 from ..pricing import Prompt2BlogTokenUsageTracker
 from ..quality import _build_constraint_checks
 from ..support import _safe_dict, _safe_str
@@ -35,15 +36,27 @@ def run_finalize_stage(
         final_content,
         state["writing_brief"],
     )
-    # An article carrying claims the sources do not support is not ready to
-    # stage, however well it scores on structure and keywords.
-    pipeline_status = (
-        "ready_for_staging"
-        if final_checks["target_word_count_met"]
-        and final_checks["primary_keyword_present"]
-        and state["groundedness"]["grounded"]
-        else "needs_revision"
+    # The checks the run is judged on: the auditor's semantic verdicts and the
+    # grounding result carried forward, with every measurable check recomputed
+    # on the text that is actually shipping.
+    settled_checks = {
+        **quality_checks,
+        **{
+            key: value
+            for key, value in final_checks.items()
+            if not key.endswith("_coverage") and key != "word_count_estimate"
+        },
+    }
+    # Readiness is one shared decision (see policies.evaluate_readiness), not a
+    # third opinion. Finalize used to accept any draft that hit its word count
+    # and primary keyword and reported `grounded`, which passed low-scoring
+    # articles and crashed grounding checks alike.
+    verdict = evaluate_readiness(
+        quality=quality,
+        checks=settled_checks,
+        groundedness=state["groundedness"],
     )
+    pipeline_status = "ready_for_staging" if verdict.ready else "needs_revision"
     usage_summary = getattr(dependencies.llm, "usage_summary", None)
     usage_kwargs = {
         "stack_id": state.get("model_stack_id"),
@@ -61,6 +74,7 @@ def run_finalize_stage(
         stage,
         {
             "pipeline_status": pipeline_status,
+            "readiness_blockers": list(verdict.blockers),
             "final_title": final_title,
             "word_count_estimate": final_checks["word_count_estimate"],
             "constraint_checks": final_checks,
@@ -71,6 +85,7 @@ def run_finalize_stage(
         "message": "Prompt2Blog pipeline v2 completed",
         "run_id": run_id,
         "pipeline_status": pipeline_status,
+        "readiness_blockers": list(verdict.blockers),
         "article_type": {
             "id": guideline["id"],
             "name": guideline["name"],
@@ -111,17 +126,8 @@ def run_finalize_stage(
             },
             # audience_match and tone_match come from the auditor and pass
             # through; the measurable checks are recomputed on the final text.
-            "constraint_checks": {
-                **quality_checks,
-                "target_word_count_met": final_checks["target_word_count_met"],
-                "paragraph_length_met": final_checks["paragraph_length_met"],
-                "cta_present": final_checks["cta_present"],
-                "primary_keyword_present": final_checks["primary_keyword_present"],
-                "secondary_keywords_present": final_checks[
-                    "secondary_keywords_present"
-                ],
-                "must_include_covered": final_checks["must_include_covered"],
-            },
+            "constraint_checks": settled_checks,
+            "readiness_blockers": list(verdict.blockers),
             "secondary_keyword_coverage": final_checks["secondary_keyword_coverage"],
             "must_include_coverage": final_checks["must_include_coverage"],
             "word_count_estimate": final_checks["word_count_estimate"],

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_readiness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_readiness.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from app.features.prompt2blog.policies import evaluate_readiness
+from app.features.prompt2blog.quality import (
+    HARD_CONSTRAINT_CHECK_KEYS,
+    _should_run_repair,
+    unchecked_groundedness,
+)
+
+PASSING_CHECKS = {key: True for key in HARD_CONSTRAINT_CHECK_KEYS}
+GOOD_QUALITY = {
+    "audit_complete": True,
+    "overall_score": 9,
+    "too_close_to_source": False,
+}
+CHECKED_GROUNDED = {"checked": True, "grounded": True}
+
+
+def test_a_clean_run_is_ready():
+    verdict = evaluate_readiness(
+        quality=GOOD_QUALITY,
+        checks=PASSING_CHECKS,
+        groundedness=CHECKED_GROUNDED,
+    )
+
+    assert verdict.ready is True
+    assert verdict.blockers == ()
+
+
+def test_a_low_scoring_article_is_not_ready():
+    # The reported reproduction: 4/10 with the repair budget spent still came
+    # back ready_for_staging because finalize never looked at the score.
+    verdict = evaluate_readiness(
+        quality={**GOOD_QUALITY, "overall_score": 4},
+        checks=PASSING_CHECKS,
+        groundedness=CHECKED_GROUNDED,
+    )
+
+    assert verdict.ready is False
+    assert "quality_score_below_threshold" in verdict.blockers
+
+
+def test_an_unchecked_grounding_result_is_not_ready():
+    # unchecked_groundedness reports grounded=True on purpose so a checker
+    # outage degrades rather than blocks the run. Reading `grounded` alone
+    # turned that into a pass.
+    result = unchecked_groundedness()
+    assert result["grounded"] is True
+
+    verdict = evaluate_readiness(
+        quality=GOOD_QUALITY,
+        checks=PASSING_CHECKS,
+        groundedness=result,
+    )
+
+    assert verdict.ready is False
+    assert verdict.blockers == ("groundedness_unchecked",)
+
+
+def test_an_ungrounded_article_is_not_ready():
+    verdict = evaluate_readiness(
+        quality=GOOD_QUALITY,
+        checks={**PASSING_CHECKS, "claims_grounded": False},
+        groundedness={"checked": True, "grounded": False},
+    )
+
+    assert verdict.ready is False
+    assert "claims_ungrounded" in verdict.blockers
+
+
+def test_an_incomplete_audit_is_not_ready():
+    verdict = evaluate_readiness(
+        quality={"audit_complete": False, "overall_score": 7},
+        checks=PASSING_CHECKS,
+        groundedness=CHECKED_GROUNDED,
+    )
+
+    assert verdict.ready is False
+    assert "audit_incomplete" in verdict.blockers
+    # A missing score is not also reported as a low score.
+    assert "quality_score_below_threshold" not in verdict.blockers
+
+
+def test_every_hard_constraint_blocks_on_its_own():
+    for key in HARD_CONSTRAINT_CHECK_KEYS:
+        verdict = evaluate_readiness(
+            quality=GOOD_QUALITY,
+            checks={**PASSING_CHECKS, key: False},
+            groundedness=CHECKED_GROUNDED,
+        )
+
+        assert verdict.ready is False, key
+        assert key in verdict.blockers
+
+
+def test_a_soft_check_does_not_block():
+    # paragraph_length_met never triggers repair, so blocking on it would mark
+    # runs needs_revision that the pipeline has no way to rescue.
+    verdict = evaluate_readiness(
+        quality=GOOD_QUALITY,
+        checks={**PASSING_CHECKS, "paragraph_length_met": False},
+        groundedness=CHECKED_GROUNDED,
+    )
+
+    assert verdict.ready is True
+
+
+def test_readiness_blockers_stay_within_what_repair_tries_to_fix():
+    """Readiness must not be stricter than the repair trigger on anything
+    repair could act on, or a run is failed without ever being retried."""
+    for key in HARD_CONSTRAINT_CHECK_KEYS:
+        checks = {**PASSING_CHECKS, key: False}
+        assert _should_run_repair(GOOD_QUALITY, checks) is True, key
+
+    assert _should_run_repair({**GOOD_QUALITY, "overall_score": 4}, PASSING_CHECKS)
+    assert _should_run_repair(
+        {**GOOD_QUALITY, "too_close_to_source": True}, PASSING_CHECKS
+    )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineResult.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineResult.tsx
@@ -21,6 +21,7 @@ export function PipelineResult(props: PipelineResultProps) {
     </div>
     {props.result.run_cost && <RunCostReceipt cost={props.result.run_cost} />}
     <p><strong>Status:</strong> {props.result.pipeline_status}</p>
+    {props.result.readiness_blockers && props.result.readiness_blockers.length > 0 && <p><strong>Held back by:</strong> {props.result.readiness_blockers.join(', ')}</p>}
     <p><strong>Article Type:</strong> {props.result.article_type.name}</p>
     <p><strong>Model Used:</strong> {props.result.quality_review.model_used}</p>
     <p><strong>Title:</strong> {props.result.improved_article.title}</p>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -145,6 +145,8 @@ export type Prompt2BlogPipelinePayload = {
   langsmith_trace_url?: string
   langsmith_trace_run_id?: string
   pipeline_status: 'ready_for_staging' | 'needs_revision'
+  // Why a run was held back. Empty when the run is ready.
+  readiness_blockers?: string[]
   article_type: {
     id: number
     name: string
@@ -218,6 +220,7 @@ export type Prompt2BlogPipelinePayload = {
       must_include_covered: boolean
       claims_grounded: boolean
     }
+    readiness_blockers?: string[]
     groundedness: {
       checked: boolean
       grounded: boolean


### PR DESCRIPTION
Audit finding #1 and #2.

## Problem

`finalize.py` decided `ready_for_staging` on three questions: word count, primary keyword, and `groundedness["grounded"]`. The repair loop's gate (`_should_run_repair`) already knew about the quality score, CTA, `must_include`, secondary keywords and `too_close_to_source`. Two gates, two different definitions of "good enough", and finalize was the lenient one.

Consequences:
- 4/10 overall score with the repair budget spent -> `ready_for_staging`
- grounding checker raises -> `unchecked_groundedness()` returns `grounded: True` (deliberate, so an outage degrades rather than blocks) -> finalize read `grounded` without `checked` -> `ready_for_staging`

## Change

- `quality.py` gains `HARD_CONSTRAINT_CHECK_KEYS`, the one list both gates read.
- `policies.evaluate_readiness()` is the single readiness decision, returning a `ReadinessVerdict` with named blockers.
- `finalize.py` calls it, against checks recomputed on the text that actually ships.
- `readiness_blockers` rides on the payload and renders in the result panel.

## Design note: why the blocker set is not stricter

Readiness blockers are deliberately **the repair loop's own trigger conditions**, plus the two failures repair cannot clear (`audit_incomplete`, `groundedness_unchecked`).

Blocking on something repair never tries to fix would mark runs `needs_revision` that the pipeline has no way of rescuing. That is why `paragraph_length_met` (soft, never triggered repair) and non-empty `required_revisions` (often advisory nitpicks on a 9/10 draft) are reported but do not block. `test_readiness_blockers_stay_within_what_repair_tries_to_fix` locks that invariant in.

## Expected effect

The ready rate will drop. That is the point of the change — some runs that previously reported `ready_for_staging` were not.

## Verification

- `pytest tests/` — 647 passed (639 before, 8 new)
- `tsc -p apps/frontend/tsconfig.json --noEmit` — clean
- `vitest run` — 694 passed
- `eslint` — 0 errors (1 pre-existing warning, unrelated file)
- `flake8` — clean
- boundary check — passed