### PR TITLE
Add Prompt2Blog direction domain and storage

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
@@ -1,23 +1,21 @@
-export type {
-  ArticleTypeGuidelines,
-  ArticleTypeOption
-} from './types/article-types.types'
-export type {
-  Prompt2BlogSavedArticle,
-  Prompt2BlogSyncStatusResponse
-} from './types/articles.types'
+export type { ArticleTypeGuidelines, ArticleTypeOption } from './types/article-types.types'
+export type { Prompt2BlogSavedArticle, Prompt2BlogSyncStatusResponse } from './types/articles.types'
 export type {
   Prompt2BlogArticleFormId,
   Prompt2BlogAudienceTagId,
   Prompt2BlogAudienceTagOption,
   Prompt2BlogCommission,
   Prompt2BlogCommissionAudience,
+  Prompt2BlogCommissionDraft,
   Prompt2BlogCommissionReference,
   Prompt2BlogCommissionRequirement,
   Prompt2BlogCommissionScope,
   Prompt2BlogCreativityLevel,
   Prompt2BlogEditorialFormOption,
   Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogDirectionOptionId,
+  Prompt2BlogDirectionResponse,
   Prompt2BlogEvidenceClaim,
   Prompt2BlogEvidenceConfidence,
   Prompt2BlogEvidenceConflict,
@@ -39,6 +37,7 @@ export type {
   Prompt2BlogV3Request,
   Prompt2BlogWritingProfiles,
 } from './types/editorial.types'
+export { PROMPT2BLOG_DIRECTION_OPTION_IDS } from './types/editorial.types'
 export type {
   Prompt2BlogArticleTypeOption,
   Prompt2BlogDebugResponse,
@@ -56,14 +55,9 @@ export type {
   Prompt2BlogStatusResponse,
   Prompt2BlogWriterModel,
 } from './types/pipeline.types'
-export {
-  PROMPT2BLOG_PIPELINE_STAGES,
-} from './types/pipeline.types'
+export { PROMPT2BLOG_PIPELINE_STAGES } from './types/pipeline.types'
 
-export {
-  fetchArticleTypeGuidelinesById,
-  fetchArticleTypes
-} from './api/article-types.api'
+export { fetchArticleTypeGuidelinesById, fetchArticleTypes } from './api/article-types.api'
 export { deleteArticle, fetchArticles } from './api/articles.api'
 export { getPrompt2BlogEditorialOptions } from './api/editorial-options.api'
 export {
@@ -88,5 +82,5 @@ export {
   rewriteBlockWithAi,
   searchPexelsImages,
   searchUnsplashImages,
-  updateArticle
+  updateArticle,
 } from '../staging/api'

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogDirectionResponse
+} from '../api'
+import { DEFAULT_COMPOSER_STATE } from './composer.storage'
+import type { P2BFormState } from './composer.types'
+import {
+  applyValidatedDirectionResponse,
+  approveCommission,
+  clearDirectionWorkflow,
+  editCommissionDraft,
+  selectDirectionOption,
+  startEditorialWorkflow
+} from './commission-state'
+
+const APP_TITLE = "Is Lima still South America's bargain expat capital?"
+const APP_LOCATION = 'Lima, Peru'
+
+function directionOption(
+  optionId: 'direction-1' | 'direction-2' | 'direction-3',
+  index: number
+): Prompt2BlogDirectionOption {
+  return {
+    option_id: optionId,
+    direction: `Lima-centered editorial direction ${index}.`,
+    form_id: 'analysis',
+    topic_module_ids: ['cost-affordability', 'long-stay-remote-work'],
+    audience: {
+      primary_reader: 'Prospective expats and remote workers',
+      tags: ['remote-worker-relocator', 'budget-focused']
+    },
+    core_reader_question: `Does Lima still deliver value under scenario ${index}?`,
+    reader_outcome: `Judge Lima's tradeoffs using scenario ${index}.`,
+    primary_subject: 'Lima',
+    scope: {
+      mode: 'single_subject',
+      references: [
+        { name: 'Lima', role: 'primary_subject' },
+        { name: 'Medellín', role: 'context_only' }
+      ]
+    },
+    requirements: [
+      {
+        requirement_id: 'r1',
+        question: `What evidence settles scenario ${index}?`
+      }
+    ],
+    exclusions: ['Do not turn context cities into co-subjects.'],
+    rationale: `Distinct rationale ${index}.`
+  }
+}
+
+function directionResponse(): Prompt2BlogDirectionResponse {
+  return {
+    schema_version: 3,
+    // Echoed identity is validated on import but never owns composer identity.
+    original_title: APP_TITLE,
+    location: APP_LOCATION,
+    options: [
+      directionOption('direction-1', 1),
+      directionOption('direction-2', 2),
+      directionOption('direction-3', 3)
+    ]
+  }
+}
+
+function state(overrides: Partial<P2BFormState> = {}): P2BFormState {
+  return {
+    ...DEFAULT_COMPOSER_STATE,
+    editorial: {
+      directionOptions: [],
+      selectedOptionId: null,
+      commissionDraft: null,
+      approval: { status: 'not_started' }
+    },
+    easySetupTitle: APP_TITLE,
+    easySetupLocation: APP_LOCATION,
+    toneId: 'editorial',
+    lengthId: 'long',
+    modelStackId: 'best-value',
+    modelName: 'gemini-3.1-flash-lite',
+    writingModel: 'gemini-3.7-flash',
+    auditModel: 'gemini-3.7-flash',
+    ...overrides
+  }
+}
+
+function selectedState(): P2BFormState {
+  return selectDirectionOption(
+    applyValidatedDirectionResponse(state(), directionResponse()),
+    'direction-2'
+  )
+}
+
+describe('commission state', () => {
+  it('starts editorial work by clearing stale direction state only', () => {
+    const approved = {
+      ...selectedState(),
+      editorial: {
+        ...selectedState().editorial,
+        approval: {
+          status: 'approved' as const,
+          commission: {
+            ...selectedState().editorial.commissionDraft!,
+            commission_fingerprint: 'sha256:old'
+          }
+        }
+      }
+    }
+
+    const next = startEditorialWorkflow(approved)
+
+    expect(next.activeWorkflow).toBe('editorial_v3')
+    expect(next.editorial).toEqual({
+      directionOptions: [],
+      selectedOptionId: null,
+      commissionDraft: null,
+      approval: { status: 'not_started' }
+    })
+    expect(next.modelStackId).toBe('best-value')
+    expect(next.toneId).toBe('editorial')
+  })
+
+  it('stores validated options without selecting one', () => {
+    const next = applyValidatedDirectionResponse(state(), directionResponse())
+
+    expect(next.activeWorkflow).toBe('editorial_v3')
+    expect(next.editorial.directionOptions).toHaveLength(3)
+    expect(next.editorial.selectedOptionId).toBeNull()
+    expect(next.editorial.commissionDraft).toBeNull()
+    expect(next.editorial.approval).toEqual({ status: 'awaiting_selection' })
+  })
+
+  it('makes the draft from the chosen option but keeps exact app-owned identity', () => {
+    const imported = applyValidatedDirectionResponse(
+      state(),
+      directionResponse()
+    )
+    // Prove selection does not read identity back from the response object;
+    // confirmation trims only outer input whitespace.
+    imported.easySetupTitle = '  Exact app title — spacing stays  '
+    imported.easySetupLocation = 'Lima, Perú — app value'
+
+    const next = selectDirectionOption(imported, 'direction-2')
+
+    expect(next.editorial.selectedOptionId).toBe('direction-2')
+    expect(next.editorial.commissionDraft).toMatchObject({
+      schema_version: 3,
+      original_title: 'Exact app title — spacing stays',
+      location: 'Lima, Perú — app value',
+      approved_direction: 'Lima-centered editorial direction 2.',
+      form_id: 'analysis',
+      primary_subject: 'Lima',
+      call_to_action: null
+    })
+    expect(next.editorial.approval).toEqual({ status: 'needs_approval' })
+    expect(next.editorial.commissionDraft).not.toHaveProperty('option_id')
+    expect(next.editorial.commissionDraft).not.toHaveProperty('rationale')
+  })
+
+  it('stores a fingerprinted approval then retracts it on a commission edit', () => {
+    const selected = selectedState()
+    const commission: Prompt2BlogCommission = {
+      ...selected.editorial.commissionDraft!,
+      commission_fingerprint: 'sha256:commission'
+    }
+    const approved = approveCommission(selected, commission)
+
+    expect(approved.editorial.approval).toEqual({
+      status: 'approved',
+      commission
+    })
+
+    const edited = editCommissionDraft(approved, {
+      approved_direction: 'Edited Lima-centered direction.',
+      original_title: 'Attempted replacement title',
+      location: 'Attempted replacement location'
+    })
+
+    expect(edited.editorial.commissionDraft?.approved_direction).toBe(
+      'Edited Lima-centered direction.'
+    )
+    expect(edited.editorial.commissionDraft?.original_title).toBe(APP_TITLE)
+    expect(edited.editorial.commissionDraft?.location).toBe(APP_LOCATION)
+    expect(edited.editorial.approval).toEqual({
+      status: 'reconfirmation_required',
+      reason: 'commission_edited'
+    })
+    expect(edited.modelStackId).toBe(approved.modelStackId)
+    expect(edited.modelName).toBe(approved.modelName)
+    expect(edited.writingModel).toBe(approved.writingModel)
+    expect(edited.auditModel).toBe(approved.auditModel)
+    expect(edited.toneId).toBe(approved.toneId)
+    expect(edited.lengthId).toBe(approved.lengthId)
+  })
+
+  it('rejects approval that replaces the app-owned title or location', () => {
+    const selected = selectedState()
+    const commission: Prompt2BlogCommission = {
+      ...selected.editorial.commissionDraft!,
+      commission_fingerprint: 'sha256:commission',
+      original_title: 'Model replacement title'
+    }
+
+    expect(() => approveCommission(selected, commission)).toThrow(
+      'Approved commission must keep the app-owned title and location.'
+    )
+  })
+
+  it('clears direction state back to legacy without clearing legacy or profile fields', () => {
+    const current = selectedState()
+    current.articleTypeId = 7
+    current.articleGoal = 'Retained legacy goal'
+    current.blobs = [{ id: 1, content: 'Retained source' }]
+
+    const next = clearDirectionWorkflow(current)
+
+    expect(next.activeWorkflow).toBe('legacy_v2')
+    expect(next.editorial).toEqual({
+      directionOptions: [],
+      selectedOptionId: null,
+      commissionDraft: null,
+      approval: { status: 'not_started' }
+    })
+    expect(next.articleTypeId).toBe(7)
+    expect(next.articleGoal).toBe('Retained legacy goal')
+    expect(next.blobs).toEqual([{ id: 1, content: 'Retained source' }])
+    expect(next.modelStackId).toBe('best-value')
+    expect(next.toneId).toBe('editorial')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
@@ -14,6 +14,7 @@ import {
   selectDirectionOption,
   startEditorialWorkflow
 } from './commission-state'
+import { fingerprintCommissionSync } from './commission'
 
 const APP_TITLE = "Is Lima still South America's bargain expat capital?"
 const APP_LOCATION = 'Lima, Peru'
@@ -164,7 +165,9 @@ describe('commission state', () => {
     const selected = selectedState()
     const commission: Prompt2BlogCommission = {
       ...selected.editorial.commissionDraft!,
-      commission_fingerprint: 'sha256:commission'
+      commission_fingerprint: fingerprintCommissionSync(
+        selected.editorial.commissionDraft!
+      )
     }
     const approved = approveCommission(selected, commission)
 
@@ -200,12 +203,31 @@ describe('commission state', () => {
     const selected = selectedState()
     const commission: Prompt2BlogCommission = {
       ...selected.editorial.commissionDraft!,
-      commission_fingerprint: 'sha256:commission',
+      commission_fingerprint: fingerprintCommissionSync(
+        selected.editorial.commissionDraft!
+      ),
       original_title: 'Model replacement title'
     }
 
     expect(() => approveCommission(selected, commission)).toThrow(
       'Approved commission must keep the app-owned title and location.'
+    )
+  })
+
+  it('rejects a stale fingerprint result after the commission draft changes', () => {
+    const selected = selectedState()
+    const staleCommission: Prompt2BlogCommission = {
+      ...selected.editorial.commissionDraft!,
+      commission_fingerprint: fingerprintCommissionSync(
+        selected.editorial.commissionDraft!
+      )
+    }
+    const edited = editCommissionDraft(selected, {
+      approved_direction: 'A newly edited direction.'
+    })
+
+    expect(() => approveCommission(edited, staleCommission)).toThrow(
+      'must match the current commission draft'
     )
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
@@ -1,0 +1,159 @@
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogDirectionOptionId,
+  Prompt2BlogDirectionResponse
+} from '../api'
+import type { P2BEditorialComposerState, P2BFormState } from './composer.types'
+import { createCommissionDraft } from './commission'
+
+function emptyEditorialState(): P2BEditorialComposerState {
+  return {
+    directionOptions: [],
+    selectedOptionId: null,
+    commissionDraft: null,
+    approval: { status: 'not_started' }
+  }
+}
+
+function cloneOption(
+  option: Prompt2BlogDirectionOption
+): Prompt2BlogDirectionOption {
+  return {
+    ...option,
+    topic_module_ids: [...option.topic_module_ids],
+    audience: {
+      ...option.audience,
+      tags: option.audience.tags ? [...option.audience.tags] : []
+    },
+    scope: {
+      ...option.scope,
+      references: option.scope.references.map((reference) => ({ ...reference }))
+    },
+    requirements: option.requirements.map((requirement) => ({
+      ...requirement
+    })),
+    exclusions: [...option.exclusions]
+  }
+}
+
+/** Enters v3 direction work without retaining a stale selection or approval. */
+export function startEditorialWorkflow(state: P2BFormState): P2BFormState {
+  return {
+    ...state,
+    activeWorkflow: 'editorial_v3',
+    editorial: emptyEditorialState()
+  }
+}
+
+/** Stores a response only after the strict direction importer has validated it. */
+export function applyValidatedDirectionResponse(
+  state: P2BFormState,
+  response: Prompt2BlogDirectionResponse
+): P2BFormState {
+  return {
+    ...state,
+    activeWorkflow: 'editorial_v3',
+    editorial: {
+      directionOptions: response.options.map(cloneOption),
+      selectedOptionId: null,
+      commissionDraft: null,
+      approval: { status: 'awaiting_selection' }
+    }
+  }
+}
+
+/**
+ * Converts one human-selected option into an editable commission. Title and
+ * location come from app state, never the model response that carried options.
+ */
+export function selectDirectionOption(
+  state: P2BFormState,
+  optionId: Prompt2BlogDirectionOptionId
+): P2BFormState {
+  const option = state.editorial.directionOptions.find(
+    (item) => item.option_id === optionId
+  )
+  if (!option)
+    throw new Error(`Direction option "${optionId}" is not available.`)
+
+  const commissionDraft = createCommissionDraft(
+    state.easySetupTitle.trim(),
+    state.easySetupLocation.trim(),
+    option
+  )
+
+  return {
+    ...state,
+    activeWorkflow: 'editorial_v3',
+    editorial: {
+      ...state.editorial,
+      selectedOptionId: optionId,
+      commissionDraft,
+      approval: { status: 'needs_approval' }
+    }
+  }
+}
+
+/** Records a fully fingerprinted snapshot without computing its fingerprint. */
+export function approveCommission(
+  state: P2BFormState,
+  commission: Prompt2BlogCommission
+): P2BFormState {
+  if (!state.editorial.commissionDraft) {
+    throw new Error('A commission draft must be selected before approval.')
+  }
+  if (
+    commission.original_title !== state.easySetupTitle.trim() ||
+    commission.location !== state.easySetupLocation.trim()
+  ) {
+    throw new Error(
+      'Approved commission must keep the app-owned title and location.'
+    )
+  }
+
+  return {
+    ...state,
+    activeWorkflow: 'editorial_v3',
+    editorial: {
+      ...state.editorial,
+      approval: { status: 'approved', commission }
+    }
+  }
+}
+
+/** Any commission-owned edit retracts approval; profile/model fields stay untouched. */
+export function editCommissionDraft(
+  state: P2BFormState,
+  patch: Partial<Prompt2BlogCommissionDraft>
+): P2BFormState {
+  if (!state.editorial.commissionDraft) return state
+
+  return {
+    ...state,
+    editorial: {
+      ...state.editorial,
+      commissionDraft: {
+        ...state.editorial.commissionDraft,
+        ...patch,
+        // Identity remains app-owned even if a broad editor patch contains it.
+        original_title: state.easySetupTitle.trim(),
+        location: state.easySetupLocation.trim()
+      },
+      approval: {
+        status: 'reconfirmation_required',
+        reason: 'commission_edited'
+      }
+    }
+  }
+}
+
+/** Leaves all legacy fields and run preferences intact while abandoning v3 work. */
+export function clearDirectionWorkflow(state: P2BFormState): P2BFormState {
+  return {
+    ...state,
+    activeWorkflow: 'legacy_v2',
+    editorial: emptyEditorialState()
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
@@ -6,7 +6,11 @@ import type {
   Prompt2BlogDirectionResponse
 } from '../api'
 import type { P2BEditorialComposerState, P2BFormState } from './composer.types'
-import { createCommissionDraft } from './commission'
+import {
+  commissionMatchesDraft,
+  createCommissionDraft,
+  fingerprintCommissionSync
+} from './commission'
 
 function emptyEditorialState(): P2BEditorialComposerState {
   return {
@@ -110,6 +114,18 @@ export function approveCommission(
   ) {
     throw new Error(
       'Approved commission must keep the app-owned title and location.'
+    )
+  }
+  if (!commissionMatchesDraft(state.editorial.commissionDraft, commission)) {
+    throw new Error(
+      'Approved commission must match the current commission draft.'
+    )
+  }
+  if (
+    fingerprintCommissionSync(commission) !== commission.commission_fingerprint
+  ) {
+    throw new Error(
+      'Approved commission fingerprint does not match its contents.'
     )
   }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-drift-v3.json'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogEditorialOptionsResponse
+} from '../api'
+import {
+  approveCommission,
+  createCommissionDraft,
+  fingerprintCommission,
+  validateCommissionDraft
+} from './commission'
+
+const catalog = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'analysis',
+      label: 'Analysis',
+      description: 'Focused interpretation.',
+      order: 2,
+      source_requirements: []
+    },
+    {
+      id: 'comparison',
+      label: 'Comparison',
+      description: 'Approved co-subjects.',
+      order: 12,
+      source_requirements: []
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost',
+      description: 'Cost evidence.',
+      order: 1
+    },
+    {
+      id: 'accommodation-neighborhoods',
+      label: 'Accommodation',
+      description: 'Housing evidence.',
+      order: 2
+    },
+    {
+      id: 'transportation',
+      label: 'Transportation',
+      description: 'Transport evidence.',
+      order: 4
+    },
+    {
+      id: 'safety',
+      label: 'Safety',
+      description: 'Safety evidence.',
+      order: 5
+    },
+    {
+      id: 'long-stay-remote-work',
+      label: 'Long stay',
+      description: 'Long-stay evidence.',
+      order: 9
+    }
+  ],
+  audience_tags: [
+    {
+      id: 'remote-worker-relocator',
+      label: 'Remote worker',
+      description: 'Long-stay reader.'
+    },
+    {
+      id: 'budget-focused',
+      label: 'Budget-focused',
+      description: 'Cost-sensitive reader.'
+    }
+  ],
+  scope_modes: [
+    {
+      id: 'single_subject',
+      label: 'Single subject',
+      description: 'One subject.'
+    },
+    {
+      id: 'head_to_head',
+      label: 'Head to head',
+      description: 'Compared subjects.'
+    },
+    { id: 'ranked_set', label: 'Ranked set', description: 'Ranked subjects.' }
+  ],
+  reference_roles: [
+    {
+      id: 'primary_subject',
+      label: 'Primary',
+      description: 'Controlling subject.'
+    },
+    {
+      id: 'context_only',
+      label: 'Context only',
+      description: 'Context, never structure.'
+    },
+    {
+      id: 'comparator',
+      label: 'Comparator',
+      description: 'Approved co-subject.'
+    }
+  ]
+} satisfies Prompt2BlogEditorialOptionsResponse
+
+function directionOption(): Prompt2BlogDirectionOption {
+  return {
+    option_id: 'direction-1',
+    direction: 'Assess whether Lima still offers strong long-stay value.',
+    form_id: 'analysis',
+    topic_module_ids: ['cost-affordability', 'long-stay-remote-work'],
+    audience: {
+      primary_reader: 'Prospective expats and remote workers',
+      tags: ['remote-worker-relocator', 'budget-focused']
+    },
+    core_reader_question: 'Does Lima still offer compelling long-stay value?',
+    reader_outcome: 'Readers can judge Lima using current evidence.',
+    primary_subject: 'Lima',
+    scope: {
+      mode: 'single_subject',
+      references: [
+        { name: 'Lima', role: 'primary_subject' },
+        { name: 'Medellín', role: 'context_only' }
+      ]
+    },
+    requirements: [
+      { requirement_id: 'r1', question: 'What are current routine costs?' }
+    ],
+    exclusions: ['Do not turn context cities into co-subjects.'],
+    rationale: 'Tests the title through a Lima-centered value analysis.'
+  }
+}
+
+describe('Prompt2Blog commission construction', () => {
+  it('uses app-owned title and location and excludes option review metadata', () => {
+    const option = directionOption()
+    const draft = createCommissionDraft(
+      "Is Lima still South America's bargain expat capital?",
+      'Lima, Peru',
+      option
+    )
+
+    expect(draft).toEqual({
+      schema_version: 3,
+      original_title: "Is Lima still South America's bargain expat capital?",
+      location: 'Lima, Peru',
+      approved_direction: option.direction,
+      form_id: option.form_id,
+      topic_module_ids: option.topic_module_ids,
+      audience: option.audience,
+      core_reader_question: option.core_reader_question,
+      reader_outcome: option.reader_outcome,
+      primary_subject: option.primary_subject,
+      scope: option.scope,
+      requirements: option.requirements,
+      exclusions: option.exclusions,
+      call_to_action: null
+    })
+    expect(draft).not.toHaveProperty('option_id')
+    expect(draft).not.toHaveProperty('rationale')
+
+    option.scope.references[0].name = 'Changed later'
+    expect(draft.scope.references[0].name).toBe('Lima')
+  })
+
+  it('validates edited commissions against catalog and scope rules before approval', async () => {
+    const draft = createCommissionDraft(
+      'Lima value',
+      'Lima, Peru',
+      directionOption()
+    )
+    draft.scope.references[1].role = 'comparator'
+
+    expect(validateCommissionDraft(draft, catalog)).toContainEqual({
+      path: 'commission.scope',
+      message: 'single_subject scope cannot contain comparators.'
+    })
+    await expect(approveCommission(draft, catalog)).rejects.toThrow(
+      'commission.scope: single_subject scope cannot contain comparators.'
+    )
+  })
+
+  it('creates a fingerprinted approved commission only after validation', async () => {
+    const draft = createCommissionDraft(
+      'Lima value',
+      'Lima, Peru',
+      directionOption()
+    )
+
+    const commission = await approveCommission(draft, catalog)
+
+    expect(commission).toEqual({
+      ...draft,
+      commission_fingerprint: await fingerprintCommission(draft)
+    })
+    expect(commission.commission_fingerprint).toMatch(/^[a-f0-9]{64}$/)
+  })
+})
+
+describe('fingerprintCommission', () => {
+  it('matches the canonical Lima regression fingerprint', async () => {
+    const commission =
+      limaFixture.commission as unknown as Prompt2BlogCommission
+    const { commission_fingerprint: _stored, ...draft } = commission
+
+    await expect(fingerprintCommission(draft)).resolves.toBe(
+      'd1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48'
+    )
+  })
+
+  it('ignores object insertion order but changes after any commission edit', async () => {
+    const original = createCommissionDraft(
+      'Lima value',
+      'Lima, Peru',
+      directionOption()
+    )
+    const reordered = JSON.parse(
+      JSON.stringify(original)
+    ) as Prompt2BlogCommissionDraft
+    reordered.audience = {
+      tags: [...(original.audience.tags ?? [])],
+      primary_reader: original.audience.primary_reader
+    }
+
+    expect(await fingerprintCommission(reordered)).toBe(
+      await fingerprintCommission(original)
+    )
+
+    reordered.approved_direction = `${reordered.approved_direction} Updated.`
+    expect(await fingerprintCommission(reordered)).not.toBe(
+      await fingerprintCommission(original)
+    )
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission.ts
@@ -1,0 +1,202 @@
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogEditorialOptionsResponse
+} from '../api'
+import {
+  validateDirectionOption,
+  type DirectionImportIssue
+} from './direction-import'
+
+const COMMISSION_KEYS = [
+  'schema_version',
+  'original_title',
+  'location',
+  'approved_direction',
+  'form_id',
+  'topic_module_ids',
+  'audience',
+  'core_reader_question',
+  'reader_outcome',
+  'primary_subject',
+  'scope',
+  'requirements',
+  'exclusions',
+  'call_to_action'
+] as const
+
+function copyDirectionOption(
+  option: Prompt2BlogDirectionOption
+): Prompt2BlogDirectionOption {
+  return {
+    ...option,
+    topic_module_ids: [...option.topic_module_ids],
+    audience: {
+      ...option.audience,
+      tags: [...(option.audience.tags ?? [])]
+    },
+    scope: {
+      ...option.scope,
+      references: option.scope.references.map((reference) => ({ ...reference }))
+    },
+    requirements: option.requirements.map((requirement) => ({
+      ...requirement
+    })),
+    exclusions: [...option.exclusions]
+  }
+}
+
+export function createCommissionDraft(
+  title: string,
+  location: string,
+  option: Prompt2BlogDirectionOption
+): Prompt2BlogCommissionDraft {
+  const copied = copyDirectionOption(option)
+  return {
+    schema_version: 3,
+    original_title: title,
+    location,
+    approved_direction: copied.direction,
+    form_id: copied.form_id,
+    topic_module_ids: copied.topic_module_ids,
+    audience: copied.audience,
+    core_reader_question: copied.core_reader_question,
+    reader_outcome: copied.reader_outcome,
+    primary_subject: copied.primary_subject,
+    scope: copied.scope,
+    requirements: copied.requirements,
+    exclusions: copied.exclusions,
+    call_to_action: null
+  }
+}
+
+export function validateCommissionDraft(
+  draft: Prompt2BlogCommissionDraft,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): DirectionImportIssue[] {
+  const issues: DirectionImportIssue[] = []
+  const record = draft as unknown as Record<string, unknown>
+  const allowedKeys = new Set<string>(COMMISSION_KEYS)
+  for (const key of Object.keys(record)) {
+    if (!allowedKeys.has(key)) {
+      issues.push({ path: `commission.${key}`, message: 'Unexpected key.' })
+    }
+  }
+  for (const key of COMMISSION_KEYS) {
+    if (!(key in record)) {
+      issues.push({
+        path: `commission.${key}`,
+        message: 'Missing required key.'
+      })
+    }
+  }
+  if (draft.schema_version !== 3) {
+    issues.push({ path: 'commission.schema_version', message: 'Must equal 3.' })
+  }
+  for (const [key, value] of [
+    ['original_title', draft.original_title],
+    ['location', draft.location]
+  ] as const) {
+    if (typeof value !== 'string' || !value.trim()) {
+      issues.push({
+        path: `commission.${key}`,
+        message: 'Must be a non-empty string.'
+      })
+    }
+  }
+  if (
+    draft.call_to_action !== null &&
+    draft.call_to_action !== undefined &&
+    typeof draft.call_to_action !== 'string'
+  ) {
+    issues.push({
+      path: 'commission.call_to_action',
+      message: 'Must be a string or null.'
+    })
+  }
+
+  const option: Prompt2BlogDirectionOption = {
+    option_id: 'direction-1',
+    direction: draft.approved_direction,
+    form_id: draft.form_id,
+    topic_module_ids: draft.topic_module_ids ?? [],
+    audience: draft.audience,
+    core_reader_question: draft.core_reader_question,
+    reader_outcome: draft.reader_outcome,
+    primary_subject: draft.primary_subject,
+    scope: draft.scope,
+    requirements: draft.requirements,
+    exclusions: draft.exclusions ?? [],
+    rationale: draft.approved_direction
+  }
+  issues.push(
+    ...validateDirectionOption(option, catalog).map((issue) => ({
+      ...issue,
+      path: issue.path.replace(/^options\[0\]/, 'commission')
+    }))
+  )
+  return issues
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string' || typeof value === 'boolean')
+    return JSON.stringify(value)
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value))
+      throw new TypeError('Commission contains a non-finite number.')
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    return `{${entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(',')}}`
+  }
+  throw new TypeError(`Commission contains unsupported ${typeof value} value.`)
+}
+
+export async function fingerprintCommission(
+  draft: Prompt2BlogCommissionDraft
+): Promise<string> {
+  const record = draft as unknown as Record<string, unknown>
+  const { commission_fingerprint: _ignored, ...payload } = record
+  const bytes = new TextEncoder().encode(canonicalJson(payload))
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')
+}
+
+export async function approveCommission(
+  draft: Prompt2BlogCommissionDraft,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): Promise<Prompt2BlogCommission> {
+  const issues = validateCommissionDraft(draft, catalog)
+  if (issues.length) {
+    throw new Error(
+      `Invalid commission: ${issues
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join(' ')}`
+    )
+  }
+  return {
+    ...draft,
+    topic_module_ids: [...(draft.topic_module_ids ?? [])],
+    audience: {
+      ...draft.audience,
+      tags: [...(draft.audience.tags ?? [])]
+    },
+    scope: {
+      ...draft.scope,
+      references: draft.scope.references.map((reference) => ({ ...reference }))
+    },
+    requirements: draft.requirements.map((requirement) => ({ ...requirement })),
+    exclusions: [...(draft.exclusions ?? [])],
+    commission_fingerprint: await fingerprintCommission(draft)
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission.ts
@@ -160,16 +160,114 @@ function canonicalJson(value: unknown): string {
   throw new TypeError(`Commission contains unsupported ${typeof value} value.`)
 }
 
+function rotateRight(value: number, amount: number): number {
+  return (value >>> amount) | (value << (32 - amount))
+}
+
+const SHA256_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+] as const
+
+function sha256Hex(input: string): string {
+  const source = new TextEncoder().encode(input)
+  const paddedLength = Math.ceil((source.length + 9) / 64) * 64
+  const bytes = new Uint8Array(paddedLength)
+  bytes.set(source)
+  bytes[source.length] = 0x80
+  const bitLength = source.length * 8
+  const view = new DataView(bytes.buffer)
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000))
+  view.setUint32(paddedLength - 4, bitLength >>> 0)
+
+  const hash = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+    0x1f83d9ab, 0x5be0cd19
+  ])
+  const words = new Uint32Array(64)
+  for (let offset = 0; offset < bytes.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      words[index] = view.getUint32(offset + index * 4)
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const left = words[index - 15]
+      const right = words[index - 2]
+      const sigma0 = rotateRight(left, 7) ^ rotateRight(left, 18) ^ (left >>> 3)
+      const sigma1 =
+        rotateRight(right, 17) ^ rotateRight(right, 19) ^ (right >>> 10)
+      words[index] =
+        (words[index - 16] + sigma0 + words[index - 7] + sigma1) >>> 0
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)
+      const choice = (e & f) ^ (~e & g)
+      const temp1 =
+        (h + sum1 + choice + SHA256_CONSTANTS[index] + words[index]) >>> 0
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22)
+      const majority = (a & b) ^ (a & c) ^ (b & c)
+      const temp2 = (sum0 + majority) >>> 0
+      h = g
+      g = f
+      f = e
+      e = (d + temp1) >>> 0
+      d = c
+      c = b
+      b = a
+      a = (temp1 + temp2) >>> 0
+    }
+    hash[0] = (hash[0] + a) >>> 0
+    hash[1] = (hash[1] + b) >>> 0
+    hash[2] = (hash[2] + c) >>> 0
+    hash[3] = (hash[3] + d) >>> 0
+    hash[4] = (hash[4] + e) >>> 0
+    hash[5] = (hash[5] + f) >>> 0
+    hash[6] = (hash[6] + g) >>> 0
+    hash[7] = (hash[7] + h) >>> 0
+  }
+  return Array.from(hash, (value) => value.toString(16).padStart(8, '0')).join(
+    ''
+  )
+}
+
+function commissionBody(
+  value: Prompt2BlogCommissionDraft | Prompt2BlogCommission
+): unknown {
+  const record = value as unknown as Record<string, unknown>
+  const { commission_fingerprint: _ignored, ...body } = record
+  return body
+}
+
+export function commissionMatchesDraft(
+  draft: Prompt2BlogCommissionDraft,
+  commission: Prompt2BlogCommission
+): boolean {
+  return (
+    canonicalJson(commissionBody(draft)) ===
+    canonicalJson(commissionBody(commission))
+  )
+}
+
+export function fingerprintCommissionSync(
+  draft: Prompt2BlogCommissionDraft | Prompt2BlogCommission
+): string {
+  return sha256Hex(canonicalJson(commissionBody(draft)))
+}
+
 export async function fingerprintCommission(
   draft: Prompt2BlogCommissionDraft
 ): Promise<string> {
-  const record = draft as unknown as Record<string, unknown>
-  const { commission_fingerprint: _ignored, ...payload } = record
-  const bytes = new TextEncoder().encode(canonicalJson(payload))
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
-  return Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, '0')
-  ).join('')
+  return fingerprintCommissionSync(draft)
 }
 
 export async function approveCommission(

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
@@ -2,10 +2,65 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   COMPOSER_STORAGE_KEY,
+  COMPOSER_STORAGE_VERSION,
   DEFAULT_COMPOSER_STATE,
   loadSavedComposerState,
   saveComposerState,
 } from './composer.storage'
+import type { Prompt2BlogCommission, Prompt2BlogCommissionDraft } from '../api'
+
+const APPROVED_COMMISSION: Prompt2BlogCommission = {
+  schema_version: 3,
+  commission_fingerprint: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  original_title: 'A week in Lima',
+  location: 'Lima, Peru',
+  approved_direction: 'A first-time visitor service guide',
+  form_id: 'service-guide',
+  topic_module_ids: ['food-drink', 'transportation'],
+  audience: {
+    primary_reader: 'First-time visitors',
+    tags: ['first-time-visitor'],
+  },
+  core_reader_question: 'How should I plan the week?',
+  reader_outcome: 'A realistic plan',
+  primary_subject: 'Lima',
+  scope: {
+    mode: 'single_subject',
+    references: [{ name: 'Lima', role: 'primary_subject' }],
+  },
+  requirements: [{ requirement_id: 'r1', question: 'What should I book first?' }],
+  exclusions: [],
+  call_to_action: null,
+}
+
+function withoutFingerprint(commission: Prompt2BlogCommission): Prompt2BlogCommissionDraft {
+  const { commission_fingerprint: fingerprint, ...draft } = commission
+  void fingerprint
+  return draft
+}
+
+function storedDirectionOptions() {
+  return (['direction-1', 'direction-2', 'direction-3'] as const).map((optionId, index) => ({
+    option_id: optionId,
+    direction: `Direction ${index + 1}`,
+    form_id: 'service-guide' as const,
+    topic_module_ids: ['food-drink' as const],
+    audience: {
+      primary_reader: `Reader ${index + 1}`,
+      tags: ['first-time-visitor' as const],
+    },
+    core_reader_question: `Question ${index + 1}?`,
+    reader_outcome: `Outcome ${index + 1}`,
+    primary_subject: 'Lima',
+    scope: {
+      mode: 'single_subject' as const,
+      references: [{ name: 'Lima', role: 'primary_subject' as const }],
+    },
+    requirements: [{ requirement_id: `r${index + 1}`, question: `Evidence ${index + 1}?` }],
+    exclusions: [`Exclusion ${index + 1}`],
+    rationale: `Rationale ${index + 1}`,
+  }))
+}
 
 describe('loadSavedComposerState', () => {
   beforeEach(() => {
@@ -13,37 +68,42 @@ describe('loadSavedComposerState', () => {
   })
 
   it('preserves the reader while dropping legacy duplicate steering fields', () => {
-    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
-      targetReader: 'Budget-conscious families',
-      audienceProfile: 'Families seeking free activities',
-      promptEnhance: true,
-    }))
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        targetReader: 'Budget-conscious families',
+        audienceProfile: 'Families seeking free activities',
+        promptEnhance: true,
+      }),
+    )
 
     const state = loadSavedComposerState()
 
-    expect(state.targetReader).toBe(
-      'Budget-conscious families — Families seeking free activities',
-    )
+    expect(state.targetReader).toBe('Budget-conscious families — Families seeking free activities')
     expect(state).not.toHaveProperty('audienceProfile')
     expect(state).not.toHaveProperty('promptEnhance')
   })
 
   it('uses legacy audience detail when the saved target reader is empty', () => {
-    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
-      targetReader: '',
-      audienceProfile: 'Families seeking free activities',
-    }))
-
-    expect(loadSavedComposerState().targetReader).toBe(
-      'Families seeking free activities',
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        targetReader: '',
+        audienceProfile: 'Families seeking free activities',
+      }),
     )
