### PR TITLE
Re-check the Prompt2Blog article that actually ships

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -42,6 +42,7 @@ class Prompt2BlogGraphState(TypedDict, total=False):
     best_quality: dict[str, Any]
     best_quality_checks: dict[str, Any]
     augmentation_rolled_back: bool
+    content_changed_by_augmentation: bool
     editorial_augmentation: dict[str, Any]
     editorial_augmentation_raw_response: str
     final_title: str

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/topology.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/topology.py
@@ -23,6 +23,7 @@ GENERATION_NODES = (
     "repair",
     "quality_settle",
     "editorial_augmentation",
+    "final_verify",
     "title",
     "finalize",
 )
@@ -71,7 +72,11 @@ def build_prompt2blog_graph(nodes: dict[str, Any]) -> Any:
     builder.add_edge("repair", "groundedness")
 
     builder.add_edge("quality_settle", "editorial_augmentation")
-    builder.add_edge("editorial_augmentation", "title")
+    # Augmentation is a full-article generation call, so the text that
+    # ships is not the text the audit saw. final_verify re-grounds it
+    # before anything reports on it.
+    builder.add_edge("editorial_augmentation", "final_verify")
+    builder.add_edge("final_verify", "title")
     builder.add_edge("title", "finalize")
     builder.add_edge("finalize", END)
     return builder

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator.py
@@ -24,6 +24,7 @@ from .stages.audit_repair import (
 )
 from .stages.augmentation import run_augmentation_stage
 from .stages.finalize import run_finalize_stage
+from .stages.final_verify import run_final_verify_stage
 from .stages.groundedness import run_groundedness_stage
 from .stages.guideline_coverage import run_coverage_stage, run_guideline_stage
 from .stages.outline import run_outline_stage
@@ -121,6 +122,7 @@ def _generation_nodes(
         ("repair", run_repair_stage),
         ("quality_settle", run_quality_settle_stage),
         ("editorial_augmentation", run_augmentation_stage),
+        ("final_verify", run_final_verify_stage),
         ("title", run_title_stage),
         ("finalize", run_finalize_stage),
     ]

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -249,9 +249,14 @@ def run_quality_settle_stage(
         stage=stage,
         output=settlement,
     )
+    # The grounding verdict travels with the draft it describes. Settling
+    # restored an earlier draft's text and scores but left `groundedness` on
+    # whatever the last loop iteration produced, so a reverted run could report
+    # a verdict belonging to a draft it had just discarded.
     return {
         "current_stage": stage,
         "rewrite": best_rewrite,
         "quality": best_quality,
         "quality_checks": best_checks,
+        "groundedness": best_quality.get("groundedness") or state["groundedness"],
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/augmentation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/augmentation.py
@@ -5,7 +5,10 @@ from typing import Any
 
 from app.shared.prompts import ANTI_AI_TELLS_FULL
 
-from ..content.editorial_blocks import _sanitize_editorial_augmentation
+from ..content.editorial_blocks import (
+    _normalize_markdown_for_comparison,
+    _sanitize_editorial_augmentation,
+)
 from ..dependencies import PipelineDependencies
 from ..graph.state import Prompt2BlogGraphState
 from ..observability import _append_stage_trace
@@ -145,6 +148,14 @@ def run_augmentation_stage(
             },
         )
 
+    # `augmentation_applied` requires components to have been added. Content
+    # can change without them -- augmentation is a full-article generation call
+    # and returns rewritten prose either way -- so what the downstream re-check
+    # keys off is the text itself, not the component list.
+    content_changed = _normalize_markdown_for_comparison(
+        augmentation["augmented_content"]
+    ) != _normalize_markdown_for_comparison(rewrite["improved_content"])
+
     rewrite = {**rewrite, "improved_content": augmentation["augmented_content"]}
     dependencies.recorder.record_stage(
         run_id,
@@ -154,6 +165,7 @@ def run_augmentation_stage(
             "raw_response": raw_response,
             "skipped": not state["enable_editorial_augmentation"],
             "rolled_back": rolled_back,
+            "content_changed": content_changed,
             "retention_checks": augmentation_diagnostics,
         },
     )
