### PR TITLE
Give the subscription its own switch, separate from the API key

### DIFF
--- a/apps/ai-blog-writer/apps/backend/.env.example
+++ b/apps/ai-blog-writer/apps/backend/.env.example
@@ -101,13 +101,30 @@ BFL_MODEL_ID=flux-2-pro-preview
 # prompts with canonical venue facts and the Reviews Digest.
 LM_API_URL=http://localhost:4002
 
-# Anthropic — currently switched OFF (no credit). Every claude-* selection is
-# transparently served by a Google model instead; see CLAUDE_GOOGLE_SUBSTITUTES
-# in packages/utils/src/utils/llm_client.py. To switch Claude back on, fund the
-# account, set ANTHROPIC_API_KEY, and set ANTHROPIC_MODELS_ENABLED=1.
+# --- Can a claude-* model name reach a real Claude? Two separate switches. ---
+# With both off (the default) every claude-* selection is transparently served
+# by a Google model instead; see CLAUDE_GOOGLE_SUBSTITUTES in
+# packages/utils/src/utils/llm_model_policy.py. They differ in who pays:
+
+# 1. The API-key path. Bills Anthropic Console credit, which is currently
+#    unfunded, which is why this is off. To switch it back on, fund the
+#    account, set ANTHROPIC_API_KEY, and set this to 1.
 ANTHROPIC_MODELS_ENABLED=0
 # Get a key at https://console.anthropic.com/settings/keys.
 ANTHROPIC_API_KEY=
+
+# 2. The subscription path. Serves claude-* names through the Claude Code CLI
+#    this machine is logged into, drawing the plan holder's own subscription
+#    allowance. No API key and no extra dependency. Requires `claude auth login`
+#    and a green GET /claude/status.
+#
+#    LOCAL AUTHORING ONLY. Anthropic's terms permit subscription OAuth for the
+#    plan holder's own use, not for serving other people's requests, so do NOT
+#    set this on the Linux laptop or any shared or serverless deployment.
+#
+#    Independent of ANTHROPIC_MODELS_ENABLED above. If both are on, the API-key
+#    path wins, so turning this on cannot re-point an already-funded machine.
+CLAUDE_SUBSCRIPTION_MODELS_ENABLED=0
 
 # URL2Blog tiered article fetch (stage 1). All optional — tiers without
 # config are skipped and the fetch falls back to a direct request.

--- a/apps/ai-blog-writer/apps/backend/tests/test_llm_seams.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_llm_seams.py
@@ -72,10 +72,13 @@ def test_shared_llm_factory_never_uses_small_generation_budget(monkeypatch):
 
 
 def test_claude_models_are_substituted_with_google_by_default(monkeypatch):
-    """Anthropic is unfunded, so claude-* must not reach the Anthropic client."""
+    """With no Claude path on, claude-* must not reach a Claude transport."""
     monkeypatch.delenv("ANTHROPIC_MODELS_ENABLED", raising=False)
+    monkeypatch.delenv("CLAUDE_SUBSCRIPTION_MODELS_ENABLED", raising=False)
 
     assert llm_client.anthropic_models_enabled() is False
+    assert llm_client.claude_provider() == llm_client.CLAUDE_PROVIDER_NONE
+    assert llm_client.claude_models_reachable() is False
     assert llm_client.resolve_effective_model("claude-opus-4-8") == (
         "gemini-3.1-pro-preview"
     )
@@ -95,6 +98,43 @@ def test_claude_models_pass_through_when_switched_back_on(monkeypatch):
     assert llm_client.resolve_effective_model("claude-opus-4-8") == "claude-opus-4-8"
 
 