+
+    expect(loadSavedComposerState().targetReader).toBe('Families seeking free activities')
   })
 
   it('does not repeat identical legacy audience detail', () => {
-    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
-      targetReader: 'Budget-conscious families',
-      audienceProfile: 'budget-conscious families',
-    }))
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        targetReader: 'Budget-conscious families',
+        audienceProfile: 'budget-conscious families',
+      }),
+    )
 
     expect(loadSavedComposerState().targetReader).toBe('Budget-conscious families')
   })
@@ -53,9 +113,12 @@ describe('loadSavedComposerState', () => {
   })
 
   it('turns off the old unversioned editorial-augmentation default', () => {
-    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
-      enableEditorialAugmentation: true,
-    }))
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        enableEditorialAugmentation: true,
+      }),
+    )
 
     expect(loadSavedComposerState().enableEditorialAugmentation).toBe(false)
   })
@@ -87,11 +150,92 @@ describe('loadSavedComposerState', () => {
   })
 
   it('does not reinterpret a draft written by a newer storage version', () => {
-    localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
-      composerStorageVersion: 999,
-      enableEditorialAugmentation: true,
-    }))
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        composerStorageVersion: 999,
+        enableEditorialAugmentation: true,
+      }),
+    )
 
     expect(loadSavedComposerState().enableEditorialAugmentation).toBe(true)
