### PR TITLE
Refuse a remote Claude sign-in the same way on every platform

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/routes.py
@@ -64,6 +64,21 @@ def start_claude_login(
             ),
         )
 
+    # Who is asking is settled before what this host can do. A remote caller is
+    # refused on every platform, not only the one that happens to have a
+    # launcher wired up -- otherwise the same request is a 403 on macOS and a
+    # 501 on Linux, which is both a platform-dependent gate and a needless hint
+    # to a caller that was never going to be allowed through.
+    if not login_module.is_loopback_client(host):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "A Claude sign-in can only be started from a browser on the "
+                "machine hosting this backend, because it signs in that machine "
+                f"rather than you. Run `{command}` there instead."
+            ),
+        )
+
     if not login_module.launcher_supported():
         raise HTTPException(
             status_code=501,
@@ -73,13 +88,13 @@ def start_claude_login(
             ),
         )
 
-    if not login_module.login_available(host):
+    if login_module.resolve_cli_path() is None:
         raise HTTPException(
-            status_code=403,
+            status_code=501,
             detail=(
-                "A Claude sign-in can only be started from a browser on the "
-                "machine hosting this backend, because it signs in that machine "
-                f"rather than you. Run `{command}` there instead."
+                "The Claude Code CLI was not found on this machine, so there is "
+                "nothing to open a terminal for. Install it, or set "
+                "ABW_CLAUDE_CLI to its path."
             ),
         )
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_connection_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_connection_routes.py
@@ -175,8 +175,18 @@ def test_login_is_offered_only_to_a_browser_on_this_machine(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_remote_caller_cannot_start_a_login(monkeypatch):
+@pytest.mark.parametrize("supported", [True, False])
+async def test_remote_caller_cannot_start_a_login(monkeypatch, supported):
+    """Who is asking is settled before what this host can do.
+
+    Parametrized over the launcher rather than left to the machine running the
+    suite: without stubbing it, this asserted a 403 on macOS and a 501 on
+    Linux, and only the platform decided which. A remote caller must be refused
+    the same way on both.
+    """
     monkeypatch.setattr(routes_module, "_client_host", lambda request: "10.0.0.5")
+    monkeypatch.setattr(login_module, "launcher_supported", lambda: supported)
+    monkeypatch.setattr(login_module, "resolve_cli_path", lambda: CLI_PATH)
     monkeypatch.setattr(login_module, "launch_login", _unreachable_launch)
 
     async with _client() as client:
@@ -184,6 +194,34 @@ async def test_remote_caller_cannot_start_a_login(monkeypatch):
 
     assert response.status_code == 403
     assert "machine hosting this backend" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_local_caller_on_an_unsupported_platform_gets_the_command(monkeypatch):
+    monkeypatch.setattr(routes_module, "_client_host", lambda request: "127.0.0.1")
+    monkeypatch.setattr(login_module, "launcher_supported", lambda: False)
+    monkeypatch.setattr(login_module, "resolve_cli_path", lambda: CLI_PATH)
+    monkeypatch.setattr(login_module, "launch_login", _unreachable_launch)
+
+    async with _client() as client:
+        response = await client.post("/claude/login")
+
+    assert response.status_code == 501
+    assert "macOS" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_missing_cli_is_reported_as_missing_rather_than_forbidden(monkeypatch):
+    monkeypatch.setattr(routes_module, "_client_host", lambda request: "127.0.0.1")
+    monkeypatch.setattr(login_module, "launcher_supported", lambda: True)
+    monkeypatch.setattr(login_module, "resolve_cli_path", lambda: None)
+    monkeypatch.setattr(login_module, "launch_login", _unreachable_launch)
+
+    async with _client() as client:
+        response = await client.post("/claude/login")
+
+    assert response.status_code == 501
+    assert "not found on this machine" in response.json()["detail"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
CI on `main` is red for this, and it blocks the Claude-writer PR series behind it.

## The bug

`POST /claude/login` checked `launcher_supported()` (macOS only) *before* it checked whether the caller was on the host. So the same remote request answers:

- **403** on the authoring Mac — "you are not on this machine"
- **501** on Linux — "this app can only open a terminal on macOS"

`test_remote_caller_cannot_start_a_login` never stubbed the launcher, so it asserted the macOS answer and passed locally while failing in CI on exactly that difference.

## The fix

Caller identity is settled first. A remote caller is refused with 403 on every platform; a local caller then gets a specific answer about what this host can actually do. That also stops a caller who was never going to be let through learning which platform the backend runs on.

A missing CLI used to fall out of the same `login_available()` check and be reported as **forbidden**, which is the wrong shape of answer for "nothing is installed here". It now reports as unavailable and names `ABW_CLAUDE_CLI`.

The remote-caller test is parametrized over the launcher rather than inheriting whatever machine runs the suite.

## Verification

`pytest apps/backend/tests/test_claude_connection_routes.py` — 16 passed (was 14). `black` + `flake8` clean.