### PR TITLE
Keep source scaffolding out of the article a person reads

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/editorial_blocks.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/editorial_blocks.py
@@ -6,6 +6,7 @@ from typing import Any
 from ..config import EDITORIAL_COMPONENT_LABELS
 from ..support import _safe_dict, _safe_str, _tokenize_words
 from .markdown import _ensure_markdown_section_headers
+from .source_citations import strip_source_citations
 
 
 def _normalize_editorial_component_name(value: str) -> str:
@@ -265,6 +266,11 @@ def _sanitize_editorial_augmentation(
         augmented_content = fallback_markdown
 
     augmented_content = _ensure_markdown_section_headers(augmented_content)
+    # Augmentation regenerates the whole article, so it can reintroduce the
+    # source citations compose had stripped.
+    augmented_content, source_citations_removed = strip_source_citations(
+        augmented_content
+    )
 
     components_added: list[dict[str, str]] = []
     raw_components = parsed.get("components_added")
@@ -339,6 +345,7 @@ def _sanitize_editorial_augmentation(
 
     return {
         "augmented_content": augmented_content,
+        "source_citations_removed": source_citations_removed,
         "components_added": components_added,
         "diagnostic": diagnostic,
         "augmentation_summary": augmentation_summary,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/source_citations.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/source_citations.py
@@ -1,0 +1,108 @@
+"""Remove the source scaffolding from reader-facing prose.
+
+`_format_raw_sources` labels each source block `Source 1:`, `Source 2:` so the
+model can tell them apart. Nothing ever told the model those labels were
+internal, while the compose, supplement and repair prompts told it six ways to
+stay faithful to the sources -- so it cited them, and articles shipped with
+"(Source 3)" sitting in the middle of a sentence.
+
+The prompts now say not to. This is the half that does not depend on the model
+having listened.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SOURCE_REF = r"sources?\s*[:#]?\s*\d+(?:\s*(?:,|;|&|and|to|-|--)\s*(?:sources?\s*[:#]?\s*)?\d+)*"
+
+# "(Source 1)", "[Sources 2, 3]", "(see source 4)", "(Source 1 and Source 2)".
+_BRACKETED_CITATION = re.compile(
+    rf"[ \t]*[(\[]\s*(?:see|per|from|cf\.?)?\s*{_SOURCE_REF}\s*[)\]]",
+    re.IGNORECASE,
+)
+
+# A bare "Source 2:" heading or line: the scaffolding echoed back verbatim.
+_SCAFFOLD_LINE = re.compile(
+    r"(?im)^[ \t]*#{0,6}[ \t]*\*{0,2}sources?[ \t]+\d+\*{0,2}[ \t]*:?[ \t]*$\n?"
+)
+
+# "...runs between US$1,300 and US$1,600, according to Source 1." The trailing
+# form is what run 58766c27 shipped most of. The comma in front goes with it,
+# or the sentence ends on a dangling clause. The lookbehind keeps this off a
+# sentence-opening "According to Source 2, ...", which the clause pattern
+# below handles because that one has to re-capitalise what follows.
+_TRAILING_ATTRIBUTION = re.compile(
+    rf"""
+    (?<=[\w)\]"'])
+    \s*,?\s*
+    (?:according\s+to|as\s+(?:stated|noted|reported|described)\s+(?:in|by)|per)
+    \s+{_SOURCE_REF}
+    (?=\s*[.!?,;:)\]]|\s*$)
+    """,
+    re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+)
+
+# "According to Source 2, the temple opens at nine." The whole clause has to
+# go, and the word after it has to be re-capitalised when the clause was what
+# opened the sentence -- otherwise stripping the citation leaves prose that
+# reads worse than the citation did.
+_ATTRIBUTION_CLAUSE = re.compile(
+    rf"""
+    (?P<lead>^|(?<=[.!?][ ])|(?<=[.!?][\n])|(?<=,[ ]))
+    (?:according\s+to|as\s+(?:stated|noted|reported|described)\s+(?:in|by)|as|per)
+    \s+{_SOURCE_REF}
+    (?:\s*(?:notes?|states?|says?|reports?|explains?))?
+    \s*,?\s*
+    (?P<next>[A-Za-z])
+    """,
+    re.IGNORECASE | re.VERBOSE | re.MULTILINE,
+)
+
+_SPACE_BEFORE_PUNCTUATION = re.compile(r"[ \t]+([.,;:!?)\]])")
+_DOUBLED_SPACES = re.compile(r"[ \t]{2,}")
+_SPACE_AT_LINE_END = re.compile(r"(?m)[ \t]+$")
+_SPACE_AT_LINE_START = re.compile(r"(?m)^[ \t]+(?=\S)")
+# Lifting a scaffold line out of the middle of a section leaves a gap.
+_BLANK_LINE_RUN = re.compile(r"\n{3,}")
+
+# Anything still naming a numbered source after the removals above. Reported,
+# not deleted: an unrecognised citation shape is worth seeing in the trace
+# rather than being guessed at with a blunter pattern.
+_RESIDUAL_SOURCE_MENTION = re.compile(r"\bsources?\s*[:#]?\s*\d+\b", re.IGNORECASE)
+
+
+def _restore_sentence_case(match: re.Match[str]) -> str:
+    following = match.group("next")
+    # The clause opened the sentence, so the word that followed now does.
+    return match.group("lead") + following.upper()
+
+
+def strip_source_citations(text: str) -> tuple[str, int]:
+    """Return the prose without source citations, and how many were removed.
+
+    The count is reported rather than swallowed: a model that keeps citing
+    after being told not to is worth seeing in the trace.
+    """
+    if not text:
+        return "", 0
+
+    # Trailing first: a leading-clause match would consume the word after it,
+    # and the trailing form ends on punctuation rather than a word.
+    text, trailing = _TRAILING_ATTRIBUTION.subn("", text)
+    text, attributions = _ATTRIBUTION_CLAUSE.subn(_restore_sentence_case, text)
+    text, bracketed = _BRACKETED_CITATION.subn("", text)
+    text, scaffold = _SCAFFOLD_LINE.subn("", text)
+    removed = trailing + attributions + bracketed + scaffold
+
+    if removed:
+        text = _SPACE_BEFORE_PUNCTUATION.sub(r"\1", text)
+        text = _DOUBLED_SPACES.sub(" ", text)
+        text = _SPACE_AT_LINE_END.sub("", text)
+        text = _SPACE_AT_LINE_START.sub("", text)
+        text = _BLANK_LINE_RUN.sub("\n\n", text)
+    return text, removed
+
+
+def count_residual_source_mentions(text: str) -> int:
+    return len(_RESIDUAL_SOURCE_MENTION.findall(text or ""))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial.py
@@ -7,6 +7,8 @@ Goal:
 - Optionally add high-signal editorial components that improve comprehension, pacing, or emphasis.
 - Default to zero add-ons when the article already reads clearly.
 - Keep output in Markdown and preserve the author's voice.
+- Never introduce numbered source citations -- no "(Source 1)", no
+  "according to Source 2". The reader never sees a source list.
 
 Return strict JSON only:
 {{

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/generation.py
@@ -76,6 +76,12 @@ Return Markdown only (no JSON).
 
 Rules:
 - Base claims on source material themes and facts.
+- The source blocks are internal working material. Never cite them in the
+  article: no "(Source 1)", no "[Source 2]", no "according to Source 3",
+  no numbered source references of any kind. The reader cannot see the
+  sources and has no idea what a numbered source is.
+- Attribute a fact in prose only by naming the real publication or body it
+  came from, never by its position in the source list.
 - Do not invent specific facts, numbers, quotes, prices, names, or policies.
 - Supplemental context may explain concepts mentioned in the source, but the final article cannot invent unsupported specifics.
 - If details are missing, use cautious phrasing and clearly mark uncertainty.
@@ -196,6 +202,12 @@ Return strict JSON only:
 
 Hard rules:
 - Preserve factual meaning from sources.
+- The source blocks are internal working material. Never cite them in the
+  article: no "(Source 1)", no "[Source 2]", no "according to Source 3",
+  no numbered source references of any kind. The reader cannot see the
+  sources and has no idea what a numbered source is.
+- Attribute a fact in prose only by naming the real publication or body it
+  came from, never by its position in the source list.
 - Do not invent facts.
 - Avoid long verbatim phrasing from sources.
 - improved_content must not contain a `#` H1.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/quality.py
@@ -148,6 +148,12 @@ Rules:
 - Resolve each required revision directly.
 - Do not invent facts.
 - Reduce similarity to source phrasing/flow.
+- The source blocks are internal working material. Never cite them in the
+  article: no "(Source 1)", no "[Source 2]", no "according to Source 3",
+  no numbered source references of any kind. The reader cannot see the
+  sources and has no idea what a numbered source is.
+- Attribute a fact in prose only by naming the real publication or body it
+  came from, never by its position in the source list.
 - Keep complete article prose with clear `##` / `###` structure.
 - Preserve CTA and keyword requirements naturally.
 - If source support is missing, explicitly state uncertainty.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 
 from .content.markdown import _clean_title
+from .content.source_citations import strip_source_citations
 from .support import (
     _safe_bool,
     _safe_dict,
@@ -247,6 +248,12 @@ def _sanitize_rewrite(
 
     improved_title = _clean_title(_safe_str(parsed.get("improved_title")))
     improved_content = _safe_str(parsed.get("improved_content"))
+    # The source blocks handed to compose are labelled "Source 1:", "Source 2:"
+    # so the model can tell them apart, and it cited them back into the prose.
+    # The prompts now forbid that; this is the half that does not rely on the
+    # model having listened.
+    improved_title, title_citations = strip_source_citations(improved_title)
+    improved_content, content_citations = strip_source_citations(improved_content)
 
     return {
         "improved_title": improved_title or _clean_title(fallback_title),
@@ -257,6 +264,7 @@ def _sanitize_rewrite(
         or "Guideline alignment summary not provided.",
         "improvements_applied": improvements,
         "remaining_gaps": remaining,
+        "source_citations_removed": title_citations + content_citations,
     }
 
 

--- a/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
@@ -109,7 +109,11 @@ have written "X — Y — Z" before the no-em-dash rule, do not write "X, Y, Z" 
 instead. Comma-bracketed adverbials like "arguing, convincingly, that" or \
 "the room is warm, and quietly so, throughout" are em dashes in disguise — \
 rewrite the sentence into two shorter sentences, or drop the aside entirely. \
-A comma should join clauses or list items, not impersonate a dash."""
+A comma should join clauses or list items, not impersonate a dash.
+Do not substitute a hyphen either. "The room is warm - and quietly so" is the \
+same dash wearing a different hat, and a spaced hyphen reads as a typewriter \
+artefact rather than punctuation anyone chose. Hyphens join compound words. \
+They do not bracket asides and they do not break sentences."""
 
 _VOICE = """\
 Voice rules. Write from a single point of view with an opinion. If the writing \

--- a/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
@@ -31,6 +31,12 @@ _FENCE_LINE = re.compile(r"^\s*(```|~~~)")
 _TABLE_DELIMITER_ROW = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
 _HORIZONTAL_RULE = re.compile(r"^\s*(?:-{3,}|\*{3,}|_{3,})\s*$")
 _DOUBLE_HYPHEN_PROSE = re.compile(r"(?<=\w)\s*--\s*(?=\w)")
+# Banning the em dash without banning its replacements just moves the tell.
+# The comma-bracketed aside was the first substitution and is caught below;
+# a spaced single hyphen ("the room is warm - and quietly so") is the next
+# one, and reads as a typewriter dash rather than as punctuation anyone
+# chose. Digit-digit spans are excluded: those are ranges, not dashes.
+_SPACED_HYPHEN_PROSE = re.compile(r"(?<=[A-Za-z,;:])\s+-\s+(?=[A-Za-z])")
 _COMMA_AS_DASH_ASIDE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r",\s+(?:and\s+)?quietly\s+so\s*,", re.I),
     re.compile(r",\s+convincingly\s*,", re.I),
