### PR TITLE
Add a Markdown round trip to the standard article stage

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage-builder.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage-builder.css
@@ -109,6 +109,78 @@
   padding: 0;
 }
 
+.sab-markdown-round-trip-status,
+.sab-markdown-round-trip-error {
+  align-self: center;
+  max-width: 22rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.sab-markdown-round-trip-status {
+  color: #27543c;
+}
+
+.sab-markdown-round-trip-error,
+.sab-markdown-import-error {
+  color: #8a3030;
+}
+
+.sab-markdown-import-modal {
+  width: min(980px, 100%);
+  display: grid;
+  gap: 1rem;
+}
+
+.sab-markdown-import-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.sab-markdown-import-header h3,
+.sab-markdown-import-header p,
+.sab-markdown-import-error {
+  margin: 0;
+}
+
+.sab-markdown-import-header p {
+  margin-top: 0.25rem;
+  color: var(--stl-muted);
+  font-size: 0.88rem;
+}
+
+.sab-markdown-import-rules {
+  border: 1px solid var(--stl-border);
+  border-radius: 10px;
+  padding: 0.65rem 0.8rem;
+  background: #f7f9fc;
+  color: var(--stl-muted);
+  font-size: 0.85rem;
+}
+
+.sab-markdown-import-rules summary {
+  color: var(--stl-ink);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.sab-markdown-import-rules ul {
+  margin: 0.65rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.sab-markdown-import-field textarea {
+  min-height: 440px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  line-height: 1.55;
+}
+
+.sab-markdown-import-actions {
+  justify-content: flex-end;
+}
+
 .sab-stage-sync-result {
   border-radius: 10px;
   padding: 0.7rem 0.8rem;

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/ArticleMarkdownRoundTripControls.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/ArticleMarkdownRoundTripControls.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from 'react'
+import type { StagedArticle } from '../../types'
+import {
+  buildArticleAiEditingClipboard,
+  buildArticleMarkdownImport,
+} from '../../features/editorial-stage-article/services/article-markdown-round-trip.service'
+
+type ArticleMarkdownRoundTripControlsProps = {
+  stagedArticle: StagedArticle
+  onUpdateArticle: (updates: Partial<StagedArticle>) => void
+}
+
+async function writeClipboard(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value)
+    return
+  }
+
+  const fallback = document.createElement('textarea')
+  fallback.value = value
+  fallback.style.position = 'fixed'
+  fallback.style.opacity = '0'
+  document.body.appendChild(fallback)
+  fallback.select()
+  const copied = document.execCommand('copy')
+  fallback.remove()
+  if (!copied) throw new Error('Clipboard unavailable')
+}
+
+export function ArticleMarkdownRoundTripControls({
+  stagedArticle,
+  onUpdateArticle,
+}: ArticleMarkdownRoundTripControlsProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [pastedMarkdown, setPastedMarkdown] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+  const statusTimerRef = useRef<number | null>(null)
+
+  useEffect(() => () => {
+    if (statusTimerRef.current !== null) window.clearTimeout(statusTimerRef.current)
+  }, [])
+
+  const showTemporaryStatus = (message: string) => {
+    setStatus(message)
+    if (statusTimerRef.current !== null) window.clearTimeout(statusTimerRef.current)
+    statusTimerRef.current = window.setTimeout(() => setStatus(null), 3500)
+  }
+
+  const copyForAi = async () => {
+    setError(null)
+    try {
+      await writeClipboard(buildArticleAiEditingClipboard(stagedArticle))
+      showTemporaryStatus('Copied text-only Markdown + strict AI rules.')
+    } catch {
+      setError('Could not copy. Browser clipboard permission may be blocked.')
+    }
+  }
+
+  const closeModal = () => {
+    setIsOpen(false)
+    setPastedMarkdown('')
+    setError(null)
+  }
+
+  const applyMarkdown = () => {
+    setError(null)
+    try {
+      const imported = buildArticleMarkdownImport(stagedArticle, pastedMarkdown)
+      onUpdateArticle({
+        title: imported.title,
+        blocks: imported.nextBlocks,
+        editorialBlocks: imported.nextEditorialBlocks,
+        lexicalConverted: false,
+      })
+      closeModal()
+      showTemporaryStatus(
+        `Imported ${imported.nextBlocks.length - imported.preservedMediaCount} text blocks; kept ${imported.preservedMediaCount} image blocks and ${imported.nextEditorialBlocks.length} editorial blocks.`,
+      )
+    } catch (importError) {
+      setError(importError instanceof Error ? importError.message : 'Markdown import failed.')
+    }
+  }
+
+  return (
+    <>
+      <button type="button" className="stl-btn stl-btn-secondary" onClick={() => void copyForAi()}>
+        Copy Markdown for AI
+      </button>
+      <button type="button" className="stl-btn stl-btn-secondary" onClick={() => {
+        setError(null)
+        setIsOpen(true)
+      }}>
+        Paste Edited Markdown
+      </button>
+      {status ? <span className="sab-markdown-round-trip-status" role="status">{status}</span> : null}
+      {!isOpen && error ? <span className="sab-markdown-round-trip-error" role="alert">{error}</span> : null}
+
+      {isOpen ? (
+        <div className="stl-modal-overlay" onClick={(event) => {
+          if (event.target === event.currentTarget) closeModal()
+        }}>
+          <div
+            className="stl-modal sab-markdown-import-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="sab-markdown-import-title"
+          >
+            <div className="sab-markdown-import-header">
+              <div>
+                <h3 id="sab-markdown-import-title">Paste Edited Markdown</h3>
+                <p>Replaces title + text. Existing images and editorial blocks stay in staged draft.</p>
+              </div>
+              <button type="button" className="stl-btn stl-btn-secondary" onClick={closeModal}>
+                Close
+              </button>
+            </div>
+
+            <details className="sab-markdown-import-rules">
+              <summary>Accepted format</summary>
+              <ul>
+                <li>One H1 title first; H2 main sections; H3 subsections.</li>
+                <li>Plain Markdown text only. Lists, links, emphasis, and blockquotes are accepted.</li>
+                <li>No images, HTML, frontmatter, code fences, editorial syntax, or comments except QUESTURA markers.</li>
+                <li>QUESTURA markers from copied prompt are removed automatically.</li>
+              </ul>
+            </details>
+
+            <label className="stl-field sab-markdown-import-field">
+              <span>Markdown</span>
+              <textarea
+                autoFocus
+                rows={20}
+                value={pastedMarkdown}
+                onChange={(event) => setPastedMarkdown(event.target.value)}
+                placeholder={'<!-- QUESTURA_ARTICLE_START -->\n# Article title\n\n## First section\n\nArticle text...\n<!-- QUESTURA_ARTICLE_END -->'}
+              />
+            </label>
+
+            {error ? <p className="sab-markdown-import-error" role="alert">{error}</p> : null}
+
+            <div className="stl-inline-actions sab-markdown-import-actions">
+              <button type="button" className="stl-btn" onClick={applyMarkdown} disabled={!pastedMarkdown.trim()}>
+                Replace Text from Markdown
+              </button>
+              <button type="button" className="stl-btn stl-btn-secondary" onClick={closeModal}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleContentPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/components/standard-article-stage/StandardArticleContentPanel.tsx
@@ -1,6 +1,7 @@
 import type { TimelineListViewProps } from '../../features/editorial-stage-article/selectors'
 import type { StagedArticle } from '../../types'
 import { EditorialTimelineList } from '../editorial-stage/EditorialTimelineList'
+import { ArticleMarkdownRoundTripControls } from './ArticleMarkdownRoundTripControls'
 
 type StandardArticleContentPanelProps = {
   stagedArticle: StagedArticle
@@ -28,6 +29,10 @@ export function StandardArticleContentPanel({
       <div className="stl-panel-header">
         <h2>{!isSynced ? <span className="stl-kicker">Step 3</span> : null} Content Blocks</h2>
         <div className="stl-inline-actions">
+          <ArticleMarkdownRoundTripControls
+            stagedArticle={stagedArticle}
+            onUpdateArticle={onUpdateArticle}
+          />
           <button type="button" className="stl-btn stl-btn-secondary" onClick={onResetToOriginalBlocks}>
             Reset to Original
           </button>

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/article-markdown-round-trip.service.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/article-markdown-round-trip.service.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import type { StagedArticle } from '../../../types'
+import {
+  ARTICLE_MARKDOWN_END,
+  ARTICLE_MARKDOWN_START,
+  buildArticleAiEditingClipboard,
+  buildArticleMarkdownImport,
+  parseArticleMarkdown,
+} from './article-markdown-round-trip.service'
+
+function makeArticle(): StagedArticle {
+  return {
+    id: 'staged_1',
+    runId: 'run_1',
+    originalTitle: 'Original title',
+    originalContent: 'Original content',
+    originalType: 'guide',
+    title: 'Current title',
+    content: 'composed content',
+    blocks: [
+      { id: 'intro', type: 'text', content: 'Opening paragraph.' },
+      { id: 'photo', type: 'image', content: '', imageAfter: 42 },
+      { id: 'section', type: 'text', content: '## Existing section\n\nExisting body.' },
+    ],
+    editorialBlocks: [{
+      id: 'editorial',
+      component: 'highlight_callout',
+      label: 'In the Know',
+      markdown: '> [!EDITORIAL-BLOCK-START|highlight_callout]\n> Secret editorial copy.\n> [!EDITORIAL-BLOCK-END|highlight_callout]',
+      afterBlockId: 'section',
+    }],
+    sharedNeighborhoods: [],
+    lexicalConverted: false,
+    publishedToPayload: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+describe('article Markdown round trip', () => {
+  it('copies strict instructions with text-only Markdown', () => {
+    const clipboard = buildArticleAiEditingClipboard(makeArticle())
+
+    expect(clipboard).toContain('Strict return contract')
+    expect(clipboard).toContain(ARTICLE_MARKDOWN_START)
+    expect(clipboard).toContain('# Current title')
+    expect(clipboard).toContain('Opening paragraph.')
+    expect(clipboard).toContain('## Existing section')
+    expect(clipboard).toContain(ARTICLE_MARKDOWN_END)
+    expect(clipboard).not.toContain('Secret editorial copy')
+    expect(clipboard).not.toContain('imageAfter')
+  })
+
+  it('extracts a marked AI response and builds text blocks', () => {
+    const parsed = parseArticleMarkdown([
+      'Here is text that import must ignore.',
+      ARTICLE_MARKDOWN_START,
+      '# Better title',
+      '',
+      'Improved opening.',
+      '',
+      '## Better section',
+      '',
+      '- One',
+      '- Two',
+      ARTICLE_MARKDOWN_END,
+      'More ignored text.',
+    ].join('\n'))
+
+    expect(parsed.title).toBe('Better title')
+    expect(parsed.blocks).toHaveLength(2)
+    expect(parsed.blocks[0].content).toBe('Improved opening.')
+    expect(parsed.blocks[1].content).toContain('## Better section')
+  })
+
+  it.each([
+    ['missing H1', '## Section\n\nBody', 'First article line'],
+    ['second H1', '# Title\n\n# Other\n\nBody', 'exactly one H1'],
+    ['image', '# Title\n\n![Alt](photo.jpg)', 'Images are not allowed'],
+    ['editorial block', '# Title\n\n> [!EDITORIAL-BLOCK-START|faq]', 'Editorial blocks'],
+    ['HTML', '# Title\n\n<section>Body</section>', 'HTML is not allowed'],
+    ['code fence', '# Title\n\n```md\nBody\n```', 'Fenced code'],
+  ])('rejects %s', (_name, markdown, expectedMessage) => {
+    expect(() => parseArticleMarkdown(markdown)).toThrow(expectedMessage)
+  })
+
+  it('replaces text while preserving image and editorial blocks', () => {
+    const article = makeArticle()
+    const imported = buildArticleMarkdownImport(article, [
+      '# Revised title',
+      '',
+      'Revised opening.',
+      '',
+      '## Revised section',
+      '',
+      'Revised body.',
+      '',
+      '## Added section',
+      '',
+      'Added body.',
+    ].join('\n'), () => 'new-section')
+
+    expect(imported.title).toBe('Revised title')
+    expect(imported.nextBlocks.map((block) => block.id)).toEqual([
+      'intro',
+      'photo',
+      'section',
+      'new-section',
+    ])
+    expect(imported.nextBlocks.find((block) => block.id === 'photo')).toEqual(article.blocks[1])
+    expect(imported.nextEditorialBlocks).toEqual(article.editorialBlocks)
+    expect(imported.preservedMediaCount).toBe(1)
+  })
+
+  it('reanchors editorial blocks when imported text has fewer sections', () => {
+    const article = makeArticle()
+    article.editorialBlocks[0].afterBlockId = 'section'
+
+    const imported = buildArticleMarkdownImport(
+      article,
+      '# Revised title\n\nOnly one text block remains.',
+    )
+
+    expect(imported.nextBlocks.map((block) => block.id)).toEqual(['intro', 'photo'])
+    expect(imported.nextEditorialBlocks[0].afterBlockId).toBe('photo')
+  })
+
+  it('allows Markdown autolinks while rejecting HTML tags', () => {
+    const parsed = parseArticleMarkdown('# Title\n\nVisit <https://example.com>.')
+    expect(parsed.body).toContain('<https://example.com>')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/article-markdown-round-trip.service.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/staging/features/editorial-stage-article/services/article-markdown-round-trip.service.ts
@@ -1,0 +1,226 @@
+import type { ContentBlock, EditorialBlock, StagedArticle } from '../../../types'
+import { createStagedId } from '../create-staged-id'
+import { isTextualBlock } from '../content-blocks/block-media'
+import { parseMarkdownToBlocks } from '../content-blocks/markdown-block-parser'
+
+export const ARTICLE_MARKDOWN_START = '<!-- QUESTURA_ARTICLE_START -->'
+export const ARTICLE_MARKDOWN_END = '<!-- QUESTURA_ARTICLE_END -->'
+
+const EDITING_RULES = [
+  'Edit only the article between the two QUESTURA markers.',
+  'Return exactly one Markdown document between the same markers. Add nothing before or after them.',
+  'Keep exactly one H1 (`# Title`) as the first article line. Use H2 (`##`) for main sections and H3 (`###`) only inside an H2 section.',
+  'Use plain Markdown text only: paragraphs, emphasis, links, blockquotes, and ordered or unordered lists are allowed.',
+  'Do not add images, HTML, frontmatter, fenced code, editorial blocks, custom components, JSON, explanations, or HTML comments other than the two required QUESTURA markers.',
+  'Keep every factual claim and destination-specific detail accurate. Do not invent facts, links, quotes, or placeholders.',
+]
+
+export type ParsedArticleMarkdown = {
+  title: string
+  body: string
+  blocks: ContentBlock[]
+}
+
+export type ArticleMarkdownImport = ParsedArticleMarkdown & {
+  nextBlocks: ContentBlock[]
+  nextEditorialBlocks: EditorialBlock[]
+  preservedMediaCount: number
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1
+}
+
+function stripOuterMarkdownFence(value: string): string {
+  const trimmed = value.trim()
+  const match = trimmed.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```$/i)
+  return match ? match[1].trim() : trimmed
+}
+
+function extractArticleDocument(value: string): string {
+  const normalized = value.replace(/\r\n?/g, '\n').trim()
+  const startCount = countOccurrences(normalized, ARTICLE_MARKDOWN_START)
+  const endCount = countOccurrences(normalized, ARTICLE_MARKDOWN_END)
+
+  if (startCount !== endCount) {
+    throw new Error('Paste includes only one QUESTURA marker. Include both start and end markers.')
+  }
+
+  if (startCount > 1 || endCount > 1) {
+    throw new Error('Paste includes duplicate QUESTURA markers. Include one start and one end marker.')
+  }
+
+  if (startCount === 1) {
+    const startIndex = normalized.indexOf(ARTICLE_MARKDOWN_START) + ARTICLE_MARKDOWN_START.length
+    const endIndex = normalized.indexOf(ARTICLE_MARKDOWN_END, startIndex)
+    if (endIndex < startIndex) {
+      throw new Error('QUESTURA end marker must follow the start marker.')
+    }
+    return normalized.slice(startIndex, endIndex).trim()
+  }
+
+  return stripOuterMarkdownFence(normalized)
+}
+
+function validateArticleDocument(markdown: string): void {
+  if (!markdown) throw new Error('Paste contains no article Markdown.')
+
+  if (/^\s*---\s*$/m.test(markdown.split('\n').slice(0, 2).join('\n'))) {
+    throw new Error('Frontmatter is not allowed. Start with one H1 title.')
+  }
+  if (/^\s*(?:```|~~~)/m.test(markdown)) {
+    throw new Error('Fenced code is not allowed. Paste raw Markdown, without a code fence.')
+  }
+  if (/!\[[^\]]*\]\s*\([^)]*\)|<img\b/i.test(markdown)) {
+    throw new Error('Images are not allowed. Existing staged images are preserved automatically.')
+  }
+  if (/\[!EDITORIAL-BLOCK-|<!--/i.test(markdown)) {
+    throw new Error('Editorial blocks and HTML comments are not allowed. Existing editorial blocks are preserved automatically.')
+  }
+  if (/<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?\/?>/i.test(markdown)) {
+    throw new Error('HTML is not allowed. Use plain Markdown only.')
+  }
+
+  const lines = markdown.split('\n')
+  const firstContentLine = lines.findIndex((line) => line.trim().length > 0)
+  if (firstContentLine < 0 || !/^#\s+\S/.test(lines[firstContentLine].trim())) {
+    throw new Error('First article line must be one H1 title: `# Title`.')
+  }
+
+  const h1Lines = lines.filter((line) => /^#\s+\S/.test(line.trim()))
+  if (h1Lines.length !== 1) {
+    throw new Error('Article must contain exactly one H1 title.')
+  }
+}
+
+export function buildTextOnlyArticleMarkdown(article: StagedArticle): string {
+  const title = (article.title || article.originalTitle || 'Untitled Article')
+    .replace(/\s+/g, ' ')
+    .trim()
+  const body = article.blocks
+    .filter(isTextualBlock)
+    .map((block) => block.content.trim())
+    .filter(Boolean)
+    .join('\n\n')
+
+  return `# ${title}\n\n${body}`.trim()
+}
+
+export function buildArticleAiEditingClipboard(article: StagedArticle): string {
+  const numberedRules = EDITING_RULES.map((rule, index) => `${index + 1}. ${rule}`).join('\n')
+  return [
+    'Revise this article using my instructions. Strict return contract:',
+    numberedRules,
+    ARTICLE_MARKDOWN_START,
+    buildTextOnlyArticleMarkdown(article),
+    ARTICLE_MARKDOWN_END,
+  ].join('\n\n')
+}
+
+export function parseArticleMarkdown(value: string): ParsedArticleMarkdown {
+  const markdown = extractArticleDocument(value)
+  validateArticleDocument(markdown)
+
+  const lines = markdown.split('\n')
+  const firstContentLine = lines.findIndex((line) => line.trim().length > 0)
+  const title = lines[firstContentLine].trim().replace(/^#\s+/, '').trim()
+  const body = lines.slice(firstContentLine + 1).join('\n').trim()
+
+  if (!title) throw new Error('H1 title cannot be empty.')
+  if (!body) throw new Error('Article body cannot be empty.')
+
+  const blocks = parseMarkdownToBlocks(body)
+  if (blocks.length === 0) throw new Error('Article body produced no text blocks.')
+
+  return { title, body, blocks }
+}
+
+function mergeTextBlocks(
+  existingBlocks: ContentBlock[],
+  importedBlocks: ContentBlock[],
+  createId: () => string,
+): {
+  blocks: ContentBlock[]
+  removedTextAnchorMap: Map<string, string | null>
+  preservedMediaCount: number
+} {
+  const existingTextBlocks = existingBlocks.filter(isTextualBlock)
+  const importedWithStableIds = importedBlocks.map((block, index) => {
+    const existing = existingTextBlocks[index]
+    return {
+      ...block,
+      id: existing?.id || createId(),
+      type: existing?.type || 'text',
+    } satisfies ContentBlock
+  })
+  const blocks: ContentBlock[] = []
+  const removedTextAnchorMap = new Map<string, string | null>()
+  let lastExistingTextIndex = -1
+  for (let index = existingBlocks.length - 1; index >= 0; index -= 1) {
+    if (isTextualBlock(existingBlocks[index])) {
+      lastExistingTextIndex = index
+      break
+    }
+  }
+  let importedIndex = 0
+  let previousSurvivingBlockId: string | null = null
+
+  if (lastExistingTextIndex < 0) {
+    blocks.push(...importedWithStableIds)
+    previousSurvivingBlockId = importedWithStableIds[importedWithStableIds.length - 1]?.id || null
+  }
+
+  existingBlocks.forEach((existingBlock, existingIndex) => {
+    if (!isTextualBlock(existingBlock)) {
+      blocks.push(existingBlock)
+      previousSurvivingBlockId = existingBlock.id
+      return
+    }
+
+    const imported = importedWithStableIds[importedIndex]
+    if (imported) {
+      blocks.push(imported)
+      previousSurvivingBlockId = imported.id
+      importedIndex += 1
+    } else {
+      removedTextAnchorMap.set(existingBlock.id, previousSurvivingBlockId)
+    }
+
+    if (existingIndex === lastExistingTextIndex && importedIndex < importedWithStableIds.length) {
+      const extras = importedWithStableIds.slice(importedIndex)
+      blocks.push(...extras)
+      previousSurvivingBlockId = extras[extras.length - 1]?.id || previousSurvivingBlockId
+      importedIndex = importedWithStableIds.length
+    }
+  })
+
+  return {
+    blocks,
+    removedTextAnchorMap,
+    preservedMediaCount: existingBlocks.filter((block) => !isTextualBlock(block)).length,
+  }
+}
+
+export function buildArticleMarkdownImport(
+  article: StagedArticle,
+  value: string,
+  createId: () => string = () => createStagedId('block'),
+): ArticleMarkdownImport {
+  const parsed = parseArticleMarkdown(value)
+  const merged = mergeTextBlocks(article.blocks, parsed.blocks, createId)
+  const nextEditorialBlocks = (article.editorialBlocks || []).map((block) => {
+    if (!block.afterBlockId || !merged.removedTextAnchorMap.has(block.afterBlockId)) return block
+    return {
+      ...block,
+      afterBlockId: merged.removedTextAnchorMap.get(block.afterBlockId) || null,
+      placeAfterImage: false,
+    }
+  })
+
+  return {
+    ...parsed,
+    nextBlocks: merged.blocks,
+    nextEditorialBlocks,
+    preservedMediaCount: merged.preservedMediaCount,
+  }
+}


### PR DESCRIPTION
Work started locally by the repo owner; reviewed, verified and shipped as-is.

## What it does

Two buttons on the Content Blocks panel of the standard article stage:

- **Copy Markdown for AI** — puts the staged article on the clipboard as text-only Markdown wrapped in `<!-- QUESTURA_ARTICLE_START -->` / `_END -->` markers, prefixed with a numbered return contract (one H1, H2 sections, plain Markdown only, no invented facts).
- **Paste Edited Markdown** — a modal that takes the edited Markdown back.

## What the import preserves

Title and text blocks are replaced. **Image blocks and editorial blocks stay.** Text blocks are matched by position so their ids survive the round trip, and an editorial block anchored to a text block the edit deleted re-anchors to the nearest surviving block above it instead of being dropped.

## What it refuses

The paste is validated before anything is applied, and each failure names the fix:

- one marker without its pair, or duplicate markers
- missing or multiple H1, or an H1 that is not the first line
- frontmatter, fenced code, images, HTML, editorial syntax, stray comments
- an empty title or body, or a body that parses to zero blocks

An outer ```` ```markdown ```` fence is stripped rather than rejected, since that is what most chat UIs paste.

## Verification

- `vitest` — 705 passed, 152 files (694 / 151 before; the new service has its own suite)
- `tsc` clean, `eslint` 0 errors, boundary check passed