### PR TITLE
Stop Prompt2Blog v3 runs on insufficient research

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -18,6 +18,7 @@ bounded contexts.
 | `models.py`, `contracts_v3.py` | Versioned HTTP requests, editorial contracts, and runtime pipeline input |
 | `config.py`, `options.py`, `editorial_catalog.py` | Feature constants plus legacy and v3 Markdown-backed catalogs |
 | `evidence_v3.py`, `instructions_v3.py` | V3 evidence normalization and the layered instruction stack |
+| `research_readiness_v3.py`, `intake_v3.py` | The v3 research gate, its `needs_research` result, and v3 run input |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -14,7 +14,7 @@ from app.shared.writer_models import resolve_writer_model
 
 from ..config import DEFAULT_MODEL, FEATURE_NAME
 from ..contracts_v3 import Prompt2BlogV3Request
-from ..intake_v3 import prepare_v3_runtime_request, v3_run_input_artifact
+from ..intake_v3 import v3_intake_result
 from ..models import Prompt2BlogInputRequest
 from ..observability import _read_langgraph_trace
 from ..orchestrator import run_full_pipeline
@@ -138,23 +138,23 @@ async def prepare_pipeline_v3(
     request: Prompt2BlogV3Request,
     staff_user=Depends(require_staff),
 ) -> JSONResponse:
-    """Validate an approved commission and assemble its v3 run input.
+    """Validate an approved commission, gate it on research, assemble its input.
 
