### PR TITLE
Make a Claude run's cost receipt say something true

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
@@ -8,6 +8,7 @@ from app.shared.text import enforce_anti_ai_tells_markdown
 from utils import get_vertex_llm, parse_json_response
 
 from .config import DEFAULT_MODEL
+from .pricing import MEASURED_COST_KEY
 from .support import _safe_str
 
 logger = logging.getLogger(__name__)
@@ -34,12 +35,28 @@ def _invoke_text_llm(
     if usage_recorder is not None:
         usage_recorder(
             str(getattr(llm, "model_name", resolved_model)),
-            getattr(llm, "last_usage_metadata", None),
+            _usage_with_measured_cost(llm),
         )
     text = _safe_str(result)
     if not text:
         raise RuntimeError("LLM returned empty response")
     return text
+
+
+def _usage_with_measured_cost(llm: Any) -> Any:
+    """Token counts, plus a per-call price when the provider reported one.
+
+    Only the subscription CLI does; Vertex and the Anthropic API report tokens
+    and leave costing to the rate table. Folded into the usage dict rather than
+    threaded through a new recorder argument, so every existing recorder --
+    including the test doubles that take exactly two positionals -- keeps
+    working untouched.
+    """
+    usage = getattr(llm, "last_usage_metadata", None)
+    cost = getattr(llm, "last_cost_usd", None)
+    if cost is None or not isinstance(usage, dict):
+        return usage
+    return {**usage, MEASURED_COST_KEY: cost}
 
 
 def _enforce_anti_ai_markdown_with_model(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -71,9 +71,7 @@ def normalize_token_usage(value: Any) -> dict[str, int] | None:
             reasoning_tokens,
             _usage_value(value, "thoughts_token_count"),
         )
-        output_tokens = (
-            _usage_value(value, "candidates_token_count") + reasoning_tokens
-        )
+        output_tokens = _usage_value(value, "candidates_token_count") + reasoning_tokens
     total_tokens = _usage_value(value, "total_tokens", "total_token_count")
     input_details = value.get("input_token_details")
     cached_input_tokens = 0
@@ -87,6 +85,19 @@ def normalize_token_usage(value: Any) -> dict[str, int] | None:
         cached_input_tokens,
         _usage_value(value, "cached_input_tokens", "cached_content_token_count"),
     )
+    # Anthropic reports the two cache figures flat and alongside, and its
+    # `input_tokens` counts only the uncached remainder. Google reports
+    # `input_tokens` gross with the cached share nested under
+    # `input_token_details`. Reading only the nested shape left every Claude
+    # call looking as though it had cached nothing -- the totals were right, the
+    # savings were invisible -- and the clamp at the end of this function then
+    # discarded the figure anyway, because a net input count is smaller than
+    # the cache read it excludes.
+    cache_read = _usage_value(value, "cache_read_input_tokens")
+    cache_creation = _usage_value(value, "cache_creation_input_tokens")
+    if cache_read or cache_creation:
+        input_tokens += cache_read + cache_creation
+        cached_input_tokens = max(cached_input_tokens, cache_read)
     if not total_tokens:
         total_tokens = input_tokens + output_tokens
     if not input_tokens and not output_tokens and not total_tokens:
@@ -101,6 +112,32 @@ def normalize_token_usage(value: Any) -> dict[str, int] | None:
         "cached_input_tokens": min(cached_input_tokens, input_tokens),
         "total_tokens": total_tokens,
     }
