### PR TITLE
Stop the stack price panel throwing on a model with no rate

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
@@ -6,6 +6,8 @@ import {
 import {
   estimatePrompt2BlogStackPrice,
   formatPerMillionRate,
+  isPlanAllowanceModel,
+  PROMPT2BLOG_ROLE_LABELS,
 } from '../../constants/prompt2blog-pricing'
 import { Panel } from './Panel'
 
@@ -18,6 +20,9 @@ interface ModelRoutingPanelProps {
 export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
   const selectedStack = resolvePrompt2BlogModelStack(props.modelStackId)
   const priceEstimate = estimatePrompt2BlogStackPrice(selectedStack)
+  const planRoleNames = priceEstimate.planRoles
+    .map(role => PROMPT2BLOG_ROLE_LABELS[role])
+    .join(' and ')
 
   return <Panel
     title="Run Stack"
@@ -46,11 +51,24 @@ export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
       aria-label={`${selectedStack.label} estimated pricing`}
       aria-live="polite"
     >
-      <div className="p2b-stack-cost-headline">
-        <span>Estimated blended rate</span>
-        <strong>{formatPerMillionRate(priceEstimate.mixedPerMillion)}</strong>
-        <span>per 1M mixed tokens</span>
-      </div>
+      {priceEstimate.mixedPerMillion === null ? (
+        <div className="p2b-stack-cost-headline p2b-stack-cost-headline--plan">
+          <strong>Included in your Claude plan</strong>
+          <span>no per-token rate</span>
+        </div>
+      ) : (
+        <div className="p2b-stack-cost-headline">
+          <span>{planRoleNames ? 'Metered part' : 'Estimated blended rate'}</span>
+          <strong>{formatPerMillionRate(priceEstimate.mixedPerMillion)}</strong>
+          <span>per 1M mixed tokens</span>
+        </div>
+      )}
+      {planRoleNames ? (
+        <p className="p2b-stack-cost-plan">
+          {planRoleNames} runs on your Claude plan, so it draws plan usage
+          instead of billing per token. The rate above covers the rest.
+        </p>
+      ) : null}
       <div className="p2b-stack-cost-breakdown">
         <span>Input {formatPerMillionRate(priceEstimate.inputPerMillion)} / 1M</span>
         <span>Output {formatPerMillionRate(priceEstimate.outputPerMillion)} / 1M</span>
@@ -67,23 +85,29 @@ export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
           Standard global Vertex rates checked August 24, 2026. Gemini 3.7 Flash
           introductory pricing ends December 31, 2026.
         </p>
+        <p>
+          Claude roles are left out of the rate rather than given an invented
+          one. Subscription calls draw your plan's allowance, so there is no
+          dollar-per-million figure to quote. What a run actually used shows on
+          the finished article's cost receipt.
+        </p>
       </details>
     </div>
     <details className="p2b-stack-details">
       <summary>See model assignments</summary>
       <div className="p2b-stack-receipt" aria-label={`${selectedStack.label} model assignments`}>
         <StackAssignment
-          label="Research worker"
+          label={PROMPT2BLOG_ROLE_LABELS.modelName}
           model={selectedStack.modelName}
           stages="Cleanup · synthesis · coverage · gap filling"
         />
         <StackAssignment
-          label="Article writer"
+          label={PROMPT2BLOG_ROLE_LABELS.writingModel}
           model={selectedStack.writingModel}
           stages="Outline · draft · repair · extras · title"
         />
         <StackAssignment
-          label="Quality judge"
+          label={PROMPT2BLOG_ROLE_LABELS.auditModel}
           model={selectedStack.auditModel}
           stages="Groundedness · quality audit"
         />
@@ -109,6 +133,14 @@ function StackAssignment({
 }
 
 function formatModelName(model: string): string {
+  if (isPlanAllowanceModel(model)) {
+    return model
+      .replace('claude-', 'Claude ')
+      .replace(/-/g, ' ')
+      .replace(' opus', ' Opus')
+      .replace(' sonnet', ' Sonnet')
+      .replace(' haiku', ' Haiku')
+  }
   return model
     .replace('gemini-', 'Gemini ')
     .replace(/-/g, ' ')

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.test.ts
@@ -3,11 +3,17 @@ import { PROMPT2BLOG_MODEL_STACKS } from './prompt2blog.constants'
 import {
   estimatePrompt2BlogStackPrice,
   formatPerMillionRate,
+  isPlanAllowanceModel,
+  type Prompt2BlogModelStackShape,
 } from './prompt2blog-pricing'
 
+const METERED_STACKS = PROMPT2BLOG_MODEL_STACKS.filter(stack =>
+  estimatePrompt2BlogStackPrice(stack).planRoles.length === 0,
+)
+
 describe('estimatePrompt2BlogStackPrice', () => {
-  it('calculates price-ordered blended rates for every stack', () => {
-    expect(PROMPT2BLOG_MODEL_STACKS.map(stack => (
+  it('calculates price-ordered blended rates for every fully metered stack', () => {
+    expect(METERED_STACKS.map(stack => (
       formatPerMillionRate(estimatePrompt2BlogStackPrice(stack).mixedPerMillion)
     ))).toEqual(['$4.00', '$3.04', '$2.55', '$1.35', '$1.04', '$0.50'])
   })
@@ -21,5 +27,53 @@ describe('estimatePrompt2BlogStackPrice', () => {
 
     expect(formatPerMillionRate(estimate.inputPerMillion)).toBe('$1.32')
     expect(formatPerMillionRate(estimate.outputPerMillion)).toBe('$7.50')
+  })
+
+  // The estimator used to throw on any model with no rate, which crashed the
+  // whole routing panel over a price label. The loud failure moved here, where
+  // it belongs: a registered stack naming a metered model with no recorded rate
+  // fails this test rather than the app.
+  it('has a recorded rate for every metered model on every registered stack', () => {
+    for (const stack of PROMPT2BLOG_MODEL_STACKS) {
+      expect(estimatePrompt2BlogStackPrice(stack).unratedRoles).toEqual([])
+    }
+  })
+
+  it('quotes no rate for a Claude role rather than inventing one', () => {
+    // Claude calls draw a plan allowance, so there is no dollar-per-million
+    // figure that could be quoted honestly.
+    const claudeWriter: Prompt2BlogModelStackShape = {
+      modelName: 'gemini-3.7-flash',
+      writingModel: 'claude-opus-4-8',
+      auditModel: 'gemini-3.7-flash',
+    }
+
+    const estimate = estimatePrompt2BlogStackPrice(claudeWriter)
+
+    expect(estimate.planRoles).toEqual(['writingModel'])
+    expect(estimate.unratedRoles).toEqual([])
+    // Averaged over the roles that are metered, not diluted by treating the
+    // unpriced writer as free.
+    expect(formatPerMillionRate(estimate.inputPerMillion)).toBe('$0.75')
+    expect(formatPerMillionRate(estimate.outputPerMillion)).toBe('$3.75')
+  })
+
+  it('reports no rate at all when every role is on the plan', () => {
+    const allClaude: Prompt2BlogModelStackShape = {
+      modelName: 'claude-sonnet-5',
+      writingModel: 'claude-opus-4-8',
+      auditModel: 'claude-sonnet-5',
+    }
+
+    const estimate = estimatePrompt2BlogStackPrice(allClaude)
+
+    expect(estimate.mixedPerMillion).toBeNull()
+    expect(formatPerMillionRate(estimate.mixedPerMillion)).toBe('—')
+    expect(estimate.planRoles).toHaveLength(3)
+  })
+
+  it('does not mistake a Gemini model for a plan model', () => {
+    expect(isPlanAllowanceModel('gemini-3.7-flash')).toBe(false)
+    expect(isPlanAllowanceModel('claude-opus-4-8')).toBe(true)
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.ts
@@ -1,14 +1,40 @@
-import type { Prompt2BlogModelStack } from './prompt2blog.constants'
-
 interface VertexTokenRate {
   input: number
   output: number
 }
 
+export type Prompt2BlogRoleKey = 'modelName' | 'writingModel' | 'auditModel'
+
+/**
+ * Just the three role assignments. Narrower than `Prompt2BlogModelStack` on
+ * purpose: pricing reads model names and nothing else, and the role unions
+ * differ per role (only the writer union carries Claude names today), so a
+ * plain string map is what this function actually needs.
+ */
+export type Prompt2BlogModelStackShape = Record<Prompt2BlogRoleKey, string>
+
 export interface Prompt2BlogStackPriceEstimate {
-  mixedPerMillion: number
-  inputPerMillion: number
-  outputPerMillion: number
+  /**
+   * Blended $/1M across the roles that have a per-token rate. Null when no role
+   * on the stack has one, which is the honest answer rather than zero.
+   */
+  mixedPerMillion: number | null
+  inputPerMillion: number | null
+  outputPerMillion: number | null
+  /**
+   * Roles served out of a Claude plan allowance. These cannot have a
+   * $/1M rate — the calls draw plan usage rather than billing per token — so
+   * inventing one would be a fabricated number, not an estimate.
+   */
+  planRoles: Prompt2BlogRoleKey[]
+  /**
+   * Roles on a metered model that has no rate recorded here. Always empty in
+   * practice; a stack that lands one is a missing table entry, and
+   * `prompt2blog-pricing.test.ts` fails on it. It is a list rather than a throw
+   * because the alternative was crashing the whole routing panel over a price
+   * label.
+   */
+  unratedRoles: Prompt2BlogRoleKey[]
 }
 
 // Standard global PayGo rates in USD per 1M tokens, checked 2026-08-24.
@@ -19,42 +45,76 @@ const VERTEX_TOKEN_RATES: Record<string, VertexTokenRate> = {
   'gemini-3.1-flash-lite': { input: 0.25, output: 1.5 },
 }
 
-const ROLE_WEIGHTS = [
+const ROLE_WEIGHTS: ReadonlyArray<{ key: Prompt2BlogRoleKey; weight: number }> = [
   { key: 'modelName', weight: 4 },
   { key: 'writingModel', weight: 5 },
   { key: 'auditModel', weight: 2 },
 ] as const
 
+export const PROMPT2BLOG_ROLE_LABELS: Record<Prompt2BlogRoleKey, string> = {
+  modelName: 'Research worker',
+  writingModel: 'Article writer',
+  auditModel: 'Quality judge',
+}
+
 const INPUT_TOKEN_SHARE = 0.8
 const OUTPUT_TOKEN_SHARE = 1 - INPUT_TOKEN_SHARE
 
+export function isPlanAllowanceModel(model: string): boolean {
+  return model.toLowerCase().startsWith('claude')
+}
+
 export function estimatePrompt2BlogStackPrice(
-  stack: Prompt2BlogModelStack,
+  stack: Prompt2BlogModelStackShape,
 ): Prompt2BlogStackPriceEstimate {
-  const totalWeight = ROLE_WEIGHTS.reduce((sum, role) => sum + role.weight, 0)
-  const blended = ROLE_WEIGHTS.reduce(
-    (total, role) => {
-      const model = stack[role.key]
-      const rate = VERTEX_TOKEN_RATES[model]
-      if (!rate) throw new Error(`Missing Vertex pricing for ${model}`)
-      return {
-        input: total.input + rate.input * role.weight,
-        output: total.output + rate.output * role.weight,
-      }
-    },
-    { input: 0, output: 0 },
-  )
-  const inputPerMillion = blended.input / totalWeight
-  const outputPerMillion = blended.output / totalWeight
+  const planRoles: Prompt2BlogRoleKey[] = []
+  const unratedRoles: Prompt2BlogRoleKey[] = []
+  let meteredWeight = 0
+  let input = 0
+  let output = 0
+
+  for (const role of ROLE_WEIGHTS) {
+    const model = stack[role.key]
+    if (isPlanAllowanceModel(model)) {
+      planRoles.push(role.key)
+      continue
+    }
+    const rate = VERTEX_TOKEN_RATES[model]
+    if (!rate) {
+      unratedRoles.push(role.key)
+      continue
+    }
+    meteredWeight += role.weight
+    input += rate.input * role.weight
+    output += rate.output * role.weight
+  }
+
+  // Averaged over the metered roles only. On an all-Gemini stack that is every
+  // role, so those numbers are unchanged; on a mixed stack it answers "what do
+  // the metered parts cost" rather than diluting them with a zero.
+  if (meteredWeight === 0) {
+    return {
+      mixedPerMillion: null,
+      inputPerMillion: null,
+      outputPerMillion: null,
+      planRoles,
+      unratedRoles,
+    }
+  }
+
+  const inputPerMillion = input / meteredWeight
+  const outputPerMillion = output / meteredWeight
 
   return {
     inputPerMillion,
     outputPerMillion,
     mixedPerMillion:
       inputPerMillion * INPUT_TOKEN_SHARE + outputPerMillion * OUTPUT_TOKEN_SHARE,
+    planRoles,
+    unratedRoles,
   }
 }
 
-export function formatPerMillionRate(value: number): string {
-  return `$${value.toFixed(2)}`
+export function formatPerMillionRate(value: number | null): string {
+  return value === null ? '—' : `$${value.toFixed(2)}`
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
@@ -121,6 +121,20 @@
   line-height: 1;
 }
 
+/* A plan-served stack has a phrase where the others have a dollar figure, and
+   the display-size numeral treatment reads as shouting on a sentence. */
+.p2b-stack-cost-headline--plan strong {
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+.p2b-stack-cost-plan {
+  margin-top: var(--space-2);
+  color: var(--ink-light);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
 .p2b-stack-cost-breakdown {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Phase 2, frontend half. Unblocks registering a Claude stack.

## The bug

`estimatePrompt2BlogStackPrice` threw for any model missing from the Vertex rate table:

```ts
if (!rate) throw new Error(`Missing Vertex pricing for ${model}`)
```

and `ModelRoutingPanel` calls it **on render**. So registering a stack whose writer draws a Claude plan allowance would crash the whole routing panel over a price label — and Claude cannot have a dollar-per-million rate, because those calls draw plan usage rather than billing per token.

## The change

Roles served by a plan are **reported rather than priced**. The blended rate is averaged over the metered roles only, so a mixed stack answers "what do the metered parts cost" instead of diluting them by treating the unpriced writer as free. On an all-Gemini stack every role is metered and **the numbers are unchanged** — the existing ordered-rate assertion still passes verbatim. A stack with no metered role at all reports no rate rather than zero.

## The loud failure moved, it did not disappear

A registered stack naming a *metered* model with no recorded rate now fails `prompt2blog-pricing.test.ts` rather than the app. That is where a missing table entry belongs — at dev time, not in the user's face.

## Panel

Says **"Included in your Claude plan"** where a plan-served stack would have had a dollar figure, at sentence size rather than in the display-numeral treatment (a 2.6rem phrase reads as shouting), and names which roles the rate does not cover. The method disclosure explains why Claude roles are left out of the rate rather than given an invented one.

## Small refactors carried along

- The estimator takes the three role assignments rather than a whole stack. It reads model names and nothing else, and the role unions differ per role — only the writer union carries Claude names today — so a plain string map is what it actually needs, and tests can build a fixture without inventing a stack id.
- Role labels come from one exported map instead of being written twice in the panel.

## Verification

`vitest` on the pricing suite — 6 passed. `tsc --noEmit` clean.