### PR TITLE
Drop Prompt2Blog checkpoints when the run that made them ends

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/ai_graph/runtime.py
+++ b/apps/ai-blog-writer/apps/backend/app/ai_graph/runtime.py
@@ -169,12 +169,52 @@ def langsmith_trace_payload(
     return payload
 
 
+def _discard_thread_checkpoints(saver: Any, thread_id: str | None) -> None:
+    """Drop one thread's checkpoints once its run is over.
+
+    LangGraph writes the whole graph state after every node, and Prompt2Blog's
+    state grows as it goes: sources, cleaned data, each draft, each audit. A
+    run therefore leaves behind a stack of snapshots roughly as large as the
+    run itself, and nothing ever removed them -- the shared checkpoint database
+    had reached 305 MB.
+
+    Checkpoints exist so an interrupted run can resume. Nothing in this
+    codebase resumes one; there is no call to `get_state`, `update_state`, or a
+    replay config anywhere. Keeping them past the end of a run buys storage and
+    nothing else, so a finished run drops its own.
+
+    Best effort by design: retention is housekeeping, and a run that has
+    already produced its article must not fail because a cleanup delete did.
+    """
+    if saver is None or not thread_id:
+        return
+    delete_thread = getattr(saver, "delete_thread", None)
+    if not callable(delete_thread):
+        return
+    try:
+        delete_thread(thread_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Could not discard LangGraph checkpoints for thread %s (%s: %s)",
+            thread_id,
+            type(exc).__name__,
+            exc,
+        )
+
+
 @contextmanager
-def langgraph_checkpoint() -> Generator[Any | None, None, None]:
+def langgraph_checkpoint(
+    *,
+    discard_thread: str | None = None,
+) -> Generator[Any | None, None, None]:
     """
     Yield a SQLite checkpoint saver when available.
 
     If langgraph or sqlite checkpoint extras are unavailable, yields None.
+
+    ``discard_thread`` names a thread whose checkpoints are dropped on the way
+    out, whether the run succeeded or raised. Pass it from any caller that has
+    no resume path, which today is all of them.
     """
     if not langgraph_is_available():
         yield None
@@ -189,7 +229,10 @@ def langgraph_checkpoint() -> Generator[Any | None, None, None]:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     checkpoint_path = Path(LANGGRAPH_CHECKPOINT_PATH).resolve()
     with SqliteSaver.from_conn_string(str(checkpoint_path)) as saver:
-        yield saver
+        try:
+            yield saver
+        finally:
+            _discard_thread_checkpoints(saver, discard_thread)
 
 
 @asynccontextmanager

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/runner.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/runner.py
@@ -62,7 +62,9 @@ def run_prompt2blog_stage_graph(
             metadata={"entrypoint": trace_name},
             inputs={"run_id": run_id},
         ) as (trace_run, trace_metadata):
-            with langgraph_checkpoint() as checkpointer:
+            # The run has no resume path, so its snapshots are dropped when
+            # it ends rather than accumulating in the shared database.
+            with langgraph_checkpoint(discard_thread=run_id) as checkpointer:
                 graph = builder.compile(checkpointer=checkpointer)
                 result = graph.invoke(
                     {

--- a/apps/ai-blog-writer/apps/backend/scripts/prune_langgraph_checkpoints.py
+++ b/apps/ai-blog-writer/apps/backend/scripts/prune_langgraph_checkpoints.py
@@ -1,0 +1,119 @@
+"""Report and optionally prune the shared LangGraph checkpoint database.
+
+Usage:
+    python3 apps/backend/scripts/prune_langgraph_checkpoints.py
+    python3 apps/backend/scripts/prune_langgraph_checkpoints.py --all --apply
+
+Read-only unless --apply is passed.
+
+There is no age filter, and deliberately so: the checkpoints table carries no
+timestamp column. LangGraph's checkpoint ids are time-ordered UUIDs, so an
+age cutoff could be reconstructed by decoding them -- but a delete tool that
+silently mis-parses its own cutoff is worse than one that only offers "all",
+and "all" is the correct answer while nothing resumes a run.
+
+Runs finished before the retention change in the pipeline runner left their
+checkpoints behind; this clears that backlog. New runs drop their own
+snapshots when they end, so this is a one-off catch-up rather than a job that
+needs scheduling.
+
+Nothing in this codebase resumes a checkpointed run, so deleting them loses no
+recoverable work. Run artifacts, stage records and articles live in
+pipeline.db and are untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_BACKEND = Path(__file__).resolve().parents[1]
+if str(REPO_BACKEND) not in sys.path:
+    sys.path.insert(0, str(REPO_BACKEND))
+
+from app.ai_graph.runtime import LANGGRAPH_CHECKPOINT_PATH  # noqa: E402
+
+
+def _human_bytes(value: int) -> str:
+    size = float(value)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
+
+
+def _threads(connection: sqlite3.Connection) -> list[tuple[str, int]]:
+    return connection.execute(
+        "SELECT thread_id, COUNT(*) FROM checkpoints GROUP BY thread_id "
+        "ORDER BY COUNT(*) DESC"
+    ).fetchall()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Select every thread in the database.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete. Without this the script only reports.",
+    )
+    args = parser.parse_args()
+
+    path = Path(LANGGRAPH_CHECKPOINT_PATH)
+    if not path.exists():
+        print(f"No checkpoint database at {path}.")
+        return 0
+
+    size_before = path.stat().st_size
+    print(f"Checkpoint database: {path}")
+    print(f"Size: {_human_bytes(size_before)}")
+
+    with sqlite3.connect(path) as connection:
+        rows = _threads(connection)
+        total_checkpoints = sum(count for _thread, count in rows)
+        print(f"Threads: {len(rows)}  Checkpoints: {total_checkpoints}")
+        for thread_id, count in rows[:10]:
+            print(f"  {thread_id}: {count}")
+        if len(rows) > 10:
+            print(f"  ... and {len(rows) - 10} more threads")
+
+        if not args.all:
+            print(
+                "\nReport only. Pass --all to select every thread, and --apply "
+                "to delete them."
+            )
+            return 0
+
+        selected = [thread_id for thread_id, _count in rows]
+        print(f"\nSelected {len(selected)} thread(s).")
+        if not args.apply:
+            print("Dry run. Re-run with --apply to delete.")
+            return 0
+
+        for thread_id in selected:
+            connection.execute(
+                "DELETE FROM checkpoints WHERE thread_id = ?", (thread_id,)
+            )
+            connection.execute(
+                "DELETE FROM writes WHERE thread_id = ?", (thread_id,)
+            )
+        connection.commit()
+        connection.execute("VACUUM")
+
+    size_after = Path(path).stat().st_size
+    print(
+        f"Deleted {len(selected)} thread(s). "
+        f"{_human_bytes(size_before)} -> {_human_bytes(size_after)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/ai-blog-writer/apps/backend/tests/test_langgraph_checkpoint_retention.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_langgraph_checkpoint_retention.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.ai_graph import runtime
+
+
+class _FakeSaver:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    def delete_thread(self, thread_id: str) -> None:
+        self.deleted.append(thread_id)
+
+
+class _RaisingSaver(_FakeSaver):
+    def delete_thread(self, thread_id: str) -> None:
+        raise RuntimeError("database is locked")
+
+
+class _OldSaver:
+    """A saver from a langgraph version without delete_thread."""
+
+
+def _patch_saver(monkeypatch, saver: Any) -> None:
+    class _Ctx:
+        def __enter__(self):  # noqa: ANN204
+            return saver
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    class _FakeSqliteSaver:
+        @staticmethod
+        def from_conn_string(_path: str):  # noqa: ANN205
+            return _Ctx()
+
+    import sys
+    import types
+
+    module = types.ModuleType("langgraph.checkpoint.sqlite")
+    module.SqliteSaver = _FakeSqliteSaver
+    monkeypatch.setitem(sys.modules, "langgraph.checkpoint.sqlite", module)
+    monkeypatch.setattr(runtime, "langgraph_is_available", lambda: True)
+
+
+def test_a_finished_run_discards_its_checkpoints(monkeypatch):
+    saver = _FakeSaver()
+    _patch_saver(monkeypatch, saver)
+
+    with runtime.langgraph_checkpoint(discard_thread="run-123") as checkpointer:
+        assert checkpointer is saver
+
+    assert saver.deleted == ["run-123"]
+
+
+def test_a_failed_run_still_discards_its_checkpoints(monkeypatch):
+    saver = _FakeSaver()
+    _patch_saver(monkeypatch, saver)
+
+    with pytest.raises(RuntimeError, match="stage exploded"):
+        with runtime.langgraph_checkpoint(discard_thread="run-456"):
+            raise RuntimeError("stage exploded")
+
+    assert saver.deleted == ["run-456"]
+
+
+def test_without_a_thread_nothing_is_discarded(monkeypatch):
+    saver = _FakeSaver()
+    _patch_saver(monkeypatch, saver)
+
+    with runtime.langgraph_checkpoint():
+        pass
+
+    assert saver.deleted == []
+
+
+def test_a_failed_delete_does_not_fail_the_run(monkeypatch):
+    # Retention is housekeeping. A run that has already produced its article
+    # must not fail because a cleanup delete did.
+    _patch_saver(monkeypatch, _RaisingSaver())
+
+    with runtime.langgraph_checkpoint(discard_thread="run-789"):
+        pass
+
+
+def test_a_saver_without_delete_thread_is_tolerated(monkeypatch):
+    _patch_saver(monkeypatch, _OldSaver())
+
+    with runtime.langgraph_checkpoint(discard_thread="run-000"):
+        pass


### PR DESCRIPTION
Audit finding #12, retention half.

## Problem

LangGraph checkpoints the entire graph state after every node, and the Prompt2Blog state accumulates as it runs — sources, cleaned data, every draft, every audit. Each run leaves a stack of snapshots roughly as large as the run itself, and nothing ever removed them.

Measured on this machine:

```
Size: 291.3 MB
Threads: 623  Checkpoints: 4491
```

Checkpoints exist so an interrupted run can resume. **Nothing in this codebase resumes one** — `rg "get_state|update_state|resume"` over `apps/backend/app` returns nothing. Past the end of a run they are pure storage.

## Change

- `langgraph_checkpoint(discard_thread=...)` drops that thread on the way out, on success **and** on exception.
- The Prompt2Blog runner passes its `run_id` (which is already the `thread_id`).
- Best effort: wrapped, logged, never raised. A run that has produced its article must not fail because a housekeeping delete did. Also tolerates a saver without `delete_thread`.
- `apps/backend/scripts/prune_langgraph_checkpoints.py` clears the existing backlog, which the runner change cannot reach.

## What I did not do

- **I did not run `--apply`.** The script reports by default; deleting 291 MB of your data is your call, not mine. `python3 apps/backend/scripts/prune_langgraph_checkpoints.py` to look, `--all --apply` to clear.
- **No age filter in the script.** The checkpoints table has no timestamp column. LangGraph checkpoint ids are time-ordered UUIDs so a cutoff is reconstructable, but a delete tool that mis-parses its own cutoff is worse than one that only offers "all".
- **The other three checkpointed features are untouched** — `youtube2blog`, `url2blog`, `editor_assist`. Same missing resume path, same one-line fix, outside this audit. Say the word and they follow.
- **Debug capture is unchanged.** The audit also proposes making `include_debug` opt-in; it is hardcoded `true` in `composer/prompt-payload.ts`. That is a product decision about your own tooling, not a defect, so I left it.

## Worth a look

Most of the leaked threads are named `run-full-contract-<uuid>` — **test runs that reached the real dev data directory.** `tests/conftest.py` redirects `DATA_DIR` now, so this is historical, but it is the same class of incident as the one that cost real data before.

## Verification

- `pytest tests/` — 665 passed (662 before, 5 new: success, exception, no-thread, failing delete, old saver)
- `flake8` clean
- Script dry-run exercised against the real 291 MB database