+  })
+
+  it('migrates a v2 draft without mapping its numeric article type into v3', () => {
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        composerStorageVersion: 2,
+        easySetupTitle: 'A week in Lima',
+        easySetupLocation: 'Lima, Peru',
+        articleTypeId: 7,
+        targetReader: 'First-time visitors',
+        toneId: 'balanced',
+        blobs: [{ id: 8, content: 'Saved source' }],
+      }),
+    )
+
+    const state = loadSavedComposerState()
+
+    expect(state).toMatchObject({
+      activeWorkflow: 'legacy_v2',
+      easySetupTitle: 'A week in Lima',
+      easySetupLocation: 'Lima, Peru',
+      articleTypeId: 7,
+      targetReader: 'First-time visitors',
+      toneId: 'balanced',
+      blobs: [{ id: 8, content: 'Saved source' }],
+      editorial: {
+        directionOptions: [],
+        commissionDraft: null,
+        approval: { status: 'reconfirmation_required', reason: 'legacy_draft' },
+      },
+    })
+  })
+
+  it('round-trips an approved v3 commission separately from its editable draft', () => {
+    saveComposerState({
+      ...DEFAULT_COMPOSER_STATE,
+      activeWorkflow: 'editorial_v3',
+      editorial: {
+        directionOptions: storedDirectionOptions(),
+        selectedOptionId: 'direction-1',
+        commissionDraft: withoutFingerprint(APPROVED_COMMISSION),
+        approval: { status: 'approved', commission: APPROVED_COMMISSION },
+      },
+    })
+
+    expect(loadSavedComposerState()).toMatchObject({
+      activeWorkflow: 'editorial_v3',
+      editorial: {
+        selectedOptionId: 'direction-1',
+        approval: { status: 'approved', commission: APPROVED_COMMISSION },
+      },
+    })
+    expect(JSON.parse(localStorage.getItem(COMPOSER_STORAGE_KEY) ?? '{}')).toHaveProperty(
+      'composerStorageVersion',
+      COMPOSER_STORAGE_VERSION,
+    )
+  })
+
+  it('fails closed when a saved approval has no commission fingerprint', () => {
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        composerStorageVersion: 3,
+        activeWorkflow: 'editorial_v3',
+        editorial: {
+          directionOptions: [],
+          selectedOptionId: null,
+          commissionDraft: null,
+          approval: {
+            status: 'approved',
+            commission: { original_title: 'Unsafe', location: 'Unknown' },
+          },
+        },
+      }),
+    )
+
+    expect(loadSavedComposerState().editorial).toEqual(DEFAULT_COMPOSER_STATE.editorial)
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
@@ -8,6 +8,7 @@ import {
   saveComposerState,
 } from './composer.storage'
 import type { Prompt2BlogCommission, Prompt2BlogCommissionDraft } from '../api'
+import { fingerprintCommissionSync } from './commission'
 
 const APPROVED_COMMISSION: Prompt2BlogCommission = {
   schema_version: 3,
@@ -38,6 +39,10 @@ function withoutFingerprint(commission: Prompt2BlogCommission): Prompt2BlogCommi
   void fingerprint
   return draft
 }