@@ -109,6 +115,10 @@ def validate_anti_ai_tells_markdown(text: str) -> AntiAiValidationResult:
             errors.append(f"Line {line_number}: em dash is not allowed.")
         if _DOUBLE_HYPHEN_PROSE.search(line):
             errors.append(f"Line {line_number}: prose double hyphen dash is not allowed.")
+        if _SPACED_HYPHEN_PROSE.search(line):
+            errors.append(
+                f"Line {line_number}: spaced hyphen used as a dash is not allowed."
+            )
         if _has_non_numeric_en_dash(line):
             errors.append(f"Line {line_number}: non-numeric en dash is not allowed.")
         for pattern in _COMMA_AS_DASH_ASIDE_PATTERNS:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_source_citations.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_source_citations.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from app.features.prompt2blog.content.editorial_blocks import (
+    _sanitize_editorial_augmentation,
+)
+from app.features.prompt2blog.content.source_citations import (
+    count_residual_source_mentions,
+    strip_source_citations,
+)
+from app.features.prompt2blog.quality import _sanitize_rewrite
+
+# Taken verbatim from run 58766c27, which shipped thirteen of these.
+LEAKED = (
+    "A comfortable monthly budget runs between US$1,300 and US$1,600, "
+    "according to Source 1. Furnished apartments typically rent for US$800 "
+    "to US$1,200 per month (Source 2). Lima sits only 0.4% higher than its "
+    "Colombian counterpart (Source 4)."
+)
+
+
+def test_the_citations_that_actually_shipped_are_removed():
+    cleaned, removed = strip_source_citations(LEAKED)
+
+    assert removed == 3
+    assert count_residual_source_mentions(cleaned) == 0
+    assert cleaned == (
+        "A comfortable monthly budget runs between US$1,300 and US$1,600. "
+        "Furnished apartments typically rent for US$800 to US$1,200 per "
+        "month. Lima sits only 0.4% higher than its Colombian counterpart."
+    )
+
+
+def test_bracketed_citations_go_in_every_shape():
+    for text in (
+        "Trains are frequent (Source 1).",
+        "Trains are frequent [Source 1].",
+        "Trains are frequent (Sources 2, 3).",
+        "Trains are frequent (see source 8).",
+        "Trains are frequent (Source 1 and Source 2).",
+    ):
+        cleaned, removed = strip_source_citations(text)
+        assert removed == 1, text
+        assert cleaned == "Trains are frequent.", text
+
+
+def test_an_attribution_clause_leaves_a_readable_sentence():
+    # Deleting the clause and nothing else would leave the sentence starting
+    # on a lowercase word, which reads worse than the citation did.
+    cleaned, removed = strip_source_citations(
+        "According to Source 2, the temple opens at nine."
+    )
+
+    assert removed == 1
+    assert cleaned == "The temple opens at nine."
+
+    cleaned, _removed = strip_source_citations(
+        "Trains run late. As Source 3 notes, the last one leaves at 23:40."
+    )
+    assert cleaned == "Trains run late. The last one leaves at 23:40."
+
+
+def test_echoed_scaffolding_lines_are_removed():
+    cleaned, removed = strip_source_citations(
+        "## Getting Around\n\nSource 1:\n\nTrains are frequent."
+    )
+
+    assert removed == 1
+    assert cleaned == "## Getting Around\n\nTrains are frequent."
+
+
+def test_ordinary_prose_about_sources_survives():
+    # "The source of the river" is not a citation, and neither is a named
+    # publication. Only numbered references go.
+    for text in (
+        "The source of the Kamo river is north of the city.",
+        "Reuters reported the change in March.",
+        "Check the official source before booking.",
+    ):
+        cleaned, removed = strip_source_citations(text)
+        assert removed == 0, text
+        assert cleaned == text, text
+
+
+def test_compose_output_is_stripped_before_it_reaches_the_article():
+    rewrite = _sanitize_rewrite(
+        {
+            "improved_title": "Living in Lima (Source 1)",
+            "improved_content": LEAKED,
+        },
+        fallback_title="Lima",
+        fallback_content="fallback",
+    )
+
+    assert rewrite["improved_title"] == "Living in Lima"
+    assert count_residual_source_mentions(rewrite["improved_content"]) == 0
+    assert rewrite["source_citations_removed"] == 4
+
+
+def test_augmentation_cannot_reintroduce_citations():
+    # Augmentation regenerates the whole article, so it can put back what
+    # compose had stripped.
+    augmentation = _sanitize_editorial_augmentation(
+        {
+            "augmented_content": "## Costs\n\nRent is US$800 (Source 2).",
+            "components_added": [],
+        },
+        fallback_content="## Costs\n\nRent is US$800.",
+    )
+
+    assert "Source 2" not in augmentation["augmented_content"]
+    assert augmentation["source_citations_removed"] == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
@@ -101,3 +101,27 @@ def test_enforce_anti_ai_tells_returns_dirty_retry_without_substitution():
         context="test",
     )
     assert result == "Still dirty — no comma rewrite."