+
+
+# What a recorded price is, once there is more than one kind.
+COST_BASIS_MEASURED = "measured"
+COST_BASIS_RATE_TABLE = "rate-table"
+
+# Set by app/features/prompt2blog/llm.py when the provider reported a price for
+# the call it just made. Only the subscription CLI does.
+MEASURED_COST_KEY = "measured_cost_usd"
+
+
+def _measured_cost(raw_usage: Any) -> float | None:
+    """A price the provider reported for this exact call, if it reported one.
+
+    Worth preferring over the rate table because it is not an estimate: it is
+    what the transport says the call came to. It is still not money leaving an
+    account -- subscription calls draw plan allowance rather than billing per
+    token -- so it is a notional API-equivalent figure. That distinction belongs
+    in what the UI says about the number, not in whether the number is recorded.
+    """
+    if not isinstance(raw_usage, dict):
+        return None
+    value = raw_usage.get(MEASURED_COST_KEY)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value >= 0 else None
 
 
 def _estimated_cost(
@@ -148,6 +185,37 @@ TOKEN_KEYS = (
 STAGE_USAGE_KEYS = TOKEN_KEYS + ("calls",)
 
 
+RATE_TABLE_NOTE = (
+    "Standard global Vertex rates checked 2026-08-24; Gemini 3.7 "
+    "Flash introductory pricing ends 2026-12-31."
+)
+
+# Subscription calls draw the plan holder's allowance rather than billing per
+# token, so the CLI's per-call figure is a notional API-equivalent price, not a
+# charge. Saying so is the whole point of carrying the basis around: the number
+# is real and worth comparing between stacks, and it is not a bill.
+MEASURED_COST_NOTE = (
+    "Claude figures are the per-call price the Claude Code CLI reported. Those "
+    "calls draw your subscription's allowance rather than billing per token, so "
+    "the amount is a comparable estimate of what the same work would cost at "
+    "API rates -- not a charge."
+)
+
+
+def _cost_basis(bases: set[str]) -> str | None:
+    if not bases:
+        return None
+    if len(bases) == 1:
+        return next(iter(bases))
+    return "mixed"
+
+
+def _pricing_note(measured_models: int) -> str:
+    if measured_models:
+        return f"{RATE_TABLE_NOTE} {MEASURED_COST_NOTE}"
+    return RATE_TABLE_NOTE
+
+
 @dataclass
 class Prompt2BlogTokenUsageTracker:
     successful_calls: int = 0
@@ -173,6 +241,7 @@ class Prompt2BlogTokenUsageTracker:
         usage = normalize_token_usage(raw_usage)
         if usage is None:
             return
+        measured_cost = _measured_cost(raw_usage)
         self.measured_calls += 1
         totals = self.by_model.setdefault(
             model_name,
@@ -185,6 +254,7 @@ class Prompt2BlogTokenUsageTracker:
                 "calls": 0,
                 "estimated_cost_usd": 0.0,
                 "unpriced_calls": 0,
+                "cost_bases": set(),
             },
         )
         totals["calls"] += 1
@@ -196,16 +266,22 @@ class Prompt2BlogTokenUsageTracker:
             "total_tokens",
         ):
             totals[key] += usage[key]
-        call_cost = _estimated_cost(
-            model_name=model_name,
-            input_tokens=usage["input_tokens"],
-            output_tokens=usage["output_tokens"],
-            cached_input_tokens=usage["cached_input_tokens"],
-        )
+        if measured_cost is not None:
+            call_cost: float | None = measured_cost
+            basis = COST_BASIS_MEASURED
+        else:
+            call_cost = _estimated_cost(
+                model_name=model_name,
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+                cached_input_tokens=usage["cached_input_tokens"],
+            )
+            basis = COST_BASIS_RATE_TABLE
         if call_cost is None:
             totals["unpriced_calls"] += 1
         else:
             totals["estimated_cost_usd"] += call_cost
+            totals["cost_bases"].add(basis)
 
     def summary(
         self,
@@ -215,6 +291,7 @@ class Prompt2BlogTokenUsageTracker:
         writing_model: str,
         audit_model: str,
     ) -> dict[str, Any]:
+        measured_models = 0
         input_tokens = sum(item["input_tokens"] for item in self.by_model.values())
         output_tokens = sum(item["output_tokens"] for item in self.by_model.values())
         reasoning_tokens = sum(
@@ -250,8 +327,13 @@ class Prompt2BlogTokenUsageTracker:
                     "estimated_cost_usd": (
                         round(model_cost, 6) if not usage["unpriced_calls"] else None
                     ),
+                    # Where the figure came from, so a reader can tell a rate
+                    # table applied to token counts from a price the provider
+                    # reported for the call it made.
+                    "cost_basis": _cost_basis(usage["cost_bases"]),
                 }
             )