+
+APPROVED_COMMISSION.commission_fingerprint = fingerprintCommissionSync(
+  withoutFingerprint(APPROVED_COMMISSION),
+)
 
 function storedDirectionOptions() {
   return (['direction-1', 'direction-2', 'direction-3'] as const).map((optionId, index) => ({
@@ -149,16 +154,17 @@ describe('loadSavedComposerState', () => {
     })
   })
 
-  it('does not reinterpret a draft written by a newer storage version', () => {
-    localStorage.setItem(
-      COMPOSER_STORAGE_KEY,
-      JSON.stringify({
-        composerStorageVersion: 999,
-        enableEditorialAugmentation: true,
-      }),
-    )
+  it('does not reinterpret or overwrite a draft written by a newer storage version', () => {
+    const futureDraft = JSON.stringify({
+      composerStorageVersion: 999,
+      activeWorkflow: 'future_v4',
+      futureEditorialState: { protected: true },
+    })
+    localStorage.setItem(COMPOSER_STORAGE_KEY, futureDraft)
 
-    expect(loadSavedComposerState().enableEditorialAugmentation).toBe(true)
+    expect(loadSavedComposerState()).toBe(DEFAULT_COMPOSER_STATE)
+    saveComposerState(DEFAULT_COMPOSER_STATE)
+    expect(localStorage.getItem(COMPOSER_STORAGE_KEY)).toBe(futureDraft)
   })
 
   it('migrates a v2 draft without mapping its numeric article type into v3', () => {
@@ -216,6 +222,55 @@ describe('loadSavedComposerState', () => {
       'composerStorageVersion',
       COMPOSER_STORAGE_VERSION,
     )
+  })
+
+  it('discards an approval whose body no longer matches the editable draft', () => {
+    const draft = withoutFingerprint(APPROVED_COMMISSION)
+    const staleCommission: Prompt2BlogCommission = {
+      ...APPROVED_COMMISSION,
+      approved_direction: 'A stale direction from another option',
+      commission_fingerprint: '',
+    }
+    staleCommission.commission_fingerprint = fingerprintCommissionSync(staleCommission)
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_COMPOSER_STATE,
+        composerStorageVersion: 3,
+        activeWorkflow: 'editorial_v3',
+        editorial: {
+          directionOptions: storedDirectionOptions(),
+          selectedOptionId: 'direction-1',
+          commissionDraft: draft,
+          approval: { status: 'approved', commission: staleCommission },
+        },
+      }),
+    )
+
+    expect(loadSavedComposerState().editorial).toEqual(DEFAULT_COMPOSER_STATE.editorial)
+  })
+
+  it('discards restored commissions containing unknown catalog IDs', () => {
+    const malformed = {
+      ...withoutFingerprint(APPROVED_COMMISSION),
+      topic_module_ids: ['invented-module'],
+    }
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_COMPOSER_STATE,
+        composerStorageVersion: 3,
+        activeWorkflow: 'editorial_v3',
+        editorial: {
+          directionOptions: storedDirectionOptions(),
+          selectedOptionId: 'direction-1',
+          commissionDraft: malformed,
+          approval: { status: 'needs_approval' },
+        },
+      }),
+    )
+
+    expect(loadSavedComposerState().editorial).toEqual(DEFAULT_COMPOSER_STATE.editorial)
   })
 
   it('fails closed when a saved approval has no commission fingerprint', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -4,13 +4,33 @@ import {
   resolvePrompt2BlogModelName,
   resolvePrompt2BlogWriterModel,
 } from '../constants/prompt2blog.constants'
-import type { P2BFormState } from './composer.types'
+import type {
+  P2BCommissionApproval,
+  P2BEditorialComposerState,
+  P2BFormState,
+} from './composer.types'
+import {
+  PROMPT2BLOG_DIRECTION_OPTION_IDS,
+  type Prompt2BlogCommission,
+  type Prompt2BlogCommissionDraft,
+  type Prompt2BlogDirectionOption,
+  type Prompt2BlogDirectionOptionId,
+} from '../api'
 
 export const COMPOSER_STORAGE_KEY = 'p2b-form-draft'
-const COMPOSER_STORAGE_VERSION = 2
+export const COMPOSER_STORAGE_VERSION = 3
 const DEFAULT_MODEL_STACK = resolvePrompt2BlogModelStack(DEFAULT_PROMPT2BLOG_MODEL_STACK_ID)
 
+export const DEFAULT_EDITORIAL_STATE: P2BEditorialComposerState = {
+  directionOptions: [],
+  selectedOptionId: null,
+  commissionDraft: null,
+  approval: { status: 'not_started' },
+}
+
 export const DEFAULT_COMPOSER_STATE: P2BFormState = {
+  activeWorkflow: 'legacy_v2',
+  editorial: DEFAULT_EDITORIAL_STATE,
   easySetupLocation: '',
   easySetupTitle: '',
   articleTypeId: null,
@@ -35,11 +55,197 @@ export const DEFAULT_COMPOSER_STATE: P2BFormState = {
   blobs: [{ id: 1, content: '' }],
 }
 
+function hasMeaningfulLegacyEditorialState(parsed: Partial<P2BFormState>): boolean {
+  return Boolean(
+    parsed.articleTypeId ||
+    parsed.easySetupTitle?.trim() ||
+    parsed.easySetupLocation?.trim() ||
+    parsed.articleGoal?.trim() ||
+    parsed.targetReader?.trim() ||
+    parsed.destinationContext?.trim() ||
+    parsed.angle?.trim() ||
+    parsed.callToAction?.trim(),
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && Boolean(value.trim())
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(item => typeof item === 'string')
+}
+
+function isCommissionDraft(value: unknown): value is Prompt2BlogCommissionDraft {
+  if (!isRecord(value)) return false
+  const audience = value.audience
+  const scope = value.scope
+  if (!isRecord(audience) || !isRecord(scope)) return false
+  const references = scope.references
+  const requirements = value.requirements
+  return (
+    value.schema_version === 3 &&
+    isNonEmptyString(value.original_title) &&
+    isNonEmptyString(value.location) &&
+    isNonEmptyString(value.approved_direction) &&
+    isNonEmptyString(value.form_id) &&
+    isStringArray(value.topic_module_ids) &&
+    isNonEmptyString(audience.primary_reader) &&
+    isStringArray(audience.tags) &&
+    (scope.mode === 'single_subject' ||
+      scope.mode === 'head_to_head' ||
+      scope.mode === 'ranked_set') &&
+    Array.isArray(references) &&
+    references.length > 0 &&
+    references.every(
+      reference =>
+        isRecord(reference) &&
+        isNonEmptyString(reference.name) &&
+        (reference.role === 'primary_subject' ||
+          reference.role === 'context_only' ||
+          reference.role === 'comparator'),
+    ) &&
+    Array.isArray(requirements) &&
+    requirements.length > 0 &&
+    requirements.every(
+      requirement =>
+        isRecord(requirement) &&
+        isNonEmptyString(requirement.requirement_id) &&
+        isNonEmptyString(requirement.question),
+    ) &&
+    isStringArray(value.exclusions) &&
+    (value.call_to_action === null || typeof value.call_to_action === 'string')
+  )
+}
+
+function isApprovedCommission(value: unknown): value is Prompt2BlogCommission {
+  if (!isRecord(value)) return false
+  const fingerprint = value.commission_fingerprint
+  return (
+    typeof fingerprint === 'string' &&
+    /^[a-f0-9]{64}$/.test(fingerprint) &&
+    isCommissionDraft(value)
+  )
+}
+
+function isDirectionOption(value: unknown): value is Prompt2BlogDirectionOption {
+  if (!isRecord(value)) return false
+  return (
+    PROMPT2BLOG_DIRECTION_OPTION_IDS.includes(value.option_id as Prompt2BlogDirectionOptionId) &&
+    isNonEmptyString(value.direction) &&
+    isNonEmptyString(value.form_id) &&
+    isStringArray(value.topic_module_ids) &&
+    isRecord(value.audience) &&
+    isNonEmptyString(value.audience.primary_reader) &&
+    isStringArray(value.audience.tags) &&
+    isNonEmptyString(value.core_reader_question) &&
+    isNonEmptyString(value.reader_outcome) &&
+    isNonEmptyString(value.primary_subject) &&
+    isRecord(value.scope) &&
+    (value.scope.mode === 'single_subject' ||
+      value.scope.mode === 'head_to_head' ||
+      value.scope.mode === 'ranked_set') &&
+    Array.isArray(value.scope.references) &&
+    value.scope.references.length > 0 &&
+    value.scope.references.every(
+      reference =>
+        isRecord(reference) &&
+        isNonEmptyString(reference.name) &&
+        (reference.role === 'primary_subject' ||
+          reference.role === 'context_only' ||
+          reference.role === 'comparator'),
+    ) &&
+    Array.isArray(value.requirements) &&
+    value.requirements.length > 0 &&
+    value.requirements.every(
+      requirement =>
+        isRecord(requirement) &&
+        isNonEmptyString(requirement.requirement_id) &&
+        isNonEmptyString(requirement.question),
+    ) &&
+    isStringArray(value.exclusions) &&
+    isNonEmptyString(value.rationale)
+  )
+}
+
+function normalizeApproval(value: unknown): P2BCommissionApproval | null {
+  if (!value || typeof value !== 'object') return null
+  const candidate = value as Record<string, unknown>
+  if (
+    candidate.status === 'not_started' ||
+    candidate.status === 'awaiting_selection' ||
+    candidate.status === 'needs_approval'
+  ) {
+    return { status: candidate.status }
+  }
+  if (
+    candidate.status === 'reconfirmation_required' &&
+    (candidate.reason === 'legacy_draft' ||
+      candidate.reason === 'commission_edited' ||
+      candidate.reason === 'title_or_location_changed')
+  ) {
+    return { status: candidate.status, reason: candidate.reason }
+  }
+  if (candidate.status === 'approved') {
+    const commission = candidate.commission
+    if (isApprovedCommission(commission)) {
+      return {
+        status: 'approved',
+        commission,
+      }
+    }
+  }
+  return null
+}
+
+function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
+  if (!value || typeof value !== 'object') return { ...DEFAULT_EDITORIAL_STATE }
+  const candidate = value as Partial<P2BEditorialComposerState>
+  const approval = normalizeApproval(candidate.approval)
+  if (!approval) return { ...DEFAULT_EDITORIAL_STATE }
+  const directionOptions = candidate.directionOptions
+  const selectedOptionId =
+    typeof candidate.selectedOptionId === 'string' ? candidate.selectedOptionId : null
+  const commissionDraft = candidate.commissionDraft
+  if (
+    !Array.isArray(directionOptions) ||
+    !directionOptions.every(isDirectionOption) ||
+    (directionOptions.length !== 0 && directionOptions.length !== 3) ||
+    (selectedOptionId !== null &&
+      !PROMPT2BLOG_DIRECTION_OPTION_IDS.includes(
+        selectedOptionId as Prompt2BlogDirectionOptionId,
+      )) ||
+    (selectedOptionId !== null &&
+      !directionOptions.some(option => option.option_id === selectedOptionId)) ||
+    (commissionDraft !== null && !isCommissionDraft(commissionDraft)) ||
+    (commissionDraft !== null && selectedOptionId === null) ||
+    (approval.status === 'approved' &&
+      (commissionDraft === null ||
+        approval.commission.original_title !== commissionDraft.original_title ||
+        approval.commission.location !== commissionDraft.location))
+  ) {
+    return { ...DEFAULT_EDITORIAL_STATE }
+  }
+  return {
+    directionOptions,
+    selectedOptionId,
+    commissionDraft,
+    approval,
+  }
+}
+
 export function saveComposerState(state: P2BFormState): void {
-  localStorage.setItem(COMPOSER_STORAGE_KEY, JSON.stringify({
-    ...state,
-    composerStorageVersion: COMPOSER_STORAGE_VERSION,
-  }))
+  localStorage.setItem(
+    COMPOSER_STORAGE_KEY,
+    JSON.stringify({
+      ...state,
+      composerStorageVersion: COMPOSER_STORAGE_VERSION,
+    }),
+  )
 }
 
 export function loadSavedComposerState(): P2BFormState {
@@ -51,20 +257,21 @@ export function loadSavedComposerState(): P2BFormState {
       composerStorageVersion?: unknown
       promptEnhance?: unknown
     }
-    const isUnversionedDraft = parsed.composerStorageVersion == null
+    const savedStorageVersion =
+      typeof parsed.composerStorageVersion === 'number' ? parsed.composerStorageVersion : null
+    const isUnversionedDraft = savedStorageVersion == null
+    const isLegacyStorageDraft = savedStorageVersion == null || savedStorageVersion < 3
     // Fold removed audience detail into the remaining reader field before
     // stripping legacy keys, so old drafts keep user-authored guidance.
-    const legacyAudienceProfile = typeof parsed.audienceProfile === 'string'
-      ? parsed.audienceProfile.trim()
-      : ''
-    const savedTargetReader = typeof parsed.targetReader === 'string'
-      ? parsed.targetReader.trim()
-      : ''
+    const legacyAudienceProfile =
+      typeof parsed.audienceProfile === 'string' ? parsed.audienceProfile.trim() : ''
+    const savedTargetReader =
+      typeof parsed.targetReader === 'string' ? parsed.targetReader.trim() : ''
     if (legacyAudienceProfile && !savedTargetReader) {
       parsed.targetReader = legacyAudienceProfile
     } else if (
-      legacyAudienceProfile
-      && savedTargetReader.toLocaleLowerCase() !== legacyAudienceProfile.toLocaleLowerCase()
+      legacyAudienceProfile &&
+      savedTargetReader.toLocaleLowerCase() !== legacyAudienceProfile.toLocaleLowerCase()
     ) {
       parsed.targetReader = `${savedTargetReader} — ${legacyAudienceProfile}`
     }
@@ -76,16 +283,30 @@ export function loadSavedComposerState(): P2BFormState {
       parsed.enableEditorialAugmentation = false
     }
     const modelStack = resolvePrompt2BlogModelStack(parsed.modelStackId)
+    const editorial = isLegacyStorageDraft
+      ? {
+          ...DEFAULT_EDITORIAL_STATE,
+          approval: hasMeaningfulLegacyEditorialState(parsed)
+            ? ({
+                status: 'reconfirmation_required',
+                reason: 'legacy_draft',
+              } as const)
+            : ({ status: 'not_started' } as const),
+        }
+      : normalizeEditorialState(parsed.editorial)
     return {
       ...DEFAULT_COMPOSER_STATE,
       ...parsed,
+      activeWorkflow: parsed.activeWorkflow === 'editorial_v3' ? 'editorial_v3' : 'legacy_v2',
+      editorial,
       modelStackId: modelStack.id,
       modelName: resolvePrompt2BlogModelName(modelStack.modelName),
       writingModel: resolvePrompt2BlogWriterModel(modelStack.writingModel),
       auditModel: resolvePrompt2BlogWriterModel(modelStack.auditModel),
-      blobs: Array.isArray(parsed.blobs) && parsed.blobs.length
-        ? parsed.blobs
-        : DEFAULT_COMPOSER_STATE.blobs,
+      blobs:
+        Array.isArray(parsed.blobs) && parsed.blobs.length
+          ? parsed.blobs
+          : DEFAULT_COMPOSER_STATE.blobs,
       creativityLevel:
         parsed.creativityLevel === 'low' || parsed.creativityLevel === 'high'
           ? parsed.creativityLevel

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -16,10 +16,79 @@ import {
   type Prompt2BlogDirectionOption,
   type Prompt2BlogDirectionOptionId,
 } from '../api'
+import { commissionMatchesDraft, fingerprintCommissionSync } from './commission'
 
 export const COMPOSER_STORAGE_KEY = 'p2b-form-draft'
 export const COMPOSER_STORAGE_VERSION = 3
 const DEFAULT_MODEL_STACK = resolvePrompt2BlogModelStack(DEFAULT_PROMPT2BLOG_MODEL_STACK_ID)
+const ARTICLE_FORM_IDS = new Set([
+  'news-report',
+  'analysis',
+  'explainer',
+  'feature-profile',
+  'interview-qa',
+  'opinion-column',
+  'personal-essay-travelogue',
+  'destination-guide',
+  'service-guide',
+  'itinerary',
+  'curated-list-best-of',
+  'comparison',
+  'review',
+  'how-to-checklist',
+  'cost-budget-breakdown',
+])
+const TOPIC_MODULE_IDS = new Set([
+  'cost-affordability',
+  'accommodation-neighborhoods',
+  'food-drink',
+  'transportation',
+  'safety',
+  'visa-entry',
+  'seasonality-weather',
+  'adventure-outdoors',
+  'long-stay-remote-work',
+  'culture-etiquette',
+])
+const AUDIENCE_TAG_IDS = new Set([
+  'first-time-visitor',
+  'solo-traveler',
+  'family',
+  'remote-worker-relocator',
+  'accessibility-needs',
+  'budget-focused',
+  'premium-focused',
+])
+const COMMISSION_DRAFT_KEYS = [
+  'schema_version',
+  'original_title',
+  'location',
+  'approved_direction',
+  'form_id',
+  'topic_module_ids',
+  'audience',
+  'core_reader_question',
+  'reader_outcome',
+  'primary_subject',
+  'scope',
+  'requirements',
+  'exclusions',
+  'call_to_action',
+] as const
+const DIRECTION_OPTION_KEYS = [
+  'option_id',
+  'direction',
+  'form_id',
+  'topic_module_ids',
+  'audience',
+  'core_reader_question',
+  'reader_outcome',
+  'primary_subject',
+  'scope',
+  'requirements',
+  'exclusions',
+  'rationale',
+] as const
 
 export const DEFAULT_EDITORIAL_STATE: P2BEditorialComposerState = {
   directionOptions: [],
@@ -76,47 +145,94 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && Boolean(value.trim())
 }
 
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const allowed = new Set(keys)
+  return Object.keys(value).every(key => allowed.has(key))
+}
+
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every(item => typeof item === 'string')
 }
 
-function isCommissionDraft(value: unknown): value is Prompt2BlogCommissionDraft {
+function hasUniqueValues(values: string[]): boolean {
+  return new Set(values.map(value => value.trim().toLocaleLowerCase())).size === values.length
+}
+
+function isCommissionDraft(
+  value: unknown,
+  allowFingerprint = false,
+): value is Prompt2BlogCommissionDraft {
   if (!isRecord(value)) return false
+  const allowedKeys = allowFingerprint
+    ? [...COMMISSION_DRAFT_KEYS, 'commission_fingerprint']
+    : COMMISSION_DRAFT_KEYS
+  if (!hasOnlyKeys(value, allowedKeys)) return false
   const audience = value.audience
   const scope = value.scope
   if (!isRecord(audience) || !isRecord(scope)) return false
+  if (!hasOnlyKeys(audience, ['primary_reader', 'tags'])) return false
+  if (!hasOnlyKeys(scope, ['mode', 'references'])) return false
   const references = scope.references
   const requirements = value.requirements
-  return (
-    value.schema_version === 3 &&
-    isNonEmptyString(value.original_title) &&
-    isNonEmptyString(value.location) &&
-    isNonEmptyString(value.approved_direction) &&
-    isNonEmptyString(value.form_id) &&
-    isStringArray(value.topic_module_ids) &&
-    isNonEmptyString(audience.primary_reader) &&
-    isStringArray(audience.tags) &&
-    (scope.mode === 'single_subject' ||
-      scope.mode === 'head_to_head' ||
-      scope.mode === 'ranked_set') &&
+  const modules = value.topic_module_ids
+  const tags = audience.tags
+  const formId = value.form_id
+  if (!isStringArray(modules) || !isStringArray(tags) || !isNonEmptyString(formId)) {
+    return false
+  }
+  const validReferences =
     Array.isArray(references) &&
-    references.length > 0 &&
     references.every(
       reference =>
         isRecord(reference) &&
+        hasOnlyKeys(reference, ['name', 'role']) &&
         isNonEmptyString(reference.name) &&
         (reference.role === 'primary_subject' ||
           reference.role === 'context_only' ||
           reference.role === 'comparator'),
-    ) &&
+    )
+  if (!validReferences || references.length === 0) return false
+  const primaryReferences = references.filter(reference => reference.role === 'primary_subject')
+  const comparatorCount = references.filter(reference => reference.role === 'comparator').length
+  const validRequirements =
     Array.isArray(requirements) &&
     requirements.length > 0 &&
     requirements.every(
       requirement =>
         isRecord(requirement) &&
+        hasOnlyKeys(requirement, ['requirement_id', 'question']) &&
         isNonEmptyString(requirement.requirement_id) &&
         isNonEmptyString(requirement.question),
-    ) &&
+    )
+  if (!validRequirements) return false
+  return (
+    value.schema_version === 3 &&
+    isNonEmptyString(value.original_title) &&
+    isNonEmptyString(value.location) &&
+    isNonEmptyString(value.approved_direction) &&
+    ARTICLE_FORM_IDS.has(formId) &&
+    modules.length <= 4 &&
+    hasUniqueValues(modules) &&
+    modules.every(moduleId => TOPIC_MODULE_IDS.has(moduleId)) &&
+    isNonEmptyString(audience.primary_reader) &&
+    hasUniqueValues(tags) &&
+    tags.every(tagId => AUDIENCE_TAG_IDS.has(tagId)) &&
+    isNonEmptyString(value.core_reader_question) &&
+    isNonEmptyString(value.reader_outcome) &&
+    isNonEmptyString(value.primary_subject) &&
+    (scope.mode === 'single_subject' ||
+      scope.mode === 'head_to_head' ||
+      scope.mode === 'ranked_set') &&
+    primaryReferences.length === 1 &&
+    primaryReferences[0].name.trim().toLocaleLowerCase() ===
+      value.primary_subject.trim().toLocaleLowerCase() &&
+    hasUniqueValues(references.map(reference => reference.name)) &&
+    (scope.mode !== 'single_subject' || comparatorCount === 0) &&
+    (scope.mode !== 'head_to_head' || comparatorCount >= 1) &&
+    (scope.mode !== 'ranked_set' || comparatorCount >= 2) &&
+    (formId !== 'comparison' || scope.mode !== 'single_subject') &&
+    (scope.mode !== 'head_to_head' || formId === 'comparison') &&
+    hasUniqueValues(requirements.map(requirement => requirement.requirement_id)) &&
     isStringArray(value.exclusions) &&
     (value.call_to_action === null || typeof value.call_to_action === 'string')
   )
@@ -128,47 +244,26 @@ function isApprovedCommission(value: unknown): value is Prompt2BlogCommission {
   return (
     typeof fingerprint === 'string' &&
     /^[a-f0-9]{64}$/.test(fingerprint) &&
-    isCommissionDraft(value)
+    isCommissionDraft(value, true) &&
+    fingerprintCommissionSync(value) === fingerprint
   )
 }
 
 function isDirectionOption(value: unknown): value is Prompt2BlogDirectionOption {
   if (!isRecord(value)) return false
+  if (!hasOnlyKeys(value, DIRECTION_OPTION_KEYS)) return false
+  const { option_id: optionId, direction, rationale, ...commissionFields } = value
   return (
-    PROMPT2BLOG_DIRECTION_OPTION_IDS.includes(value.option_id as Prompt2BlogDirectionOptionId) &&
-    isNonEmptyString(value.direction) &&
-    isNonEmptyString(value.form_id) &&
-    isStringArray(value.topic_module_ids) &&
-    isRecord(value.audience) &&
-    isNonEmptyString(value.audience.primary_reader) &&
-    isStringArray(value.audience.tags) &&
-    isNonEmptyString(value.core_reader_question) &&
-    isNonEmptyString(value.reader_outcome) &&
-    isNonEmptyString(value.primary_subject) &&
-    isRecord(value.scope) &&
-    (value.scope.mode === 'single_subject' ||
-      value.scope.mode === 'head_to_head' ||
-      value.scope.mode === 'ranked_set') &&
-    Array.isArray(value.scope.references) &&
-    value.scope.references.length > 0 &&
-    value.scope.references.every(
-      reference =>
-        isRecord(reference) &&
-        isNonEmptyString(reference.name) &&
-        (reference.role === 'primary_subject' ||
-          reference.role === 'context_only' ||
-          reference.role === 'comparator'),
-    ) &&
-    Array.isArray(value.requirements) &&
-    value.requirements.length > 0 &&
-    value.requirements.every(
-      requirement =>
-        isRecord(requirement) &&
-        isNonEmptyString(requirement.requirement_id) &&
-        isNonEmptyString(requirement.question),
-    ) &&
-    isStringArray(value.exclusions) &&
-    isNonEmptyString(value.rationale)
+    PROMPT2BLOG_DIRECTION_OPTION_IDS.includes(optionId as Prompt2BlogDirectionOptionId) &&
+    isNonEmptyString(rationale) &&
+    isCommissionDraft({
+      ...commissionFields,
+      schema_version: 3,
+      original_title: 'Stored direction',
+      location: 'Stored location',
+      approved_direction: direction,
+      call_to_action: null,
+    })
   )
 }
 
@@ -215,6 +310,10 @@ function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
     !Array.isArray(directionOptions) ||
     !directionOptions.every(isDirectionOption) ||
     (directionOptions.length !== 0 && directionOptions.length !== 3) ||
+    (directionOptions.length === 3 &&
+      directionOptions.some(
+        (option, index) => option.option_id !== PROMPT2BLOG_DIRECTION_OPTION_IDS[index],
+      )) ||
     (selectedOptionId !== null &&
       !PROMPT2BLOG_DIRECTION_OPTION_IDS.includes(
         selectedOptionId as Prompt2BlogDirectionOptionId,
@@ -224,9 +323,7 @@ function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
     (commissionDraft !== null && !isCommissionDraft(commissionDraft)) ||
     (commissionDraft !== null && selectedOptionId === null) ||
     (approval.status === 'approved' &&
-      (commissionDraft === null ||
-        approval.commission.original_title !== commissionDraft.original_title ||
-        approval.commission.location !== commissionDraft.location))
+      (commissionDraft === null || !commissionMatchesDraft(commissionDraft, approval.commission)))
   ) {
     return { ...DEFAULT_EDITORIAL_STATE }
   }
@@ -239,6 +336,17 @@ function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
 }
 
 export function saveComposerState(state: P2BFormState): void {
+  try {
+    const raw = localStorage.getItem(COMPOSER_STORAGE_KEY)
+    const stored = raw ? (JSON.parse(raw) as { composerStorageVersion?: unknown }) : null
+    if (
+      typeof stored?.composerStorageVersion === 'number' &&
+      stored.composerStorageVersion > COMPOSER_STORAGE_VERSION
+    )
+      return
+  } catch {
+    // A malformed draft is safe to replace with the current validated shape.
+  }
   localStorage.setItem(
     COMPOSER_STORAGE_KEY,
     JSON.stringify({
@@ -259,6 +367,9 @@ export function loadSavedComposerState(): P2BFormState {
     }
     const savedStorageVersion =
       typeof parsed.composerStorageVersion === 'number' ? parsed.composerStorageVersion : null
+    if (savedStorageVersion !== null && savedStorageVersion > COMPOSER_STORAGE_VERSION) {
+      return DEFAULT_COMPOSER_STATE
+    }
     const isUnversionedDraft = savedStorageVersion == null
     const isLegacyStorageDraft = savedStorageVersion == null || savedStorageVersion < 3
     // Fold removed audience detail into the remaining reader field before

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
@@ -1,4 +1,11 @@
-import type { Prompt2BlogModelName, Prompt2BlogWriterModel } from '../api'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogDirectionOptionId,
+  Prompt2BlogModelName,
+  Prompt2BlogWriterModel,
+} from '../api'
 import type { Prompt2BlogModelStackId } from '../constants/prompt2blog.constants'
 
 export interface RawBlob {
@@ -6,7 +13,28 @@ export interface RawBlob {
   content: string
 }
 
+export type P2BActiveWorkflow = 'legacy_v2' | 'editorial_v3'
+
+export type P2BCommissionApproval =
+  | { status: 'not_started' }
+  | { status: 'awaiting_selection' }
+  | { status: 'needs_approval' }
+  | {
+      status: 'reconfirmation_required'
+      reason: 'legacy_draft' | 'commission_edited' | 'title_or_location_changed'
+    }
+  | { status: 'approved'; commission: Prompt2BlogCommission }
+
+export interface P2BEditorialComposerState {
+  directionOptions: Prompt2BlogDirectionOption[]
+  selectedOptionId: Prompt2BlogDirectionOptionId | null
+  commissionDraft: Prompt2BlogCommissionDraft | null
+  approval: P2BCommissionApproval
+}
+
 export interface P2BFormState {
+  activeWorkflow: P2BActiveWorkflow
+  editorial: P2BEditorialComposerState
   easySetupLocation: string
   easySetupTitle: string
   articleTypeId: number | null

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.test.ts
@@ -112,17 +112,44 @@ function option(
   optionId: 'direction-1' | 'direction-2' | 'direction-3',
   index: number
 ) {
+  const directions = [
+    "Test Lima's affordability claim against current housing, food, and transport costs.",
+    'Explain which neighborhoods make long stays workable for remote professionals.',
+    'Assess the practical tradeoffs of choosing Lima for a year abroad.'
+  ] as const
+  const questions = [
+    'What does a realistic monthly budget buy in Lima now?',
+    'Where can remote workers build a convenient daily routine?',
+    'Which benefits and frictions matter most over a full year?'
+  ] as const
+  const outcomes = [
+    'Build a current budget and decide whether Lima remains affordable.',
+    'Shortlist neighborhoods using work, housing, and mobility needs.',
+    'Weigh long-term advantages against the costs of living in Lima.'
+  ] as const
+  const requirements = [
+    'What do current housing, food, and transportation costs show?',
+    'Which neighborhoods best combine housing, workspaces, and transport?',
+    'What evidence captures the strongest long-stay benefits and frictions?'
+  ] as const
+  const rationales = [
+    'Grounds the bargain claim in a concrete, current monthly budget.',
+    'Turns a broad relocation question into a practical neighborhood decision.',
+    'Gives readers a balanced decision framework for a year-long move.'
+  ] as const
+  const position = index - 1
+
   return {
     option_id: optionId,
-    direction: `Assess Lima's current long-stay value through editorial take ${index}.`,
+    direction: directions[position],
     form_id: 'analysis',
     topic_module_ids: ['cost-affordability', 'long-stay-remote-work'],
     audience: {
       primary_reader: 'Prospective expats and remote workers',
       tags: ['remote-worker-relocator', 'budget-focused']
     },
-    core_reader_question: `Does Lima still deliver value under scenario ${index}?`,
-    reader_outcome: `Judge Lima's tradeoffs using scenario ${index}.`,
+    core_reader_question: questions[position],
+    reader_outcome: outcomes[position],
     primary_subject: 'Lima',
     scope: {
       mode: 'single_subject',
@@ -135,13 +162,13 @@ function option(
     requirements: [
       {
         requirement_id: 'r1',
-        question: `What current evidence settles scenario ${index}?`
+        question: requirements[position]
       }
     ],
     exclusions: [
       'Do not organize the article as a city-versus-city comparison.'
     ],
-    rationale: `This option tests a distinct value proposition ${index}.`
+    rationale: rationales[position]
   }
 }
 
@@ -327,6 +354,21 @@ describe('reviewDirectionResponseJson', () => {
         'options[0].scope.references',
         'options[0].requirements',
         'options[1].direction'
+      ])
+    )
+  })
+
+  it('rejects options that differ only by trivial suffixes', () => {
+    const nearDuplicates = response()
+    nearDuplicates.options[1].direction = `${nearDuplicates.options[0].direction} Option 2.`
+    nearDuplicates.options[1].core_reader_question = `${nearDuplicates.options[0].core_reader_question} Choice 2?`
+    nearDuplicates.options[1].reader_outcome = `${nearDuplicates.options[0].reader_outcome} Version 2.`
+
+    expect(review(nearDuplicates).issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'options[1].direction' }),
+        expect.objectContaining({ path: 'options[1].core_reader_question' }),
+        expect.objectContaining({ path: 'options[1].reader_outcome' })
       ])
     )
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Prompt2BlogDirectionResponse,
+  Prompt2BlogEditorialOptionsResponse
+} from '../api'
+import { reviewDirectionResponseJson } from './direction-import'
+
+const catalog = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'analysis',
+      label: 'Analysis',
+      description: 'Focused interpretation.',
+      order: 2,
+      source_requirements: []
+    },
+    {
+      id: 'comparison',
+      label: 'Comparison',
+      description: 'Approved co-subjects.',
+      order: 12,
+      source_requirements: []
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost',
+      description: 'Cost evidence.',
+      order: 1
+    },
+    {
+      id: 'accommodation-neighborhoods',
+      label: 'Accommodation',
+      description: 'Housing evidence.',
+      order: 2
+    },
+    {
+      id: 'transportation',
+      label: 'Transportation',
+      description: 'Transport evidence.',
+      order: 4
+    },
+    {
+      id: 'safety',
+      label: 'Safety',
+      description: 'Safety evidence.',
+      order: 5
+    },
+    {
+      id: 'long-stay-remote-work',
+      label: 'Long stay',
+      description: 'Long-stay evidence.',
+      order: 9
+    }
+  ],
+  audience_tags: [
+    {
+      id: 'remote-worker-relocator',
+      label: 'Remote worker',
+      description: 'Long-stay reader.'
+    },
+    {
+      id: 'budget-focused',
+      label: 'Budget-focused',
+      description: 'Cost-sensitive reader.'
+    }
+  ],
+  scope_modes: [
+    {
+      id: 'single_subject',
+      label: 'Single subject',
+      description: 'One subject.'
+    },
+    {
+      id: 'head_to_head',
+      label: 'Head to head',
+      description: 'Two or more co-subjects.'
+    },
+    {
+      id: 'ranked_set',
+      label: 'Ranked set',
+      description: 'Ranked co-subjects.'
+    }
+  ],
+  reference_roles: [
+    {
+      id: 'primary_subject',
+      label: 'Primary',
+      description: 'Controlling subject.'
+    },
+    {
+      id: 'context_only',
+      label: 'Context only',
+      description: 'Context, never structure.'
+    },
+    {
+      id: 'comparator',
+      label: 'Comparator',
+      description: 'Approved co-subject.'
+    }
+  ]
+} satisfies Prompt2BlogEditorialOptionsResponse
+
+const expected = {
+  originalTitle: "Is Lima still South America's bargain expat capital?",
+  location: 'Lima, Peru'
+}
+
+function option(
+  optionId: 'direction-1' | 'direction-2' | 'direction-3',
+  index: number
+) {
+  return {
+    option_id: optionId,
+    direction: `Assess Lima's current long-stay value through editorial take ${index}.`,
+    form_id: 'analysis',
+    topic_module_ids: ['cost-affordability', 'long-stay-remote-work'],
+    audience: {
+      primary_reader: 'Prospective expats and remote workers',
+      tags: ['remote-worker-relocator', 'budget-focused']
+    },
+    core_reader_question: `Does Lima still deliver value under scenario ${index}?`,
+    reader_outcome: `Judge Lima's tradeoffs using scenario ${index}.`,
+    primary_subject: 'Lima',
+    scope: {
+      mode: 'single_subject',
+      references: [
+        { name: 'Lima', role: 'primary_subject' },
+        { name: 'Medellín', role: 'context_only' },
+        { name: 'Buenos Aires', role: 'context_only' }
+      ]
+    },
+    requirements: [
+      {
+        requirement_id: 'r1',
+        question: `What current evidence settles scenario ${index}?`
+      }
+    ],
+    exclusions: [
+      'Do not organize the article as a city-versus-city comparison.'
+    ],
+    rationale: `This option tests a distinct value proposition ${index}.`
+  }
+}
+
+function response(): Prompt2BlogDirectionResponse {
+  return {
+    schema_version: 3,
+    original_title: expected.originalTitle,
+    location: expected.location,
+    options: [
+      option('direction-1', 1),
+      option('direction-2', 2),
+      option('direction-3', 3)
+    ]
+  } as Prompt2BlogDirectionResponse
+}
+
+function review(value: unknown) {
+  return reviewDirectionResponseJson(JSON.stringify(value), expected, catalog)
+}
+
+describe('reviewDirectionResponseJson', () => {
+  it('accepts exactly three Lima-centered options with context-only benchmarks', () => {
+    const result = review(response())
+
+    expect(result.issues).toEqual([])
+    expect(result.response).toEqual(response())
+  })
+
+  it('requires a bare strict JSON object with no extra keys', () => {
+    expect(
+      reviewDirectionResponseJson(
+        `\`\`\`json\n${JSON.stringify(response())}\n\`\`\``,
+        expected,
+        catalog
+      ).issues[0].path
+    ).toBe('json')
+
+    const payload = response() as Prompt2BlogDirectionResponse & {
+      note: string
+    }
+    payload.note = 'Here you go'
+    expect(review(payload).issues).toContainEqual({
+      path: 'note',
+      message: 'Unexpected key.'
+    })
+  })
+
+  it('requires the response to echo the exact app-owned title and location', () => {
+    const payload = response()
+    payload.original_title = 'A different article'
+    payload.location = 'Lima'
+
+    const result = review(payload)
+
+    expect(result.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining(['original_title', 'location'])
+    )
+    expect(result.response).toBeNull()
+  })
+
+  it('requires exactly three fixed option IDs in order', () => {
+    const tooFew = response() as unknown as { options: unknown[] }
+    tooFew.options.pop()
+    expect(review(tooFew).issues).toContainEqual({
+      path: 'options',
+      message: 'Must contain exactly 3 options.'
+    })
+
+    const reordered = response()
+    ;[reordered.options[0], reordered.options[1]] = [
+      reordered.options[1],
+      reordered.options[0]
+    ]
+    expect(
+      review(reordered).issues.some(
+        (issue) =>
+          issue.path === 'options[0].option_id' &&
+          issue.message.includes('direction-1')
+      )
+    ).toBe(true)
+  })
+
+  it('rejects unknown catalog IDs and a fifth topic module', () => {
+    const unknown = response() as unknown as {
+      options: Array<{
+        form_id: string
+        topic_module_ids: string[]
+        audience: { tags: string[] }
+        scope: { references: Array<{ role: string }> }
+      }>
+    }
+    unknown.options[0].form_id = 'comparison-article'
+    unknown.options[0].topic_module_ids[0] = 'packing'
+    unknown.options[0].audience.tags[0] = 'everyone'
+    unknown.options[0].scope.references[1].role = 'benchmark'
+
+    expect(review(unknown).issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        'options[0].form_id',
+        'options[0].topic_module_ids[0]',
+        'options[0].audience.tags[0]',
+        'options[0].scope.references[1].role'
+      ])
+    )
+
+    const tooMany = response()
+    tooMany.options[0].topic_module_ids = [
+      'cost-affordability',
+      'accommodation-neighborhoods',
+      'transportation',
+      'safety',
+      'long-stay-remote-work'
+    ]
+    expect(review(tooMany).issues).toContainEqual({
+      path: 'options[0].topic_module_ids',
+      message: 'Must contain at most 4 module IDs.'
+    })
+  })
+
+  it('rejects comparison drift and inconsistent comparison scope', () => {
+    const drifted = response()
+    drifted.options[0].scope.references[1].role = 'comparator'
+    expect(review(drifted).issues).toContainEqual({
+      path: 'options[0].scope',
+      message: 'single_subject scope cannot contain comparators.'
+    })
+
+    const comparison = response()
+    comparison.options[0].form_id = 'comparison'
+    expect(review(comparison).issues).toContainEqual({
+      path: 'options[0].scope.mode',
+      message: 'Comparison form cannot use single_subject scope.'
+    })
+
+    const hiddenComparison = response()
+    hiddenComparison.options[0].scope.mode = 'head_to_head'
+    hiddenComparison.options[0].scope.references[1].role = 'comparator'
+    expect(review(hiddenComparison).issues).toContainEqual({
+      path: 'options[0].form_id',
+      message: 'head_to_head scope requires Comparison form.'
+    })
+  })
+
+  it('requires one matching primary reference and consistent comparator counts', () => {
+    const mismatch = response()
+    mismatch.options[0].scope.references[0].name = 'Peru'
+    expect(review(mismatch).issues).toContainEqual({
+      path: 'options[0].primary_subject',
+      message: 'Must exactly match the primary_subject reference name.'
+    })
+
+    const ranked = response()
+    ranked.options[0].form_id = 'comparison'
+    ranked.options[0].scope.mode = 'ranked_set'
+    ranked.options[0].scope.references[1].role = 'comparator'
+    expect(review(ranked).issues).toContainEqual({
+      path: 'options[0].scope',
+      message: 'ranked_set scope requires at least 2 comparators.'
+    })
+  })
+
+  it('rejects duplicate modules, tags, references, requirements, and options', () => {
+    const duplicates = response()
+    duplicates.options[0].topic_module_ids = [
+      'cost-affordability',
+      'cost-affordability'
+    ]
+    duplicates.options[0].audience.tags = ['budget-focused', 'budget-focused']
+    duplicates.options[0].scope.references.push({
+      name: 'lima',
+      role: 'context_only'
+    })
+    duplicates.options[0].requirements.push({
+      requirement_id: 'r1',
+      question: 'A duplicated requirement id?'
+    })
+    duplicates.options[1].direction = duplicates.options[0].direction
+
+    expect(review(duplicates).issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        'options[0].topic_module_ids',
+        'options[0].audience.tags',
+        'options[0].scope.references',
+        'options[0].requirements',
+        'options[1].direction'
+      ])
+    )
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.ts
@@ -1,0 +1,500 @@
+import {
+  PROMPT2BLOG_DIRECTION_OPTION_IDS,
+  type Prompt2BlogDirectionOption,
+  type Prompt2BlogDirectionResponse,
+  type Prompt2BlogEditorialOptionsResponse
+} from '../api'
+
+export type DirectionImportIssue = {
+  path: string
+  message: string
+}
+
+export type DirectionImportReview = {
+  issues: DirectionImportIssue[]
+  response: Prompt2BlogDirectionResponse | null
+}
+
+type JsonObject = Record<string, unknown>
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizedText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLocaleLowerCase()
+}
+
+function reportUnexpectedKeys(
+  value: JsonObject,
+  keys: readonly string[],
+  path: string,
+  issues: DirectionImportIssue[]
+): void {
+  const expected = new Set(keys)
+  for (const key of Object.keys(value)) {
+    if (!expected.has(key)) {
+      issues.push({
+        path: path ? `${path}.${key}` : key,
+        message: 'Unexpected key.'
+      })
+    }
+  }
+  for (const key of keys) {
+    if (!(key in value)) {
+      issues.push({
+        path: path ? `${path}.${key}` : key,
+        message: 'Missing required key.'
+      })
+    }
+  }
+}
+
+function requireString(
+  value: unknown,
+  path: string,
+  issues: DirectionImportIssue[]
+): value is string {
+  if (typeof value !== 'string') {
+    issues.push({ path, message: 'Must be a string.' })
+    return false
+  }
+  if (!value.trim()) {
+    issues.push({ path, message: 'Must not be empty.' })
+    return false
+  }
+  return true
+}
+
+function reportDuplicates(
+  values: string[],
+  path: string,
+  label: string,
+  issues: DirectionImportIssue[]
+): void {
+  if (new Set(values).size !== values.length) {
+    issues.push({ path, message: `${label} must be unique.` })
+  }
+}
+
+function validateIdArray(
+  value: unknown,
+  path: string,
+  allowedIds: Set<string>,
+  label: string,
+  issues: DirectionImportIssue[],
+  maximum?: number
+): string[] {
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: 'Must be an array.' })
+    return []
+  }
+  if (maximum !== undefined && value.length > maximum) {
+    issues.push({
+      path,
+      message: `Must contain at most ${maximum} module IDs.`
+    })
+  }
+
+  const ids: string[] = []
+  value.forEach((item, index) => {
+    const itemPath = `${path}[${index}]`
+    if (!requireString(item, itemPath, issues)) return
+    ids.push(item)
+    if (!allowedIds.has(item)) {
+      issues.push({ path: itemPath, message: `Unknown ${label} ID.` })
+    }
+  })
+  reportDuplicates(ids, path, `${label} IDs`, issues)
+  return ids
+}
+
+function validateAudience(
+  value: unknown,
+  path: string,
+  catalog: Prompt2BlogEditorialOptionsResponse,
+  issues: DirectionImportIssue[]
+): void {
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return
+  }
+  reportUnexpectedKeys(value, ['primary_reader', 'tags'], path, issues)
+  requireString(value.primary_reader, `${path}.primary_reader`, issues)
+  validateIdArray(
+    value.tags,
+    `${path}.tags`,
+    new Set(catalog.audience_tags.map((item) => item.id)),
+    'audience tag',
+    issues
+  )
+}
+
+function validateScope(
+  value: unknown,
+  path: string,
+  primarySubject: unknown,
+  formId: unknown,
+  catalog: Prompt2BlogEditorialOptionsResponse,
+  issues: DirectionImportIssue[]
+): void {
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return
+  }
+  reportUnexpectedKeys(value, ['mode', 'references'], path, issues)
+
+  const allowedModes = new Set<string>(
+    catalog.scope_modes.map((item) => item.id)
+  )
+  const mode = value.mode
+  const modeIsString = requireString(mode, `${path}.mode`, issues)
+  if (modeIsString && !allowedModes.has(mode)) {
+    issues.push({ path: `${path}.mode`, message: 'Unknown scope mode ID.' })
+  }
+
+  if (!Array.isArray(value.references)) {
+    issues.push({ path: `${path}.references`, message: 'Must be an array.' })
+    return
+  }
+  if (value.references.length === 0) {
+    issues.push({
+      path: `${path}.references`,
+      message: 'Must contain at least 1 reference.'
+    })
+  }
+
+  const allowedRoles = new Set<string>(
+    catalog.reference_roles.map((item) => item.id)
+  )
+  const names: string[] = []
+  let primaryCount = 0
+  let primaryName = ''
+  let comparatorCount = 0
+
+  value.references.forEach((reference, index) => {
+    const referencePath = `${path}.references[${index}]`
+    if (!isObject(reference)) {
+      issues.push({ path: referencePath, message: 'Must be an object.' })
+      return
+    }
+    reportUnexpectedKeys(reference, ['name', 'role'], referencePath, issues)
+    if (requireString(reference.name, `${referencePath}.name`, issues)) {
+      names.push(normalizedText(reference.name))
+    }
+    if (!requireString(reference.role, `${referencePath}.role`, issues)) return
+    if (!allowedRoles.has(reference.role)) {
+      issues.push({
+        path: `${referencePath}.role`,
+        message: 'Unknown reference role ID.'
+      })
+      return
+    }
+    if (reference.role === 'primary_subject') {
+      primaryCount += 1
+      if (typeof reference.name === 'string') primaryName = reference.name
+    }
+    if (reference.role === 'comparator') comparatorCount += 1
+  })
+
+  reportDuplicates(names, `${path}.references`, 'Reference names', issues)
+  if (primaryCount !== 1) {
+    issues.push({
+      path,
+      message: 'Scope must contain exactly 1 primary_subject reference.'
+    })
+  } else if (
+    typeof primarySubject === 'string' &&
+    primaryName !== primarySubject
+  ) {
+    issues.push({
+      path: path.replace(/\.scope$/, '.primary_subject'),
+      message: 'Must exactly match the primary_subject reference name.'
+    })
+  }
+
+  if (value.mode === 'single_subject' && comparatorCount > 0) {
+    issues.push({
+      path,
+      message: 'single_subject scope cannot contain comparators.'
+    })
+  }
+  if (value.mode === 'head_to_head' && comparatorCount < 1) {
+    issues.push({
+      path,
+      message: 'head_to_head scope requires at least 1 comparator.'
+    })
+  }
+  if (value.mode === 'ranked_set' && comparatorCount < 2) {
+    issues.push({
+      path,
+      message: 'ranked_set scope requires at least 2 comparators.'
+    })
+  }
+  if (formId === 'comparison' && value.mode === 'single_subject') {
+    issues.push({
+      path: `${path}.mode`,
+      message: 'Comparison form cannot use single_subject scope.'
+    })
+  }
+  if (value.mode === 'head_to_head' && formId !== 'comparison') {
+    issues.push({
+      path: path.replace(/\.scope$/, '.form_id'),
+      message: 'head_to_head scope requires Comparison form.'
+    })
+  }
+}
+
+function validateRequirements(
+  value: unknown,
+  path: string,
+  issues: DirectionImportIssue[]
+): void {
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: 'Must be an array.' })
+    return
+  }
+  if (!value.length) {
+    issues.push({ path, message: 'Must contain at least 1 requirement.' })
+  }
+  const ids: string[] = []
+  value.forEach((requirement, index) => {
+    const requirementPath = `${path}[${index}]`
+    if (!isObject(requirement)) {
+      issues.push({ path: requirementPath, message: 'Must be an object.' })
+      return
+    }
+    reportUnexpectedKeys(
+      requirement,
+      ['requirement_id', 'question'],
+      requirementPath,
+      issues
+    )
+    if (
+      requireString(
+        requirement.requirement_id,
+        `${requirementPath}.requirement_id`,
+        issues
+      )
+    ) {
+      ids.push(requirement.requirement_id)
+      if (!/^r[1-9]\d*$/.test(requirement.requirement_id)) {
+        issues.push({
+          path: `${requirementPath}.requirement_id`,
+          message: 'Must use the stable r1, r2, … format.'
+        })
+      }
+    }
+    requireString(requirement.question, `${requirementPath}.question`, issues)
+  })
+  reportDuplicates(ids, path, 'Requirement IDs', issues)
+}
+
+function validateStringArray(
+  value: unknown,
+  path: string,
+  issues: DirectionImportIssue[]
+): void {
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: 'Must be an array.' })
+    return
+  }
+  if (!value.length)
+    issues.push({ path, message: 'Must contain at least 1 exclusion.' })
+  value.forEach((item, index) =>
+    requireString(item, `${path}[${index}]`, issues)
+  )
+}
+
+function validateOption(
+  value: unknown,
+  index: number,
+  catalog: Prompt2BlogEditorialOptionsResponse,
+  issues: DirectionImportIssue[]
+): void {
+  const path = `options[${index}]`
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return
+  }
+  reportUnexpectedKeys(
+    value,
+    [
+      'option_id',
+      'direction',
+      'form_id',
+      'topic_module_ids',
+      'audience',
+      'core_reader_question',
+      'reader_outcome',
+      'primary_subject',
+      'scope',
+      'requirements',
+      'exclusions',
+      'rationale'
+    ],
+    path,
+    issues
+  )
+
+  const optionIdPath = `${path}.option_id`
+  if (requireString(value.option_id, optionIdPath, issues)) {
+    const expectedId = PROMPT2BLOG_DIRECTION_OPTION_IDS[index]
+    if (value.option_id !== expectedId) {
+      issues.push({ path: optionIdPath, message: `Must be "${expectedId}".` })
+    }
+  }
+
+  requireString(value.direction, `${path}.direction`, issues)
+  const formId = value.form_id
+  const formIdIsString = requireString(formId, `${path}.form_id`, issues)
+  if (
+    formIdIsString &&
+    !new Set<string>(catalog.forms.map((item) => item.id)).has(formId)
+  ) {
+    issues.push({
+      path: `${path}.form_id`,
+      message: 'Unknown article form ID.'
+    })
+  }
+  validateIdArray(
+    value.topic_module_ids,
+    `${path}.topic_module_ids`,
+    new Set(catalog.topic_modules.map((item) => item.id)),
+    'topic module',
+    issues,
+    4
+  )
+  validateAudience(value.audience, `${path}.audience`, catalog, issues)
+  requireString(
+    value.core_reader_question,
+    `${path}.core_reader_question`,
+    issues
+  )
+  requireString(value.reader_outcome, `${path}.reader_outcome`, issues)
+  requireString(value.primary_subject, `${path}.primary_subject`, issues)
+  validateScope(
+    value.scope,
+    `${path}.scope`,
+    value.primary_subject,
+    value.form_id,
+    catalog,
+    issues
+  )
+  validateRequirements(value.requirements, `${path}.requirements`, issues)
+  validateStringArray(value.exclusions, `${path}.exclusions`, issues)
+  requireString(value.rationale, `${path}.rationale`, issues)
+}
+
+function validateDistinctOptions(
+  options: unknown[],
+  issues: DirectionImportIssue[]
+): void {
+  for (const field of [
+    'direction',
+    'core_reader_question',
+    'reader_outcome'
+  ] as const) {
+    const seen = new Set<string>()
+    options.forEach((option, index) => {
+      if (!isObject(option) || typeof option[field] !== 'string') return
+      const normalized = normalizedText(option[field])
+      if (seen.has(normalized)) {
+        issues.push({
+          path: `options[${index}].${field}`,
+          message: `Must be materially different from the other option ${field.replace(/_/g, ' ')} values.`
+        })
+      }
+      seen.add(normalized)
+    })
+  }
+}
+
+export function reviewDirectionResponseJson(
+  raw: string,
+  expected: { originalTitle: string; location: string },
+  catalog: Prompt2BlogEditorialOptionsResponse
+): DirectionImportReview {
+  const issues: DirectionImportIssue[] = []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw.trim())
+  } catch (error) {
+    return {
+      issues: [
+        {
+          path: 'json',
+          message: `Not valid JSON: ${error instanceof Error ? error.message : 'parse failed'}.`
+        }
+      ],
+      response: null
+    }
+  }
+
+  if (!isObject(parsed)) {
+    return {
+      issues: [{ path: 'json', message: 'Must be one JSON object.' }],
+      response: null
+    }
+  }
+
+  reportUnexpectedKeys(
+    parsed,
+    ['schema_version', 'original_title', 'location', 'options'],
+    '',
+    issues
+  )
+  if (parsed.schema_version !== 3) {
+    issues.push({ path: 'schema_version', message: 'Must equal 3.' })
+  }
+  if (requireString(parsed.original_title, 'original_title', issues)) {
+    if (parsed.original_title !== expected.originalTitle) {
+      issues.push({
+        path: 'original_title',
+        message: 'Must exactly match the app-owned title.'
+      })
+    }
+  }
+  if (requireString(parsed.location, 'location', issues)) {
+    if (parsed.location !== expected.location) {
+      issues.push({
+        path: 'location',
+        message: 'Must exactly match the app-owned location.'
+      })
+    }
+  }
+
+  if (!Array.isArray(parsed.options)) {
+    issues.push({ path: 'options', message: 'Must be an array.' })
+  } else {
+    if (parsed.options.length !== 3) {
+      issues.push({
+        path: 'options',
+        message: 'Must contain exactly 3 options.'
+      })
+    }
+    parsed.options.forEach((option, index) =>
+      validateOption(option, index, catalog, issues)
+    )
+    validateDistinctOptions(parsed.options, issues)
+  }
+
+  return {
+    issues,
+    response: issues.length ? null : (parsed as Prompt2BlogDirectionResponse)
+  }
+}
+
+export function validateDirectionOption(
+  option: Prompt2BlogDirectionOption,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): DirectionImportIssue[] {
+  const issues: DirectionImportIssue[] = []
+  validateOption(
+    option,
+    PROMPT2BLOG_DIRECTION_OPTION_IDS.indexOf(option.option_id),
+    catalog,
+    issues
+  )
+  return issues
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.ts
@@ -25,6 +25,28 @@ function normalizedText(value: string): string {
   return value.replace(/\s+/g, ' ').trim().toLocaleLowerCase()
 }
 
+function meaningfulTokens(value: string): Set<string> {
+  return new Set(
+    normalizedText(value)
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .split(' ')
+      .filter((token) => token && !/^\d+$/.test(token))
+  )
+}
+
+function textSimilarity(left: string, right: string): number {
+  const leftTokens = meaningfulTokens(left)
+  const rightTokens = meaningfulTokens(right)
+  if (leftTokens.size < 4 || rightTokens.size < 4) {
+    return normalizedText(left) === normalizedText(right) ? 1 : 0
+  }
+  const intersection = [...leftTokens].filter((token) =>
+    rightTokens.has(token)
+  ).length
+  const union = new Set([...leftTokens, ...rightTokens]).size
+  return intersection / union
+}
+
 function reportUnexpectedKeys(
   value: JsonObject,
   keys: readonly string[],
@@ -404,6 +426,20 @@ function validateDistinctOptions(
           path: `options[${index}].${field}`,
           message: `Must be materially different from the other option ${field.replace(/_/g, ' ')} values.`
         })
+      }
+      for (let priorIndex = 0; priorIndex < index; priorIndex += 1) {
+        const prior = options[priorIndex]
+        if (
+          isObject(prior) &&
+          typeof prior[field] === 'string' &&
+          textSimilarity(prior[field], option[field]) >= 0.8
+        ) {
+          issues.push({
+            path: `options[${index}].${field}`,
+            message: `Must be materially different from option ${priorIndex + 1}; trivial wording changes do not count.`
+          })
+          break
+        }
       }
       seen.add(normalized)
     })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import type { Prompt2BlogEditorialOptionsResponse } from '../api'
