### PR TITLE
Add Prompt2Blog editorial direction workflow UI

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CommissionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CommissionEditor.tsx
@@ -1,0 +1,599 @@
+import { useId } from 'react'
+import type {
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogCommissionReference,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogReferenceRole
+} from '../../types/editorial.types'
+
+interface CommissionEditorProps {
+  draft: Prompt2BlogCommissionDraft
+  editorialOptions: Prompt2BlogEditorialOptionsResponse
+  isApproved: boolean
+  onApprove?: () => void
+  onChange: (draft: Prompt2BlogCommissionDraft) => void
+}
+
+function nextRequirementId(draft: Prompt2BlogCommissionDraft): string {
+  const used = new Set(draft.requirements.map((item) => item.requirement_id))
+  let index = draft.requirements.length + 1
+  while (used.has(`r${index}`)) index += 1
+  return `r${index}`
+}
+
+function getCommissionDraftIssues(draft: Prompt2BlogCommissionDraft): string[] {
+  const issues: string[] = []
+  const references = draft.scope.references
+  const primaryReferences = references.filter(
+    (reference) => reference.role === 'primary_subject'
+  )
+  const comparators = references.filter(
+    (reference) => reference.role === 'comparator'
+  )
+  const normalizedNames = references.map((reference) =>
+    reference.name.trim().toLocaleLowerCase()
+  )
+  const requirementIds = draft.requirements.map((item) =>
+    item.requirement_id.trim()
+  )
+
+  if (!draft.approved_direction.trim()) issues.push('Direction is required.')
+  if (!draft.audience.primary_reader.trim())
+    issues.push('Primary audience is required.')
+  if (!draft.core_reader_question.trim())
+    issues.push('Core reader question is required.')
+  if (!draft.reader_outcome.trim()) issues.push('Reader outcome is required.')
+  if (!draft.primary_subject.trim()) issues.push('Primary subject is required.')
+  if (draft.topic_module_ids && draft.topic_module_ids.length > 4) {
+    issues.push('Choose no more than four topic modules.')
+  }
+  if (primaryReferences.length !== 1) {
+    issues.push('Scope must contain exactly one primary-subject reference.')
+  } else if (
+    primaryReferences[0].name.trim().toLocaleLowerCase() !==
+    draft.primary_subject.trim().toLocaleLowerCase()
+  ) {
+    issues.push('Primary subject and primary reference must match.')
+  }
+  if (normalizedNames.some((name) => !name))
+    issues.push('Every named reference needs a name.')
+  if (new Set(normalizedNames).size !== normalizedNames.length) {
+    issues.push('Named references must be unique.')
+  }
+  if (draft.scope.mode === 'single_subject' && comparators.length > 0) {
+    issues.push('Single-subject scope cannot contain comparators.')
+  }
+  if (draft.scope.mode === 'head_to_head' && comparators.length < 1) {
+    issues.push('Head-to-head scope needs at least one comparator.')
+  }
+  if (draft.scope.mode === 'ranked_set' && comparators.length < 2) {
+    issues.push('Ranked-set scope needs at least two comparators.')
+  }
+  if (draft.requirements.length === 0)
+    issues.push('Add at least one research requirement.')
+  if (
+    draft.requirements.some(
+      (item) => !item.requirement_id.trim() || !item.question.trim()
+    )
+  ) {
+    issues.push('Every research requirement needs an ID and question.')
+  }
+  if (new Set(requirementIds).size !== requirementIds.length) {
+    issues.push('Research requirement IDs must be unique.')
+  }
+
+  return issues
+}
+
+export function CommissionEditor({
+  draft,
+  editorialOptions,
+  isApproved,
+  onApprove,
+  onChange
+}: CommissionEditorProps) {
+  const idPrefix = useId().replace(/:/g, '')
+  const moduleIds = draft.topic_module_ids ?? []
+  const audienceTags = draft.audience.tags ?? []
+  const issues = getCommissionDraftIssues(draft)
+  const primaryReference = draft.scope.references.find(
+    (reference) => reference.role === 'primary_subject'
+  )
+  const secondaryReferences = draft.scope.references.filter(
+    (reference) => reference.role !== 'primary_subject'
+  )
+  const secondaryRoles = editorialOptions.reference_roles.filter(
+    (option) => option.id !== 'primary_subject'
+  )
+
+  const update = (patch: Partial<Prompt2BlogCommissionDraft>) => {
+    onChange({ ...draft, ...patch })
+  }
+
+  const updatePrimarySubject = (value: string) => {
+    update({
+      primary_subject: value,
+      scope: {
+        ...draft.scope,
+        references: draft.scope.references.map((reference) =>
+          reference.role === 'primary_subject'
+            ? { ...reference, name: value }
+            : reference
+        )
+      }
+    })
+  }
+
+  const updateSecondaryReferences = (
+    references: Prompt2BlogCommissionReference[]
+  ) => {
+    update({
+      scope: {
+        ...draft.scope,
+        references: primaryReference
+          ? [primaryReference, ...references]
+          : references
+      }
+    })
+  }
+
+  return (
+    <section
+      className="p2b-commission-editor"
+      aria-labelledby={`${idPrefix}-heading`}
+    >
+      <div className="p2b-commission-editor-header">
+        <div>
+          <p className="p2b-eyebrow">Approved direction</p>
+          <h3 id={`${idPrefix}-heading`}>Edit the commission</h3>
+          <p>Research will be locked to these choices.</p>
+        </div>
+        <span
+          className={`p2b-commission-status${isApproved ? ' is-approved' : ''}`}
+          role="status"
+        >
+          {isApproved ? 'Approved' : 'Needs approval'}
+        </span>
+      </div>
+
+      <fieldset className="p2b-commission-fieldset">
+        <legend>Locked setup</legend>
+        <div className="p2b-field-row p2b-field-row--2">
+          <div className="p2b-field">
+            <label htmlFor={`${idPrefix}-title`}>Original title</label>
+            <input
+              id={`${idPrefix}-title`}
+              className="p2b-input"
+              value={draft.original_title}
+              readOnly
+            />
+          </div>
+          <div className="p2b-field">
+            <label htmlFor={`${idPrefix}-location`}>Location</label>
+            <input
+              id={`${idPrefix}-location`}
+              className="p2b-input"
+              value={draft.location}
+              readOnly
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      <div className="p2b-field">
+        <label htmlFor={`${idPrefix}-direction`}>Approved direction</label>
+        <textarea
+          id={`${idPrefix}-direction`}
+          className="p2b-textarea"
+          rows={3}
+          value={draft.approved_direction}
+          onChange={(event) =>
+            update({ approved_direction: event.target.value })
+          }
+        />
+      </div>
+
+      <div className="p2b-field">
+        <label htmlFor={`${idPrefix}-form`}>Article form</label>
+        <select
+          id={`${idPrefix}-form`}
+          className="p2b-select"
+          value={draft.form_id}
+          onChange={(event) =>
+            update({
+              form_id: event.target
+                .value as Prompt2BlogCommissionDraft['form_id']
+            })
+          }
+        >
+          {editorialOptions.forms.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <fieldset className="p2b-commission-fieldset">
+        <legend>Topic modules</legend>
+        <p className="p2b-field-hint">
+          Choose up to four. Modules constrain facts, not structure.
+        </p>
+        <div className="p2b-commission-checkbox-grid">
+          {editorialOptions.topic_modules.map((option) => {
+            const checked = moduleIds.includes(option.id)
+            return (
+              <label key={option.id} className="p2b-commission-checkbox">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={!checked && moduleIds.length >= 4}
+                  onChange={() =>
+                    update({
+                      topic_module_ids: checked
+                        ? moduleIds.filter((id) => id !== option.id)
+                        : [...moduleIds, option.id]
+                    })
+                  }
+                />
+                <span>
+                  <strong>{option.label}</strong>
+                  {option.description}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      </fieldset>
+
+      <fieldset className="p2b-commission-fieldset">
+        <legend>Audience</legend>
+        <div className="p2b-field">
+          <label htmlFor={`${idPrefix}-audience`}>Primary audience</label>
+          <input
+            id={`${idPrefix}-audience`}
+            className="p2b-input"
+            value={draft.audience.primary_reader}
+            onChange={(event) =>
+              update({
+                audience: {
+                  ...draft.audience,
+                  primary_reader: event.target.value
+                }
+              })
+            }
+          />
+        </div>
+        <div className="p2b-commission-checkbox-grid p2b-commission-checkbox-grid--compact">
+          {editorialOptions.audience_tags.map((option) => {
+            const checked = audienceTags.includes(option.id)
+            return (
+              <label key={option.id} className="p2b-commission-checkbox">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() =>
+                    update({
+                      audience: {
+                        ...draft.audience,
+                        tags: checked
+                          ? audienceTags.filter((id) => id !== option.id)
+                          : [...audienceTags, option.id]
+                      }
+                    })
+                  }
+                />
+                <span>
+                  <strong>{option.label}</strong>
+                  {option.description}
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      </fieldset>
+
+      <div className="p2b-field-row p2b-field-row--2">
+        <div className="p2b-field">
+          <label htmlFor={`${idPrefix}-question`}>Core reader question</label>
+          <textarea
+            id={`${idPrefix}-question`}
+            className="p2b-textarea"
+            rows={3}
+            value={draft.core_reader_question}
+            onChange={(event) =>
+              update({ core_reader_question: event.target.value })
+            }
+          />
+        </div>
+        <div className="p2b-field">
+          <label htmlFor={`${idPrefix}-outcome`}>Reader outcome</label>
+          <textarea
+            id={`${idPrefix}-outcome`}
+            className="p2b-textarea"
+            rows={3}
+            value={draft.reader_outcome}
+            onChange={(event) => update({ reader_outcome: event.target.value })}
+          />
+        </div>
+      </div>
+
+      <fieldset className="p2b-commission-fieldset">
+        <legend>Subject and scope</legend>
+        <div className="p2b-field-row p2b-field-row--2">
+          <div className="p2b-field">
+            <label htmlFor={`${idPrefix}-subject`}>Primary subject</label>
+            <input
+              id={`${idPrefix}-subject`}
+              className="p2b-input"
+              value={draft.primary_subject}
+              onChange={(event) => updatePrimarySubject(event.target.value)}
+            />
+            <p className="p2b-field-hint">
+              Primary reference stays synced to this field.
+            </p>
+          </div>
+          <div className="p2b-field">
+            <label htmlFor={`${idPrefix}-scope-mode`}>Scope mode</label>
+            <select
+              id={`${idPrefix}-scope-mode`}
+              className="p2b-select"
+              value={draft.scope.mode}
+              onChange={(event) =>
+                update({
+                  scope: {
+                    ...draft.scope,
+                    mode: event.target
+                      .value as Prompt2BlogCommissionDraft['scope']['mode']
+                  }
+                })
+              }
+            >
+              {editorialOptions.scope_modes.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="p2b-reference-list" aria-label="Named references">
+          <div className="p2b-reference-row p2b-reference-row--primary">
+            <div className="p2b-field">
+              <label htmlFor={`${idPrefix}-primary-reference`}>
+                Primary reference
+              </label>
+              <input
+                id={`${idPrefix}-primary-reference`}
+                className="p2b-input"
+                value={primaryReference?.name ?? ''}
+                readOnly
+              />
+            </div>
+            <div className="p2b-field">
+              <label htmlFor={`${idPrefix}-primary-role`}>Role</label>
+              <select
+                id={`${idPrefix}-primary-role`}
+                className="p2b-select"
+                value="primary_subject"
+                disabled
+              >
+                <option value="primary_subject">Primary subject</option>
+              </select>
+            </div>
+          </div>
+
+          {secondaryReferences.map((reference, index) => (
+            <div className="p2b-reference-row" key={`reference-${index}`}>
+              <div className="p2b-field">
+                <label htmlFor={`${idPrefix}-reference-${index}`}>
+                  Reference {index + 1}
+                </label>
+                <input
+                  id={`${idPrefix}-reference-${index}`}
+                  className="p2b-input"
+                  value={reference.name}
+                  onChange={(event) =>
+                    updateSecondaryReferences(
+                      secondaryReferences.map((item, itemIndex) =>
+                        itemIndex === index
+                          ? { ...item, name: event.target.value }
+                          : item
+                      )
+                    )
+                  }
+                />
+              </div>
+              <div className="p2b-field">
+                <label htmlFor={`${idPrefix}-reference-role-${index}`}>
+                  Reference {index + 1} role
+                </label>
+                <select
+                  id={`${idPrefix}-reference-role-${index}`}
+                  className="p2b-select"
+                  value={reference.role}
+                  onChange={(event) =>
+                    updateSecondaryReferences(
+                      secondaryReferences.map((item, itemIndex) =>
+                        itemIndex === index
+                          ? {
+                              ...item,
+                              role: event.target
+                                .value as Prompt2BlogReferenceRole
+                            }
+                          : item
+                      )
+                    )
+                  }
+                >
+                  {secondaryRoles.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="button"
+                className="p2b-reference-remove"
+                aria-label={`Remove reference ${index + 1}`}
+                onClick={() =>
+                  updateSecondaryReferences(
+                    secondaryReferences.filter(
+                      (_, itemIndex) => itemIndex !== index
+                    )
+                  )
+                }
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="p2b-add-blob-btn"
+          onClick={() =>
+            updateSecondaryReferences([
+              ...secondaryReferences,
+              { name: '', role: 'context_only' }
+            ])
+          }
+        >
+          Add named reference
+        </button>
+      </fieldset>
+
+      <fieldset className="p2b-commission-fieldset">
+        <legend>Research requirements</legend>
+        <div className="p2b-requirement-list">
+          {draft.requirements.map((requirement, index) => (
+            <div className="p2b-requirement-row" key={`requirement-${index}`}>
+              <div className="p2b-field p2b-requirement-id">
+                <label htmlFor={`${idPrefix}-requirement-id-${index}`}>
+                  Requirement {index + 1} ID
+                </label>
+                <input
+                  id={`${idPrefix}-requirement-id-${index}`}
+                  className="p2b-input"
+                  value={requirement.requirement_id}
+                  onChange={(event) =>
+                    update({
+                      requirements: draft.requirements.map((item, itemIndex) =>
+                        itemIndex === index
+                          ? { ...item, requirement_id: event.target.value }
+                          : item
+                      )
+                    })
+                  }
+                />
+              </div>
+              <div className="p2b-field">
+                <label htmlFor={`${idPrefix}-requirement-question-${index}`}>
+                  Requirement {index + 1} question
+                </label>
+                <input
+                  id={`${idPrefix}-requirement-question-${index}`}
+                  className="p2b-input"
+                  value={requirement.question}
+                  onChange={(event) =>
+                    update({
+                      requirements: draft.requirements.map((item, itemIndex) =>
+                        itemIndex === index
+                          ? { ...item, question: event.target.value }
+                          : item
+                      )
+                    })
+                  }
+                />
+              </div>
+              <button
+                type="button"
+                className="p2b-reference-remove"
+                aria-label={`Remove requirement ${index + 1}`}
+                onClick={() =>
+                  update({
+                    requirements: draft.requirements.filter(
+                      (_, itemIndex) => itemIndex !== index
+                    )
+                  })
+                }
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="p2b-add-blob-btn"
+          onClick={() =>
+            update({
+              requirements: [
+                ...draft.requirements,
+                { requirement_id: nextRequirementId(draft), question: '' }
+              ]
+            })
+          }
+        >
+          Add research requirement
+        </button>
+      </fieldset>
+
+      <div className="p2b-field">
+        <label htmlFor={`${idPrefix}-exclusions`}>
+          Exclusions (one per line)
+        </label>
+        <textarea
+          id={`${idPrefix}-exclusions`}
+          className="p2b-textarea"
+          rows={3}
+          value={(draft.exclusions ?? []).join('\n')}
+          onChange={(event) =>
+            update({ exclusions: event.target.value.split('\n') })
+          }
+        />
+      </div>
+
+      <div className="p2b-field">
+        <label htmlFor={`${idPrefix}-cta`}>Call to action (optional)</label>
+        <input
+          id={`${idPrefix}-cta`}
+          className="p2b-input"
+          value={draft.call_to_action ?? ''}
+          onChange={(event) =>
+            update({ call_to_action: event.target.value || null })
+          }
+        />
+      </div>
+
+      {issues.length > 0 && (
+        <div
+          className="p2b-commission-alert p2b-commission-alert--error"
+          role="alert"
+        >
+          <strong>Commission needs attention.</strong>
+          <ul>
+            {issues.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {onApprove && (
+        <div className="p2b-panel-actions">
+          <button
+            type="button"
+            className="p2b-submit-btn"
+            disabled={issues.length > 0 || isApproved}
+            onClick={onApprove}
+          >
+            {isApproved ? 'Commission approved' : 'Approve commission'}
+          </button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CommissionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/CommissionEditor.tsx
@@ -5,6 +5,7 @@ import type {
   Prompt2BlogEditorialOptionsResponse,
   Prompt2BlogReferenceRole
 } from '../../types/editorial.types'
+import { validateCommissionDraft } from '../commission'
 
 interface CommissionEditorProps {
   draft: Prompt2BlogCommissionDraft
@@ -21,70 +22,6 @@ function nextRequirementId(draft: Prompt2BlogCommissionDraft): string {
   return `r${index}`
 }
 
-function getCommissionDraftIssues(draft: Prompt2BlogCommissionDraft): string[] {
-  const issues: string[] = []
-  const references = draft.scope.references
-  const primaryReferences = references.filter(
-    (reference) => reference.role === 'primary_subject'
-  )
-  const comparators = references.filter(
-    (reference) => reference.role === 'comparator'
-  )
-  const normalizedNames = references.map((reference) =>
-    reference.name.trim().toLocaleLowerCase()
-  )
-  const requirementIds = draft.requirements.map((item) =>
-    item.requirement_id.trim()
-  )
-
-  if (!draft.approved_direction.trim()) issues.push('Direction is required.')
-  if (!draft.audience.primary_reader.trim())
-    issues.push('Primary audience is required.')
-  if (!draft.core_reader_question.trim())
-    issues.push('Core reader question is required.')
-  if (!draft.reader_outcome.trim()) issues.push('Reader outcome is required.')
-  if (!draft.primary_subject.trim()) issues.push('Primary subject is required.')
-  if (draft.topic_module_ids && draft.topic_module_ids.length > 4) {
-    issues.push('Choose no more than four topic modules.')
-  }
-  if (primaryReferences.length !== 1) {
-    issues.push('Scope must contain exactly one primary-subject reference.')
-  } else if (
-    primaryReferences[0].name.trim().toLocaleLowerCase() !==
-    draft.primary_subject.trim().toLocaleLowerCase()
-  ) {
-    issues.push('Primary subject and primary reference must match.')
-  }
-  if (normalizedNames.some((name) => !name))
-    issues.push('Every named reference needs a name.')
-  if (new Set(normalizedNames).size !== normalizedNames.length) {
-    issues.push('Named references must be unique.')
-  }
-  if (draft.scope.mode === 'single_subject' && comparators.length > 0) {
-    issues.push('Single-subject scope cannot contain comparators.')
-  }
-  if (draft.scope.mode === 'head_to_head' && comparators.length < 1) {
-    issues.push('Head-to-head scope needs at least one comparator.')
-  }
-  if (draft.scope.mode === 'ranked_set' && comparators.length < 2) {
-    issues.push('Ranked-set scope needs at least two comparators.')
-  }
-  if (draft.requirements.length === 0)
-    issues.push('Add at least one research requirement.')
-  if (
-    draft.requirements.some(
-      (item) => !item.requirement_id.trim() || !item.question.trim()
-    )
-  ) {
-    issues.push('Every research requirement needs an ID and question.')
-  }
-  if (new Set(requirementIds).size !== requirementIds.length) {
-    issues.push('Research requirement IDs must be unique.')
-  }
-
-  return issues
-}
-
 export function CommissionEditor({
   draft,
   editorialOptions,
@@ -95,7 +32,13 @@ export function CommissionEditor({
   const idPrefix = useId().replace(/:/g, '')
   const moduleIds = draft.topic_module_ids ?? []
   const audienceTags = draft.audience.tags ?? []
-  const issues = getCommissionDraftIssues(draft)
+  const issues = [
+    ...new Set(
+      validateCommissionDraft(draft, editorialOptions).map(
+        (issue) => issue.message
+      )
+    )
+  ]
   const primaryReference = draft.scope.references.find(
     (reference) => reference.role === 'primary_subject'
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/DirectionCards.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/DirectionCards.tsx
@@ -1,0 +1,143 @@
+import type {
+  Prompt2BlogDirectionOption,
+  Prompt2BlogDirectionOptionId,
+  Prompt2BlogEditorialOptionsResponse
+} from '../../types/editorial.types'
+
+interface DirectionCardsProps {
+  editorialOptions: Prompt2BlogEditorialOptionsResponse
+  options: readonly Prompt2BlogDirectionOption[]
+  selectedOptionId: Prompt2BlogDirectionOptionId | null
+  onSelect: (option: Prompt2BlogDirectionOption) => void
+}
+
+function findLabel(
+  items: ReadonlyArray<{ id: string; label: string }>,
+  id: string
+): string {
+  return items.find((item) => item.id === id)?.label ?? id
+}
+
+export function DirectionCards({
+  editorialOptions,
+  options,
+  selectedOptionId,
+  onSelect
+}: DirectionCardsProps) {
+  // Runtime guard still matters for restored localStorage and model JSON, even
+  // though the TypeScript contract describes a three-item tuple.
+  if (options.length !== 3) {
+    return (
+      <p
+        className="p2b-commission-alert p2b-commission-alert--error"
+        role="alert"
+      >
+        Direction import must contain exactly three options.
+      </p>
+    )
+  }
+
+  return (
+    <fieldset className="p2b-direction-picker">
+      <legend>Choose one editorial direction</legend>
+      <p className="p2b-field-hint">
+        Selection locks the article commission. You can edit it before research.
+      </p>
+      <div className="p2b-direction-grid">
+        {options.map((option, index) => {
+          const selected = selectedOptionId === option.option_id
+          const choiceId = `p2b-${option.option_id}-choice`
+          const headingId = `p2b-${option.option_id}-heading`
+          const directionId = `p2b-${option.option_id}-direction`
+          const formLabel = findLabel(editorialOptions.forms, option.form_id)
+          const moduleLabels = option.topic_module_ids.map((id) =>
+            findLabel(editorialOptions.topic_modules, id)
+          )
+          const audienceTagLabels = (option.audience.tags ?? []).map((id) =>
+            findLabel(editorialOptions.audience_tags, id)
+          )
+          const scopeLabel = findLabel(
+            editorialOptions.scope_modes,
+            option.scope.mode
+          )
+
+          return (
+            <label
+              key={option.option_id}
+              className={`p2b-direction-card${selected ? ' is-selected' : ''}`}
+            >
+              <span className="p2b-direction-card-choice" id={choiceId}>
+                <input
+                  type="radio"
+                  name="p2b-editorial-direction"
+                  value={option.option_id}
+                  checked={selected}
+                  aria-labelledby={`${choiceId} ${headingId} ${directionId}`}
+                  onChange={() => onSelect(option)}
+                />
+                Direction {index + 1}
+              </span>
+              <span className="p2b-direction-card-form" id={headingId}>
+                {formLabel}
+              </span>
+              <span className="p2b-direction-card-direction" id={directionId}>
+                {option.direction}
+              </span>
+
+              {moduleLabels.length > 0 && (
+                <span
+                  className="p2b-direction-card-tags"
+                  aria-label="Topic modules"
+                >
+                  {moduleLabels.map((label) => (
+                    <span key={label}>{label}</span>
+                  ))}
+                </span>
+              )}
+
+              <dl className="p2b-direction-card-details">
+                <div>
+                  <dt>Audience</dt>
+                  <dd>
+                    {option.audience.primary_reader}
+                    {audienceTagLabels.length > 0
+                      ? ` · ${audienceTagLabels.join(', ')}`
+                      : ''}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Reader question</dt>
+                  <dd>{option.core_reader_question}</dd>
+                </div>
+                <div>
+                  <dt>Outcome</dt>
+                  <dd>{option.reader_outcome}</dd>
+                </div>
+                <div>
+                  <dt>Scope</dt>
+                  <dd>
+                    {scopeLabel}:{' '}
+                    {option.scope.references
+                      .map((reference) => {
+                        const role = findLabel(
+                          editorialOptions.reference_roles,
+                          reference.role
+                        )
+                        return `${reference.name} (${role})`
+                      })
+                      .join(', ')}
+                  </dd>
+                </div>
+              </dl>
+
+              <span className="p2b-direction-card-rationale">
+                <strong>Why this works</strong>
+                {option.rationale}
+              </span>
+            </label>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/DirectionCards.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/DirectionCards.tsx
@@ -62,20 +62,23 @@ export function DirectionCards({
           )
 
           return (
-            <label
+            <div
               key={option.option_id}
               className={`p2b-direction-card${selected ? ' is-selected' : ''}`}
             >
-              <span className="p2b-direction-card-choice" id={choiceId}>
+              <span className="p2b-direction-card-choice">
                 <input
+                  id={choiceId}
                   type="radio"
                   name="p2b-editorial-direction"
                   value={option.option_id}
                   checked={selected}
-                  aria-labelledby={`${choiceId} ${headingId} ${directionId}`}
+                  aria-labelledby={`${choiceId}-label ${headingId} ${directionId}`}
                   onChange={() => onSelect(option)}
                 />
-                Direction {index + 1}
+                <label id={`${choiceId}-label`} htmlFor={choiceId}>
+                  Direction {index + 1}
+                </label>
               </span>
               <span className="p2b-direction-card-form" id={headingId}>
                 {formLabel}
@@ -134,7 +137,7 @@ export function DirectionCards({
                 <strong>Why this works</strong>
                 {option.rationale}
               </span>
-            </label>
+            </div>
           )
         })}
       </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -1,8 +1,17 @@
 import { useEffect, useState } from 'react'
-import type { Prompt2BlogInputOptionsResponse } from '../../api'
-import type { P2BFormState } from '../composer.types'
+import type {
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogDirectionOptionId,
+  Prompt2BlogDirectionResponse,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogInputOptionsResponse,
+} from '../../api'
+import type { P2BEditorialComposerState, P2BFormState } from '../composer.types'
+import { reviewDirectionResponseJson, type DirectionImportReview } from '../direction-import'
+import { buildDirectionPrompt } from '../direction-prompt'
 import { reviewEasySetupJson, type EasySetupImportReview } from '../easy-setup-import'
-import { buildEasySetupPrompt } from '../easy-setup-prompt'
+import { CommissionEditor } from './CommissionEditor'
+import { DirectionCards } from './DirectionCards'
 
 type CopyStatus = 'idle' | 'copied' | 'error'
 
@@ -13,20 +22,38 @@ const COPY_LABELS: Record<CopyStatus, string> = {
 }
 
 interface EasySetupPanelProps {
+  activeWorkflow: P2BFormState['activeWorkflow']
+  editorial: P2BEditorialComposerState
+  editorialOptions: Prompt2BlogEditorialOptionsResponse | null
   inputOptions: Prompt2BlogInputOptionsResponse | null
   location: string
   title: string
   onApply: (patch: Partial<P2BFormState>) => void
+  onApplyDirectionResponse: (response: Prompt2BlogDirectionResponse) => void
+  onApproveCommission: () => Promise<void>
+  onClearDirectionWorkflow: () => void
+  onCommissionChange: (draft: Prompt2BlogCommissionDraft) => void
   onLocationChange: (value: string) => void
+  onSelectDirection: (optionId: Prompt2BlogDirectionOptionId) => Promise<void>
+  onStartDirectionWorkflow: () => void
   onTitleChange: (value: string) => void
 }
 
 export function EasySetupPanel({
+  activeWorkflow,
+  editorial,
+  editorialOptions,
   inputOptions,
   location,
   title,
   onApply,
+  onApplyDirectionResponse,
+  onApproveCommission,
+  onClearDirectionWorkflow,
+  onCommissionChange,
   onLocationChange,
+  onSelectDirection,
+  onStartDirectionWorkflow,
   onTitleChange,
 }: EasySetupPanelProps) {
   const [prompt, setPrompt] = useState<string | null>(null)
@@ -34,9 +61,13 @@ export function EasySetupPanel({
   const [pastedJson, setPastedJson] = useState('')
   const [review, setReview] = useState<EasySetupImportReview | null>(null)
   const [appliedCount, setAppliedCount] = useState<number | null>(null)
+  const [directionJson, setDirectionJson] = useState('')
+  const [directionReview, setDirectionReview] = useState<DirectionImportReview | null>(null)
+  const [directionStatus, setDirectionStatus] = useState<string | null>(null)
   // The prompt lists the option catalogs verbatim, so a prompt built before
   // they arrived is missing the fields it should have constrained.
-  const catalogsLoaded = Boolean(inputOptions?.article_types.length)
+  const catalogsLoaded = Boolean(editorialOptions?.forms.length)
+  const showDirectionStep = prompt !== null || activeWorkflow === 'editorial_v3'
 
   useEffect(() => {
     setPrompt(null)
@@ -53,8 +84,35 @@ export function EasySetupPanel({
     const confirmedTitle = title.trim()
     const confirmedLocation = location.trim()
     if (!confirmedTitle || !confirmedLocation) return
-    setPrompt(buildEasySetupPrompt(confirmedTitle, confirmedLocation, inputOptions))
+    if (!editorialOptions) return
+    onStartDirectionWorkflow()
+    setPrompt(buildDirectionPrompt(confirmedTitle, confirmedLocation, editorialOptions))
     setCopyStatus('idle')
+  }
+
+  const handleDirectionJsonChange = (value: string) => {
+    setDirectionJson(value)
+    setDirectionReview(null)
+    setDirectionStatus(null)
+  }
+
+  const handleCheckDirectionJson = () => {
+    if (!editorialOptions) return
+    setDirectionStatus(null)
+    setDirectionReview(
+      reviewDirectionResponseJson(
+        directionJson,
+        { originalTitle: title.trim(), location: location.trim() },
+        editorialOptions,
+      ),
+    )
+  }
+
+  const handleApplyDirectionJson = () => {
+    if (!directionReview?.response) return
+    onApplyDirectionResponse(directionReview.response)
+    setDirectionReview(null)
+    setDirectionStatus('Three directions are ready for approval.')
   }
 
   const handleCopyPrompt = () => {
@@ -94,13 +152,13 @@ export function EasySetupPanel({
       <div className="p2b-panel-header">
         <div className="p2b-panel-header-text">
           <h2>Easy Set Up</h2>
-          <p>Generate a structured brief, or import one you already approved.</p>
+          <p>Compare three editorial directions, then approve the commission.</p>
         </div>
       </div>
       <div className="p2b-panel-body">
         <div className="p2b-subsection-heading">
-          <h3>Generate a setup prompt</h3>
-          <p>Start with the working title and destination.</p>
+          <h3>Generate a direction prompt</h3>
+          <p>Only the working title and location leave the app at this step.</p>
         </div>
         <div className="p2b-field-row p2b-field-row--2">
           <div className="p2b-field">
@@ -130,27 +188,20 @@ export function EasySetupPanel({
           <button
             type="button"
             className="p2b-submit-btn"
-            disabled={!title.trim() || !location.trim()}
+            disabled={!title.trim() || !location.trim() || !editorialOptions}
             onClick={handleConfirmSetup}
           >
-            Generate setup prompt
+            Generate direction prompt
           </button>
         </div>
         {!catalogsLoaded && (
-          <p className="p2b-field-hint">
-            Article types, tones, lengths, and brand voices are still loading. Confirm again once
-            they arrive so the prompt can list them.
-          </p>
+          <p className="p2b-field-hint">Editorial forms and topic modules are still loading.</p>
         )}
         {prompt !== null && (
           <div className="p2b-field">
             <div className="p2b-field-label-row">
               <label htmlFor="p2b-easy-setup-prompt">Prompt</label>
-              <button
-                type="button"
-                className="p2b-inline-copy-btn"
-                onClick={handleCopyPrompt}
-              >
+              <button type="button" className="p2b-inline-copy-btn" onClick={handleCopyPrompt}>
                 {COPY_LABELS[copyStatus]}
               </button>
             </div>
@@ -163,88 +214,179 @@ export function EasySetupPanel({
             />
           </div>
         )}
-        <div className="p2b-subsection-heading p2b-subsection-heading--divided">
-          <h3>Import an approved brief</h3>
-          <p>Validate model JSON before it changes any fields below.</p>
-        </div>
-        <div className="p2b-field">
-          <label htmlFor="p2b-easy-setup-json">Approved JSON</label>
-          <textarea
-            id="p2b-easy-setup-json"
-            className="p2b-textarea"
-            rows={10}
-            placeholder="Paste the JSON the model returned, then check it before applying."
-            value={pastedJson}
-            onChange={event => handlePastedJsonChange(event.target.value)}
-          />
-        </div>
-        <div className="p2b-panel-actions">
-          <button
-            type="button"
-            className="p2b-copy-json-btn"
-            disabled={!pastedJson.trim()}
-            onClick={handleCheckJson}
-          >
-            Check JSON
-          </button>
-          <button
-            type="button"
-            className="p2b-submit-btn"
-            disabled={!review?.patch}
-            onClick={handleApplyJson}
-          >
-            Apply to form
-          </button>
-        </div>
-        {appliedCount !== null && (
-          <p className="p2b-import-applied" role="status">
-            Applied {appliedCount} fields to the form below.
-          </p>
-        )}
-        {review?.direction && (
-          <div className="p2b-import-direction">
-            <span className="p2b-import-direction-label">Direction</span>
-            <p>{review.direction}</p>
-          </div>
-        )}
-        {review !== null && review.issues.length > 0 && (
-          <div className="p2b-import-report p2b-import-report--blocked">
-            <p className="p2b-import-report-title">
-              {review.issues.length} problem{review.issues.length === 1 ? '' : 's'} — nothing was applied.
-            </p>
-            <ul className="p2b-import-list">
-              {review.issues.map(issue => (
-                <li key={`${issue.field}-${issue.message}`}>
-                  <code>{issue.field}</code> {issue.message}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {review?.patch && (
-          <div className="p2b-import-report">
-            <p className="p2b-import-report-title">
-              Every value matches the loaded options. Review and apply.
-            </p>
-            {review.corrections.length > 0 && (
-              <ul className="p2b-import-list p2b-import-list--corrections">
-                {review.corrections.map(correction => (
-                  <li key={`${correction.field}-${correction.message}`}>
-                    <code>{correction.field}</code> {correction.message}
-                  </li>
-                ))}
-              </ul>
+        {showDirectionStep && (
+          <>
+            <div className="p2b-subsection-heading p2b-subsection-heading--divided">
+              <h3>Import three directions</h3>
+              <p>Strict validation rejects unknown IDs, extra keys, and comparison drift.</p>
+            </div>
+            <div className="p2b-field">
+              <label htmlFor="p2b-direction-json">Direction JSON</label>
+              <textarea
+                id="p2b-direction-json"
+                className="p2b-textarea"
+                rows={10}
+                value={directionJson}
+                onChange={event => handleDirectionJsonChange(event.target.value)}
+                placeholder="Paste the three-option JSON response."
+              />
+            </div>
+            <div className="p2b-panel-actions">
+              <button
+                type="button"
+                className="p2b-copy-json-btn"
+                disabled={!directionJson.trim() || !editorialOptions}
+                onClick={handleCheckDirectionJson}
+              >
+                Check directions
+              </button>
+              <button
+                type="button"
+                className="p2b-submit-btn"
+                disabled={!directionReview?.response}
+                onClick={handleApplyDirectionJson}
+              >
+                Show direction cards
+              </button>
+              {activeWorkflow === 'editorial_v3' && (
+                <button type="button" className="p2b-clear-btn" onClick={onClearDirectionWorkflow}>
+                  Clear direction work
+                </button>
+              )}
+            </div>
+            {directionStatus && (
+              <p className="p2b-import-applied" role="status">
+                {directionStatus}
+              </p>
             )}
-            <dl className="p2b-import-rows">
-              {review.rows.map(row => (
-                <div key={row.field} className="p2b-import-row">
-                  <dt>{row.field}</dt>
-                  <dd>{row.value}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
+            {directionReview && directionReview.issues.length > 0 && (
+              <div className="p2b-import-report p2b-import-report--blocked">
+                <p className="p2b-import-report-title">
+                  Direction JSON is blocked — nothing was imported.
+                </p>
+                <ul className="p2b-import-list">
+                  {directionReview.issues.map(issue => (
+                    <li key={`${issue.path}-${issue.message}`}>
+                      <code>{issue.path}</code> {issue.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {editorialOptions && editorial.directionOptions.length > 0 && (
+              <DirectionCards
+                editorialOptions={editorialOptions}
+                options={editorial.directionOptions}
+                selectedOptionId={editorial.selectedOptionId}
+                onSelect={option => {
+                  void onSelectDirection(option.option_id).catch(error =>
+                    setDirectionStatus(error instanceof Error ? error.message : 'Approval failed.'),
+                  )
+                }}
+              />
+            )}
+            {editorialOptions && editorial.commissionDraft && (
+              <CommissionEditor
+                draft={editorial.commissionDraft}
+                editorialOptions={editorialOptions}
+                isApproved={editorial.approval.status === 'approved'}
+                onApprove={() => {
+                  void onApproveCommission().catch(error =>
+                    setDirectionStatus(error instanceof Error ? error.message : 'Approval failed.'),
+                  )
+                }}
+                onChange={onCommissionChange}
+              />
+            )}
+          </>
         )}
+        <details className="p2b-disclosure">
+          <summary>Legacy v2 brief import</summary>
+          <div className="p2b-disclosure-body">
+            <p className="p2b-field-hint">
+              Temporary compatibility path for saved one-shot briefs.
+            </p>
+            <div className="p2b-field">
+              <label htmlFor="p2b-easy-setup-json">Approved JSON</label>
+              <textarea
+                id="p2b-easy-setup-json"
+                className="p2b-textarea"
+                rows={10}
+                placeholder="Paste the JSON the model returned, then check it before applying."
+                value={pastedJson}
+                onChange={event => handlePastedJsonChange(event.target.value)}
+              />
+            </div>
+            <div className="p2b-panel-actions">
+              <button
+                type="button"
+                className="p2b-copy-json-btn"
+                disabled={!pastedJson.trim()}
+                onClick={handleCheckJson}
+              >
+                Check JSON
+              </button>
+              <button
+                type="button"
+                className="p2b-submit-btn"
+                disabled={!review?.patch}
+                onClick={handleApplyJson}
+              >
+                Apply to form
+              </button>
+            </div>
+            {appliedCount !== null && (
+              <p className="p2b-import-applied" role="status">
+                Applied {appliedCount} fields to the form below.
+              </p>
+            )}
+            {review?.direction && (
+              <div className="p2b-import-direction">
+                <span className="p2b-import-direction-label">Direction</span>
+                <p>{review.direction}</p>
+              </div>
+            )}
+            {review !== null && review.issues.length > 0 && (
+              <div className="p2b-import-report p2b-import-report--blocked">
+                <p className="p2b-import-report-title">
+                  {review.issues.length} problem
+                  {review.issues.length === 1 ? '' : 's'} — nothing was applied.
+                </p>
+                <ul className="p2b-import-list">
+                  {review.issues.map(issue => (
+                    <li key={`${issue.field}-${issue.message}`}>
+                      <code>{issue.field}</code> {issue.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {review?.patch && (
+              <div className="p2b-import-report">
+                <p className="p2b-import-report-title">
+                  Every value matches the loaded options. Review and apply.
+                </p>
+                {review.corrections.length > 0 && (
+                  <ul className="p2b-import-list p2b-import-list--corrections">
+                    {review.corrections.map(correction => (
+                      <li key={`${correction.field}-${correction.message}`}>
+                        <code>{correction.field}</code> {correction.message}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <dl className="p2b-import-rows">
+                  {review.rows.map(row => (
+                    <div key={row.field} className="p2b-import-row">
+                      <dt>{row.field}</dt>
+                      <dd>{row.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            )}
+          </div>
+        </details>
       </div>
     </section>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -25,6 +25,8 @@ interface EasySetupPanelProps {
   activeWorkflow: P2BFormState['activeWorkflow']
   editorial: P2BEditorialComposerState
   editorialOptions: Prompt2BlogEditorialOptionsResponse | null
+  editorialOptionsError: boolean
+  editorialOptionsLoading: boolean
   inputOptions: Prompt2BlogInputOptionsResponse | null
   location: string
   title: string
@@ -34,6 +36,7 @@ interface EasySetupPanelProps {
   onClearDirectionWorkflow: () => void
   onCommissionChange: (draft: Prompt2BlogCommissionDraft) => void
   onLocationChange: (value: string) => void
+  onRetryEditorialOptions: () => void
   onSelectDirection: (optionId: Prompt2BlogDirectionOptionId) => Promise<void>
   onStartDirectionWorkflow: () => void
   onTitleChange: (value: string) => void
@@ -43,6 +46,8 @@ export function EasySetupPanel({
   activeWorkflow,
   editorial,
   editorialOptions,
+  editorialOptionsError,
+  editorialOptionsLoading,
   inputOptions,
   location,
   title,
@@ -52,6 +57,7 @@ export function EasySetupPanel({
   onClearDirectionWorkflow,
   onCommissionChange,
   onLocationChange,
+  onRetryEditorialOptions,
   onSelectDirection,
   onStartDirectionWorkflow,
   onTitleChange,
@@ -66,12 +72,14 @@ export function EasySetupPanel({
   const [directionStatus, setDirectionStatus] = useState<string | null>(null)
   // The prompt lists the option catalogs verbatim, so a prompt built before
   // they arrived is missing the fields it should have constrained.
-  const catalogsLoaded = Boolean(editorialOptions?.forms.length)
   const showDirectionStep = prompt !== null || activeWorkflow === 'editorial_v3'
 
   useEffect(() => {
     setPrompt(null)
     setCopyStatus('idle')
+    setDirectionJson('')
+    setDirectionReview(null)
+    setDirectionStatus(null)
   }, [location, title])
 
   useEffect(() => {
@@ -194,8 +202,16 @@ export function EasySetupPanel({
             Generate direction prompt
           </button>
         </div>
-        {!catalogsLoaded && (
+        {editorialOptionsLoading && (
           <p className="p2b-field-hint">Editorial forms and topic modules are still loading.</p>
+        )}
+        {editorialOptionsError && (
+          <div className="p2b-commission-alert p2b-commission-alert--error" role="alert">
+            <span>Editorial forms and topic modules could not be loaded.</span>
+            <button type="button" className="p2b-clear-btn" onClick={onRetryEditorialOptions}>
+              Retry
+            </button>
+          </div>
         )}
         {prompt !== null && (
           <div className="p2b-field">

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/editorial-direction-components.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/editorial-direction-components.test.tsx
@@ -316,7 +316,7 @@ describe('CommissionEditor', () => {
       'context_only'
     )
     expect(screen.getByRole('alert')).toHaveTextContent(
-      'Head-to-head scope needs at least one comparator.'
+      'head_to_head scope requires at least 1 comparator.'
     )
     expect(
       screen.getByRole('button', { name: 'Approve commission' })
@@ -324,6 +324,13 @@ describe('CommissionEditor', () => {
 
     fireEvent.change(screen.getByLabelText('Reference 1 role'), {
       target: { value: 'comparator' }
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'head_to_head scope requires Comparison form.'
+    )
+    fireEvent.change(screen.getByLabelText('Article form'), {
+      target: { value: 'comparison' }
     })
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/editorial-direction-components.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/editorial-direction-components.test.tsx
@@ -1,0 +1,333 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom/vitest'
+import { useState } from 'react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within
+} from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogDirectionOption,
+  Prompt2BlogEditorialOptionsResponse
+} from '../../types/editorial.types'
+import { CommissionEditor } from './CommissionEditor'
+import { DirectionCards } from './DirectionCards'
+
+afterEach(cleanup)
+
+const editorialOptions: Prompt2BlogEditorialOptionsResponse = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'analysis',
+      label: 'Analysis',
+      description: 'Interprets evidence.',
+      order: 1,
+      source_requirements: []
+    },
+    {
+      id: 'comparison',
+      label: 'Comparison',
+      description: 'Compares peers.',
+      order: 2,
+      source_requirements: []
+    },
+    {
+      id: 'explainer',
+      label: 'Explainer',
+      description: 'Explains a question.',
+      order: 3,
+      source_requirements: []
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost',
+      description: 'Current costs.',
+      order: 1
+    },
+    {
+      id: 'accommodation-neighborhoods',
+      label: 'Accommodation',
+      description: 'Where to live.',
+      order: 2
+    },
+    { id: 'food-drink', label: 'Food', description: 'Eating costs.', order: 3 },
+    {
+      id: 'long-stay-remote-work',
+      label: 'Long stay',
+      description: 'Remote work.',
+      order: 4
+    },
+    { id: 'safety', label: 'Safety', description: 'Current risks.', order: 5 }
+  ],
+  audience_tags: [
+    {
+      id: 'remote-worker-relocator',
+      label: 'Relocator',
+      description: 'Planning a move.'
+    },
+    {
+      id: 'budget-focused',
+      label: 'Budget-focused',
+      description: 'Watching costs.'
+    }
+  ],
+  scope_modes: [
+    {
+      id: 'single_subject',
+      label: 'Single subject',
+      description: 'One subject.'
+    },
+    { id: 'head_to_head', label: 'Head to head', description: 'Two peers.' },
+    {
+      id: 'ranked_set',
+      label: 'Ranked set',
+      description: 'Three or more peers.'
+    }
+  ],
+  reference_roles: [
+    {
+      id: 'primary_subject',
+      label: 'Primary subject',
+      description: 'Article center.'
+    },
+    {
+      id: 'context_only',
+      label: 'Context only',
+      description: 'Benchmark only.'
+    },
+    { id: 'comparator', label: 'Comparator', description: 'Co-subject.' }
+  ]
+}
+
+function makeDirection(
+  optionId: Prompt2BlogDirectionOption['option_id'],
+  formId: Prompt2BlogDirectionOption['form_id'],
+  direction: string
+): Prompt2BlogDirectionOption {
+  return {
+    option_id: optionId,
+    direction,
+    form_id: formId,
+    topic_module_ids: ['cost-affordability'],
+    audience: {
+      primary_reader:
+        'Remote workers deciding whether Lima still offers value.',
+      tags: ['remote-worker-relocator', 'budget-focused']
+    },
+    core_reader_question: 'Does Lima still deliver compelling long-stay value?',
+    reader_outcome: 'Know which costs and tradeoffs decide the answer.',
+    primary_subject: 'Lima',
+    scope: {
+      mode: 'single_subject',
+      references: [
+        { name: 'Lima', role: 'primary_subject' },
+        { name: 'Medellín', role: 'context_only' }
+      ]
+    },
+    requirements: [
+      { requirement_id: 'r1', question: 'What do current housing costs show?' }
+    ],
+    exclusions: ['Do not organize the article by city.'],
+    rationale: 'Keeps Lima central while allowing limited regional context.'
+  }
+}
+
+const directions: Prompt2BlogDirectionOption[] = [
+  makeDirection(
+    'direction-1',
+    'analysis',
+    'Test whether Lima still earns its bargain reputation.'
+  ),
+  makeDirection(
+    'direction-2',
+    'comparison',
+    'Compare relocation costs across three cities.'
+  ),
+  makeDirection(
+    'direction-3',
+    'explainer',
+    'Explain which expenses changed most.'
+  )
+]
+
+const commissionDraft: Prompt2BlogCommissionDraft = {
+  schema_version: 3,
+  original_title: "Is Lima still South America's bargain expat capital?",
+  location: 'Lima, Peru',
+  approved_direction: directions[0].direction,
+  form_id: 'analysis',
+  topic_module_ids: [
+    'cost-affordability',
+    'accommodation-neighborhoods',
+    'food-drink',
+    'long-stay-remote-work'
+  ],
+  audience: directions[0].audience,
+  core_reader_question: directions[0].core_reader_question,
+  reader_outcome: directions[0].reader_outcome,
+  primary_subject: 'Lima',
+  scope: directions[0].scope,
+  requirements: directions[0].requirements,
+  exclusions: directions[0].exclusions,
+  call_to_action: null
+}
+
+describe('DirectionCards', () => {
+  it('renders exactly three native radio choices with decision context', () => {
+    render(
+      <DirectionCards
+        editorialOptions={editorialOptions}
+        options={directions}
+        selectedOptionId={null}
+        onSelect={vi.fn()}
+      />
+    )
+
+    const picker = screen.getByRole('group', {
+      name: 'Choose one editorial direction'
+    })
+    expect(within(picker).getAllByRole('radio')).toHaveLength(3)
+    expect(
+      within(picker).getByRole('radio', {
+        name: /Direction 1 Analysis Test whether Lima/
+      })
+    ).toBeInTheDocument()
+    expect(within(picker).getByText('Analysis')).toBeInTheDocument()
+    expect(within(picker).getAllByText('Cost')).toHaveLength(3)
+    expect(within(picker).getAllByText(/Remote workers deciding/)).toHaveLength(
+      3
+    )
+    expect(within(picker).getAllByText(/Does Lima still deliver/)).toHaveLength(
+      3
+    )
+    expect(within(picker).getAllByText(/Know which costs/)).toHaveLength(3)
+    expect(
+      within(picker).getAllByText(/Single subject: Lima \(Primary subject\)/)
+    ).toHaveLength(3)
+    expect(within(picker).getAllByText(/Keeps Lima central/)).toHaveLength(3)
+  })
+
+  it('reports selected option through native radio interaction', () => {
+    const onSelect = vi.fn()
+    render(
+      <DirectionCards
+        editorialOptions={editorialOptions}
+        options={directions}
+        selectedOptionId="direction-1"
+        onSelect={onSelect}
+      />
+    )
+
+    const radios = screen.getAllByRole('radio')
+    expect(radios[0]).toBeChecked()
+    fireEvent.click(radios[1])
+    expect(onSelect).toHaveBeenCalledWith(directions[1])
+  })
+
+  it('blocks malformed option counts at runtime', () => {
+    render(
+      <DirectionCards
+        editorialOptions={editorialOptions}
+        options={directions.slice(0, 2)}
+        selectedOptionId={null}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('exactly three options')
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+  })
+})
+
+function CommissionHarness({
+  onApprove = vi.fn()
+}: {
+  onApprove?: () => void
+}) {
+  const [draft, setDraft] = useState(commissionDraft)
+  return (
+    <CommissionEditor
+      draft={draft}
+      editorialOptions={editorialOptions}
+      isApproved={false}
+      onApprove={onApprove}
+      onChange={setDraft}
+    />
+  )
+}
+
+describe('CommissionEditor', () => {
+  it('exposes every commission control and enforces the four-module limit', () => {
+    render(<CommissionHarness />)
+
+    expect(screen.getByLabelText('Original title')).toHaveAttribute('readonly')
+    expect(screen.getByLabelText('Location')).toHaveAttribute('readonly')
+    expect(screen.getByLabelText('Approved direction')).toBeInTheDocument()
+    expect(screen.getByLabelText('Article form')).toHaveValue('analysis')
+    expect(screen.getByLabelText('Primary audience')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /Relocator/ })).toBeChecked()
+    expect(screen.getByLabelText('Core reader question')).toBeInTheDocument()
+    expect(screen.getByLabelText('Reader outcome')).toBeInTheDocument()
+    expect(screen.getByLabelText('Primary subject')).toHaveValue('Lima')
+    expect(screen.getByLabelText('Scope mode')).toHaveValue('single_subject')
+    expect(screen.getByLabelText('Reference 1')).toHaveValue('Medellín')
+    expect(screen.getByLabelText('Reference 1 role')).toHaveValue(
+      'context_only'
+    )
+    expect(screen.getByLabelText('Requirement 1 ID')).toHaveValue('r1')
+    expect(screen.getByLabelText('Requirement 1 question')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Exclusions (one per line)')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Call to action (optional)')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /Safety/ })).toBeDisabled()
+  })
+
+  it('keeps primary reference visibly synced to primary subject', () => {
+    render(<CommissionHarness />)
+
+    fireEvent.change(screen.getByLabelText('Primary subject'), {
+      target: { value: 'Greater Lima' }
+    })
+
+    expect(screen.getByLabelText('Primary reference')).toHaveValue(
+      'Greater Lima'
+    )
+  })
+
+  it('surfaces invalid scope without silently changing reference roles', () => {
+    const onApprove = vi.fn()
+    render(<CommissionHarness onApprove={onApprove} />)
+
+    fireEvent.change(screen.getByLabelText('Scope mode'), {
+      target: { value: 'head_to_head' }
+    })
+
+    expect(screen.getByLabelText('Reference 1 role')).toHaveValue(
+      'context_only'
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Head-to-head scope needs at least one comparator.'
+    )
+    expect(
+      screen.getByRole('button', { name: 'Approve commission' })
+    ).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Reference 1 role'), {
+      target: { value: 'comparator' }
+    })
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Approve commission' }))
+    expect(onApprove).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  getPrompt2BlogEditorialOptions,
   getPrompt2BlogGuidelinePreview,
   getPrompt2BlogInputOptions,
+  type Prompt2BlogEditorialOptionsResponse,
+  type Prompt2BlogCommissionDraft,
+  type Prompt2BlogDirectionOptionId,
+  type Prompt2BlogDirectionResponse,
   type Prompt2BlogGuidelinePreviewResponse,
   type Prompt2BlogInputOptionsResponse,
 } from '../../api'
@@ -9,7 +14,11 @@ import {
   resolvePrompt2BlogModelStack,
   type Prompt2BlogModelStackId,
 } from '../../constants/prompt2blog.constants'
-import { buildGroupedArticleTypes, findDefaultOption, getArticleTypeQuickPicks } from '../article-type-options'
+import {
+  buildGroupedArticleTypes,
+  findDefaultOption,
+  getArticleTypeQuickPicks,
+} from '../article-type-options'
 import {
   COMPOSER_STORAGE_KEY,
   DEFAULT_COMPOSER_STATE,
@@ -18,10 +27,24 @@ import {
 } from '../composer.storage'
 import type { P2BFormState } from '../composer.types'
 import { buildPrompt2BlogPayload } from '../prompt-payload'
+import { approveCommission as fingerprintApprovedCommission } from '../commission'
+import {
+  applyValidatedDirectionResponse,
+  approveCommission as storeApprovedCommission,
+  clearDirectionWorkflow as resetDirectionWorkflow,
+  editCommissionDraft,
+  selectDirectionOption as selectCommissionDirection,
+  startEditorialWorkflow,
+} from '../commission-state'
 
 function createDefaultComposerState(): P2BFormState {
   return {
     ...DEFAULT_COMPOSER_STATE,
+    editorial: {
+      ...DEFAULT_COMPOSER_STATE.editorial,
+      directionOptions: [],
+      approval: { ...DEFAULT_COMPOSER_STATE.editorial.approval },
+    },
     blobs: DEFAULT_COMPOSER_STATE.blobs.map(blob => ({ ...blob })),
   }
 }
@@ -30,21 +53,48 @@ export function usePrompt2BlogComposer() {
   const saved = useRef(loadSavedComposerState())
   const [state, setState] = useState<P2BFormState>(saved.current)
   const [inputOptions, setInputOptions] = useState<Prompt2BlogInputOptionsResponse | null>(null)
+  const [editorialOptions, setEditorialOptions] =
+    useState<Prompt2BlogEditorialOptionsResponse | null>(null)
   const [guidelinePreview, setGuidelinePreview] =
     useState<Prompt2BlogGuidelinePreviewResponse | null>(null)
   const [guidelineLoading, setGuidelineLoading] = useState(false)
 
-  const updateField = useCallback(<K extends keyof P2BFormState>(
-    field: K,
-    value: P2BFormState[K],
-  ) => {
-    setState(prev => ({ ...prev, [field]: value }))
-  }, [])
+  const updateField = useCallback(
+    <K extends keyof P2BFormState>(field: K, value: P2BFormState[K]) => {
+      setState(prev => {
+        const changedSetupIdentity =
+          (field === 'easySetupTitle' && value !== prev.easySetupTitle) ||
+          (field === 'easySetupLocation' && value !== prev.easySetupLocation)
+        if (changedSetupIdentity && prev.activeWorkflow === 'editorial_v3') {
+          return {
+            ...prev,
+            [field]: value,
+            editorial: {
+              directionOptions: [],
+              selectedOptionId: null,
+              commissionDraft: null,
+              approval: {
+                status: 'reconfirmation_required',
+                reason: 'title_or_location_changed',
+              },
+            },
+          }
+        }
+        return { ...prev, [field]: value }
+      })
+    },
+    [],
+  )
 
   // The Easy Set Up import lands as one patch so the whole form moves to the
   // approved brief in a single state change.
   const applyFields = useCallback((patch: Partial<P2BFormState>) => {
-    setState(prev => ({ ...prev, ...patch }))
+    setState(prev => ({
+      ...prev,
+      ...patch,
+      activeWorkflow: 'legacy_v2',
+      editorial: { ...DEFAULT_COMPOSER_STATE.editorial },
+    }))
   }, [])
 
   useEffect(() => {
@@ -54,17 +104,18 @@ export function usePrompt2BlogComposer() {
   useEffect(() => {
     let cancelled = false
     getPrompt2BlogInputOptions()
-      .then((options) => {
+      .then(options => {
         if (cancelled) return
         setInputOptions(options)
         setState(prev => ({
           ...prev,
           toneId: prev.toneId || options.defaults.tone_id || findDefaultOption(options.tones),
-          lengthId: prev.lengthId || options.defaults.length_id || findDefaultOption(options.lengths),
+          lengthId:
+            prev.lengthId || options.defaults.length_id || findDefaultOption(options.lengths),
           brandVoiceId:
-            prev.brandVoiceId
-            || options.defaults.brand_voice_id
-            || findDefaultOption(options.brand_voices),
+            prev.brandVoiceId ||
+            options.defaults.brand_voice_id ||
+            findDefaultOption(options.brand_voices),
         }))
       })
       .catch(() => {
@@ -88,6 +139,21 @@ export function usePrompt2BlogComposer() {
   }, [])
 
   useEffect(() => {
+    let cancelled = false
+    getPrompt2BlogEditorialOptions()
+      .then(options => {
+        if (!cancelled) setEditorialOptions(options)
+      })
+      .catch(() => {
+        if (!cancelled) setEditorialOptions(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
     if (!state.articleTypeId) {
       setGuidelinePreview(null)
       return
@@ -96,7 +162,7 @@ export function usePrompt2BlogComposer() {
     let cancelled = false
     setGuidelineLoading(true)
     getPrompt2BlogGuidelinePreview(state.articleTypeId)
-      .then((payload) => {
+      .then(payload => {
         if (!cancelled) setGuidelinePreview(payload)
       })
       .catch(() => {
@@ -125,23 +191,76 @@ export function usePrompt2BlogComposer() {
     [articleTypeOptions, state.articleTypeId],
   )
   const payload = useMemo(() => buildPrompt2BlogPayload(state), [state])
+  const submissionBlockedReason =
+    state.activeWorkflow === 'editorial_v3'
+      ? 'Editorial v3 direction work is active. Research import ships next; clear direction work to use legacy v2.'
+      : null
+
+  const startDirectionWorkflow = useCallback(() => {
+    setState(startEditorialWorkflow)
+  }, [])
+
+  const applyDirectionResponse = useCallback((response: Prompt2BlogDirectionResponse) => {
+    setState(prev => applyValidatedDirectionResponse(prev, response))
+  }, [])
+
+  const selectDirectionOption = useCallback(
+    async (optionId: Prompt2BlogDirectionOptionId) => {
+      if (!editorialOptions) throw new Error('Editorial options are still loading.')
+      const selectedState = selectCommissionDirection(state, optionId)
+      const draft = selectedState.editorial.commissionDraft
+      if (!draft) throw new Error('The selected direction did not create a commission.')
+      setState(selectedState)
+      const commission = await fingerprintApprovedCommission(draft, editorialOptions)
+      setState(prev => {
+        if (
+          prev.easySetupTitle.trim() !== draft.original_title ||
+          prev.easySetupLocation.trim() !== draft.location ||
+          prev.editorial.selectedOptionId !== optionId
+        )
+          return prev
+        return storeApprovedCommission(prev, commission)
+      })
+    },
+    [editorialOptions, state],
+  )
+
+  const updateCommissionDraft = useCallback((draft: Prompt2BlogCommissionDraft) => {
+    setState(prev => editCommissionDraft(prev, draft))
+  }, [])
+
+  const approveCommissionChanges = useCallback(async () => {
+    if (!editorialOptions || !state.editorial.commissionDraft) {
+      throw new Error('Complete the commission before approving it.')
+    }
+    const draft = state.editorial.commissionDraft
+    const commission = await fingerprintApprovedCommission(draft, editorialOptions)
+    setState(prev =>
+      prev.editorial.commissionDraft !== draft ? prev : storeApprovedCommission(prev, commission),
+    )
+  }, [editorialOptions, state.editorial.commissionDraft])
+
+  const clearDirectionWorkflow = useCallback(() => {
+    setState(resetDirectionWorkflow)
+  }, [])
 
   const addBlob = useCallback(() => {
-    setState(prev => ({ ...prev, blobs: [...prev.blobs, { id: Date.now(), content: '' }] }))
+    setState(prev => ({
+      ...prev,
+      blobs: [...prev.blobs, { id: Date.now(), content: '' }],
+    }))
   }, [])
 
   const removeBlob = useCallback((id: number) => {
-    setState(prev => (
-      prev.blobs.length <= 1
-        ? prev
-        : { ...prev, blobs: prev.blobs.filter(blob => blob.id !== id) }
-    ))
+    setState(prev =>
+      prev.blobs.length <= 1 ? prev : { ...prev, blobs: prev.blobs.filter(blob => blob.id !== id) },
+    )
   }, [])
 
   const updateBlob = useCallback((id: number, content: string) => {
     setState(prev => ({
       ...prev,
-      blobs: prev.blobs.map(blob => blob.id === id ? { ...blob, content } : blob),
+      blobs: prev.blobs.map(blob => (blob.id === id ? { ...blob, content } : blob)),
     }))
   }, [])
 
@@ -217,12 +336,20 @@ export function usePrompt2BlogComposer() {
     updateField,
     applyFields,
     inputOptions,
+    editorialOptions,
     guidelinePreview,
     guidelineLoading,
     groupedArticleTypeOptions,
     articleTypeQuickPicks,
     selectedArticleType,
     payload,
+    submissionBlockedReason,
+    startDirectionWorkflow,
+    applyDirectionResponse,
+    selectDirectionOption,
+    updateCommissionDraft,
+    approveCommissionChanges,
+    clearDirectionWorkflow,
     addBlob,
     removeBlob,
     updateBlob,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import {
   getPrompt2BlogEditorialOptions,
   getPrompt2BlogGuidelinePreview,
@@ -53,8 +54,6 @@ export function usePrompt2BlogComposer() {
   const saved = useRef(loadSavedComposerState())
   const [state, setState] = useState<P2BFormState>(saved.current)
   const [inputOptions, setInputOptions] = useState<Prompt2BlogInputOptionsResponse | null>(null)
-  const [editorialOptions, setEditorialOptions] =
-    useState<Prompt2BlogEditorialOptionsResponse | null>(null)
   const [guidelinePreview, setGuidelinePreview] =
     useState<Prompt2BlogGuidelinePreviewResponse | null>(null)
   const [guidelineLoading, setGuidelineLoading] = useState(false)
@@ -138,20 +137,12 @@ export function usePrompt2BlogComposer() {
     }
   }, [])
 
-  useEffect(() => {
-    let cancelled = false
-    getPrompt2BlogEditorialOptions()
-      .then(options => {
-        if (!cancelled) setEditorialOptions(options)
-      })
-      .catch(() => {
-        if (!cancelled) setEditorialOptions(null)
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [])
+  const editorialOptionsQuery = useQuery<Prompt2BlogEditorialOptionsResponse>({
+    queryKey: ['prompt2blog', 'editorial-options'],
+    queryFn: getPrompt2BlogEditorialOptions,
+    staleTime: 5 * 60 * 1000,
+  })
+  const editorialOptions = editorialOptionsQuery.data ?? null
 
   useEffect(() => {
     if (!state.articleTypeId) {
@@ -337,6 +328,11 @@ export function usePrompt2BlogComposer() {
     applyFields,
     inputOptions,
     editorialOptions,
+    editorialOptionsError: editorialOptionsQuery.isError,
+    editorialOptionsLoading: editorialOptionsQuery.isPending,
+    retryEditorialOptions: () => {
+      void editorialOptionsQuery.refetch()
+    },
     guidelinePreview,
     guidelineLoading,
     groupedArticleTypeOptions,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -962,6 +962,31 @@ describe('Prompt2BlogPage', () => {
     expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeEnabled()
   })
 
+  it('retracts a checked direction response when title identity changes', async () => {
+    renderPage()
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'A weekend in Lisbon' },
+    })
+    fireEvent.change(screen.getByLabelText('Location'), {
+      target: { value: 'Lisbon, Portugal' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Generate direction prompt' }))
+    fireEvent.change(screen.getByLabelText('Direction JSON'), {
+      target: { value: createDirectionResponseJson() },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Check directions' }))
+    expect(screen.getByRole('button', { name: 'Show direction cards' })).toBeEnabled()
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Three days in Lisbon' },
+    })
+
+    expect(screen.getByRole('button', { name: 'Show direction cards' })).toBeDisabled()
+    expect(screen.getByLabelText('Direction JSON')).toHaveValue('')
+  })
+
   it('lets users choose a travel quick pick and shows the selected definition', async () => {
     renderPage()
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -5,14 +5,13 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as prompt2blogApi from '../api'
-import {
-  DEFAULT_COMPOSER_STATE,
-  saveComposerState,
-} from '../composer/composer.storage'
+import { DEFAULT_COMPOSER_STATE, saveComposerState } from '../composer/composer.storage'
 import Prompt2BlogPage from './Prompt2BlogPage'
 
 vi.mock('../api', () => ({
+  PROMPT2BLOG_DIRECTION_OPTION_IDS: ['direction-1', 'direction-2', 'direction-3'],
   getPrompt2BlogDebug: vi.fn(),
+  getPrompt2BlogEditorialOptions: vi.fn(),
   getPrompt2BlogGuidelinePreview: vi.fn(),
   getPrompt2BlogInputOptions: vi.fn(),
   getPrompt2BlogResult: vi.fn(),
@@ -21,6 +20,7 @@ vi.mock('../api', () => ({
 }))
 
 const getPrompt2BlogDebugMock = vi.mocked(prompt2blogApi.getPrompt2BlogDebug)
+const getPrompt2BlogEditorialOptionsMock = vi.mocked(prompt2blogApi.getPrompt2BlogEditorialOptions)
 const getPrompt2BlogGuidelinePreviewMock = vi.mocked(prompt2blogApi.getPrompt2BlogGuidelinePreview)
 const getPrompt2BlogInputOptionsMock = vi.mocked(prompt2blogApi.getPrompt2BlogInputOptions)
 const getPrompt2BlogResultMock = vi.mocked(prompt2blogApi.getPrompt2BlogResult)
@@ -159,6 +159,70 @@ function createStoredPipelineResult() {
   }
 }
 
+function createDirectionResponseJson() {
+  const directions = [
+    'Build a food-first weekend around markets, bakeries, and traditional restaurants.',
+    'Explain how to connect major sights efficiently with trams, metro, and walking.',
+    'Design a low-stress first visit with neighborhood bases and realistic daily pacing.',
+  ] as const
+  const questions = [
+    'Which food experiences deserve limited weekend time?',
+    'How should a visitor move between essential Lisbon sights?',
+    'Where should a first-time visitor stay and slow down?',
+  ] as const
+  const outcomes = [
+    'Choose a compact set of distinctive meals and markets.',
+    'Plan efficient routes without overloading each day.',
+    'Select a convenient base and a manageable weekend rhythm.',
+  ] as const
+  const evidenceQuestions = [
+    'Which current venues and markets best represent Lisbon food culture?',
+    'What do current transit routes, fares, and walking times support?',
+    'Which neighborhoods balance access, atmosphere, and rest?',
+  ] as const
+  const rationales = [
+    'Makes Lisbon food the organizing promise for a short visit.',
+    'Solves the practical mobility problem that shapes a first weekend.',
+    'Centers comfort and pacing for readers unfamiliar with the city.',
+  ] as const
+  const makeOption = (optionId: 'direction-1' | 'direction-2' | 'direction-3', index: number) => ({
+    option_id: optionId,
+    direction: directions[index - 1],
+    form_id: 'service-guide',
+    topic_module_ids: index === 1 ? ['food-drink'] : ['transportation'],
+    audience: {
+      primary_reader: index === 1 ? 'First-time weekend visitors' : `Lisbon reader ${index}`,
+      tags: ['first-time-visitor'],
+    },
+    core_reader_question: questions[index - 1],
+    reader_outcome: outcomes[index - 1],
+    primary_subject: 'Lisbon',
+    scope: {
+      mode: 'single_subject',
+      references: [{ name: 'Lisbon', role: 'primary_subject' }],
+    },
+    requirements: [
+      {
+        requirement_id: `r${index}`,
+        question: evidenceQuestions[index - 1],
+      },
+    ],
+    exclusions: [`Do not drift into direction ${index + 1}`],
+    rationale: rationales[index - 1],
+  })
+
+  return JSON.stringify({
+    schema_version: 3,
+    original_title: 'A weekend in Lisbon',
+    location: 'Lisbon, Portugal',
+    options: [
+      makeOption('direction-1', 1),
+      makeOption('direction-2', 2),
+      makeOption('direction-3', 3),
+    ],
+  })
+}
+
 describe('Prompt2BlogPage', () => {
   let restoreClipboard: (() => void) | null = null
 
@@ -169,7 +233,78 @@ describe('Prompt2BlogPage', () => {
   })
 
   beforeEach(() => {
+    vi.clearAllMocks()
     localStorage.clear()
+
+    getPrompt2BlogEditorialOptionsMock.mockResolvedValue({
+      schema_version: 3,
+      forms: [
+        {
+          id: 'service-guide',
+          label: 'Service Guide',
+          description: 'Practical guidance for making a trip work.',
+          order: 1,
+          source_requirements: [],
+        },
+        {
+          id: 'comparison',
+          label: 'Comparison',
+          description: 'A scoped comparison between named subjects.',
+          order: 2,
+          source_requirements: [],
+        },
+      ],
+      topic_modules: [
+        {
+          id: 'food-drink',
+          label: 'Food & Drink',
+          description: 'Eating well.',
+          order: 1,
+        },
+        {
+          id: 'transportation',
+          label: 'Transportation',
+          description: 'Getting around.',
+          order: 2,
+        },
+      ],
+      audience_tags: [
+        {
+          id: 'first-time-visitor',
+          label: 'First-time visitor',
+          description: 'New arrivals.',
+        },
+      ],
+      scope_modes: [
+        {
+          id: 'single_subject',
+          label: 'Single subject',
+          description: 'One primary subject.',
+        },
+        {
+          id: 'head_to_head',
+          label: 'Head to head',
+          description: 'Direct comparison.',
+        },
+      ],
+      reference_roles: [
+        {
+          id: 'primary_subject',
+          label: 'Primary subject',
+          description: 'The article subject.',
+        },
+        {
+          id: 'context_only',
+          label: 'Context only',
+          description: 'Context, not a comparison.',
+        },
+        {
+          id: 'comparator',
+          label: 'Comparator',
+          description: 'Compared directly.',
+        },
+      ],
+    })
 
     getPrompt2BlogInputOptionsMock.mockResolvedValue({
       article_types: [
@@ -241,24 +376,26 @@ describe('Prompt2BlogPage', () => {
   it('starts with an Easy Set Up block containing Title and Location fields', async () => {
     renderPage()
 
-    const easySetupPanel = screen.getByRole('heading', { name: 'Easy Set Up' })
-      .closest('section')
-    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' })
-      .closest('section')
-    const modelRoutingPanel = screen.getByRole('heading', { name: 'Run Stack' })
-      .closest('section')
+    const easySetupPanel = screen.getByRole('heading', { name: 'Easy Set Up' }).closest('section')
+    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' }).closest('section')
+    const modelRoutingPanel = screen.getByRole('heading', { name: 'Run Stack' }).closest('section')
 
     expect(easySetupPanel).toBeInTheDocument()
-    expect(modelRoutingPanel?.compareDocumentPosition(easySetupPanel!))
-      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
-    expect(easySetupPanel?.compareDocumentPosition(coreInputsPanel!))
-      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(modelRoutingPanel?.compareDocumentPosition(easySetupPanel!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+    expect(easySetupPanel?.compareDocumentPosition(coreInputsPanel!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
     expect(within(easySetupPanel!).getByLabelText('Title')).toBeInTheDocument()
     expect(within(easySetupPanel!).getByLabelText('Location')).toBeInTheDocument()
-    expect(within(easySetupPanel!).getByLabelText('Approved JSON')).toBeInTheDocument()
-    expect(within(easySetupPanel!).getAllByRole('textbox')).toHaveLength(3)
-    expect(within(easySetupPanel!).getByRole('button', { name: 'Generate setup prompt' }))
-      .toBeDisabled()
+    expect(within(easySetupPanel!).getByLabelText('Approved JSON')).not.toBeVisible()
+    expect(within(easySetupPanel!).queryByLabelText('Direction JSON')).not.toBeInTheDocument()
+    expect(
+      within(easySetupPanel!).getByRole('button', {
+        name: 'Generate direction prompt',
+      }),
+    ).toBeDisabled()
     expect(within(easySetupPanel!).queryByLabelText('Prompt')).not.toBeInTheDocument()
   })
 
@@ -267,7 +404,9 @@ describe('Prompt2BlogPage', () => {
 
     // The prompt quotes the loaded option catalogs, so wait for them to arrive.
     await screen.findByRole('option', { name: 'Destination Guide' })
-    const confirmSetup = screen.getByRole('button', { name: 'Generate setup prompt' })
+    const confirmSetup = screen.getByRole('button', {
+      name: 'Generate direction prompt',
+    })
 
     fireEvent.change(screen.getByLabelText('Title'), {
       target: { value: 'A weekend in Lisbon' },
@@ -281,19 +420,17 @@ describe('Prompt2BlogPage', () => {
     fireEvent.click(confirmSetup)
 
     const prompt = screen.getByLabelText('Prompt')
+    expect((prompt as HTMLTextAreaElement).value).toContain('Original title: "A weekend in Lisbon"')
+    expect((prompt as HTMLTextAreaElement).value).toContain('Location: "Lisbon, Portugal"')
     expect((prompt as HTMLTextAreaElement).value).toContain(
-      'Working title: "A weekend in Lisbon"',
+      'Return one JSON object and nothing else',
     )
     expect((prompt as HTMLTextAreaElement).value).toContain(
-      'Location: "Lisbon, Portugal"',
+      '- service-guide (Service Guide) — Practical guidance for making a trip work.',
     )
     expect((prompt as HTMLTextAreaElement).value).toContain(
-      'One JSON object, nothing before or after it',
+      'Do not browse, research facts, or write the article.',
     )
-    expect((prompt as HTMLTextAreaElement).value).toContain(
-      '- Destination Guide — Comprehensive overview of a place for trip planning.',
-    )
-    expect((prompt as HTMLTextAreaElement).value).toContain('- balanced (Balanced) [house default]')
 
     fireEvent.change(prompt, {
       target: { value: 'Edited prompt' },
@@ -319,7 +456,7 @@ describe('Prompt2BlogPage', () => {
     fireEvent.change(screen.getByLabelText('Location'), {
       target: { value: 'Lisbon, Portugal' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Generate setup prompt' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Generate direction prompt' }))
 
     const promptValue = (screen.getByLabelText('Prompt') as HTMLTextAreaElement).value
     fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }))
@@ -340,7 +477,7 @@ describe('Prompt2BlogPage', () => {
     fireEvent.change(screen.getByLabelText('Location'), {
       target: { value: 'Lisbon, Portugal' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Generate setup prompt' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Generate direction prompt' }))
     fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }))
 
     expect(await screen.findByRole('button', { name: 'Copy failed' })).toBeInTheDocument()
@@ -349,6 +486,7 @@ describe('Prompt2BlogPage', () => {
   it('fills the whole form from an approved JSON brief once it checks out', async () => {
     renderPage()
     await screen.findByRole('option', { name: 'Destination Guide' })
+    fireEvent.click(screen.getByText('Legacy v2 brief import'))
 
     const approved = JSON.stringify({
       direction: 'A routing piece for a reader who loses their weekend to transit.',
@@ -374,36 +512,49 @@ describe('Prompt2BlogPage', () => {
       writing_model: 'gemini-2.5-flash',
     })
 
-    fireEvent.change(screen.getByLabelText('Approved JSON'), { target: { value: approved } })
+    fireEvent.change(screen.getByLabelText('Approved JSON'), {
+      target: { value: approved },
+    })
     expect(screen.getByRole('button', { name: 'Apply to form' })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Check JSON' }))
 
-    expect(screen.getByText('Every value matches the loaded options. Review and apply.'))
-      .toBeInTheDocument()
+    expect(
+      screen.getByText('Every value matches the loaded options. Review and apply.'),
+    ).toBeInTheDocument()
     expect(screen.getByText('Itinerary Article (id 9)')).toBeInTheDocument()
-    expect(screen.getByText('A routing piece for a reader who loses their weekend to transit.'))
-      .toBeInTheDocument()
+    expect(
+      screen.getByText('A routing piece for a reader who loses their weekend to transit.'),
+    ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply to form' }))
 
     expect(screen.getByLabelText('Article Type')).toHaveValue('9')
-    expect(screen.getByLabelText('Article Goal')).toHaveValue('Plan two full days without wasted transit.')
-    expect(screen.getByLabelText('Target Reader')).toHaveValue('A first-time visitor with 48 hours.')
-    expect(screen.getByLabelText('Editorial Angle (Optional)'))
-      .toHaveValue('Neighbourhood-first planning beats landmark ticking.')
-    expect(screen.getByLabelText('Call to Action (Optional)'))
-      .toHaveValue('Book the viewpoint slot before arriving.')
+    expect(screen.getByLabelText('Article Goal')).toHaveValue(
+      'Plan two full days without wasted transit.',
+    )
+    expect(screen.getByLabelText('Target Reader')).toHaveValue(
+      'A first-time visitor with 48 hours.',
+    )
+    expect(screen.getByLabelText('Editorial Angle (Optional)')).toHaveValue(
+      'Neighbourhood-first planning beats landmark ticking.',
+    )
+    expect(screen.getByLabelText('Call to Action (Optional)')).toHaveValue(
+      'Book the viewpoint slot before arriving.',
+    )
     expect(screen.getByLabelText('Tone')).toHaveValue('balanced')
     expect(screen.getByLabelText('Creativity Level')).toHaveValue('high')
     expect(screen.getByLabelText('Pipeline preset')).toHaveValue('editorial-premium')
     expect(screen.getByLabelText('Primary Keyword')).toHaveValue('weekend in lisbon')
-    expect(screen.getByLabelText('Secondary Keywords (comma-separated)'))
-      .toHaveValue('lisbon itinerary, 48 hours in lisbon')
-    expect(screen.getByLabelText('Must Include (one per line)'))
-      .toHaveValue('Tram 28 crowding\nAirport transfer costs')
-    expect(screen.getByLabelText('Negative Instructions (one per line)'))
-      .toHaveValue('No unsourced price claims')
+    expect(screen.getByLabelText('Secondary Keywords (comma-separated)')).toHaveValue(
+      'lisbon itinerary, 48 hours in lisbon',
+    )
+    expect(screen.getByLabelText('Must Include (one per line)')).toHaveValue(
+      'Tram 28 crowding\nAirport transfer costs',
+    )
+    expect(screen.getByLabelText('Negative Instructions (one per line)')).toHaveValue(
+      'No unsourced price claims',
+    )
     expect(screen.getByLabelText('Add editorial extras')).toBeChecked()
     expect(screen.getByLabelText('Title')).toHaveValue('A Weekend in Lisbon')
     expect(screen.getByText('Applied 18 fields to the form below.')).toBeInTheDocument()
@@ -412,6 +563,7 @@ describe('Prompt2BlogPage', () => {
   it('blocks applying a brief whose values are not in the loaded options', async () => {
     renderPage()
     await screen.findByRole('option', { name: 'Destination Guide' })
+    fireEvent.click(screen.getByText('Legacy v2 brief import'))
 
     fireEvent.change(screen.getByLabelText('Approved JSON'), {
       target: { value: '{"article_type": "Destination Guides"}' },
@@ -427,13 +579,18 @@ describe('Prompt2BlogPage', () => {
   it('retracts an approved check as soon as the pasted JSON is edited', async () => {
     renderPage()
     await screen.findByRole('option', { name: 'Destination Guide' })
+    fireEvent.click(screen.getByText('Legacy v2 brief import'))
 
     const box = screen.getByLabelText('Approved JSON')
-    fireEvent.change(box, { target: { value: '{"article_type": "Destination Guides"}' } })
+    fireEvent.change(box, {
+      target: { value: '{"article_type": "Destination Guides"}' },
+    })
     fireEvent.click(screen.getByRole('button', { name: 'Check JSON' }))
     expect(screen.getByText(/nothing was applied/)).toBeInTheDocument()
 
-    fireEvent.change(box, { target: { value: '{"article_type": "Destination Guide"}' } })
+    fireEvent.change(box, {
+      target: { value: '{"article_type": "Destination Guide"}' },
+    })
 
     expect(screen.queryByText(/nothing was applied/)).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Apply to form' })).toBeDisabled()
@@ -449,11 +606,12 @@ describe('Prompt2BlogPage', () => {
       target: { value: 'Lisbon, Portugal' },
     })
     await waitFor(() => {
-      expect(JSON.parse(localStorage.getItem('p2b-form-draft') || '{}'))
-        .toEqual(expect.objectContaining({
+      expect(JSON.parse(localStorage.getItem('p2b-form-draft') || '{}')).toEqual(
+        expect.objectContaining({
           easySetupLocation: 'Lisbon, Portugal',
           easySetupTitle: 'A weekend in Lisbon',
-        }))
+        }),
+      )
     })
 
     unmount()
@@ -474,7 +632,9 @@ describe('Prompt2BlogPage', () => {
     // points on one scale, because a Claude-writer stack pays for its writing
     // out of the subscription instead of per token.
     expect(
-      within(preset).getAllByRole('group').map(group => group.getAttribute('label')),
+      within(preset)
+        .getAllByRole('group')
+        .map(group => group.getAttribute('label')),
     ).toEqual(['Gemini — billed per token', 'Claude writes — included in your plan'])
     expect(options.map(option => option.textContent)).toEqual([
       '$$$$$$ · Maximum Quality · Slowest',
@@ -515,9 +675,7 @@ describe('Prompt2BlogPage', () => {
     expect(within(pricing).getByText('$1.35')).toBeInTheDocument()
     expect(within(pricing).getByText('Input $0.75 / 1M')).toBeInTheDocument()
     expect(within(pricing).getByText('Metered part')).toBeInTheDocument()
-    expect(
-      within(pricing).getByText(/Article writer runs on your Claude plan/),
-    ).toBeInTheDocument()
+    expect(within(pricing).getByText(/Article writer runs on your Claude plan/)).toBeInTheDocument()
 
     const receipt = screen.getByLabelText('Opus · Balanced model assignments')
     expect(within(receipt).getByText('Claude Opus 5')).toBeInTheDocument()
@@ -550,7 +708,9 @@ describe('Prompt2BlogPage', () => {
     const optionalGuidanceSummary = screen.getByText('Optional editorial guidance')
     const optionalGuidance = optionalGuidanceSummary.closest('details')
 
-    const articleDetailsHeading = screen.getByRole('heading', { name: 'Article Details' })
+    const articleDetailsHeading = screen.getByRole('heading', {
+      name: 'Article Details',
+    })
     const articleDetails = articleDetailsHeading.closest('details')
     const middlePanels = [
       'Core Inputs',
@@ -578,9 +738,9 @@ describe('Prompt2BlogPage', () => {
     expect(screen.getByLabelText('Pipeline preset').closest('details')).toBeNull()
     expect(screen.queryByLabelText('Audience Profile (Optional)')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Prompt Enhance')).not.toBeInTheDocument()
-    expect(
-      screen.getByLabelText('Secondary Keywords (comma-separated)').closest('details'),
-    ).toBe(advancedSeo)
+    expect(screen.getByLabelText('Secondary Keywords (comma-separated)').closest('details')).toBe(
+      advancedSeo,
+    )
     expect(screen.getByLabelText('Editorial Angle (Optional)').closest('details')).toBe(
       optionalGuidance,
     )
@@ -626,7 +786,9 @@ describe('Prompt2BlogPage', () => {
     const callToAction = screen.getByLabelText('Call to Action (Optional)')
 
     fireEvent.click(optionalGuidanceSummary)
-    fireEvent.change(angle, { target: { value: 'Peru is the better first stop' } })
+    fireEvent.change(angle, {
+      target: { value: 'Peru is the better first stop' },
+    })
     fireEvent.change(callToAction, { target: { value: 'Compare fares' } })
     fireEvent.click(optionalGuidanceSummary)
     fireEvent.click(optionalGuidanceSummary)
@@ -634,8 +796,7 @@ describe('Prompt2BlogPage', () => {
     expect(angle).toHaveValue('Peru is the better first stop')
     expect(callToAction).toHaveValue('Compare fares')
 
-    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' })
-      .closest('section')
+    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' }).closest('section')
     fireEvent.click(within(coreInputsPanel!).getByRole('button', { name: 'Clear section' }))
 
     expect(angle).toHaveValue('')
@@ -651,24 +812,32 @@ describe('Prompt2BlogPage', () => {
     const secondaryKeywords = screen.getByLabelText('Secondary Keywords (comma-separated)')
 
     fireEvent.click(advancedGenerationSummary)
-    fireEvent.change(negativeInstructions, { target: { value: 'Avoid generic praise' } })
+    fireEvent.change(negativeInstructions, {
+      target: { value: 'Avoid generic praise' },
+    })
     fireEvent.click(advancedGenerationSummary)
     fireEvent.click(advancedGenerationSummary)
 
     fireEvent.click(advancedSeoSummary)
-    fireEvent.change(secondaryKeywords, { target: { value: 'family hotels, free museums' } })
+    fireEvent.change(secondaryKeywords, {
+      target: { value: 'family hotels, free museums' },
+    })
     fireEvent.click(advancedSeoSummary)
     fireEvent.click(advancedSeoSummary)
 
     expect(negativeInstructions).toHaveValue('Avoid generic praise')
     expect(secondaryKeywords).toHaveValue('family hotels, free museums')
 
-    const promptProfilesPanel = screen.getByRole('heading', { name: 'Prompt Profiles' })
+    const promptProfilesPanel = screen
+      .getByRole('heading', { name: 'Prompt Profiles' })
       .closest('section')
-    const seoPanel = screen.getByRole('heading', { name: 'SEO + Constraints' })
-      .closest('section')
+    const seoPanel = screen.getByRole('heading', { name: 'SEO + Constraints' }).closest('section')
 
-    fireEvent.click(within(promptProfilesPanel!).getByRole('button', { name: 'Clear section' }))
+    fireEvent.click(
+      within(promptProfilesPanel!).getByRole('button', {
+        name: 'Clear section',
+      }),
+    )
     fireEvent.click(within(seoPanel!).getByRole('button', { name: 'Clear section' }))
 
     expect(negativeInstructions).toHaveValue('')
@@ -698,7 +867,9 @@ describe('Prompt2BlogPage', () => {
       target: { value: 'best-value' },
     })
     fireEvent.change(screen.getByLabelText('Source Block 1'), {
-      target: { value: 'Alfama is historic. Principe Real is calmer and more upscale.' },
+      target: {
+        value: 'Alfama is historic. Principe Real is calmer and more upscale.',
+      },
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' }))
@@ -719,10 +890,84 @@ describe('Prompt2BlogPage', () => {
     })
   })
 
+  it('blocks legacy submission while an editorial v3 direction is active', async () => {
+    saveComposerState({
+      ...DEFAULT_COMPOSER_STATE,
+      activeWorkflow: 'editorial_v3',
+      articleTypeId: 7,
+      editorial: {
+        ...DEFAULT_COMPOSER_STATE.editorial,
+        approval: { status: 'awaiting_selection' },
+      },
+    })
+
+    renderPage()
+
+    const runButton = screen.getByRole('button', {
+      name: 'Run Prompt2Blog Pipeline',
+    })
+    expect(runButton).toBeDisabled()
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Editorial v3 direction work is active. Research import ships next',
+    )
+    fireEvent.click(runButton)
+    expect(startPrompt2BlogRunMock).not.toHaveBeenCalled()
+  })
+
+  it('imports three directions, approves an editable commission, and can return to legacy', async () => {
+    renderPage()
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'A weekend in Lisbon' },
+    })
+    fireEvent.change(screen.getByLabelText('Location'), {
+      target: { value: 'Lisbon, Portugal' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Generate direction prompt' }))
+
+    expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeDisabled()
+    fireEvent.change(screen.getByLabelText('Direction JSON'), {
+      target: { value: createDirectionResponseJson() },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Check directions' }))
+    expect(screen.getByRole('button', { name: 'Show direction cards' })).toBeEnabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Show direction cards' }))
+
+    const directions = screen.getAllByRole('radio')
+    expect(directions).toHaveLength(3)
+    fireEvent.click(directions[0])
+
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+    expect(screen.getByLabelText('Original title')).toHaveValue('A weekend in Lisbon')
+    expect(screen.getByLabelText('Primary reference')).toHaveValue('Lisbon')
+
+    fireEvent.change(screen.getByLabelText('Primary subject'), {
+      target: { value: 'Historic Lisbon' },
+    })
+    expect(screen.getByText('Needs approval')).toBeInTheDocument()
+    expect(screen.getByLabelText('Primary reference')).toHaveValue('Historic Lisbon')
+    fireEvent.click(screen.getByRole('button', { name: 'Approve commission' }))
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Three days in Lisbon' },
+    })
+    expect(
+      screen.queryByRole('group', { name: 'Choose one editorial direction' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear direction work' }))
+    expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeEnabled()
+  })
+
   it('lets users choose a travel quick pick and shows the selected definition', async () => {
     renderPage()
 
-    const quickPick = await screen.findByRole('button', { name: 'Itinerary Article' })
+    const quickPick = await screen.findByRole('button', {
+      name: 'Itinerary Article',
+    })
     fireEvent.click(quickPick)
 
     expect(screen.getByLabelText('Article Type')).toHaveValue('9')
@@ -730,11 +975,14 @@ describe('Prompt2BlogPage', () => {
   })
 
   it('opens cleanup details from the pipeline step', async () => {
-    localStorage.setItem('p2b-run-state', JSON.stringify({
-      sourceStep: 'pipeline_complete',
-      pipelineRunId: 'run-123',
-      pipelineResult: createStoredPipelineResult(),
-    }))
+    localStorage.setItem(
+      'p2b-run-state',
+      JSON.stringify({
+        sourceStep: 'pipeline_complete',
+        pipelineRunId: 'run-123',
+        pipelineResult: createStoredPipelineResult(),
+      }),
+    )
 
     getPrompt2BlogDebugMock.mockResolvedValue({
       run_id: 'run-123',
@@ -758,10 +1006,7 @@ describe('Prompt2BlogPage', () => {
               { input_chars: 120, output_chars: 100, removed_lines: 2 },
               { input_chars: 80, output_chars: 76, removed_lines: 0 },
             ],
-            cleaned_sources: [
-              'Cleaned source one.',
-              'Cleaned source two.',
-            ],
+            cleaned_sources: ['Cleaned source one.', 'Cleaned source two.'],
             sources: [
               {
                 source_index: 1,
@@ -804,21 +1049,32 @@ describe('Prompt2BlogPage', () => {
     expect(within(receipt).getByText('Editorial Premium')).toBeInTheDocument()
     expect(within(receipt).getByText('$0.18')).toBeInTheDocument()
     expect(within(receipt).getByText('146,912')).toBeInTheDocument()
-    expect(within(receipt).getByText('Measured from all 11 successful model calls.'))
-      .toBeInTheDocument()
+    expect(
+      within(receipt).getByText('Measured from all 11 successful model calls.'),
+    ).toBeInTheDocument()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'View clean source material details' }))
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'View clean source material details',
+      }),
+    )
 
-    const dialog = await screen.findByRole('dialog', { name: 'Clean source material details' })
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Clean source material details',
+    })
     expect(dialog).toBeInTheDocument()
     expect(getPrompt2BlogDebugMock).toHaveBeenCalledWith('run-123')
     expect(within(dialog).getByText('ai_always_aggressive_v1')).toBeInTheDocument()
     expect(within(dialog).getByText('gemini-2.5-flash-lite')).toBeInTheDocument()
-    expect(within(dialog).getByText('Is It Safe to Travel to Peru (2026 Update)')).toBeInTheDocument()
+    expect(
+      within(dialog).getByText('Is It Safe to Travel to Peru (2026 Update)'),
+    ).toBeInTheDocument()
     expect(within(dialog).getByText('Travel insurance CTA')).toBeInTheDocument()
     expect(within(dialog).getByText('Fallback used')).toBeInTheDocument()
     expect(within(dialog).getByText('Cleaned source one.')).toBeInTheDocument()
     expect(within(dialog).getByText('Input: 120')).toBeInTheDocument()
-    expect(within(dialog).getByText('No removed-block breakdown is available for fallback cleanup.')).toBeInTheDocument()
+    expect(
+      within(dialog).getByText('No removed-block breakdown is available for fallback cleanup.'),
+    ).toBeInTheDocument()
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -83,6 +83,8 @@ export default function Prompt2BlogPage() {
             activeWorkflow={state.activeWorkflow}
             editorial={state.editorial}
             editorialOptions={composer.editorialOptions}
+            editorialOptionsError={composer.editorialOptionsError}
+            editorialOptionsLoading={composer.editorialOptionsLoading}
             inputOptions={composer.inputOptions}
             location={state.easySetupLocation}
             title={state.easySetupTitle}
@@ -92,6 +94,7 @@ export default function Prompt2BlogPage() {
             onClearDirectionWorkflow={composer.clearDirectionWorkflow}
             onCommissionChange={composer.updateCommissionDraft}
             onLocationChange={value => composer.updateField('easySetupLocation', value)}
+            onRetryEditorialOptions={composer.retryEditorialOptions}
             onSelectDirection={composer.selectDirectionOption}
             onStartDirectionWorkflow={composer.startDirectionWorkflow}
             onTitleChange={value => composer.updateField('easySetupTitle', value)}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -27,12 +27,15 @@ export default function Prompt2BlogPage() {
   const { state } = composer
 
   const handleCopyJson = useCallback(() => {
-    navigator.clipboard.writeText(JSON.stringify(composer.payload, null, 2)).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    }).catch(() => {
-      pipeline.setError('Unable to copy JSON to clipboard.')
-    })
+    navigator.clipboard
+      .writeText(JSON.stringify(composer.payload, null, 2))
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      })
+      .catch(() => {
+        pipeline.setError('Unable to copy JSON to clipboard.')
+      })
   }, [composer.payload, pipeline])
 
   const handleResetRun = useCallback(() => {
@@ -55,28 +58,42 @@ export default function Prompt2BlogPage() {
             <span className="p2b-dot">.</span>
           </h1>
           <p className="p2b-lede">
-            Choose article type, set voice controls, paste source material, and run the full guideline-aware pipeline.
+            Choose article type, set voice controls, paste source material, and run the full
+            guideline-aware pipeline.
           </p>
         </div>
         <div className="p2b-badge-row">
-          <Link to="/" className="p2b-nav-link">&larr; Home</Link>
-          <Link to="/prompt2blog/articles" className="p2b-nav-link">Saved Articles</Link>
+          <Link to="/" className="p2b-nav-link">
+            &larr; Home
+          </Link>
+          <Link to="/prompt2blog/articles" className="p2b-nav-link">
+            Saved Articles
+          </Link>
         </div>
       </header>
 
       <main className="p2b-form-container">
-        <form className="p2b-form" onSubmit={(event) => event.preventDefault()}>
+        <form className="p2b-form" onSubmit={event => event.preventDefault()}>
           <ModelRoutingPanel
             modelStackId={state.modelStackId}
             onChange={composer.applyModelStack}
             onClear={composer.clearModelRouting}
           />
           <EasySetupPanel
+            activeWorkflow={state.activeWorkflow}
+            editorial={state.editorial}
+            editorialOptions={composer.editorialOptions}
             inputOptions={composer.inputOptions}
             location={state.easySetupLocation}
             title={state.easySetupTitle}
             onApply={composer.applyFields}
+            onApplyDirectionResponse={composer.applyDirectionResponse}
+            onApproveCommission={composer.approveCommissionChanges}
+            onClearDirectionWorkflow={composer.clearDirectionWorkflow}
+            onCommissionChange={composer.updateCommissionDraft}
             onLocationChange={value => composer.updateField('easySetupLocation', value)}
+            onSelectDirection={composer.selectDirectionOption}
+            onStartDirectionWorkflow={composer.startDirectionWorkflow}
             onTitleChange={value => composer.updateField('easySetupTitle', value)}
           />
           <MiddleSectionsFold>
@@ -95,7 +112,9 @@ export default function Prompt2BlogPage() {
               onArticleTypeChange={value => composer.updateField('articleTypeId', value)}
               onCallToActionChange={value => composer.updateField('callToAction', value)}
               onClear={composer.clearCoreInputs}
-              onDestinationContextChange={value => composer.updateField('destinationContext', value)}
+              onDestinationContextChange={value =>
+                composer.updateField('destinationContext', value)
+              }
               onTargetReaderChange={value => composer.updateField('targetReader', value)}
             />
             <PromptProfilesPanel
@@ -134,6 +153,7 @@ export default function Prompt2BlogPage() {
             run={pipeline}
             onOpenCleanupModal={() => void cleanupModal.open()}
             onReset={handleResetRun}
+            submissionBlockedReason={composer.submissionBlockedReason}
           />
 
           <div className="p2b-submit-row">
@@ -147,12 +167,14 @@ export default function Prompt2BlogPage() {
         </form>
       </main>
 
-      {cleanupModal.isOpen && <CleanupDetailsModal
-        data={cleanupModal.data}
-        error={cleanupModal.error}
-        loading={cleanupModal.isLoading}
-        onClose={cleanupModal.close}
-      />}
+      {cleanupModal.isOpen && (
+        <CleanupDetailsModal
+          data={cleanupModal.data}
+          error={cleanupModal.error}
+          loading={cleanupModal.isLoading}
+          onClose={cleanupModal.close}
+        />
+      )}
     </div>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
@@ -9,9 +9,15 @@ interface PipelinePanelProps {
   run: ReturnType<typeof usePrompt2BlogPipelineRun>
   onOpenCleanupModal: () => void
   onReset: () => void
+  submissionBlockedReason?: string | null
 }
 
-export function PipelinePanel({ run, onOpenCleanupModal, onReset }: PipelinePanelProps) {
+export function PipelinePanel({
+  run,
+  onOpenCleanupModal,
+  onReset,
+  submissionBlockedReason,
+}: PipelinePanelProps) {
   const {
     canOpenCleanupModal,
     error,
@@ -35,26 +41,40 @@ export function PipelinePanel({ run, onOpenCleanupModal, onReset }: PipelinePane
       </div>
       <div className="p2b-panel-body">
         <div className="p2b-button-row">
-          <button type="button" className="p2b-synthesize-btn" onClick={() => void run.run()}>
+          <button
+            type="button"
+            className="p2b-synthesize-btn"
+            disabled={Boolean(submissionBlockedReason)}
+            onClick={() => void run.run()}
+          >
             Run Prompt2Blog Pipeline
           </button>
           <button type="button" className="p2b-rerun-btn" onClick={onReset}>
             Reset Run
           </button>
         </div>
+        {submissionBlockedReason && (
+          <p className="p2b-field-hint" role="status">
+            {submissionBlockedReason}
+          </p>
+        )}
 
         <div className="p2b-progress-grid">
           {PROMPT2BLOG_PIPELINE_STAGES.map(step => (
             <PipelineStageItem
               key={step}
-              action={step === CLEANUP_STAGE_KEY && canOpenCleanupModal ? onOpenCleanupModal : undefined}
+              action={
+                step === CLEANUP_STAGE_KEY && canOpenCleanupModal ? onOpenCleanupModal : undefined
+              }
               label={PIPELINE_STAGE_LABELS[step]}
               status={getPipelineStepStatus(step, pipelineStatus)}
             />
           ))}
           {pipelineStatus?.stage === 'unknown' && (
             <PipelineStageItem
-              label={pipelineStatus.raw_stage ? `Unknown: ${pipelineStatus.raw_stage}` : 'Unknown stage'}
+              label={
+                pipelineStatus.raw_stage ? `Unknown: ${pipelineStatus.raw_stage}` : 'Unknown stage'
+              }
               status={pipelineStatus.state === 'failed' ? 'failed' : 'running'}
             />
           )}
@@ -125,9 +145,5 @@ function PipelineStageItem({
     )
   }
 
-  return (
-    <div className={className}>
-      {content}
-    </div>
-  )
+  return <div className={className}>{content}</div>
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
@@ -978,15 +978,13 @@
   border-radius: var(--p2b-control-radius);
   background: var(--surface);
   color: var(--ink);
-  cursor: pointer;
   transition:
     border-color var(--transition-base),
     background-color var(--transition-base);
 }
 
-.p2b-direction-card:hover {
-  border-color: var(--p2b-accent);
-  background: var(--p2b-accent-softer);
+.p2b-direction-card-choice label {
+  cursor: pointer;
 }
 
 .p2b-direction-card.is-selected {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
@@ -183,7 +183,10 @@
 
 .p2b-stack-assignment {
   display: grid;
-  grid-template-columns: minmax(7.5rem, 0.8fr) minmax(11rem, 1fr) minmax(14rem, 1.5fr);
+  grid-template-columns: minmax(7.5rem, 0.8fr) minmax(11rem, 1fr) minmax(
+      14rem,
+      1.5fr
+    );
   align-items: center;
   gap: var(--space-4);
   min-width: 0;
@@ -236,7 +239,9 @@
   background: var(--panel);
   cursor: pointer;
   list-style: none;
-  transition: background-color var(--transition-base), border-color var(--transition-base);
+  transition:
+    background-color var(--transition-base),
+    border-color var(--transition-base);
 }
 
 .p2b-middle-fold-summary::-webkit-details-marker {
@@ -756,7 +761,8 @@
 }
 
 .p2b-import-list code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
   font-size: 0.8125rem;
   font-weight: 600;
@@ -936,6 +942,342 @@
   justify-content: flex-end;
   padding: var(--space-5) 0 0;
   border-top: 1px solid var(--border-strong);
+}
+
+/* V3 direction choice and editable commission */
+.p2b-direction-picker,
+.p2b-commission-fieldset {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.p2b-direction-picker > legend,
+.p2b-commission-fieldset > legend {
+  margin-bottom: var(--space-2);
+  color: var(--ink);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.p2b-direction-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.p2b-direction-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--p2b-control-radius);
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+  transition:
+    border-color var(--transition-base),
+    background-color var(--transition-base);
+}
+
+.p2b-direction-card:hover {
+  border-color: var(--p2b-accent);
+  background: var(--p2b-accent-softer);
+}
+
+.p2b-direction-card.is-selected {
+  border-color: var(--p2b-accent);
+  box-shadow: inset 0 0 0 1px var(--p2b-accent);
+  background: var(--p2b-accent-softer);
+}
+
+.p2b-direction-card:has(input:focus-visible) {
+  outline: 3px solid var(--p2b-accent-soft);
+  outline-offset: 2px;
+}
+
+.p2b-direction-card-choice {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--p2b-accent-hover);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.p2b-direction-card-choice input,
+.p2b-commission-checkbox input {
+  flex: 0 0 auto;
+  accent-color: var(--p2b-accent);
+}
+
+.p2b-direction-card-form {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.p2b-direction-card-direction {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.55;
+}
+
+.p2b-direction-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.p2b-direction-card-tags span {
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--p2b-accent);
+  border-radius: 999px;
+  color: var(--p2b-accent-hover);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.p2b-direction-card-details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.p2b-direction-card-details div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.p2b-direction-card-details dt {
+  color: var(--muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.p2b-direction-card-details dd {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.p2b-direction-card-rationale {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-top: auto;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+  color: var(--ink-light);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.p2b-direction-card-rationale strong {
+  color: var(--ink);
+}
+
+.p2b-commission-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border-strong);
+}
+
+.p2b-commission-editor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.p2b-commission-editor-header .p2b-eyebrow {
+  margin-bottom: var(--space-1);
+}
+
+.p2b-commission-editor-header h3,
+.p2b-commission-editor-header p {
+  margin: 0;
+}
+
+.p2b-commission-editor-header h3 {
+  color: var(--ink);
+  font-size: 1.1rem;
+}
+
+.p2b-commission-editor-header p:last-child {
+  margin-top: var(--space-1);
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+.p2b-commission-status {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.p2b-commission-status.is-approved {
+  border-color: var(--success);
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.p2b-commission-fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--p2b-accent);
+  background: var(--surface);
+}
+
+.p2b-commission-fieldset > legend {
+  padding: 0 var(--space-2);
+}
+
+.p2b-input[readonly],
+.p2b-select:disabled {
+  background-color: var(--panel);
+  color: var(--ink-light);
+  cursor: not-allowed;
+}
+
+.p2b-commission-checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.p2b-commission-checkbox-grid--compact {
+  margin-top: var(--space-2);
+}
+
+.p2b-commission-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.p2b-commission-checkbox:has(input:checked) {
+  border-color: var(--p2b-accent);
+  background: var(--p2b-accent-softer);
+}
+
+.p2b-commission-checkbox:has(input:focus-visible) {
+  outline: 3px solid var(--p2b-accent-soft);
+  outline-offset: 1px;
+}
+
+.p2b-commission-checkbox:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.p2b-commission-checkbox span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.p2b-commission-checkbox strong {
+  color: var(--ink);
+  font-size: 0.8125rem;
+}
+
+.p2b-reference-list,
+.p2b-requirement-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.p2b-reference-row,
+.p2b-requirement-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(10rem, 0.55fr) auto;
+  align-items: end;
+  gap: var(--space-3);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+
+.p2b-requirement-row {
+  grid-template-columns: minmax(7rem, 0.25fr) minmax(0, 1fr) auto;
+}
+
+.p2b-reference-row--primary {
+  opacity: 0.85;
+}
+
+.p2b-reference-remove {
+  min-height: 42px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--p2b-control-radius);
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.p2b-reference-remove:hover {
+  border-color: var(--error);
+  background: var(--error-soft);
+  color: var(--error);
+}
+
+.p2b-reference-remove:focus-visible {
+  outline: 3px solid var(--p2b-accent-soft);
+  outline-offset: 2px;
+}
+
+.p2b-commission-alert {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--p2b-control-radius);
+  color: var(--ink);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.p2b-commission-alert--error {
+  border-color: var(--error);
+  background: var(--error-soft);
+}
+
+.p2b-commission-alert ul {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-5);
 }
 
 .p2b-source-block {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/responsive.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/responsive.css
@@ -37,6 +37,21 @@
     gap: var(--space-1);
   }
 
+  .p2b-direction-grid,
+  .p2b-commission-checkbox-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .p2b-reference-row,
+  .p2b-requirement-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .p2b-reference-remove {
+    justify-self: start;
+  }
+
   .p2b-input,
   .p2b-textarea,
   .p2b-select {
@@ -69,6 +84,10 @@
   }
 
   .p2b-panel-header {
+    flex-direction: column;
+  }
+
+  .p2b-commission-editor-header {
     flex-direction: column;
   }
 


### PR DESCRIPTION
## Summary
- expose the title/location direction prompt and strict three-direction import
- add accessible comparison cards and a complete editable commission
- retract approval on authoritative edits and keep legacy v2 submission fenced
- load editorial catalogs through TanStack Query with explicit retry

## Verification
- 160 frontend test files / 780 tests
- frontend TypeScript, boundary check, and ESLint
- frontend production build
- two-axis spec and standards review