### PR TITLE
Add six Claude-writer run stacks to Prompt2Blog

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/shared/writer_models.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/writer_models.py
@@ -2,15 +2,20 @@
 
 The writing stages (compose / editorial augmentation) historically ran on a
 pinned Claude model. These constants make that choice a per-run option shared
-by every blog pipeline. Names route via the existing provider dispatch:
-claude-* -> Anthropic, gemini-* -> Vertex.
+by every blog pipeline. Names route via the existing provider dispatch in
+utils.get_vertex_llm: gemini-* to Vertex, claude-* to whichever Claude path is
+switched on.
 """
 
-# Anthropic billing is exhausted. The Claude names stay valid selections so
-# saved runs and existing clients keep working, but utils.resolve_effective_model
-# transparently serves them with a Google model. Restore by setting
-# ANTHROPIC_MODELS_ENABLED=1 and flipping DEFAULT_WRITER_MODEL back.
+# These are always valid selections, so saved runs and existing clients keep
+# working. What actually serves them is decided further down, by
+# utils.resolve_effective_model: with neither Claude path switched on they are
+# transparently served by a Google model, with ANTHROPIC_MODELS_ENABLED=1 they
+# go to the Anthropic API, and with CLAUDE_SUBSCRIPTION_MODELS_ENABLED=1 they go
+# to the Claude Code CLI on this machine. Being on this list is permission to
+# ask for a name, not a claim about which transport answers.
 CLAUDE_WRITER_MODELS = (
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-5",

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
@@ -1,5 +1,7 @@
 import {
   PROMPT2BLOG_MODEL_STACKS,
+  PROMPT2BLOG_STACK_FAMILY_LABELS,
+  PROMPT2BLOG_STACK_FAMILY_ORDER,
   resolvePrompt2BlogModelStack,
   type Prompt2BlogModelStackId,
 } from '../../constants/prompt2blog.constants'
@@ -26,7 +28,7 @@ export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
 
   return <Panel
     title="Run Stack"
-    description="Select one option. Quality-first appears first; fastest appears last."
+    description="Select one option. Within each group, quality-first appears first and fastest appears last."
     onClear={props.onClear}
   >
     <div className="p2b-field p2b-stack-picker">
@@ -37,12 +39,20 @@ export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
         value={selectedStack.id}
         onChange={event => props.onChange(event.target.value as Prompt2BlogModelStackId)}
       >
-        {PROMPT2BLOG_MODEL_STACKS.map(stack => (
-          <option key={stack.id} value={stack.id}>
-            {stack.priceTier} · {stack.label}
-            {stack.label === stack.speedTier ? '' : ` · ${stack.speedTier}`}
-          </option>
-        ))}
+        {PROMPT2BLOG_STACK_FAMILY_ORDER.map(family => {
+          const stacks = PROMPT2BLOG_MODEL_STACKS.filter(
+            stack => stack.family === family,
+          )
+          if (stacks.length === 0) return null
+          return <optgroup key={family} label={PROMPT2BLOG_STACK_FAMILY_LABELS[family]}>
+            {stacks.map(stack => (
+              <option key={stack.id} value={stack.id}>
+                {stack.priceTier} · {stack.label}
+                {stack.label === stack.speedTier ? '' : ` · ${stack.speedTier}`}
+              </option>
+            ))}
+          </optgroup>
+        })}
       </select>
       <p className="p2b-stack-description">{selectedStack.description}</p>
     </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-stacks.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-stacks.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PROMPT2BLOG_MODEL_STACKS,
+  PROMPT2BLOG_STACK_FAMILY_ORDER,
+  PROMPT2BLOG_WRITER_MODEL_OPTIONS,
+  resolvePrompt2BlogModelStack,
+  resolvePrompt2BlogWriterModel,
+} from './prompt2blog.constants'
+import { isPlanAllowanceModel } from './prompt2blog-pricing'
+
+const CLAUDE_STACKS = PROMPT2BLOG_MODEL_STACKS.filter(
+  stack => stack.family === 'claude-writer',
+)
+
+describe('Claude-writer run stacks', () => {
+  it('is a 2x3 grid: two writers across three research tiers', () => {
+    // The grid shape is the point. Comparing two runs is only informative when
+    // exactly one thing differs between them, so every writer must appear
+    // against every research tier.
+    const grid = CLAUDE_STACKS.map(stack => [stack.writingModel, stack.modelName])
+
+    expect(grid).toEqual([
+      ['claude-opus-5', 'gemini-3.1-pro-preview'],
+      ['claude-opus-5', 'gemini-3.7-flash'],
+      ['claude-opus-5', 'gemini-3.1-flash-lite'],
+      ['claude-sonnet-5', 'gemini-3.1-pro-preview'],
+      ['claude-sonnet-5', 'gemini-3.7-flash'],
+      ['claude-sonnet-5', 'gemini-3.1-flash-lite'],
+    ])
+  })
+
+  it('never puts Claude on research or audit', () => {
+    // Not a UI convention. Claude writes and Gemini does the rest; a stack that
+    // quietly moved the grunt work onto the subscription would spend the
+    // owner's plan allowance on work it was never meant to do.
+    for (const stack of PROMPT2BLOG_MODEL_STACKS) {
+      expect(isPlanAllowanceModel(stack.modelName)).toBe(false)
+      expect(isPlanAllowanceModel(stack.auditModel)).toBe(false)
+    }
+  })
+
+  it('leaves the Gemini control group untouched', () => {
+    const gemini = PROMPT2BLOG_MODEL_STACKS.filter(stack => stack.family === 'gemini')
+
+    expect(gemini.map(stack => stack.id)).toEqual([
+      'maximum-quality',
+      'premium-review',
+      'editorial-premium',
+      'balanced',
+      'best-value',
+      'economy',
+    ])
+    expect(gemini.every(stack => !isPlanAllowanceModel(stack.writingModel))).toBe(true)
+  })
+
+  it('gives every stack a family the picker knows how to group', () => {
+    for (const stack of PROMPT2BLOG_MODEL_STACKS) {
+      expect(PROMPT2BLOG_STACK_FAMILY_ORDER).toContain(stack.family)
+    }
+  })
+
+  it('has a unique id per stack', () => {
+    const ids = PROMPT2BLOG_MODEL_STACKS.map(stack => stack.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    // resolvePrompt2BlogModelStack looks a stack up by id, so a duplicate would
+    // make one of them unreachable rather than fail loudly.
+    for (const id of ids) {
+      expect(resolvePrompt2BlogModelStack(id).id).toBe(id)
+    }
+  })
+
+  it('offers the writing models the stacks actually use', () => {
+    const offered = PROMPT2BLOG_WRITER_MODEL_OPTIONS.map(option => option.value)
+
+    for (const stack of CLAUDE_STACKS) {
+      expect(offered).toContain(stack.writingModel)
+      expect(resolvePrompt2BlogWriterModel(stack.writingModel)).toBe(stack.writingModel)
+    }
+  })
+
+  it('falls a stored selection back to the default rather than failing', () => {
+    // A run saved under one configuration has to still open under another.
+    expect(resolvePrompt2BlogWriterModel('claude-opus-4-8')).toBe(
+      'gemini-3.1-pro-preview',
+    )
+    expect(resolvePrompt2BlogWriterModel('not-a-model')).toBe('gemini-3.1-pro-preview')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
@@ -1,4 +1,7 @@
-import { CLAUDE_MODELS_ENABLED } from '../../../shared/api/ai/models'
+import {
+  CLAUDE_MODELS_ENABLED,
+  CLAUDE_SUBSCRIPTION_WRITER_ENABLED,
+} from '../../../shared/api/ai/models'
 import type { Prompt2BlogModelName, Prompt2BlogWriterModel } from '../types/pipeline.types'
 
 export const FEATURE_PREFIX = '/prompt2blog'
@@ -10,9 +13,30 @@ export type Prompt2BlogModelStackId =
   | 'balanced'
   | 'best-value'
   | 'economy'
+  | 'opus-max'
+  | 'opus-balanced'
+  | 'opus-lean'
+  | 'sonnet-max'
+  | 'sonnet-balanced'
+  | 'sonnet-lean'
+
+/**
+ * Which family a stack belongs to, so the picker can group them. The two are
+ * not points on one scale: an all-Gemini stack bills per token, and a
+ * Claude-writer stack pays for its writing out of the subscription, so sorting
+ * them into one price-ordered list would compare things that are not
+ * comparable.
+ */
+export type Prompt2BlogStackFamily = 'gemini' | 'claude-writer'
+
+export const PROMPT2BLOG_STACK_FAMILY_LABELS: Record<Prompt2BlogStackFamily, string> = {
+  gemini: 'Gemini — billed per token',
+  'claude-writer': 'Claude writes — included in your plan',
+}
 
 export interface Prompt2BlogModelStack {
   id: Prompt2BlogModelStackId
+  family: Prompt2BlogStackFamily
   label: string
   priceTier: string
   speedTier: 'Slowest' | 'Slow' | 'Moderate' | 'Fast' | 'Faster' | 'Fastest'
@@ -25,6 +49,7 @@ export interface Prompt2BlogModelStack {
 export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   {
     id: 'maximum-quality',
+    family: 'gemini',
     label: 'Maximum Quality',
     priceTier: '$$$$$$',
     speedTier: 'Slowest',
@@ -35,6 +60,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'premium-review',
+    family: 'gemini',
     label: 'Premium Review',
     priceTier: '$$$$$',
     speedTier: 'Slow',
@@ -45,6 +71,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'editorial-premium',
+    family: 'gemini',
     label: 'Editorial Premium',
     priceTier: '$$$$',
     speedTier: 'Moderate',
@@ -55,6 +82,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'balanced',
+    family: 'gemini',
     label: 'Fast + Optimal',
     priceTier: '$$$',
     speedTier: 'Fast',
@@ -65,6 +93,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'best-value',
+    family: 'gemini',
     label: 'Best Value',
     priceTier: '$$',
     speedTier: 'Faster',
@@ -75,6 +104,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'economy',
+    family: 'gemini',
     label: 'Fastest',
     priceTier: '$',
     speedTier: 'Fastest',
@@ -83,6 +113,89 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
     writingModel: 'gemini-3.1-flash-lite',
     auditModel: 'gemini-3.1-flash-lite',
   },
+  // A 2x3 grid, on purpose. Two writers across three research-and-audit tiers,
+  // so comparing two runs isolates one variable: if Opus + Lean beats
+  // Sonnet + Max the writer matters more than the research, and if they tie
+  // there is no reason to keep paying for Pro research. The six Gemini stacks
+  // above stay untouched as the control group.
+  //
+  // Research and audit stay on Gemini in every one of them. Claude writes; the
+  // grunt work does not move.
+  //
+  // The price tier reads "Plan + $" because only part of the run is metered:
+  // the writing draws the subscription's allowance and has no per-token rate,
+  // and the dollars count the Gemini research and audit alone.
+  {
+    id: 'opus-max',
+    family: 'claude-writer',
+    label: 'Opus · Max',
+    priceTier: 'Plan + $$$',
+    speedTier: 'Slowest',
+    description: 'Claude Opus writes; Gemini 3.1 Pro researches and judges. The most thorough combination, and the slowest.',
+    modelName: 'gemini-3.1-pro-preview',
+    writingModel: 'claude-opus-5',
+    auditModel: 'gemini-3.1-pro-preview',
+  },
+  {
+    id: 'opus-balanced',
+    family: 'claude-writer',
+    label: 'Opus · Balanced',
+    priceTier: 'Plan + $$',
+    speedTier: 'Slow',
+    description: 'Claude Opus writes; Gemini 3.7 Flash researches and judges. The default Claude stack.',
+    modelName: 'gemini-3.7-flash',
+    writingModel: 'claude-opus-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+  {
+    id: 'opus-lean',
+    family: 'claude-writer',
+    label: 'Opus · Lean',
+    priceTier: 'Plan + $',
+    speedTier: 'Moderate',
+    description: 'Claude Opus writes on the cheapest research available. Tests how much the research tier actually matters.',
+    modelName: 'gemini-3.1-flash-lite',
+    writingModel: 'claude-opus-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+  {
+    id: 'sonnet-max',
+    family: 'claude-writer',
+    label: 'Sonnet · Max',
+    priceTier: 'Plan + $$$',
+    speedTier: 'Slow',
+    description: 'Claude Sonnet writes; Gemini 3.1 Pro researches and judges. The best research a faster writer can be given.',
+    modelName: 'gemini-3.1-pro-preview',
+    writingModel: 'claude-sonnet-5',
+    auditModel: 'gemini-3.1-pro-preview',
+  },
+  {
+    id: 'sonnet-balanced',
+    family: 'claude-writer',
+    label: 'Sonnet · Balanced',
+    priceTier: 'Plan + $$',
+    speedTier: 'Moderate',
+    description: 'Claude Sonnet writes; Gemini 3.7 Flash researches and judges. The quickest Claude stack worth comparing.',
+    modelName: 'gemini-3.7-flash',
+    writingModel: 'claude-sonnet-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+  {
+    id: 'sonnet-lean',
+    family: 'claude-writer',
+    label: 'Sonnet · Lean',
+    priceTier: 'Plan + $',
+    speedTier: 'Fast',
+    description: 'Claude Sonnet writes on the cheapest research available. The floor of the grid.',
+    modelName: 'gemini-3.1-flash-lite',
+    writingModel: 'claude-sonnet-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+]
+
+export const PROMPT2BLOG_STACK_FAMILY_ORDER: Prompt2BlogStackFamily[] = [
+  'gemini',
+  'claude-writer',
 ]
 
 export const DEFAULT_PROMPT2BLOG_MODEL_STACK_ID: Prompt2BlogModelStackId = 'editorial-premium'
@@ -115,6 +228,21 @@ export const PROMPT2BLOG_MODEL_OPTIONS: Array<{
 
 export const DEFAULT_PROMPT2BLOG_WRITER_MODEL: Prompt2BlogWriterModel = 'gemini-3.1-pro-preview'
 
+/**
+ * Offered when the subscription path is on. The two current models are the ones
+ * the CLI transport has aliases for and the ones the run stacks use; the older
+ * point releases stay out of the picker rather than being offered as choices
+ * nobody has a reason to make.
+ */
+const CLAUDE_SUBSCRIPTION_WRITER_OPTIONS: Array<{
+  value: Prompt2BlogWriterModel
+  label: string
+}> = [
+  { value: 'claude-opus-5', label: 'Claude Opus 5 (premier writer — your plan)' },
+  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5 (faster writer — your plan)' },
+]
+
+/** Offered when the Anthropic API key is funded. It is not. */
 const CLAUDE_PROMPT2BLOG_WRITER_OPTIONS: Array<{
   value: Prompt2BlogWriterModel
   label: string
@@ -128,6 +256,7 @@ export const PROMPT2BLOG_WRITER_MODEL_OPTIONS: Array<{
   value: Prompt2BlogWriterModel
   label: string
 }> = [
+  ...(CLAUDE_SUBSCRIPTION_WRITER_ENABLED ? CLAUDE_SUBSCRIPTION_WRITER_OPTIONS : []),
   ...(CLAUDE_MODELS_ENABLED ? CLAUDE_PROMPT2BLOG_WRITER_OPTIONS : []),
   { value: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash' },
   { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
@@ -139,7 +268,10 @@ export const PROMPT2BLOG_WRITER_MODEL_OPTIONS: Array<{
 ]
 
 export function resolvePrompt2BlogWriterModel(value?: string): Prompt2BlogWriterModel {
-  // Stored Claude selections fall through to the default while Claude is off.
+  // Stored Claude selections fall through to the default while no Claude path
+  // is on, so a run saved under one configuration still opens under another.
+  if (CLAUDE_SUBSCRIPTION_WRITER_ENABLED && value === 'claude-opus-5') return value
+  if (CLAUDE_SUBSCRIPTION_WRITER_ENABLED && value === 'claude-sonnet-5') return value
   if (CLAUDE_MODELS_ENABLED && value === 'claude-opus-4-8') return value
   if (CLAUDE_MODELS_ENABLED && value === 'claude-opus-4-7') return value
   if (CLAUDE_MODELS_ENABLED && value === 'claude-sonnet-5') return value

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -470,6 +470,12 @@ describe('Prompt2BlogPage', () => {
     const options = within(preset).getAllByRole('option')
     const receipt = screen.getByLabelText('Editorial Premium model assignments')
 
+    // Grouped rather than one price-ordered list: the two families are not
+    // points on one scale, because a Claude-writer stack pays for its writing
+    // out of the subscription instead of per token.
+    expect(
+      within(preset).getAllByRole('group').map(group => group.getAttribute('label')),
+    ).toEqual(['Gemini — billed per token', 'Claude writes — included in your plan'])
     expect(options.map(option => option.textContent)).toEqual([
       '$$$$$$ · Maximum Quality · Slowest',
       '$$$$$ · Premium Review · Slow',
@@ -477,6 +483,12 @@ describe('Prompt2BlogPage', () => {
       '$$$ · Fast + Optimal · Fast',
       '$$ · Best Value · Faster',
       '$ · Fastest',
+      'Plan + $$$ · Opus · Max · Slowest',
+      'Plan + $$ · Opus · Balanced · Slow',
+      'Plan + $ · Opus · Lean · Moderate',
+      'Plan + $$$ · Sonnet · Max · Slow',
+      'Plan + $$ · Sonnet · Balanced · Moderate',
+      'Plan + $ · Sonnet · Lean · Fast',
     ])
     expect(preset).toHaveValue('editorial-premium')
     expect(within(receipt).getByText('Research worker')).toBeInTheDocument()
@@ -487,6 +499,30 @@ describe('Prompt2BlogPage', () => {
     expect(within(pricing).getByText('$2.55')).toBeInTheDocument()
     expect(within(pricing).getByText('Input $1.32 / 1M')).toBeInTheDocument()
     expect(within(pricing).getByText('Output $7.50 / 1M')).toBeInTheDocument()
+  })
+
+  it('prices a Claude-writer stack as plan usage rather than inventing a rate', async () => {
+    renderPage()
+
+    const preset = await screen.findByLabelText('Pipeline preset')
+    fireEvent.change(preset, { target: { value: 'opus-balanced' } })
+
+    // Before this, estimatePrompt2BlogStackPrice threw for any model with no
+    // Vertex rate, and this selection took the whole panel down with it.
+    const pricing = screen.getByLabelText('Opus · Balanced estimated pricing')
+    // The rate covers the metered roles only -- research and audit -- rather
+    // than being diluted by treating the plan-served writer as free.
+    expect(within(pricing).getByText('$1.35')).toBeInTheDocument()
+    expect(within(pricing).getByText('Input $0.75 / 1M')).toBeInTheDocument()
+    expect(within(pricing).getByText('Metered part')).toBeInTheDocument()
+    expect(
+      within(pricing).getByText(/Article writer runs on your Claude plan/),
+    ).toBeInTheDocument()
+
+    const receipt = screen.getByLabelText('Opus · Balanced model assignments')
+    expect(within(receipt).getByText('Claude Opus 5')).toBeInTheDocument()
+    // The grunt work does not move.
+    expect(within(receipt).getAllByText('Gemini 3.7 Flash')).toHaveLength(2)
   })
 
   it('keeps editorial extras off until the operator opts in', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -14,6 +14,7 @@ export type Prompt2BlogModelName =
 // Writing-quality model for the compose / editorial stages, independent of the
 // base drafting model. Backend allowlist: app/shared/writer_models.py.
 export type Prompt2BlogWriterModel =
+  | 'claude-opus-5'
   | 'claude-opus-4-8'
   | 'claude-opus-4-7'
   | 'claude-sonnet-5'

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/ai/models.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/ai/models.ts
@@ -1,12 +1,35 @@
 /**
- * Anthropic billing is exhausted, so Claude options are hidden from every
- * picker and the defaults point at Google models. The `claude-*` names stay in
- * the unions so saved runs and stored selections still type-check, and the
- * backend substitutes a Google model for them (utils.resolve_effective_model).
- * To restore: set ANTHROPIC_MODELS_ENABLED=1 on the backend and move the
- * entries in CLAUDE_*_OPTIONS back into the exported option lists.
+ * Whether the Anthropic **API-key** path is funded. It is not, so Claude options
+ * stay hidden from these pickers and the defaults point at Google models. The
+ * `claude-*` names stay in the unions so saved runs and stored selections still
+ * type-check, and the backend substitutes a Google model for them
+ * (utils.resolve_effective_model). To restore: fund the account, set
+ * ANTHROPIC_MODELS_ENABLED=1 on the backend, and flip this.
+ *
+ * This is no longer the only way Claude can answer -- see
+ * CLAUDE_SUBSCRIPTION_WRITER_ENABLED below -- so it is now specifically about
+ * the API key, not about Claude in general.
  */
 export const CLAUDE_MODELS_ENABLED = false
+
+/**
+ * Whether Claude may be picked as the **writing model** for a Prompt2Blog run,
+ * served by the Claude Code CLI the authoring machine is logged into.
+ *
+ * A different switch from CLAUDE_MODELS_ENABLED above, with a different payer:
+ * that one spends Anthropic Console credit against an API key, this one draws
+ * the plan holder's own subscription allowance. The backend half is
+ * CLAUDE_SUBSCRIPTION_MODELS_ENABLED.
+ *
+ * Deliberately narrower than app-wide. It reaches the Prompt2Blog writer picker
+ * and the Claude-writer run stacks, and nothing else: research and audit stay
+ * on Gemini, and the other pipelines' pickers are untouched. Anthropic's terms
+ * permit subscription OAuth for the plan holder's own use, not for serving
+ * other people's requests, so a deployment serving anyone but the owner must
+ * leave the backend switch off -- and then a Claude selection is transparently
+ * served by Google exactly as before.
+ */
+export const CLAUDE_SUBSCRIPTION_WRITER_ENABLED = true
 
 export type EditorAssistModelName = 'claude-opus-4-8' | 'claude-sonnet-5' | 'gemini-3.1-pro-preview'
 


### PR DESCRIPTION
Phase 3. The dropdown. Depends on [#385](https://github.com/Questurian/questurian/pull/385) — without it, selecting any of these crashes the routing panel.

## The grid

Claude writes; Gemini keeps research and audit. Six stacks, arranged as a **2×3 grid on purpose**:

| | Max (Pro research) | Balanced (3.7 Flash) | Lean (Flash-Lite) |
|---|---|---|---|
| **Claude Opus 5** | `opus-max` | `opus-balanced` | `opus-lean` |
| **Claude Sonnet 5** | `sonnet-max` | `sonnet-balanced` | `sonnet-lean` |

Comparing two runs isolates one variable. If **Opus · Lean beats Sonnet · Max**, the writer matters more than the research. If they tie, there is no reason to keep paying for Pro research. The six Gemini stacks are untouched and are the control group.

## Grouped, not merged into one list

The picker uses `<optgroup>`: "Gemini — billed per token" and "Claude writes — included in your plan". The two families are not points on one scale — a Gemini stack bills per token and a Claude-writer stack pays for its writing out of the subscription — so a single price-ordered list would compare things that are not comparable. The price tier reads `Plan + $$` for the same reason: the dollars count the Gemini research and audit alone.

## Claude never lands on research or audit

That is not a UI convention, it is the arrangement the plan rests on, so there is a test asserting it across **every** stack — a stack that quietly moved the grunt work onto the subscription would spend the owner's plan allowance on work it was never meant to do.

## A new flag, not a flip of the old one

`CLAUDE_SUBSCRIPTION_WRITER_ENABLED = true` is new. `CLAUDE_MODELS_ENABLED` stays **false**.

They have different payers — the old one spends Anthropic Console credit against an API key, the new one draws the plan holder's subscription allowance — and flipping the old one would unhide Claude in every picker in the app, including pipelines this work does not reach. Its docstring now says which of the two it is.

Note: `PROMPT2BLOG_WRITER_MODEL_OPTIONS` is exported but has no consumer in the UI today — the stack preset is the only routing control on the page. It is kept correct rather than left stale.

## `claude-opus-5`

Added to the frontend union and the backend allowlist. The CLI transport already had an alias for it and it is the current name. The older point releases stay out of the picker rather than being offered as choices nobody has a reason to make; they remain valid selections so saved runs still open.

## Verification

`vitest` on `src/features/prompt2blog` — **99 passed** (13 files), including a new `prompt2blog-stacks.test.ts`. `tsc --noEmit` clean. Backend writer-model tests pass.

One existing assertion changed: the page test's flat option list is now a grouped list, with the group labels asserted.