### PR TITLE
Store Prompt2Blog evidence against the approved commission

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type {
   Prompt2BlogCommission,
   Prompt2BlogDirectionOption,
-  Prompt2BlogDirectionResponse
+  Prompt2BlogDirectionResponse,
+  Prompt2BlogEvidencePackage
 } from '../api'
 import { DEFAULT_COMPOSER_STATE } from './composer.storage'
 import type { P2BFormState } from './composer.types'
@@ -10,9 +11,11 @@ import {
   applyValidatedDirectionResponse,
   approveCommission,
   clearDirectionWorkflow,
+  clearEvidencePackage,
   editCommissionDraft,
   selectDirectionOption,
-  startEditorialWorkflow
+  startEditorialWorkflow,
+  storeEvidencePackage
 } from './commission-state'
 import { fingerprintCommissionSync } from './commission'
 
@@ -74,7 +77,8 @@ function state(overrides: Partial<P2BFormState> = {}): P2BFormState {
       directionOptions: [],
       selectedOptionId: null,
       commissionDraft: null,
-      approval: { status: 'not_started' }
+      approval: { status: 'not_started' },
+      evidencePackage: null
     },
     easySetupTitle: APP_TITLE,
     easySetupLocation: APP_LOCATION,
@@ -118,7 +122,8 @@ describe('commission state', () => {
       directionOptions: [],
       selectedOptionId: null,
       commissionDraft: null,
-      approval: { status: 'not_started' }
+      approval: { status: 'not_started' },
+      evidencePackage: null
     })
     expect(next.modelStackId).toBe('best-value')
     expect(next.toneId).toBe('editorial')
@@ -244,12 +249,111 @@ describe('commission state', () => {
       directionOptions: [],
       selectedOptionId: null,
       commissionDraft: null,
-      approval: { status: 'not_started' }
+      approval: { status: 'not_started' },
+      evidencePackage: null
     })
     expect(next.articleTypeId).toBe(7)
     expect(next.articleGoal).toBe('Retained legacy goal')
     expect(next.blobs).toEqual([{ id: 1, content: 'Retained source' }])
     expect(next.modelStackId).toBe('best-value')
     expect(next.toneId).toBe('editorial')
