### PR TITLE
Serve claude-* names from the subscription CLI in the shared factory

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
@@ -128,6 +128,39 @@ DENIED_TOOLS = (
 )
 
 
+# A refusal does not arrive shaped like a refusal.
+#
+# Asking for a model this plan cannot serve returns `subtype: "success"` with
+# the apology sitting in `result` -- "You've hit your monthly spend limit.
+# Switch to another model..." -- alongside `is_error: true`,
+# `terminal_reason: "api_error"` and `total_cost_usd: 0`. A caller that trusts
+# `subtype` and reads `result` publishes that sentence as article prose.
+#
+# So `subtype` is not evidence of anything and is not consulted. Three things
+# are checked instead, at the one chokepoint both call shapes go through:
+#
+#   is_error          the flag that was actually set on the observed refusal.
+#   terminal_reason   named reasons a run stopped without answering. A deny
+#                     list, not an allow list: the CLI is free to add new
+#                     benign values, and failing an unrecognised one would
+#                     break working calls on a version bump.
+#   output tokens     zero generated tokens means the model wrote nothing, so
+#                     whatever is in `result` came from the harness rather than
+#                     from Claude. This is the check that does not depend on
+#                     guessing which flags a future refusal will carry.
+FAILED_TERMINAL_REASONS = frozenset(
+    {
+        "api_error",
+        "budget_exhausted",
+        "error",
+        "error_during_execution",
+        "max_turns",
+        "refusal",
+        "timeout",
+    }
+)
+
+
 class ClaudeCliWriterError(RuntimeError):
     """A writer call that could not be made, or whose output was unusable."""
 