+            measured_models += 1 if COST_BASIS_MEASURED in usage["cost_bases"] else 0
         # Sorted by spend so the stages worth capping or de-thinking are the
         # ones read first.
         stage_rows = [
@@ -290,8 +372,5 @@ class Prompt2BlogTokenUsageTracker:
             "currency": "USD",
             "by_model": model_rows,
             "by_stage": stage_rows,
-            "pricing_note": (
-                "Standard global Vertex rates checked 2026-08-24; Gemini 3.7 "
-                "Flash introductory pricing ends 2026-12-31."
-            ),
+            "pricing_note": _pricing_note(measured_models),
         }

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_llm_provider.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_llm_provider.py
@@ -204,8 +204,13 @@ def test_usage_lands_in_the_shape_the_token_tracker_reads(
         "cache_read_input_tokens": 8741,
         "cache_creation_input_tokens": 2729,
     }
+    # The transport's `input_tokens` counts only the uncached remainder, so the
+    # normalizer folds the two cache figures back in to get the real prompt
+    # size. 10 was never the input count -- it was what was not served from
+    # cache.
     normalized = normalize_token_usage(llm.last_usage_metadata)
-    assert normalized["input_tokens"] == 10
+    assert normalized["input_tokens"] == 11_480
+    assert normalized["cached_input_tokens"] == 8_741
     assert normalized["output_tokens"] == 503
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
@@ -208,12 +208,15 @@ def test_default_prompt2blog_llm_records_each_successful_call(monkeypatch):
     )
     llm = DefaultPrompt2BlogLLM()
 