@@ -163,4 +175,5 @@ def run_augmentation_stage(
         "editorial_augmentation": augmentation,
         "editorial_augmentation_raw_response": raw_response,
         "augmentation_rolled_back": rolled_back,
+        "content_changed_by_augmentation": content_changed,
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/final_verify.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/final_verify.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..dependencies import PipelineDependencies
+from ..graph.state import Prompt2BlogGraphState
+from ..observability import _append_stage_trace
+from ..quality import _build_constraint_checks
+from .groundedness import check_groundedness
+
+logger = logging.getLogger(__name__)
+
+
+def run_final_verify_stage(
+    state: Prompt2BlogGraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Re-check the article the run is actually going to ship.
+
+    The quality audit and the grounding check both ran before editorial
+    augmentation. Augmentation is additive by contract, but it is a full-article
+    generation call: it returns rewritten prose, and the only thing standing
+    between its output and the reader was a word-count ratio and a heading
+    count. Everything downstream then reported pre-augmentation groundedness
+    for post-augmentation text.
+
+    So when augmentation actually changed the prose, the grounding check runs
+    again over the changed text and its verdict replaces the stale one. When
+    augmentation was skipped, rolled back, or returned the draft unchanged, the
+    text still matches what the auditor saw, the earlier verdict still
+    describes it, and no second call is bought.
+    """
+    stage = "stage_final_verify"
+    run_id = state["run_id"]
+    rewrite = state["rewrite"]
+    quality = state["quality"]
+    dependencies.recorder.start_stage(run_id, stage)
+
+    content_changed = bool(state.get("content_changed_by_augmentation", False))
+
+    groundedness = state["groundedness"]
+    if content_changed:
+        groundedness = check_groundedness(
+            state,
+            dependencies,
+            stage=stage,
+            rewrite=rewrite,
+        )
+
+    # Recomputed on the shipping text so the settled checks describe it rather
+    # than the draft the auditor saw.
+    final_checks = _build_constraint_checks(
+        rewrite["improved_title"],
+        rewrite["improved_content"],
+        state["writing_brief"],
+    )
+    measurements = {
+        "word_count_estimate",
+        "secondary_keyword_coverage",
+        "must_include_coverage",
+    }
+    quality_checks = {
+        **state["quality_checks"],
+        **{
+            key: value
+            for key, value in final_checks.items()
+            if key not in measurements
+        },
+        "claims_grounded": groundedness["grounded"],
+    }
+    quality = {
+        **quality,
+        "constraint_checks": quality_checks,
+        "groundedness": groundedness,
+    }
+
+    verification = {
+        "content_changed_after_audit": content_changed,
+        "regrounded": content_changed,
+        "claims_grounded": groundedness["grounded"],
+        "groundedness_checked": groundedness["checked"],
+        "high_severity_count": groundedness["high_severity_count"],
+    }
+    if content_changed and not groundedness["grounded"]:
+        logger.warning(
+            "Prompt2Blog run %s lost grounding during editorial augmentation "
+            "(%d high-severity claims)",
+            run_id,
+            groundedness["high_severity_count"],
+        )
+
+    dependencies.recorder.record_stage(run_id, stage, verification)
+    _append_stage_trace(
+        state["trace"],
+        state["include_debug"],
+        stage=stage,
+        output=verification,
+    )
+    return {
+        "current_stage": stage,
+        "groundedness": groundedness,
+        "quality": quality,
+        "quality_checks": quality_checks,
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/groundedness.py
@@ -12,25 +12,19 @@ from ..quality import _sanitize_groundedness, unchecked_groundedness
 logger = logging.getLogger(__name__)
 
 
-def run_groundedness_stage(
+def check_groundedness(
     state: Prompt2BlogGraphState,
     dependencies: PipelineDependencies,
+    *,
+    stage: str,
+    rewrite: dict[str, Any],
 ) -> dict[str, Any]:
-    """Check the draft's claims against the source material.
+    """Run the grounding check over one draft and return the sanitised result.
 
-    The quality audit scored `too_close_to_source` -- the plagiarism direction.
-    Nothing checked the opposite direction, so a draft that invented a visa
-    rule, a price or an opening time passed every gate. The supplement stage
-    can generate content the sources never contained, and that content flows
-    straight into compose, so the risk is structural rather than incidental.
-
-    Runs inside the repair loop, so a repaired draft is re-checked.
+    Shared by the in-loop check and the post-augmentation re-check so both ask
+    the same question of the same sources.
     """
-    stage = "stage_groundedness"
     run_id = state["run_id"]
-    rewrite = state["rewrite"]
-    dependencies.recorder.start_stage(run_id, stage)
-
     prompt = P2B_GROUNDEDNESS_PROMPT.format(
         raw_sources=state["raw_sources_text"],
         cleaned_data=state["cleaned_data"],
@@ -81,6 +75,31 @@ def run_groundedness_stage(
         run_id,
         stage,
         {"groundedness": groundedness, "raw_response": raw_response},
+    )
+    return groundedness
+
+
+def run_groundedness_stage(
+    state: Prompt2BlogGraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Check the draft's claims against the source material.
+
+    The quality audit scored `too_close_to_source` -- the plagiarism direction.
+    Nothing checked the opposite direction, so a draft that invented a visa
+    rule, a price or an opening time passed every gate. The supplement stage
+    can generate content the sources never contained, and that content flows
+    straight into compose, so the risk is structural rather than incidental.
+
+    Runs inside the repair loop, so a repaired draft is re-checked.
+    """
+    stage = "stage_groundedness"
+    dependencies.recorder.start_stage(state["run_id"], stage)
+    groundedness = check_groundedness(
+        state,
+        dependencies,
+        stage=stage,
+        rewrite=state["rewrite"],
     )
     return {
         "current_stage": stage,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_final_verify.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_final_verify.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.dependencies import PipelineDependencies
+from app.features.prompt2blog.run_recorder import RunRecorder
+from app.features.prompt2blog.stages.final_verify import run_final_verify_stage
+
+AUDITED = "## Plan Your Visit\n\nKyoto rewards travelers who plan transport.\n"
+AUGMENTED = (
+    "## Plan Your Visit\n\nKyoto rewards travelers who plan transport.\n\n"
+    "> [!EDITORIAL-BOX|highlight_callout]\n"
+    "> The Kyoto tourist tax is 4,000 yen a night.\n"
+)
+
+
+def _fakes(*, grounded: bool, error: bool = False):
+    recorded: dict[str, Any] = {"stages": [], "grounding_calls": 0}
+
+    class FakeLLM:
+        def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
+            recorded["grounding_calls"] += 1
+            if error:
+                raise RuntimeError("grounding checker unavailable")
+            claims = (
+                []
+                if grounded
+                else [
+                    {
+                        "claim": "The Kyoto tourist tax is 4,000 yen a night.",
+                        "reason": "No source states a tourist tax.",
+                        "severity": "high",
+                    }
+                ]
+            )
+            return (
+                {
+                    "grounded": grounded,
+                    "assessment": "Checked.",
+                    "unsupported_claims": claims,
+                },
+                "{}",
+            )
+
+    recorder = RunRecorder(
+        status_writer=lambda *a, **k: None,
+        stage_writer=lambda run_id, stage, payload: recorded["stages"].append(
+            (stage, payload)
+        ),
+        artifact_writer=lambda *a, **k: None,
+        clock=lambda: "2026-08-24T00:00:00+00:00",
+    )
+    return recorded, PipelineDependencies(llm=FakeLLM(), recorder=recorder)
+
+
+def _verify_payload(recorded: dict[str, Any]) -> dict[str, Any]:
+    """The last stage_final_verify record: the verification summary.
+
+    The re-grounding call records under the same stage name first.
+    """
+    return [
+        payload["data"]
+        for stage, payload in recorded["stages"]
+        if stage == "stage_final_verify"
+    ][-1]
+
+
+def _state(*, content: str, content_changed: bool) -> dict[str, Any]:
+    return {
+        "run_id": "run-final-verify",
+        "trace": [],
+        "include_debug": False,
+        "audit_model": "test-audit",
+        "raw_sources_text": "Kyoto source material.",
+        "cleaned_data": "Kyoto source material.",
+        "writing_brief": {},
+        "rewrite": {"improved_title": "Kyoto", "improved_content": content},
+        "quality": {"audit_complete": True, "overall_score": 9},
+        "quality_checks": {"audience_match": True, "claims_grounded": True},
+        "groundedness": {
+            "checked": True,
+            "grounded": True,
+            "assessment": "Checked before augmentation.",
+            "unsupported_claims": [],
+            "high_severity_count": 0,
+        },
+        "content_changed_by_augmentation": content_changed,
+    }
+
+
+def test_unchanged_content_is_not_re_grounded():
+    # The audited text and the shipping text are the same bytes, so the earlier
+    # verdict still describes it. Buying a second grounding call here would be
+    # pure cost.
+    recorded, dependencies = _fakes(grounded=True)
+
+    updates = run_final_verify_stage(
+        _state(content=AUDITED, content_changed=False),
+        dependencies,
+    )
+
+    assert recorded["grounding_calls"] == 0
+    assert updates["groundedness"]["assessment"] == "Checked before augmentation."
+    payload = _verify_payload(recorded)
+    assert payload["content_changed_after_audit"] is False
+    assert payload["regrounded"] is False
+
+
+def test_changed_content_is_re_grounded():
+    recorded, dependencies = _fakes(grounded=True)
+
+    updates = run_final_verify_stage(
+        _state(content=AUGMENTED, content_changed=True),
+        dependencies,
+    )
+
+    assert recorded["grounding_calls"] == 1
+    assert updates["groundedness"]["assessment"] == "Checked."
+    assert _verify_payload(recorded)["regrounded"] is True
+
+
+def test_a_claim_introduced_by_augmentation_is_caught():
+    # The reported hole: augmentation can rewrite the whole article after the
+    # audit has settled, and the pipeline went on reporting the pre-augmentation
+    # grounding verdict for it.
+    recorded, dependencies = _fakes(grounded=False)
+
+    updates = run_final_verify_stage(
+        _state(content=AUGMENTED, content_changed=True),
+        dependencies,
+    )
+
+    assert updates["groundedness"]["grounded"] is False
+    assert updates["groundedness"]["high_severity_count"] == 1
+    assert updates["quality_checks"]["claims_grounded"] is False
+    assert updates["quality"]["groundedness"]["grounded"] is False
+
+
+def test_a_failed_re_check_is_recorded_as_unchecked():
+    recorded, dependencies = _fakes(grounded=True, error=True)
+
+    updates = run_final_verify_stage(
+        _state(content=AUGMENTED, content_changed=True),
+        dependencies,
+    )
+
+    # Degraded, not silently inherited from the pre-augmentation pass.
+    assert updates["groundedness"]["checked"] is False
+    assert _verify_payload(recorded)["groundedness_checked"] is False
+
+
+def test_settling_restores_the_grounding_verdict_of_the_draft_it_restores():
+    """Settling reverted the draft's text and scores but left `groundedness`
+    on whatever the last repair iteration produced."""
+    from app.features.prompt2blog.stages.audit_repair import run_quality_settle_stage
+
+    recorded, dependencies = _fakes(grounded=True)
+    best_groundedness = {
+        "checked": True,
+        "grounded": True,
+        "assessment": "The kept draft is grounded.",
+        "unsupported_claims": [],
+        "high_severity_count": 0,
+    }
+    state = {
+        "run_id": "run-settle",
+        "trace": [],
+        "include_debug": False,
+        "rewrite": {"improved_title": "Late", "improved_content": "Late draft."},
+        "quality": {"overall_score": 5},
+        "quality_checks": {},
+        # The last loop iteration was ungrounded; the draft being restored was not.
+        "groundedness": {
+            "checked": True,
+            "grounded": False,
+            "assessment": "The discarded draft invented a fee.",
+            "unsupported_claims": [],
+            "high_severity_count": 1,
+        },
+        "best_rewrite": {"improved_title": "Best", "improved_content": "Best draft."},
+        "best_quality": {"overall_score": 9, "groundedness": best_groundedness},
+        "best_quality_checks": {"claims_grounded": True},
+    }
+
+    updates = run_quality_settle_stage(state, dependencies)
+
+    assert updates["rewrite"]["improved_content"] == "Best draft."
+    assert updates["groundedness"] == best_groundedness

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_graph_routing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_graph_routing.py
@@ -47,6 +47,7 @@ def test_prompt2blog_pipeline_v2_routes_each_stage_through_graph(monkeypatch):
         "repair",
         "quality_settle",
         "editorial_augmentation",
+        "final_verify",
         "title",
         "finalize",
     ]
@@ -87,6 +88,7 @@ def test_prompt2blog_full_run_prepends_preparation_node(monkeypatch):
         "repair",
         "quality_settle",
         "editorial_augmentation",
+        "final_verify",
         "title",
         "finalize",
     ]

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
@@ -293,6 +293,7 @@ def test_pipeline_contract_preserves_stage_order_and_artifact():
         "stage_quality_audit",
         "stage_quality_settle",
         "stage_editorial_augmentation",
+        "stage_final_verify",
         "stage_title",
         "stage_finalize",
         "pipeline_v2",

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.ts
@@ -22,6 +22,7 @@ export const PIPELINE_STAGE_LABELS: Record<Prompt2BlogPipelineStage, string> = {
   stage_repair: 'Repair pass (if needed)',
   stage_quality_settle: 'Settle on the best-scoring draft',
   stage_editorial_augmentation: 'Apply editorial blocks (if helpful)',
+  stage_final_verify: 'Re-check the article being shipped',
   stage_title: 'Generate final title',
   stage_finalize: 'Finalize markdown output',
   complete: 'Complete',

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -109,6 +109,7 @@ export const PROMPT2BLOG_PIPELINE_STAGES = [
   'stage_repair',
   'stage_quality_settle',
   'stage_editorial_augmentation',
+  'stage_final_verify',
   'stage_title',
   'stage_finalize',
   'complete',


### PR DESCRIPTION
Audit finding #4. Follows #369 and #370.

## Problem

`quality_settle -> editorial_augmentation -> title -> finalize`. The quality audit and the grounding check both ran *before* augmentation.

Augmentation is additive by contract, but it is a full-article generation call — it returns rewritten prose, and the only thing between its output and the reader was `evaluate_augmentation`, which checks a word-count retention ratio and a heading count. Everything downstream then reported pre-augmentation groundedness for post-augmentation text.

Found while wiring this up: **settling had a related hole.** `run_quality_settle_stage` restored an earlier draft's text and scores but left `groundedness` on whatever the last repair iteration produced, so a reverted run could report a verdict belonging to the draft it had just discarded.

## Change

- New `final_verify` node between `editorial_augmentation` and `title`. It re-runs the grounding check over the changed text, and recomputes the constraint checks on the shipping text.
- `groundedness.py` grows a reusable `check_groundedness()` so the in-loop check and the re-check ask the same question of the same sources.
- Settling now carries the grounding verdict of the draft it restores.
- `stage_final_verify` added to the frontend stage list and label map, so the progress UI does not render it as `unknown`.

## Cost

**Zero extra calls on the common path.** The re-check only fires when augmentation actually changed the prose. Augmentation disabled, rolled back, or a no-op pass -> text is byte-identical to what the auditor saw -> earlier verdict stands, no second call.

The trigger is a normalized comparison of the text itself, deliberately **not** `augmentation_applied` — that flag also requires components to have been added, and augmentation can rewrite prose while adding none.

## Not done here

Making augmentation a deterministic insertion (the cheaper of the two options in the audit) is a larger behavioural change to the editorial-blocks contract. This PR closes the correctness hole; that remains open as a cost optimisation.

## Verification

- `pytest tests/` — 652 passed (647 before, 5 new)
- `tsc` clean, `vitest` 694 passed, `eslint` 0 errors, `flake8` clean, boundary check passed
- Stage-order assertions in `test_prompt2blog_graph_routing.py` and `test_prompt2blog_pipeline_contract.py` updated for the new node.