+import { buildDirectionPrompt } from './direction-prompt'
+
+const catalog = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'analysis',
+      label: 'Analysis',
+      description: 'Interprets evidence to answer a focused question.',
+      order: 2,
+      source_requirements: []
+    },
+    {
+      id: 'comparison',
+      label: 'Comparison',
+      description: 'Compares approved co-subjects against consistent criteria.',
+      order: 12,
+      source_requirements: []
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost and affordability',
+      description: 'Constrains cost evidence and comparisons.',
+      order: 1
+    }
+  ],
+  audience_tags: [
+    {
+      id: 'budget-focused',
+      label: 'Budget-focused',
+      description: 'Prioritizes costs and value.'
+    }
+  ],
+  scope_modes: [
+    {
+      id: 'single_subject',
+      label: 'Single subject',
+      description: 'Keeps one subject primary.'
+    }
+  ],
+  reference_roles: [
+    {
+      id: 'primary_subject',
+      label: 'Primary subject',
+      description: 'The controlling subject.'
+    },
+    {
+      id: 'context_only',
+      label: 'Context only',
+      description: 'Cannot organize the article.'
+    }
+  ]
+} satisfies Prompt2BlogEditorialOptionsResponse
+
+describe('buildDirectionPrompt', () => {
+  it('asks for exactly three fixed editorial options from the v3 catalog', () => {
+    const prompt = buildDirectionPrompt(
+      "Is Lima still South America's bargain expat capital?",
+      'Lima, Peru',
+      catalog
+    )
+
+    expect(prompt).toContain(
+      `Original title: "Is Lima still South America's bargain expat capital?"`
+    )
+    expect(prompt).toContain('Location: "Lima, Peru"')
+    expect(prompt).toContain(
+      'exactly three materially different editorial options'
+    )
+    expect(prompt.match(/"direction-[123]"/g)).toEqual([
+      '"direction-1"',
+      '"direction-2"',
+      '"direction-3"'
+    ])
+    expect(prompt).toContain('- analysis (Analysis) — Interprets evidence')
+    expect(prompt).toContain('- cost-affordability (Cost and affordability)')
+    expect(prompt).toContain('- budget-focused (Budget-focused)')
+    expect(prompt).toContain('- single_subject (Single subject)')
+    expect(prompt).toContain('- context_only (Context only)')
+  })
+
+  it('keeps direction generation separate from research and legacy controls', () => {
+    const prompt = buildDirectionPrompt(
+      'A weekend in Lisbon',
+      'Lisbon, Portugal',
+      catalog
+    )
+
+    expect(prompt).toContain(
+      'Do not browse, research facts, or write the article'
+    )
+    expect(prompt).toContain('required research questions')
+    expect(prompt).toContain(
+      'Context-only references cannot become co-subjects'
+    )
+    expect(prompt).not.toContain('tone_id')
+    expect(prompt).not.toContain('article_type')
+    expect(prompt).not.toContain('source_material')
+  })
+
+  it('quotes untrusted title and location text as JSON strings', () => {
+    const prompt = buildDirectionPrompt(
+      'The "quiet" side of Lima',
+      'Lima "Centro"',
+      catalog
+    )
+
+    expect(prompt).toContain('Original title: "The \\"quiet\\" side of Lima"')
+    expect(prompt).toContain('Location: "Lima \\"Centro\\""')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.ts
@@ -1,0 +1,125 @@
+import type { Prompt2BlogEditorialOptionsResponse } from '../api'
+
+function formatCatalog(
+  items: Array<{ id: string; label: string; description: string }>
+): string {
+  return items
+    .map(
+      (item) =>
+        `- ${item.id} (${item.label}) — ${item.description.replace(/\s+/g, ' ').trim()}`
+    )
+    .join('\n')
+}
+
+export function buildDirectionPrompt(
+  title: string,
+  location: string,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): string {
+  return `You are a commissioning editor for a travel publication. Turn one working title and location into exactly three materially different editorial options for a human editor to review. Do not select an option yourself.
+
+INPUT
+Original title: ${JSON.stringify(title.trim())}
+Location: ${JSON.stringify(location.trim())}
+
+BOUNDARY
+Do not browse, research facts, or write the article. This step chooses editorial direction only. Phrase requirements as required research questions; never invent answers or citations.
+
+EDITORIAL RULES
+- Read the original title as the controlling reader promise.
+- Keep one explicit primary subject. Do not broaden a place-centered idea into an accidental comparison.
+- Context-only references can calibrate the piece but cannot organize it. Context-only references cannot become co-subjects or section headings.
+- A comparator is an approved co-subject. single_subject cannot contain one.
+- head_to_head needs at least one comparator. ranked_set needs at least two.
+- Comparison form cannot use single_subject scope; head_to_head scope uses Comparison form.
+- Choose zero to four unique topic modules.
+- Choose one plain-language primary reader and zero or more unique audience tags.
+- Give every option at least one concrete required research question and one specific exclusion.
+- Make options materially distinct in direction, reader question, and outcome. They may share an article form when the editorial takes remain genuinely different.
+
+OUTPUT
+Return one JSON object and nothing else. No Markdown fence, preamble, or trailing note. Echo original_title and location exactly, character for character. Return exactly three options. Use the three fixed option_id values in the shown order. Every object must contain exactly the shown keys.
+
+{
+  "schema_version": 3,
+  "original_title": ${JSON.stringify(title.trim())},
+  "location": ${JSON.stringify(location.trim())},
+  "options": [
+    {
+      "option_id": "direction-1",
+      "direction": "A concise editor-to-writer direction statement",
+      "form_id": "one exact form id",
+      "topic_module_ids": ["zero to four exact module ids"],
+      "audience": {
+        "primary_reader": "one specific reader",
+        "tags": ["zero or more exact audience tag ids"]
+      },
+      "core_reader_question": "the exact question this article answers",
+      "reader_outcome": "what the reader can decide or do afterward",
+      "primary_subject": "the one controlling subject",
+      "scope": {
+        "mode": "one exact scope mode id",
+        "references": [
+          { "name": "the controlling subject", "role": "primary_subject" }
+        ]
+      },
+      "requirements": [
+        { "requirement_id": "r1", "question": "a required research question" }
+      ],
+      "exclusions": ["a specific way this direction must not drift"],
+      "rationale": "why this option is distinct and worth commissioning"
+    },
+    {
+      "option_id": "direction-2",
+      "direction": "...",
+      "form_id": "...",
+      "topic_module_ids": [],
+      "audience": { "primary_reader": "...", "tags": [] },
+      "core_reader_question": "...",
+      "reader_outcome": "...",
+      "primary_subject": "...",
+      "scope": {
+        "mode": "...",
+        "references": [{ "name": "...", "role": "primary_subject" }]
+      },
+      "requirements": [{ "requirement_id": "r1", "question": "..." }],
+      "exclusions": ["..."],
+      "rationale": "..."
+    },
+    {
+      "option_id": "direction-3",
+      "direction": "...",
+      "form_id": "...",
+      "topic_module_ids": [],
+      "audience": { "primary_reader": "...", "tags": [] },
+      "core_reader_question": "...",
+      "reader_outcome": "...",
+      "primary_subject": "...",
+      "scope": {
+        "mode": "...",
+        "references": [{ "name": "...", "role": "primary_subject" }]
+      },
+      "requirements": [{ "requirement_id": "r1", "question": "..." }],
+      "exclusions": ["..."],
+      "rationale": "..."
+    }
+  ]
+}
+
+ALLOWED form_id VALUES
+${formatCatalog(catalog.forms)}
+
+ALLOWED topic_module_ids VALUES
+${formatCatalog(catalog.topic_modules)}
+
+ALLOWED audience.tags VALUES
+${formatCatalog(catalog.audience_tags)}
+
+ALLOWED scope.mode VALUES
+${formatCatalog(catalog.scope_modes)}
+
+ALLOWED scope.references[].role VALUES
+${formatCatalog(catalog.reference_roles)}
+
+Use IDs exactly. Never return labels in ID fields and never invent an ID.`
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.test.ts
@@ -31,6 +31,10 @@ describe('buildPrompt2BlogPayload', () => {
     expect(buildPrompt2BlogPayload(createState({ articleTypeId: null }))).toBeNull()
   })
 
+  it('returns null for editorial v3 even when retained legacy fields are complete', () => {
+    expect(buildPrompt2BlogPayload(createState({ activeWorkflow: 'editorial_v3' }))).toBeNull()
+  })
+
   it('returns a request with the selected article type id', () => {
     expect(buildPrompt2BlogPayload(createState())).toEqual(
       expect.objectContaining({
@@ -46,7 +50,10 @@ describe('buildPrompt2BlogPayload', () => {
 
   it('sends the editorial angle and call to action when supplied', () => {
     const payload = buildPrompt2BlogPayload(
-      createState({ angle: 'Peru is the better first stop', callToAction: 'Compare fares' }),
+      createState({
+        angle: 'Peru is the better first stop',
+        callToAction: 'Compare fares',
+      }),
     )
 
     expect(payload).toEqual(

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/prompt-payload.ts
@@ -2,14 +2,21 @@ import type { P2BFormState } from './composer.types'
 import type { Prompt2BlogRunRequest } from '../api'
 
 function splitCommaSeparated(value: string): string[] {
-  return value.split(',').map(item => item.trim()).filter(Boolean)
+  return value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
 }
 
 function splitLineSeparated(value: string): string[] {
-  return value.split('\n').map(item => item.trim()).filter(Boolean)
+  return value
+    .split('\n')
+    .map(item => item.trim())
+    .filter(Boolean)
 }
 
 export function buildPrompt2BlogPayload(state: P2BFormState): Prompt2BlogRunRequest | null {
+  if (state.activeWorkflow !== 'legacy_v2') return null
   if (!state.articleTypeId) return null
 
   return {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/editorial.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/editorial.types.ts
@@ -38,10 +38,7 @@ export type Prompt2BlogAudienceTagId =
 
 export type Prompt2BlogScopeMode = 'single_subject' | 'head_to_head' | 'ranked_set'
 
-export type Prompt2BlogReferenceRole =
-  | 'primary_subject'
-  | 'context_only'
-  | 'comparator'
+export type Prompt2BlogReferenceRole = 'primary_subject' | 'context_only' | 'comparator'
 
 export type Prompt2BlogEvidenceSourceType =
   | 'official'
@@ -108,6 +105,38 @@ export type Prompt2BlogCommission = {
   exclusions?: string[]
   call_to_action?: string | null
 }
+
+export const PROMPT2BLOG_DIRECTION_OPTION_IDS = [
+  'direction-1',
+  'direction-2',
+  'direction-3',
+] as const
+
+export type Prompt2BlogDirectionOptionId = (typeof PROMPT2BLOG_DIRECTION_OPTION_IDS)[number]
+
+export type Prompt2BlogDirectionOption = {
+  option_id: Prompt2BlogDirectionOptionId
+  direction: string
+  form_id: Prompt2BlogArticleFormId
+  topic_module_ids: Prompt2BlogTopicModuleId[]
+  audience: Prompt2BlogCommissionAudience
+  core_reader_question: string
+  reader_outcome: string
+  primary_subject: string
+  scope: Prompt2BlogCommissionScope
+  requirements: Prompt2BlogCommissionRequirement[]
+  exclusions: string[]
+  rationale: string
+}
+
+export type Prompt2BlogDirectionResponse = {
+  schema_version: 3
+  original_title: string
+  location: string
+  options: [Prompt2BlogDirectionOption, Prompt2BlogDirectionOption, Prompt2BlogDirectionOption]
+}
+
+export type Prompt2BlogCommissionDraft = Omit<Prompt2BlogCommission, 'commission_fingerprint'>
 
 export type Prompt2BlogEvidenceSource = {
   source_id: string

--- a/apps/ai-blog-writer/data/fixtures/prompt2blog/lima-scope-drift-v3.json
+++ b/apps/ai-blog-writer/data/fixtures/prompt2blog/lima-scope-drift-v3.json
@@ -1,7 +1,7 @@
 {
   "commission": {
     "schema_version": 3,
-    "commission_fingerprint": "5f7cb1ce6313526ffc883606650c13851723fd967f5cf6e30d8122ecba65db98",
+    "commission_fingerprint": "d1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48",
     "original_title": "Is Lima still South America's bargain expat capital?",
     "location": "Lima, Peru",
     "approved_direction": "Assess whether Lima still offers strong long-stay value without turning the article into a city-versus-city comparison.",
@@ -49,7 +49,7 @@
   },
   "evidence_package": {
     "schema_version": 3,
-    "commission_fingerprint": "5f7cb1ce6313526ffc883606650c13851723fd967f5cf6e30d8122ecba65db98",
+    "commission_fingerprint": "d1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48",
     "sources": [
       {
         "source_id": "s1",


### PR DESCRIPTION
## Summary
- add strict three-option direction prompt/import contracts
- add editable commission drafting, canonical fingerprints, and approval integrity checks
- migrate composer storage without mapping legacy numeric article types into v3
- fence editorial v3 state from legacy v2 submission

## Verification
- 159 frontend test files / 771 tests
- frontend TypeScript
- frontend boundary check and ESLint
- frontend production build
- two-axis spec and standards review