+  })
+})
+
+function evidence(fingerprint: string): Prompt2BlogEvidencePackage {
+  return {
+    schema_version: 3,
+    commission_fingerprint: fingerprint,
+    sources: [],
+    claims: [],
+    requirements: [
+      { requirement_id: 'r1', status: 'missing', claim_ids: [], gap: 'Open.' }
+    ],
+    conflicts: [],
+    gaps: []
+  }
+}
+
+function approvedState(): {
+  state: P2BFormState
+  commission: Prompt2BlogCommission
+} {
+  const selected = selectedState()
+  const commission: Prompt2BlogCommission = {
+    ...selected.editorial.commissionDraft!,
+    commission_fingerprint: fingerprintCommissionSync(
+      selected.editorial.commissionDraft!
+    )
+  }
+  return { state: approveCommission(selected, commission), commission }
+}
+
+describe('commission evidence state', () => {
+  it('attaches evidence to the approved commission and drops it on edit', () => {
+    const { state: approved, commission } = approvedState()
+
+    const withEvidence = storeEvidencePackage(
+      approved,
+      evidence(commission.commission_fingerprint)
+    )
+    expect(withEvidence.editorial.evidencePackage).not.toBeNull()
+
+    const edited = editCommissionDraft(withEvidence, {
+      approved_direction: 'Edited Lima-centered direction.'
+    })
+    expect(edited.editorial.evidencePackage).toBeNull()
+  })
+
+  it('refuses evidence that belongs to another commission or to no approval', () => {
+    const { state: approved } = approvedState()
+
+    expect(() =>
+      storeEvidencePackage(approved, evidence('f'.repeat(64)))
+    ).toThrow(/currently approved commission/)
+    expect(() =>
+      storeEvidencePackage(selectedState(), evidence('f'.repeat(64)))
+    ).toThrow(/currently approved commission/)
+  })
+
+  it('keeps evidence across a re-approval of the same commission only', () => {
+    const { state: approved, commission } = approvedState()
+    const withEvidence = storeEvidencePackage(
+      approved,
+      evidence(commission.commission_fingerprint)
+    )
+
+    expect(
+      approveCommission(withEvidence, commission).editorial.evidencePackage
+    ).not.toBeNull()
+
+    const edited = editCommissionDraft(withEvidence, {
+      approved_direction: 'A materially different Lima direction.'
+    })
+    const reApproved = approveCommission(
+      { ...edited, editorial: { ...edited.editorial, evidencePackage: withEvidence.editorial.evidencePackage } },
+      {
+        ...edited.editorial.commissionDraft!,
+        commission_fingerprint: fingerprintCommissionSync(
+          edited.editorial.commissionDraft!
+        )
+      }
+    )
+    expect(reApproved.editorial.evidencePackage).toBeNull()
+  })
+
+  it('drops evidence when research or the whole workflow is cleared', () => {
+    const { state: approved, commission } = approvedState()
+    const withEvidence = storeEvidencePackage(
+      approved,
+      evidence(commission.commission_fingerprint)
+    )
+
+    expect(clearEvidencePackage(withEvidence).editorial.evidencePackage).toBeNull()
+    expect(
+      clearEvidencePackage(withEvidence).editorial.approval
+    ).toEqual(withEvidence.editorial.approval)
+    expect(
+      clearDirectionWorkflow(withEvidence).editorial.evidencePackage
+    ).toBeNull()
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
@@ -3,9 +3,14 @@ import type {
   Prompt2BlogCommissionDraft,
   Prompt2BlogDirectionOption,
   Prompt2BlogDirectionOptionId,
-  Prompt2BlogDirectionResponse
+  Prompt2BlogDirectionResponse,
+  Prompt2BlogEvidencePackage
 } from '../api'
-import type { P2BEditorialComposerState, P2BFormState } from './composer.types'
+import type {
+  P2BCommissionApproval,
+  P2BEditorialComposerState,
+  P2BFormState
+} from './composer.types'
 import {
   commissionMatchesDraft,
   createCommissionDraft,
@@ -17,8 +22,26 @@ function emptyEditorialState(): P2BEditorialComposerState {
     directionOptions: [],
     selectedOptionId: null,
     commissionDraft: null,
-    approval: { status: 'not_started' }
+    approval: { status: 'not_started' },
+    evidencePackage: null
   }
+}
+
+/**
+ * Evidence survives only while the exact commission it was researched against
+ * is still approved. Every transition runs through this, so an edit, a new
+ * direction import, or a re-approval with a new fingerprint drops research
+ * instead of silently carrying it forward.
+ */
+export function retainedEvidencePackage(
+  evidencePackage: Prompt2BlogEvidencePackage | null,
+  approval: P2BCommissionApproval
+): Prompt2BlogEvidencePackage | null {
+  if (!evidencePackage || approval.status !== 'approved') return null
+  return evidencePackage.commission_fingerprint ===
+    approval.commission.commission_fingerprint
+    ? evidencePackage
+    : null
 }
 
 function cloneOption(
@@ -63,7 +86,8 @@ export function applyValidatedDirectionResponse(
       directionOptions: response.options.map(cloneOption),
       selectedOptionId: null,
       commissionDraft: null,
-      approval: { status: 'awaiting_selection' }
+      approval: { status: 'awaiting_selection' },
+      evidencePackage: null
     }
   }
 }
@@ -95,7 +119,8 @@ export function selectDirectionOption(
       ...state.editorial,
       selectedOptionId: optionId,
       commissionDraft,
-      approval: { status: 'needs_approval' }
+      approval: { status: 'needs_approval' },
+      evidencePackage: null
     }
   }
 }
@@ -134,7 +159,11 @@ export function approveCommission(
     activeWorkflow: 'editorial_v3',
     editorial: {
       ...state.editorial,
-      approval: { status: 'approved', commission }
+      approval: { status: 'approved', commission },
+      evidencePackage: retainedEvidencePackage(state.editorial.evidencePackage, {
+        status: 'approved',
+        commission
+      })
     }
   }
 }
@@ -160,8 +189,43 @@ export function editCommissionDraft(
       approval: {
         status: 'reconfirmation_required',
         reason: 'commission_edited'
-      }
+      },
+      evidencePackage: null
     }