+
+
+def test_a_spaced_hyphen_used_as_a_dash_is_rejected():
+    """Banning the em dash without banning its replacements moves the tell
+    rather than removing it. The comma-bracketed aside was the first
+    substitution; a spaced hyphen is the next one."""
+    result = validate_anti_ai_tells_markdown(
+        "The room is warm - and quietly so - throughout."
+    )
+
+    assert result.valid is False
+    assert any("spaced hyphen" in error for error in result.errors)
+
+
+def test_hyphens_that_are_not_dashes_are_left_alone():
+    for line in (
+        "Open 9 - 5 on weekdays.",
+        "The bus runs 9-5 daily.",
+        "- Trains are frequent",
+        "A well-known, family-run spot near the market.",
+        "Rent runs US$800 - US$1,200 per month.",
+        "| Route | Cost |\n| --- | --- |",
+    ):
+        assert validate_anti_ai_tells_markdown(line).valid is True, line


### PR DESCRIPTION
Reported from a real run: `(Source 1)`, `(Source 8)` scattered through the finished article.

## Cause

`support.py:79` builds the source block by labelling each one:

```python
cleaned.append(f"Source {index}:\n{text}")
```

That labelled block goes into the compose, supplement, repair, coverage, audit and grounding prompts. Compose then says *"Preserve factual meaning from sources"*, *"Do not invent facts"*, *"If required details are missing, explicitly mark them as not confirmed."*

