### PR TITLE
Attribute Prompt2Blog token spend to the stage that spent it

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -65,3 +65,9 @@ The generation graph exposes these first-class nodes:
 
 The full-run graph prepends source preparation. Individual stages continue to
 record their existing `stage_*` payloads through `RunRecorder`.
+
+`RunRecorder` snapshots the token tracker's cumulative totals on `start_stage`
+and writes the delta into each stage payload as `stage_usage`, which is also
+what feeds the `by_stage` rows of the `run_cost` receipt. Recorders built
+without a `usage_reader` -- every test that constructs one directly -- behave
+as they did before attribution existed.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Protocol
 
 from app.core import get_article_type_by_id
@@ -88,3 +88,18 @@ class PipelineDependencies:
     build_writing_brief: Callable[..., dict[str, Any]] = _build_writing_brief_from_input
     resolve_writer_model: Callable[..., str] = resolve_writer_model
     normalize_dashes: Callable[[str], str] = normalize_dashes
+
+    def __post_init__(self) -> None:
+        # Per-stage attribution only exists when the two halves are wired to
+        # each other. A test LLM double carries no tracker, and the recorder
+        # then behaves exactly as it did before this existed.
+        tracker = getattr(self.llm, "usage_tracker", None)
+        reader = getattr(tracker, "totals", None)
+        writer = getattr(tracker, "record_stage_usage", None)
+        if not callable(reader) or not callable(writer):
+            return
+        object.__setattr__(
+            self,
+            "recorder",
+            replace(self.recorder, usage_reader=reader, usage_writer=writer),
+        )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -137,11 +137,36 @@ def _estimated_cost(
     ) / 1_000_000
 
 
+TOKEN_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "cached_input_tokens",
+    "total_tokens",
+)
+
+STAGE_USAGE_KEYS = TOKEN_KEYS + ("calls",)
+
+
 @dataclass
 class Prompt2BlogTokenUsageTracker:
     successful_calls: int = 0
     measured_calls: int = 0
     by_model: dict[str, dict[str, Any]] = field(default_factory=dict)
+    by_stage: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    def totals(self) -> dict[str, int]:
+        return {
+            key: sum(item[key] for item in self.by_model.values())
+            for key in STAGE_USAGE_KEYS
+        }
+
+    def record_stage_usage(self, stage: str, usage: dict[str, int]) -> None:
+        row = self.by_stage.setdefault(stage, dict.fromkeys(STAGE_USAGE_KEYS, 0))
+        # Stages repeat: groundedness and the quality audit run once per repair
+        # pass, so a stage's cost is the sum of its passes, not the last one.
+        for key in STAGE_USAGE_KEYS:
+            row[key] += _token_count(usage.get(key))
 
     def record(self, model_name: str, raw_usage: Any) -> None:
         self.successful_calls += 1
@@ -227,6 +252,15 @@ class Prompt2BlogTokenUsageTracker:
                     ),
                 }
             )
+        # Sorted by spend so the stages worth capping or de-thinking are the
+        # ones read first.
+        stage_rows = [
+            {"stage": stage_name, **usage}
+            for stage_name, usage in sorted(
+                self.by_stage.items(),
+                key=lambda item: (-item[1]["total_tokens"], item[0]),
+            )
+        ]
         if self.measured_calls == 0:
             measurement_status = "unavailable"
         elif self.measured_calls < self.successful_calls or not fully_priced:
@@ -255,6 +289,7 @@ class Prompt2BlogTokenUsageTracker:
             ),
             "currency": "USD",
             "by_model": model_rows,
