### PR TITLE
Add the Prompt2Blog research and evidence review step

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -4,22 +4,17 @@ import type {
   Prompt2BlogDirectionOptionId,
   Prompt2BlogDirectionResponse,
   Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage,
   Prompt2BlogInputOptionsResponse,
 } from '../../api'
 import type { P2BEditorialComposerState, P2BFormState } from '../composer.types'
 import { reviewDirectionResponseJson, type DirectionImportReview } from '../direction-import'
 import { buildDirectionPrompt } from '../direction-prompt'
 import { reviewEasySetupJson, type EasySetupImportReview } from '../easy-setup-import'
+import { useClipboardCopy } from '../hooks/useClipboardCopy'
 import { CommissionEditor } from './CommissionEditor'
 import { DirectionCards } from './DirectionCards'
-
-type CopyStatus = 'idle' | 'copied' | 'error'
-
-const COPY_LABELS: Record<CopyStatus, string> = {
-  idle: 'Copy prompt',
-  copied: 'Copied!',
-  error: 'Copy failed',
-}
+import { ResearchPanel } from './ResearchPanel'
 
 interface EasySetupPanelProps {
   activeWorkflow: P2BFormState['activeWorkflow']
@@ -34,11 +29,13 @@ interface EasySetupPanelProps {
   onApplyDirectionResponse: (response: Prompt2BlogDirectionResponse) => void
   onApproveCommission: () => Promise<void>
   onClearDirectionWorkflow: () => void
+  onClearEvidence: () => void
   onCommissionChange: (draft: Prompt2BlogCommissionDraft) => void
   onLocationChange: (value: string) => void
   onRetryEditorialOptions: () => void
   onSelectDirection: (optionId: Prompt2BlogDirectionOptionId) => Promise<void>
   onStartDirectionWorkflow: () => void
+  onStoreEvidence: (evidencePackage: Prompt2BlogEvidencePackage) => void
   onTitleChange: (value: string) => void
 }
 
@@ -55,15 +52,17 @@ export function EasySetupPanel({
   onApplyDirectionResponse,
   onApproveCommission,
   onClearDirectionWorkflow,
+  onClearEvidence,
   onCommissionChange,
   onLocationChange,
   onRetryEditorialOptions,
   onSelectDirection,
   onStartDirectionWorkflow,
+  onStoreEvidence,
   onTitleChange,
 }: EasySetupPanelProps) {
   const [prompt, setPrompt] = useState<string | null>(null)
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle')
+  const directionCopy = useClipboardCopy()
   const [pastedJson, setPastedJson] = useState('')
   const [review, setReview] = useState<EasySetupImportReview | null>(null)
   const [appliedCount, setAppliedCount] = useState<number | null>(null)
@@ -74,19 +73,17 @@ export function EasySetupPanel({
   // they arrived is missing the fields it should have constrained.
   const showDirectionStep = prompt !== null || activeWorkflow === 'editorial_v3'
 
+  // The hook object is new on every render; only its stable reset belongs in
+  // the dependency list, or this would wipe the prompt on every keystroke.
+  const resetDirectionCopy = directionCopy.reset
+
   useEffect(() => {
     setPrompt(null)
-    setCopyStatus('idle')
+    resetDirectionCopy()
     setDirectionJson('')
     setDirectionReview(null)
     setDirectionStatus(null)
-  }, [location, title])
-
-  useEffect(() => {
-    if (copyStatus === 'idle') return
-    const timer = setTimeout(() => setCopyStatus('idle'), 2000)
-    return () => clearTimeout(timer)
-  }, [copyStatus])
+  }, [location, resetDirectionCopy, title])
 
   const handleConfirmSetup = () => {
     const confirmedTitle = title.trim()
@@ -95,7 +92,7 @@ export function EasySetupPanel({
     if (!editorialOptions) return
     onStartDirectionWorkflow()
     setPrompt(buildDirectionPrompt(confirmedTitle, confirmedLocation, editorialOptions))
-    setCopyStatus('idle')
+    directionCopy.reset()
   }
 
   const handleDirectionJsonChange = (value: string) => {
@@ -121,18 +118,6 @@ export function EasySetupPanel({
     onApplyDirectionResponse(directionReview.response)
     setDirectionReview(null)
     setDirectionStatus('Three directions are ready for approval.')
-  }
-
-  const handleCopyPrompt = () => {
-    if (prompt === null) return
-    // Clipboard access is missing outside secure contexts, so the button has to
-    // say so rather than silently doing nothing.
-    const copied = navigator.clipboard?.writeText(prompt)
-    if (!copied) {
-      setCopyStatus('error')
-      return
-    }
-    copied.then(() => setCopyStatus('copied')).catch(() => setCopyStatus('error'))
   }
 
   // The review is tied to the exact text it was run against; editing the box
@@ -217,8 +202,12 @@ export function EasySetupPanel({
           <div className="p2b-field">
             <div className="p2b-field-label-row">
               <label htmlFor="p2b-easy-setup-prompt">Prompt</label>
-              <button type="button" className="p2b-inline-copy-btn" onClick={handleCopyPrompt}>
-                {COPY_LABELS[copyStatus]}
+              <button
+                type="button"
+                className="p2b-inline-copy-btn"
+                onClick={() => directionCopy.copy(prompt)}
+              >
+                {directionCopy.label}
               </button>
             </div>
             <textarea
@@ -312,6 +301,15 @@ export function EasySetupPanel({
                   )
                 }}
                 onChange={onCommissionChange}
+              />
+            )}
+            {editorialOptions && editorial.approval.status === 'approved' && (
+              <ResearchPanel
+                commission={editorial.approval.commission}
+                editorialOptions={editorialOptions}
+                evidencePackage={editorial.evidencePackage}
+                onClearEvidence={onClearEvidence}
+                onStoreEvidence={onStoreEvidence}
               />
             )}
           </>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage,
+} from '../../api'
+import {
+  evidenceReadinessFindings,
+  reviewEvidencePackageJson,
+  type EvidenceImportReview,
+} from '../evidence-import'
+import { buildFollowUpResearchPrompt } from '../follow-up-research-prompt'
+import { buildResearchPrompt } from '../research-prompt'
+import { useClipboardCopy } from '../hooks/useClipboardCopy'
+
+interface ResearchPanelProps {
+  commission: Prompt2BlogCommission
+  editorialOptions: Prompt2BlogEditorialOptionsResponse
+  evidencePackage: Prompt2BlogEvidencePackage | null
+  onClearEvidence: () => void
+  onStoreEvidence: (evidencePackage: Prompt2BlogEvidencePackage) => void
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  supported: 'Supported',
+  partial: 'Partial',
+  missing: 'Missing',
+}
+
+export function ResearchPanel({
+  commission,
+  editorialOptions,
+  evidencePackage,
+  onClearEvidence,
+  onStoreEvidence,
+}: ResearchPanelProps) {
+  const [evidenceJson, setEvidenceJson] = useState('')
+  const [review, setReview] = useState<EvidenceImportReview | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+  const researchCopy = useClipboardCopy()
+  const followUpCopy = useClipboardCopy()
+
+  const fingerprint = commission.commission_fingerprint
+
+  // A new commission is new research. Nothing typed against the previous one
+  // may stay on screen where it could be attached to this one.
+  useEffect(() => {
+    setEvidenceJson('')
+    setReview(null)
+    setStatus(null)
+  }, [fingerprint])
+
+  const researchPrompt = useMemo(
+    () => buildResearchPrompt(commission, editorialOptions),
+    [commission, editorialOptions],
+  )
+
+  const findings = useMemo(
+    () =>
+      evidencePackage
+        ? evidenceReadinessFindings(evidencePackage, commission, editorialOptions)
+        : [],
+    [commission, editorialOptions, evidencePackage],
+  )
+
+  const followUpPrompt = useMemo(
+    () =>
+      evidencePackage
+        ? buildFollowUpResearchPrompt(commission, evidencePackage, findings, editorialOptions)
+        : null,
+    [commission, editorialOptions, evidencePackage, findings],
+  )
+
+  const handleEvidenceJsonChange = (value: string) => {
+    setEvidenceJson(value)
+    setReview(null)
+    setStatus(null)
+  }
+
+  const handleCheckEvidence = () => {
+    setStatus(null)
+    setReview(reviewEvidencePackageJson(evidenceJson, commission, editorialOptions))
+  }
+
+  const handleAttachEvidence = () => {
+    if (!review?.evidencePackage) return
+    try {
+      onStoreEvidence(review.evidencePackage)
+      setReview(null)
+      setEvidenceJson('')
+      setStatus('Research is attached to the approved commission.')
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Research could not be attached.')
+    }
+  }
+
+  const handleRemoveEvidence = () => {
+    onClearEvidence()
+    setStatus('Research was removed. The approved commission is unchanged.')
+  }
+
+  return (
+    <>
+      <div className="p2b-subsection-heading p2b-subsection-heading--divided">
+        <h3>Research the approved commission</h3>
+        <p>
+          The prompt carries the locked commission. Research may close gaps; it may never change
+          the form, subject, or scope.
+        </p>
+      </div>
+      <div className="p2b-field">
+        <div className="p2b-field-label-row">
+          <label htmlFor="p2b-research-prompt">Research prompt</label>
+          <button
+            type="button"
+            className="p2b-inline-copy-btn"
+            onClick={() => researchCopy.copy(researchPrompt)}
+          >
+            {researchCopy.label}
+          </button>
+        </div>
+        <textarea
+          id="p2b-research-prompt"
+          className="p2b-textarea"
+          rows={16}
+          readOnly
+          value={researchPrompt}
+        />
+      </div>
+      <div className="p2b-field">
+        <label htmlFor="p2b-evidence-json">Evidence JSON</label>
+        <textarea
+          id="p2b-evidence-json"
+          className="p2b-textarea"
+          rows={10}
+          value={evidenceJson}
+          onChange={event => handleEvidenceJsonChange(event.target.value)}
+          placeholder="Paste the evidence package the research chatbot returned."
+        />
+      </div>
+      <div className="p2b-panel-actions">
+        <button
+          type="button"
+          className="p2b-copy-json-btn"
+          disabled={!evidenceJson.trim()}
+          onClick={handleCheckEvidence}
+        >
+          Check evidence
+        </button>
+        <button
+          type="button"
+          className="p2b-submit-btn"
+          disabled={!review?.evidencePackage}
+          onClick={handleAttachEvidence}
+        >
+          Attach research
+        </button>
+        {evidencePackage && (
+          <button type="button" className="p2b-clear-btn" onClick={handleRemoveEvidence}>
+            Remove research
+          </button>
+        )}
+      </div>
+      {status && (
+        <p className="p2b-import-applied" role="status">
+          {status}
+        </p>
+      )}
+      {review && review.issues.length > 0 && (
+        <div className="p2b-import-report p2b-import-report--blocked">
+          <p className="p2b-import-report-title">
+            Evidence JSON is blocked — nothing was attached.
+          </p>
+          <ul className="p2b-import-list">
+            {review.issues.map(issue => (
+              <li key={`${issue.path}-${issue.message}`}>
+                <code>{issue.path}</code> {issue.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {evidencePackage && (
+        <div className="p2b-import-report">
+          <p className="p2b-import-report-title">
+            {evidencePackage.sources?.length ?? 0} sources and{' '}
+            {evidencePackage.claims?.length ?? 0} claims are attached to this commission.
+          </p>
+          <ul className="p2b-requirement-list">
+            {evidencePackage.requirements.map(requirement => (
+              <li key={requirement.requirement_id} className="p2b-requirement-row">
+                <code>{requirement.requirement_id}</code>{' '}
+                {STATUS_LABELS[requirement.status] ?? requirement.status}
+                {requirement.gap ? ` — ${requirement.gap}` : ''}
+              </li>
+            ))}
+          </ul>
+          {findings.length > 0 ? (
+            <>
+              <p className="p2b-import-report-title">
+                {findings.length} readiness {findings.length === 1 ? 'gap' : 'gaps'} remain. The
+                run stays blocked until research closes them.
+              </p>
+              <ul className="p2b-import-list">
+                {findings.map(finding => (
+                  <li key={`${finding.code}-${finding.message}`}>
+                    <code>{finding.code}</code> {finding.message}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p className="p2b-field-hint">
+              Every locked requirement is supported and no conflict or source gate is open.
+            </p>
+          )}
+          {followUpPrompt !== null && (
+            <div className="p2b-field">
+              <div className="p2b-field-label-row">
+                <label htmlFor="p2b-follow-up-prompt">Follow-up research prompt</label>
+                <button
+                  type="button"
+                  className="p2b-inline-copy-btn"
+                  onClick={() => followUpCopy.copy(followUpPrompt)}
+                >
+                  {followUpCopy.label}
+                </button>
+              </div>
+              <textarea
+                id="p2b-follow-up-prompt"
+                className="p2b-textarea"
+                rows={10}
+                readOnly
+                value={followUpPrompt}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
@@ -1,0 +1,236 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  Prompt2BlogCommission,
+  Prompt2BlogEditorialOptionsResponse,
+  Prompt2BlogEvidencePackage
+} from '../../types/editorial.types'
+import { fingerprintCommissionSync } from '../commission'
+import { ResearchPanel } from './ResearchPanel'
+
+afterEach(cleanup)
+
+const editorialOptions: Prompt2BlogEditorialOptionsResponse = {
+  schema_version: 3,
+  forms: [
+    {
+      id: 'analysis',
+      label: 'Analysis',
+      description: 'Interprets evidence.',
+      order: 1,
+      source_requirements: []
+    }
+  ],
+  topic_modules: [
+    {
+      id: 'cost-affordability',
+      label: 'Cost',
+      description: 'Current costs.',
+      order: 1
+    }
+  ],
+  audience_tags: [
+    {
+      id: 'budget-focused',
+      label: 'Budget-focused',
+      description: 'Watching costs.'
+    }
+  ],
+  scope_modes: [
+    {
+      id: 'single_subject',
+      label: 'Single subject',
+      description: 'One subject.'
+    }
+  ],
+  reference_roles: [
+    {
+      id: 'primary_subject',
+      label: 'Primary subject',
+      description: 'Article center.'
+    }
+  ]
+}
+
+function makeCommission(): Prompt2BlogCommission {
+  const draft = {
+    schema_version: 3 as const,
+    original_title: "Is Lima still South America's bargain expat capital?",
+    location: 'Lima, Peru',
+    approved_direction: 'Assess Lima as one subject using current evidence.',
+    form_id: 'analysis' as const,
+    topic_module_ids: ['cost-affordability' as const],
+    audience: {
+      primary_reader: 'Prospective long-stay residents',
+      tags: ['budget-focused' as const]
+    },
+    core_reader_question: 'Does Lima still offer compelling long-stay value?',
+    reader_outcome: 'Judge Lima using current evidence.',
+    primary_subject: 'Lima',
+    scope: {
+      mode: 'single_subject' as const,
+      references: [{ name: 'Lima', role: 'primary_subject' as const }]
+    },
+    requirements: [
+      { requirement_id: 'r1', question: 'What do current costs show?' }
+    ],
+    exclusions: [],
+    call_to_action: null
+  }
+  return { ...draft, commission_fingerprint: fingerprintCommissionSync(draft) }
+}
+
+const commission = makeCommission()
+
+function evidence(
+  overrides: Partial<Prompt2BlogEvidencePackage> = {}
+): Prompt2BlogEvidencePackage {
+  return {
+    schema_version: 3,
+    commission_fingerprint: commission.commission_fingerprint,
+    sources: [
+      {
+        source_id: 's1',
+        title: 'Lima consumer price bulletin',
+        publisher: 'Statistics office',
+        url: 'https://example.com/lima-prices',
+        published_at: '2026-07-01',
+        retrieved_at: '2026-08-25',
+        source_type: 'official',
+        material_type: 'report',
+        notes: ['Gives a dated current cost baseline.']
+      }
+    ],
+    claims: [
+      {
+        claim_id: 'c1',
+        text: 'Official figures establish a current cost baseline.',
+        source_ids: ['s1'],
+        requirement_ids: ['r1'],
+        as_of: '2026-07-01',
+        confidence: 'high'
+      }
+    ],
+    requirements: [
+      { requirement_id: 'r1', status: 'supported', claim_ids: ['c1'], gap: '' }
+    ],
+    conflicts: [],
+    gaps: [],
+    ...overrides
+  }
+}
+
+function renderPanel(
+  evidencePackage: Prompt2BlogEvidencePackage | null,
+  handlers: {
+    onStoreEvidence?: (value: Prompt2BlogEvidencePackage) => void
+    onClearEvidence?: () => void
+  } = {}
+) {
+  const onStoreEvidence = handlers.onStoreEvidence ?? vi.fn()
+  const onClearEvidence = handlers.onClearEvidence ?? vi.fn()
+  render(
+    <ResearchPanel
+      commission={commission}
+      editorialOptions={editorialOptions}
+      evidencePackage={evidencePackage}
+      onClearEvidence={onClearEvidence}
+      onStoreEvidence={onStoreEvidence}
+    />
+  )
+  return { onStoreEvidence, onClearEvidence }
+}
+
+function pasteEvidence(value: unknown): void {
+  fireEvent.change(screen.getByLabelText('Evidence JSON'), {
+    target: { value: JSON.stringify(value) }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Check evidence' }))
+}
+
+describe('ResearchPanel', () => {
+  it('offers the locked research prompt for the approved commission', () => {
+    renderPanel(null)
+
+    const prompt = screen.getByLabelText('Research prompt') as HTMLTextAreaElement
+    expect(prompt).toHaveAttribute('readonly')
+    expect(prompt.value).toContain(commission.commission_fingerprint)
+    expect(prompt.value).toContain('Lima')
+  })
+
+  it('blocks evidence that belongs to another commission', () => {
+    const { onStoreEvidence } = renderPanel(null)
+
+    pasteEvidence(evidence({ commission_fingerprint: 'a'.repeat(64) }))
+
+    expect(screen.getByText(/nothing was attached/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Attach research' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Attach research' }))
+    expect(onStoreEvidence).not.toHaveBeenCalled()
+  })
+
+  it('attaches validated evidence exactly once', () => {
+    const onStoreEvidence = vi.fn()
+    renderPanel(null, { onStoreEvidence })
+
+    pasteEvidence(evidence())
+    fireEvent.click(screen.getByRole('button', { name: 'Attach research' }))
+
+    expect(onStoreEvidence).toHaveBeenCalledTimes(1)
+    expect(onStoreEvidence.mock.calls[0][0]).toMatchObject({
+      commission_fingerprint: commission.commission_fingerprint
+    })
+  })
+
+  it('reports readiness gaps and offers a follow-up prompt', () => {
+    renderPanel(
+      evidence({
+        claims: [],
+        requirements: [
+          {
+            requirement_id: 'r1',
+            status: 'missing',
+            claim_ids: [],
+            gap: 'Current cost evidence is still missing.'
+          }
+        ]
+      })
+    )
+
+    expect(screen.getByText(/1 readiness gap remain/i)).toBeInTheDocument()
+    // The gap reads more than once on purpose: as the requirement's status, as
+    // the finding that blocks the run, and inside the follow-up prompt.
+    expect(
+      screen.getAllByText(/Current cost evidence is still missing\./).length
+    ).toBeGreaterThanOrEqual(2)
+    const followUp = screen.getByLabelText(
+      'Follow-up research prompt'
+    ) as HTMLTextAreaElement
+    expect(followUp.value).toContain('r1 — What do current costs show?')
+  })
+
+  it('hides the follow-up prompt once research is ready', () => {
+    renderPanel(evidence())
+
+    expect(
+      screen.getByText(/Every locked requirement is supported/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText('Follow-up research prompt')
+    ).not.toBeInTheDocument()
+  })
+
+  it('removes attached research without touching the commission', () => {
+    const { onClearEvidence } = renderPanel(evidence())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove research' }))
+
+    expect(onClearEvidence).toHaveBeenCalledTimes(1)
+    expect(
+      screen.getByText(/The approved commission is unchanged/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/useClipboardCopy.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/useClipboardCopy.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type ClipboardCopyStatus = 'idle' | 'copied' | 'error'
+
+const COPY_LABELS: Record<ClipboardCopyStatus, string> = {
+  idle: 'Copy prompt',
+  copied: 'Copied!',
+  error: 'Copy failed',
+}
+
+/**
+ * One clipboard affordance for every prompt the composer hands to a chatbot.
+ * Clipboard access is missing outside secure contexts, so the button has to
+ * say so rather than silently doing nothing.
+ */
+export function useClipboardCopy() {
+  const [status, setStatus] = useState<ClipboardCopyStatus>('idle')
+
+  useEffect(() => {
+    if (status === 'idle') return
+    const timer = setTimeout(() => setStatus('idle'), 2000)
+    return () => clearTimeout(timer)
+  }, [status])
+
+  const copy = useCallback((text: string | null) => {
+    if (text === null) return
+    const copied = navigator.clipboard?.writeText(text)
+    if (!copied) {
+      setStatus('error')
+      return
+    }
+    copied.then(() => setStatus('copied')).catch(() => setStatus('error'))
+  }, [])
+
+  const reset = useCallback(() => setStatus('idle'), [])
+
+  return { status, label: COPY_LABELS[status], copy, reset }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -8,6 +8,7 @@ import {
   type Prompt2BlogCommissionDraft,
   type Prompt2BlogDirectionOptionId,
   type Prompt2BlogDirectionResponse,
+  type Prompt2BlogEvidencePackage,
   type Prompt2BlogGuidelinePreviewResponse,
   type Prompt2BlogInputOptionsResponse,
 } from '../../api'
@@ -33,6 +34,8 @@ import {
   applyValidatedDirectionResponse,
   approveCommission as storeApprovedCommission,
   clearDirectionWorkflow as resetDirectionWorkflow,
+  clearEvidencePackage,
+  storeEvidencePackage,
   editCommissionDraft,
   selectDirectionOption as selectCommissionDirection,
   startEditorialWorkflow,
@@ -232,6 +235,14 @@ export function usePrompt2BlogComposer() {
     )
   }, [editorialOptions, state.editorial.commissionDraft])
 
+  const storeEvidence = useCallback((evidencePackage: Prompt2BlogEvidencePackage) => {
+    setState(prev => storeEvidencePackage(prev, evidencePackage))
+  }, [])
+
+  const clearEvidence = useCallback(() => {
+    setState(clearEvidencePackage)
+  }, [])
+
   const clearDirectionWorkflow = useCallback(() => {
     setState(resetDirectionWorkflow)
   }, [])
@@ -346,6 +357,8 @@ export function usePrompt2BlogComposer() {
     selectDirectionOption,
     updateCommissionDraft,
     approveCommissionChanges,
+    storeEvidence,
+    clearEvidence,
     clearDirectionWorkflow,
     addBlob,
     removeBlob,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -92,11 +92,13 @@ export default function Prompt2BlogPage() {
             onApplyDirectionResponse={composer.applyDirectionResponse}
             onApproveCommission={composer.approveCommissionChanges}
             onClearDirectionWorkflow={composer.clearDirectionWorkflow}
+            onClearEvidence={composer.clearEvidence}
             onCommissionChange={composer.updateCommissionDraft}
             onLocationChange={value => composer.updateField('easySetupLocation', value)}
             onRetryEditorialOptions={composer.retryEditorialOptions}
             onSelectDirection={composer.selectDirectionOption}
             onStartDirectionWorkflow={composer.startDirectionWorkflow}
+            onStoreEvidence={composer.storeEvidence}
             onTitleChange={value => composer.updateField('easySetupTitle', value)}
           />
           <MiddleSectionsFold>


### PR DESCRIPTION
## Why

PR3C completes PR 3 of the Prompt2Blog v3 migration. #392 added the research domain and #393 gave evidence a place in composer state; this PR is the step the owner actually uses — generate the locked research prompt, paste the result back, and see what still blocks a run.

## What

- `ResearchPanel` appears under Easy Set Up only once a commission is approved.
- The research prompt is rendered read-only. It carries the locked commission and the fingerprint the returned evidence must match, so editing it in place would only break the import it exists to enable.
- Pasted evidence goes through the strict validator. Issues block the attach button and nothing unchecked reaches composer state; a refused attach reports why instead of failing silently.
- Attached research is reviewed by requirement status, by readiness findings, and by the deterministic follow-up prompt — which is absent once every requirement is supported and no conflict or source gate is open.
- Removing research leaves the approved commission untouched.
- The clipboard affordance both prompt steps use is extracted to `useClipboardCopy` rather than copied a second time.

## Verification

- frontend full suite: 817 passed (164 files), including 6 new `ResearchPanel` tests
- `tsc --noEmit`: clean
- frontend boundary check + ESLint on `features/prompt2blog`: clean
- production Vite build: passes (only the repo's existing chunk-size warning)

## Boundaries

No run activation and no backend change. Attaching research still cannot start a pipeline run — the readiness gate and the v3 intake route are PR 4 and PR 5. The legacy v2 submission fence is untouched.