### PR TITLE
Let writer calls answer on the Claude Code subscription

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -148,3 +148,29 @@ ABW_CLAUDE_CLI=
 # this backend over loopback through a proxy, where that check cannot tell the
 # two apart.
 ABW_ENABLE_CLAUDE_LOGIN=
+
+# Writer provider — which backend serves pipeline writing calls. Leave blank
+# (the default) for the existing behaviour: Vertex for gemini-* names, and
+# claude-* names substituted to Google while ANTHROPIC_MODELS_ENABLED=0.
+#
+#   claude-cli   Route writer calls through the Claude Code CLI, answering on
+#                the subscription this machine is logged into. No API key and
+#                no extra dependency -- the CLI is the transport. Refuses to
+#                send unless GET /claude/status is green, because an API key
+#                anywhere in the environment would silently move the spend off
+#                the subscription and onto API billing.
+#
+# Scope: this only affects calls routed through app/shared/writer_invocation.py
+# -- editor_assist and itineraries_pipeline. Prompt2Blog, url2blog and
+# youtube2blog call utils.get_vertex_llm directly and ignore this flag. It is
+# also unrelated to ANTHROPIC_MODELS_ENABLED above, which governs the API-key
+# path; the two switches do not interact.
+#
+# Local authoring only. Anthropic's terms do not permit routing other people's
+# requests through one Pro/Max login, so do NOT set this on the Linux laptop or
+# any shared deployment. See scripts/claude-agent-sdk-smoke/README.md.
+#
+# Subscription usage draws a monthly credit ($20/mo on Pro) before overflowing
+# to standard API rates. A cold call costs ~$0.028 and a warm one ~$0.010, so
+# an article's worth of stages is cents, not free.
+WRITER_PROVIDER=