@@ -285,10 +318,33 @@ def _invoke(
         raise ClaudeCliWriterError(
             "Claude answered with output this app could not read."
         )
+    _assert_claude_actually_answered(payload)
+
+    return payload, alias
+
+
+def _assert_claude_actually_answered(payload: dict[str, Any]) -> None:
+    """Reject a reply that carries a refusal instead of an answer.
+
+    See FAILED_TERMINAL_REASONS above for why this is three checks and why
+    ``subtype`` is not one of them.
+    """
     if payload.get("is_error"):
         raise ClaudeCliWriterError("Claude reported an error answering the call.")
 
-    return payload, alias
+    reason = payload.get("terminal_reason")
+    if isinstance(reason, str) and reason.strip().lower() in FAILED_TERMINAL_REASONS:
+        raise ClaudeCliWriterError(
+            "Claude stopped without answering the call, so nothing was used."
+        )
+
+    # Absent rather than zero means the CLI did not report it; only a reported
+    # zero is evidence that nothing was generated.
+    output_tokens = _usage_from(payload).get("outputTokens")
+    if output_tokens == 0:
+        raise ClaudeCliWriterError(
+            "Claude generated no output, so its reply was not used."
+        )
 
 
 def invoke_text(
@@ -310,6 +366,27 @@ def invoke_text(
         "costUsd": _cost_of(payload),
         "usage": _usage_from(payload),
     }
+
+
+def frame_schema_prompt(
+    prompt: str,
+    *,
+    tool_name: str,
+    tool_description: str,
+) -> str:
+    """Restate a forced-tool instruction as something the CLI can honour.
+
+    ``--json-schema`` forces the shape without naming a tool, so a prompt ending
+    "call the emit_seo_patch tool" would be an instruction about something that
+    does not exist. Dropping the caller's wording instead would lose the
+    description, which is often the only place the semantics of the schema are
+    written down.
+    """
+    return (
+        f"{prompt}\n\n"
+        f"Return your answer as JSON matching the required schema "
+        f"({tool_name}): {tool_description}"
+    )
 
 
 def invoke_structured(

--- a/apps/ai-blog-writer/apps/backend/app/shared/writer_invocation.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/writer_invocation.py
@@ -171,13 +171,10 @@ def _invoke_structured_via_cli(
     input_schema: dict,
 ) -> StructuredWriterResult:
     cli_writer = _cli_writer()
-    # The CLI has no tool to name, so a prompt that ends "call the emit_seo_patch
-    # tool" would be an instruction about something that does not exist. Restate
-    # it as what the CLI actually does.
-    framed = (
-        f"{prompt}\n\n"
-        f"Return your answer as JSON matching the required schema "
-        f"({tool_name}): {tool_description}"
+    framed = cli_writer.frame_schema_prompt(
+        prompt,
+        tool_name=tool_name,
+        tool_description=tool_description,
     )
     try:
         result = cli_writer.invoke_structured(

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_llm_provider.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_llm_provider.py
@@ -1,0 +1,281 @@
+"""``get_vertex_llm`` serving claude-* names on the subscription CLI.
+
+This is the door Prompt2Blog uses. It calls ``utils.get_vertex_llm`` directly
+and never passes through ``app.shared.writer_invocation``, so ``WRITER_PROVIDER``
+does not reach it and none of the writer-invocation tests cover it.
+
+The property under test is the same as the transport's: this is an *added*
+provider. With no Claude switch on, nothing here may run.
+"""
+
+import json
+import subprocess
+
+import pytest
+
+from app.features.claude_connection import cli_writer
+from app.features.claude_connection import status as status_module
+from utils import llm_client
+
+CLI_PATH = "/fake/bin/claude"
+
+TEXT_JSON = json.dumps(
+    {
+        "result": "Barranco after dark.",
+        "is_error": False,
+        "total_cost_usd": 0.0099,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 503,
+            "cache_read_input_tokens": 8741,
+            "cache_creation_input_tokens": 2729,
+        },
+        "modelUsage": {
+            "claude-sonnet-5-20260101": {"canonicalModel": "claude-sonnet-5"}
+        },
+    }
+)
+
+STRUCTURED_JSON = json.dumps(
+    {
+        "result": '{"seoTitle":"Hidden Cafes in Barranco"}',
+        "structured_output": {"seoTitle": "Hidden Cafes in Barranco"},
+        "is_error": False,
+        "stop_reason": "tool_use",
+        "total_cost_usd": 0.0099,
+        "usage": {"input_tokens": 10, "output_tokens": 430},
+        "modelUsage": {"claude-opus-5-20260101": {"canonicalModel": "claude-opus-5"}},
+    }
+)
+
+SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["seoTitle"],
+    "properties": {"seoTitle": {"type": "string"}},
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_claude_switches(monkeypatch):
+    """Both switches off, and no inherited credential that could confuse either.
+
+    Cleared explicitly rather than assumed absent: a suite that populates one
+    elsewhere would otherwise decide the result of every test in this file.
+    """
+    monkeypatch.delenv(llm_client.ANTHROPIC_MODELS_ENABLED_ENV, raising=False)
+    monkeypatch.delenv(llm_client.CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV, raising=False)
+    monkeypatch.delenv(cli_writer.WRITER_PROVIDER_ENV, raising=False)
+    for name in status_module.API_BILLED_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def subscription_on(monkeypatch):
+    monkeypatch.setenv(llm_client.CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV, "1")
+
+
+@pytest.fixture
+def connected(monkeypatch):
+    """A green connection, so the transport is willing to spend."""
+    monkeypatch.setattr(status_module, "resolve_cli_path", lambda: CLI_PATH)
+    monkeypatch.setattr(
+        status_module,
+        "_run_cli",
+        lambda cli_path, args: subprocess.CompletedProcess(
+            args=[cli_path],
+            returncode=0,
+            stdout=(
+                "1.0.0"
+                if args[:1] == ["--version"]
+                else json.dumps(
+                    {
+                        "loggedIn": True,
+                        "authMethod": "claude.ai",
+                        "apiProvider": "firstParty",
+                        "subscriptionType": "pro",
+                    }
+                )
+            ),
+            stderr="",
+        ),
+    )
+
+
+def _capture(monkeypatch, stdout: str):
+    calls: list[dict] = []
+    monkeypatch.setattr(cli_writer, "resolve_cli_path", lambda: CLI_PATH)
+
+    def fake_run(args, **kwargs):
+        calls.append({"args": list(args), "kwargs": kwargs})
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=stdout, stderr=""
+        )
+
+    monkeypatch.setattr(cli_writer.subprocess, "run", fake_run)
+    return calls
+
+
+# --- The default path is untouched ------------------------------------------
+
+
+def test_claude_names_still_reach_vertex_with_no_switch_on(monkeypatch):
+    captured = {}
+
+    class _VertexLLM:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(llm_client, "VertexAI", _VertexLLM)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.setattr(
+        llm_client,
+        "_claude_cli_transport",
+        _unreachable_transport,
+    )
+
+    llm = llm_client.get_vertex_llm(model_name="claude-sonnet-5", max_tokens=1024)
+
+    assert not isinstance(llm, llm_client.ClaudeCliTextLLM)
+    assert captured["model_name"] == "gemini-2.5-pro"
+
+
+def test_the_api_key_path_still_wins_over_the_subscription(monkeypatch):
+    monkeypatch.setenv(llm_client.ANTHROPIC_MODELS_ENABLED_ENV, "1")
+    monkeypatch.setenv(llm_client.CLAUDE_SUBSCRIPTION_MODELS_ENABLED_ENV, "1")
+    monkeypatch.setattr(
+        llm_client,
+        "_claude_cli_transport",
+        _unreachable_transport,
+    )
+
+    llm = llm_client.get_vertex_llm(model_name="claude-sonnet-5", max_tokens=1024)
+
+    assert isinstance(llm, llm_client.ClaudeTextLLM)
+
+
+# --- The subscription path ---------------------------------------------------
+
+
+def test_subscription_path_serves_claude_names_from_the_cli(
+    monkeypatch, subscription_on, connected
+):
+    calls = _capture(monkeypatch, TEXT_JSON)
+
+    llm = llm_client.get_vertex_llm(model_name="claude-opus-5", max_tokens=6144)
+    text = llm.invoke("Draft the opening.")
+
+    assert isinstance(llm, llm_client.ClaudeCliTextLLM)
+    assert text == "Barranco after dark."
+    assert calls[0]["args"][0] == CLI_PATH
+    assert "--print" in calls[0]["args"]
+    # Reused from the transport rather than rebuilt here: the isolation flags
+    # and the closed stdin are the same ones the bench and the writer use.
+    assert calls[0]["kwargs"]["stdin"] is subprocess.DEVNULL
+    assert "--setting-sources" in calls[0]["args"]
+
+
+def test_invoke_reports_the_model_that_answered_not_the_alias(
+    monkeypatch, subscription_on, connected
+):
+    _capture(monkeypatch, TEXT_JSON)
+
+    llm = llm_client.get_vertex_llm(model_name="claude-opus-5", max_tokens=6144)
+    llm.invoke("Draft the opening.")
+
+    # 'opus' is a moving target, so a spend record keyed on the request would
+    # not say what it paid for.
+    assert llm.model_name == "claude-sonnet-5"
+
+
+def test_usage_lands_in_the_shape_the_token_tracker_reads(
+    monkeypatch, subscription_on, connected
+):
+    from app.features.prompt2blog.pricing import normalize_token_usage
+
+    _capture(monkeypatch, TEXT_JSON)
+
+    llm = llm_client.get_vertex_llm(model_name="claude-sonnet-5", max_tokens=6144)
+    llm.invoke("Draft the opening.")
+
+    assert llm.last_usage_metadata == {
+        "input_tokens": 10,
+        "output_tokens": 503,
+        "cache_read_input_tokens": 8741,
+        "cache_creation_input_tokens": 2729,
+    }
+    normalized = normalize_token_usage(llm.last_usage_metadata)
+    assert normalized["input_tokens"] == 10
+    assert normalized["output_tokens"] == 503
+
+
+def test_measured_cost_is_carried_off_the_call(monkeypatch, subscription_on, connected):
+    _capture(monkeypatch, TEXT_JSON)
+
+    llm = llm_client.get_vertex_llm(model_name="claude-sonnet-5", max_tokens=6144)
+    llm.invoke("Draft the opening.")
+
+    assert llm.last_cost_usd == 0.0099
+
+
+def test_a_refused_call_raises_instead_of_returning_prose(
+    monkeypatch, subscription_on, connected
+):
+    """The named failure mode: a refusal arrives shaped like an answer.
+
+    `subtype` says "success" and the apology sits in `result`. Anything that
+    returns that string publishes it as article prose.
+    """
+    refusal = json.dumps(
+        {
+            "is_error": True,
+            "subtype": "success",
+            "terminal_reason": "api_error",
+            "total_cost_usd": 0,
+            "result": (
+                "You've hit your monthly spend limit. Switch to another model, "
+                "or manage usage credits at claude.ai/settings/usage."
+            ),
+        }
+    )
+    _capture(monkeypatch, refusal)
+
+    llm = llm_client.get_vertex_llm(model_name="claude-opus-5", max_tokens=6144)
+    with pytest.raises(llm_client.ClaudeCliUnavailable) as error:
+        llm.invoke("Draft the opening.")
+
+    assert "monthly spend limit" not in str(error.value)
+
+
+def test_structured_calls_use_the_cli_rather_than_an_unconfigured_api_key(
+    monkeypatch, subscription_on, connected
+):
+    """Switching the subscription on must not leave half the surface broken.
+
+    Without this, a working text call would sit beside a forced-tool call still
+    reaching for an Anthropic key that was never configured.
+    """
+    calls = _capture(monkeypatch, STRUCTURED_JSON)
+
+    payload, resolved = llm_client.invoke_structured_tool(
+        prompt="Write the SEO title.",
+        model_name="claude-opus-5",
+        tool_name="emit_seo_patch",
+        tool_description="One SEO title.",
+        input_schema=SCHEMA,
+    )
+
+    assert payload == {"seoTitle": "Hidden Cafes in Barranco"}
+    assert resolved == "claude-opus-5"
+    args = calls[0]["args"]
+    assert "--json-schema" in args
+    # The caller's tool name and description survive into the prompt: the CLI
+    # has no tool to name, but the description is often the only place the
+    # meaning of the schema is written down.
+    prompt = args[args.index("--print") + 1]
+    assert "emit_seo_patch" in prompt
+    assert "One SEO title." in prompt
+
+
+def _unreachable_transport():  # pragma: no cover - must not run
+    raise AssertionError("the CLI transport was consulted with no Claude switch on")

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_writer.py
@@ -332,6 +332,129 @@ def test_model_reported_error_is_raised(monkeypatch, connected, provider_on):
         cli_writer.invoke_text(prompt="write something")
 
 
+def test_a_limit_refusal_never_becomes_prose(monkeypatch, connected, provider_on):
+    """The refusal that arrives shaped like an answer.
+
+    Measured by asking for a model this plan cannot serve: `subtype` reads
+    "success", `total_cost_usd` is 0, and the apology sits in `result` where a
+    trusting caller would read it and publish it as article prose.
+    """
+    _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "is_error": True,
+                "subtype": "success",
+                "terminal_reason": "api_error",
+                "total_cost_usd": 0,
+                "result": (
+                    "You've hit your monthly spend limit. Switch to another "
+                    "model, or manage usage credits at claude.ai/settings/usage."
+                ),
+            }
+        ),
+    )
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError) as caught:
+        cli_writer.invoke_text(prompt="write something")
+
+    assert "monthly spend limit" not in str(caught.value)
+
+
+@pytest.mark.parametrize("reason", sorted(cli_writer.FAILED_TERMINAL_REASONS))
+def test_a_named_stop_reason_is_refused_even_without_the_error_flag(
+    monkeypatch, connected, provider_on, reason
+):
+    """`is_error` is one signal, not the only one.
+
+    A run that stopped for a named reason did not answer, whatever else the
+    payload claims about itself.
+    """
+    _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "result": "Sorry, I cannot continue.",
+                "is_error": False,
+                "subtype": "success",
+                "terminal_reason": reason,
+                "usage": {"input_tokens": 10, "output_tokens": 12},
+            }
+        ),
+    )
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_text(prompt="write something")
+
+
+def test_zero_generated_tokens_means_the_text_did_not_come_from_claude(
+    monkeypatch, connected, provider_on
+):
+    """The check that does not depend on guessing future refusal flags.
+
+    If the model generated nothing, whatever is sitting in `result` was written
+    by the harness rather than by Claude.
+    """
+    _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "result": "Switch to another model to continue.",
+                "is_error": False,
+                "subtype": "success",
+                "usage": {"input_tokens": 10, "output_tokens": 0},
+            }
+        ),
+    )
+
+    with pytest.raises(cli_writer.ClaudeCliWriterError):
+        cli_writer.invoke_text(prompt="write something")
+
+
+def test_an_unreported_token_count_is_not_treated_as_zero(
+    monkeypatch, connected, provider_on
+):
+    """Absent is not the same as zero.
+
+    Only a reported zero is evidence that nothing was generated; a payload that
+    omits usage entirely must still be usable, or a CLI version that stops
+    reporting it takes the pipeline down.
+    """
+    _capture(
+        monkeypatch,
+        json.dumps({"result": "Barranco after dark.", "is_error": False}),
+    )
+
+    assert cli_writer.invoke_text(prompt="write something")["text"] == (
+        "Barranco after dark."
+    )
+
+
+def test_an_unrecognised_stop_reason_is_allowed_through(
+    monkeypatch, connected, provider_on
+):
+    """A deny list, not an allow list.
+
+    The CLI is free to add benign `terminal_reason` values, and failing an
+    unrecognised one would break every working call on a version bump.
+    """
+    _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "result": "Barranco after dark.",
+                "is_error": False,
+                "terminal_reason": "some_new_benign_reason",
+                "usage": {"input_tokens": 10, "output_tokens": 503},
+            }
+        ),
+    )
+
+    assert cli_writer.invoke_text(prompt="write something")["text"] == (
+        "Barranco after dark."
+    )
+
+
 def test_cli_output_is_never_echoed_into_the_error(monkeypatch, connected, provider_on):
     """stderr is the one place a credential could appear, and these strings
     reach an API response."""