+  }
+}
+
+/**
+ * Attaches imported research to the approved commission. The caller must have
+ * validated the package first; this only refuses evidence that cannot belong
+ * to what is approved right now.
+ */
+export function storeEvidencePackage(
+  state: P2BFormState,
+  evidencePackage: Prompt2BlogEvidencePackage
+): P2BFormState {
+  const retained = retainedEvidencePackage(
+    evidencePackage,
+    state.editorial.approval
+  )
+  if (!retained) {
+    throw new Error(
+      'Evidence can only be stored against the currently approved commission.'
+    )
+  }
+  return {
+    ...state,
+    activeWorkflow: 'editorial_v3',
+    editorial: { ...state.editorial, evidencePackage: retained }
+  }
+}
+
+/** Drops imported research without disturbing the approved commission. */
+export function clearEvidencePackage(state: P2BFormState): P2BFormState {
+  if (!state.editorial.evidencePackage) return state
+  return {
+    ...state,
+    editorial: { ...state.editorial, evidencePackage: null }
   }
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
@@ -7,7 +7,11 @@ import {
   loadSavedComposerState,
   saveComposerState,
 } from './composer.storage'
-import type { Prompt2BlogCommission, Prompt2BlogCommissionDraft } from '../api'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogCommissionDraft,
+  Prompt2BlogEvidencePackage,
+} from '../api'
 import { fingerprintCommissionSync } from './commission'
 
 const APPROVED_COMMISSION: Prompt2BlogCommission = {
@@ -208,6 +212,7 @@ describe('loadSavedComposerState', () => {
         selectedOptionId: 'direction-1',
         commissionDraft: withoutFingerprint(APPROVED_COMMISSION),
         approval: { status: 'approved', commission: APPROVED_COMMISSION },
+        evidencePackage: null,
       },
     })
 
