### PR TITLE
Add locked Prompt2Blog evidence research domain

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage
+} from '../api'
+import { reviewEvidencePackageJson } from './evidence-import'
+
+const fingerprint =
+  'd1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48'
+
+const commission: Prompt2BlogCommission = {
+  schema_version: 3,
+  commission_fingerprint: fingerprint,
+  original_title: "Is Lima still South America's bargain expat capital?",
+  location: 'Lima, Peru',
+  approved_direction:
+    'Assess Lima as one subject using current long-stay evidence.',
+  form_id: 'analysis',
+  topic_module_ids: ['cost-affordability'],
+  audience: {
+    primary_reader: 'Prospective long-stay residents',
+    tags: ['budget-focused']
+  },
+  core_reader_question: 'Does Lima still offer compelling long-stay value?',
+  reader_outcome: 'Judge Lima using current evidence and explicit tradeoffs.',
+  primary_subject: 'Lima',
+  scope: {
+    mode: 'single_subject',
+    references: [
+      { name: 'Lima', role: 'primary_subject' },
+      { name: 'Medellín', role: 'context_only' }
+    ]
+  },
+  requirements: [
+    { requirement_id: 'r1', question: 'What do current routine costs show?' },
+    {
+      requirement_id: 'r2',
+      question: 'Which tradeoffs change the value judgment?'
+    }
+  ],
+  exclusions: ['Do not make Medellín a co-subject.'],
+  call_to_action: null
+}
+
+const catalog: Prompt2BlogEditorialOptionsResponse = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'analysis',
+      label: 'Analysis',
+      description: 'Evidence-led interpretation.',
+      order: 2,
+      source_requirements: []
+    },
+    {
+      id: 'interview-qa',
+      label: 'Interview/Q&A',
+      description: 'Attributable answers.',
+      order: 5,
+      source_requirements: ['attributable-responses']
+    },
+    {
+      id: 'personal-essay-travelogue',
+      label: 'Personal Essay/Travelogue',
+      description: 'Supplied lived experience.',
+      order: 7,
+      source_requirements: ['first-person-material']
+    },
+    {
+      id: 'review',
+      label: 'Review',
+      description: 'Documented evaluation.',
+      order: 13,
+      source_requirements: ['documented-evaluation']
+    },
+    {
+      id: 'feature-profile',
+      label: 'Feature/Profile',
+      description: 'Reported people, scenes, and quotations.',
+      order: 4,
+      source_requirements: ['reported-people-scenes-quotations']
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost and affordability',
+      description: 'Current dated cost evidence.',
+      order: 1
+    }
+  ],
+  audience_tags: [],
+  scope_modes: [],
+  reference_roles: []
+}
+
+function evidence(): Prompt2BlogEvidencePackage {
+  return {
+    schema_version: 3,
+    commission_fingerprint: fingerprint,
+    sources: [
+      {
+        source_id: 's1',
+        title: 'Lima consumer price bulletin',
+        publisher: 'Statistics office',
+        url: 'https://example.com/lima-prices',
+        published_at: '2026-07-01',
+        retrieved_at: '2026-08-25',
+        source_type: 'official',
+        material_type: 'report',
+        notes: ['Provides a dated current cost baseline.']
+      }
+    ],
+    claims: [
+      {
+        claim_id: 'c1',
+        text: 'Official figures establish a current cost baseline.',
+        source_ids: ['s1'],
+        requirement_ids: ['r1'],
+        as_of: '2026-07-01',
+        confidence: 'high'
+      }
+    ],
+    requirements: [
+      { requirement_id: 'r1', status: 'supported', claim_ids: ['c1'], gap: '' },
+      {
+        requirement_id: 'r2',
+        status: 'missing',
+        claim_ids: [],
+        gap: 'Current quality-of-life evidence is still needed.'
+      }
+    ],
+    conflicts: [],
+    gaps: [
+      {
+        gap_id: 'g1',
+        requirement_ids: ['r2'],
+        summary: 'Find current evidence for practical tradeoffs.'
+      }
+    ]
+  }
+}
+
+function review(value: unknown, activeCommission = commission) {
+  return reviewEvidencePackageJson(
+    JSON.stringify(value),
+    activeCommission,
+    catalog
+  )
+}
+
+describe('reviewEvidencePackageJson', () => {
+  it('imports honest incomplete evidence and reports readiness without replacing commission', () => {
+    const result = review(evidence())
+
+    expect(result.issues).toEqual([])
+    expect(result.evidencePackage).toEqual(evidence())
+    expect(result.evidencePackage).not.toHaveProperty('commission')
+    expect(result.readinessFindings).toEqual([
+      {
+        code: 'requirement_gap',
+        requirement_ids: ['r2'],
+        message: 'Current quality-of-life evidence is still needed.'
+      }
+    ])
+  })
+
+  it('requires one bare exact evidence object with the approved fingerprint', () => {
+    const fenced = reviewEvidencePackageJson(
+      `\`\`\`json\n${JSON.stringify(evidence())}\n\`\`\``,
+      commission,
+      catalog
+    )
+    expect(fenced.issues[0].path).toBe('json')
+
+    const wrong = evidence()
+    wrong.commission_fingerprint = '0'.repeat(64)
+    expect(review(wrong).issues).toContainEqual({
+      path: 'commission_fingerprint',
+      message: 'Must match the currently approved commission.'
+    })
+
+    const authority = {
+      ...evidence(),
+      commission,
+      form_id: 'comparison',
+      scope: {}
+    }
+    const paths = review(authority).issues.map((issue) => issue.path)
+    expect(paths).toEqual(
+      expect.arrayContaining(['commission', 'form_id', 'scope'])
+    )
+  })
+
+  it('requires the exact commission requirement set and resolvable unique links', () => {
+    const value = evidence()
+    value.requirements = [value.requirements[0]]
+    value.claims![0].source_ids = ['missing-source', 'missing-source']
+    value.gaps![0].requirement_ids = ['r9']
+
+    const result = review(value)
+
+    expect(result.evidencePackage).toBeNull()
+    expect(result.issues.map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([
+        'Requirement IDs must exactly match the approved commission.',
+        'Values must be unique.',
+        'Unknown source ID.',
+        'Unknown requirement ID.'
+      ])
+    )
+  })
+
+  it('requires stable source, claim, conflict, and gap IDs', () => {
+    const value = evidence()
+    value.sources![0].source_id = 'source-one'
+    value.claims![0].claim_id = 'claim-one'
+    value.gaps![0].gap_id = 'gap-one'
+    value.conflicts = [
+      {
+        conflict_id: 'conflict-one',
+        claim_ids: ['c1', 'c2'],
+        summary: 'Unresolved discrepancy.',
+        resolution: null
+      }
+    ]
+
+    expect(review(value).issues.map((issue) => issue.message)).toEqual(
+      expect.arrayContaining([
+        'Must use the stable s1, s2, … format.',
+        'Must use the stable c1, c2, … format.',
+        'Must use the stable x1, x2, … format.',
+        'Must use the stable g1, g2, … format.'
+      ])
+    )
+  })
+
+  it('requires reciprocal claim and requirement mappings', () => {
+    const value = evidence()
+    value.requirements[0].claim_ids = []
+
+    expect(review(value).issues).toContainEqual({
+      path: 'claims[0].requirement_ids',
+      message: 'Requirement r1 does not link back to c1.'
+    })
+
+    const reverse = evidence()
+    reverse.claims![0].requirement_ids = ['r2']
+    expect(review(reverse).issues).toContainEqual({
+      path: 'requirements[0].claim_ids',
+      message: 'Claim c1 does not link back to r1.'
+    })
+  })
+
+  it('validates real dates, HTTP metadata, and useful source notes', () => {
+    const value = evidence()
+    const source = value.sources![0]
+    source.published_at = '2026-02-30'
+    source.retrieved_at = '25-08-2026'
+    source.url = 'file:///tmp/source'
+    source.publisher = null
+    source.notes = []
+
+    const messages = review(value).issues.map((issue) => issue.message)
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        'Must be a real YYYY-MM-DD date or null.',
+        'Must be a real YYYY-MM-DD date.',
+        'Must be an HTTP(S) URL or null.',
+        'Must contain at least 1 item(s).',
+        'Web and report sources require publisher and URL metadata.'
+      ])
+    )
+  })
+
+  it.each([
+    ['supported', [], '', 'Supported requirements need at least one claim.'],
+    ['partial', ['c1'], '', 'Partial requirements need a non-empty gap.'],
+    [
+      'missing',
+      ['c1'],
+      'Missing',
+      'Missing requirements need no claims and a non-empty gap.'
+    ],
+    [
+      'missing',
+      [],
+      '',
+      'Missing requirements need no claims and a non-empty gap.'
+    ]
+  ])('enforces %s status semantics', (status, claimIds, gap, message) => {
+    const value = evidence()
+    value.requirements[0] = {
+      requirement_id: 'r1',
+      status: status as 'supported',
+      claim_ids: claimIds,
+      gap
+    }
+    expect(review(value).issues.map((issue) => issue.message)).toContain(
+      message
+    )
+  })
+
+  it('allows partial requirements with an explicit gap before any claim is usable', () => {
+    const value = evidence()
+    value.requirements[1] = {
+      requirement_id: 'r2',
+      status: 'partial',
+      claim_ids: [],
+      gap: 'Available material is relevant but not yet claim-ready.'
+    }
+
+    expect(review(value).issues).toEqual([])
+  })
+
+  it('validates conflict and gap references while allowing unresolved conflicts', () => {
+    const value = evidence()
+    value.claims!.push({
+      claim_id: 'c2',
+      text: 'A second source disagrees with the baseline.',
+      source_ids: ['s1'],
+      requirement_ids: ['r1'],
+      as_of: '2026-07-01',
+      confidence: 'medium'
+    })
+    value.requirements[0].claim_ids = ['c1', 'c2']
+    value.conflicts = [
+      {
+        conflict_id: 'x1',
+        claim_ids: ['c1', 'c2'],
+        summary: 'Current estimates disagree.',
+        resolution: null
+      }
+    ]
+
+    const result = review(value)
+    expect(result.issues).toEqual([])
+    expect(result.readinessFindings).toContainEqual({
+      code: 'unresolved_conflict',
+      requirement_ids: ['r1'],
+      message: 'Current estimates disagree.'
+    })
+
+    value.conflicts[0].claim_ids = ['c1', 'unknown']
+    expect(review(value).issues).toContainEqual({
+      path: 'conflicts[0].claim_ids[1]',
+      message: 'Unknown claim ID.'
+    })
+  })
+
+  it.each([
+    ['interview-qa', 'transcript', 'report'],
+    ['personal-essay-travelogue', 'first-person-notes', 'report'],
+    ['review', 'evaluation-notes', 'report'],
+    ['feature-profile', 'interview-responses', 'report']
+  ] as const)(
+    'reports the %s source gate deterministically',
+    (formId, satisfyingMaterial, weakMaterial) => {
+      const activeCommission: Prompt2BlogCommission = {
+        ...commission,
+        form_id: formId
+      }
+      const weak = evidence()
+      weak.sources![0].material_type = weakMaterial
+      expect(review(weak, activeCommission).readinessFindings).toContainEqual(
+        expect.objectContaining({ code: 'source_gate' })
+      )
+
+      const strong = evidence()
+      strong.sources![0].material_type = satisfyingMaterial
+      if (formId === 'feature-profile')
+        strong.sources![0].source_type = 'reporting'
+      expect(
+        review(strong, activeCommission).readinessFindings
+      ).not.toContainEqual(expect.objectContaining({ code: 'source_gate' }))
+    }
+  )
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.test.ts
@@ -4,6 +4,7 @@ import type {
   Prompt2BlogEditorialOptionsResponse,
   Prompt2BlogEvidencePackage
 } from '../api'
