### PR TITLE
Assemble Prompt2Blog v3 instructions from evidence and commission

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -17,6 +17,7 @@ bounded contexts.
 | `api/` and `routes.py` | FastAPI handlers and the public router facade |
 | `models.py`, `contracts_v3.py` | Versioned HTTP requests, editorial contracts, and runtime pipeline input |
 | `config.py`, `options.py`, `editorial_catalog.py` | Feature constants plus legacy and v3 Markdown-backed catalogs |
+| `evidence_v3.py`, `instructions_v3.py` | V3 evidence normalization and the layered instruction stack |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v3.py
@@ -206,6 +206,8 @@ class EvidenceRequirement(V3ContractModel):
         _require_unique(self.claim_ids, "requirement claim reference")
         if self.status == "supported" and not self.claim_ids:
             raise ValueError("supported requirements must reference at least one claim")
+        if self.status == "supported" and self.gap:
+            raise ValueError("supported requirements cannot describe a gap")
         if self.status in {"partial", "missing"} and not self.gap:
             raise ValueError("partial and missing requirements must describe the gap")
         if self.status == "missing" and self.claim_ids:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
@@ -1,0 +1,249 @@
+"""Deterministic normalization of a v3 evidence package.
+
+Normalization only reshapes what research already returned. It never adds,
+summarizes away, or repairs a fact: publisher, URL, dates, and the exact notes
+have to survive into grounding, so every downstream stage compares a draft with
+the same records the researcher supplied.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from .contracts_v3 import (
+    EvidenceClaim,
+    EvidencePackage,
+    EvidenceSource,
+    Prompt2BlogCommission,
+)
+
+
+class NormalizedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class NormalizedSource(NormalizedModel):
+    source_id: str
+    title: str
+    publisher: str | None
+    url: str | None
+    published_at: str | None
+    retrieved_at: str
+    source_type: str
+    material_type: str
+    notes: list[str]
+    citation: str
+
+
+class NormalizedClaim(NormalizedModel):
+    claim_id: str
+    text: str
+    source_ids: list[str]
+    requirement_ids: list[str]
+    as_of: str | None
+    confidence: str
+
+
+class NormalizedRequirement(NormalizedModel):
+    requirement_id: str
+    question: str
+    status: str
+    claim_ids: list[str]
+    gap: str
+
+
+class NormalizedEvidence(NormalizedModel):
+    sources: list[NormalizedSource]
+    claims: list[NormalizedClaim]
+    requirements: list[NormalizedRequirement]
+    conflicts: list[dict[str, Any]]
+    gaps: list[dict[str, Any]]
+    records_text: str
+
+    def unresolved_requirement_ids(self) -> list[str]:
+        return [
+            requirement.requirement_id
+            for requirement in self.requirements
+            if requirement.status != "supported"
+        ]
+
+    def unresolved_conflict_ids(self) -> list[str]:
+        return [
+            conflict["conflict_id"]
+            for conflict in self.conflicts
+            if not (conflict.get("resolution") or "").strip()
+        ]
+
+    def receipt(self) -> dict[str, Any]:
+        """The evidence facts a finished run has to be able to show later."""
+        return {
+            "source_ids": [source.source_id for source in self.sources],
+            "claim_ids": [claim.claim_id for claim in self.claims],
+            "requirement_status": {
+                requirement.requirement_id: requirement.status
+                for requirement in self.requirements
+            },
+            "unresolved_requirement_ids": self.unresolved_requirement_ids(),
+            "unresolved_conflict_ids": self.unresolved_conflict_ids(),
+        }
+
+
+def _citation(source: EvidenceSource) -> str:
+    parts = [source.title]
+    if source.publisher:
+        parts.append(source.publisher)
+    if source.published_at:
+        parts.append(f"published {source.published_at.isoformat()}")
+    parts.append(f"retrieved {source.retrieved_at.isoformat()}")
+    if source.url:
+        parts.append(str(source.url))
+    return " — ".join(parts)
+
+
+def _normalize_source(source: EvidenceSource) -> NormalizedSource:
+    return NormalizedSource(
+        source_id=source.source_id,
+        title=source.title,
+        publisher=source.publisher,
+        url=str(source.url) if source.url else None,
+        published_at=source.published_at.isoformat() if source.published_at else None,
+        retrieved_at=source.retrieved_at.isoformat(),
+        source_type=source.source_type,
+        material_type=source.material_type,
+        # Notes are the researcher's exact words and are copied, never rewritten.
+        notes=list(source.notes),
+        citation=_citation(source),
+    )
+
+
+def _normalize_claim(claim: EvidenceClaim) -> NormalizedClaim:
+    return NormalizedClaim(
+        claim_id=claim.claim_id,
+        text=claim.text,
+        source_ids=list(claim.source_ids),
+        requirement_ids=list(claim.requirement_ids),
+        as_of=claim.as_of.isoformat() if claim.as_of else None,
+        confidence=claim.confidence,
+    )
+
+
+def _records_text(
+    sources: list[NormalizedSource],
+    claims: list[NormalizedClaim],
+    requirements: list[NormalizedRequirement],
+    conflicts: list[dict[str, Any]],
+    gaps: list[dict[str, Any]],
+) -> str:
+    lines: list[str] = ["SOURCES"]
+    if sources:
+        for source in sources:
+            lines.append(
+                f"- {source.source_id} | {source.citation} "
+                f"| type: {source.source_type} | material: {source.material_type}"
+            )
+            lines.extend(f"    note: {note}" for note in source.notes)
+    else:
+        lines.append("- None supplied.")
+
+    lines.append("")
+    lines.append("CLAIMS")
+    if claims:
+        for claim in claims:
+            as_of = f" | as of {claim.as_of}" if claim.as_of else ""
+            lines.append(
+                f"- {claim.claim_id} | {claim.text} "
+                f"| sources: {', '.join(claim.source_ids)} "
+                f"| requirements: {', '.join(claim.requirement_ids)}"
+                f"{as_of} | confidence: {claim.confidence}"
+            )
+    else:
+        lines.append("- None supplied.")
+
+    lines.append("")
+    lines.append("REQUIREMENT COVERAGE")
+    for requirement in requirements:
+        claim_ids = ", ".join(requirement.claim_ids) or "none"
+        gap = f" | gap: {requirement.gap}" if requirement.gap else ""
+        lines.append(
+            f"- {requirement.requirement_id} | {requirement.question} "
+            f"| status: {requirement.status} | claims: {claim_ids}{gap}"
+        )
+
+    lines.append("")
+    lines.append("CONFLICTS")
+    if conflicts:
+        for conflict in conflicts:
+            resolution = (conflict.get("resolution") or "").strip() or "unresolved"
+            lines.append(
+                f"- {conflict['conflict_id']} | {conflict['summary']} "
+                f"| claims: {', '.join(conflict['claim_ids'])} "
+                f"| resolution: {resolution}"
+            )
+    else:
+        lines.append("- None reported.")
+
+    lines.append("")
+    lines.append("REPORTED GAPS")
+    if gaps:
+        for gap in gaps:
+            lines.append(
+                f"- {gap['gap_id']} | {gap['summary']} "
+                f"| requirements: {', '.join(gap['requirement_ids'])}"
+            )
+    else:
+        lines.append("- None reported.")
+
+    return "\n".join(lines)
+
+
+def normalize_evidence(
+    commission: Prompt2BlogCommission,
+    evidence_package: EvidencePackage,
+) -> NormalizedEvidence:
+    """Reshapes an already-validated package into the records every stage reads."""
+    questions = {
+        requirement.requirement_id: requirement.question
+        for requirement in commission.requirements
+    }
+    missing_questions = [
+        requirement.requirement_id
+        for requirement in evidence_package.requirements
+        if requirement.requirement_id not in questions
+    ]
+    if missing_questions:
+        raise ValueError(
+            "evidence requirements are not part of the commission: "
+            f"{sorted(missing_questions)}"
+        )
+
+    sources = [_normalize_source(source) for source in evidence_package.sources]
+    claims = [_normalize_claim(claim) for claim in evidence_package.claims]
+    # Commission order is the authority; a researcher's ordering never
+    # reorders the locked requirements.
+    status_by_id = {
+        requirement.requirement_id: requirement
+        for requirement in evidence_package.requirements
+    }
+    requirements = [
+        NormalizedRequirement(
+            requirement_id=requirement.requirement_id,
+            question=requirement.question,
+            status=status_by_id[requirement.requirement_id].status,
+            claim_ids=list(status_by_id[requirement.requirement_id].claim_ids),
+            gap=status_by_id[requirement.requirement_id].gap,
+        )
+        for requirement in commission.requirements
+    ]
+    conflicts = [conflict.model_dump() for conflict in evidence_package.conflicts]
+    gaps = [gap.model_dump() for gap in evidence_package.gaps]
+
+    return NormalizedEvidence(
+        sources=sources,
+        claims=claims,
+        requirements=requirements,
+        conflicts=conflicts,
+        gaps=gaps,
+        records_text=_records_text(sources, claims, requirements, conflicts, gaps),
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -1,0 +1,256 @@
+"""Instruction assembly for Prompt2Blog v3.
+
+Replaces the v2 guideline fetch. Every writing stage reads one assembled stack
+whose precedence is explicit and fixed:
+
+    verified evidence → approved commission → article-form rules
+    → topic modules → audience guidance → house style
+
+A lower layer may refine emphasis. It can never add a subject, comparator,
+fact, or obligation that a higher layer did not authorize.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from .contracts_v3 import Prompt2BlogCommission, Prompt2BlogV3Request
+from .editorial_catalog import EditorialCatalog, load_editorial_catalog
+from .evidence_v3 import NormalizedEvidence, normalize_evidence
+
+INSTRUCTION_SCHEMA_VERSION = 3
+
+PRECEDENCE = (
+    "verified evidence",
+    "approved commission",
+    "article-form rules",
+    "topic modules",
+    "audience guidance",
+    "house style",
+)
+
+_HEADLINE_HEADING = "## Headline note"
+
+
+class InstructionModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class InstructionLayer(InstructionModel):
+    layer: str
+    title: str
+    body: str
+
+
+class V3InstructionSet(InstructionModel):
+    schema_version: int = INSTRUCTION_SCHEMA_VERSION
+    precedence: list[str]
+    layers: list[InstructionLayer]
+    instruction_text: str
+    headline_instructions: str
+    instruction_meta: dict[str, Any]
+
+
+def _precedence_block() -> str:
+    ordered = "\n".join(
+        f"{index}. {label}" for index, label in enumerate(PRECEDENCE, start=1)
+    )
+    return (
+        "AUTHORITY ORDER\n"
+        f"{ordered}\n"
+        "A lower layer may refine emphasis. It may never add a subject, "
+        "comparator, factual claim, or obligation that a higher layer did not "
+        "authorize."
+    )
+
+
+def _commission_body(commission: Prompt2BlogCommission) -> str:
+    references = "\n".join(
+        f"- {reference.name} — {reference.role}"
+        for reference in commission.scope.references
+    )
+    requirements = "\n".join(
+        f"- {requirement.requirement_id} — {requirement.question}"
+        for requirement in commission.requirements
+    )
+    exclusions = (
+        "\n".join(f"- {item}" for item in commission.exclusions) or "- None recorded."
+    )
+    tags = ", ".join(commission.audience.tags) or "none"
+    lines = [
+        f"Original title: {commission.original_title}",
+        f"Location: {commission.location}",
+        f"Approved direction: {commission.approved_direction}",
+        f"Primary subject: {commission.primary_subject}",
+        f"Scope mode: {commission.scope.mode}",
+        "References and roles:",
+        references,
+        f"Core reader question: {commission.core_reader_question}",
+        f"Reader outcome: {commission.reader_outcome}",
+        f"Primary reader: {commission.audience.primary_reader}",
+        f"Audience tags: {tags}",
+        "Requirements:",
+        requirements,
+        "Exclusions:",
+        exclusions,
+    ]
+    if commission.call_to_action:
+        lines.append(f"Call to action: {commission.call_to_action}")
+    lines.append(
+        "Context-only references may calibrate a fact or explain significance. "
+        "They may never become co-subjects, recurring sections, rankings, or "
+        "verdicts, and the approved form may not change."
+    )
+    return "\n".join(lines)
+
+
+def _evidence_body(evidence: NormalizedEvidence) -> str:
+    return (
+        "These records are the only permitted source of fact. Use them exactly: "
+        "preserve attribution, dates, units, geography, and stated uncertainty. "
+        "An unsupported requirement stays a visible gap; never invent a bridge "
+        "fact to close it.\n\n"
+        f"{evidence.records_text}"
+    )
+
+
+def _audience_body(
+    commission: Prompt2BlogCommission,
+    catalog: EditorialCatalog,
+) -> str:
+    tags_by_id = {tag.id: tag for tag in catalog.audience_tags}
+    lines = [f"Primary reader: {commission.audience.primary_reader}"]
+    if commission.audience.tags:
+        lines.append("Emphasis tags:")
+        lines.extend(
+            f"- {tags_by_id[tag_id].label} — {tags_by_id[tag_id].description}"
+            for tag_id in commission.audience.tags
+        )
+    else:
+        lines.append("Emphasis tags: none.")
+    lines.append(
+        "Tags adjust emphasis only. They do not change structure, scope, or the "
+        "approved form."
+    )
+    return "\n".join(lines)
+
+
+def _headline_note(form_instructions: str) -> str:
+    if _HEADLINE_HEADING not in form_instructions:
+        return ""
+    section = form_instructions.split(_HEADLINE_HEADING, 1)[1]
+    return section.split("\n## ", 1)[0].strip()
+
+
+def assemble_v3_instructions(
+    request: Prompt2BlogV3Request,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> V3InstructionSet:
+    """Builds the layered instruction stack for one approved commission."""
+    catalog = catalog or load_editorial_catalog()
+    commission = request.commission
+
+    form = next((item for item in catalog.forms if item.id == commission.form_id), None)
+    if form is None:
+        raise ValueError(f"Unknown article form: {commission.form_id}")
+
+    modules_by_id = {module.id: module for module in catalog.topic_modules}
+    unknown_modules = [
+        module_id
+        for module_id in commission.topic_module_ids
+        if module_id not in modules_by_id
+    ]
+    if unknown_modules:
+        raise ValueError(f"Unknown topic modules: {sorted(unknown_modules)}")
+    unknown_tags = [
+        tag_id
+        for tag_id in commission.audience.tags
+        if tag_id not in {tag.id for tag in catalog.audience_tags}
+    ]
+    if unknown_tags:
+        raise ValueError(f"Unknown audience tags: {sorted(unknown_tags)}")
+
+    # Catalog order, not commission order, so two runs with the same modules
+    # assemble byte-identical instructions.
+    active_modules = [
+        module
+        for module in catalog.topic_modules
+        if module.id in set(commission.topic_module_ids)
+    ]
+    evidence = normalize_evidence(commission, request.evidence_package)
+
+    layers = [
+        InstructionLayer(
+            layer="evidence",
+            title="VERIFIED EVIDENCE",
+            body=_evidence_body(evidence),
+        ),
+        InstructionLayer(
+            layer="commission",
+            title="APPROVED COMMISSION",
+            body=_commission_body(commission),
+        ),
+        InstructionLayer(
+            layer="form",
+            title=f"ARTICLE FORM — {form.label}",
+            body=form.instructions,
+        ),
+        InstructionLayer(
+            layer="topic_modules",
+            title="TOPIC MODULES",
+            body="\n\n".join(module.instructions for module in active_modules)
+            or "No topic module is active for this commission.",
+        ),
+        InstructionLayer(
+            layer="audience",
+            title="AUDIENCE GUIDANCE",
+            body=_audience_body(commission, catalog),
+        ),
+        InstructionLayer(
+            layer="house_style",
+            title="HOUSE STYLE",
+            body=catalog.house_rules.instructions,
+        ),
+    ]
+
+    instruction_text = "\n\n".join(
+        [_precedence_block()] + [f"{layer.title}\n{layer.body}" for layer in layers]
+    )
+    headline_note = _headline_note(form.instructions)
+    headline_instructions = "\n\n".join(
+        part
+        for part in (
+            catalog.headline_rules.instructions,
+            (
+                f"FORM HEADLINE NOTE — {form.label}\n{headline_note}"
+                if headline_note
+                else ""
+            ),
+            f"ORIGINAL TITLE (author intent, not a template)\n"
+            f"{commission.original_title}",
+        )
+        if part
+    )
+
+    return V3InstructionSet(
+        precedence=list(PRECEDENCE),
+        layers=layers,
+        instruction_text=instruction_text,
+        headline_instructions=headline_instructions,
+        instruction_meta={
+            "schema_version": INSTRUCTION_SCHEMA_VERSION,
+            "form_id": form.id,
+            "form_label": form.label,
+            "source_requirements": list(form.source_requirements),
+            "topic_module_ids": [module.id for module in active_modules],
+            "audience_tag_ids": list(commission.audience.tags),
+            "house_rules_id": catalog.house_rules.id,
+            "headline_rules_id": catalog.headline_rules.id,
+            "precedence": list(PRECEDENCE),
+            "commission_fingerprint": commission.commission_fingerprint,
+            "evidence_receipt": evidence.receipt(),
+        },
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.prompt2blog.contracts_v3 import (
+    EvidenceRequirement,
+    Prompt2BlogV3Request,
+)
+from app.features.prompt2blog.evidence_v3 import normalize_evidence
+from app.features.prompt2blog.instructions_v3 import (
+    PRECEDENCE,
+    assemble_v3_instructions,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v3.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _request(**overrides) -> Prompt2BlogV3Request:
+    fixture = _fixture()
+    payload = {
+        "schema_version": 3,
+        "commission": fixture["commission"],
+        "evidence_package": fixture["evidence_package"],
+        "profiles": {
+            "tone_id": "editorial",
+            "length_id": "standard",
+            "brand_voice_id": None,
+            "creativity_level": "medium",
+        },
+    }
+    payload.update(overrides)
+    return Prompt2BlogV3Request.model_validate(payload)
+
+
+def test_instruction_layers_follow_the_fixed_authority_order():
+    instructions = assemble_v3_instructions(_request())
+
+    assert [layer.layer for layer in instructions.layers] == [
+        "evidence",
+        "commission",
+        "form",
+        "topic_modules",
+        "audience",
+        "house_style",
+    ]
+    assert instructions.precedence == list(PRECEDENCE)
+    positions = [
+        instructions.instruction_text.index(layer.title)
+        for layer in instructions.layers
+    ]
+    assert positions == sorted(positions)
+    assert "may never add a subject" in instructions.instruction_text
+
+
+def test_commission_layer_locks_form_subject_scope_and_exclusions():
+    fixture = _fixture()
+    instructions = assemble_v3_instructions(_request())
+    commission_layer = next(
+        layer for layer in instructions.layers if layer.layer == "commission"
+    )
+
+    assert fixture["commission"]["original_title"] in commission_layer.body
+    assert "Primary subject: Lima" in commission_layer.body
+    assert "Scope mode: single_subject" in commission_layer.body
+    assert "- Medellín — context_only" in commission_layer.body
+    assert "never become co-subjects" in commission_layer.body
+    for exclusion in fixture["commission"]["exclusions"]:
+        assert exclusion in commission_layer.body
+    assert instructions.instruction_meta["form_id"] == "analysis"
+
+
+def test_only_the_commissioned_modules_and_tags_reach_the_stack():
+    instructions = assemble_v3_instructions(_request())
+    modules_layer = next(
+        layer for layer in instructions.layers if layer.layer == "topic_modules"
+    )
+    audience_layer = next(
+        layer for layer in instructions.layers if layer.layer == "audience"
+    )
+
+    assert instructions.instruction_meta["topic_module_ids"] == (
+        _fixture()["commission"]["topic_module_ids"]
+    )
+    assert "## Research questions" in modules_layer.body
+    assert "Safety" not in instructions.instruction_meta["topic_module_ids"]
+    assert "adjust emphasis only" in audience_layer.body
+
+
+def test_evidence_layer_preserves_publisher_url_dates_and_exact_notes():
+    fixture = _fixture()
+    source = fixture["evidence_package"]["sources"][0]
+    instructions = assemble_v3_instructions(_request())
+    evidence_layer = next(
+        layer for layer in instructions.layers if layer.layer == "evidence"
+    )
+
+    assert source["publisher"] in evidence_layer.body
+    assert source["url"].rstrip("/") in evidence_layer.body
+    assert source["retrieved_at"] in evidence_layer.body
+    for note in source["notes"]:
+        assert note in evidence_layer.body
+    assert "never invent a bridge" in evidence_layer.body
+
+
+def test_normalized_requirements_keep_commission_order_and_report_gaps():
+    request = _request()
+
+    evidence = normalize_evidence(request.commission, request.evidence_package)
+
+    assert [item.requirement_id for item in evidence.requirements] == [
+        item.requirement_id for item in request.commission.requirements
+    ]
+    assert evidence.unresolved_requirement_ids() == ["r2", "r3"]
+    receipt = evidence.receipt()
+    assert receipt["requirement_status"]["r1"] == "supported"
+    assert receipt["unresolved_requirement_ids"] == ["r2", "r3"]
+
+
+def test_headline_instructions_carry_the_original_title_and_form_note():
+    fixture = _fixture()
+
+    instructions = assemble_v3_instructions(_request())
+
+    assert fixture["commission"]["original_title"] in (
+        instructions.headline_instructions
+    )
+    assert "FORM HEADLINE NOTE — Analysis" in instructions.headline_instructions
+    assert "author intent, not a template" in instructions.headline_instructions
+
+
+def test_unknown_catalog_ids_fail_instead_of_silently_dropping():
+    # The request contract already rejects unknown IDs, so the assembler is
+    # forced past it to prove it fails loudly rather than dropping the module.
+    broken = _request().model_copy(deep=True)
+    broken.commission.topic_module_ids = ["not-a-module"]
+
+    with pytest.raises(ValueError, match="Unknown topic modules"):
+        assemble_v3_instructions(broken)
+
+
+def test_supported_requirement_cannot_also_declare_a_gap():
+    with pytest.raises(ValidationError, match="cannot describe a gap"):
+        EvidenceRequirement.model_validate(
+            {
+                "requirement_id": "r1",
+                "status": "supported",
+                "claim_ids": ["c1"],
+                "gap": "Still incomplete.",
+            }
+        )


### PR DESCRIPTION
## Why

First half of PR 4 of the Prompt2Blog v3 migration. The v3 request contract landed in #389 and the frontend now produces approved commissions with attached evidence. Before a v3 route can exist, the backend needs the two pure pieces it will call: evidence normalization and instruction assembly. This PR is those pieces and nothing else — no route, no graph, no runtime change.

## What

**`evidence_v3.py`** — normalizes a validated evidence package into the records every downstream stage reads.

- Publisher, URL, published/retrieved dates, and the researcher's exact notes are copied, never rewritten, so grounding compares a draft against what research actually returned.
- Requirements are emitted in *commission* order, so a research response cannot reorder locked work.
- Exposes unresolved requirement/conflict IDs and an evidence receipt for the finished run to persist.

**`instructions_v3.py`** — replaces the v2 guideline fetch with one layered stack in fixed authority order:

```
verified evidence → approved commission → article-form rules
→ topic modules → audience guidance → house style
```

- The stack states plainly that a lower layer may refine emphasis but may never add a subject, comparator, fact, or obligation a higher layer did not authorize.
- The commission layer carries the locked title, location, direction, subject, scope mode, reference roles, requirements, and exclusions, plus the rule that context-only references may calibrate a fact but never become co-subjects or sections.
- Only the commissioned modules and audience tags reach the stack, in catalog order, so the same commission assembles byte-identical instructions twice.
- Headline instructions carry the shared headline rules, the form's headline note, and the original title as author intent rather than a template.

**Contract alignment** — a `supported` requirement may no longer also declare a gap. The frontend importer already rejected that; the backend now agrees.

## Verification

- full backend suite: 808 collected, all passed (was 800; 8 new tests)
- `black` and `flake8` clean on every touched file — the one `E501` in `contracts_v3.py` is pre-existing and untouched, verified against the same file at `main`
- frontend untouched, so vitest was not re-run

## Boundaries

No route, no graph node, no stage change, and no v2 behavior change. Nothing here is reachable from a running pipeline yet — the `/pipeline-v3` intake, the versioned run artifacts, and the mock end-to-end contract test are the second half of PR 4.