+            "by_stage": stage_rows,
             "pricing_note": (
                 "Standard global Vertex rates checked 2026-08-24; Gemini 3.7 "
                 "Flash introductory pricing ends 2026-12-31."

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/run_recorder.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/run_recorder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -9,8 +10,12 @@ from app.core import write_artifact, write_stage_result, write_status
 from .config import FEATURE_NAME
 from .observability import _now_iso
 
+logger = logging.getLogger(__name__)
+
 StageWriter = Callable[[str, str, dict[str, Any]], None]
 ArtifactWriter = Callable[[str, dict[str, Any]], None]
+UsageReader = Callable[[], dict[str, int]]
+UsageWriter = Callable[[str, dict[str, int]], None]
 
 
 @dataclass(frozen=True)
@@ -21,7 +26,16 @@ class RunRecorder:
     stage_writer: StageWriter = write_stage_result
     artifact_writer: ArtifactWriter = write_artifact
     clock: Callable[[], str] = _now_iso
+    # Left unset by the pipeline's own tests and by any caller that builds a
+    # recorder without a token tracker; attribution is then simply absent.
+    usage_reader: UsageReader | None = None
+    usage_writer: UsageWriter | None = None
     active_stages: dict[str, str] = field(
+        default_factory=dict,
+        compare=False,
+        repr=False,
+    )
+    usage_marks: dict[str, dict[str, int]] = field(
         default_factory=dict,
         compare=False,
         repr=False,
@@ -41,8 +55,42 @@ class RunRecorder:
             owner_staff_id=owner_staff_id,
         )
 
+    def _mark_usage(self, run_id: str) -> None:
+        if self.usage_reader is None:
+            return
+        try:
+            self.usage_marks[run_id] = dict(self.usage_reader())
+        except Exception as exc:  # pragma: no cover -- telemetry only
+            logger.warning("Prompt2Blog stage usage snapshot failed: %s", exc)
+            self.usage_marks.pop(run_id, None)
+
+    def _stage_usage(self, run_id: str, stage: str) -> dict[str, int] | None:
+        # Only the stage that is currently open gets attribution. Debug dumps
+        # like `pipeline_v2` and `langgraph_trace` are written under a name no
+        # `start_stage` ever opened, and they are not stages that spend tokens.
+        if self.usage_reader is None or self.active_stages.get(run_id) != stage:
+            return None
+        mark = self.usage_marks.get(run_id)
+        if mark is None:
+            return None
+        try:
+            current = dict(self.usage_reader())
+        except Exception as exc:  # pragma: no cover -- telemetry only
+            logger.warning("Prompt2Blog stage usage read failed: %s", exc)
+            return None
+        delta = {
+            key: max(0, value - mark.get(key, 0)) for key, value in current.items()
+        }
+        # `stage_final_verify` records twice: the re-grounding call writes under
+        # the stage name, then the verification summary does. Advancing the mark
+        # on every write keeps the second one from re-charging the first's
+        # tokens.
+        self.usage_marks[run_id] = current
+        return delta
+
     def start_stage(self, run_id: str, stage: str) -> None:
         self.active_stages[run_id] = stage
+        self._mark_usage(run_id)
         self.status_writer(
             run_id,
             {
@@ -56,6 +104,17 @@ class RunRecorder:
         )
 
     def record_stage(self, run_id: str, stage: str, data: dict[str, Any]) -> None:
+        stage_usage = self._stage_usage(run_id, stage)
+        if stage_usage is not None:
+            data = {**data, "stage_usage": stage_usage}
+            if self.usage_writer is not None:
+                try:
+                    self.usage_writer(stage, stage_usage)
+                except Exception as exc:  # pragma: no cover -- telemetry only
+                    logger.warning(
+                        "Prompt2Blog stage usage attribution failed: %s",
+                        exc,
+                    )
         self.stage_writer(
             run_id,
             stage,
@@ -81,6 +140,7 @@ class RunRecorder:
             feature=FEATURE_NAME,
         )
         self.active_stages.pop(run_id, None)
+        self.usage_marks.pop(run_id, None)
 
     def active_stage(self, run_id: str, fallback: str = "graph_execution") -> str:
         return self.active_stages.get(run_id, fallback)
@@ -115,3 +175,4 @@ class RunRecorder:
                 },
             )
         self.active_stages.pop(run_id, None)