-    assert llm.invoke_text(
-        prompt="Write",
-        max_tokens=2048,
-        temperature=0.2,
-        model_name="gemini-3.7-flash",
-    ) == "Article"
+    assert (
+        llm.invoke_text(
+            prompt="Write",
+            max_tokens=2048,
+            temperature=0.2,
+            model_name="gemini-3.7-flash",
+        )
+        == "Article"
+    )
     summary = llm.usage_summary(
         stack_id="balanced",
         worker_model="gemini-3.7-flash",
@@ -244,3 +247,210 @@ def test_a_run_with_no_reported_usage_is_unavailable_not_free():
     assert summary["measured_calls"] == 0
     assert summary["by_model"] == []
     assert summary["by_stage"] == []
+
+
+def test_anthropic_cache_reads_are_visible_instead_of_being_clamped_away():
+    """Anthropic and Google report cached input in different shapes.
+
+    Google nests the cached share under `input_token_details` and counts
+    `input_tokens` gross. Anthropic reports the two cache figures flat and
+    alongside, and its `input_tokens` counts only the uncached remainder.
+    Reading only the nested shape left every Claude call looking as though it
+    had cached nothing -- and the clamp at the end of normalize_token_usage
+    then discarded the figure anyway, because a net input count is smaller than
+    the cache read it excludes.
+    """
+    usage = normalize_token_usage(
+        {
+            "input_tokens": 10,
+            "output_tokens": 503,
+            "cache_read_input_tokens": 8741,
+            "cache_creation_input_tokens": 2729,
+        }
+    )
+
+    # The prompt really was 11480 tokens; 10 was only the part not served from
+    # cache, and reporting that as the input count understated the call by 1000x.
+    assert usage["input_tokens"] == 11_480
+    assert usage["cached_input_tokens"] == 8_741
+    assert usage["output_tokens"] == 503
+
+
+def test_google_shaped_cache_reporting_is_unchanged():
+    usage = normalize_token_usage(
+        {
+            "input_tokens": 11_480,
+            "output_tokens": 503,
+            "input_token_details": {"cache_read": 8_741},
+        }
+    )
+
+    assert usage["input_tokens"] == 11_480
+    assert usage["cached_input_tokens"] == 8_741
+
+
+def test_a_price_the_provider_measured_beats_the_rate_table():
+    """Claude has no dollar-per-million rate and cannot have one.
+
+    Without this its calls landed in `unpriced_calls`, which made the whole run
+    read as partially priced and blanked the run's cost even though the
+    transport had reported an exact figure for every call it made.
+    """
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.record(
+        "claude-sonnet-5",
+        {"input_tokens": 10, "output_tokens": 503, "measured_cost_usd": 0.0099},
+    )
+    tracker.record(
+        "claude-sonnet-5",
+        {"input_tokens": 12, "output_tokens": 640, "measured_cost_usd": 0.0101},
+    )
+
+    summary = tracker.summary(
+        stack_id="opus-balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="claude-sonnet-5",
+        audit_model="gemini-3.7-flash",
+    )
+
+    assert summary["measurement_status"] == "complete"
+    assert summary["estimated_cost_usd"] == 0.02
+    row = summary["by_model"][0]
+    assert row["cost_basis"] == "measured"
+    assert row["estimated_cost_usd"] == 0.02
+    # The number is real and comparable between stacks. It is not a charge, and
+    # the note has to say so.
+    assert "not a charge" in summary["pricing_note"]
+
+
+def test_a_mixed_run_prices_each_model_by_its_own_basis():
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.record(
+        "claude-sonnet-5",
+        {"input_tokens": 10, "output_tokens": 503, "measured_cost_usd": 0.0099},
+    )
+    tracker.record("gemini-3.7-flash", {"input_tokens": 1_000, "output_tokens": 200})
+
+    summary = tracker.summary(
+        stack_id="sonnet-balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="claude-sonnet-5",
+        audit_model="gemini-3.7-flash",
+    )
+
+    bases = {row["model"]: row["cost_basis"] for row in summary["by_model"]}
+    assert bases == {
+        "claude-sonnet-5": "measured",
+        "gemini-3.7-flash": "rate-table",
+    }
+    assert summary["measurement_status"] == "complete"
+    assert summary["estimated_cost_usd"] == round(0.0099 + 0.00150, 6)
+
+
+def test_a_gemini_only_run_keeps_the_rate_table_note_alone():
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.record("gemini-3.7-flash", {"input_tokens": 1_000, "output_tokens": 200})
+
+    summary = tracker.summary(
+        stack_id="balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="gemini-3.7-flash",
+        audit_model="gemini-3.7-flash",
+    )
+
+    assert "not a charge" not in summary["pricing_note"]
+
+
+def test_a_nonsense_measured_cost_falls_back_to_the_rate_table():
+    tracker = Prompt2BlogTokenUsageTracker()
+    for bad in (True, "0.01", None, -1):
+        tracker.record(
+            "gemini-3.7-flash",
+            {"input_tokens": 1_000, "output_tokens": 200, "measured_cost_usd": bad},
+        )
+
+    summary = tracker.summary(
+        stack_id="balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="gemini-3.7-flash",
+        audit_model="gemini-3.7-flash",
+    )
+
+    assert summary["by_model"][0]["cost_basis"] == "rate-table"
+
+
+def test_a_provider_reported_price_reaches_the_tracker(monkeypatch):
+    """End to end through the seam, not just the tracker in isolation.
+
+    The subscription CLI is the only provider that reports a per-call price,
+    and it arrives on the LLM object rather than in the usage metadata, so the
+    invocation seam has to fold the two together. Without that the figure
+    exists and never reaches the receipt.
+    """
+
+    class FakeCliLLM:
+        model_name = "claude-sonnet-5"
+        last_usage_metadata = {
+            "input_tokens": 10,
+            "output_tokens": 503,
+            "cache_read_input_tokens": 8_741,
+            "cache_creation_input_tokens": 2_729,
+        }
+        last_cost_usd = 0.0099
+
+        def invoke(self, prompt):  # noqa: ANN001
+            return "Article"
+
+    monkeypatch.setattr(
+        prompt2blog_llm,
+        "get_vertex_llm",
+        lambda **kwargs: FakeCliLLM(),
+    )
+    llm = DefaultPrompt2BlogLLM()
+    llm.invoke_text(
+        prompt="Write",
+        max_tokens=2048,
+        temperature=0.2,
+        model_name="claude-sonnet-5",
+    )
+
+    summary = llm.usage_summary(
+        stack_id="sonnet-balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="claude-sonnet-5",
+        audit_model="gemini-3.7-flash",
+    )
+
+    assert summary["estimated_cost_usd"] == 0.0099
+    assert summary["by_model"][0]["cost_basis"] == "measured"
+    # The cache read is visible rather than clamped away, which is the whole
+    # reason the fixed prompt prefix was worth designing for.
+    assert summary["cached_input_tokens"] == 8_741
+    assert summary["input_tokens"] == 11_480
+
+
+def test_a_provider_without_a_price_is_unaffected_by_the_fold(monkeypatch):
+    class FakeLLM:
+        model_name = "gemini-3.7-flash"
+        last_usage_metadata = {"input_tokens": 400, "output_tokens": 100}
+
+        def invoke(self, prompt):  # noqa: ANN001
+            return "Article"
+
+    monkeypatch.setattr(prompt2blog_llm, "get_vertex_llm", lambda **kwargs: FakeLLM())
+    llm = DefaultPrompt2BlogLLM()
+    llm.invoke_text(
+        prompt="Write",
+        max_tokens=2048,
+        temperature=0.2,
+        model_name="gemini-3.7-flash",
+    )
+
+    summary = llm.usage_summary(
+        stack_id="balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="gemini-3.7-flash",
+        audit_model="gemini-3.7-flash",
+    )
+
+    assert summary["by_model"][0]["cost_basis"] == "rate-table"


### PR DESCRIPTION
Phase 2, backend half. Two things the tracker recorded wrongly for a subscription call.

## 1. Cache reads were invisible

`normalize_token_usage` looked for the cached share nested under `input_token_details` — Google's shape. Anthropic reports the two cache figures **flat and alongside**, and its `input_tokens` counts **only the uncached remainder**.

So a call like this:

```json
{"input_tokens": 10, "output_tokens": 503,
 "cache_read_input_tokens": 8741, "cache_creation_input_tokens": 2729}
```

…was recorded as **10 input tokens, nothing cached**. The prompt was really 11,480 tokens. And the clamp at the end of the function then discarded the cache figure anyway, because a net input count is smaller than the cache read it excludes.

Both shapes are read now. The totals were always right — the *savings* were the part that did not exist, which matters because the fixed prompt prefix in `cli_writer` was designed specifically to earn them.

## 2. Claude calls were unpriced

There is no dollar-per-million rate for Claude and there cannot be one. So every call fell into `unpriced_calls`, which made the whole run read as partially priced and **blanked its cost** — while the transport had reported an exact figure for every call it made.

A price the provider measured now beats the rate table, and each model row carries a `cost_basis` (`measured` / `rate-table` / `mixed`) so a reader can tell the two apart.

**That figure is not a charge.** Subscription calls draw the plan holder's allowance rather than billing per token, so it is a comparable estimate of what the same work would cost at API rates. `pricing_note` says so — but only on a run that actually had one.

## Design note

The price arrives on the LLM object (`last_cost_usd`) rather than in the usage metadata, so the invocation seam folds the two together. Folded rather than threaded through a new recorder argument, so every existing recorder — including the test doubles that take exactly two positionals — keeps working untouched.

## Verification

`pytest apps/backend/tests` — **780 passed**. `black` + `flake8` clean apart from the three pre-existing E402 in `test_cors_error_responses.py`.

One existing assertion changed: `test_usage_lands_in_the_shape_the_token_tracker_reads` asserted `input_tokens == 10`. That was the bug, not the contract; it now asserts 11,480 with the reason written down.