--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
@@ -1,0 +1,347 @@
+"""Writer transport that answers on the Claude Code CLI's subscription login.
+
+This is the pipeline-facing sibling of ``messaging.py``. The bench answers "does
+Claude reply and what did it cost"; this answers the two questions the article
+stages actually ask -- give me prose, and give me JSON in this shape -- behind
+the ``WriterResult`` / ``StructuredWriterResult`` contract the Gemini path
+already satisfies.
+
+Why the CLI and not the Agent SDK
+---------------------------------
+Installing ``claude-agent-sdk`` into the shared backend virtualenv pulls in
+``mcp``, which drags ``starlette`` and ``uvicorn`` past the versions FastAPI
+0.111 pins. The CLI needs no dependency at all, and it turns out to give away
+nothing that mattered:
+
+* ``--json-schema`` is a real forced-tool equivalent. The CLI returns a
+  ``structured_output`` field that is already a parsed object, and the reply
+  comes back with ``stop_reason: "tool_use"``. Measured against the pipeline's
+  own SEO schema and a harder nested one, it honours ``required``, ``enum``,
+  array bounds, integer types, and ``additionalProperties: false`` -- including
+  refusing an extra field a prompt explicitly asked it to add.
+* ``total_cost_usd`` and ``usage.*`` come back per call, which is what per-stage
+  cost attribution needs.
+
+What that means for cost, which drove the design here
+-----------------------------------------------------
+A call carrying the CLI's default system prompt writes ~18k cache-creation
+tokens (~$0.037). Replacing it with ``--system-prompt`` cuts that to ~11k, and
+-- the part that matters -- a *second independent* call sharing the same system
+prompt and the same schema reads that prefix from cache instead of writing it
+(~$0.010).
+
+So the prefix is only cheap if it is *identical* across calls. That is why
+``SYSTEM_PROMPT`` is a module constant rather than a per-stage string, and why
+stage-specific instructions belong in the prompt body. Session threading via
+``--resume`` is marginally cheaper still, but it couples a stage to a
+conversation and leaks one stage's context into the next; independent calls that
+warm their own cache are worth the difference.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+from app.features.claude_connection.status import (
+    STATE_CONNECTED,
+    read_claude_status,
+    resolve_cli_path,
+)
+
+# What this flag actually reaches, which is less than its name suggests.
+#
+# Only calls that go through ``app.shared.writer_invocation`` -- editor_assist
+# and itineraries_pipeline. Prompt2Blog, url2blog, and youtube2blog call
+# ``utils.get_vertex_llm`` directly and bypass that seam entirely, so they are
+# untouched by this flag no matter what it is set to. Widening it means adding a
+# provider inside ``packages/utils``, which is shared with url2blog and
+# youtube2blog; that was considered and deliberately deferred rather than done
+# quietly here.
+#
+# Practical consequence worth knowing before switching this on: Prompt2Blog's
+# model stacks are unaffected, and a stack that names a Claude model is still
+# substituted to Gemini by ``resolve_effective_model`` because that is governed
+# by ANTHROPIC_MODELS_ENABLED -- a different switch, on the API-key path, which
+# has nothing to do with this one.
+WRITER_PROVIDER_ENV = "WRITER_PROVIDER"
+
+# The one value that turns this transport on. Anything else -- including unset,
+# which is the default -- leaves the Gemini path untouched.
+PROVIDER_CLAUDE_CLI = "claude-cli"
+
+CALL_TIMEOUT_SECONDS = 600.0
+
+# Stable, and outside the repo so no CLAUDE.md, settings file, or skill is
+# discovered. Stable also because a moving working directory would defeat the
+# prompt cache the cost model above depends on.
+WORKING_DIR = Path(tempfile.gettempdir()) / "abw-claude-writer"
+
+# Deliberately terse and deliberately constant. Every character here is paid for
+# once and then read from cache by every later call; per-stage text would turn
+# each stage into its own cold start. See the module docstring.
+SYSTEM_PROMPT = (
+    "You are a writing engine inside an editorial publishing pipeline. "
+    "Follow the instructions in the message exactly. Return only what is "
+    "asked for, with no preamble, commentary, or explanation of your work."
+)
+
+# Requested model names arrive as pipeline strings ("claude-sonnet-5") and have
+# to become CLI aliases. An allow-list, not a transformation, because the value
+# becomes a subprocess argument and "is one of five known strings" is a stronger
+# guarantee than "looks like a model name".
+MODEL_ALIASES: dict[str, str] = {
+    "claude-opus-5": "opus",
+    "claude-opus-4-8": "opus",
+    "claude-opus-4-7": "opus",
+    "claude-sonnet-5": "sonnet",
+    "claude-haiku-4-5": "haiku",
+    "claude-fable-5": "fable",
+    "opus": "opus",
+    "sonnet": "sonnet",
+    "haiku": "haiku",
+    "fable": "fable",
+}
+
+# What a non-Claude request maps to when this provider is switched on. The
+# pipeline pins Gemini names in places (see editor_assist), and refusing them
+# would make the flag unusable; serving them on the balanced model is the
+# behaviour a reader of `WRITER_PROVIDER=claude-cli` would expect.
+DEFAULT_ALIAS = "sonnet"
+
+DENIED_TOOLS = (
+    "Bash",
+    "BashOutput",
+    "Edit",
+    "Glob",
+    "Grep",
+    "KillShell",
+    "NotebookEdit",
+    "Read",
+    "Task",
+    "TodoWrite",
+    "WebFetch",
+    "WebSearch",
+    "Write",
+)
+
+
+class ClaudeCliWriterError(RuntimeError):
+    """A writer call that could not be made, or whose output was unusable."""
+
+
+def writer_provider() -> str:
+    return (os.getenv(WRITER_PROVIDER_ENV) or "").strip().lower()
+
+
+def claude_cli_writer_enabled() -> bool:
+    """Whether pipeline writer calls should go to the subscription CLI.
+
+    Off unless asked for. The flag is the whole opt-in: there is no automatic
+    promotion based on what is installed or logged in, because that would move
+    real spend onto the owner's personal plan without anyone choosing it.
+    """
+    return writer_provider() == PROVIDER_CLAUDE_CLI
+
+
+def resolve_alias(model_name: Optional[str]) -> str:
+    return MODEL_ALIASES.get(str(model_name or "").strip().lower(), DEFAULT_ALIAS)
+
+
+def _assert_billing_to_subscription() -> None:
+    """Refuse to spend unless the money lands where the operator thinks it does.
+
+    The state worth guarding is ``api_billed_override``: Claude answers fine, so
+    nothing looks wrong, and every stage of every run quietly bills API credit
+    instead of the subscription. Same guard the bench uses, for the same reason,
+    and it matters more here because the pipeline makes many calls per article.
+    """
+    snapshot = read_claude_status()
+    if snapshot.get("state") != STATE_CONNECTED:
+        raise ClaudeCliWriterError(
+            snapshot.get("detail")
+            or "Claude is not connected on this machine, so nothing was sent."
+        )
+
+
+def _build_args(
+    cli_path: str,
+    prompt: str,
+    alias: str,
+    input_schema: Optional[dict[str, Any]],
+) -> list[str]:
+    args = [
+        cli_path,
+        "--print",
+        prompt,
+        "--output-format",
+        "json",
+        "--system-prompt",
+        SYSTEM_PROMPT,
+        # No user, project, or local settings, and no MCP server from anywhere.
+        "--setting-sources",
+        "",
+        "--strict-mcp-config",
+        "--allowed-tools",
+        "",
+        "--disallowed-tools",
+        *DENIED_TOOLS,
+        "--model",
+        alias,
+    ]
+    if input_schema is not None:
+        args += ["--json-schema", json.dumps(input_schema, sort_keys=True)]
+    return args
+
+
+def _usage_from(payload: dict[str, Any]) -> dict[str, Optional[int]]:
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        usage = {}
+
+    def read(key: str) -> Optional[int]:
+        value = usage.get(key)
+        return value if isinstance(value, int) else None
+
+    return {
+        "inputTokens": read("input_tokens"),
+        "outputTokens": read("output_tokens"),
+        "cacheReadInputTokens": read("cache_read_input_tokens"),
+        "cacheCreationInputTokens": read("cache_creation_input_tokens"),
+    }
+
+
+def _canonical_model(payload: dict[str, Any], alias: str) -> str:
+    """The model that actually answered, not the alias that was asked for.
+
+    Worth carrying into cost attribution: 'sonnet' is a moving target, so a
+    per-stage spend record keyed on the alias would not say what it paid for.
+    """
+    model_usage = payload.get("modelUsage")
+    if isinstance(model_usage, dict) and model_usage:
+        first_key = next(iter(model_usage))
+        entry = model_usage[first_key]
+        if isinstance(entry, dict):
+            canonical = entry.get("canonicalModel")
+            if isinstance(canonical, str) and canonical.strip():
+                return canonical.strip()
+        return str(first_key)
+    return alias
+
+
+def _invoke(
+    prompt: str,
+    model_name: Optional[str],
+    input_schema: Optional[dict[str, Any]],
+) -> tuple[dict[str, Any], str]:
+    cleaned = (prompt or "").strip()
+    if not cleaned:
+        raise ClaudeCliWriterError("Writer call had an empty prompt")
+
+    _assert_billing_to_subscription()
+
+    cli_path = resolve_cli_path()
+    if cli_path is None:
+        raise ClaudeCliWriterError("The Claude Code CLI was not found on this machine.")
+
+    alias = resolve_alias(model_name)
+    WORKING_DIR.mkdir(parents=True, exist_ok=True)
+
+    try:
+        completed = subprocess.run(
+            _build_args(cli_path, cleaned, alias, input_schema),
+            capture_output=True,
+            text=True,
+            timeout=CALL_TIMEOUT_SECONDS,
+            check=False,
+            cwd=WORKING_DIR,
+            # The CLI waits ~3s for piped stdin that is never coming, even when
+            # the prompt arrived as an argument. Measured at ~3.7s of pure
+            # latency per call under a server that inherited stdin.
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise ClaudeCliWriterError(
+            f"Claude did not answer within {int(CALL_TIMEOUT_SECONDS)}s."
+        ) from error
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ClaudeCliWriterError(
+            f"Could not run the Claude CLI: {type(error).__name__}"
+        ) from error
+
+    # Never surface raw stdout or stderr. On a hard CLI failure stdout is empty
+    # and the reason is on stderr, and stderr is the one place a credential
+    # could appear -- these strings reach an API response.
+    try:
+        payload = json.loads(completed.stdout or "")
+    except (TypeError, ValueError) as error:
+        raise ClaudeCliWriterError(
+            "Claude answered with output this app could not read."
+        ) from error
+
+    if not isinstance(payload, dict):
+        raise ClaudeCliWriterError(
+            "Claude answered with output this app could not read."
+        )
+    if payload.get("is_error"):
+        raise ClaudeCliWriterError("Claude reported an error answering the call.")
+
+    return payload, alias
+
+
+def invoke_text(
+    *,
+    prompt: str,
+    model_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Free-text writer call. Returns the reply plus what it cost."""
+    payload, alias = _invoke(prompt, model_name, None)
+
+    result = payload.get("result")
+    text = result.strip() if isinstance(result, str) else ""
+    if not text:
+        raise ClaudeCliWriterError("Writer model returned empty content")
+
+    return {
+        "text": text,
+        "modelName": _canonical_model(payload, alias),
+        "costUsd": _cost_of(payload),
+        "usage": _usage_from(payload),
+    }
+
+
+def invoke_structured(
+    *,
+    prompt: str,
+    input_schema: dict[str, Any],
+    model_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Schema-shaped writer call. Returns the parsed payload plus what it cost.
+
+    Reads ``structured_output`` rather than parsing ``result``. Both carry the
+    same JSON, but ``result`` is a string the model produced and
+    ``structured_output`` is the object the CLI validated against the schema, so
+    only one of them is a guarantee.
+    """
+    if not isinstance(input_schema, dict) or not input_schema:
+        raise ClaudeCliWriterError("Structured writer call had no schema")
+
+    payload, alias = _invoke(prompt, model_name, input_schema)
+
+    structured = payload.get("structured_output")
+    if not isinstance(structured, dict) or not structured:
+        raise ClaudeCliWriterError("Structured writer call returned no schema payload")
+
+    return {
+        "payload": structured,
+        "modelName": _canonical_model(payload, alias),
+        "costUsd": _cost_of(payload),
+        "usage": _usage_from(payload),
+    }
+
+
+def _cost_of(payload: dict[str, Any]) -> Optional[float]:
+    cost = payload.get("total_cost_usd")
+    return float(cost) if isinstance(cost, (int, float)) else None

--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/messaging.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/messaging.py
@@ -216,6 +216,11 @@ def send_test_message(
             timeout=CALL_TIMEOUT_SECONDS,
             check=False,
             cwd=WORKING_DIR,
+            # The CLI waits ~3s for piped stdin before giving up and warning
+            # about it, even when the prompt came in as an argument. Under a
+            # server that inherited stdin from its parent that wait is paid on
+            # every call. Closing it removes about 3.7s of pure latency.
+            stdin=subprocess.DEVNULL,
         )
     except subprocess.TimeoutExpired as error:
         raise TestMessageError(

--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/status.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/status.py
@@ -99,6 +99,9 @@ def _run_cli(cli_path: str, args: list[str]) -> subprocess.CompletedProcess:
         text=True,
         timeout=CLI_TIMEOUT_SECONDS,
         check=False,
+        # Never let the CLI block on stdin it will not be given. See the same
+        # note in messaging.py -- the wait is silent and costs seconds.
+        stdin=subprocess.DEVNULL,
     )
 
 

--- a/apps/ai-blog-writer/apps/backend/app/shared/writer_invocation.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/writer_invocation.py
@@ -4,23 +4,38 @@ Free-text calls go through ``utils.get_vertex_llm``. That shared factory routes
 ``claude-*`` model names to Anthropic and Gemini names to Vertex. Forced-tool
 calls also live in utils; this module normalizes the result shapes and errors
 used by backend features.
+
+``WRITER_PROVIDER=claude-cli`` diverts both call shapes to the Claude Code CLI
+instead, answering on the machine's subscription login. It is a *third* backend
+alongside Vertex and the Anthropic API, not a replacement for either: unset --
+the default -- leaves every existing path byte-identical. See
+``app.features.claude_connection.cli_writer`` for the transport and why it is
+the CLI rather than the Agent SDK.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class WriterResult:
     text: str
     model_name: str
+    # Only the CLI transport reports these; the Vertex and Anthropic paths do
+    # not surface a per-call price. Optional and trailing so every existing
+    # construction site, real and faked in tests, keeps working untouched.
+    cost_usd: Optional[float] = None
+    usage: Optional[dict] = None
 
 
 @dataclass(frozen=True)
 class StructuredWriterResult:
     payload: dict
     model_name: str
+    cost_usd: Optional[float] = None
+    usage: Optional[dict] = None
 
 
 class WriterModelError(RuntimeError):
@@ -40,7 +55,24 @@ def invoke_anthropic_structured(
 
     Dispatches on ``model_name``: Anthropic when Claude is switched on, the
     Gemini equivalent otherwise. The name is kept for call-site compatibility.
+
+    ``WRITER_PROVIDER=claude-cli`` takes precedence over both. ``tool_name`` and
+    ``tool_description`` have no counterpart on the CLI, whose ``--json-schema``
+    forces the shape without naming a tool; they are folded into the prompt so
+    the instruction a caller wrote is not silently dropped. ``max_tokens`` has
+    no CLI equivalent at all -- there is no flag for it -- so on that provider
+    the cap is whatever the model's default is. ``--max-budget-usd`` is the
+    nearest rail and is not wired up here.
     """
+    if _claude_cli_writer_enabled():
+        return _invoke_structured_via_cli(
+            prompt=prompt,
+            model_name=model_name,
+            tool_name=tool_name,
+            tool_description=tool_description,
+            input_schema=input_schema,
+        )
+
     try:
         from utils import invoke_structured_tool  # type: ignore
     except ImportError as exc:
@@ -68,7 +100,15 @@ def invoke_writer_model(
     max_tokens: int = 16384,
     temperature: float = 0.15,
 ) -> WriterResult:
-    """Invoke the shared LLM factory and normalize output for writer callers."""
+    """Invoke the shared LLM factory and normalize output for writer callers.
+
+    ``WRITER_PROVIDER=claude-cli`` diverts the call to the subscription CLI.
+    ``temperature`` and ``max_tokens`` have no CLI equivalent and are dropped
+    there rather than faked.
+    """
+    if _claude_cli_writer_enabled():
+        return _invoke_text_via_cli(prompt=prompt, model_name=model_name)
+
     try:
         from utils import get_vertex_llm  # type: ignore
     except ImportError as exc:
@@ -90,3 +130,66 @@ def invoke_writer_model(
 
     resolved_model = getattr(llm, "model_name", None) or model_name
     return WriterResult(text=text, model_name=resolved_model)
+
+
+def _cli_writer():
+    """Imported lazily so the default path never touches the CLI module."""
+    try:
+        from app.features.claude_connection import cli_writer
+    except ImportError as exc:  # pragma: no cover - packaging failure
+        raise WriterModelError("Claude CLI writer unavailable") from exc
+    return cli_writer
+
+
+def _claude_cli_writer_enabled() -> bool:
+    try:
+        return _cli_writer().claude_cli_writer_enabled()
+    except WriterModelError:
+        return False
+
+
+def _invoke_text_via_cli(*, prompt: str, model_name: str) -> WriterResult:
+    cli_writer = _cli_writer()
+    try:
+        result = cli_writer.invoke_text(prompt=prompt, model_name=model_name)
+    except cli_writer.ClaudeCliWriterError as exc:
+        raise WriterModelError(f"Writer model call failed: {exc}") from exc
+    return WriterResult(
+        text=result["text"],
+        model_name=result["modelName"],
+        cost_usd=result["costUsd"],
+        usage=result["usage"],
+    )
+
+
+def _invoke_structured_via_cli(
+    *,
+    prompt: str,
+    model_name: str,
+    tool_name: str,
+    tool_description: str,
+    input_schema: dict,
+) -> StructuredWriterResult:
+    cli_writer = _cli_writer()
+    # The CLI has no tool to name, so a prompt that ends "call the emit_seo_patch
+    # tool" would be an instruction about something that does not exist. Restate
+    # it as what the CLI actually does.
+    framed = (
+        f"{prompt}\n\n"
+        f"Return your answer as JSON matching the required schema "
+        f"({tool_name}): {tool_description}"
+    )
+    try:
+        result = cli_writer.invoke_structured(
+            prompt=framed,
+            input_schema=input_schema,
+            model_name=model_name,
+        )
+    except cli_writer.ClaudeCliWriterError as exc:
+        raise WriterModelError(f"Structured writer call failed: {exc}") from exc
+    return StructuredWriterResult(
+        payload=result["payload"],
+        model_name=result["modelName"],
+        cost_usd=result["costUsd"],
+        usage=result["usage"],
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_writer.py
@@ -1,0 +1,423 @@
+"""The Claude CLI writer backend: when it runs, what it sends, what it refuses.
+
+The property under test throughout is that this is an *added* provider. With
+``WRITER_PROVIDER`` unset -- the default -- nothing here may run.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from app.features.claude_connection import cli_writer
+from app.features.claude_connection import status as status_module
+from app.shared.writer_invocation import (
+    WriterModelError,
+    invoke_anthropic_structured,
+    invoke_writer_model,
+)
+
+CLI_PATH = "/fake/bin/claude"
+
+SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["seoTitle"],
+    "properties": {"seoTitle": {"type": "string"}},
+}
+
+TEXT_JSON = json.dumps(
+    {
+        "result": "Barranco after dark.",
+        "is_error": False,
+        "total_cost_usd": 0.0099,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 503,
+            "cache_read_input_tokens": 8741,
+            "cache_creation_input_tokens": 2729,
+        },
+        "modelUsage": {
+            "claude-sonnet-5-20260101": {"canonicalModel": "claude-sonnet-5"}
+        },
+    }
+)
+
+STRUCTURED_JSON = json.dumps(
+    {
+        "result": '{"seoTitle":"Hidden Cafes in Barranco"}',
+        "structured_output": {"seoTitle": "Hidden Cafes in Barranco"},
+        "is_error": False,
+        "stop_reason": "tool_use",
+        "total_cost_usd": 0.0099,
+        "usage": {"input_tokens": 10, "output_tokens": 430},
+        "modelUsage": {
+            "claude-haiku-4-5-20251001": {"canonicalModel": "claude-haiku-4-5"}
+        },
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_api_credentials(monkeypatch):
+    for name in status_module.API_BILLED_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv(cli_writer.WRITER_PROVIDER_ENV, raising=False)
+
+
+@pytest.fixture
+def connected(monkeypatch):
+    """A green connection, so the writer is willing to spend."""
+    monkeypatch.setattr(status_module, "resolve_cli_path", lambda: CLI_PATH)
+    monkeypatch.setattr(
+        status_module,
+        "_run_cli",
+        lambda cli_path, args: subprocess.CompletedProcess(
+            args=[cli_path],
+            returncode=0,
+            stdout=(
+                "1.0.0"
+                if args[:1] == ["--version"]
+                else json.dumps(
+                    {
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "apiProvider": "firstParty",
+                        "subscriptionType": "pro",
+                    }
+                )
+            ),
+            stderr="",
+        ),
+    )
+
+
+@pytest.fixture
+def provider_on(monkeypatch):
+    monkeypatch.setenv(cli_writer.WRITER_PROVIDER_ENV, "claude-cli")
+
+
+def _capture(monkeypatch, stdout: str, returncode: int = 0, stderr: str = ""):
+    """Record argv and kwargs the writer builds, without running anything."""
+    calls: list[dict] = []
+    monkeypatch.setattr(cli_writer, "resolve_cli_path", lambda: CLI_PATH)
+
+    def fake_run(args, **kwargs):
+        calls.append({"args": list(args), "kwargs": kwargs})
+        return subprocess.CompletedProcess(
+            args=args, returncode=returncode, stdout=stdout, stderr=stderr
+        )
+
+    monkeypatch.setattr(cli_writer.subprocess, "run", fake_run)
+    return calls
+
+
+# --- The flag is the whole opt-in -------------------------------------------
+
+
+def test_provider_is_off_when_unset():
+    assert cli_writer.claude_cli_writer_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["", "gemini", "anthropic", "claude", "CLAUDE-CLI "])
+def test_only_the_exact_value_switches_the_provider_on(monkeypatch, value):
+    monkeypatch.setenv(cli_writer.WRITER_PROVIDER_ENV, value)
+    # "CLAUDE-CLI " is the one that must still count: case and padding are
+    # normalized, but a near-miss name is not.
+    expected = value.strip().lower() == "claude-cli"
+    assert cli_writer.claude_cli_writer_enabled() is expected
+
+
+def test_writer_invocation_leaves_the_default_path_alone(monkeypatch):
+    """With the flag unset, the CLI transport must not be consulted at all.
+
+    Asserted by making the CLI path fatal and the shared factory succeed, so
+    the test proves which branch ran rather than inferring it from a failure.
+    """
+    import utils
+
+    def explode(*_args, **_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("the CLI transport ran with WRITER_PROVIDER unset")
+
+    monkeypatch.setattr(cli_writer, "invoke_text", explode)
+    monkeypatch.setattr(cli_writer, "invoke_structured", explode)
+
+    class _Llm:
+        model_name = "gemini-2.5-flash-lite"
+
+        def invoke(self, _prompt):
+            return "from the shared factory"
+
+    monkeypatch.setattr(utils, "get_vertex_llm", lambda **_kwargs: _Llm())
+
+    result = invoke_writer_model(prompt="hello", model_name="gemini-2.5-flash-lite")
+
+    assert result.text == "from the shared factory"
+    # The default path reports no price, and must not start inventing one.
+    assert result.cost_usd is None
+    assert result.usage is None
+
+
+# --- Spending guard ---------------------------------------------------------
+
+
+def test_refuses_to_spend_when_the_connection_is_not_green(monkeypatch, provider_on):
+    """The state being guarded is api_billed_override: it answers, and bills elsewhere."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-whatever")
+    monkeypatch.setattr(status_module, "resolve_cli_path", lambda: CLI_PATH)
+    monkeypatch.setattr(
+        status_module,
+        "_run_cli",
+        lambda cli_path, args: subprocess.CompletedProcess(
+            args=[cli_path],
+            returncode=0,
+            stdout=(
+                "1.0.0"
+                if args[:1] == ["--version"]
+                else json.dumps(
+                    {
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "apiProvider": "firstParty",
+                        "subscriptionType": "pro",
+                    }
+                )
+            ),
+            stderr="",
+        ),
+    )
+    calls = _capture(monkeypatch, TEXT_JSON)
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_text(prompt="write something")
+
+    assert calls == [], "a refused call must not reach the CLI"
+
+
+# --- Argument construction --------------------------------------------------
+
+
+def test_text_call_is_isolated_and_carries_no_schema(
+    monkeypatch, connected, provider_on
+):
+    calls = _capture(monkeypatch, TEXT_JSON)
+
+    cli_writer.invoke_text(prompt="write something", model_name="claude-sonnet-5")
+
+    args = calls[0]["args"]
+    kwargs = calls[0]["kwargs"]
+    assert args[0] == CLI_PATH
+    assert "--json-schema" not in args
+    # No settings, no MCP servers, no tools, and a working directory outside the
+    # repo so no CLAUDE.md is discovered.
+    assert args[args.index("--setting-sources") + 1] == ""
+    assert "--strict-mcp-config" in args
+    assert args[args.index("--allowed-tools") + 1] == ""
+    for tool in cli_writer.DENIED_TOOLS:
+        assert tool in args
+    assert kwargs["cwd"] == cli_writer.WORKING_DIR
+    # Closing stdin: the CLI otherwise waits ~3s for input that never arrives.
+    assert kwargs["stdin"] is subprocess.DEVNULL
+
+
+def test_structured_call_passes_the_schema_verbatim(
+    monkeypatch, connected, provider_on
+):
+    calls = _capture(monkeypatch, STRUCTURED_JSON)
+
+    cli_writer.invoke_structured(
+        prompt="fill this in", input_schema=SCHEMA, model_name="claude-haiku-4-5"
+    )
+
+    args = calls[0]["args"]
+    assert json.loads(args[args.index("--json-schema") + 1]) == SCHEMA
+
+
+def test_system_prompt_is_constant_across_calls(monkeypatch, connected, provider_on):
+    """The prompt cache only pays off if the prefix is byte-identical.
+
+    A stage-specific system prompt would turn every stage into a cold start,
+    which measured ~3x the price of a warm one.
+    """
+    calls = _capture(monkeypatch, TEXT_JSON)
+
+    cli_writer.invoke_text(prompt="first stage", model_name="claude-sonnet-5")
+    cli_writer.invoke_text(prompt="second stage", model_name="claude-haiku-4-5")
+
+    prompts = [c["args"][c["args"].index("--system-prompt") + 1] for c in calls]
+    assert prompts == [cli_writer.SYSTEM_PROMPT, cli_writer.SYSTEM_PROMPT]
+
+
+# --- Model names become subprocess arguments, so they are allow-listed ------
+
+
+@pytest.mark.parametrize(
+    "requested,expected",
+    [
+        ("claude-sonnet-5", "sonnet"),
+        ("claude-opus-5", "opus"),
+        ("claude-haiku-4-5", "haiku"),
+        ("claude-fable-5", "fable"),
+        ("CLAUDE-SONNET-5", "sonnet"),
+        # Unknown names -- including a Gemini one the pipeline pins, and a flag
+        # -- fall back rather than reaching argv.
+        ("gemini-3.1-pro-preview", cli_writer.DEFAULT_ALIAS),
+        ("--dangerously-skip-permissions", cli_writer.DEFAULT_ALIAS),
+        (None, cli_writer.DEFAULT_ALIAS),
+    ],
+)
+def test_model_names_resolve_through_an_allow_list(requested, expected):
+    assert cli_writer.resolve_alias(requested) == expected
+
+
+def test_a_flag_shaped_model_name_never_reaches_argv(
+    monkeypatch, connected, provider_on
+):
+    calls = _capture(monkeypatch, TEXT_JSON)
+
+    cli_writer.invoke_text(
+        prompt="write something", model_name="--dangerously-skip-permissions"
+    )
+
+    args = calls[0]["args"]
+    assert "--dangerously-skip-permissions" not in args
+    assert args[args.index("--model") + 1] == cli_writer.DEFAULT_ALIAS
+
+
+# --- Reading the reply ------------------------------------------------------
+
+
+def test_structured_reply_comes_from_structured_output(
+    monkeypatch, connected, provider_on
+):
+    """Not from parsing `result`: only structured_output was schema-validated."""
+    _capture(monkeypatch, STRUCTURED_JSON)
+
+    result = cli_writer.invoke_structured(prompt="fill this in", input_schema=SCHEMA)
+
+    assert result["payload"] == {"seoTitle": "Hidden Cafes in Barranco"}
+    assert result["modelName"] == "claude-haiku-4-5"
+    assert result["costUsd"] == 0.0099
+
+
+def test_missing_structured_output_is_an_error_not_a_fallback(
+    monkeypatch, connected, provider_on
+):
+    payload = json.loads(STRUCTURED_JSON)
+    del payload["structured_output"]
+    _capture(monkeypatch, json.dumps(payload))
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_structured(prompt="fill this in", input_schema=SCHEMA)
+
+
+def test_text_reply_reports_usage_and_the_canonical_model(
+    monkeypatch, connected, provider_on
+):
+    _capture(monkeypatch, TEXT_JSON)
+
+    result = cli_writer.invoke_text(prompt="write something")
+
+    assert result["text"] == "Barranco after dark."
+    # The model that answered, not the alias asked for -- 'sonnet' moves.
+    assert result["modelName"] == "claude-sonnet-5"
+    assert result["usage"]["cacheReadInputTokens"] == 8741
+    assert result["usage"]["cacheCreationInputTokens"] == 2729
+
+
+def test_model_reported_error_is_raised(monkeypatch, connected, provider_on):
+    _capture(monkeypatch, json.dumps({"result": "nope", "is_error": True}))
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_text(prompt="write something")
+
+
+def test_cli_output_is_never_echoed_into_the_error(monkeypatch, connected, provider_on):
+    """stderr is the one place a credential could appear, and these strings
+    reach an API response."""
+    secret = "sk-ant-oat01-SECRET-TOKEN"
+    _capture(monkeypatch, stdout="", returncode=1, stderr=f"boom {secret}")
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError) as caught:
+        cli_writer.invoke_text(prompt="write something")
+
+    assert secret not in str(caught.value)
+
+
+def test_empty_prompt_is_refused_before_spending(monkeypatch, connected, provider_on):
+    calls = _capture(monkeypatch, TEXT_JSON)
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_text(prompt="   ")
+
+    assert calls == []
+
+
+def test_structured_call_without_a_schema_is_refused(
+    monkeypatch, connected, provider_on
+):
+    calls = _capture(monkeypatch, STRUCTURED_JSON)
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_structured(prompt="fill this in", input_schema={})
+
+    assert calls == []
+
+
+# --- The shared writer contract --------------------------------------------
+
+
+def test_invoke_writer_model_routes_to_the_cli_and_carries_cost(
+    monkeypatch, connected, provider_on
+):
+    _capture(monkeypatch, TEXT_JSON)
+
+    result = invoke_writer_model(prompt="write something", model_name="claude-sonnet-5")
+
+    assert result.text == "Barranco after dark."
+    assert result.model_name == "claude-sonnet-5"
+    assert result.cost_usd == 0.0099
+    assert result.usage["outputTokens"] == 503
+
+
+def test_invoke_structured_routes_to_the_cli_and_folds_in_the_tool_description(
+    monkeypatch, connected, provider_on
+):
+    """The CLI has no tool to name, so a prompt telling the model to call one
+    would reference something that does not exist."""
+    calls = _capture(monkeypatch, STRUCTURED_JSON)
+
+    result = invoke_anthropic_structured(
+        prompt="Generate SEO metadata.",
+        model_name="claude-haiku-4-5",
+        tool_name="emit_seo_patch",
+        tool_description="Emit the generated SEO metadata patch.",
+        input_schema=SCHEMA,
+    )
+
+    assert result.payload == {"seoTitle": "Hidden Cafes in Barranco"}
+    assert result.cost_usd == 0.0099
+    sent = calls[0]["args"][2]
+    assert "Generate SEO metadata." in sent
+    assert "emit_seo_patch" in sent
+    assert "Emit the generated SEO metadata patch." in sent
+
+
+def test_transport_errors_surface_as_writer_model_errors(
+    monkeypatch, connected, provider_on
+):
+    """Callers already catch WriterModelError; a new provider must not leak a
+    new exception type past the seam."""
+    _capture(monkeypatch, stdout="not json", returncode=0)
+
+    with pytest.raises(WriterModelError):
+        invoke_writer_model(prompt="write something", model_name="claude-sonnet-5")
+
+    with pytest.raises(WriterModelError):
+        invoke_anthropic_structured(
+            prompt="p",
+            model_name="claude-sonnet-5",
+            tool_name="t",
+            tool_description="d",
+            input_schema=SCHEMA,
+        )

--- a/apps/ai-blog-writer/scripts/claude-agent-sdk-smoke/README.md
+++ b/apps/ai-blog-writer/scripts/claude-agent-sdk-smoke/README.md
@@ -95,3 +95,77 @@ deployment where one person's click re-points everyone's Claude session is the
 arrangement Anthropic's terms rule out. Everywhere else the page shows the
 command to run by hand. See `apps/backend/.env.example` for `ABW_CLAUDE_CLI` and
 `ABW_ENABLE_CLAUDE_LOGIN`.
+
+## Using the subscription as a writer backend
+
+`WRITER_PROVIDER=claude-cli` points the pipeline's writing calls at this same
+subscription login. The transport is
+`apps/backend/app/features/claude_connection/cli_writer.py`, behind the existing
+`WriterResult` / `StructuredWriterResult` contract, so it is a third provider
+beside Vertex and the Anthropic API rather than a replacement for either. Unset
+— the default — changes nothing.
+
+It is the CLI and not the Agent SDK for the dependency reason above: installing
+`claude-agent-sdk` into the backend virtualenv drags `starlette` and `uvicorn`
+past FastAPI 0.111's pin. Measured against the real thing, the CLI gives up
+nothing that mattered.
+
+### `--json-schema` is a real forced-tool equivalent
+
+This was the open risk, and it is closed. `claude --print --json-schema <schema>`
+returns a top-level `structured_output` field that is **already a parsed
+object**, and the reply carries `stop_reason: "tool_use"`. Read
+`structured_output`, not `result`: both hold the same JSON, but `result` is a
+string the model wrote and `structured_output` is what the CLI validated.
+
+Verified against the pipeline's own `SEO_PATCH_INPUT_SCHEMA` and a harder nested
+schema. It honours `required`, `enum`, `minItems`/`maxItems`, integer types, and
+`additionalProperties: false` — including refusing to add an extra field when the
+prompt explicitly asked it to. Optional fields are correctly omitted rather than
+filled with empties.
+
+Failures are loud, not silent: a malformed schema or an unknown `--resume` id
+exits non-zero with empty stdout and the reason on stderr.
+
+### Cost: a stable prefix is the whole game
+
+| | cache created | cache read | cost |
+|---|---|---|---|
+| Default system prompt | ~18.0k | 0 | ~$0.039 |
+| Small `--system-prompt` | ~11.5k | 0 | ~$0.028 |
+| Second call, same prompt + schema | ~2.7k | ~8.7k | ~$0.010 |
+| Continuing via `--resume` | ~0.6k | ~11.5k | ~$0.005 |
+
+The earlier read of this — that continuing a session is ~12× cheaper than
+starting one, so per-stage one-shot calls pay a cold start every time — was only
+true of the CLI's *default* system prompt. With a fixed `--system-prompt` and a
+fixed schema, independent calls warm their own prefix and the gap narrows to
+about 2×. So the pipeline does **not** need session threading, which would
+otherwise couple a stage to a conversation and leak one stage's context into the
+next.
+
+The prefix is only cheap while it is byte-identical, which is why
+`cli_writer.SYSTEM_PROMPT` is a module constant and stage-specific instructions
+go in the prompt body. There is a test pinning that.
+
+### Two things that cost time
+
+- **Close stdin.** The CLI waits ~3s for piped input that is never coming, even
+  when the prompt arrived as an argument, then warns about it on stderr. Under a
+  server that inherited stdin from its parent, that is ~3.7s of pure latency on
+  every call. `stdin=subprocess.DEVNULL` — now set on every CLI call here.
+- **Never use `--bare`.** It looks like the right flag for an isolated call, but
+  its auth is "strictly `ANTHROPIC_API_KEY` or `apiKeyHelper`; OAuth and keychain
+  are never read". It would move the spend straight off the subscription — the
+  exact failure the status light exists to catch.
+
+### The spending guard
+
+`cli_writer` refuses to send unless `GET /claude/status` is green, the same guard
+the test bench uses. The state it is really guarding is `api_billed_override`:
+Claude answers normally, so nothing looks wrong, while every stage of every run
+quietly bills API credit instead of the subscription. It matters more here than
+on the bench because the pipeline makes many calls per article.
+
+Local authoring only, for the licensing reason above. Do not set
+`WRITER_PROVIDER=claude-cli` on the Linux laptop or any shared deployment.


### PR DESCRIPTION
First of a 6-PR series putting Claude on the writer role of the ai-blog-writer pipeline. This one is the already-reviewed transport commit; the rest build on it.

## What this adds

- `claude_connection/cli_writer.py` — a writer transport that answers on the machine's Claude Code subscription login, behind the existing `WriterResult` / `StructuredWriterResult` contract.
- `WRITER_PROVIDER=claude-cli` dispatch in `app/shared/writer_invocation.py`, on both the free-text and structured call shapes.
- `stdin=subprocess.DEVNULL` on every CLI subprocess call (~3.7s of pure latency per call without it).
- 30 tests, plus the smoke-test README section recording the measured cost table and the `--json-schema` findings.

## Scope

`WRITER_PROVIDER` reaches only calls routed through `app/shared/writer_invocation.py` — editor_assist and itineraries_pipeline. Prompt2Blog, url2blog and youtube2blog call `utils.get_vertex_llm` directly and are untouched by this flag. Widening that is the next PR's job, via the factory rather than this flag.

## Safety

- Refuses to send unless `GET /claude/status` is green, so a call cannot quietly land on API billing.
- Never echoes raw CLI stdout/stderr into an API response.
- Values that become subprocess arguments are allow-listed, not shape-validated.
- Local authoring only. Do not set the provider on a shared deployment — subscription OAuth is for the plan holder's own use.

Unset (the default) leaves every existing path byte-identical.

## Verification

`pytest` 747 passed, `vitest` 725 passed, `tsc --noEmit` clean, `black` + `flake8` clean.