-    Intake is synchronous and starts nothing. V3 has no terminal state for
-    insufficient research yet, so queueing a run here would leave runs with
-    nowhere to finish; the readiness gate that gives them one lands next.
+    Intake is synchronous and starts nothing. Insufficient research terminates
+    here as `needs_research` — a product state, not a failure — before any
+    writing work exists to spend a token on.
     """
     try:
-        runtime = prepare_v3_runtime_request(request)
+        result = v3_intake_result(request)
     except (RuntimeError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    return JSONResponse(
-        {
-            "message": "Prompt2Blog v3 run input assembled",
-            "run_input": v3_run_input_artifact(runtime),
-        }
+    message = (
+        "Prompt2Blog v3 run input assembled"
+        if result["status"] == "ready"
+        else "Prompt2Blog v3 commission needs more research"
     )
+    return JSONResponse({"message": message, **result})
 
 
 @router.get("/status/{run_id}")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v3.py
@@ -13,9 +13,14 @@ from typing import Any
 
 from .contracts_v3 import Prompt2BlogV3Request
 from .editorial_catalog import EditorialCatalog
-from .evidence_v3 import normalize_evidence
+from .evidence_v3 import NormalizedEvidence, normalize_evidence
 from .instructions_v3 import INSTRUCTION_SCHEMA_VERSION, assemble_v3_instructions
 from .models import PipelineV3RuntimeRequest
+from .research_readiness_v3 import (
+    ResearchReadiness,
+    assess_research_readiness,
+    needs_research_payload,
+)
 from .options import (
     _default_option,
     _find_option_or_raise,
@@ -124,4 +129,40 @@ def v3_run_input_artifact(runtime: PipelineV3RuntimeRequest) -> dict[str, Any]:
         },
         "include_debug": runtime.include_debug,
         "enable_editorial_augmentation": runtime.enable_editorial_augmentation,
+    }
+
+
+def v3_readiness(
+    request: Prompt2BlogV3Request,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> tuple[NormalizedEvidence, ResearchReadiness]:
+    """Runs the research gate for one request without touching a model."""
+    evidence = normalize_evidence(request.commission, request.evidence_package)
+    return evidence, assess_research_readiness(
+        request.commission, evidence, catalog=catalog
+    )
+
+
+def v3_intake_result(
+    request: Prompt2BlogV3Request,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> dict[str, Any]:
+    """Assembles a run input, or reports the research that has to happen first.
+
+    Insufficient research is a product state, not an error: it terminates here,
+    before any instruction assembly or writing work, and reports exactly what
+    is missing plus the prompt that closes it.
+    """
+    evidence, readiness = v3_readiness(request, catalog=catalog)
+    if not readiness.ready:
+        return needs_research_payload(
+            request.commission, evidence, readiness, catalog=catalog
+        )
+
+    runtime = prepare_v3_runtime_request(request, catalog=catalog)
+    return {
+        "status": "ready",
+        "run_input": v3_run_input_artifact(runtime),
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_readiness_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_readiness_v3.py
@@ -1,0 +1,300 @@
+"""Research readiness for Prompt2Blog v3.
+
+The gate that makes thin research stop a run instead of starting one. It is
+entirely deterministic: it can diagnose what is missing, and it can never write
+the missing fact. `needs_research` is a real product state, not a failure, and
+reaching it must not spend a single writer-model token.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from .contracts_v3 import Prompt2BlogCommission
+from .editorial_catalog import (
+    ArticleFormRule,
+    EditorialCatalog,
+    SourceRequirement,
+    load_editorial_catalog,
+)
+from .evidence_v3 import NormalizedEvidence, NormalizedSource
+
+ReadinessStatus = Literal["ready", "needs_research"]
+FindingCode = Literal["requirement_gap", "unresolved_conflict", "source_gate"]
+
+_ATTRIBUTABLE_VOICE = {"transcript", "interview-responses"}
+
+
+class ReadinessModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ReadinessFinding(ReadinessModel):
+    code: FindingCode
+    requirement_ids: list[str]
+    message: str
+
+
+class ResearchReadiness(ReadinessModel):
+    status: ReadinessStatus
+    findings: list[ReadinessFinding]
+    unresolved_requirement_ids: list[str]
+    unresolved_conflict_ids: list[str]
+    missing_source_requirements: list[str]
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+
+def evidence_satisfies_source_requirement(
+    requirement: SourceRequirement,
+    sources: list[NormalizedSource],
+) -> bool:
+    """Mirrors the composer's gate so a package cannot pass one side only."""
+    if requirement == "reported-people-scenes-quotations":
+        has_attributable_voice = any(
+            source.material_type in _ATTRIBUTABLE_VOICE for source in sources
+        )
+        has_documented_scene = any(
+            source.source_type in {"reporting", "firsthand"} for source in sources
+        )
+        return has_attributable_voice and has_documented_scene
+    if requirement == "attributable-responses":
+        return any(source.material_type in _ATTRIBUTABLE_VOICE for source in sources)
+    if requirement == "first-person-material":
+        return any(source.material_type == "first-person-notes" for source in sources)
+    return any(
+        source.material_type == "evaluation-notes" or source.source_type == "firsthand"
+        for source in sources
+    )
+
+
+def _form_rule(
+    commission: Prompt2BlogCommission,
+    catalog: EditorialCatalog,
+) -> ArticleFormRule:
+    form = next((item for item in catalog.forms if item.id == commission.form_id), None)
+    if form is None:
+        raise ValueError(f"Unknown article form: {commission.form_id}")
+    return form
+
+
+def assess_research_readiness(
+    commission: Prompt2BlogCommission,
+    evidence: NormalizedEvidence,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> ResearchReadiness:
+    """Reports every reason this evidence cannot support this commission."""
+    catalog = catalog or load_editorial_catalog()
+    form = _form_rule(commission, catalog)
+
+    findings: list[ReadinessFinding] = []
+    for requirement in evidence.requirements:
+        if requirement.status == "supported":
+            continue
+        findings.append(
+            ReadinessFinding(
+                code="requirement_gap",
+                requirement_ids=[requirement.requirement_id],
+                message=requirement.gap
+                or f"Requirement {requirement.requirement_id} is incomplete.",
+            )
+        )
+
+    claims_by_id = {claim.claim_id: claim for claim in evidence.claims}
+    for conflict in evidence.conflicts:
+        if (conflict.get("resolution") or "").strip():
+            continue
+        requirement_ids = sorted(
+            {
+                requirement_id
+                for claim_id in conflict["claim_ids"]
+                for requirement_id in (
+                    claims_by_id[claim_id].requirement_ids
+                    if claim_id in claims_by_id
+                    else []
+                )
+            }
+        )
+        findings.append(
+            ReadinessFinding(
+                code="unresolved_conflict",
+                requirement_ids=requirement_ids,
+                message=conflict["summary"],
+            )
+        )
+
+    missing_gates = [
+        requirement
+        for requirement in form.source_requirements
+        if not evidence_satisfies_source_requirement(requirement, evidence.sources)
+    ]
+    findings.extend(
+        ReadinessFinding(
+            code="source_gate",
+            requirement_ids=[],
+            message=f"The {form.id} form still needs {requirement}.",
+        )
+        for requirement in missing_gates
+    )
+
+    return ResearchReadiness(
+        status="needs_research" if findings else "ready",
+        findings=findings,
+        unresolved_requirement_ids=evidence.unresolved_requirement_ids(),
+        unresolved_conflict_ids=evidence.unresolved_conflict_ids(),
+        missing_source_requirements=list(missing_gates),
+    )
+
+
+def build_follow_up_research_prompt(
+    commission: Prompt2BlogCommission,
+    evidence: NormalizedEvidence,
+    readiness: ResearchReadiness,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> str:
+    """Builds the prompt that closes exactly the gaps the gate reported."""
+    catalog = catalog or load_editorial_catalog()
+    form = _form_rule(commission, catalog)
+    modules_by_id = {module.id: module for module in catalog.topic_modules}
+
+    unresolved_ids = set(readiness.unresolved_requirement_ids)
+    for finding in readiness.findings:
+        unresolved_ids.update(finding.requirement_ids)
+    for gap in evidence.gaps:
+        unresolved_ids.update(gap["requirement_ids"])
+
+    requirement_lines = (
+        "\n".join(
+            f"- {requirement.requirement_id} — {requirement.question}"
+            for requirement in commission.requirements
+            if requirement.requirement_id in unresolved_ids
+        )
+        or "- None beyond the source-gate or conflict work below."
+    )
+    conflict_lines = (
+        "\n".join(
+            f"- {conflict['conflict_id']} — {conflict['summary']}"
+            for conflict in evidence.conflicts
+            if not (conflict.get("resolution") or "").strip()
+        )
+        or "- None."
+    )
+    finding_lines = (
+        "\n".join(
+            f"- {finding.code} — {finding.message}"
+            + (
+                f" [requirements: {', '.join(finding.requirement_ids)}]"
+                if finding.requirement_ids
+                else ""
+            )
+            for finding in readiness.findings
+        )
+        or "- None."
+    )
+    gate_lines = (
+        "\n".join(
+            f"- {requirement}"
+            + (
+                " — unresolved"
+                if requirement in readiness.missing_source_requirements
+                else " — already satisfied; preserve the supporting evidence"
+            )
+            for requirement in form.source_requirements
+        )
+        or "- None."
+    )
+    module_lines = (
+        "\n".join(
+            f"- {modules_by_id[module_id].id} ({modules_by_id[module_id].label}) — "
+            f"{modules_by_id[module_id].description}"
+            for module_id in commission.topic_module_ids
+            if module_id in modules_by_id
+        )
+        or "- None."
+    )
+    locked_commission = json.dumps(
+        commission.model_dump(mode="json"), indent=2, ensure_ascii=False
+    )
+
+    return f"""You are completing unresolved research for an approved travel commission. Return a complete replacement evidence package, not a patch.
+
+AUTHORITY LOCK
+The locked commission remains read-only authority.
+- Keep commission_fingerprint exactly as supplied.
+- Do not change the form, primary subject, scope, reference roles, requirements, exclusions, audience, title, location, or approved direction.
+- Do not add a comparator, promote a context-only reference, or broaden scope.
+- Research only the unresolved work listed below. Do not write the article.
+
+LOCKED COMMISSION
+{locked_commission}
+
+CURRENT EVIDENCE RECORDS
+{evidence.records_text}
+
+UNRESOLVED REQUIREMENTS ONLY
+{requirement_lines}
+
+UNRESOLVED CONFLICTS ONLY
+{conflict_lines}
+
+READINESS FINDINGS
+{finding_lines}
+
+ACTIVE FORM SOURCE GATES
+{gate_lines}
+Meet unresolved gates with genuine matching material. Never simulate interviews, first-person experience, documented evaluation, scenes, or quotations.
+
+ACTIVE TOPIC MODULES
+{module_lines}
+
+REPLACEMENT RULES
+- Do not redo or weaken already supported work. Preserve valid existing sources, claims, requirement links, dates, metadata, and resolved conflicts.
+- Add or revise only what is needed to close the listed requirements, conflicts, findings, and source gates.
+- Use partial or missing honestly when the follow-up still cannot close a gap.
+- Keep every locked requirement exactly once in requirements, including already supported requirements.
+- Keep source and claim mappings resolvable in both directions. Web and report sources require publisher and URL.
+- Preserve exact material_type so source-gate readiness stays deterministic."""
+
+
+def needs_research_payload(
+    commission: Prompt2BlogCommission,
+    evidence: NormalizedEvidence,
+    readiness: ResearchReadiness,
+    *,
+    catalog: EditorialCatalog | None = None,
+) -> dict[str, Any]:
+    """The terminal result a stopped run reports. No writing stage has run."""
+    catalog = catalog or load_editorial_catalog()
+    questions = {
+        requirement.requirement_id: requirement.question
+        for requirement in commission.requirements
+    }
+    gaps_by_requirement = {
+        requirement.requirement_id: requirement.gap
+        for requirement in evidence.requirements
+    }
+    return {
+        "status": "needs_research",
+        "commission_fingerprint": commission.commission_fingerprint,
+        "findings": [finding.model_dump() for finding in readiness.findings],
+        "unresolved_requirements": [
+            {
+                "requirement_id": requirement_id,
+                "question": questions[requirement_id],
+                "gap": gaps_by_requirement.get(requirement_id, ""),
+            }
+            for requirement_id in readiness.unresolved_requirement_ids
+        ],
+        "unresolved_conflict_ids": list(readiness.unresolved_conflict_ids),
+        "missing_source_requirements": list(readiness.missing_source_requirements),
+        "follow_up_research_prompt": build_follow_up_research_prompt(
+            commission, evidence, readiness, catalog=catalog
+        ),
+    }

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
@@ -49,6 +49,42 @@ def _payload(**overrides) -> dict:
     return payload
 
 
+def _ready_evidence() -> dict:
+    """The fixture package with every locked requirement genuinely supported."""
+    evidence = deepcopy(_fixture()["evidence_package"])
+    evidence["claims"].extend(
+        [
+            {
+                "claim_id": "c2",
+                "text": "Current reporting documents Lima's practical tradeoffs.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r2"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+            {
+                "claim_id": "c3",
+                "text": "Comparable earlier reporting shows how those costs moved.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r3"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+        ]
+    )
+    evidence["requirements"] = [
+        {"requirement_id": "r1", "status": "supported", "claim_ids": ["c1"], "gap": ""},
+        {"requirement_id": "r2", "status": "supported", "claim_ids": ["c2"], "gap": ""},
+        {"requirement_id": "r3", "status": "supported", "claim_ids": ["c3"], "gap": ""},
+    ]
+    evidence["gaps"] = []
+    return evidence
+
+
+def _ready_payload(**overrides) -> dict:
+    return _payload(evidence_package=_ready_evidence(), **overrides)
+
+
 def _request(**overrides) -> Prompt2BlogV3Request:
     return Prompt2BlogV3Request.model_validate(_payload(**overrides))
 
@@ -66,7 +102,7 @@ def _intake(payload: dict) -> dict:
 def test_intake_returns_a_versioned_run_input_for_the_approved_commission():
     fixture = _fixture()
 
-    payload = _intake(_payload())
+    payload = _intake(_ready_payload())
     run_input = payload["run_input"]
 
     assert payload["message"] == "Prompt2Blog v3 run input assembled"
@@ -86,15 +122,15 @@ def test_intake_returns_a_versioned_run_input_for_the_approved_commission():
 
 
 def test_run_input_records_the_evidence_receipt_and_resolved_profiles():
-    run_input = _intake(_payload())["run_input"]
+    run_input = _intake(_ready_payload())["run_input"]
 
     receipt = run_input["evidence_receipt"]
     assert receipt["requirement_status"] == {
         "r1": "supported",
-        "r2": "missing",
-        "r3": "missing",
+        "r2": "supported",
+        "r3": "supported",
     }
-    assert receipt["unresolved_requirement_ids"] == ["r2", "r3"]
+    assert receipt["unresolved_requirement_ids"] == []
     assert run_input["source_ids"] == receipt["source_ids"]
     assert run_input["profiles"]["tone_id"] == "editorial"
     assert run_input["profiles"]["length_id"] == "medium"
@@ -105,7 +141,7 @@ def test_run_input_records_the_evidence_receipt_and_resolved_profiles():
 def test_runtime_request_keeps_the_commission_and_evidence_whole():
     fixture = _fixture()
 
-    runtime = prepare_v3_runtime_request(_request())
+    runtime = prepare_v3_runtime_request(_request(evidence_package=_ready_evidence()))
 
     assert runtime.commission == fixture["commission"]
     source = runtime.evidence["sources"][0]
@@ -121,7 +157,7 @@ def test_runtime_request_keeps_the_commission_and_evidence_whole():
 
 
 def test_intake_rejects_an_unknown_writing_profile_by_name():
-    payload = _payload()
+    payload = _ready_payload()
     payload["profiles"]["tone_id"] = "not-a-tone"
 
     with pytest.raises(HTTPException) as excinfo:
@@ -153,7 +189,7 @@ def test_intake_cannot_be_used_to_change_the_commission():
     with pytest.raises(ValidationError):
         _intake(payload)
 
-    unchanged = _intake(_payload())["run_input"]
+    unchanged = _intake(_ready_payload())["run_input"]
     assert (
         unchanged["commission_fingerprint"]
         == fixture["commission"]["commission_fingerprint"]
@@ -161,7 +197,7 @@ def test_intake_cannot_be_used_to_change_the_commission():
 
 
 def test_v3_run_input_does_not_reintroduce_v2_shapes():
-    runtime = prepare_v3_runtime_request(_request())
+    runtime = prepare_v3_runtime_request(_request(evidence_package=_ready_evidence()))
 
     artifact = v3_run_input_artifact(runtime)
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
@@ -1,0 +1,210 @@
+"""The v3 research gate: insufficient evidence stops before any writing."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import app.features.prompt2blog.llm as prompt2blog_llm
+from app.features.prompt2blog.graph.state import Prompt2BlogV3GraphState
+import app.features.prompt2blog.routes as prompt2blog_routes
+from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
+from app.features.prompt2blog.evidence_v3 import normalize_evidence
+from app.features.prompt2blog.research_readiness_v3 import (
+    assess_research_readiness,
+    build_follow_up_research_prompt,
+)
+from tests.prompt2blog_test_support import response_payload
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v3.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _payload(commission: dict | None = None, evidence: dict | None = None) -> dict:
+    fixture = _fixture()
+    return {
+        "schema_version": 3,
+        "commission": commission or fixture["commission"],
+        "evidence_package": evidence or fixture["evidence_package"],
+        "profiles": {
+            "tone_id": "editorial",
+            "length_id": "medium",
+            "creativity_level": "medium",
+        },
+    }
+
+
+def _request(**kwargs) -> Prompt2BlogV3Request:
+    return Prompt2BlogV3Request.model_validate(_payload(**kwargs))
+
+
+def _assess(request: Prompt2BlogV3Request):
+    evidence = normalize_evidence(request.commission, request.evidence_package)
+    return evidence, assess_research_readiness(request.commission, evidence)
+
+
+def _supported_evidence() -> dict:
+    evidence = deepcopy(_fixture()["evidence_package"])
+    evidence["claims"].extend(
+        [
+            {
+                "claim_id": "c2",
+                "text": "Current reporting documents Lima's practical tradeoffs.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r2"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+            {
+                "claim_id": "c3",
+                "text": "Comparable earlier reporting shows how those costs moved.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r3"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+        ]
+    )
+    evidence["requirements"] = [
+        {"requirement_id": "r1", "status": "supported", "claim_ids": ["c1"], "gap": ""},
+        {"requirement_id": "r2", "status": "supported", "claim_ids": ["c2"], "gap": ""},
+        {"requirement_id": "r3", "status": "supported", "claim_ids": ["c3"], "gap": ""},
+    ]
+    evidence["gaps"] = []
+    return evidence
+
+
+def test_incomplete_research_is_not_ready_and_names_every_gap():
+    evidence, readiness = _assess(_request())
+
+    assert readiness.status == "needs_research"
+    assert readiness.unresolved_requirement_ids == ["r2", "r3"]
+    assert [finding.requirement_ids for finding in readiness.findings] == [
+        ["r2"],
+        ["r3"],
+    ]
+    assert all(finding.code == "requirement_gap" for finding in readiness.findings)
+    assert evidence.requirements[0].status == "supported"
+
+
+def test_fully_supported_research_is_ready():
+    _evidence, readiness = _assess(_request(evidence=_supported_evidence()))
+
+    assert readiness.status == "ready"
+    assert readiness.findings == []
+    assert readiness.missing_source_requirements == []
+
+
+def test_an_unresolved_conflict_blocks_a_fully_supported_package():
+    evidence = _supported_evidence()
+    evidence["conflicts"] = [
+        {
+            "conflict_id": "x1",
+            "claim_ids": ["c1", "c2"],
+            "summary": "Two cost baselines disagree.",
+            "resolution": None,
+        }
+    ]
+
+    _normalized, readiness = _assess(_request(evidence=evidence))
+
+    assert readiness.status == "needs_research"
+    conflict = next(
+        finding
+        for finding in readiness.findings
+        if finding.code == "unresolved_conflict"
+    )
+    assert conflict.requirement_ids == ["r1", "r2"]
+    assert readiness.unresolved_conflict_ids == ["x1"]
+
+
+def test_a_source_gated_form_blocks_evidence_without_matching_material():
+    commission = deepcopy(_fixture()["commission"])
+    commission["form_id"] = "interview-qa"
+
+    _normalized, readiness = _assess(
+        _request(commission=commission, evidence=_supported_evidence())
+    )
+
+    assert readiness.missing_source_requirements == ["attributable-responses"]
+    gate = next(
+        finding for finding in readiness.findings if finding.code == "source_gate"
+    )
+    assert "attributable-responses" in gate.message
+
+
+def test_the_follow_up_prompt_targets_only_unresolved_work():
+    request = _request()
+    evidence, readiness = _assess(request)
+
+    prompt = build_follow_up_research_prompt(request.commission, evidence, readiness)
+
+    assert "Do not redo or weaken already supported work" in prompt
+    assert "Do not add a comparator" in prompt
+    assert request.commission.commission_fingerprint in prompt
+    assert "- r2 — " in prompt
+    assert "- r3 — " in prompt
+    assert "- r1 — " not in prompt
+
+
+def test_intake_terminates_as_needs_research_without_calling_a_model(monkeypatch):
+    def fail_on_model_call(*_args, **_kwargs):
+        raise AssertionError("needs_research must not spend a writer-model call")
+
+    for attribute in dir(prompt2blog_llm):
+        if attribute.startswith("_"):
+            continue
+        if callable(getattr(prompt2blog_llm, attribute)):
+            monkeypatch.setattr(
+                prompt2blog_llm, attribute, fail_on_model_call, raising=False
+            )
+
+    payload = response_payload(
+        asyncio.run(prompt2blog_routes.prepare_pipeline_v3(_request()))
+    )
+
+    assert payload["status"] == "needs_research"
+    assert payload["message"] == "Prompt2Blog v3 commission needs more research"
+    assert "run_input" not in payload
+    assert [item["requirement_id"] for item in payload["unresolved_requirements"]] == [
+        "r2",
+        "r3",
+    ]
+    assert payload["unresolved_requirements"][0]["question"]
+    assert payload["unresolved_requirements"][0]["gap"]
+    assert "Return a complete replacement evidence package" in (
+        payload["follow_up_research_prompt"]
+    )
+
+
+def test_ready_research_reaches_run_input_instead_of_the_gate():
+    payload = response_payload(
+        asyncio.run(
+            prompt2blog_routes.prepare_pipeline_v3(
+                _request(evidence=_supported_evidence())
+            )
+        )
+    )
+
+    assert payload["status"] == "ready"
+    assert payload["run_input"]["form_id"] == "analysis"
+    assert "follow_up_research_prompt" not in payload
+
+
+def test_v3_has_no_supplemental_fact_surface():
+    # v2 closes coverage gaps by generating supplemental content. v3 reports
+    # the gap instead, so the state has nowhere to put invented facts.
+    assert "supplemental_content" not in Prompt2BlogV3GraphState.__annotations__
+    assert "coverage" not in Prompt2BlogV3GraphState.__annotations__
+    assert "readiness" in Prompt2BlogV3GraphState.__annotations__


### PR DESCRIPTION
## Why

PR 5 of the Prompt2Blog v3 migration. This is the change the whole redesign exists for: when research does not support the commission, v3 stops and says exactly what is missing, instead of generating the missing facts the way v2's supplement stage does.

## What

- `research_readiness_v3.py` — a deterministic gate over the normalized evidence: unsupported requirements, unresolved conflicts (mapped back to the requirements they touch), and the form's source gates. It uses the same rules the composer's importer uses, so a package cannot pass on one side and fail on the other.
- `needs_research` as a real product state, not a failure. Its payload carries the findings, the unresolved requirements with their locked questions and stated gaps, unresolved conflict IDs, missing source requirements, and a follow-up research prompt aimed only at unresolved work.
- The v3 intake now terminates at the gate **before** instruction assembly. Ready research assembles a run input as before.
- The follow-up prompt repeats the authority lock: keep the fingerprint, do not change form, subject, scope, or roles, do not add a comparator or promote a context-only reference, and never simulate interviews, first-person experience, evaluation, scenes, or quotations.

## Verification

- full backend suite: 823 collected, all passed (was 815; 8 new tests)
- one test monkeypatches every callable in the Prompt2Blog LLM module to raise, then drives `needs_research` end to end — proving the stopped path spends no writer-model call
- one test asserts the v3 graph state has no `supplemental_content` and no `coverage` key, so there is nowhere for invented facts to live
- `black` clean; `flake8` clean apart from `E501` inside the follow-up prompt's literal text, matching the existing `prompts/*.py` convention — that copy is what the model reads, so it is not wrapped

## Boundaries

V2 is untouched: its coverage and supplement stages, its routes, and its artifacts all behave exactly as before. No UI submits to the v3 path yet, and the v3 writing stages themselves are PR 6.