The model is handed blocks named `Source 1:`, told six ways to stay faithful to them, and **never told the output is prose a human reads.** No rule anywhere forbade citing them. It was doing what it was asked.

## Confirmed in your data, not assumed

`data/pipeline.db`, run `58766c27` (16:46 today) — **13 citations shipped**:

```
...runs between US$1,300 and US$1,600, according to Source 1.
...typically rent for US$800 to US$1,200 per month (Source 2).
...Level 2 advisory due to crime and civil unrest (Source 7).
```

The very next run (`96d39846`, 17:07) had **zero**. Same pipeline, same prompts. That coin-flip is why the prompt rule alone is not the fix.

## Change

**Prompt rules** in compose, supplement, repair and augmentation: the source blocks are internal working material, never cite them, and attribute a fact by naming the real publication or body rather than its position in the list.

**`strip_source_citations`** removes whatever survives, in the three shapes that actually occur:

| shape | example |
|---|---|
| bracketed | `(Source 2)`, `[Sources 3, 4]`, `(see source 8)` |
| trailing attribution | `..., according to Source 1.` |
| leading clause | `According to Source 2, the temple opens at nine.` |

The leading clause **re-capitalises the word it was standing in front of** — deleting it and nothing else leaves the sentence starting lowercase, which reads worse than the citation did. Echoed `Source 1:` scaffold lines go too.