--- a/apps/ai-blog-writer/packages/utils/src/utils/claude_cli_llm.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/claude_cli_llm.py
@@ -1,0 +1,131 @@
+"""Text LLM backed by the Claude Code CLI's subscription login.
+
+``get_vertex_llm`` picks a provider per call from the model name and builds a
+fresh object every time -- no caching, no module singleton, no shared state --
+so a pipeline run already mixes providers freely. This adds a third one beside
+Vertex and the Anthropic API, reachable only when
+``CLAUDE_SUBSCRIPTION_MODELS_ENABLED`` is on.
+
+The contract every caller in this codebase relies on is three members::
+
+    .invoke(prompt) -> str
+    .model_name
+    .last_usage_metadata
+
+That is all this class promises. There is no LangChain here, the same way
+``ClaudeTextLLM`` has none.
+
+Why it delegates rather than shells out itself
+----------------------------------------------
+``app.features.claude_connection.cli_writer`` already owns the argument
+building, the isolation flags, the allow-listed model aliases, the closed
+stdin, and -- the part that matters most -- the refusal to send at all unless
+``GET /claude/status`` is green. Re-implementing any of that here would mean two
+places that can disagree about whether a call is safe to make, and the one that
+would drift is the copy. So this is a thin adapter over that transport.
+
+That makes this the one module in ``packages/utils`` that reaches up into the
+backend app, which is backwards. It is a deliberate, single, lazily-taken
+import rather than a layering the rest of the package follows: the transport
+cannot move down here without dragging the whole Claude status reader with it,
+and the default path never touches this module at all.
+"""
+
+from typing import Any, Optional
+
+
+class ClaudeCliUnavailable(RuntimeError):
+    """The CLI transport could not be imported or could not answer."""
+
+
+def _transport() -> Any:
+    """The CLI writer module, imported at call time.
+
+    Lazy so that importing ``utils`` from a context without the backend app on
+    the path -- a script, a converter process -- does not fail on an import it
+    was never going to use.
+    """
+    try:
+        from app.features.claude_connection import cli_writer
+    except ImportError as error:  # pragma: no cover - packaging failure
+        raise ClaudeCliUnavailable(
+            "The Claude CLI writer transport is not importable here."
+        ) from error
+    return cli_writer
+
+
+# The transport reports usage in the shape its HTTP responses use. The token
+# tracker reads snake_case. Translating here keeps the API surface and the
+# accounting surface from having to agree on one spelling.
+_USAGE_KEYS = (
+    ("inputTokens", "input_tokens"),
+    ("outputTokens", "output_tokens"),
+    ("cacheReadInputTokens", "cache_read_input_tokens"),
+    ("cacheCreationInputTokens", "cache_creation_input_tokens"),
+)
+
+
+def _usage_metadata(usage: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Carry the CLI's own token counts through under the tracker's names.
+
+    ``input_tokens`` and ``output_tokens`` are the keys the existing usage
+    normalizer already reads, so token totals land in the per-run tracker with
+    no further wiring. The two cache figures stay flat, the way the CLI reports
+    them; nothing reads them under those names yet, so cache savings are still
+    invisible on this provider -- a separate fix, not a silent re-shaping here.
+
+    Note what these numbers mean before comparing them to Gemini's:
+    ``input_tokens`` counts only the uncached prompt. The cached prefix sits in
+    the two cache fields and is not folded in.
+    """
+    if not isinstance(usage, dict):
+        return None
+    carried = {
+        target: usage[source]
+        for source, target in _USAGE_KEYS
+        if isinstance(usage.get(source), int) and not isinstance(usage[source], bool)
+    }
+    return carried or None
+
+
+class ClaudeCliTextLLM:
+    """One writer call, answered on the machine's Claude subscription.
+
+    ``temperature`` and ``max_tokens`` are accepted and dropped rather than
+    faked: the CLI has no flag for either. The output cap is whatever the
+    model's own default is, which is roomier than anything the pipeline asks
+    for (stages request ~6k and the shared floor already widens that to 64k),
+    so nothing is being silently truncated. See the smoke-test README.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        max_tokens: int,
+        temperature: Optional[float] = None,
+    ) -> None:
+        self.model_name = model_name
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.last_usage_metadata: Optional[dict[str, Any]] = None
+        # The CLI is the only provider here that reports a per-call price. It
+        # is a notional API-equivalent figure rather than money leaving an
+        # account -- subscription calls draw plan allowance -- but it is
+        # measured, per call, and it is the only cost signal this provider has.
+        self.last_cost_usd: Optional[float] = None
+
+    def invoke(self, prompt: str) -> str:
+        cli_writer = _transport()
+        try:
+            result = cli_writer.invoke_text(prompt=prompt, model_name=self.model_name)
+        except cli_writer.ClaudeCliWriterError as error:
+            raise ClaudeCliUnavailable(str(error)) from error
+
+        # The alias asked for is not the model that answered: 'sonnet' is a
+        # moving target, so a spend record keyed on it would not say what it
+        # paid for.
+        self.model_name = result.get("modelName") or self.model_name
+        self.last_usage_metadata = _usage_metadata(result.get("usage"))
+        self.last_cost_usd = result.get("costUsd")
+        return result["text"]

