### PR TITLE
Rank Prompt2Blog drafts on validity before score

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/policies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/policies.py
@@ -82,11 +82,32 @@ def evaluate_readiness(
     return ReadinessVerdict(ready=not blockers, blockers=tuple(blockers))
 
 
-def _quality_rank(quality: dict[str, Any]) -> tuple[int, int]:
-    """Rank a draft for keep-best comparison. Overall score first, then
-    guideline coverage as the tie-break."""
+def _quality_rank(quality: dict[str, Any]) -> tuple[int, int, int, int]:
+    """Rank a draft for keep-best comparison, validity before quality.
+
+    Ranking on score alone let an unsafe draft win. A repair pass that fixed
+    an invented visa fee but scored 8 lost to the ungrounded original scoring
+    9, and the settle node restored the ungrounded one.
+
+    So the ordering is: grounded first, then how many readiness blockers the
+    draft carries, and only then the auditor's scores. The blocker count is
+    read from `evaluate_readiness`, the same function finalize ships on, so a
+    draft cannot rank first and then be refused at the gate for a reason
+    ranking never looked at.
+    """
     quality = _safe_dict(quality)
+    groundedness = _safe_dict(quality.get("groundedness"))
+    verdict = evaluate_readiness(
+        quality=quality,
+        checks=_safe_dict(quality.get("constraint_checks")),
+        groundedness=groundedness,
+    )
+    grounded = _safe_bool(groundedness.get("checked"), default=False) and _safe_bool(
+        groundedness.get("grounded"), default=False
+    )
     return (
+        1 if grounded else 0,
+        -len(verdict.blockers),
         _safe_int(quality.get("overall_score"), default=0),
         _safe_int(quality.get("guideline_coverage_score"), default=0),
     )
@@ -99,7 +120,9 @@ def is_better_quality(
     """True when ``candidate`` should replace ``incumbent`` as the best draft.
 
     Repair used to overwrite the draft unconditionally, so a repair pass that
-    scored worse than the draft it replaced still shipped.
+    scored worse than the draft it replaced still shipped. Ranking then ran on
+    scores alone, so a safer draft could still lose to a higher-scoring unsafe
+    one; see `_quality_rank`.
     """
     if not incumbent:
         return True

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_gate.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_gate.py
@@ -79,6 +79,59 @@ def test_keep_best_breaks_ties_on_guideline_coverage():
     )
 
 
+GROUNDED = {"checked": True, "grounded": True}
+UNGROUNDED = {"checked": True, "grounded": False}
+
+
+def _draft_quality(score, groundedness, **checks):
+    """A quality dict shaped the way stage_quality_audit emits one."""
+    return {
+        "audit_complete": True,
+        "overall_score": score,
+        "guideline_coverage_score": score,
+        "too_close_to_source": False,
+        "groundedness": groundedness,
+        "constraint_checks": {
+            **PASSING_CHECKS,
+            "claims_grounded": groundedness["grounded"],
+            **checks,
+        },
+    }
+
+
+def test_keep_best_prefers_a_grounded_draft_over_a_higher_scoring_ungrounded_one():
+    # The reported case: repair removes an invented visa fee and scores 8; the
+    # ungrounded original scored 9 and the settle node restored it.
+    safe_repair = _draft_quality(8, GROUNDED)
+    ungrounded_original = _draft_quality(9, UNGROUNDED)
+
+    assert is_better_quality(safe_repair, ungrounded_original)
+    assert not is_better_quality(ungrounded_original, safe_repair)
+
+
+def test_keep_best_prefers_a_draft_with_fewer_readiness_blockers():
+    fewer_blockers = _draft_quality(7, GROUNDED)
+    more_blockers = _draft_quality(9, GROUNDED, must_include_covered=False)
+
+    assert is_better_quality(fewer_blockers, more_blockers)
+    assert not is_better_quality(more_blockers, fewer_blockers)
+
+
+def test_keep_best_still_ranks_on_score_when_validity_is_equal():
+    assert is_better_quality(_draft_quality(9, GROUNDED), _draft_quality(7, GROUNDED))
+    assert not is_better_quality(
+        _draft_quality(7, GROUNDED), _draft_quality(9, GROUNDED)
+    )
+
+
+def test_keep_best_prefers_a_checked_grounding_result_over_an_unchecked_one():
+    # An outage reports grounded=True; that is a degraded signal, not evidence.
+    checked = _draft_quality(8, GROUNDED)
+    unchecked = _draft_quality(9, {"checked": False, "grounded": True})
+
+    assert is_better_quality(checked, unchecked)
+
+
 def test_augmentation_accepted_when_it_only_adds():
     augmented = DRAFT + "\n> [!EDITORIAL-BOX|highlight_callout]\n> Budget extra time.\n"
 


### PR DESCRIPTION
Audit finding #3. Follows #369.

## Problem

`_quality_rank` was `(overall_score, guideline_coverage_score)`. Groundedness and the hard constraints carried no rank weight, so keep-best could restore an unsafe draft:

- repair removes an invented visa fee, scores 8
- ungrounded original scored 9
- settle node restores the ungrounded one

## Change

Rank is now `(grounded, -blocker_count, overall_score, guideline_coverage_score)`.

The blocker count comes from `evaluate_readiness` — the same function `finalize` ships on — so a draft cannot win the ranking and then be refused at the gate for a reason ranking never looked at. That coupling is the reason this PR follows #369 rather than standing alone.

An unchecked grounding result loses to a checked one at equal score, consistent with the readiness gate: `grounded: True` from a crashed checker is a degraded signal, not evidence.

## Not changed

`route_quality_gate` and the repair budget are untouched. This only affects which of the drafts already seen gets restored at settle time.

## Verification

- `pytest tests/` — 651 passed (647 before, 4 new)
- `flake8` — clean
- Existing `is_better_quality` tests pass unchanged: bare quality dicts rank equal on validity and fall through to score, as before.