### PR TITLE
Keep the task in Prompt2Blog's JSON retry prompt

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
@@ -63,6 +63,13 @@ def _enforce_anti_ai_markdown_with_model(
     )
 
 
+# The parse error names what went wrong, so the excerpt only has to show the
+# shape of the failure -- a fenced block, a preamble, a truncation. Sending
+# more of the bad output costs input tokens and invites the model to anchor on
+# text it has already been told is wrong.
+JSON_RETRY_EXCERPT_CHARS = 1_200
+
+
 def _invoke_json_llm(
     *,
     prompt: str,
@@ -102,11 +109,24 @@ def _invoke_json_llm(
                 attempt,
                 last_error,
             )
+            # The retry used to send only the truncated bad output. That
+            # discarded the task, the source material and the schema, so the
+            # model was asked to re-emit a full article as JSON while no
+            # longer able to see the article -- and the two paid retries after
+            # a compose failure could not have succeeded on their own terms.
+            # The instructions come back, and the parse error goes with them:
+            # naming what was wrong is worth more than a longer sample of the
+            # output that was wrong.
             current_prompt = (
-                "Your previous output was invalid JSON.\n"
-                "Return ONLY one strict JSON object.\n"
-                "No markdown fences, no commentary.\n\n"
-                f"Previous invalid output:\n{raw_response[:4000]}"
+                f"{strict_prompt}\n\n"
+                "RETRY NOTICE\n"
+                "Your previous response to this exact task could not be parsed "
+                f"as JSON: {last_error}\n"
+                "Return the same content again as one strict JSON object. "
+                "No markdown fences, no commentary, no text before or after "
+                "the object.\n\n"
+                "Start of the unparseable response, for reference only:\n"
+                f"{raw_response[:JSON_RETRY_EXCERPT_CHARS]}"
             )
 
     raise RuntimeError(

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_json_retry.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_json_retry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.prompt2blog import llm as prompt2blog_llm
+
+TASK_MARKER = "Rewrite the Kyoto transport section using only the sources below."
+
+
+def _capture_invocations(monkeypatch, responses: list[str]) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    pending = list(responses)
+
+    def _fake_invoke_text_llm(**kwargs: Any) -> str:
+        calls.append(kwargs)
+        return pending.pop(0)
+
+    monkeypatch.setattr(prompt2blog_llm, "_invoke_text_llm", _fake_invoke_text_llm)
+    return calls
+
+
+def test_a_json_retry_keeps_the_original_task(monkeypatch):
+    """The retry used to send only the truncated bad output, discarding the
+    task, the sources and the schema -- so a compose retry was asked to
+    re-emit an article it could no longer see."""
+    calls = _capture_invocations(
+        monkeypatch,
+        ["```json\nnot actually json", '{"improved_title": "Kyoto"}'],
+    )
+
+    parsed, _raw = prompt2blog_llm._invoke_json_llm(
+        prompt=TASK_MARKER,
+        max_tokens=4096,
+        temperature=0.2,
+        model_name="test-model",
+    )
+
+    assert parsed == {"improved_title": "Kyoto"}
+    assert len(calls) == 2
+    retry_prompt = calls[1]["prompt"]
+    assert TASK_MARKER in retry_prompt
+    assert "Return ONLY one valid JSON object." in retry_prompt
+    assert "RETRY NOTICE" in retry_prompt
+
+
+def test_a_json_retry_reports_the_parse_error_and_bounds_the_excerpt(monkeypatch):
+    junk = "x" * 10_000
+    calls = _capture_invocations(monkeypatch, [junk, '{"ok": true}'])
+
+    prompt2blog_llm._invoke_json_llm(
+        prompt=TASK_MARKER,
+        max_tokens=4096,
+        temperature=0.2,
+        model_name="test-model",
+    )
+
+    retry_prompt = calls[1]["prompt"]
+    assert "could not be parsed" in retry_prompt
+    excerpt = retry_prompt.split(
+        "Start of the unparseable response, for reference only:\n"
+    )[1]
+    assert len(excerpt) == prompt2blog_llm.JSON_RETRY_EXCERPT_CHARS
+
+
+def test_a_retry_drops_the_temperature(monkeypatch):
+    calls = _capture_invocations(monkeypatch, ["nope", '{"ok": true}'])
+
+    prompt2blog_llm._invoke_json_llm(
+        prompt=TASK_MARKER,
+        max_tokens=4096,
+        temperature=0.7,
+        model_name="test-model",
+    )
+
+    assert calls[0]["temperature"] == 0.7
+    assert calls[1]["temperature"] == 0.0
+
+
+def test_exhausted_retries_still_raise(monkeypatch):
+    calls = _capture_invocations(monkeypatch, ["nope", "still nope", "nope again"])
+
+    with pytest.raises(RuntimeError, match="Failed to parse JSON LLM response"):
+        prompt2blog_llm._invoke_json_llm(
+            prompt=TASK_MARKER,
+            max_tokens=4096,
+            temperature=0.2,
+            model_name="test-model",
+        )
+
+    assert len(calls) == 3


### PR DESCRIPTION
Audit finding #8, in part.

## Problem

`_invoke_json_llm` retries a JSON parse failure up to twice. The retry prompt was:

```
Your previous output was invalid JSON.
Return ONLY one strict JSON object.
No markdown fences, no commentary.

Previous invalid output:
<first 4000 chars of the bad output>
```

No instructions, no source material, no schema. After a compose or repair failure this asks the model to re-emit a full article as JSON **while no longer able to see the article**. Both paid retries were structurally incapable of succeeding on their own terms.

## Change

- The retry re-sends the original strict prompt, plus a `RETRY NOTICE` naming the actual parse error.
- The bad-output excerpt shrinks from 4,000 to 1,200 chars (`JSON_RETRY_EXCERPT_CHARS`). The error message now carries the diagnosis, so the excerpt only has to show the *shape* of the failure — a code fence, a preamble, a truncation. Sending more costs input tokens and invites the model to anchor on text it has just been told is broken.

## Cost note

Retry attempts now carry the full prompt again, so a retry is more expensive than it was. That is the correct trade: the previous retries were cheap because they were unable to work. Attempt 1 — the overwhelming majority of calls — is unchanged.

## Not done here

Native schema-constrained output. `packages/utils/src/utils/gemini_tools.py` already has the forced-tool infrastructure; moving the Prompt2Blog stages onto it removes prompt-only JSON entirely and is a larger piece of work worth its own PR.

## Verification

- `pytest tests/` — 662 passed (658 before, 4 new; the retry path had no test at all)
- `flake8` clean