+import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-drift-v3.json'
 import { reviewEvidencePackageJson } from './evidence-import'
 
 const fingerprint =
@@ -151,6 +152,20 @@ function review(value: unknown, activeCommission = commission) {
 }
 
 describe('reviewEvidencePackageJson', () => {
+  it('keeps the permanent Lima scope-drift fixture importable with explicit gaps', () => {
+    const result = reviewEvidencePackageJson(
+      JSON.stringify(limaFixture.evidence_package),
+      limaFixture.commission as unknown as Prompt2BlogCommission,
+      catalog
+    )
+
+    expect(result.issues).toEqual([])
+    expect(result.readinessFindings).toHaveLength(2)
+    expect(
+      result.readinessFindings.map((finding) => finding.requirement_ids)
+    ).toEqual([['r2'], ['r3']])
+  })
+
   it('imports honest incomplete evidence and reports readiness without replacing commission', () => {
     const result = review(evidence())
 
@@ -276,7 +291,7 @@ describe('reviewEvidencePackageJson', () => {
   })
 
   it.each([
-    ['supported', [], '', 'Supported requirements need at least one claim.'],
+    ['supported', [], '', 'Supported requirements need claims and an empty gap.'],
     ['partial', ['c1'], '', 'Partial requirements need a non-empty gap.'],
     [
       'missing',
@@ -377,4 +392,31 @@ describe('reviewEvidencePackageJson', () => {
       ).not.toContainEqual(expect.objectContaining({ code: 'source_gate' }))
     }
   )
+
+  it('keeps the feature-profile gate unsatisfied without a reported or firsthand source', () => {
+    const activeCommission: Prompt2BlogCommission = {
+      ...commission,
+      form_id: 'feature-profile'
+    }
+    const value = evidence()
+    value.sources![0].material_type = 'interview-responses'
+    value.sources![0].source_type = 'official'
+
+    expect(review(value, activeCommission).readinessFindings).toContainEqual({
+      code: 'source_gate',
+      requirement_ids: [],
+      message:
+        'The feature-profile form still needs reported-people-scenes-quotations.'
+    })
+  })
+
+  it('rejects a supported requirement that still declares a gap', () => {
+    const value = evidence()
+    value.requirements[0].gap = 'Still missing a second baseline.'
+
+    expect(review(value).issues).toContainEqual({
+      path: 'requirements[0]',
+      message: 'Supported requirements need claims and an empty gap.'
+    })
+  })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
@@ -393,10 +393,10 @@ function validateRequirement(
     issues.push({ path: `${path}.gap`, message: 'Must be a string.' })
   }
   const gap = typeof value.gap === 'string' ? value.gap : ''
-  if (status === 'supported' && claimIds.length === 0) {
+  if (status === 'supported' && (claimIds.length === 0 || gap.trim())) {
     issues.push({
       path,
-      message: 'Supported requirements need at least one claim.'
+      message: 'Supported requirements need claims and an empty gap.'
     })
   }
   if (status === 'partial' && !gap.trim()) {
@@ -521,6 +521,18 @@ export function evidenceSatisfiesSourceRequirement(
   requirement: Prompt2BlogSourceRequirement,
   sources: readonly Prompt2BlogEvidenceSource[]
 ): boolean {
+  if (requirement === 'reported-people-scenes-quotations') {
+    const hasAttributableVoice = sources.some(
+      (source) =>
+        source.material_type === 'transcript' ||
+        source.material_type === 'interview-responses'
+    )
+    const hasDocumentedScene = sources.some(
+      (source) =>
+        source.source_type === 'reporting' || source.source_type === 'firsthand'
+    )
+    return hasAttributableVoice && hasDocumentedScene
+  }
   return sources.some((source) => {
     if (requirement === 'attributable-responses') {
       return (
@@ -531,17 +543,9 @@ export function evidenceSatisfiesSourceRequirement(
     if (requirement === 'first-person-material') {
       return source.material_type === 'first-person-notes'
     }
-    if (requirement === 'documented-evaluation') {
-      return (
-        source.material_type === 'evaluation-notes' ||
-        source.source_type === 'firsthand'
-      )
-    }
     return (
-      source.source_type === 'reporting' ||
-      source.source_type === 'firsthand' ||
-      source.material_type === 'transcript' ||
-      source.material_type === 'interview-responses'
+      source.material_type === 'evaluation-notes' ||
+      source.source_type === 'firsthand'
     )
   })
 }
@@ -559,9 +563,7 @@ function sourceGateFindings(
     .filter((gate) => !evidenceSatisfiesSourceRequirement(gate, sources))
     .map((gate) => ({
       code: 'source_gate' as const,
-      requirement_ids: commission.requirements.map(
-        (item) => item.requirement_id
-      ),
+      requirement_ids: [],
       message: `The ${commission.form_id} form still needs ${gate}.`
     }))
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
@@ -1,0 +1,821 @@
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage,
+  Prompt2BlogEvidenceSource,
+  Prompt2BlogSourceRequirement
+} from '../api'
+
+export type EvidenceImportIssue = {
+  path: string
+  message: string
+}
+
+export type EvidenceReadinessFinding = {
+  code: 'requirement_gap' | 'unresolved_conflict' | 'source_gate'
+  requirement_ids: string[]
+  message: string
+}
+
+export type EvidenceImportReview = {
+  issues: EvidenceImportIssue[]
+  readinessFindings: EvidenceReadinessFinding[]
+  evidencePackage: Prompt2BlogEvidencePackage | null
+}
+
+type JsonObject = Record<string, unknown>
+
+const SOURCE_TYPES = new Set([
+  'official',
+  'reporting',
+  'specialist',
+  'firsthand',
+  'other'
+])
+const MATERIAL_TYPES = new Set([
+  'web',
+  'report',
+  'transcript',
+  'interview-responses',
+  'first-person-notes',
+  'evaluation-notes',
+  'other'
+])
+const CONFIDENCE_LEVELS = new Set(['high', 'medium', 'low'])
+const REQUIREMENT_STATUSES = new Set(['supported', 'partial', 'missing'])
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function reportExactKeys(
+  value: JsonObject,
+  keys: readonly string[],
+  path: string,
+  issues: EvidenceImportIssue[]
+): void {
+  const expected = new Set(keys)
+  for (const key of Object.keys(value)) {
+    if (!expected.has(key)) {
+      issues.push({
+        path: path ? `${path}.${key}` : key,
+        message: 'Unexpected key.'
+      })
+    }
+  }
+  for (const key of keys) {
+    if (!(key in value)) {
+      issues.push({
+        path: path ? `${path}.${key}` : key,
+        message: 'Missing required key.'
+      })
+    }
+  }
+}
+
+function requireString(
+  value: unknown,
+  path: string,
+  issues: EvidenceImportIssue[],
+  nullable?: false
+): value is string
+function requireString(
+  value: unknown,
+  path: string,
+  issues: EvidenceImportIssue[],
+  nullable: true
+): value is string | null
+function requireString(
+  value: unknown,
+  path: string,
+  issues: EvidenceImportIssue[],
+  nullable = false
+): value is string | null {
+  if (nullable && value === null) return true
+  if (typeof value !== 'string') {
+    issues.push({
+      path,
+      message: nullable ? 'Must be a string or null.' : 'Must be a string.'
+    })
+    return false
+  }
+  if (!value.trim()) {
+    issues.push({ path, message: 'Must not be empty.' })
+    return false
+  }
+  return true
+}
+
+function isRealDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  )
+}
+
+function validateDate(
+  value: unknown,
+  path: string,
+  issues: EvidenceImportIssue[],
+  nullable: boolean
+): void {
+  if (nullable && value === null) return
+  if (typeof value !== 'string' || !isRealDate(value)) {
+    issues.push({
+      path,
+      message: `Must be a real YYYY-MM-DD date${nullable ? ' or null' : ''}.`
+    })
+  }
+}
+
+function validateUrl(
+  value: unknown,
+  path: string,
+  issues: EvidenceImportIssue[]
+): boolean {
+  if (value === null) return true
+  if (typeof value !== 'string') {
+    issues.push({ path, message: 'Must be an HTTP(S) URL or null.' })
+    return false
+  }
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return true
+  } catch {
+    // Fall through to the shared issue below.
+  }
+  issues.push({ path, message: 'Must be an HTTP(S) URL or null.' })
+  return false
+}
+
+function validateStringArray(
+  value: unknown,
+  path: string,
+  issues: EvidenceImportIssue[],
+  options: { minimum?: number; unique?: boolean } = {}
+): string[] {
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: 'Must be an array.' })
+    return []
+  }
+  if (value.length < (options.minimum ?? 0)) {
+    issues.push({
+      path,
+      message: `Must contain at least ${options.minimum} item(s).`
+    })
+  }
+  const result: string[] = []
+  value.forEach((item, index) => {
+    if (requireString(item, `${path}[${index}]`, issues)) result.push(item)
+  })
+  if (options.unique && new Set(result).size !== result.length) {
+    issues.push({ path, message: 'Values must be unique.' })
+  }
+  return result
+}
+
+function reportDuplicateIds(
+  ids: string[],
+  path: string,
+  issues: EvidenceImportIssue[]
+): void {
+  if (new Set(ids).size !== ids.length) {
+    issues.push({ path, message: 'IDs must be unique.' })
+  }
+}
+
+function validateStableId(
+  value: unknown,
+  path: string,
+  prefix: 's' | 'c' | 'x' | 'g',
+  issues: EvidenceImportIssue[]
+): value is string {
+  if (!requireString(value, path, issues)) return false
+  if (!new RegExp(`^${prefix}[1-9]\\d*$`).test(value)) {
+    issues.push({
+      path,
+      message: `Must use the stable ${prefix}1, ${prefix}2, … format.`
+    })
+    return false
+  }
+  return true
+}
+
+function validateSource(
+  value: unknown,
+  index: number,
+  issues: EvidenceImportIssue[]
+): string | null {
+  const path = `sources[${index}]`
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return null
+  }
+  reportExactKeys(
+    value,
+    [
+      'source_id',
+      'title',
+      'publisher',
+      'url',
+      'published_at',
+      'retrieved_at',
+      'source_type',
+      'material_type',
+      'notes'
+    ],
+    path,
+    issues
+  )
+  const idIsValid = validateStableId(
+    value.source_id,
+    `${path}.source_id`,
+    's',
+    issues
+  )
+  requireString(value.title, `${path}.title`, issues)
+  requireString(value.publisher, `${path}.publisher`, issues, true)
+  validateUrl(value.url, `${path}.url`, issues)
+  validateDate(value.published_at, `${path}.published_at`, issues, true)
+  validateDate(value.retrieved_at, `${path}.retrieved_at`, issues, false)
+  if (
+    typeof value.source_type !== 'string' ||
+    !SOURCE_TYPES.has(value.source_type)
+  ) {
+    issues.push({
+      path: `${path}.source_type`,
+      message: 'Unknown source type.'
+    })
+  }
+  if (
+    typeof value.material_type !== 'string' ||
+    !MATERIAL_TYPES.has(value.material_type)
+  ) {
+    issues.push({
+      path: `${path}.material_type`,
+      message: 'Unknown material type.'
+    })
+  }
+  validateStringArray(value.notes, `${path}.notes`, issues, { minimum: 1 })
+  if (
+    (value.material_type === 'web' || value.material_type === 'report') &&
+    (typeof value.publisher !== 'string' ||
+      !value.publisher.trim() ||
+      typeof value.url !== 'string')
+  ) {
+    issues.push({
+      path,
+      message: 'Web and report sources require publisher and URL metadata.'
+    })
+  }
+  return idIsValid && typeof value.source_id === 'string'
+    ? value.source_id
+    : null
+}
+
+type ClaimLinks = {
+  claimId: string
+  sourceIds: string[]
+  requirementIds: string[]
+}
+
+function validateClaim(
+  value: unknown,
+  index: number,
+  issues: EvidenceImportIssue[]
+): ClaimLinks | null {
+  const path = `claims[${index}]`
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return null
+  }
+  reportExactKeys(
+    value,
+    [
+      'claim_id',
+      'text',
+      'source_ids',
+      'requirement_ids',
+      'as_of',
+      'confidence'
+    ],
+    path,
+    issues
+  )
+  const idIsValid = validateStableId(
+    value.claim_id,
+    `${path}.claim_id`,
+    'c',
+    issues
+  )
+  requireString(value.text, `${path}.text`, issues)
+  const sourceIds = validateStringArray(
+    value.source_ids,
+    `${path}.source_ids`,
+    issues,
+    {
+      minimum: 1,
+      unique: true
+    }
+  )
+  const requirementIds = validateStringArray(
+    value.requirement_ids,
+    `${path}.requirement_ids`,
+    issues,
+    { minimum: 1, unique: true }
+  )
+  validateDate(value.as_of, `${path}.as_of`, issues, true)
+  if (
+    typeof value.confidence !== 'string' ||
+    !CONFIDENCE_LEVELS.has(value.confidence)
+  ) {
+    issues.push({
+      path: `${path}.confidence`,
+      message: 'Unknown confidence level.'
+    })
+  }
+  return idIsValid && typeof value.claim_id === 'string'
+    ? { claimId: value.claim_id, sourceIds, requirementIds }
+    : null
+}
+
+type RequirementLinks = {
+  requirementId: string
+  status: string
+  claimIds: string[]
+  gap: string
+}
+
+function validateRequirement(
+  value: unknown,
+  index: number,
+  issues: EvidenceImportIssue[]
+): RequirementLinks | null {
+  const path = `requirements[${index}]`
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return null
+  }
+  reportExactKeys(
+    value,
+    ['requirement_id', 'status', 'claim_ids', 'gap'],
+    path,
+    issues
+  )
+  const idIsValid = requireString(
+    value.requirement_id,
+    `${path}.requirement_id`,
+    issues
+  )
+  const status = typeof value.status === 'string' ? value.status : ''
+  if (!REQUIREMENT_STATUSES.has(status)) {
+    issues.push({
+      path: `${path}.status`,
+      message: 'Unknown requirement status.'
+    })
+  }
+  const claimIds = validateStringArray(
+    value.claim_ids,
+    `${path}.claim_ids`,
+    issues,
+    {
+      unique: true
+    }
+  )
+  if (typeof value.gap !== 'string') {
+    issues.push({ path: `${path}.gap`, message: 'Must be a string.' })
+  }
+  const gap = typeof value.gap === 'string' ? value.gap : ''
+  if (status === 'supported' && claimIds.length === 0) {
+    issues.push({
+      path,
+      message: 'Supported requirements need at least one claim.'
+    })
+  }
+  if (status === 'partial' && !gap.trim()) {
+    issues.push({
+      path,
+      message: 'Partial requirements need a non-empty gap.'
+    })
+  }
+  if (status === 'missing' && (claimIds.length > 0 || !gap.trim())) {
+    issues.push({
+      path,
+      message: 'Missing requirements need no claims and a non-empty gap.'
+    })
+  }
+  return idIsValid && typeof value.requirement_id === 'string'
+    ? { requirementId: value.requirement_id, status, claimIds, gap }
+    : null
+}
+
+type ConflictLinks = {
+  claimIds: string[]
+  resolution: string | null
+}
+
+function validateConflict(
+  value: unknown,
+  index: number,
+  issues: EvidenceImportIssue[]
+): { id: string; links: ConflictLinks } | null {
+  const path = `conflicts[${index}]`
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return null
+  }
+  reportExactKeys(
+    value,
+    ['conflict_id', 'claim_ids', 'summary', 'resolution'],
+    path,
+    issues
+  )
+  const idIsValid = validateStableId(
+    value.conflict_id,
+    `${path}.conflict_id`,
+    'x',
+    issues
+  )
+  const claimIds = validateStringArray(
+    value.claim_ids,
+    `${path}.claim_ids`,
+    issues,
+    {
+      minimum: 2,
+      unique: true
+    }
+  )
+  requireString(value.summary, `${path}.summary`, issues)
+  if (value.resolution !== null && typeof value.resolution !== 'string') {
+    issues.push({
+      path: `${path}.resolution`,
+      message: 'Must be a string or null.'
+    })
+  }
+  return idIsValid && typeof value.conflict_id === 'string'
+    ? {
+        id: value.conflict_id,
+        links: {
+          claimIds,
+          resolution:
+            typeof value.resolution === 'string' ? value.resolution : null
+        }
+      }
+    : null
+}
+
+function validateGap(
+  value: unknown,
+  index: number,
+  issues: EvidenceImportIssue[]
+): { id: string; requirementIds: string[] } | null {
+  const path = `gaps[${index}]`
+  if (!isObject(value)) {
+    issues.push({ path, message: 'Must be an object.' })
+    return null
+  }
+  reportExactKeys(value, ['gap_id', 'requirement_ids', 'summary'], path, issues)
+  const idIsValid = validateStableId(
+    value.gap_id,
+    `${path}.gap_id`,
+    'g',
+    issues
+  )
+  const requirementIds = validateStringArray(
+    value.requirement_ids,
+    `${path}.requirement_ids`,
+    issues,
+    { minimum: 1, unique: true }
+  )
+  requireString(value.summary, `${path}.summary`, issues)
+  return idIsValid && typeof value.gap_id === 'string'
+    ? { id: value.gap_id, requirementIds }
+    : null
+}
+
+function reportUnknownLinks(
+  ids: string[],
+  allowed: Set<string>,
+  path: string,
+  label: string,
+  issues: EvidenceImportIssue[]
+): void {
+  ids.forEach((id, index) => {
+    if (!allowed.has(id)) {
+      issues.push({
+        path: `${path}[${index}]`,
+        message: `Unknown ${label} ID.`
+      })
+    }
+  })
+}
+
+export function evidenceSatisfiesSourceRequirement(
+  requirement: Prompt2BlogSourceRequirement,
+  sources: readonly Prompt2BlogEvidenceSource[]
+): boolean {
+  return sources.some((source) => {
+    if (requirement === 'attributable-responses') {
+      return (
+        source.material_type === 'transcript' ||
+        source.material_type === 'interview-responses'
+      )
+    }
+    if (requirement === 'first-person-material') {
+      return source.material_type === 'first-person-notes'
+    }
+    if (requirement === 'documented-evaluation') {
+      return (
+        source.material_type === 'evaluation-notes' ||
+        source.source_type === 'firsthand'
+      )
+    }
+    return (
+      source.source_type === 'reporting' ||
+      source.source_type === 'firsthand' ||
+      source.material_type === 'transcript' ||
+      source.material_type === 'interview-responses'
+    )
+  })
+}
+
+function sourceGateFindings(
+  evidencePackage: Prompt2BlogEvidencePackage,
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): EvidenceReadinessFinding[] {
+  const gates =
+    catalog.forms.find((form) => form.id === commission.form_id)
+      ?.source_requirements ?? []
+  const sources = evidencePackage.sources ?? []
+  return gates
+    .filter((gate) => !evidenceSatisfiesSourceRequirement(gate, sources))
+    .map((gate) => ({
+      code: 'source_gate' as const,
+      requirement_ids: commission.requirements.map(
+        (item) => item.requirement_id
+      ),
+      message: `The ${commission.form_id} form still needs ${gate}.`
+    }))
+}
+
+function buildReadinessFindings(
+  evidencePackage: Prompt2BlogEvidencePackage,
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): EvidenceReadinessFinding[] {
+  const findings: EvidenceReadinessFinding[] = []
+  for (const requirement of evidencePackage.requirements) {
+    if (requirement.status === 'partial' || requirement.status === 'missing') {
+      findings.push({
+        code: 'requirement_gap',
+        requirement_ids: [requirement.requirement_id],
+        message:
+          requirement.gap ||
+          `Requirement ${requirement.requirement_id} is incomplete.`
+      })
+    }
+  }
+  const claims = new Map(
+    (evidencePackage.claims ?? []).map((claim) => [claim.claim_id, claim])
+  )
+  for (const conflict of evidencePackage.conflicts ?? []) {
+    if (conflict.resolution?.trim()) continue
+    const requirementIds = [
+      ...new Set(
+        conflict.claim_ids.flatMap(
+          (claimId) => claims.get(claimId)?.requirement_ids ?? []
+        )
+      )
+    ]
+    findings.push({
+      code: 'unresolved_conflict',
+      requirement_ids: requirementIds,
+      message: conflict.summary
+    })
+  }
+  findings.push(...sourceGateFindings(evidencePackage, commission, catalog))
+  return findings
+}
+
+export function reviewEvidencePackageJson(
+  raw: string,
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): EvidenceImportReview {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {
+      issues: [
+        {
+          path: 'json',
+          message: 'Must be one bare JSON object without prose or fences.'
+        }
+      ],
+      readinessFindings: [],
+      evidencePackage: null
+    }
+  }
+  if (!isObject(parsed)) {
+    return {
+      issues: [{ path: 'json', message: 'Must be one bare JSON object.' }],
+      readinessFindings: [],
+      evidencePackage: null
+    }
+  }
+
+  const issues: EvidenceImportIssue[] = []
+  reportExactKeys(
+    parsed,
+    [
+      'schema_version',
+      'commission_fingerprint',
+      'sources',
+      'claims',
+      'requirements',
+      'conflicts',
+      'gaps'
+    ],
+    '',
+    issues
+  )
+  if (parsed.schema_version !== 3) {
+    issues.push({ path: 'schema_version', message: 'Must equal 3.' })
+  }
+  if (parsed.commission_fingerprint !== commission.commission_fingerprint) {
+    issues.push({
+      path: 'commission_fingerprint',
+      message: 'Must match the currently approved commission.'
+    })
+  }
+
+  const sources = Array.isArray(parsed.sources) ? parsed.sources : []
+  if (!Array.isArray(parsed.sources))
+    issues.push({ path: 'sources', message: 'Must be an array.' })
+  const sourceIds = sources
+    .map((source, index) => validateSource(source, index, issues))
+    .filter(Boolean) as string[]
+  reportDuplicateIds(sourceIds, 'sources', issues)
+
+  const claims = Array.isArray(parsed.claims) ? parsed.claims : []
+  if (!Array.isArray(parsed.claims))
+    issues.push({ path: 'claims', message: 'Must be an array.' })
+  const claimLinks = claims
+    .map((claim, index) => validateClaim(claim, index, issues))
+    .filter(Boolean) as ClaimLinks[]
+  reportDuplicateIds(
+    claimLinks.map((claim) => claim.claimId),
+    'claims',
+    issues
+  )
+
+  const requirements = Array.isArray(parsed.requirements)
+    ? parsed.requirements
+    : []
+  if (!Array.isArray(parsed.requirements)) {
+    issues.push({ path: 'requirements', message: 'Must be an array.' })
+  }
+  const requirementLinks = requirements
+    .map((requirement, index) =>
+      validateRequirement(requirement, index, issues)
+    )
+    .filter(Boolean) as RequirementLinks[]
+  reportDuplicateIds(
+    requirementLinks.map((requirement) => requirement.requirementId),
+    'requirements',
+    issues
+  )
+
+  const conflicts = Array.isArray(parsed.conflicts) ? parsed.conflicts : []
+  if (!Array.isArray(parsed.conflicts))
+    issues.push({ path: 'conflicts', message: 'Must be an array.' })
+  const conflictLinks = conflicts
+    .map((conflict, index) => validateConflict(conflict, index, issues))
+    .filter(Boolean) as Array<{ id: string; links: ConflictLinks }>
+  reportDuplicateIds(
+    conflictLinks.map((conflict) => conflict.id),
+    'conflicts',
+    issues
+  )
+
+  const gaps = Array.isArray(parsed.gaps) ? parsed.gaps : []
+  if (!Array.isArray(parsed.gaps))
+    issues.push({ path: 'gaps', message: 'Must be an array.' })
+  const gapLinks = gaps
+    .map((gap, index) => validateGap(gap, index, issues))
+    .filter(Boolean) as Array<{
+    id: string
+    requirementIds: string[]
+  }>
+  reportDuplicateIds(
+    gapLinks.map((gap) => gap.id),
+    'gaps',
+    issues
+  )
+
+  const knownSourceIds = new Set(sourceIds)
+  const knownClaimIds = new Set(claimLinks.map((claim) => claim.claimId))
+  const commissionRequirementIds = new Set(
+    commission.requirements.map((requirement) => requirement.requirement_id)
+  )
+  const evidenceRequirementIds = new Set(
+    requirementLinks.map((requirement) => requirement.requirementId)
+  )
+  if (
+    commissionRequirementIds.size !== evidenceRequirementIds.size ||
+    [...commissionRequirementIds].some((id) => !evidenceRequirementIds.has(id))
+  ) {
+    issues.push({
+      path: 'requirements',
+      message: 'Requirement IDs must exactly match the approved commission.'
+    })
+  }
+
+  claimLinks.forEach((claim, index) => {
+    reportUnknownLinks(
+      claim.sourceIds,
+      knownSourceIds,
+      `claims[${index}].source_ids`,
+      'source',
+      issues
+    )
+    reportUnknownLinks(
+      claim.requirementIds,
+      commissionRequirementIds,
+      `claims[${index}].requirement_ids`,
+      'requirement',
+      issues
+    )
+  })
+  requirementLinks.forEach((requirement, index) => {
+    reportUnknownLinks(
+      requirement.claimIds,
+      knownClaimIds,
+      `requirements[${index}].claim_ids`,
+      'claim',
+      issues
+    )
+    requirement.claimIds.forEach((claimId) => {
+      const claim = claimLinks.find((item) => item.claimId === claimId)
+      if (claim && !claim.requirementIds.includes(requirement.requirementId)) {
+        issues.push({
+          path: `requirements[${index}].claim_ids`,
+          message: `Claim ${claimId} does not link back to ${requirement.requirementId}.`
+        })
+      }
+    })
+  })
+  claimLinks.forEach((claim, index) => {
+    claim.requirementIds.forEach((requirementId) => {
+      const requirement = requirementLinks.find(
+        (item) => item.requirementId === requirementId
+      )
+      if (requirement && !requirement.claimIds.includes(claim.claimId)) {
+        issues.push({
+          path: `claims[${index}].requirement_ids`,
+          message: `Requirement ${requirementId} does not link back to ${claim.claimId}.`
+        })
+      }
+    })
+  })
+  conflictLinks.forEach((conflict, index) =>
+    reportUnknownLinks(
+      conflict.links.claimIds,
+      knownClaimIds,
+      `conflicts[${index}].claim_ids`,
+      'claim',
+      issues
+    )
+  )
+  gapLinks.forEach((gap, index) =>
+    reportUnknownLinks(
+      gap.requirementIds,
+      commissionRequirementIds,
+      `gaps[${index}].requirement_ids`,
+      'requirement',
+      issues
+    )
+  )
+
+  if (issues.length)
+    return { issues, readinessFindings: [], evidencePackage: null }
+  const evidencePackage = parsed as unknown as Prompt2BlogEvidencePackage
+  return {
+    issues: [],
+    readinessFindings: buildReadinessFindings(
+      evidencePackage,
+      commission,
+      catalog
+    ),
+    evidencePackage
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage
+} from '../api'
+import type { EvidenceReadinessFinding } from './evidence-import'
+import { buildFollowUpResearchPrompt } from './follow-up-research-prompt'
+
+const fingerprint =
+  'd1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48'
+
+const commission: Prompt2BlogCommission = {
+  schema_version: 3,
+  commission_fingerprint: fingerprint,
+  original_title: 'Lima after the bargain era',
+  location: 'Lima, Peru',
+  approved_direction:
+    'Report Lima as one subject through current costs and lived context.',
+  form_id: 'feature-profile',
+  topic_module_ids: ['cost-affordability'],
+  audience: { primary_reader: 'Prospective long-stay residents', tags: [] },
+  core_reader_question: 'What does Lima offer long-stay residents now?',
+  reader_outcome: 'Understand current value and tradeoffs.',
+  primary_subject: 'Lima',
+  scope: {
+    mode: 'single_subject',
+    references: [
+      { name: 'Lima', role: 'primary_subject' },
+      { name: 'Medellín', role: 'context_only' }
+    ]
+  },
+  requirements: [
+    { requirement_id: 'r1', question: 'What are current routine costs?' },
+    {
+      requirement_id: 'r2',
+      question: 'Which people and scenes show lived context?'
+    }
+  ],
+  exclusions: ['Do not make Medellín a co-subject.'],
+  call_to_action: null
+}
+
+const catalog: Prompt2BlogEditorialOptionsResponse = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'feature-profile',
+      label: 'Feature/Profile',
+      description: 'Reported narrative using people, scenes, and quotations.',
+      order: 4,
+      source_requirements: ['reported-people-scenes-quotations']
+    },
+    {
+      id: 'interview-qa',
+      label: 'Interview/Q&A',
+      description: 'Attributable interview responses.',
+      order: 5,
+      source_requirements: ['attributable-responses']
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost and affordability',
+      description: 'Use current, comparable, dated price evidence.',
+      order: 1
+    },
+    {
+      id: 'food-drink',
+      label: 'Food and drink',
+      description: 'Inactive guidance must stay out.',
+      order: 3
+    }
+  ],
+  audience_tags: [],
+  scope_modes: [],
+  reference_roles: []
+}
+
+const incompleteEvidence: Prompt2BlogEvidencePackage = {
+  schema_version: 3,
+  commission_fingerprint: fingerprint,
+  sources: [
+    {
+      source_id: 's1',
+      title: 'Current price bulletin',
+      publisher: 'Statistics office',
+      url: 'https://example.com/prices',
+      published_at: '2026-07-01',
+      retrieved_at: '2026-08-25',
+      source_type: 'official',
+      material_type: 'report',
+      notes: ['Provides a dated current cost baseline.']
+    }
+  ],
+  claims: [
+    {
+      claim_id: 'c1',
+      text: 'Current official figures establish a cost baseline.',
+      source_ids: ['s1'],
+      requirement_ids: ['r1'],
+      as_of: '2026-07-01',
+      confidence: 'high'
+    },
+    {
+      claim_id: 'c2',
+      text: 'A second estimate conflicts with the official baseline.',
+      source_ids: ['s1'],
+      requirement_ids: ['r1'],
+      as_of: '2026-07-01',
+      confidence: 'low'
+    }
+  ],
+  requirements: [
+    {
+      requirement_id: 'r1',
+      status: 'supported',
+      claim_ids: ['c1', 'c2'],
+      gap: ''
+    },
+    {
+      requirement_id: 'r2',
+      status: 'partial',
+      claim_ids: [],
+      gap: 'No attributable people or documented scenes yet.'
+    }
+  ],
+  conflicts: [
+    {
+      conflict_id: 'x1',
+      claim_ids: ['c1', 'c2'],
+      summary: 'Two cost baselines disagree.',
+      resolution: null
+    }
+  ],
+  gaps: [
+    {
+      gap_id: 'g1',
+      requirement_ids: ['r2'],
+      summary: 'Find attributable people and documented scenes.'
+    }
+  ]
+}
+
+describe('buildFollowUpResearchPrompt', () => {
+  it('returns null when requirements, conflicts, source gates, and findings are ready', () => {
+    const interviewCommission: Prompt2BlogCommission = {
+      ...commission,
+      form_id: 'interview-qa',
+      topic_module_ids: [],
+      requirements: [
+        { requirement_id: 'r1', question: 'What did the speaker say?' }
+      ]
+    }
+    const readyEvidence: Prompt2BlogEvidencePackage = {
+      schema_version: 3,
+      commission_fingerprint: fingerprint,
+      sources: [
+        {
+          source_id: 's1',
+          title: 'Interview transcript',
+          publisher: null,
+          url: null,
+          published_at: null,
+          retrieved_at: '2026-08-25',
+          source_type: 'firsthand',
+          material_type: 'interview-responses',
+          notes: ['Attributable answer from the named speaker.']
+        }
+      ],
+      claims: [
+        {
+          claim_id: 'c1',
+          text: 'The speaker supplied an attributable answer.',
+          source_ids: ['s1'],
+          requirement_ids: ['r1'],
+          as_of: null,
+          confidence: 'high'
+        }
+      ],
+      requirements: [
+        {
+          requirement_id: 'r1',
+          status: 'supported',
+          claim_ids: ['c1'],
+          gap: ''
+        }
+      ],
+      conflicts: [],
+      gaps: []
+    }
+
+    expect(
+      buildFollowUpResearchPrompt(
+        interviewCommission,
+        readyEvidence,
+        [],
+        catalog
+      )
+    ).toBeNull()
+  })
+
+  it('requests a complete replacement package targeted only at unresolved work', () => {
+    const findings: EvidenceReadinessFinding[] = [
+      {
+        code: 'source_gate',
+        message:
+          'Feature lacks attributable people, documented scenes, and quotations.',
+        requirement_ids: ['r2']
+      }
+    ]
+
+    const prompt = buildFollowUpResearchPrompt(
+      commission,
+      incompleteEvidence,
+      findings,
+      catalog
+    )
+
+    expect(prompt).not.toBeNull()
+    expect(prompt).toContain(`"commission_fingerprint": "${fingerprint}"`)
+    expect(prompt).toContain('Return a complete replacement evidence package')
+    expect(prompt).toContain('Do not redo or weaken already supported work')
+    expect(prompt).toContain(
+      '- r2 — Which people and scenes show lived context?'
+    )
+    expect(prompt).not.toContain('- r1 — What are current routine costs?')
+    expect(prompt).toContain('- x1 — Two cost baselines disagree.')
+    expect(prompt).toContain('source_gate — Feature lacks attributable people')
+    expect(prompt).toContain('cost-affordability (Cost and affordability)')
+    expect(prompt).not.toContain('Inactive guidance must stay out.')
+    expect(prompt).toContain('Do not add a comparator')
+    expect(prompt).toContain(
+      '"material_type": "web|report|transcript|interview-responses|first-person-notes|evaluation-notes|other"'
+    )
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.ts
@@ -1,0 +1,160 @@
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage
+} from '../api'
+import {
+  evidenceSatisfiesSourceRequirement,
+  type EvidenceReadinessFinding
+} from './evidence-import'
+import { formatEvidencePackageContract } from './research-prompt'
+
+function formatActiveModules(
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): string {
+  const modules = (commission.topic_module_ids ?? []).map((moduleId) => {
+    const module = catalog.topic_modules.find(
+      (option) => option.id === moduleId
+    )
+    if (!module)
+      throw new Error(`Unknown commission topic module "${moduleId}".`)
+    return `- ${module.id} (${module.label}) — ${module.description.replace(/\s+/g, ' ').trim()}`
+  })
+  return modules.length ? modules.join('\n') : '- None.'
+}
+
+/**
+ * Builds a replacement-package prompt only when deterministic readiness data
+ * identifies unresolved research. Returns null for a ready package.
+ */
+export function buildFollowUpResearchPrompt(
+  commission: Prompt2BlogCommission,
+  evidencePackage: Prompt2BlogEvidencePackage,
+  findings: readonly EvidenceReadinessFinding[],
+  catalog: Prompt2BlogEditorialOptionsResponse
+): string | null {
+  if (
+    evidencePackage.commission_fingerprint !== commission.commission_fingerprint
+  ) {
+    throw new Error('Evidence package belongs to a different commission.')
+  }
+
+  const form = catalog.forms.find((option) => option.id === commission.form_id)
+  if (!form) throw new Error(`Unknown commission form "${commission.form_id}".`)
+
+  const unresolvedRequirementIds = new Set(
+    evidencePackage.requirements
+      .filter((requirement) => requirement.status !== 'supported')
+      .map((requirement) => requirement.requirement_id)
+  )
+  for (const gap of evidencePackage.gaps ?? []) {
+    gap.requirement_ids.forEach((requirementId) =>
+      unresolvedRequirementIds.add(requirementId)
+    )
+  }
+  for (const finding of findings) {
+    finding.requirement_ids.forEach((requirementId) =>
+      unresolvedRequirementIds.add(requirementId)
+    )
+  }
+
+  const unresolvedRequirements = commission.requirements.filter((requirement) =>
+    unresolvedRequirementIds.has(requirement.requirement_id)
+  )
+  const unresolvedConflicts = (evidencePackage.conflicts ?? []).filter(
+    (conflict) => !conflict.resolution?.trim()
+  )
+  const missingSourceGates = form.source_requirements.filter(
+    (requirement) =>
+      !evidenceSatisfiesSourceRequirement(
+        requirement,
+        evidencePackage.sources ?? []
+      )
+  )
+
+  if (
+    unresolvedRequirements.length === 0 &&
+    unresolvedConflicts.length === 0 &&
+    missingSourceGates.length === 0 &&
+    findings.length === 0
+  ) {
+    return null
+  }
+
+  const requirementLines = unresolvedRequirements.length
+    ? unresolvedRequirements
+        .map(
+          (requirement) =>
+            `- ${requirement.requirement_id} — ${requirement.question}`
+        )
+        .join('\n')
+    : '- None beyond source-gate or conflict work below.'
+  const conflictLines = unresolvedConflicts.length
+    ? unresolvedConflicts
+        .map((conflict) => `- ${conflict.conflict_id} — ${conflict.summary}`)
+        .join('\n')
+    : '- None.'
+  const findingLines = findings.length
+    ? findings
+        .map((finding) => {
+          const linked = finding.requirement_ids.length
+            ? ` [requirements: ${finding.requirement_ids.join(', ')}]`
+            : ''
+          return `- ${finding.code} — ${finding.message}${linked}`
+        })
+        .join('\n')
+    : '- None.'
+  const sourceGateLines = form.source_requirements.length
+    ? form.source_requirements
+        .map(
+          (requirement) =>
+            `- ${requirement}${missingSourceGates.includes(requirement) ? ' — unresolved' : ' — already satisfied; preserve supporting evidence'}`
+        )
+        .join('\n')
+    : '- None.'
+
+  return `You are completing unresolved research for an approved travel commission. Return a complete replacement evidence package, not a patch.
+
+AUTHORITY LOCK
+The locked commission remains read-only authority.
+- Keep commission_fingerprint exactly as supplied.
+- Do not change the form, primary subject, scope, reference roles, requirements, exclusions, audience, title, location, or approved direction.
+- Do not add a comparator, promote a context-only reference, or broaden scope.
+- Research only the unresolved work listed below. Do not write the article.
+
+LOCKED COMMISSION
+${JSON.stringify(commission, null, 2)}
+
+CURRENT EVIDENCE PACKAGE
+${JSON.stringify(evidencePackage, null, 2)}
+
+UNRESOLVED REQUIREMENTS ONLY
+${requirementLines}
+
+UNRESOLVED CONFLICTS ONLY
+${conflictLines}
+
+READINESS FINDINGS
+${findingLines}
+
+ACTIVE FORM SOURCE GATES
+${sourceGateLines}
+Meet unresolved gates with genuine matching material. Never simulate interviews, first-person experience, documented evaluation, scenes, or quotations.
+
+ACTIVE TOPIC MODULE METADATA
+${formatActiveModules(commission, catalog)}
+
+REPLACEMENT RULES
+- Do not redo or weaken already supported work. Preserve valid existing sources, claims, requirement links, dates, metadata, and resolved conflicts.
+- Add or revise only what is needed to close the listed requirements, conflicts, findings, and source gates.
+- Use partial or missing honestly when the follow-up still cannot close a gap.
+- Keep every locked requirement exactly once in requirements, including already supported requirements.
+- Keep source/claim mappings bidirectional and resolvable. Web and report sources require publisher and URL.
+- Preserve exact material_type so source-gate readiness remains deterministic.
+
+OUTPUT
+Return one bare JSON object and nothing else. No Markdown fence, preamble, commentary, or trailing note. Use exactly the shown keys and empty arrays rather than omitted collections. Return the entire replacement package with the locked fingerprint; return no commission object or editorial-authority fields.
+
+${formatEvidencePackageContract(commission.commission_fingerprint)}`
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse
+} from '../api'
+import { buildResearchPrompt } from './research-prompt'
+
+const commission: Prompt2BlogCommission = {
+  schema_version: 3,
+  commission_fingerprint:
+    'd1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48',
+  original_title: "Is Lima still South America's bargain expat capital?",
+  location: 'Lima, Peru',
+  approved_direction:
+    'Assess Lima as one long-stay subject without turning context cities into co-subjects.',
+  form_id: 'feature-profile',
+  topic_module_ids: ['cost-affordability', 'long-stay-remote-work'],
+  audience: {
+    primary_reader: 'Prospective expats and remote workers',
+    tags: ['remote-worker-relocator', 'budget-focused']
+  },
+  core_reader_question: 'Does Lima still deliver compelling long-stay value?',
+  reader_outcome: 'Judge Lima using current evidence and explicit tradeoffs.',
+  primary_subject: 'Lima',
+  scope: {
+    mode: 'single_subject',
+    references: [
+      { name: 'Lima', role: 'primary_subject' },
+      { name: 'Medellín', role: 'context_only' }
+    ]
+  },
+  requirements: [
+    { requirement_id: 'r1', question: 'What do current routine costs show?' },
+    {
+      requirement_id: 'r2',
+      question: 'Which reported people and scenes establish lived context?'
+    }
+  ],
+  exclusions: ['Do not organize the article as a city comparison.'],
+  call_to_action: null
+}
+
+const catalog: Prompt2BlogEditorialOptionsResponse = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'feature-profile',
+      label: 'Feature/Profile',
+      description: 'Reported narrative using people, scenes, and quotations.',
+      order: 4,
+      source_requirements: ['reported-people-scenes-quotations']
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost and affordability',
+      description:
+        'Use current, comparable price evidence with dated assumptions.',
+      order: 1
+    },
+    {
+      id: 'long-stay-remote-work',
+      label: 'Long stay and remote work',
+      description: 'Verify practical long-stay rules and infrastructure.',
+      order: 9
+    },
+    {
+      id: 'food-drink',
+      label: 'Food and drink',
+      description: 'Inactive module that must not broaden this research.',
+      order: 3
+    }
+  ],
+  audience_tags: [],
+  scope_modes: [],
+  reference_roles: []
+}
+
+describe('buildResearchPrompt', () => {
+  it('locks authority and requests one exact bare evidence package', () => {
+    const prompt = buildResearchPrompt(commission, catalog)
+
+    expect(prompt).toContain(
+      `"commission_fingerprint": "${commission.commission_fingerprint}"`
+    )
+    expect(prompt).toContain('The commission is read-only authority')
+    expect(prompt).toContain(
+      'Do not change the form, primary subject, scope, reference roles'
+    )
+    expect(prompt).toContain('Do not add a comparator')
+    expect(prompt).toContain('Return one bare JSON object and nothing else')
+    expect(prompt).toContain(
+      '"material_type": "web|report|transcript|interview-responses|first-person-notes|evaluation-notes|other"'
+    )
+    expect(prompt).toContain('Use partial or missing honestly')
+    expect(prompt).toContain(
+      'Every commission requirement ID must appear exactly once'
+    )
+    expect(prompt).not.toContain('"commission": {')
+  })
+
+  it('includes only active module metadata and the active form source gate', () => {
+    const prompt = buildResearchPrompt(commission, catalog)
+
+    expect(prompt).toContain(
+      'reported-people-scenes-quotations — Require attributable people, documented scenes, and exact supported quotations.'
+    )
+    expect(prompt).toContain(
+      'cost-affordability (Cost and affordability) — Use current, comparable price evidence with dated assumptions.'
+    )
+    expect(prompt).toContain(
+      'long-stay-remote-work (Long stay and remote work) — Verify practical long-stay rules and infrastructure.'
+    )
+    expect(prompt).not.toContain(
+      'Inactive module that must not broaden this research.'
+    )
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.ts
@@ -1,0 +1,143 @@
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogSourceRequirement
+} from '../api'
+
+const SOURCE_GATE_GUIDANCE: Record<Prompt2BlogSourceRequirement, string> = {
+  'reported-people-scenes-quotations':
+    'Require attributable people, documented scenes, and exact supported quotations.',
+  'attributable-responses':
+    'Require a transcript, recording record, or written interview responses attributable to the named speaker.',
+  'first-person-material':
+    'Require supplied first-person notes, journals, recordings, or equivalent lived-experience material.',
+  'documented-evaluation':
+    'Require firsthand notes or a documented evaluation record naming evaluator, date, method, conditions, and limitations.'
+}
+
+function activeResearchGuidance(
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): { form: string; modules: string; sourceGates: string } {
+  const form = catalog.forms.find((option) => option.id === commission.form_id)
+  if (!form) throw new Error(`Unknown commission form "${commission.form_id}".`)
+
+  const activeModules = (commission.topic_module_ids ?? []).map((moduleId) => {
+    const module = catalog.topic_modules.find(
+      (option) => option.id === moduleId
+    )
+    if (!module)
+      throw new Error(`Unknown commission topic module "${moduleId}".`)
+    return `- ${module.id} (${module.label}) — ${module.description.replace(/\s+/g, ' ').trim()}`
+  })
+
+  const sourceGates = form.source_requirements.map(
+    (requirement) => `- ${requirement} — ${SOURCE_GATE_GUIDANCE[requirement]}`
+  )
+
+  return {
+    form: `${form.id} (${form.label}) — ${form.description.replace(/\s+/g, ' ').trim()}`,
+    modules: activeModules.length ? activeModules.join('\n') : '- None.',
+    sourceGates: sourceGates.length ? sourceGates.join('\n') : '- None.'
+  }
+}
+
+/** Exact bare response shape shared by initial and follow-up research prompts. */
+export function formatEvidencePackageContract(fingerprint: string): string {
+  return `{
+  "schema_version": 3,
+  "commission_fingerprint": ${JSON.stringify(fingerprint)},
+  "sources": [
+    {
+      "source_id": "s1",
+      "title": "Source title",
+      "publisher": "Publisher",
+      "url": "https://example.com",
+      "published_at": "YYYY-MM-DD",
+      "retrieved_at": "YYYY-MM-DD",
+      "source_type": "official|reporting|specialist|firsthand|other",
+      "material_type": "web|report|transcript|interview-responses|first-person-notes|evaluation-notes|other",
+      "notes": ["Exact useful fact, observation, quotation, or qualification"]
+    }
+  ],
+  "claims": [
+    {
+      "claim_id": "c1",
+      "text": "One precise supported claim",
+      "source_ids": ["s1"],
+      "requirement_ids": ["r1"],
+      "as_of": "YYYY-MM-DD or null",
+      "confidence": "high|medium|low"
+    }
+  ],
+  "requirements": [
+    {
+      "requirement_id": "r1",
+      "status": "supported|partial|missing",
+      "claim_ids": ["c1"],
+      "gap": "Empty only when fully supported; otherwise say exactly what is missing"
+    }
+  ],
+  "conflicts": [
+    {
+      "conflict_id": "x1",
+      "claim_ids": ["c1", "c2"],
+      "summary": "What conflicts",
+      "resolution": "Resolution or null"
+    }
+  ],
+  "gaps": [
+    {
+      "gap_id": "g1",
+      "requirement_ids": ["r1"],
+      "summary": "Exact unresolved research work"
+    }
+  ]
+}`
+}
+
+/** Builds the external-research prompt without granting the chatbot editorial authority. */
+export function buildResearchPrompt(
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): string {
+  const guidance = activeResearchGuidance(commission, catalog)
+
+  return `You are a research desk gathering structured evidence for an already approved travel commission.
+
+AUTHORITY LOCK
+The commission is read-only authority. Research it; never rewrite or reinterpret it.
+- Keep commission_fingerprint exactly as supplied.
+- Do not change the form, primary subject, scope, reference roles, requirements, exclusions, audience, title, location, or approved direction.
+- Do not add a comparator, promote a context-only reference, or broaden the article into a comparison.
+- Do not write the article, an outline, or editorial recommendations.
+
+LOCKED COMMISSION
+${JSON.stringify(commission, null, 2)}
+
+ACTIVE ARTICLE FORM
+${guidance.form}
+
+ACTIVE FORM SOURCE GATES
+${guidance.sourceGates}
+If a source gate cannot be met, leave affected requirements partial or missing and describe the gap. Never simulate interviews, firsthand experience, evaluation, scenes, or quotations.
+
+ACTIVE TOPIC MODULE METADATA
+${guidance.modules}
+Use these modules to focus source selection and factual treatment. Do not research inactive modules merely because they appear generally relevant.
+
+RESEARCH DISCIPLINE
+- Answer only the locked requirement questions.
+- Prefer primary, official, attributable, current sources; preserve publisher, URL, dates, source type, material type, and useful notes.
+- Use separate source and claim IDs. Every claim must cite existing source IDs and one or more locked requirement IDs.
+- Record volatile facts with an as-of date. Explain conflicts instead of choosing silently.
+- Use partial or missing honestly. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims.
+- Every commission requirement ID must appear exactly once in requirements. Do not invent requirement IDs.
+- Web and report material requires publisher and URL. Every source requires at least one useful note.
+- For transcript, interview-response, first-person-note, evaluation-note, or other operator-supplied material, publisher, URL, and published_at may be JSON null.
+
+OUTPUT
+Return one bare JSON object and nothing else. No Markdown fence, preamble, commentary, or trailing note. Use exactly the shown keys; use empty arrays rather than omitting collections. Return no commission object or editorial-authority fields.
+
+${formatEvidencePackageContract(commission.commission_fingerprint)}`
+}


### PR DESCRIPTION
## Why

PR3A of the Prompt2Blog v3 migration. The approved commission now needs a research step that can gather evidence without ever being able to rewrite the commission itself. This PR adds only the pure domain code for that step — no state, no UI, no backend, and no activation of a v3 run.

## What

- `research-prompt.ts` — builds the locked research prompt from an approved commission plus the v3 catalog, including per-form source-gate guidance and the evidence-package output contract.
- `evidence-import.ts` — strict evidence-package parser: schema version, commission fingerprint, source/claim/requirement/conflict/gap ID resolution, link direction, dates, metadata, and status semantics. Emits deterministic readiness findings (`requirement_gap`, `unresolved_conflict`, `source_gate`).
- `follow-up-research-prompt.ts` — deterministic replacement-package prompt, built only when readiness data shows unresolved work, sharing the source-gate logic with the importer.

Readiness rules tightened during review:

- the `reported-people-scenes-quotations` gate now needs both an attributable-voice source (transcript or interview responses) and a reported or firsthand source, instead of any single loosely matching source
- a `supported` requirement must carry claims and an empty gap
- `source_gate` findings no longer claim every locked requirement ID; the gate is recomputed from the form, so the finding carries none

## Verification

- frontend full suite: 803 passed (163 files)
- Prompt2Blog composer suite: 105 passed
- `tsc --noEmit`: clean
- frontend boundary check + ESLint on `features/prompt2blog`: clean
- production Vite build: passes (only the repo's existing chunk-size warning)

## Boundaries

No pipeline cutover, no run activation, no UI or hook wiring, no backend change, no shared article-type DB change, and no URL2Blog/YouTube2Blog change.