### PR TITLE
Ask Claude for JSON it validates instead of JSON to parse

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
@@ -33,6 +33,10 @@ class Prompt2BlogLLM(Protocol):
         max_tokens: int,
         temperature: float,
         model_name: str | None,
+        # Optional and trailing so every existing double keeps satisfying this.
+        # A provider that can enforce a schema uses it; one that cannot ignores
+        # it and asks in prose exactly as before.
+        schema: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], str]: ...
 
     def enforce_anti_ai(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -87,14 +88,72 @@ def _enforce_anti_ai_markdown_with_model(
 JSON_RETRY_EXCERPT_CHARS = 1_200
 
 
+def _invoke_schema_json_llm(
+    *,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    model_name: str | None,
+    schema: dict[str, Any],
+    usage_recorder: UsageRecorder | None = None,
+) -> tuple[dict[str, Any], str] | None:
+    """One validated call, or None if this provider cannot make one.
+
+    Capability is asked of the object the factory returned rather than inferred
+    from the model name, so the question is "can this thing enforce a schema"
+    and not "do I believe this name is served by something that can". A
+    provider without the method falls through to asking in prose.
+
+    There is no retry here on purpose. The retry loop below exists because a
+    model asked in prose can return something unparseable; a validated call
+    either produced a conforming object or failed for a reason that asking
+    again three times would not fix -- and each of those attempts is a full
+    article rewrite on the writer model.
+    """
+    llm = get_vertex_llm(
+        temperature=temperature,
+        max_tokens=max_tokens,
+        model_name=model_name or DEFAULT_MODEL,
+    )
+    invoke_json = getattr(llm, "invoke_json", None)
+    if not callable(invoke_json):
+        return None
+
+    parsed = invoke_json(prompt, input_schema=schema)
+    if usage_recorder is not None:
+        usage_recorder(
+            str(getattr(llm, "model_name", model_name or DEFAULT_MODEL)),
+            _usage_with_measured_cost(llm),
+        )
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Schema-validated LLM response was not an object")
+    # The trace wants the raw response the stage saw. There was no prose reply
+    # to record, so this is the validated object rendered back -- honest about
+    # what happened rather than an empty string in the trace.
+    return parsed, json.dumps(parsed, ensure_ascii=False)
+
+
 def _invoke_json_llm(
     *,
     prompt: str,
     max_tokens: int,
     temperature: float,
     model_name: str | None,
+    schema: dict[str, Any] | None = None,
     usage_recorder: UsageRecorder | None = None,
 ) -> tuple[dict[str, Any], str]:
+    if schema is not None:
+        validated = _invoke_schema_json_llm(
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            model_name=model_name,
+            schema=schema,
+            usage_recorder=usage_recorder,
+        )
+        if validated is not None:
+            return validated
+
     strict_prompt = (
         f"{prompt}\n\n"
         "CRITICAL OUTPUT RULE:\n"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -1,0 +1,119 @@
+"""JSON shapes for the writer-model stages, for providers that can enforce one.
+
+Why these exist and the other stages' do not
+--------------------------------------------
+Prompt2Blog asks for JSON in prose and parses whatever comes back, retrying up
+to three times when it does not parse. That is the only option on a provider
+with no schema enforcement, and it stays the path for those.
+
+The Claude Code CLI does have one: ``--json-schema`` returns an already-parsed,
+already-validated object. Claude only ever holds the **writer** role in this
+pipeline -- research and audit stay on Gemini -- so these are exactly the four
+call sites that a Claude stack can reach, and no others were written
+speculatively.
+
+Two deliberate choices about strictness
+---------------------------------------
+``additionalProperties`` is left open. The prompts ask for more than the
+sanitizers read, and the schema refusing a field the prompt requested would
+quietly lose it on Claude while Gemini kept it. ``required`` names only what the
+sanitizer actually needs to produce a usable result, for the same reason: a
+schema stricter than the code downstream turns a recoverable omission into a
+failed call.
+
+``component`` is the exception. The sanitizer accepts a table of aliases
+because a model asked in prose picks its own wording; a model handed an enum
+does not have to guess, so the canonical names are pinned and the alias table
+is left to keep serving the providers still being asked in prose.
+"""
+
+from typing import Any
+
+# Compose requires at least three `##` headings, so `sections` is required --
+# an outline without them is discarded downstream anyway.
+OUTLINE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["working_title", "sections"],
+    "properties": {
+        "working_title": {"type": "string"},
+        "direct_answer_focus": {"type": "string"},
+        "sections": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 12,
+            "items": {
+                "type": "object",
+                "required": ["heading"],
+                "properties": {
+                    "heading": {"type": "string"},
+                    "purpose": {"type": "string"},
+                    "source_support": {"type": "string"},
+                    "target_words": {"type": "integer", "minimum": 0},
+                },
+            },
+        },
+        "takeaway_focus": {"type": "string"},
+        "guideline_alignment": {"type": "string"},
+        "unsupported_requests": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+# Shared by compose and by repair: both return a whole rewritten article, and
+# both go through _sanitize_rewrite.
+REWRITE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["improved_title", "improved_content"],
+    "properties": {
+        "improved_title": {"type": "string"},
+        "improved_content": {"type": "string"},
+        "guideline_alignment_summary": {"type": "string"},
+        "improvements_applied": {"type": "array", "items": {"type": "string"}},
+        "remaining_gaps": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+EDITORIAL_COMPONENT_NAMES = (
+    "pull_quote",
+    "in_the_know_box",
+    "key_takeaways_box",
+    "highlight_callout",
+    "faq_block",
+)
+
+EDITORIAL_DIAGNOSTIC_AXES = (
+    "cognitive_load",
+    "narrative_density",
+    "emphasis_clarity",
+    "reading_behavior_risk",
+)
+
+EDITORIAL_AUGMENTATION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["augmented_content"],
+    "properties": {
+        "augmented_content": {"type": "string"},
+        "augmentation_summary": {"type": "string"},
+        "components_added": {
+            "type": "array",
+            "maxItems": 5,
+            "items": {
+                "type": "object",
+                "required": ["component"],
+                "properties": {
+                    "component": {
+                        "type": "string",
+                        "enum": list(EDITORIAL_COMPONENT_NAMES),
+                    },
+                    "justification": {"type": "string"},
+                    "placement": {"type": "string"},
+                },
+            },
+        },
+        "diagnostic": {
+            "type": "object",
+            "properties": {
+                axis: {"type": "string"} for axis in EDITORIAL_DIAGNOSTIC_AXES
+            },
+        },
+    },
+}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -10,6 +10,7 @@ from ..observability import _append_stage_trace
 from ..prompts.generation import SEO_SAFE_CONTENT_GENERATION_GUIDELINES
 from ..prompts.quality import P2B_QUALITY_AUDIT_PROMPT, P2B_REPAIR_PROMPT
 from ..policies import is_better_quality
+from ..schemas import REWRITE_SCHEMA
 from ..quality import (
     _build_constraint_checks,
     _sanitize_quality,
@@ -174,6 +175,7 @@ def run_repair_stage(
         max_tokens=6144,
         temperature=0.1,
         model_name=state["writing_model"],
+        schema=REWRITE_SCHEMA,
     )
     repaired = _sanitize_rewrite(
         parsed,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/augmentation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/augmentation.py
@@ -14,6 +14,7 @@ from ..graph.state import Prompt2BlogGraphState
 from ..observability import _append_stage_trace
 from ..policies import evaluate_augmentation
 from ..prompts.editorial import P2B_EDITORIAL_AUGMENTATION_PROMPT
+from ..schemas import EDITORIAL_AUGMENTATION_SCHEMA
 from ..support import _json
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ def run_augmentation_stage(
                 max_tokens=6144,
                 temperature=0.05,
                 model_name=state["writing_model"],
+                schema=EDITORIAL_AUGMENTATION_SCHEMA,
             )
             if isinstance(parsed.get("augmented_content"), str):
                 parsed["augmented_content"] = dependencies.llm.enforce_anti_ai(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/outline.py
@@ -12,6 +12,7 @@ from ..dependencies import PipelineDependencies
 from ..graph.state import Prompt2BlogGraphState
 from ..observability import _append_stage_trace
 from ..prompts.generation import P2B_OUTLINE_PROMPT
+from ..schemas import OUTLINE_SCHEMA
 from ..support import _json, _safe_dict, _safe_int
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,7 @@ def run_outline_stage(
             max_tokens=2048,
             temperature=0.1,
             model_name=state["writing_model"],
+            schema=OUTLINE_SCHEMA,
         )
         candidate = _sanitize_outline(parsed)
         accepted, diagnostics = validate_outline(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/supplement_compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/supplement_compose.py
@@ -13,6 +13,7 @@ from ..prompts.generation import (
     SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
 )
 from ..quality import _sanitize_rewrite
+from ..schemas import REWRITE_SCHEMA
 from ..support import _json
 
 
@@ -128,6 +129,7 @@ def run_compose_stage(
         max_tokens=6144,
         temperature=state["compose_temperature"],
         model_name=state["writing_model"],
+        schema=REWRITE_SCHEMA,
     )
     rewrite = _sanitize_rewrite(
         parsed,

--- a/apps/ai-blog-writer/apps/backend/app/shared/writer_models.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/writer_models.py
@@ -2,15 +2,20 @@
 
 The writing stages (compose / editorial augmentation) historically ran on a
 pinned Claude model. These constants make that choice a per-run option shared
-by every blog pipeline. Names route via the existing provider dispatch:
-claude-* -> Anthropic, gemini-* -> Vertex.
+by every blog pipeline. Names route via the existing provider dispatch in
+utils.get_vertex_llm: gemini-* to Vertex, claude-* to whichever Claude path is
+switched on.
 """
 
-# Anthropic billing is exhausted. The Claude names stay valid selections so
-# saved runs and existing clients keep working, but utils.resolve_effective_model
-# transparently serves them with a Google model. Restore by setting
-# ANTHROPIC_MODELS_ENABLED=1 and flipping DEFAULT_WRITER_MODEL back.
+# These are always valid selections, so saved runs and existing clients keep
+# working. What actually serves them is decided further down, by
+# utils.resolve_effective_model: with neither Claude path switched on they are
+# transparently served by a Google model, with ANTHROPIC_MODELS_ENABLED=1 they
+# go to the Anthropic API, and with CLAUDE_SUBSCRIPTION_MODELS_ENABLED=1 they go
+# to the Claude Code CLI on this machine. Being on this list is permission to
+# ask for a name, not a claim about which transport answers.
 CLAUDE_WRITER_MODELS = (
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-sonnet-5",

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_llm_provider.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_llm_provider.py
@@ -284,3 +284,167 @@ def test_structured_calls_use_the_cli_rather_than_an_unconfigured_api_key(
 
 def _unreachable_transport():  # pragma: no cover - must not run
     raise AssertionError("the CLI transport was consulted with no Claude switch on")
+
+
+# --- Phase 4: JSON that is validated rather than parsed ----------------------
+
+
+def test_writer_json_calls_go_through_the_schema_on_a_claude_stack(
+    monkeypatch, subscription_on, connected
+):
+    """The whole point: no ask-politely-and-retry loop on this provider.
+
+    Prompt2Blog's JSON calls are free text plus parse_json_response, retried up
+    to three times. Each of those retries on a compose or repair stage is a
+    full article rewrite on the writer model.
+    """
+    from app.features.prompt2blog import llm as prompt2blog_llm
+    from app.features.prompt2blog.schemas import REWRITE_SCHEMA
+
+    calls = _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "result": "ignored",
+                "structured_output": {
+                    "improved_title": "Barranco after dark",
+                    "improved_content": "## Where to start\n\nText.",
+                },
+                "is_error": False,
+                "stop_reason": "tool_use",
+                "total_cost_usd": 0.0099,
+                "usage": {"input_tokens": 10, "output_tokens": 900},
+            }
+        ),
+    )
+
+    parsed, raw = prompt2blog_llm._invoke_json_llm(
+        prompt="Rewrite the article.",
+        max_tokens=6144,
+        temperature=0.1,
+        model_name="claude-opus-5",
+        schema=REWRITE_SCHEMA,
+    )
+
+    assert parsed["improved_title"] == "Barranco after dark"
+    # One call, not one plus two retries.
+    assert len(calls) == 1
+    args = calls[0]["args"]
+    assert "--json-schema" in args
+    assert json.loads(args[args.index("--json-schema") + 1]) == REWRITE_SCHEMA
+    # The prompt does not carry the "return only one valid JSON object" plea
+    # any more; the schema is the enforcement.
+    prompt = args[args.index("--print") + 1]
+    assert "CRITICAL OUTPUT RULE" not in prompt
+    # The trace still gets a raw response to record.
+    assert json.loads(raw) == parsed
+
+
+def test_the_schema_reply_comes_from_structured_output_not_the_result_string(
+    monkeypatch, subscription_on, connected
+):
+    """Both hold the same JSON; only one of them was validated."""
+    from app.features.prompt2blog import llm as prompt2blog_llm
+    from app.features.prompt2blog.schemas import REWRITE_SCHEMA
+
+    _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "result": '{"improved_title":"From the result string"}',
+                "structured_output": {
+                    "improved_title": "From structured_output",
+                    "improved_content": "Text.",
+                },
+                "is_error": False,
+                "usage": {"input_tokens": 10, "output_tokens": 900},
+            }
+        ),
+    )
+
+    parsed, _ = prompt2blog_llm._invoke_json_llm(
+        prompt="Rewrite the article.",
+        max_tokens=6144,
+        temperature=0.1,
+        model_name="claude-opus-5",
+        schema=REWRITE_SCHEMA,
+    )
+
+    assert parsed["improved_title"] == "From structured_output"
+
+
+def test_a_schema_call_records_its_usage_and_price(
+    monkeypatch, subscription_on, connected
+):
+    from app.features.prompt2blog import llm as prompt2blog_llm
+    from app.features.prompt2blog.pricing import Prompt2BlogTokenUsageTracker
+    from app.features.prompt2blog.schemas import REWRITE_SCHEMA
+
+    _capture(
+        monkeypatch,
+        json.dumps(
+            {
+                "structured_output": {
+                    "improved_title": "T",
+                    "improved_content": "C",
+                },
+                "is_error": False,
+                "total_cost_usd": 0.0099,
+                "usage": {"input_tokens": 10, "output_tokens": 900},
+                "modelUsage": {"m": {"canonicalModel": "claude-opus-5"}},
+            }
+        ),
+    )
+    tracker = Prompt2BlogTokenUsageTracker()
+
+    prompt2blog_llm._invoke_json_llm(
+        prompt="Rewrite the article.",
+        max_tokens=6144,
+        temperature=0.1,
+        model_name="claude-opus-5",
+        schema=REWRITE_SCHEMA,
+        usage_recorder=tracker.record,
+    )
+
+    summary = tracker.summary(
+        stack_id="opus-balanced",
+        worker_model="gemini-3.7-flash",
+        writing_model="claude-opus-5",
+        audit_model="gemini-3.7-flash",
+    )
+    assert summary["estimated_cost_usd"] == 0.0099
+    assert summary["by_model"][0]["model"] == "claude-opus-5"
+
+
+def test_a_provider_that_cannot_enforce_a_schema_still_asks_in_prose(monkeypatch):
+    """The schema argument is a capability offer, not a requirement.
+
+    Asked of the object the factory returned rather than inferred from the
+    model name, so a Gemini stack is completely unaffected by a call site
+    gaining a schema.
+    """
+    from app.features.prompt2blog import llm as prompt2blog_llm
+    from app.features.prompt2blog.schemas import REWRITE_SCHEMA
+
+    prompts: list[str] = []
+
+    class _ProseLLM:
+        model_name = "gemini-3.7-flash"
+        last_usage_metadata = {"input_tokens": 10, "output_tokens": 20}
+
+        def invoke(self, prompt):  # noqa: ANN001
+            prompts.append(prompt)
+            return '{"improved_title": "T", "improved_content": "C"}'
+
+    monkeypatch.setattr(prompt2blog_llm, "get_vertex_llm", lambda **kwargs: _ProseLLM())
+
+    parsed, _ = prompt2blog_llm._invoke_json_llm(
+        prompt="Rewrite the article.",
+        max_tokens=6144,
+        temperature=0.1,
+        model_name="gemini-3.7-flash",
+        schema=REWRITE_SCHEMA,
+    )
+
+    assert parsed["improved_title"] == "T"
+    assert "CRITICAL OUTPUT RULE" in prompts[0]

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
@@ -1,5 +1,7 @@
 import {
   PROMPT2BLOG_MODEL_STACKS,
+  PROMPT2BLOG_STACK_FAMILY_LABELS,
+  PROMPT2BLOG_STACK_FAMILY_ORDER,
   resolvePrompt2BlogModelStack,
   type Prompt2BlogModelStackId,
 } from '../../constants/prompt2blog.constants'
@@ -26,7 +28,7 @@ export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
 
   return <Panel
     title="Run Stack"
-    description="Select one option. Quality-first appears first; fastest appears last."
+    description="Select one option. Within each group, quality-first appears first and fastest appears last."
     onClear={props.onClear}
   >
     <div className="p2b-field p2b-stack-picker">
@@ -37,12 +39,20 @@ export function ModelRoutingPanel(props: ModelRoutingPanelProps) {
         value={selectedStack.id}
         onChange={event => props.onChange(event.target.value as Prompt2BlogModelStackId)}
       >
-        {PROMPT2BLOG_MODEL_STACKS.map(stack => (
-          <option key={stack.id} value={stack.id}>
-            {stack.priceTier} · {stack.label}
-            {stack.label === stack.speedTier ? '' : ` · ${stack.speedTier}`}
-          </option>
-        ))}
+        {PROMPT2BLOG_STACK_FAMILY_ORDER.map(family => {
+          const stacks = PROMPT2BLOG_MODEL_STACKS.filter(
+            stack => stack.family === family,
+          )
+          if (stacks.length === 0) return null
+          return <optgroup key={family} label={PROMPT2BLOG_STACK_FAMILY_LABELS[family]}>
+            {stacks.map(stack => (
+              <option key={stack.id} value={stack.id}>
+                {stack.priceTier} · {stack.label}
+                {stack.label === stack.speedTier ? '' : ` · ${stack.speedTier}`}
+              </option>
+            ))}
+          </optgroup>
+        })}
       </select>
       <p className="p2b-stack-description">{selectedStack.description}</p>
     </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-stacks.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-stacks.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PROMPT2BLOG_MODEL_STACKS,
+  PROMPT2BLOG_STACK_FAMILY_ORDER,
+  PROMPT2BLOG_WRITER_MODEL_OPTIONS,
+  resolvePrompt2BlogModelStack,
+  resolvePrompt2BlogWriterModel,
+} from './prompt2blog.constants'
+import { isPlanAllowanceModel } from './prompt2blog-pricing'
+
+const CLAUDE_STACKS = PROMPT2BLOG_MODEL_STACKS.filter(
+  stack => stack.family === 'claude-writer',
+)
+
+describe('Claude-writer run stacks', () => {
+  it('is a 2x3 grid: two writers across three research tiers', () => {
+    // The grid shape is the point. Comparing two runs is only informative when
+    // exactly one thing differs between them, so every writer must appear
+    // against every research tier.
+    const grid = CLAUDE_STACKS.map(stack => [stack.writingModel, stack.modelName])
+
+    expect(grid).toEqual([
+      ['claude-opus-5', 'gemini-3.1-pro-preview'],
+      ['claude-opus-5', 'gemini-3.7-flash'],
+      ['claude-opus-5', 'gemini-3.1-flash-lite'],
+      ['claude-sonnet-5', 'gemini-3.1-pro-preview'],
+      ['claude-sonnet-5', 'gemini-3.7-flash'],
+      ['claude-sonnet-5', 'gemini-3.1-flash-lite'],
+    ])
+  })
+
+  it('never puts Claude on research or audit', () => {
+    // Not a UI convention. Claude writes and Gemini does the rest; a stack that
+    // quietly moved the grunt work onto the subscription would spend the
+    // owner's plan allowance on work it was never meant to do.
+    for (const stack of PROMPT2BLOG_MODEL_STACKS) {
+      expect(isPlanAllowanceModel(stack.modelName)).toBe(false)
+      expect(isPlanAllowanceModel(stack.auditModel)).toBe(false)
+    }
+  })
+
+  it('leaves the Gemini control group untouched', () => {
+    const gemini = PROMPT2BLOG_MODEL_STACKS.filter(stack => stack.family === 'gemini')
+
+    expect(gemini.map(stack => stack.id)).toEqual([
+      'maximum-quality',
+      'premium-review',
+      'editorial-premium',
+      'balanced',
+      'best-value',
+      'economy',
+    ])
+    expect(gemini.every(stack => !isPlanAllowanceModel(stack.writingModel))).toBe(true)
+  })
+
+  it('gives every stack a family the picker knows how to group', () => {
+    for (const stack of PROMPT2BLOG_MODEL_STACKS) {
+      expect(PROMPT2BLOG_STACK_FAMILY_ORDER).toContain(stack.family)
+    }
+  })
+
+  it('has a unique id per stack', () => {
+    const ids = PROMPT2BLOG_MODEL_STACKS.map(stack => stack.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    // resolvePrompt2BlogModelStack looks a stack up by id, so a duplicate would
+    // make one of them unreachable rather than fail loudly.
+    for (const id of ids) {
+      expect(resolvePrompt2BlogModelStack(id).id).toBe(id)
+    }
+  })
+
+  it('offers the writing models the stacks actually use', () => {
+    const offered = PROMPT2BLOG_WRITER_MODEL_OPTIONS.map(option => option.value)
+
+    for (const stack of CLAUDE_STACKS) {
+      expect(offered).toContain(stack.writingModel)
+      expect(resolvePrompt2BlogWriterModel(stack.writingModel)).toBe(stack.writingModel)
+    }
+  })
+
+  it('falls a stored selection back to the default rather than failing', () => {
+    // A run saved under one configuration has to still open under another.
+    expect(resolvePrompt2BlogWriterModel('claude-opus-4-8')).toBe(
+      'gemini-3.1-pro-preview',
+    )
+    expect(resolvePrompt2BlogWriterModel('not-a-model')).toBe('gemini-3.1-pro-preview')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
@@ -1,4 +1,7 @@
-import { CLAUDE_MODELS_ENABLED } from '../../../shared/api/ai/models'
+import {
+  CLAUDE_MODELS_ENABLED,
+  CLAUDE_SUBSCRIPTION_WRITER_ENABLED,
+} from '../../../shared/api/ai/models'
 import type { Prompt2BlogModelName, Prompt2BlogWriterModel } from '../types/pipeline.types'
 
 export const FEATURE_PREFIX = '/prompt2blog'
@@ -10,9 +13,30 @@ export type Prompt2BlogModelStackId =
   | 'balanced'
   | 'best-value'
   | 'economy'
+  | 'opus-max'
+  | 'opus-balanced'
+  | 'opus-lean'
+  | 'sonnet-max'
+  | 'sonnet-balanced'
+  | 'sonnet-lean'
+
+/**
+ * Which family a stack belongs to, so the picker can group them. The two are
+ * not points on one scale: an all-Gemini stack bills per token, and a
+ * Claude-writer stack pays for its writing out of the subscription, so sorting
+ * them into one price-ordered list would compare things that are not
+ * comparable.
+ */
+export type Prompt2BlogStackFamily = 'gemini' | 'claude-writer'
+
+export const PROMPT2BLOG_STACK_FAMILY_LABELS: Record<Prompt2BlogStackFamily, string> = {
+  gemini: 'Gemini — billed per token',
+  'claude-writer': 'Claude writes — included in your plan',
+}
 
 export interface Prompt2BlogModelStack {
   id: Prompt2BlogModelStackId
+  family: Prompt2BlogStackFamily
   label: string
   priceTier: string
   speedTier: 'Slowest' | 'Slow' | 'Moderate' | 'Fast' | 'Faster' | 'Fastest'
@@ -25,6 +49,7 @@ export interface Prompt2BlogModelStack {
 export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   {
     id: 'maximum-quality',
+    family: 'gemini',
     label: 'Maximum Quality',
     priceTier: '$$$$$$',
     speedTier: 'Slowest',
@@ -35,6 +60,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'premium-review',
+    family: 'gemini',
     label: 'Premium Review',
     priceTier: '$$$$$',
     speedTier: 'Slow',
@@ -45,6 +71,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'editorial-premium',
+    family: 'gemini',
     label: 'Editorial Premium',
     priceTier: '$$$$',
     speedTier: 'Moderate',
@@ -55,6 +82,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'balanced',
+    family: 'gemini',
     label: 'Fast + Optimal',
     priceTier: '$$$',
     speedTier: 'Fast',
@@ -65,6 +93,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'best-value',
+    family: 'gemini',
     label: 'Best Value',
     priceTier: '$$',
     speedTier: 'Faster',
@@ -75,6 +104,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   },
   {
     id: 'economy',
+    family: 'gemini',
     label: 'Fastest',
     priceTier: '$',
     speedTier: 'Fastest',
@@ -83,6 +113,89 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
     writingModel: 'gemini-3.1-flash-lite',
     auditModel: 'gemini-3.1-flash-lite',
   },
+  // A 2x3 grid, on purpose. Two writers across three research-and-audit tiers,
+  // so comparing two runs isolates one variable: if Opus + Lean beats
+  // Sonnet + Max the writer matters more than the research, and if they tie
+  // there is no reason to keep paying for Pro research. The six Gemini stacks
+  // above stay untouched as the control group.
+  //
+  // Research and audit stay on Gemini in every one of them. Claude writes; the
+  // grunt work does not move.
+  //
+  // The price tier reads "Plan + $" because only part of the run is metered:
+  // the writing draws the subscription's allowance and has no per-token rate,
+  // and the dollars count the Gemini research and audit alone.
+  {
+    id: 'opus-max',
+    family: 'claude-writer',
+    label: 'Opus · Max',
+    priceTier: 'Plan + $$$',
+    speedTier: 'Slowest',
+    description: 'Claude Opus writes; Gemini 3.1 Pro researches and judges. The most thorough combination, and the slowest.',
+    modelName: 'gemini-3.1-pro-preview',
+    writingModel: 'claude-opus-5',
+    auditModel: 'gemini-3.1-pro-preview',
+  },
+  {
+    id: 'opus-balanced',
+    family: 'claude-writer',
+    label: 'Opus · Balanced',
+    priceTier: 'Plan + $$',
+    speedTier: 'Slow',
+    description: 'Claude Opus writes; Gemini 3.7 Flash researches and judges. The default Claude stack.',
+    modelName: 'gemini-3.7-flash',
+    writingModel: 'claude-opus-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+  {
+    id: 'opus-lean',
+    family: 'claude-writer',
+    label: 'Opus · Lean',
+    priceTier: 'Plan + $',
+    speedTier: 'Moderate',
+    description: 'Claude Opus writes on the cheapest research available. Tests how much the research tier actually matters.',
+    modelName: 'gemini-3.1-flash-lite',
+    writingModel: 'claude-opus-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+  {
+    id: 'sonnet-max',
+    family: 'claude-writer',
+    label: 'Sonnet · Max',
+    priceTier: 'Plan + $$$',
+    speedTier: 'Slow',
+    description: 'Claude Sonnet writes; Gemini 3.1 Pro researches and judges. The best research a faster writer can be given.',
+    modelName: 'gemini-3.1-pro-preview',
+    writingModel: 'claude-sonnet-5',
+    auditModel: 'gemini-3.1-pro-preview',
+  },
+  {
+    id: 'sonnet-balanced',
+    family: 'claude-writer',
+    label: 'Sonnet · Balanced',
+    priceTier: 'Plan + $$',
+    speedTier: 'Moderate',
+    description: 'Claude Sonnet writes; Gemini 3.7 Flash researches and judges. The quickest Claude stack worth comparing.',
+    modelName: 'gemini-3.7-flash',
+    writingModel: 'claude-sonnet-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+  {
+    id: 'sonnet-lean',
+    family: 'claude-writer',
+    label: 'Sonnet · Lean',
+    priceTier: 'Plan + $',
+    speedTier: 'Fast',
+    description: 'Claude Sonnet writes on the cheapest research available. The floor of the grid.',
+    modelName: 'gemini-3.1-flash-lite',
+    writingModel: 'claude-sonnet-5',
+    auditModel: 'gemini-3.7-flash',
+  },
+]
+
+export const PROMPT2BLOG_STACK_FAMILY_ORDER: Prompt2BlogStackFamily[] = [
+  'gemini',
+  'claude-writer',
 ]
 
 export const DEFAULT_PROMPT2BLOG_MODEL_STACK_ID: Prompt2BlogModelStackId = 'editorial-premium'
@@ -115,6 +228,21 @@ export const PROMPT2BLOG_MODEL_OPTIONS: Array<{
 
 export const DEFAULT_PROMPT2BLOG_WRITER_MODEL: Prompt2BlogWriterModel = 'gemini-3.1-pro-preview'
 
+/**
+ * Offered when the subscription path is on. The two current models are the ones
+ * the CLI transport has aliases for and the ones the run stacks use; the older
+ * point releases stay out of the picker rather than being offered as choices
+ * nobody has a reason to make.
+ */
+const CLAUDE_SUBSCRIPTION_WRITER_OPTIONS: Array<{
+  value: Prompt2BlogWriterModel
+  label: string
+}> = [
+  { value: 'claude-opus-5', label: 'Claude Opus 5 (premier writer — your plan)' },
+  { value: 'claude-sonnet-5', label: 'Claude Sonnet 5 (faster writer — your plan)' },
+]
+
+/** Offered when the Anthropic API key is funded. It is not. */
 const CLAUDE_PROMPT2BLOG_WRITER_OPTIONS: Array<{
   value: Prompt2BlogWriterModel
   label: string
@@ -128,6 +256,7 @@ export const PROMPT2BLOG_WRITER_MODEL_OPTIONS: Array<{
   value: Prompt2BlogWriterModel
   label: string
 }> = [
+  ...(CLAUDE_SUBSCRIPTION_WRITER_ENABLED ? CLAUDE_SUBSCRIPTION_WRITER_OPTIONS : []),
   ...(CLAUDE_MODELS_ENABLED ? CLAUDE_PROMPT2BLOG_WRITER_OPTIONS : []),
   { value: 'gemini-3.7-flash', label: 'Gemini 3.7 Flash' },
   { value: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
@@ -139,7 +268,10 @@ export const PROMPT2BLOG_WRITER_MODEL_OPTIONS: Array<{
 ]
 
 export function resolvePrompt2BlogWriterModel(value?: string): Prompt2BlogWriterModel {
-  // Stored Claude selections fall through to the default while Claude is off.
+  // Stored Claude selections fall through to the default while no Claude path
+  // is on, so a run saved under one configuration still opens under another.
+  if (CLAUDE_SUBSCRIPTION_WRITER_ENABLED && value === 'claude-opus-5') return value
+  if (CLAUDE_SUBSCRIPTION_WRITER_ENABLED && value === 'claude-sonnet-5') return value
   if (CLAUDE_MODELS_ENABLED && value === 'claude-opus-4-8') return value
   if (CLAUDE_MODELS_ENABLED && value === 'claude-opus-4-7') return value
   if (CLAUDE_MODELS_ENABLED && value === 'claude-sonnet-5') return value

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -470,6 +470,12 @@ describe('Prompt2BlogPage', () => {
     const options = within(preset).getAllByRole('option')
     const receipt = screen.getByLabelText('Editorial Premium model assignments')
 
+    // Grouped rather than one price-ordered list: the two families are not
+    // points on one scale, because a Claude-writer stack pays for its writing
+    // out of the subscription instead of per token.
+    expect(
+      within(preset).getAllByRole('group').map(group => group.getAttribute('label')),
+    ).toEqual(['Gemini — billed per token', 'Claude writes — included in your plan'])
     expect(options.map(option => option.textContent)).toEqual([
       '$$$$$$ · Maximum Quality · Slowest',
       '$$$$$ · Premium Review · Slow',
@@ -477,6 +483,12 @@ describe('Prompt2BlogPage', () => {
       '$$$ · Fast + Optimal · Fast',
       '$$ · Best Value · Faster',
       '$ · Fastest',
+      'Plan + $$$ · Opus · Max · Slowest',
+      'Plan + $$ · Opus · Balanced · Slow',
+      'Plan + $ · Opus · Lean · Moderate',
+      'Plan + $$$ · Sonnet · Max · Slow',
+      'Plan + $$ · Sonnet · Balanced · Moderate',
+      'Plan + $ · Sonnet · Lean · Fast',
     ])
     expect(preset).toHaveValue('editorial-premium')
     expect(within(receipt).getByText('Research worker')).toBeInTheDocument()
@@ -487,6 +499,30 @@ describe('Prompt2BlogPage', () => {
     expect(within(pricing).getByText('$2.55')).toBeInTheDocument()
     expect(within(pricing).getByText('Input $1.32 / 1M')).toBeInTheDocument()
     expect(within(pricing).getByText('Output $7.50 / 1M')).toBeInTheDocument()
+  })
+
+  it('prices a Claude-writer stack as plan usage rather than inventing a rate', async () => {
+    renderPage()
+
+    const preset = await screen.findByLabelText('Pipeline preset')
+    fireEvent.change(preset, { target: { value: 'opus-balanced' } })
+
+    // Before this, estimatePrompt2BlogStackPrice threw for any model with no
+    // Vertex rate, and this selection took the whole panel down with it.
+    const pricing = screen.getByLabelText('Opus · Balanced estimated pricing')
+    // The rate covers the metered roles only -- research and audit -- rather
+    // than being diluted by treating the plan-served writer as free.
+    expect(within(pricing).getByText('$1.35')).toBeInTheDocument()
+    expect(within(pricing).getByText('Input $0.75 / 1M')).toBeInTheDocument()
+    expect(within(pricing).getByText('Metered part')).toBeInTheDocument()
+    expect(
+      within(pricing).getByText(/Article writer runs on your Claude plan/),
+    ).toBeInTheDocument()
+
+    const receipt = screen.getByLabelText('Opus · Balanced model assignments')
+    expect(within(receipt).getByText('Claude Opus 5')).toBeInTheDocument()
+    // The grunt work does not move.
+    expect(within(receipt).getAllByText('Gemini 3.7 Flash')).toHaveLength(2)
   })
 
   it('keeps editorial extras off until the operator opts in', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -14,6 +14,7 @@ export type Prompt2BlogModelName =
 // Writing-quality model for the compose / editorial stages, independent of the
 // base drafting model. Backend allowlist: app/shared/writer_models.py.
 export type Prompt2BlogWriterModel =
+  | 'claude-opus-5'
   | 'claude-opus-4-8'
   | 'claude-opus-4-7'
   | 'claude-sonnet-5'

--- a/apps/ai-blog-writer/apps/frontend/src/shared/api/ai/models.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/api/ai/models.ts
@@ -1,12 +1,35 @@
 /**
- * Anthropic billing is exhausted, so Claude options are hidden from every
- * picker and the defaults point at Google models. The `claude-*` names stay in
- * the unions so saved runs and stored selections still type-check, and the
- * backend substitutes a Google model for them (utils.resolve_effective_model).
- * To restore: set ANTHROPIC_MODELS_ENABLED=1 on the backend and move the
- * entries in CLAUDE_*_OPTIONS back into the exported option lists.
+ * Whether the Anthropic **API-key** path is funded. It is not, so Claude options
+ * stay hidden from these pickers and the defaults point at Google models. The
+ * `claude-*` names stay in the unions so saved runs and stored selections still
+ * type-check, and the backend substitutes a Google model for them
+ * (utils.resolve_effective_model). To restore: fund the account, set
+ * ANTHROPIC_MODELS_ENABLED=1 on the backend, and flip this.
+ *
+ * This is no longer the only way Claude can answer -- see
+ * CLAUDE_SUBSCRIPTION_WRITER_ENABLED below -- so it is now specifically about
+ * the API key, not about Claude in general.
  */
 export const CLAUDE_MODELS_ENABLED = false
+
+/**
+ * Whether Claude may be picked as the **writing model** for a Prompt2Blog run,
+ * served by the Claude Code CLI the authoring machine is logged into.
+ *
+ * A different switch from CLAUDE_MODELS_ENABLED above, with a different payer:
+ * that one spends Anthropic Console credit against an API key, this one draws
+ * the plan holder's own subscription allowance. The backend half is
+ * CLAUDE_SUBSCRIPTION_MODELS_ENABLED.
+ *
+ * Deliberately narrower than app-wide. It reaches the Prompt2Blog writer picker
+ * and the Claude-writer run stacks, and nothing else: research and audit stay
+ * on Gemini, and the other pipelines' pickers are untouched. Anthropic's terms
+ * permit subscription OAuth for the plan holder's own use, not for serving
+ * other people's requests, so a deployment serving anyone but the owner must
+ * leave the backend switch off -- and then a Claude selection is transparently
+ * served by Google exactly as before.
+ */
+export const CLAUDE_SUBSCRIPTION_WRITER_ENABLED = true
 
 export type EditorAssistModelName = 'claude-opus-4-8' | 'claude-sonnet-5' | 'gemini-3.1-pro-preview'
 

--- a/apps/ai-blog-writer/packages/utils/src/utils/claude_cli_llm.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/claude_cli_llm.py
@@ -116,9 +116,39 @@ class ClaudeCliTextLLM:
         self.last_cost_usd: Optional[float] = None
 
     def invoke(self, prompt: str) -> str:
+        return self._call(prompt, None)["text"]
+
+    def invoke_json(self, prompt: str, *, input_schema: dict[str, Any]) -> Any:
+        """Ask for JSON the transport validates, rather than JSON to parse.
+
+        Present only on this provider, and callers detect it by asking whether
+        it exists. That is what keeps the schema path opt-in per provider: a
+        caller that finds no such method keeps asking in prose and parsing the
+        answer, exactly as before.
+
+        The reply comes from the CLI's ``structured_output``, which is the
+        object it validated -- not ``result``, which is a string the model
+        wrote. Both carry the same JSON and only one of them is a guarantee.
+        """
+        return self._call(prompt, input_schema)["payload"]
+
+    def _call(
+        self,
+        prompt: str,
+        input_schema: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
         cli_writer = _transport()
         try:
-            result = cli_writer.invoke_text(prompt=prompt, model_name=self.model_name)
+            if input_schema is None:
+                result = cli_writer.invoke_text(
+                    prompt=prompt, model_name=self.model_name
+                )
+            else:
+                result = cli_writer.invoke_structured(
+                    prompt=prompt,
+                    input_schema=input_schema,
+                    model_name=self.model_name,
+                )
         except cli_writer.ClaudeCliWriterError as error:
             raise ClaudeCliUnavailable(str(error)) from error
 
@@ -128,4 +158,4 @@ class ClaudeCliTextLLM:
         self.model_name = result.get("modelName") or self.model_name
         self.last_usage_metadata = _usage_metadata(result.get("usage"))
         self.last_cost_usd = result.get("costUsd")
-        return result["text"]
+        return result


### PR DESCRIPTION
Phase 4, the last of the plan.

## What it replaces

Prompt2Blog's JSON calls are free text plus `parse_json_response`, **retried up to three times** when the reply does not parse. That is the only option on a provider with no schema enforcement, and it stays the path for those.

The Claude Code CLI has one: `--json-schema` returns an already-parsed, already-**validated** object with `stop_reason: "tool_use"`.

## Four call sites, and only four

Claude only ever holds the **writer** role here — research and audit stay on Gemini — so the writer-model JSON stages are exactly the ones a Claude stack can reach:

| stage | schema |
|---|---|
| outline | `OUTLINE_SCHEMA` |
| compose | `REWRITE_SCHEMA` |
| repair | `REWRITE_SCHEMA` |
| editorial augmentation | `EDITORIAL_AUGMENTATION_SCHEMA` |

No schema was written for a stage Claude cannot serve.

## Capability, not model-name guessing

`_invoke_json_llm` asks the object the factory returned whether it has an `invoke_json`. The question is "can this thing enforce a schema", not "do I believe this name is served by something that can" — so a provider without the method keeps asking in prose, and **a Gemini stack is completely unaffected by a call site gaining a schema.** There is a test for exactly that.

The reply is read from `structured_output`, never from `result`. Both carry the same JSON and only one of them was validated.

## No retry on the schema path

The loop exists because a model asked in prose can return something unparseable. A validated call either produced a conforming object or failed for a reason three more attempts would not fix — and on compose or repair, **each of those attempts is a full article rewrite on the writer model.**

## How strict the schemas are, and why

- **`additionalProperties` is left open.** The prompts ask for more than the sanitizers read, and a schema refusing a requested field would quietly lose it on Claude while Gemini kept it.
- **`required` names only what the sanitizer needs** to produce a usable result. A schema stricter than the code downstream turns a recoverable omission into a failed call.
- **The editorial component name is the exception** and is pinned to an enum. The alias table in `_normalize_editorial_component_name` exists because a model asked in prose picks its own wording; a model handed an enum does not have to guess. The alias table stays, for the providers still being asked in prose.

## Verification

`pytest apps/backend/tests` — **784 passed**. `black` + `flake8` clean apart from the three pre-existing E402.

Five new tests, including one asserting the CLI is invoked **once** rather than once plus two retries, and one asserting the reply comes from `structured_output` when `result` deliberately disagrees with it.