### PR TITLE
Bill Prompt2Blog reasoning tokens on the run receipt

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -50,11 +50,29 @@ def normalize_token_usage(value: Any) -> dict[str, int] | None:
         "prompt_token_count",
         "prompt_tokens",
     )
+    # Google bills reasoning tokens at the output rate, but LangChain does not
+    # put them in `output_tokens`. `_get_usage_metadata_gemini` sets
+    # `output_tokens = candidates_token_count` and files the thinking tokens
+    # under `output_token_details["reasoning"]`, so reading `output_tokens`
+    # alone charged the run for the visible answer and nothing for the
+    # reasoning that produced it.
+    reasoning_tokens = 0
+    output_details = value.get("output_token_details")
+    if isinstance(output_details, dict):
+        reasoning_tokens = _usage_value(output_details, "reasoning", "reasoning_tokens")
+
     output_tokens = _usage_value(value, "output_tokens", "completion_tokens")
-    if not output_tokens:
-        output_tokens = _usage_value(value, "candidates_token_count") + _usage_value(
-            value,
-            "thoughts_token_count",
+    if output_tokens:
+        output_tokens += reasoning_tokens
+    else:
+        # Raw Vertex metadata rather than LangChain's: `candidates_token_count`
+        # excludes thinking too, and `thoughts_token_count` carries it.
+        reasoning_tokens = max(
+            reasoning_tokens,
+            _usage_value(value, "thoughts_token_count"),
+        )
+        output_tokens = (
+            _usage_value(value, "candidates_token_count") + reasoning_tokens
         )
     total_tokens = _usage_value(value, "total_tokens", "total_token_count")
     input_details = value.get("input_token_details")
@@ -76,6 +94,10 @@ def normalize_token_usage(value: Any) -> dict[str, int] | None:
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
+        # Reported separately as well as folded into output_tokens: a receipt
+        # that shows a title call spending thousands of tokens is the signal
+        # that stage-level thinking control is worth having.
+        "reasoning_tokens": reasoning_tokens,
         "cached_input_tokens": min(cached_input_tokens, input_tokens),
         "total_tokens": total_tokens,
     }
@@ -132,6 +154,7 @@ class Prompt2BlogTokenUsageTracker:
             {
                 "input_tokens": 0,
                 "output_tokens": 0,
+                "reasoning_tokens": 0,
                 "cached_input_tokens": 0,
                 "total_tokens": 0,
                 "calls": 0,
@@ -143,6 +166,7 @@ class Prompt2BlogTokenUsageTracker:
         for key in (
             "input_tokens",
             "output_tokens",
+            "reasoning_tokens",
             "cached_input_tokens",
             "total_tokens",
         ):
@@ -168,6 +192,9 @@ class Prompt2BlogTokenUsageTracker:
     ) -> dict[str, Any]:
         input_tokens = sum(item["input_tokens"] for item in self.by_model.values())
         output_tokens = sum(item["output_tokens"] for item in self.by_model.values())
+        reasoning_tokens = sum(
+            item["reasoning_tokens"] for item in self.by_model.values()
+        )
         cached_input_tokens = sum(
             item["cached_input_tokens"] for item in self.by_model.values()
         )
@@ -189,6 +216,7 @@ class Prompt2BlogTokenUsageTracker:
                         for key in (
                             "input_tokens",
                             "output_tokens",
+                            "reasoning_tokens",
                             "cached_input_tokens",
                             "total_tokens",
                             "calls",
@@ -214,6 +242,7 @@ class Prompt2BlogTokenUsageTracker:
             },
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
+            "reasoning_tokens": reasoning_tokens,
             "cached_input_tokens": cached_input_tokens,
             "total_tokens": total_tokens,
             "successful_calls": self.successful_calls,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
@@ -18,6 +18,7 @@ def test_normalize_token_usage_accepts_langchain_and_google_shapes():
     ) == {
         "input_tokens": 120,
         "output_tokens": 30,
+        "reasoning_tokens": 0,
         "cached_input_tokens": 20,
         "total_tokens": 150,
     }
@@ -32,9 +33,58 @@ def test_normalize_token_usage_accepts_langchain_and_google_shapes():
     ) == {
         "input_tokens": 80,
         "output_tokens": 25,
+        "reasoning_tokens": 5,
         "cached_input_tokens": 10,
         "total_tokens": 105,
     }
