### PR TITLE
Ban hyphenated compounds from generated prose

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
@@ -112,8 +112,13 @@ rewrite the sentence into two shorter sentences, or drop the aside entirely. \
 A comma should join clauses or list items, not impersonate a dash.
 Do not substitute a hyphen either. "The room is warm - and quietly so" is the \
 same dash wearing a different hat, and a spaced hyphen reads as a typewriter \
-artefact rather than punctuation anyone chose. Hyphens join compound words. \
-They do not bracket asides and they do not break sentences."""
+artefact rather than punctuation anyone chose. Hyphens do not bracket asides and they do not break sentences.
+Do not use hyphenated compounds at all. "Two-bedroom apartments", \
+"a long-stay visa", "a well-known, family-run spot" -- each is correct \
+English on its own, but a run of them through an article is one of the \
+clearest signals the text was generated. Rephrase instead: "apartments with \
+two bedrooms", "a visa for long stays", "a spot the family runs, and people \
+know it". Proper names keep their hyphens; nothing else does."""
 
 _VOICE = """\
 Voice rules. Write from a single point of view with an opinion. If the writing \

--- a/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
@@ -37,6 +37,43 @@ _DOUBLE_HYPHEN_PROSE = re.compile(r"(?<=\w)\s*--\s*(?=\w)")
 # one, and reads as a typewriter dash rather than as punctuation anyone
 # chose. Digit-digit spans are excluded: those are ranges, not dashes.
 _SPACED_HYPHEN_PROSE = re.compile(r"(?<=[A-Za-z,;:])\s+-\s+(?=[A-Za-z])")
+
+# Spans where a hyphen is syntax or data rather than a writer's choice, blanked
+# before the compound check reads a line.
+_NON_PROSE_SPANS = (
+    re.compile(r"`[^`]*`"),
+    re.compile(r"\]\([^)]*\)"),
+    re.compile(r"https?://\S+"),
+    re.compile(r"\[![^\]]*\]"),
+    re.compile(r"<[^>]+>"),
+)
+
+# Hyphenated compounds. A run of them is a strong AI tell -- "one-bedroom",
+# "long-stay", "well-known", "cost-of-living" stacked through an article read
+# as generated even though each word is correct English. House style is none:
+# rephrase, and a human adds one back if the sentence really needs it.
+_HYPHENATED_COMPOUND = re.compile(r"\b[A-Za-z]+(?:-[A-Za-z]+)+\b")
+
+# ...except proper nouns, where the hyphen is part of the name and rewriting it
+# corrupts a fact. "Aix-en-Provence" and "Colombia-Peru" keep theirs;
+# "Two-bedroom" at the start of a sentence does not, because only its first
+# letter is capitalised.
+
+
+def _is_proper_noun_compound(word: str) -> bool:
+    return any(part[:1].isupper() for part in word.split("-")[1:])
+
+
+def _hyphenated_compounds(line: str) -> list[str]:
+    for pattern in _NON_PROSE_SPANS:
+        line = pattern.sub(" ", line)
+    return [
+        word
+        for word in _HYPHENATED_COMPOUND.findall(line)
+        if not _is_proper_noun_compound(word)
+    ]
+
+
 _COMMA_AS_DASH_ASIDE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r",\s+(?:and\s+)?quietly\s+so\s*,", re.I),
     re.compile(r",\s+convincingly\s*,", re.I),
@@ -119,6 +156,12 @@ def validate_anti_ai_tells_markdown(text: str) -> AntiAiValidationResult:
             errors.append(
                 f"Line {line_number}: spaced hyphen used as a dash is not allowed."
             )
+        compounds = _hyphenated_compounds(line)
+        if compounds:
+            listed = ", ".join(sorted(set(compounds))[:8])
+            errors.append(
+                f"Line {line_number}: hyphenated compounds are not allowed: {listed}"
+            )
         if _has_non_numeric_en_dash(line):
             errors.append(f"Line {line_number}: non-numeric en dash is not allowed.")
         for pattern in _COMMA_AS_DASH_ASIDE_PATTERNS:
@@ -138,7 +181,9 @@ def build_anti_ai_repair_prompt(content: str, errors: list[str]) -> str:
         "Your previous output violated the anti-AI voice rules.\n"
         "Repair only the listed issues. Preserve markdown, facts, headings, tables, "
         "and source meaning. Do not replace dashes with comma-bracketed asides; "
-        "rewrite affected sentences into clean prose.\n\n"
+        "rewrite affected sentences into clean prose. Fix a hyphenated compound "
+        "by rephrasing the sentence, never by deleting the hyphen or splitting "
+        "the word in place.\n\n"
         f"Validation errors:\n{error_lines}\n\n"
         "Previous output:\n"
         "<<<CONTENT>>>\n"

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
@@ -120,8 +120,55 @@ def test_hyphens_that_are_not_dashes_are_left_alone():
         "Open 9 - 5 on weekdays.",
         "The bus runs 9-5 daily.",
         "- Trains are frequent",
-        "A well-known, family-run spot near the market.",
         "Rent runs US$800 - US$1,200 per month.",
         "| Route | Cost |\n| --- | --- |",
     ):
         assert validate_anti_ai_tells_markdown(line).valid is True, line
+
+
+def test_hyphenated_compounds_are_rejected():
+    """Each is correct English on its own, but a run of them through an
+    article is one of the clearest signals the text was generated."""
+    result = validate_anti_ai_tells_markdown(
+        "Two-bedroom apartments suit a long-stay visa holder."
+    )
+
+    assert result.valid is False
+    assert any("hyphenated compounds" in error for error in result.errors)
+    assert "Two-bedroom" in result.errors[0]
+    assert "long-stay" in result.errors[0]
+
+
+def test_proper_names_keep_their_hyphens():
+    """Rewriting a name corrupts a fact. A capitalised segment after the first
+    hyphen is what separates a name from a compound modifier -- "Two-bedroom"
+    at the start of a sentence has only its first letter capitalised."""
+    for line in (
+        "Aix-en-Provence is worth a detour.",
+        "The Colombia-Peru border crossing takes a day.",
+        "COVID-19 rules were lifted in 2023.",
+    ):
+        assert validate_anti_ai_tells_markdown(line).valid is True, line
+
+
+def test_hyphens_that_are_syntax_are_not_compounds():
+    """Link targets, inline code and editorial directives carry hyphens that
+    no writer chose."""
+    for line in (
+        "See the guide at https://example.com/long-stay-visa for details.",
+        "Set `max-width` on the container.",
+        "> [!EDITORIAL-BOX|highlight_callout]",
+        "| Route | Cost |",
+    ):
+        assert validate_anti_ai_tells_markdown(line).valid is True, line
+
+
+def test_the_repair_prompt_says_how_to_fix_a_compound():
+    # Deleting the hyphen in place would produce "Twobedroom".
+    prompt = build_anti_ai_repair_prompt(
+        "Two-bedroom apartments.",
+        ["Line 1: hyphenated compounds are not allowed: Two-bedroom"],
+    )
+
+    assert "rephrasing the sentence" in prompt
+    assert "never by deleting the hyphen" in prompt


### PR DESCRIPTION
Requested directly: none at all, and you add one back if you read it and want it.

## The rule

"Two-bedroom apartments", "a long-stay visa", "a well-known, family-run spot" — each is correct English on its own. A run of them through an article is one of the clearest signals the text was generated. House style is now zero.

Enforced in two places:
- **Anti-AI voice block** tells the writer to rephrase rather than hyphenate, with worked examples ("apartments with two bedrooms", "a visa for long stays").
- **Validator** rejects what survives, so the existing repair pass fixes it. The repair prompt says to *rephrase the sentence*, never to delete the hyphen in place — otherwise "Two-bedroom" becomes "Twobedroom".

## Proper names keep their hyphens

Rewriting a name corrupts a fact, so `Aix-en-Provence`, `Colombia-Peru` and `COVID-19` pass while `Two-bedroom` at the start of a sentence does not. What separates them is **a capitalised segment after the first hyphen** — a sentence-initial compound only has its first letter capitalised.

**Flag this if you disagree.** It is the one judgment call here, and the alternative is a repair pass mangling real place names in travel copy.

Hyphens that are syntax rather than a writer choice are blanked before a line is read: link targets, inline code, `[!EDITORIAL-BOX|…]` directives, table rules, bare URLs.

## What it does to your two real runs

```
16:46 run  ->  5 errors
   Line  5: one-bedroom, two-bedroom
   Line  9: near-parity
   Line 17: long-stay
   Line 23: blue-dollar, cost-of-living
   Line 31: long-stay, still-nonoperational

17:07 run  ->  5 errors
   Line  3: single-person, trade-off
   Line 20: blue-dollar, one-bedroom, post-convergence
   Line 24: One-bedroom, Two-bedroom
   Line 28: long-stay, non-operational
   Line 36: long-stay
```

`still-nonoperational` and `post-convergence` are the kind of construction nobody writes by hand.

## Cost — read this bit

Both runs trip it, ~10 compounds each. **In practice every article now spends one repair call it did not before.** That is the trade for the rule you asked for.

Enforcement degrades rather than fails: one repair attempt, keep the result, log anything left over. A run never fails because of this.

## Blast radius

`validate_anti_ai_tells_markdown` is shared, so this applies to **url2blog, youtube2blog and editor_assist** as well as prompt2blog. That seemed right given the complaint was about articles generally — say if you want it scoped to prompt2blog only.

## Verification

- `pytest tests/` — 694 passed (690 before, 4 new; 1 assertion updated)
- `flake8` clean
- Validator exercised against both real articles from `pipeline.db`

One assertion from #377 claimed "A well-known, family-run spot near the market" was clean. Under this policy it is not, and the test now says so.