### PR TITLE
Add the Prompt2Blog v3 intake route and runtime request

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -13,6 +13,8 @@ from app.core.staff_auth import require_staff, staff_user_id
 from app.shared.writer_models import resolve_writer_model
 
 from ..config import DEFAULT_MODEL, FEATURE_NAME
+from ..contracts_v3 import Prompt2BlogV3Request
+from ..intake_v3 import prepare_v3_runtime_request, v3_run_input_artifact
 from ..models import Prompt2BlogInputRequest
 from ..observability import _read_langgraph_trace
 from ..orchestrator import run_full_pipeline
@@ -129,6 +131,30 @@ async def start_full_run(
     )
     background_tasks.add_task(_run_full_pipeline_background, run_id, request)
     return JSONResponse({"message": "Prompt2Blog full run queued", "run_id": run_id})
+
+
+@router.post("/pipeline-v3/intake")
+async def prepare_pipeline_v3(
+    request: Prompt2BlogV3Request,
+    staff_user=Depends(require_staff),
+) -> JSONResponse:
+    """Validate an approved commission and assemble its v3 run input.
+
+    Intake is synchronous and starts nothing. V3 has no terminal state for
+    insufficient research yet, so queueing a run here would leave runs with
+    nowhere to finish; the readiness gate that gives them one lands next.
+    """
+    try:
+        runtime = prepare_v3_runtime_request(request)
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return JSONResponse(
+        {
+            "message": "Prompt2Blog v3 run input assembled",
+            "run_input": v3_run_input_artifact(runtime),
+        }
+    )
 
 
 @router.get("/status/{run_id}")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
-from ..models import PipelineV2RuntimeRequest, Prompt2BlogInputRequest
+from ..models import (
+    PipelineV2RuntimeRequest,
+    PipelineV3RuntimeRequest,
+    Prompt2BlogInputRequest,
+)
 
 
 class Prompt2BlogGraphState(TypedDict, total=False):
@@ -45,6 +49,43 @@ class Prompt2BlogGraphState(TypedDict, total=False):
     content_changed_by_augmentation: bool
     editorial_augmentation: dict[str, Any]
     editorial_augmentation_raw_response: str