+
+
+def test_langchain_reasoning_tokens_are_billed_as_output():
+    """LangChain's Gemini adapter sets `output_tokens` to
+    `candidates_token_count` and files thinking tokens under
+    `output_token_details["reasoning"]`. Reading `output_tokens` alone charged
+    the run for the visible answer and nothing for the reasoning."""
+    assert normalize_token_usage(
+        {
+            "input_tokens": 5_000,
+            "output_tokens": 40,
+            "total_tokens": 9_040,
+            "input_token_details": {"cache_read": 0},
+            "output_token_details": {"reasoning": 4_000},
+        }
+    ) == {
+        "input_tokens": 5_000,
+        "output_tokens": 4_040,
+        "reasoning_tokens": 4_000,
+        "cached_input_tokens": 0,
+        "total_tokens": 9_040,
+    }
+
+
+def test_reasoning_tokens_are_not_counted_twice():
+    """Raw Vertex metadata carries thinking in `thoughts_token_count`, which
+    `candidates_token_count` excludes. Both shapes must land on the same
+    number rather than one of them double-adding."""
+    langchain_shape = normalize_token_usage(
+        {
+            "input_tokens": 80,
+            "output_tokens": 20,
+            "total_tokens": 105,
+            "output_token_details": {"reasoning": 5},
+        }
+    )
+    raw_shape = normalize_token_usage(
+        {
+            "prompt_token_count": 80,
+            "candidates_token_count": 20,
+            "thoughts_token_count": 5,
+            "total_token_count": 105,
+        }
+    )
+
+    assert langchain_shape["output_tokens"] == 25
+    assert raw_shape["output_tokens"] == 25
+    assert langchain_shape["reasoning_tokens"] == raw_shape["reasoning_tokens"] == 5
 
 
 def test_usage_tracker_aggregates_models_and_prices_cached_tokens():

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/RunCostReceipt.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/RunCostReceipt.tsx
@@ -26,6 +26,7 @@ export function RunCostReceipt({ cost }: { cost: RunCost }) {
       <RunMetric label="Total tokens" value={formatTokens(cost.total_tokens)} />
       <RunMetric label="Input" value={formatTokens(cost.input_tokens)} />
       <RunMetric label="Output" value={formatTokens(cost.output_tokens)} />
+      {cost.reasoning_tokens != null && cost.reasoning_tokens > 0 && <RunMetric label="of which reasoning" value={formatTokens(cost.reasoning_tokens)} />}
       <RunMetric label="Cached input" value={formatTokens(cost.cached_input_tokens)} />
     </div>
     <p className="p2b-run-cost__coverage">{coverageLabel}</p>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -179,6 +179,8 @@ export type Prompt2BlogPipelinePayload = {
     }
     input_tokens: number
     output_tokens: number
+    // Billed at the output rate, and included in output_tokens.
+    reasoning_tokens?: number
     cached_input_tokens: number
     total_tokens: number
     successful_calls: number
@@ -190,6 +192,7 @@ export type Prompt2BlogPipelinePayload = {
       model: string
       input_tokens: number
       output_tokens: number
+      reasoning_tokens?: number
       cached_input_tokens: number
       total_tokens: number
       calls: number


### PR DESCRIPTION
Audit finding #11 — **verified against the installed adapter**, not taken on trust.

## Evidence

`langchain-google-vertexai==3.2.2`, `chat_models.py:2944`:

```python
def _get_usage_metadata_gemini(raw_metadata: dict) -> UsageMetadata | None:
    output_tokens = raw_metadata.get("candidates_token_count", 0)
    thought_tokens = raw_metadata.get("thoughts_token_count", 0)
    ...
    output_token_details={"reasoning": thought_tokens},
```

`output_tokens` is `candidates_token_count` — **excluding** thinking. Our `normalize_token_usage` read `output_tokens` and only summed `candidates + thoughts` when `output_tokens` was falsy, which on this path it never is. Google bills reasoning at the output rate, so every receipt undercharged by the whole reasoning spend.

I flagged this one as uncertain in the original assessment because the opposite bug — double-counting — was equally plausible without reading the adapter. It is not double-counting; the undercount is real.

## Change

- Reasoning tokens fold into `output_tokens` (billed together).
- `reasoning_tokens` reported separately on the summary and per-model rows, and shown in the receipt when non-zero.
- The raw-Vertex metadata shape still lands on the same number rather than double-adding. `test_reasoning_tokens_are_not_counted_twice` pins both shapes to the same result.

## Why this and not the token-cap change (#9)

I branched for the `MIN_GENERATION_MAX_TOKENS` work first and backed out. The 64k floor was introduced deliberately (`4517cfe1`) with a rationale that is largely correct: `max_tokens` is a ceiling, not a bill, and lowering it risks truncating a writer mid-article. Picking safe per-stage caps needs measured p95 output per stage, and **no measurement exists** — which is precisely what this PR starts producing. #9 and #10 should follow the data, not lead it.

## Verification

- `pytest tests/` — 653 passed (652 before; 2 new, 1 updated for the new key)
- `tsc` clean, `vitest` 694 passed, `eslint` 0 errors, `flake8` clean