+def test_subscription_switch_reaches_claude_without_the_api_key_switch(monkeypatch):
+    """The two switches are independent, and the new one alone is enough.
+
+    Asserted through the switch rather than through an absent API key: an
+    environment that happens to carry no credentials is not evidence about
+    routing, and a suite that populates one elsewhere would flip the result.
+    """
+    monkeypatch.delenv("ANTHROPIC_MODELS_ENABLED", raising=False)
+    monkeypatch.setenv("CLAUDE_SUBSCRIPTION_MODELS_ENABLED", "1")
+
+    assert llm_client.anthropic_models_enabled() is False
+    assert llm_client.claude_subscription_models_enabled() is True
+    assert llm_client.claude_provider() == llm_client.CLAUDE_PROVIDER_SUBSCRIPTION_CLI
+    assert llm_client.claude_models_reachable() is True
+    assert llm_client.resolve_effective_model("claude-opus-4-8") == "claude-opus-4-8"
+    # An unmapped Claude name is no longer rewritten either -- the transport
+    # decides what it can serve, not the substitution table.
+    assert llm_client.resolve_effective_model("claude-opus-5") == "claude-opus-5"
+    assert llm_client.resolve_effective_model("gemini-2.5-flash") == "gemini-2.5-flash"
+
+
+def test_api_key_path_wins_when_both_claude_switches_are_on(monkeypatch):
+    """Turning the subscription on must not re-point an already-funded machine."""
+    monkeypatch.setenv("ANTHROPIC_MODELS_ENABLED", "1")
+    monkeypatch.setenv("CLAUDE_SUBSCRIPTION_MODELS_ENABLED", "1")
+
+    assert llm_client.claude_provider() == llm_client.CLAUDE_PROVIDER_ANTHROPIC_API
+
+
+def test_subscription_switch_ignores_non_truthy_values(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_MODELS_ENABLED", raising=False)
+    for value in ("", "  ", "0", "false", "no", "off", "maybe"):
+        monkeypatch.setenv("CLAUDE_SUBSCRIPTION_MODELS_ENABLED", value)
+        assert llm_client.claude_subscription_models_enabled() is False
+        assert llm_client.claude_provider() == llm_client.CLAUDE_PROVIDER_NONE
+
+
 def test_get_vertex_llm_routes_disabled_claude_to_vertex(monkeypatch):
     captured = {}
 
@@ -105,6 +145,7 @@ def test_get_vertex_llm_routes_disabled_claude_to_vertex(monkeypatch):
     monkeypatch.setattr(llm_client, "VertexAI", _VertexLLM)
     monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
     monkeypatch.delenv("ANTHROPIC_MODELS_ENABLED", raising=False)
+    monkeypatch.delenv("CLAUDE_SUBSCRIPTION_MODELS_ENABLED", raising=False)
 
     llm = llm_client.get_vertex_llm(model_name="claude-sonnet-5", max_tokens=1024)
 

--- a/apps/ai-blog-writer/packages/utils/CONTEXT.md
+++ b/apps/ai-blog-writer/packages/utils/CONTEXT.md
@@ -32,7 +32,18 @@ Without this package every feature would re-create Vertex clients and re-impleme
 
 Factory that returns a configured text LLM client. Gemini models use Vertex AI; Claude models route to Anthropic through the same `.invoke(prompt)` surface.
 
-**Anthropic is currently switched off** (no credit). `resolve_effective_model()` runs before dispatch and rewrites every `claude-*` name to its Google counterpart from `CLAUDE_GOOGLE_SUBSTITUTES`, so no call can reach the Anthropic API and fail on billing. The Claude transport is untouched — set `ANTHROPIC_MODELS_ENABLED=1` (plus `ANTHROPIC_API_KEY`) to route back.
+`resolve_effective_model()` runs one line before provider dispatch and is the gate: while it rewrites a name, the Claude branches below it are unreachable no matter what a caller asks for.
+
+There are **two independent switches**, and they differ in who pays:
+
+| switch | transport | pays with |
+|---|---|---|
+| `ANTHROPIC_MODELS_ENABLED=1` (+ `ANTHROPIC_API_KEY`) | Anthropic API | Anthropic Console credit — currently unfunded |
+| `CLAUDE_SUBSCRIPTION_MODELS_ENABLED=1` | the Claude Code CLI this machine is logged into | the plan holder's own subscription allowance |
+
+Both default to off, and with neither on every `claude-*` name is rewritten to its Google counterpart from `CLAUDE_GOOGLE_SUBSTITUTES`. When both are on the API-key path wins, so switching the subscription on cannot re-point a machine that already had a funded key. Ask `claude_provider()` rather than re-reading the environment.
+
+The subscription path is **local authoring only** — Anthropic's terms permit it for the plan holder's own use, not for serving other people's requests, so it must not be set on a shared or serverless deployment.
 
 ### `invoke_structured_tool()`
 

--- a/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
@@ -21,6 +21,11 @@ from .llm_model_policy import (  # noqa: F401
     ANTHROPIC_MODELS_ENABLED_DEFAULT as ANTHROPIC_MODELS_ENABLED_DEFAULT,
     ANTHROPIC_MODELS_ENABLED_ENV as ANTHROPIC_MODELS_ENABLED_ENV,
     CLAUDE_GOOGLE_SUBSTITUTES as CLAUDE_GOOGLE_SUBSTITUTES,
+    CLAUDE_PROVIDER_ANTHROPIC_API as CLAUDE_PROVIDER_ANTHROPIC_API,
+    CLAUDE_PROVIDER_NONE as CLAUDE_PROVIDER_NONE,
+    CLAUDE_PROVIDER_SUBSCRIPTION_CLI as CLAUDE_PROVIDER_SUBSCRIPTION_CLI,
+    CLAUDE_SUBSCRIPTION_MODELS_ENABLED_DEFAULT as CLAUDE_SUBSCRIPTION_MODELS_ENABLED_DEFAULT,
+    CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV as CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV,
     DEFAULT_CLAUDE_GOOGLE_SUBSTITUTE as DEFAULT_CLAUDE_GOOGLE_SUBSTITUTE,
     DEFAULT_LOCATION as DEFAULT_LOCATION,
     DEFAULT_MODEL as DEFAULT_MODEL,
@@ -31,6 +36,9 @@ from .llm_model_policy import (  # noqa: F401
     _resolve_vertex_location,
     _resolve_vertex_project,
     anthropic_models_enabled as anthropic_models_enabled,
+    claude_models_reachable as claude_models_reachable,
+    claude_provider as claude_provider,
+    claude_subscription_models_enabled as claude_subscription_models_enabled,
     is_claude_model as is_claude_model,
     resolve_effective_model as resolve_effective_model,
 )
@@ -74,10 +82,14 @@ class ClaudeTextLLM:
         ) as stream:
             message = stream.get_final_message()
         usage = getattr(message, 'usage', None)
-        self.last_usage_metadata = {
-            'input_tokens': getattr(usage, 'input_tokens', 0),
-            'output_tokens': getattr(usage, 'output_tokens', 0),
-        } if usage is not None else None
+        self.last_usage_metadata = (
+            {
+                'input_tokens': getattr(usage, 'input_tokens', 0),
+                'output_tokens': getattr(usage, 'output_tokens', 0),
+            }
+            if usage is not None
+            else None
+        )
         text = _message_text(message)
         if not text:
             raise _empty_message_error(message)

--- a/apps/ai-blog-writer/packages/utils/src/utils/llm_model_policy.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/llm_model_policy.py
@@ -10,8 +10,33 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = "gemini-2.5-flash-lite"
 DEFAULT_LOCATION = "us-central1"
 GEMINI3_LOCATION = "global"
+# Two independent ways a claude-* name can reach a real Claude, and they must
+# not be conflated -- they differ in who pays and in what has to be installed.
+#
+#   ANTHROPIC_MODELS_ENABLED           the API-key path. Calls go to the
+#                                      Anthropic API with ANTHROPIC_API_KEY and
+#                                      bill Anthropic Console credit. Off, and
+#                                      unfunded, since the credit ran out.
+#
+#   CLAUDE_SUBSCRIPTION_MODELS_ENABLED the subscription path. Calls shell out to
+#                                      the Claude Code CLI this machine is
+#                                      logged into and draw the plan holder's
+#                                      own subscription allowance. No API key,
+#                                      no extra dependency.
+#
+# Both default to off, in which case claude-* names are still substituted to
+# Google exactly as before. When both are on the API-key path wins, so turning
+# the new switch on can never change what an existing configured machine does.
 ANTHROPIC_MODELS_ENABLED_ENV = "ANTHROPIC_MODELS_ENABLED"
 ANTHROPIC_MODELS_ENABLED_DEFAULT = False
+CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV = "CLAUDE_SUBSCRIPTION_MODELS_ENABLED"
+CLAUDE_SUBSCRIPTION_MODELS_ENABLED_DEFAULT = False
+
+# What ``claude_provider()`` answers with. Callers dispatch on these rather than
+# re-reading the environment, so there is one place that decides precedence.
+CLAUDE_PROVIDER_NONE = "none"
+CLAUDE_PROVIDER_ANTHROPIC_API = "anthropic-api"
+CLAUDE_PROVIDER_SUBSCRIPTION_CLI = "subscription-cli"
 CLAUDE_GOOGLE_SUBSTITUTES = {
     "claude-opus-4-8": "gemini-3.1-pro-preview",
     "claude-opus-4-7": "gemini-3.1-pro-preview",
@@ -22,12 +47,50 @@ MIN_GENERATION_MAX_TOKENS = 64_000
 _TRUTHY = {"1", "true", "yes", "on"}
 
 
-def anthropic_models_enabled() -> bool:
-    """Whether claude-* names may reach the Anthropic API."""
-    raw = os.getenv(ANTHROPIC_MODELS_ENABLED_ENV)
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
     if raw is None or not raw.strip():
-        return ANTHROPIC_MODELS_ENABLED_DEFAULT
+        return default
     return raw.strip().lower() in _TRUTHY
+
+
+def anthropic_models_enabled() -> bool:
+    """Whether claude-* names may reach the Anthropic API on an API key."""
+    return _env_flag(ANTHROPIC_MODELS_ENABLED_ENV, ANTHROPIC_MODELS_ENABLED_DEFAULT)
+
+
+def claude_subscription_models_enabled() -> bool:
+    """Whether claude-* names may reach the Claude Code CLI on the machine's
+    subscription login.
+
+    Deliberately a separate switch from ``anthropic_models_enabled``: that one
+    spends API credit against a key, this one spends the plan holder's own
+    subscription allowance. Anthropic's terms allow the latter only for the
+    plan holder's own use, so it is local-authoring only -- do not set it on a
+    shared or serverless deployment.
+    """
+    return _env_flag(
+        CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV,
+        CLAUDE_SUBSCRIPTION_MODELS_ENABLED_DEFAULT,
+    )
+
+
+def claude_provider() -> str:
+    """Which transport, if any, will serve a claude-* name.
+
+    The API-key path takes precedence so that switching the subscription path on
+    cannot silently re-point a machine that already had a funded key configured.
+    """
+    if anthropic_models_enabled():
+        return CLAUDE_PROVIDER_ANTHROPIC_API
+    if claude_subscription_models_enabled():
+        return CLAUDE_PROVIDER_SUBSCRIPTION_CLI
+    return CLAUDE_PROVIDER_NONE
+
+
+def claude_models_reachable() -> bool:
+    """Whether a claude-* name survives ``resolve_effective_model`` unchanged."""
+    return claude_provider() != CLAUDE_PROVIDER_NONE
 
 
 def is_claude_model(model_name: Optional[str]) -> bool:
@@ -37,16 +100,24 @@ def is_claude_model(model_name: Optional[str]) -> bool:
 def resolve_effective_model(model_name: Optional[str]) -> Optional[str]:
     """Map a requested model to the one that will actually serve the call.
 
-    Non-Claude names and (once re-funded) Claude names pass through unchanged.
+    Non-Claude names pass through unchanged. A claude-* name passes through when
+    *either* Claude path is switched on, and is substituted to its Google
+    counterpart only when neither is.
+
+    This runs one line before provider dispatch, so it is the gate: while it
+    rewrites the name, the Claude branches downstream are unreachable no matter
+    what a caller asks for.
     """
-    if not is_claude_model(model_name) or anthropic_models_enabled():
+    if not is_claude_model(model_name) or claude_models_reachable():
         return model_name
     substitute = CLAUDE_GOOGLE_SUBSTITUTES.get(
         str(model_name).strip().lower(), DEFAULT_CLAUDE_GOOGLE_SUBSTITUTE
     )
     logger.info(
-        "Anthropic models are disabled (%s); serving '%s' with '%s'.",
+        "No Claude path is switched on (%s and %s are both off); "
+        "serving '%s' with '%s'.",
         ANTHROPIC_MODELS_ENABLED_ENV,
+        CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV,
         model_name,
         substitute,
     )


### PR DESCRIPTION
Phase 1a of putting Claude on the writer role. Policy only — no transport, nothing new can be called yet.

## The problem

`resolve_effective_model` rewrites every `claude-*` name to a Google one, and it runs **one line before** provider dispatch ([llm_client.py](apps/ai-blog-writer/packages/utils/src/utils/llm_client.py)). So the `ClaudeTextLLM` branch below it is unreachable no matter what a caller asks for. It gated on `ANTHROPIC_MODELS_ENABLED` — the API-key path, which is unfunded.

## The change

There are now **two independent switches**, and they differ in who pays:

| switch | transport | pays with |
|---|---|---|
| `ANTHROPIC_MODELS_ENABLED=1` (+ `ANTHROPIC_API_KEY`) | Anthropic API | Anthropic Console credit — unfunded |
| `CLAUDE_SUBSCRIPTION_MODELS_ENABLED=1` | Claude Code CLI on this machine | the plan holder's own subscription allowance |

`claude_provider()` is the single place that decides precedence; callers dispatch on its answer rather than re-reading the environment. That is what keeps two similarly named switches from being conflated at a call site.

## Non-breaking

- Both default to off, so an existing machine behaves identically.
- When both are on the **API-key path wins**, so switching the new one on cannot re-point a machine that was already funded.
- No transport is added here. Turning the new switch on today just stops the name being swapped.

## Scope note

The subscription path is **local authoring only**. Anthropic's terms permit subscription OAuth for the plan holder's own use, not for serving other people's requests, so it must not be set on the Linux laptop or any shared/serverless deployment. Documented at both the env entry and the policy module.

## Tests

Three new cases, plus two existing ones tightened. The existing default-substitution tests asserted behaviour by leaving one switch unset; there are two now, so both are cleared explicitly — an environment that happens to carry no credentials is not evidence about routing.

`pytest apps/backend/tests` — 750 passed. `black` + `flake8` clean.