+    final_title: str
+    final_markdown: str
+    response_payload: dict[str, Any]
+    completed: bool
+
+
+class Prompt2BlogV3GraphState(TypedDict, total=False):
+    """State for the v3 graph.
+
+    Kept separate from the v2 state on purpose. The v3 path carries the whole
+    commission, the exact evidence records, and one assembled instruction
+    stack; it has no article type, no guideline pair, and no supplemental
+    content, because v3 never synthesizes a missing fact.
+    """
+
+    run_id: str
+    request: PipelineV3RuntimeRequest
+    commission: dict[str, Any]
+    evidence: dict[str, Any]
+    instructions: dict[str, Any]
+    instruction_text: str
+    headline_instructions: str
+    option_context: dict[str, Any]
+    model_name: str
+    writing_model: str
+    audit_model: str
+    model_stack_id: str | None
+    compose_temperature: float
+    include_debug: bool
+    enable_editorial_augmentation: bool
+    current_stage: str
+    trace: list[dict[str, Any]]
+    readiness: dict[str, Any]
+    outline: dict[str, Any]
+    rewrite: dict[str, Any]
+    groundedness: dict[str, Any]
+    quality: dict[str, Any]
     final_title: str
     final_markdown: str
     response_payload: dict[str, Any]

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v3.py
@@ -1,0 +1,127 @@
+"""Prompt2Blog v3 intake.
+
+Turns an approved commission plus its verified evidence into the runtime
+request a v3 run will execute, and into the versioned run-input artifact a
+finished run has to be able to show. Nothing here calls a model, and nothing
+here flattens the commission or the evidence into v2 shapes: preserving both
+whole is the point of the migration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts_v3 import Prompt2BlogV3Request
+from .editorial_catalog import EditorialCatalog
+from .evidence_v3 import normalize_evidence
+from .instructions_v3 import INSTRUCTION_SCHEMA_VERSION, assemble_v3_instructions
+from .models import PipelineV3RuntimeRequest
+from .options import (
+    _default_option,
+    _find_option_or_raise,
+    _load_prompt2blog_option_catalog,
+)
+from .config import PROMPT2BLOG_CREATIVITY_LEVELS
+from .support import _safe_str
+
+RUN_INPUT_STAGE = "pipeline_input_v3"
+
+
+def resolve_v3_option_context(request: Prompt2BlogV3Request) -> dict[str, Any]:
+    """Resolves the writing profiles a v3 request names, or fails by name."""
+    catalog = _load_prompt2blog_option_catalog()
+    profiles = request.profiles
+
+    tone = _find_option_or_raise(
+        catalog.get("tones", []), profiles.tone_id, field_name="tone_id"
+    )
+    length = _find_option_or_raise(
+        catalog.get("lengths", []), profiles.length_id, field_name="length_id"
+    )
+    brand_voices = catalog.get("brand_voices", [])
+    if profiles.brand_voice_id:
+        brand_voice = _find_option_or_raise(
+            brand_voices, profiles.brand_voice_id, field_name="brand_voice_id"
+        )
+    else:
+        brand_voice = _default_option(brand_voices)
+        if not brand_voice:
+            raise RuntimeError("No brand voice options are configured.")
+
+    creativity_level = _safe_str(profiles.creativity_level).lower() or "medium"
+    if creativity_level not in PROMPT2BLOG_CREATIVITY_LEVELS:
+        raise RuntimeError(
+            "creativity_level must be one of: "
+            f"{', '.join(sorted(PROMPT2BLOG_CREATIVITY_LEVELS))}"
+        )
+
+    return {
+        "tone": tone,
+        "length": length,
+        "brand_voice": brand_voice,
+        "creativity_level": creativity_level,
+    }
+
+
+def prepare_v3_runtime_request(
+    request: Prompt2BlogV3Request,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> PipelineV3RuntimeRequest:
+    """Assembles one v3 runtime request without running or recording anything."""
+    option_context = resolve_v3_option_context(request)
+    instructions = assemble_v3_instructions(request, catalog=catalog)
+    evidence = normalize_evidence(request.commission, request.evidence_package)
+
+    return PipelineV3RuntimeRequest(
+        commission=request.commission.model_dump(mode="json"),
+        evidence=evidence.model_dump(mode="json"),
+        instructions=instructions.model_dump(mode="json"),
+        option_context=option_context,
+        include_debug=request.include_debug,
+        enable_editorial_augmentation=request.enable_editorial_augmentation,
+        model_name=request.model_routing.model_name,
+        writing_model=request.model_routing.writing_model,
+        audit_model=request.model_routing.audit_model,
+        model_stack_id=request.model_routing.model_stack_id,
+    )
+
+
+def v3_run_input_artifact(runtime: PipelineV3RuntimeRequest) -> dict[str, Any]:
+    """The versioned run-input record; readable without replaying the run."""
+    commission = runtime.commission
+    instructions = runtime.instructions
+    evidence = runtime.evidence
+    instruction_meta = instructions.get("instruction_meta", {})
+    return {
+        "schema_version": runtime.schema_version,
+        "instruction_schema_version": INSTRUCTION_SCHEMA_VERSION,
+        "commission_fingerprint": commission["commission_fingerprint"],
+        "original_title": commission["original_title"],
+        "location": commission["location"],
+        "form_id": commission["form_id"],
+        "topic_module_ids": list(commission["topic_module_ids"]),
+        "audience": commission["audience"],
+        "scope_mode": commission["scope"]["mode"],
+        "requirement_ids": [
+            requirement["requirement_id"] for requirement in commission["requirements"]
+        ],
+        "precedence": list(instructions.get("precedence", [])),
+        "instruction_meta": instruction_meta,
+        "evidence_receipt": instruction_meta.get("evidence_receipt", {}),
+        "source_ids": [source["source_id"] for source in evidence["sources"]],
+        "profiles": {
+            "tone_id": runtime.option_context["tone"]["id"],
+            "length_id": runtime.option_context["length"]["id"],
+            "brand_voice_id": runtime.option_context["brand_voice"]["id"],
+            "creativity_level": runtime.option_context["creativity_level"],
+        },
+        "model_routing": {
+            "model_name": runtime.model_name,
+            "writing_model": runtime.writing_model,
+            "audit_model": runtime.audit_model,
+            "model_stack_id": runtime.model_stack_id,
+        },
+        "include_debug": runtime.include_debug,
+        "enable_editorial_augmentation": runtime.enable_editorial_augmentation,
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
@@ -51,6 +51,26 @@ class PipelineV2RuntimeRequest(BaseModel):
     model_stack_id: str | None = None
 
 
+class PipelineV3RuntimeRequest(BaseModel):
+    """Everything a v3 run needs, derived only from an approved commission.
+
+    Deliberately not a flattened v2 request: the commission and the exact
+    evidence records stay whole so no stage has to reconstruct them.
+    """
+
+    schema_version: int = 3
+    commission: dict[str, Any]
+    evidence: dict[str, Any]
+    instructions: dict[str, Any]
+    option_context: dict[str, Any] = Field(default_factory=dict)
+    include_debug: bool = True
+    enable_editorial_augmentation: bool = False
+    model_name: str | None = None
+    writing_model: str | None = None
+    audit_model: str | None = None
+    model_stack_id: str | None = None
+
+
 class Prompt2BlogInputRequest(BaseModel):
     article_type_id: int
     source_material: List[str] = Field(default_factory=list)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/routes.py
@@ -5,12 +5,14 @@ from .api import generation as _generation_api
 from .api import options as _options_api
 from .api import runs as _runs_api
 from .api.router import router
+from .contracts_v3 import Prompt2BlogV3Request  # noqa: F401
 from .models import (  # noqa: F401
     ArticleTypeOption,
     ClassificationResult,
     ClassifyRequest,
     ClassifyResponse,
     PipelineV2RuntimeRequest,
+    PipelineV3RuntimeRequest,
     Prompt2BlogInputRequest,
     SynthesizeRequest,
     SynthesizeResponse,
@@ -44,6 +46,13 @@ async def start_pipeline_v2(
     staff_user=None,
 ):
     return await _runs_api.start_pipeline_v2(request, background_tasks, staff_user)
+
+
+async def prepare_pipeline_v3(
+    request: Prompt2BlogV3Request,
+    staff_user=None,
+):
+    return await _runs_api.prepare_pipeline_v3(request, staff_user)
 
 
 async def start_full_run(
@@ -90,6 +99,7 @@ __all__ = [
     "get_editorial_options",
     "get_article_type_guideline_preview",
     "start_pipeline_v2",
+    "prepare_pipeline_v3",
     "start_full_run",
     "get_status",
     "get_result",

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
@@ -1,0 +1,171 @@
+"""Prompt2Blog v3 intake contract."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+import app.features.prompt2blog.routes as prompt2blog_routes
+from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
+from app.features.prompt2blog.intake_v3 import (
+    prepare_v3_runtime_request,
+    v3_run_input_artifact,
+)
+from tests.prompt2blog_test_support import response_payload
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v3.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _payload(**overrides) -> dict:
+    fixture = _fixture()
+    payload = {
+        "schema_version": 3,
+        "commission": fixture["commission"],
+        "evidence_package": fixture["evidence_package"],
+        "profiles": {
+            "tone_id": "editorial",
+            "length_id": "medium",
+            "creativity_level": "medium",
+        },
+        "model_routing": {"writing_model": "test-writer"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _request(**overrides) -> Prompt2BlogV3Request:
+    return Prompt2BlogV3Request.model_validate(_payload(**overrides))
+
+
+def _intake(payload: dict) -> dict:
+    return response_payload(
+        asyncio.run(
+            prompt2blog_routes.prepare_pipeline_v3(
+                Prompt2BlogV3Request.model_validate(payload)
+            )
+        )
+    )
+
+
+def test_intake_returns_a_versioned_run_input_for_the_approved_commission():
+    fixture = _fixture()
+
+    payload = _intake(_payload())
+    run_input = payload["run_input"]
+
+    assert payload["message"] == "Prompt2Blog v3 run input assembled"
+    assert run_input["schema_version"] == 3
+    assert run_input["instruction_schema_version"] == 3
+    assert (
+        run_input["commission_fingerprint"]
+        == fixture["commission"]["commission_fingerprint"]
+    )
+    assert run_input["original_title"] == fixture["commission"]["original_title"]
+    assert run_input["location"] == fixture["commission"]["location"]
+    assert run_input["form_id"] == "analysis"
+    assert run_input["scope_mode"] == "single_subject"
+    assert run_input["requirement_ids"] == ["r1", "r2", "r3"]
+    assert run_input["precedence"][0] == "verified evidence"
+    assert run_input["precedence"][-1] == "house style"
+
+
+def test_run_input_records_the_evidence_receipt_and_resolved_profiles():
+    run_input = _intake(_payload())["run_input"]
+
+    receipt = run_input["evidence_receipt"]
+    assert receipt["requirement_status"] == {
+        "r1": "supported",
+        "r2": "missing",
+        "r3": "missing",
+    }
+    assert receipt["unresolved_requirement_ids"] == ["r2", "r3"]
+    assert run_input["source_ids"] == receipt["source_ids"]
+    assert run_input["profiles"]["tone_id"] == "editorial"
+    assert run_input["profiles"]["length_id"] == "medium"
+    assert run_input["profiles"]["brand_voice_id"]
+    assert run_input["model_routing"]["writing_model"] == "test-writer"
+
+
+def test_runtime_request_keeps_the_commission_and_evidence_whole():
+    fixture = _fixture()
+
+    runtime = prepare_v3_runtime_request(_request())
+
+    assert runtime.commission == fixture["commission"]
+    source = runtime.evidence["sources"][0]
+    original = fixture["evidence_package"]["sources"][0]
+    assert source["publisher"] == original["publisher"]
+    assert source["published_at"] == original["published_at"]
+    assert source["retrieved_at"] == original["retrieved_at"]
+    assert source["notes"] == original["notes"]
+    assert original["url"].rstrip("/") in source["url"]
+    # A v2 field must not reappear under a new name.
+    assert "source_material" not in runtime.model_dump()
+    assert "article_type_id" not in runtime.model_dump()
+
+
+def test_intake_rejects_an_unknown_writing_profile_by_name():
+    payload = _payload()
+    payload["profiles"]["tone_id"] = "not-a-tone"
+
+    with pytest.raises(HTTPException) as excinfo:
+        _intake(payload)
+
+    assert excinfo.value.status_code == 400
+    assert "tone_id" in str(excinfo.value.detail)
+
+
+def test_intake_rejects_evidence_from_a_different_commission():
+    payload = _payload()
+    evidence = deepcopy(payload["evidence_package"])
+    evidence["commission_fingerprint"] = "b" * 64
+    payload["evidence_package"] = evidence
+
+    with pytest.raises(ValidationError, match="fingerprint must match commission"):
+        _intake(payload)
+
+
+def test_intake_cannot_be_used_to_change_the_commission():
+    fixture = _fixture()
+    payload = _payload()
+    # A research response that tries to promote a context-only city has to be
+    # refused by the contract, not normalized into an accepted commission.
+    commission = deepcopy(payload["commission"])
+    commission["scope"]["references"][1]["role"] = "comparator"
+    payload["commission"] = commission
+
+    with pytest.raises(ValidationError):
+        _intake(payload)
+
+    unchanged = _intake(_payload())["run_input"]
+    assert (
+        unchanged["commission_fingerprint"]
+        == fixture["commission"]["commission_fingerprint"]
+    )
+
+
+def test_v3_run_input_does_not_reintroduce_v2_shapes():
+    runtime = prepare_v3_runtime_request(_request())
+
+    artifact = v3_run_input_artifact(runtime)
+
+    assert "article_type_id" not in artifact
+    assert "guideline" not in artifact
+    assert artifact["instruction_meta"]["house_rules_id"] == "house-rules"
+    assert artifact["instruction_meta"]["headline_rules_id"] == "headlines"


### PR DESCRIPTION
## Why

Second half of PR 4. #395 added evidence normalization and instruction assembly as pure functions; this PR gives them an entry point — a versioned backend path that accepts an approved commission with its verified evidence, in parallel with the untouched v2 route.

## What

- `PipelineV3RuntimeRequest` and `Prompt2BlogV3GraphState`. Both deliberately carry the commission whole, the exact evidence records, and one assembled instruction stack. Neither has an article type, a guideline pair, or supplemental content — v3 never synthesizes a missing fact, so there is nothing for those fields to hold.
- `intake_v3.py` resolves the v3 writing profiles against the existing option catalog (failing by field name), assembles instructions, normalizes evidence, and produces the versioned run-input artifact.
- `POST /prompt2blog/pipeline-v3/intake`, staff-guarded like the other run routes.
- The run input records the evidence receipt (per-requirement status, unresolved requirements and conflicts) and the instruction meta (form, modules, audience tags, house/headline rule IDs, precedence), so a finished run can be audited later without replaying it.

**One deliberate deviation from the plan, worth reviewing.** The plan describes `/pipeline-v3` as a request route. This intake is **synchronous and starts nothing**. V3 has no terminal state for insufficient research until the readiness gate lands in PR 5, so queueing a run here would put runs on `main` with nowhere to finish. The endpoint validates and assembles; PR 5 turns it into a real run entry point once `needs_research` exists to receive one.

## Verification

- full backend suite: 815 collected, all passed (was 808; 7 new tests)
- `black` and `flake8` clean on every touched file
- frontend untouched, so vitest was not re-run

Tests drive the route functions directly rather than through the ASGI app, matching the existing Prompt2Blog route tests.

## Boundaries

The v2 routes, request shape, graph, stages, and artifacts are untouched, and no UI submits to the new path. Evidence that does not belong to the commission, and a commission that tries to promote a context-only reference to a comparator, are both refused by the contract rather than normalized into something acceptable.