Applied to compose and repair output, and again after editorial augmentation — that stage regenerates the whole article and can put back what compose stripped. The removal count is reported rather than swallowed.

### Run against the article that actually shipped

```
removed: 13
residual mentions: 0
```

Sentences read cleanly afterwards, and real attributions survive untouched — "Livingcost.org places Lima at only 0.4% higher…", "a US State Department Level 2 advisory…". Only numbered references go.

## Second thing: the next dash substitution

The anti-AI validator banned the em dash, the prose `--`, the non-numeric en dash, and the comma-bracketed aside that was the first substitution for them. It did not ban the next one: **a spaced single hyphen**. `The room is warm - and quietly so` is the same dash wearing a different hat.

Now rejected. Deliberately left alone: numeric ranges (`9 - 5`), currency spans (`US$800 - US$1,200`), list bullets, table delimiters, and compound words (`well-known`, `family-run`).

**Blast radius:** this validator is shared with url2blog, youtube2blog and editor_assist. A violation costs one targeted repair retry, not a failure. It did not fire on either of the recent prompt2blog runs.

## What I checked and did NOT find

I counted every hyphen in both recent runs before touching anything:

```
16:46 run: total "-"=17   editorial-markers=4  word-compounds=9   spaced-as-dash=0
17:07 run: total "-"=18   editorial-markers=4  word-compounds=11  spaced-as-dash=0
```

Zero em dashes, zero en dashes, zero spaced hyphens. The hyphens present are ordinary compounds (`one-bedroom`, `long-stay`, `trade-off`) plus the `EDITORIAL-BLOCK` markers. The em-dash ban is working. I added the spaced-hyphen rule as a guard against the obvious next substitution, not because it reproduced.

## Verification

- `pytest tests/` — 690 passed (681 before, 9 new)
- `flake8` clean, `tsc` clean, boundary check passed
- Stripper exercised against the real leaked article from `pipeline.db`

*Note: unrelated in-progress staging/markdown-round-trip files were in my working tree while I worked. They are not in this commit — I staged only the files above.*