@@ -292,5 +297,116 @@ describe('loadSavedComposerState', () => {
     )
 
     expect(loadSavedComposerState().editorial).toEqual(DEFAULT_COMPOSER_STATE.editorial)
+  })
+})
+
+function storedEvidence(
+  fingerprint = APPROVED_COMMISSION.commission_fingerprint,
+): Prompt2BlogEvidencePackage {
+  return {
+    schema_version: 3,
+    commission_fingerprint: fingerprint,
+    sources: [
+      {
+        source_id: 's1',
+        title: 'Lima booking guidance',
+        publisher: 'City tourism office',
+        url: 'https://example.com/lima-booking',
+        published_at: '2026-06-01',
+        retrieved_at: '2026-08-25',
+        source_type: 'official',
+        material_type: 'web',
+        notes: ['Names the booking windows that matter first.'],
+      },
+    ],
+    claims: [
+      {
+        claim_id: 'c1',
+        text: 'Airport transfers should be booked before arrival.',
+        source_ids: ['s1'],
+        requirement_ids: ['r1'],
+        as_of: '2026-06-01',
+        confidence: 'high',
+      },
+    ],
+    requirements: [
+      { requirement_id: 'r1', status: 'supported', claim_ids: ['c1'], gap: '' },
+    ],
+    conflicts: [],
+    gaps: [],
+  }
+}
+
+function saveApprovedDraftWithEvidence(evidencePackage: unknown): void {
+  localStorage.setItem(
+    COMPOSER_STORAGE_KEY,
+    JSON.stringify({
+      ...DEFAULT_COMPOSER_STATE,
+      composerStorageVersion: COMPOSER_STORAGE_VERSION,
+      activeWorkflow: 'editorial_v3',
+      editorial: {
+        directionOptions: storedDirectionOptions(),
+        selectedOptionId: 'direction-1',
+        commissionDraft: withoutFingerprint(APPROVED_COMMISSION),
+        approval: { status: 'approved', commission: APPROVED_COMMISSION },
+        evidencePackage,
+      },
+    }),
+  )
+}
+
+describe('stored evidence packages', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('restores evidence that still matches the approved commission', () => {
+    saveApprovedDraftWithEvidence(storedEvidence())
+
+    expect(loadSavedComposerState().editorial.evidencePackage).toEqual(storedEvidence())
+  })
+
+  it('drops evidence fingerprinted for a different commission', () => {
+    saveApprovedDraftWithEvidence(storedEvidence('b'.repeat(64)))
+
+    const loaded = loadSavedComposerState()
+    expect(loaded.editorial.evidencePackage).toBeNull()
+    expect(loaded.editorial.approval).toEqual({
+      status: 'approved',
+      commission: APPROVED_COMMISSION,
+    })
+  })
+
+  it('drops evidence whose stored body no longer validates', () => {
+    const broken = storedEvidence()
+    broken.claims![0].source_ids = ['s404']
+    saveApprovedDraftWithEvidence(broken)
+
+    const loaded = loadSavedComposerState()
+    expect(loaded.editorial.evidencePackage).toBeNull()
+    expect(loaded.editorial.approval).toEqual({
+      status: 'approved',
+      commission: APPROVED_COMMISSION,
+    })
+  })
+
+  it('drops evidence stored against an unapproved commission', () => {
+    localStorage.setItem(
+      COMPOSER_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_COMPOSER_STATE,
+        composerStorageVersion: COMPOSER_STORAGE_VERSION,
+        activeWorkflow: 'editorial_v3',
+        editorial: {
+          directionOptions: storedDirectionOptions(),
+          selectedOptionId: 'direction-1',
+          commissionDraft: withoutFingerprint(APPROVED_COMMISSION),
+          approval: { status: 'needs_approval' },
+          evidencePackage: storedEvidence(),
+        },
+      }),
+    )
+
+    expect(loadSavedComposerState().editorial.evidencePackage).toBeNull()
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -17,6 +17,8 @@ import {
   type Prompt2BlogDirectionOptionId,
 } from '../api'
 import { commissionMatchesDraft, fingerprintCommissionSync } from './commission'
+import { retainedEvidencePackage } from './commission-state'
+import { validateEvidencePackageValue } from './evidence-import'
 
 export const COMPOSER_STORAGE_KEY = 'p2b-form-draft'
 export const COMPOSER_STORAGE_VERSION = 3
@@ -95,6 +97,7 @@ export const DEFAULT_EDITORIAL_STATE: P2BEditorialComposerState = {
   selectedOptionId: null,
   commissionDraft: null,
   approval: { status: 'not_started' },
+  evidencePackage: null,
 }
 
 export const DEFAULT_COMPOSER_STATE: P2BFormState = {
@@ -297,6 +300,20 @@ function normalizeApproval(value: unknown): P2BCommissionApproval | null {
   return null
 }
 
+/**
+ * Stored evidence is re-validated against the approved commission on every
+ * load. A draft that no longer matches loses its research instead of carrying
+ * unverified sources into a run.
+ */
+function normalizeEvidencePackage(
+  value: unknown,
+  approval: P2BCommissionApproval,
+): P2BEditorialComposerState['evidencePackage'] {
+  if (value == null || approval.status !== 'approved') return null
+  const { evidencePackage } = validateEvidencePackageValue(value, approval.commission)
+  return retainedEvidencePackage(evidencePackage, approval)
+}
+
 function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
   if (!value || typeof value !== 'object') return { ...DEFAULT_EDITORIAL_STATE }
   const candidate = value as Partial<P2BEditorialComposerState>
@@ -332,6 +349,7 @@ function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
     selectedOptionId,
     commissionDraft,
     approval,
+    evidencePackage: normalizeEvidencePackage(candidate.evidencePackage, approval),
   }
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
@@ -3,6 +3,7 @@ import type {
   Prompt2BlogCommissionDraft,
   Prompt2BlogDirectionOption,
   Prompt2BlogDirectionOptionId,
+  Prompt2BlogEvidencePackage,
   Prompt2BlogModelName,
   Prompt2BlogWriterModel,
 } from '../api'
@@ -30,6 +31,12 @@ export interface P2BEditorialComposerState {
   selectedOptionId: Prompt2BlogDirectionOptionId | null
   commissionDraft: Prompt2BlogCommissionDraft | null
   approval: P2BCommissionApproval
+  /**
+   * Imported research for the currently approved commission. Readiness
+   * findings stay derived rather than stored, so they cannot drift from the
+   * commission they describe.
+   */
+  evidencePackage: Prompt2BlogEvidencePackage | null
 }
 
 export interface P2BFormState {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
@@ -17,6 +17,11 @@ export type EvidenceReadinessFinding = {
   message: string
 }
 
+export type EvidenceImportValidation = {
+  issues: EvidenceImportIssue[]
+  evidencePackage: Prompt2BlogEvidencePackage | null
+}
+
 export type EvidenceImportReview = {
   issues: EvidenceImportIssue[]
   readinessFindings: EvidenceReadinessFinding[]
@@ -607,30 +612,18 @@ function buildReadinessFindings(
   return findings
 }
 
-export function reviewEvidencePackageJson(
-  raw: string,
-  commission: Prompt2BlogCommission,
-  catalog: Prompt2BlogEditorialOptionsResponse
-): EvidenceImportReview {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
-    return {
-      issues: [
-        {
-          path: 'json',
-          message: 'Must be one bare JSON object without prose or fences.'
-        }
-      ],
-      readinessFindings: [],
-      evidencePackage: null
-    }
-  }
+/**
+ * Deterministic structural validation of an already-parsed evidence package
+ * against one approved commission. Catalog-free on purpose so stored evidence
+ * can be re-validated before the editorial catalog has loaded.
+ */
+export function validateEvidencePackageValue(
+  parsed: unknown,
+  commission: Prompt2BlogCommission
+): EvidenceImportValidation {
   if (!isObject(parsed)) {
     return {
       issues: [{ path: 'json', message: 'Must be one bare JSON object.' }],
-      readinessFindings: [],
       evidencePackage: null
     }
   }
@@ -808,9 +801,48 @@ export function reviewEvidencePackageJson(
     )
   )
 
-  if (issues.length)
-    return { issues, readinessFindings: [], evidencePackage: null }
-  const evidencePackage = parsed as unknown as Prompt2BlogEvidencePackage
+  if (issues.length) return { issues, evidencePackage: null }
+  return {
+    issues: [],
+    evidencePackage: parsed as unknown as Prompt2BlogEvidencePackage
+  }
+}
+
+/** Recomputes readiness findings for evidence that already validated. */
+export function evidenceReadinessFindings(
+  evidencePackage: Prompt2BlogEvidencePackage,
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): EvidenceReadinessFinding[] {
+  return buildReadinessFindings(evidencePackage, commission, catalog)
+}
+
+export function reviewEvidencePackageJson(
+  raw: string,
+  commission: Prompt2BlogCommission,
+  catalog: Prompt2BlogEditorialOptionsResponse
+): EvidenceImportReview {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {
+      issues: [
+        {
+          path: 'json',
+          message: 'Must be one bare JSON object without prose or fences.'
+        }
+      ],
+      readinessFindings: [],
+      evidencePackage: null
+    }
+  }
+
+  const { issues, evidencePackage } = validateEvidencePackageValue(
+    parsed,
+    commission
+  )
+  if (!evidencePackage) return { issues, readinessFindings: [], evidencePackage }
   return {
     issues: [],
     readinessFindings: buildReadinessFindings(

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -76,6 +76,7 @@ export function usePrompt2BlogComposer() {
                 status: 'reconfirmation_required',
                 reason: 'title_or_location_changed',
               },
+              evidencePackage: null,
             },
           }
         }


### PR DESCRIPTION
## Why

PR3B of the Prompt2Blog v3 migration. PR3A (#392) added the research prompt, the evidence parser, and the readiness gates as pure functions. This PR gives imported research a place to live in composer state, with the invalidation rules the plan requires, before any UI exists to drive it.

## What

- `P2BEditorialComposerState` gains `evidencePackage`. Readiness findings stay derived, never stored, so they cannot drift from the commission they describe.
- One retention rule, applied by every transition: evidence survives only while the exact commission it was researched against is still approved. Research is dropped on direction re-import, option reselection, commission edit, title/location change, workflow clear, and any re-approval whose fingerprint changed.
- `storeEvidencePackage` / `clearEvidencePackage` state transitions. Storing refuses any package that cannot belong to what is approved right now.
- Stored drafts are re-validated on load through the same importer rules. A drifted or malformed stored package loses its research while leaving the approved commission intact.
- `reviewEvidencePackageJson` is split so the catalog-free structural validator (`validateEvidencePackageValue`) is shared with storage instead of duplicated — storage runs before the editorial catalog has loaded. Import behavior is unchanged.

## Verification

- frontend full suite: 811 passed (163 files), including 8 new tests for retention, refusal, restore, and invalidation
- `tsc --noEmit`: clean
- frontend boundary check + ESLint on `features/prompt2blog`: clean
- production Vite build: passes (only the repo's existing chunk-size warning)

## Boundaries

No UI, no run activation, no backend change. The legacy v2 submission fence from PR2A is untouched, and nothing here can send evidence to a pipeline run.