--- a/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
@@ -5,6 +5,11 @@ from typing import Any, Optional
 
 from langchain_google_vertexai import ChatVertexAI, VertexAI  # noqa: F401
 
+from .claude_cli_llm import (  # noqa: F401
+    ClaudeCliTextLLM as ClaudeCliTextLLM,
+    ClaudeCliUnavailable as ClaudeCliUnavailable,
+    _transport as _claude_cli_transport,
+)
 from .anthropic_transport import (
     _empty_message_error,
     _get_anthropic_client as _create_anthropic_client,
@@ -166,6 +171,40 @@ def _invoke_gemini_structured_tool(
     )
 
 
+def _invoke_claude_cli_structured_tool(
+    *,
+    prompt: str,
+    model_name: str,
+    tool_name: str,
+    tool_description: str,
+    input_schema: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Forced-tool equivalent on the subscription CLI.
+
+    Routed here so that switching the subscription path on cannot leave a
+    working text call beside a structured one that still tries the Anthropic
+    API and fails on a key that was never configured.
+
+    ``max_tokens`` has no CLI equivalent -- there is no flag for it -- so it is
+    not threaded through rather than being faked.
+    """
+    cli_writer = _claude_cli_transport()
+    framed = cli_writer.frame_schema_prompt(
+        prompt,
+        tool_name=tool_name,
+        tool_description=tool_description,
+    )
+    try:
+        result = cli_writer.invoke_structured(
+            prompt=framed,
+            input_schema=input_schema,
+            model_name=model_name,
+        )
+    except cli_writer.ClaudeCliWriterError as error:
+        raise ClaudeCliUnavailable(str(error)) from error
+    return (result["payload"], result["modelName"])
+
+
 def invoke_structured_tool(
     *,
     prompt: str,
@@ -181,6 +220,14 @@ def invoke_structured_tool(
     regardless of whether Anthropic is switched on."""
     effective_model = resolve_effective_model(model_name) or model_name
     if is_claude_model(effective_model):
+        if claude_provider() == CLAUDE_PROVIDER_SUBSCRIPTION_CLI:
+            return _invoke_claude_cli_structured_tool(
+                prompt=prompt,
+                model_name=effective_model,
+                tool_name=tool_name,
+                tool_description=tool_description,
+                input_schema=input_schema,
+            )
         return invoke_anthropic_structured_tool(
             prompt=prompt,
             model_name=effective_model,
@@ -206,7 +253,7 @@ def get_vertex_llm(
     model_name: Optional[str] = None,
     project: Optional[str] = None,
     location: Optional[str] = None,
-) -> 'VertexAI | ClaudeTextLLM | Gemini3ChatTextLLM':
+) -> 'VertexAI | ClaudeTextLLM | ClaudeCliTextLLM | Gemini3ChatTextLLM':
     """
     Create a configured LLM instance (Vertex AI, or Anthropic for claude-* models).
 
@@ -227,6 +274,17 @@ def get_vertex_llm(
     effective_max_tokens = _resolve_generation_max_tokens(max_tokens)
     model_name = resolve_effective_model(model_name)
     if is_claude_model(model_name):
+        # A claude-* name only survives resolve_effective_model when one of the
+        # two Claude paths is on, so this branch is not reachable by accident.
+        if claude_provider() == CLAUDE_PROVIDER_SUBSCRIPTION_CLI:
+            logger.debug(
+                f'Routing LLM call to the Claude subscription CLI: model={model_name}'
+            )
+            return ClaudeCliTextLLM(
+                model_name=model_name,
+                max_tokens=effective_max_tokens,
+                temperature=temperature,
+            )
         logger.debug(
             f'Routing LLM call to Anthropic: model={model_name}, max_tokens={effective_max_tokens}'
         )


### PR DESCRIPTION
Phase 1b. With [#382](https://github.com/Questurian/questurian/pull/382) the name survives; this makes something answer to it.

## Why here and not the existing flag

`WRITER_PROVIDER=claude-cli` only reaches calls routed through `app/shared/writer_invocation.py` — editor_assist and itineraries_pipeline. **Prompt2Blog calls `utils.get_vertex_llm` directly**, so the flag never touches it. This adds the provider where Prompt2Blog actually lives: a `claude-*` name returns a `ClaudeCliTextLLM` whenever the subscription switch is on.

`ClaudeCliTextLLM` is a plain class carrying the three members every caller here duck-types against — `invoke`, `model_name`, `last_usage_metadata` — the same way `ClaudeTextLLM` is. No LangChain in either.

## It delegates rather than shelling out

`cli_writer` already owns the argument building, the isolation flags, the allow-listed aliases, the closed stdin, and the refusal to send unless the connection is green. A second copy would be a second thing that can disagree about whether a call is safe to make, and the copy is what drifts.

The cost is one lazily-taken import from `packages/utils` up into the backend app, which is backwards. It is documented as deliberate at the import: the transport cannot move down without dragging the whole Claude status reader with it, and the default path never touches the module.

## The refusal guard

**A refusal does not arrive shaped like a refusal.** Asking for a model the plan cannot serve returns `subtype: "success"` with the apology sitting in `result`:

```json
{"is_error": true, "subtype": "success", "terminal_reason": "api_error",
 "total_cost_usd": 0,
 "result": "You've hit your monthly spend limit. Switch to another model..."}
```

Anything that trusts `subtype` and reads `result` publishes that sentence as article prose. The guard sits at the one chokepoint both call shapes go through, and it is three checks:

- `is_error` — the flag actually set on the observed refusal.
- **a deny list** of named `terminal_reason` values. Deny rather than allow, so a benign new value on a CLI version bump does not take the pipeline down.
- **zero reported generated tokens** — the check that does not depend on guessing which flags a future refusal carries. If the model wrote nothing, whatever is in `result` came from the harness.

`subtype` is not consulted at all. Absent usage is not treated as zero, so a CLI that stops reporting it does not break every call.

## Also

- **Forced-tool calls route to the CLI on the same switch.** Without that, turning the subscription on leaves a working text call beside a structured one still reaching for an Anthropic key that was never configured.
- Token counts land under the keys `normalize_token_usage` already reads, so totals flow into the existing tracker with no further wiring. The two cache figures stay flat the way the CLI reports them — **cache savings are still invisible on this provider**, which is the next PR, not a silent re-shaping here.
- `temperature` and `max_tokens` are accepted and dropped rather than faked. The CLI has no flag for either; the model's own default cap is roomier than anything the pipeline asks for.

## Verification

`pytest apps/backend/tests` — **772 passed** (+22 over the baseline). `black` clean; `flake8` clean apart from the three pre-existing E402 in `test_cors_error_responses.py`.

Still off by default: with no Claude switch on, the transport is not consulted at all, and there is a test that fails loudly if it is.