+        self.usage_marks.pop(run_id, None)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
@@ -57,6 +57,19 @@ def run_finalize_stage(
         groundedness=state["groundedness"],
     )
     pipeline_status = "ready_for_staging" if verdict.ready else "needs_revision"
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {
+            "pipeline_status": pipeline_status,
+            "readiness_blockers": list(verdict.blockers),
+            "final_title": final_title,
+            "word_count_estimate": final_checks["word_count_estimate"],
+            "constraint_checks": final_checks,
+        },
+    )
+    # Summarised after this stage is recorded, so the `by_stage` breakdown the
+    # receipt shows includes finalize itself rather than stopping one row short.
     usage_summary = getattr(dependencies.llm, "usage_summary", None)
     usage_kwargs = {
         "stack_id": state.get("model_stack_id"),
@@ -68,17 +81,6 @@ def run_finalize_stage(
         usage_summary(**usage_kwargs)
         if callable(usage_summary)
         else Prompt2BlogTokenUsageTracker().summary(**usage_kwargs)
-    )
-    dependencies.recorder.record_stage(
-        run_id,
-        stage,
-        {
-            "pipeline_status": pipeline_status,
-            "readiness_blockers": list(verdict.blockers),
-            "final_title": final_title,
-            "word_count_estimate": final_checks["word_count_estimate"],
-            "constraint_checks": final_checks,
-        },
     )
 
     response_payload: dict[str, Any] = {

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pipeline_contract.py
@@ -17,6 +17,7 @@ from app.features.prompt2blog.models import (
     Prompt2BlogInputRequest,
 )
 from app.features.prompt2blog.orchestrator import run_full_pipeline, run_pipeline_v2
+from app.features.prompt2blog.pricing import Prompt2BlogTokenUsageTracker
 from app.features.prompt2blog.run_recorder import RunRecorder
 
 
@@ -221,8 +222,16 @@ def _pipeline_fakes(
             return "A Practical First Visit to Kyoto"
         raise AssertionError(f"Unexpected text prompt: {prompt[:120]}")
 
+    tracker = Prompt2BlogTokenUsageTracker()
+
     class FakeLLM:
-        def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
+        # Carries a real tracker so a full run exercises per-stage attribution
+        # end to end. Usage is fabricated from prompt length, which is enough
+        # to tell an expensive stage from a cheap one. PipelineDependencies
+        # looks for this attribute to wire the recorder up.
+        usage_tracker = tracker
+
+        def _record(self, **kwargs: Any) -> None:
             recorded["calls"].append(
                 {
                     "prompt": kwargs["prompt"],
@@ -230,17 +239,25 @@ def _pipeline_fakes(
                     "temperature": kwargs.get("temperature"),
                 }
             )
+            tracker.record(
+                kwargs.get("model_name") or "test-model",
+                {
+                    "input_tokens": len(kwargs["prompt"]) // 4,
+                    "output_tokens": 100,
+                    "total_tokens": len(kwargs["prompt"]) // 4 + 100,
+                },
+            )
+
+        def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
+            self._record(**kwargs)
             return invoke_json(**kwargs)
 
         def invoke_text(self, **kwargs: Any) -> str:
-            recorded["calls"].append(
-                {
-                    "prompt": kwargs["prompt"],
-                    "model_name": kwargs.get("model_name"),
-                    "temperature": kwargs.get("temperature"),
-                }
-            )
+            self._record(**kwargs)
             return invoke_text(**kwargs)
+
+        def usage_summary(self, **kwargs: Any) -> dict[str, Any]:
+            return tracker.summary(**kwargs)
 
         @staticmethod
         def enforce_anti_ai(text: str, **kwargs: Any) -> str:
@@ -299,6 +316,20 @@ def test_pipeline_contract_preserves_stage_order_and_artifact():
         "pipeline_v2",
     ]
     assert stage_names[-1] in {"pipeline_v2", "langgraph_trace"}
+
+    # Every stage the run recorded is attributed, including the ones that spend
+    # nothing. A stage missing from by_stage would be spend nobody can see.
+    run_cost = _stage_payload(recorded, "pipeline_v2")["data"]["run_cost"]
+    attributed = {row["stage"] for row in run_cost["by_stage"]}
+    assert attributed == {
+        stage for stage in stage_names if stage.startswith("stage_")
+    }
+    assert sum(row["total_tokens"] for row in run_cost["by_stage"]) == (
+        run_cost["total_tokens"]
+    )
+    assert sum(row["calls"] for row in run_cost["by_stage"]) == (
+        run_cost["measured_calls"]
+    )
     assert recorded["statuses"][-1][1]["state"] == "completed"
     assert recorded["statuses"][-1][1]["stage"] == "complete"
 
@@ -310,10 +341,14 @@ def test_pipeline_contract_preserves_stage_order_and_artifact():
         "name": "Travel Guide",
         "definition": "A practical destination guide.",
     }
-    assert artifact["pipeline_v2"]["run_cost"]["measurement_status"] == (
-        "unavailable"
-    )
-    assert artifact["pipeline_v2"]["run_cost"]["models"] == {
+    run_cost = artifact["pipeline_v2"]["run_cost"]
+    # "partial", not "complete": the harness reports usage for every call, but
+    # its model names are not in the price table, so the run is measured and
+    # unpriced. (The "unavailable" branch -- no usage reported at all -- is
+    # covered directly in test_prompt2blog_pricing.py.)
+    assert run_cost["measurement_status"] == "partial"
+    assert run_cost["estimated_cost_usd"] is None
+    assert run_cost["models"] == {
         "worker": "test-model",
         "writer": "test-writer",
         "judge": P2B_AUDIT_MODEL,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
@@ -223,3 +223,24 @@ def test_default_prompt2blog_llm_records_each_successful_call(monkeypatch):
     assert summary["measured_calls"] == 1
     assert summary["total_tokens"] == 500
     assert summary["estimated_cost_usd"] == 0.000675
+
+
+def test_a_run_with_no_reported_usage_is_unavailable_not_free():
+    """Providers that return no usage metadata must not read as a zero-cost
+    run. Previously only the pipeline contract test covered this."""
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.record("gemini-3.7-flash", None)
+    tracker.record("gemini-3.7-flash", {})
+
+    summary = tracker.summary(
+        stack_id="balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="gemini-3.7-flash",
+        audit_model="gemini-3.7-flash",
+    )
+
+    assert summary["measurement_status"] == "unavailable"
+    assert summary["successful_calls"] == 2
+    assert summary["measured_calls"] == 0
+    assert summary["by_model"] == []
+    assert summary["by_stage"] == []

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_stage_attribution.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_stage_attribution.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.dependencies import (
+    DefaultPrompt2BlogLLM,
+    PipelineDependencies,
+)
+from app.features.prompt2blog.pricing import Prompt2BlogTokenUsageTracker
+from app.features.prompt2blog.run_recorder import RunRecorder
+
+MODEL = "gemini-3.7-flash"
+
+
+def _usage(input_tokens: int, output_tokens: int) -> dict[str, int]:
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+
+
+def _wired_recorder():
+    tracker = Prompt2BlogTokenUsageTracker()
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    recorder = RunRecorder(
+        status_writer=lambda *args, **kwargs: None,
+        stage_writer=lambda run_id, stage, payload: recorded.append((stage, payload)),
+        artifact_writer=lambda *args, **kwargs: None,
+        clock=lambda: "2026-08-24T00:00:00+00:00",
+        usage_reader=tracker.totals,
+        usage_writer=tracker.record_stage_usage,
+    )
+    return tracker, recorder, recorded
+
+
+def _by_stage(tracker: Prompt2BlogTokenUsageTracker) -> list[dict[str, Any]]:
+    return tracker.summary(
+        stack_id="balanced",
+        worker_model=MODEL,
+        writing_model=MODEL,
+        audit_model=MODEL,
+    )["by_stage"]
+
+
+def test_a_stage_carries_the_tokens_spent_inside_it():
+    tracker, recorder, recorded = _wired_recorder()
+
+    recorder.start_stage("run-1", "stage_outline")
+    tracker.record(MODEL, _usage(400, 100))
+    recorder.record_stage("run-1", "stage_outline", {"outline": "ok"})
+
+    stage, payload = recorded[0]
+    assert stage == "stage_outline"
+    assert payload["data"]["outline"] == "ok"
+    assert payload["data"]["stage_usage"] == {
+        "input_tokens": 400,
+        "output_tokens": 100,
+        "reasoning_tokens": 0,
+        "cached_input_tokens": 0,
+        "total_tokens": 500,
+        "calls": 1,
+    }
+
+
+def test_a_stage_is_not_charged_for_what_earlier_stages_spent():
+    tracker, recorder, recorded = _wired_recorder()
+
+    recorder.start_stage("run-1", "stage_outline")
+    tracker.record(MODEL, _usage(400, 100))
+    recorder.record_stage("run-1", "stage_outline", {})
+    recorder.start_stage("run-1", "stage_compose")
+    tracker.record(MODEL, _usage(1_000, 2_000))
+    recorder.record_stage("run-1", "stage_compose", {})
+
+    assert recorded[1][1]["data"]["stage_usage"]["total_tokens"] == 3_000
+    assert _by_stage(tracker) == [
+        {
+            "stage": "stage_compose",
+            "input_tokens": 1_000,
+            "output_tokens": 2_000,
+            "reasoning_tokens": 0,
+            "cached_input_tokens": 0,
+            "total_tokens": 3_000,
+            "calls": 1,
+        },
+        {
+            "stage": "stage_outline",
+            "input_tokens": 400,
+            "output_tokens": 100,
+            "reasoning_tokens": 0,
+            "cached_input_tokens": 0,
+            "total_tokens": 500,
+            "calls": 1,
+        },
+    ]
+
+
+def test_a_repeated_stage_accumulates_its_usage():
+    """Groundedness and the quality audit run once per repair pass."""
+    tracker, recorder, _ = _wired_recorder()
+
+    for _pass in range(3):
+        recorder.start_stage("run-1", "stage_groundedness")
+        tracker.record(MODEL, _usage(200, 50))
+        recorder.record_stage("run-1", "stage_groundedness", {})
+
+    rows = _by_stage(tracker)
+    assert len(rows) == 1
+    assert rows[0]["total_tokens"] == 750
+    assert rows[0]["calls"] == 3
+
+
+def test_a_stage_that_records_twice_does_not_double_count():
+    """`stage_final_verify` writes once for the re-grounding call and once for
+    the verification summary."""
+    tracker, recorder, recorded = _wired_recorder()
+
+    recorder.start_stage("run-1", "stage_final_verify")
+    tracker.record(MODEL, _usage(900, 100))
+    recorder.record_stage("run-1", "stage_final_verify", {"groundedness": {}})
+    recorder.record_stage("run-1", "stage_final_verify", {"regrounded": True})
+
+    assert recorded[0][1]["data"]["stage_usage"]["total_tokens"] == 1_000
+    assert recorded[1][1]["data"]["stage_usage"]["total_tokens"] == 0
+    rows = _by_stage(tracker)
+    assert len(rows) == 1
+    assert rows[0]["total_tokens"] == 1_000
+    assert rows[0]["calls"] == 1
+
+
+def test_a_stage_with_no_llm_call_gets_a_zero_row():
+    tracker, recorder, recorded = _wired_recorder()
+
+    recorder.start_stage("run-1", "stage_input_validate")
+    recorder.record_stage("run-1", "stage_input_validate", {})
+
+    assert recorded[0][1]["data"]["stage_usage"]["total_tokens"] == 0
+    assert _by_stage(tracker) == [
+        {
+            "stage": "stage_input_validate",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "reasoning_tokens": 0,
+            "cached_input_tokens": 0,
+            "total_tokens": 0,
+            "calls": 0,
+        }
+    ]
+
+
+def test_debug_dumps_written_outside_any_open_stage_are_not_attributed():
+    tracker, recorder, recorded = _wired_recorder()
+
+    tracker.record(MODEL, _usage(400, 100))
+    recorder.record_stage("run-1", "langgraph_trace", {"nodes": []})
+
+    assert "stage_usage" not in recorded[0][1]["data"]
+    assert _by_stage(tracker) == []
+
+
+def test_a_recorder_without_a_usage_reader_writes_no_stage_usage():
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    recorder = RunRecorder(
+        status_writer=lambda *args, **kwargs: None,
+        stage_writer=lambda run_id, stage, payload: recorded.append((stage, payload)),
+        artifact_writer=lambda *args, **kwargs: None,
+        clock=lambda: "2026-08-24T00:00:00+00:00",
+    )
+
+    recorder.start_stage("run-1", "stage_outline")
+    recorder.record_stage("run-1", "stage_outline", {"outline": "ok"})
+
+    assert recorded[0][1]["data"] == {"outline": "ok"}
+
+
+def test_a_broken_usage_reader_never_breaks_the_stage_record():
+    recorded: list[tuple[str, dict[str, Any]]] = []
+
+    def exploding_reader() -> dict[str, int]:
+        raise RuntimeError("tracker gone")
+
+    recorder = RunRecorder(
+        status_writer=lambda *args, **kwargs: None,
+        stage_writer=lambda run_id, stage, payload: recorded.append((stage, payload)),
+        artifact_writer=lambda *args, **kwargs: None,
+        clock=lambda: "2026-08-24T00:00:00+00:00",
+        usage_reader=exploding_reader,
+    )
+
+    recorder.start_stage("run-1", "stage_outline")
+    recorder.record_stage("run-1", "stage_outline", {"outline": "ok"})
+
+    assert recorded[0][1]["data"] == {"outline": "ok"}
+
+
+def test_pipeline_dependencies_wires_the_recorder_to_the_usage_tracker():
+    dependencies = PipelineDependencies(llm=DefaultPrompt2BlogLLM())
+    tracker = dependencies.llm.usage_tracker
+
+    dependencies.recorder.start_stage("run-1", "stage_title")
+    tracker.record(MODEL, _usage(60, 20))
+    dependencies.recorder.record_stage("run-1", "stage_title", {})
+
+    assert _by_stage(tracker) == [
+        {
+            "stage": "stage_title",
+            "input_tokens": 60,
+            "output_tokens": 20,
+            "reasoning_tokens": 0,
+            "cached_input_tokens": 0,
+            "total_tokens": 80,
+            "calls": 1,
+        }
+    ]
+
+
+def test_an_llm_double_without_a_tracker_leaves_the_recorder_alone():
+    class FakeLLM:
+        def invoke_text(self, **kwargs: Any) -> str:
+            return ""
+
+    dependencies = PipelineDependencies(llm=FakeLLM())
+
+    assert dependencies.recorder.usage_reader is None
+    assert dependencies.recorder.usage_writer is None
+
+
+def test_stage_attribution_sums_to_the_run_total():
+    """Per-stage rows are only worth acting on if they account for the whole
+    run. A stage boundary that leaked would quietly hide spend."""
+    tracker, recorder, _ = _wired_recorder()
+
+    spends = [
+        ("stage_input_cleanup", 5_000, 3_000),
+        ("stage_outline", 8_000, 900),
+        ("stage_compose", 20_000, 4_000),
+        ("stage_quality_audit", 22_000, 600),
+        ("stage_title", 9_000, 40),
+    ]
+    for stage, input_tokens, output_tokens in spends:
+        recorder.start_stage("run-1", stage)
+        tracker.record(MODEL, _usage(input_tokens, output_tokens))
+        recorder.record_stage("run-1", stage, {})
+
+    summary = tracker.summary(
+        stack_id="balanced",
+        worker_model=MODEL,
+        writing_model=MODEL,
+        audit_model=MODEL,
+    )
+    rows = summary["by_stage"]
+
+    assert sum(row["total_tokens"] for row in rows) == summary["total_tokens"]
+    assert sum(row["input_tokens"] for row in rows) == summary["input_tokens"]
+    assert sum(row["output_tokens"] for row in rows) == summary["output_tokens"]
+    assert sum(row["calls"] for row in rows) == summary["measured_calls"]
+    # Sorted by spend, so the stage worth capping first is the first row.
+    assert rows[0]["stage"] == "stage_compose"

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/RunCostReceipt.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/RunCostReceipt.tsx
@@ -1,5 +1,9 @@
 import { PROMPT2BLOG_MODEL_STACKS } from '../../constants/prompt2blog.constants'
-import type { Prompt2BlogPipelinePayload } from '../../types/pipeline.types'
+import type {
+  Prompt2BlogPipelinePayload,
+  Prompt2BlogPipelineStage,
+} from '../../types/pipeline.types'
+import { PIPELINE_STAGE_LABELS } from '../pipeline-status'
 
 type RunCost = NonNullable<Prompt2BlogPipelinePayload['run_cost']>
 
@@ -32,6 +36,7 @@ export function RunCostReceipt({ cost }: { cost: RunCost }) {
     <p className="p2b-run-cost__coverage">{coverageLabel}</p>
     <details className="p2b-run-cost__details">
       <summary>Price and model breakdown</summary>
+      <span className="p2b-run-cost__eyebrow">By model</span>
       <div className="p2b-run-cost__models">
         {cost.by_model.map(model => <div key={model.model}>
           <strong>{formatModelName(model.model)}</strong>
@@ -40,6 +45,17 @@ export function RunCostReceipt({ cost }: { cost: RunCost }) {
           <span>{formatUsd(model.estimated_cost_usd)}</span>
         </div>)}
       </div>
+      {cost.by_stage != null && cost.by_stage.length > 0 && <>
+        <span className="p2b-run-cost__eyebrow">By stage</span>
+        <div className="p2b-run-cost__models">
+          {cost.by_stage.map(row => <div key={row.stage}>
+            <strong>{formatStageName(row.stage)}</strong>
+            <span>{formatTokens(row.total_tokens)} tokens</span>
+            <span>{row.calls} {row.calls === 1 ? 'call' : 'calls'}</span>
+            <span>{formatTokens(row.reasoning_tokens)} reasoning</span>
+          </div>)}
+        </div>
+      </>}
       <p>{cost.pricing_note}</p>
       <p>Estimate excludes network, storage, grounding, and other non-token charges.</p>
     </details>
@@ -64,6 +80,11 @@ function formatUsd(
   if (value == null) return 'Unavailable'
   const digits = value < 0.01 ? 4 : 2
   return `${measurementStatus === 'partial' ? '≥' : ''}$${value.toFixed(digits)}`
+}
+
+function formatStageName(stage: string): string {
+  return PIPELINE_STAGE_LABELS[stage as Prompt2BlogPipelineStage]
+    || stage.replace(/^stage_/, '').replace(/_/g, ' ')
 }
 
 function formatModelName(model: string): string {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -198,6 +198,17 @@ export type Prompt2BlogPipelinePayload = {
       calls: number
       estimated_cost_usd: number | null
     }>
+    // Sorted by total tokens descending. Absent on runs recorded before
+    // per-stage attribution existed.
+    by_stage?: Array<{
+      stage: string
+      input_tokens: number
+      output_tokens: number
+      reasoning_tokens: number
+      cached_input_tokens: number
+      total_tokens: number
+      calls: number
+    }>
     pricing_note: string
   }
   quality_review: {


### PR DESCRIPTION
Unblocks audit findings #9 (output caps) and #10 (thinking control). Follows #369-#375.

## Problem

`Prompt2BlogTokenUsageTracker` aggregated per run and per model. Nobody could say which *stage* cost what — which is exactly the measurement both remaining audit items need before anything can be capped or de-thought safely.

## Change

Attribution rides on stage boundaries that already exist. `RunRecorder.start_stage` snapshots cumulative totals; `record_stage` writes the delta into the stage payload as `stage_usage` and feeds it to the tracker, which emits `by_stage` on the run receipt sorted by spend. Rendered in the existing "Price and model breakdown" panel.

A recorder built without a usage reader — every test that constructs one directly — behaves exactly as before. Nothing is required to adopt it.

## Real output, from a full graph run

```
stage                                 total    input  output  calls
stage_compose                          3026     2926     100      1
stage_quality_audit                     833      733     100      1
stage_outline                           616      516     100      1
stage_groundedness                      538      438     100      1
stage_coverage_check                    481      381     100      1
stage_title                             317      217     100      1
stage_editorial_augmentation              0        0       0      0
stage_final_verify                        0        0       0      0
stage_finalize                            0        0       0      0
stage_guideline_fetch                     0        0       0      0
stage_quality_settle                      0        0       0      0
stage_supplement                          0        0       0      0
RUN TOTAL                              5811     5211     600      6
```

Stages that spend nothing get a zero row, not a missing one — a visible zero is the useful answer.

## Three cases the snapshot has to get right

1. **Stages repeat.** `stage_groundedness` and `stage_quality_audit` run once per repair pass, so a stage cost is the sum of its passes, not the last one.
2. **`stage_final_verify` records twice** under one name (re-grounding call, then verification summary). The mark advances on every write, not just the first, so the second does not re-charge the first.
3. **`record_stage` also writes debug dumps** — `pipeline_v2`, `langgraph_trace` — that no `start_stage` ever opened. Attribution is gated on the stage actually being the open one, or those got a bogus `stage_usage` and a junk `by_stage` row.

Attribution failure can never fail a run. Every read and write is wrapped and logged; this is telemetry.

## Behaviour change worth calling out

`finalize` now records its own stage **before** summarising the run cost. Previously it summarised first, so `stage_finalize` would have been the one stage permanently missing from `by_stage`. Otherwise neutral — the stage payload never contained `run_cost`.

The contract test's `measurement_status` assertion moves from `"unavailable"` to `"partial"`: the harness now reports usage under unpriced model names, so the run is measured-and-unpriced. That branch was the *only* coverage of `"unavailable"`, so it gains its own direct test in `test_prompt2blog_pricing.py` rather than being lost.

## Known limits

- Per-stage rows carry tokens, not dollars. Cost needs a per-(stage, model) split that the delta snapshot flattens away.
- Attribution is by ordering within a run. Exact here — stages are sequential — but it would misattribute if a stage were ever run concurrently with another for the same `run_id`.

## Verification

- `pytest tests/` — **681 passed** (669 before; 12 new: 11 attribution unit tests, 1 pricing)
- `flake8` clean, `tsc` clean, `vitest` 694 passed, `eslint` 0 errors, boundary check passed