### PR TITLE
Add Prompt2Blog v3 outline and compose

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -19,6 +19,7 @@ bounded contexts.
 | `config.py`, `options.py`, `editorial_catalog.py` | Feature constants plus legacy and v3 Markdown-backed catalogs |
 | `evidence_v3.py`, `instructions_v3.py` | V3 evidence normalization and the layered instruction stack |
 | `research_readiness_v3.py`, `intake_v3.py` | The v3 research gate, its `needs_research` result, and v3 run input |
+| `stages/v3/`, `prompts/editorial_v3.py`, `content/outline_v3.py` | V3 writing stages, their prompts, and pure section-plan scope guards |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -1,0 +1,189 @@
+"""Section-plan normalization and scope guards for the v3 outline stage.
+
+Everything here is pure. The plan is checked against the approved commission
+and the exact evidence records before any prose exists, so scope drift and
+unsupported sections are caught while they are still cheap to reject.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..support import _safe_dict, _safe_int, _safe_str
+
+MIN_OUTLINE_SECTIONS = 3
+MAX_OUTLINE_SECTIONS = 12
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [_safe_str(item) for item in value if _safe_str(item)]
+
+
+def _sanitize_section(raw: Any) -> dict[str, Any] | None:
+    record = _safe_dict(raw)
+    heading = _safe_str(record.get("heading"))
+    if not heading:
+        return None
+    return {
+        "heading": heading,
+        "purpose": _safe_str(record.get("purpose")) or "Purpose not stated.",
+        "claim_ids": _string_list(record.get("claim_ids")),
+        "requirement_ids": _string_list(record.get("requirement_ids")),
+        "target_words": max(0, _safe_int(record.get("target_words"), default=0)),
+    }
+
+
+def sanitize_v3_outline(parsed: dict[str, Any]) -> dict[str, Any]:
+    sections_raw = parsed.get("sections")
+    sections: list[dict[str, Any]] = []
+    if isinstance(sections_raw, list):
+        for item in sections_raw[:MAX_OUTLINE_SECTIONS]:
+            section = _sanitize_section(item)
+            if section:
+                sections.append(section)
+
+    return {
+        "working_title": _safe_str(parsed.get("working_title")),
+        "direct_answer_focus": _safe_str(parsed.get("direct_answer_focus")),
+        "sections": sections,
+        "takeaway_focus": _safe_str(parsed.get("takeaway_focus")),
+        "commission_alignment": _safe_str(parsed.get("commission_alignment"))
+        or "Commission alignment not stated.",
+        "unsupported_requirements": _string_list(
+            parsed.get("unsupported_requirements")
+        ),
+    }
+
+
+def _mentions(text: str, name: str) -> bool:
+    return name.casefold() in text.casefold()
+
+
+def validate_v3_outline(
+    outline: dict[str, Any],
+    *,
+    commission: dict[str, Any],
+    claim_ids: set[str],
+    requirement_ids: set[str],
+    target_word_count: int,
+) -> tuple[bool, dict[str, Any]]:
+    """Check a plan against the commission's scope and the real evidence.
+
+    A plan that drifts is discarded rather than fed to compose: an outline that
+    organizes the article around a context-only place, or that cites a claim
+    the evidence does not contain, would put the drift into the prose.
+    """
+    sections = outline.get("sections") or []
+    planned_words = sum(_safe_int(s.get("target_words"), default=0) for s in sections)
+
+    within_budget = True
+    if target_word_count > 0 and planned_words > 0:
+        tolerance = max(200, int(target_word_count * 0.35))
+        within_budget = abs(planned_words - target_word_count) <= tolerance
+
+    unknown_claim_ids = sorted(
+        {
+            claim_id
+            for section in sections
+            for claim_id in section["claim_ids"]
+            if claim_id not in claim_ids
+        }
+    )
+    unknown_requirement_ids = sorted(
+        {
+            requirement_id
+            for section in sections
+            for requirement_id in section["requirement_ids"]
+            if requirement_id not in requirement_ids
+        }
+    )
+
+    scope = _safe_dict(commission.get("scope"))
+    references = scope.get("references") or []
+    context_only = [
+        _safe_str(reference.get("name"))
+        for reference in references
+        if reference.get("role") == "context_only"
+    ]
+    context_only_headings = sorted(
+        {
+            section["heading"]
+            for section in sections
+            for name in context_only
+            if name and _mentions(section["heading"], name)
+        }
+    )
+    primary_subject = _safe_str(commission.get("primary_subject"))
+    covers_primary_subject = not primary_subject or any(
+        _mentions(section["heading"], primary_subject)
+        or _mentions(section["purpose"], primary_subject)
+        for section in sections
+    )
+
+    checks = {
+        "enough_sections": len(sections) >= MIN_OUTLINE_SECTIONS,
+        "headings_unique": len({s["heading"].casefold() for s in sections})
+        == len(sections),
+        "within_word_budget": within_budget,
+        "claims_resolve": not unknown_claim_ids,
+        "requirements_resolve": not unknown_requirement_ids,
+        # A context-only place may be discussed inside a section; it may never
+        # be what a section is about.
+        "no_context_only_sections": not context_only_headings,
+        "covers_primary_subject": covers_primary_subject,
+    }
+    diagnostics = {
+        **checks,
+        "section_count": len(sections),
+        "planned_word_count": planned_words,
+        "target_word_count": target_word_count,
+        "unknown_claim_ids": unknown_claim_ids,
+        "unknown_requirement_ids": unknown_requirement_ids,
+        "context_only_headings": context_only_headings,
+    }
+    return all(checks.values()), diagnostics
+
+
+def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
+    """Render a validated plan as the section brief compose writes against."""
+    sections = outline.get("sections") or []
+    if not sections:
+        return (
+            "No outline was produced. Structure the article from the approved "
+            "commission and the evidence records only."
+        )
+
+    lines: list[str] = []
+    direct_answer = _safe_str(outline.get("direct_answer_focus"))
+    if direct_answer:
+        lines.append(f"Direct answer near the top should cover: {direct_answer}")
+        lines.append("")
+
+    lines.append("Planned sections (use these as the `##` headings, in order):")
+    for index, section in enumerate(sections, start=1):
+        target = section.get("target_words") or 0
+        budget = f" (~{target} words)" if target else ""
+        claims = ", ".join(section["claim_ids"]) or "none"
+        requirements = ", ".join(section["requirement_ids"]) or "none"
+        lines.append(f"{index}. {section['heading']}{budget}")
+        lines.append(f"   Purpose: {section['purpose']}")
+        lines.append(f"   Evidence claims: {claims}")
+        lines.append(f"   Requirements served: {requirements}")
+
+    takeaway = _safe_str(outline.get("takeaway_focus"))
+    if takeaway:
+        lines.append("")
+        lines.append(f"Closing takeaways should land on: {takeaway}")
+
+    unsupported = outline.get("unsupported_requirements") or []
+    if unsupported:
+        lines.append("")
+        lines.append(
+            "The evidence does not support the following. Say so plainly "
+            "rather than inventing detail:"
+        )
+        lines.extend(f"- {item}" for item in unsupported)
+
+    return "\n".join(lines)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -1,0 +1,110 @@
+"""Prompt2Blog v3 writing prompts.
+
+Every v3 prompt is handed one assembled instruction stack instead of a
+guideline pair, and the exact evidence records instead of cleaned source text.
+The authority order is stated in the stack itself, so these templates only have
+to keep the stage honest about what it may add.
+"""
+
+P2B_V3_OUTLINE_PROMPT = """You are a commissioning editor planning an article before it is written.
+
+Goal:
+Plan the sections that answer the approved commission using only the verified
+evidence records. Plan the structure only. Do not write the article.
+
+Return strict JSON only:
+{{
+  "working_title": "string",
+  "direct_answer_focus": "string",
+  "sections": [
+    {{
+      "heading": "string",
+      "purpose": "string",
+      "claim_ids": ["string"],
+      "requirement_ids": ["string"],
+      "target_words": 0
+    }}
+  ],
+  "takeaway_focus": "string",
+  "commission_alignment": "string",
+  "unsupported_requirements": ["string"]
+}}
+
+Rules:
+- Plan at least 3 and at most 12 sections.
+- Headings must be specific and distinct. No generic "Introduction" or
+  "Conclusion" headings.
+- Every section must name the claim_ids it rests on, using IDs that exist in
+  the evidence records. Never cite a claim the records do not contain.
+- Every section must name the requirement_ids it serves, using the locked
+  commission's requirement IDs.
+- The primary subject controls the article. A context-only reference may
+  calibrate a fact inside a section; it may never be what a section is about,
+  and it may never appear as a heading subject.
+- Only an approved comparator may share comparison scope, and only when the
+  scope mode allows it.
+- If the commission asks for something the evidence cannot support, list it in
+  unsupported_requirements instead of planning a section that would need an
+  invented fact.
+- target_words across all sections should total roughly the target word count.
+- commission_alignment must explain in one or two sentences how this structure
+  answers the core reader question for the primary subject.
+
+{instructions}
+
+TARGET WORD COUNT:
+{target_word_count}
+"""
+
+P2B_V3_COMPOSE_PROMPT = """You are an expert editor writing a publish-ready article from verified evidence.
+
+Goal:
+Write the article the approved commission describes, using only the evidence
+records supplied.
+
+Return strict JSON only:
+{{
+  "improved_title": "string",
+  "improved_content": "string",
+  "commission_alignment_summary": "string",
+  "improvements_applied": ["string"],
+  "remaining_gaps": ["string"]
+}}
+
+Hard rules:
+- Every factual statement must trace to a claim in the evidence records.
+  Preserve attribution, dates, units, geography, and stated uncertainty.
+- Never invent a bridge fact, scene, quotation, experience, statistic, price,
+  consensus, or practical detail. An unsupported point stays a visible gap and
+  belongs in remaining_gaps.
+- The evidence records are internal working material. Never cite them in the
+  article: no claim IDs, no source IDs, no "(Source 1)", no numbered
+  references of any kind. The reader cannot see them.
+- Attribute a fact in prose only by naming the real publication or body it came
+  from, never by its position in the records.
+- Keep the approved form, primary subject, scope mode, and reference roles. A
+  context-only reference may calibrate a fact; it may never become a
+  co-subject, a recurring section, a ranking, or a verdict.
+- Answer the core reader question and deliver the stated reader outcome.
+- Honour every exclusion in the commission.
+- improved_content must not contain a `#` H1.
+- Use at least 3 `##` headings.
+- Include one direct 40-60 word answer near the top.
+- Include a concise takeaway section near the end.
+- Follow the STYLE DIRECTIVE exactly. Tone, length, and brand voice are
+  requirements, not suggestions.
+- Follow the SECTION PLAN when one is provided: use its headings, in order, and
+  hold each section to roughly its word budget. Depart from it only where the
+  evidence makes a planned section unsupportable, and say so in remaining_gaps.
+
+SECTION PLAN:
+{outline}
+
+{instructions}
+
+SEO-SAFE RULES:
+{seo_guideline}
+
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+"""

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -58,6 +58,34 @@ OUTLINE_SCHEMA: dict[str, Any] = {
     },
 }
 
+V3_OUTLINE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["working_title", "sections"],
+    "properties": {
+        "working_title": {"type": "string"},
+        "direct_answer_focus": {"type": "string"},
+        "sections": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 12,
+            "items": {
+                "type": "object",
+                "required": ["heading"],
+                "properties": {
+                    "heading": {"type": "string"},
+                    "purpose": {"type": "string"},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                    "requirement_ids": {"type": "array", "items": {"type": "string"}},
+                    "target_words": {"type": "integer", "minimum": 0},
+                },
+            },
+        },
+        "takeaway_focus": {"type": "string"},
+        "commission_alignment": {"type": "string"},
+        "unsupported_requirements": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
 # Shared by compose and by repair: both return a whole rewritten article, and
 # both go through _sanitize_rewrite.
 REWRITE_SCHEMA: dict[str, Any] = {

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+
+from ...dependencies import PipelineDependencies
+from ...graph.state import Prompt2BlogV3GraphState
+from ...observability import _append_stage_trace
+from ...prompts.editorial_v3 import P2B_V3_COMPOSE_PROMPT
+from ...prompts.generation import SEO_SAFE_CONTENT_GENERATION_GUIDELINES
+from ...quality import _sanitize_rewrite
+from ...schemas import REWRITE_SCHEMA
+from ...support import _format_style_directive
+
+
+def run_v3_compose_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Write the article from the instruction stack and the evidence records.
+
+    Compose never sees cleaned source prose or supplemental material, because
+    v3 has neither. Its only permitted facts are the claims the researcher
+    supplied, which is what makes grounding a comparison rather than a guess.
+    """
+    stage = "stage_v3_compose"
+    run_id = state["run_id"]
+    dependencies.recorder.start_stage(run_id, stage)
+
+    style_directive = _format_style_directive(state["option_context"])
+    prompt = P2B_V3_COMPOSE_PROMPT.format(
+        outline=state["outline_text"],
+        instructions=state["instruction_text"],
+        seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
+        style_directive=style_directive,
+    )
+    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
+
+    parsed, raw_response = dependencies.llm.invoke_json(
+        prompt=prompt,
+        max_tokens=6144,
+        temperature=state["compose_temperature"],
+        model_name=state["writing_model"],
+        schema=REWRITE_SCHEMA,
+    )
+    rewrite = _sanitize_rewrite(
+        parsed,
+        # The commission owns the working title until the title stage runs; the
+        # evidence is never a fallback body, because empty prose is honest and
+        # pasted records are not.
+        fallback_title=state["commission"]["original_title"],
+        fallback_content="",
+    )
+    rewrite["improved_content"] = dependencies.llm.enforce_anti_ai(
+        rewrite["improved_content"],
+        model_name=state["writing_model"],
+        max_tokens=6144,
+        context="prompt2blog v3 compose",
+    )
+
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {"rewrite": rewrite, "raw_response": raw_response},
+    )
+    _append_stage_trace(
+        state["trace"],
+        state["include_debug"],
+        stage=stage,
+        model_name=state["writing_model"],
+        input_payload={
+            "commission_fingerprint": state["commission"]["commission_fingerprint"],
+            "form_id": state["commission"]["form_id"],
+            "outline_accepted": state.get("outline_accepted", False),
+            "style_directive": style_directive,
+        },
+        prompt=prompt,
+        raw_response=raw_response,
+        parsed=parsed,
+        output=rewrite,
+    )
+    return {"current_stage": stage, "rewrite": rewrite}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ...content.outline_v3 import (
+    format_v3_outline_for_prompt,
+    sanitize_v3_outline,
+    validate_v3_outline,
+)
+from ...dependencies import PipelineDependencies
+from ...graph.state import Prompt2BlogV3GraphState
+from ...observability import _append_stage_trace
+from ...prompts.editorial_v3 import P2B_V3_OUTLINE_PROMPT
+from ...schemas import V3_OUTLINE_SCHEMA
+from ...support import _safe_dict, _safe_int
+
+logger = logging.getLogger(__name__)
+
+EMPTY_OUTLINE: dict[str, Any] = {
+    "working_title": "",
+    "direct_answer_focus": "",
+    "sections": [],
+    "takeaway_focus": "",
+    "commission_alignment": "Commission alignment not stated.",
+    "unsupported_requirements": [],
+}
+
+
+def _target_word_count(state: Prompt2BlogV3GraphState) -> int:
+    length = _safe_dict(_safe_dict(state["option_context"]).get("length"))
+    return _safe_int(length.get("target_word_count"), default=0)
+
+
+def run_v3_outline_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Plan the article against the commission before any prose exists.
+
+    A plan that drifts from the approved scope, or that cites a claim the
+    evidence does not contain, is rejected here rather than turned into prose.
+    A failed or unusable plan degrades to no plan; it never fails the run.
+    """
+    stage = "stage_v3_outline"
+    run_id = state["run_id"]
+    dependencies.recorder.start_stage(run_id, stage)
+
+    evidence = state["evidence"]
+    target_word_count = _target_word_count(state)
+    outline = dict(EMPTY_OUTLINE)
+    diagnostics: dict[str, Any] = {}
+    accepted = False
+    raw_response = ""
+
+    prompt = P2B_V3_OUTLINE_PROMPT.format(
+        instructions=state["instruction_text"],
+        target_word_count=target_word_count or "Not specified.",
+    )
+
+    try:
+        parsed, raw_response = dependencies.llm.invoke_json(
+            prompt=prompt,
+            max_tokens=2048,
+            temperature=0.1,
+            model_name=state["writing_model"],
+            schema=V3_OUTLINE_SCHEMA,
+        )
+        candidate = sanitize_v3_outline(parsed)
+        accepted, diagnostics = validate_v3_outline(
+            candidate,
+            commission=state["commission"],
+            claim_ids={claim["claim_id"] for claim in evidence["claims"]},
+            requirement_ids={
+                requirement["requirement_id"]
+                for requirement in evidence["requirements"]
+            },
+            target_word_count=target_word_count,
+        )
+        if accepted:
+            outline = candidate
+        else:
+            logger.warning(
+                "Prompt2Blog v3 outline rejected for run %s: %s", run_id, diagnostics
+            )
+        _append_stage_trace(
+            state["trace"],
+            state["include_debug"],
+            stage=stage,
+            model_name=state["writing_model"],
+            prompt=prompt,
+            raw_response=raw_response,
+            parsed=parsed,
+            output={"outline": outline, "accepted": accepted, "checks": diagnostics},
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Prompt2Blog v3 outline stage failed: %s", exc)
+        _append_stage_trace(
+            state["trace"],
+            state["include_debug"],
+            stage=stage,
+            model_name=state["writing_model"],
+            prompt=prompt,
+            error=str(exc),
+        )
+
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {
+            "outline": outline,
+            "accepted": accepted,
+            "checks": diagnostics,
+            "raw_response": raw_response,
+        },
+    )
+    return {
+        "current_stage": stage,
+        "outline": outline,
+        "outline_accepted": accepted,
+        "outline_text": format_v3_outline_for_prompt(outline),
+    }

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
@@ -1,0 +1,294 @@
+"""V3 outline and compose: commission-first planning, evidence-only prose."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.features.prompt2blog.content.outline_v3 import (
+    format_v3_outline_for_prompt,
+    sanitize_v3_outline,
+    validate_v3_outline,
+)
+from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
+from app.features.prompt2blog.dependencies import PipelineDependencies
+from app.features.prompt2blog.intake_v3 import prepare_v3_runtime_request
+from app.features.prompt2blog.stages.v3.compose import run_v3_compose_stage
+from app.features.prompt2blog.stages.v3.outline import run_v3_outline_stage
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v3.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _supported_evidence() -> dict:
+    evidence = json.loads(json.dumps(_fixture()["evidence_package"]))
+    evidence["claims"].extend(
+        [
+            {
+                "claim_id": "c2",
+                "text": "Current reporting documents Lima's practical tradeoffs.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r2"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+            {
+                "claim_id": "c3",
+                "text": "Comparable earlier reporting shows how those costs moved.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r3"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+        ]
+    )
+    evidence["requirements"] = [
+        {"requirement_id": "r1", "status": "supported", "claim_ids": ["c1"], "gap": ""},
+        {"requirement_id": "r2", "status": "supported", "claim_ids": ["c2"], "gap": ""},
+        {"requirement_id": "r3", "status": "supported", "claim_ids": ["c3"], "gap": ""},
+    ]
+    evidence["gaps"] = []
+    return evidence
+
+
+def _runtime():
+    request = Prompt2BlogV3Request.model_validate(
+        {
+            "schema_version": 3,
+            "commission": _fixture()["commission"],
+            "evidence_package": _supported_evidence(),
+            "profiles": {
+                "tone_id": "editorial",
+                "length_id": "medium",
+                "creativity_level": "medium",
+            },
+        }
+    )
+    return prepare_v3_runtime_request(request)
+
+
+def _state(**overrides) -> dict[str, Any]:
+    runtime = _runtime()
+    state: dict[str, Any] = {
+        "run_id": "v3-run",
+        "commission": runtime.commission,
+        "evidence": runtime.evidence,
+        "instructions": runtime.instructions,
+        "instruction_text": runtime.instructions["instruction_text"],
+        "headline_instructions": runtime.instructions["headline_instructions"],
+        "option_context": runtime.option_context,
+        "writing_model": "test-writer",
+        "model_name": "test-model",
+        "compose_temperature": 0.4,
+        "include_debug": True,
+        "trace": [],
+        "outline_text": "",
+    }
+    state.update(overrides)
+    return state
+
+
+@dataclass
+class FakeRecorder:
+    started: list[str] = field(default_factory=list)
+    recorded: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def start_stage(self, _run_id: str, stage: str) -> None:
+        self.started.append(stage)
+
+    def record_stage(self, _run_id: str, stage: str, payload: dict[str, Any]) -> None:
+        self.recorded.append((stage, payload))
+
+
+@dataclass
+class FakeLLM:
+    json_response: dict[str, Any] = field(default_factory=dict)
+    prompts: list[str] = field(default_factory=list)
+
+    def invoke_json(self, *, prompt: str, **_kwargs) -> tuple[dict[str, Any], str]:
+        self.prompts.append(prompt)
+        return self.json_response, json.dumps(self.json_response)
+
+    def invoke_text(self, *, prompt: str, **_kwargs) -> str:
+        self.prompts.append(prompt)
+        return ""
+
+    def enforce_anti_ai(self, text: str, **_kwargs) -> str:
+        return text
+
+
+def _dependencies(llm: FakeLLM) -> tuple[PipelineDependencies, FakeRecorder]:
+    recorder = FakeRecorder()
+    return PipelineDependencies(llm=llm, recorder=recorder), recorder
+
+
+def _outline_payload(**overrides) -> dict[str, Any]:
+    payload = {
+        "working_title": "What Lima costs now",
+        "direct_answer_focus": "Whether Lima still offers long-stay value.",
+        "sections": [
+            {
+                "heading": "What Lima costs now",
+                "purpose": "Establish the current cost baseline for Lima.",
+                "claim_ids": ["c1"],
+                "requirement_ids": ["r1"],
+                "target_words": 300,
+            },
+            {
+                "heading": "The tradeoffs behind the price",
+                "purpose": "Show the practical tradeoffs a resident meets.",
+                "claim_ids": ["c2"],
+                "requirement_ids": ["r2"],
+                "target_words": 300,
+            },
+            {
+                "heading": "How the picture changed",
+                "purpose": "Compare the current baseline with earlier reporting.",
+                "claim_ids": ["c3"],
+                "requirement_ids": ["r3"],
+                "target_words": 300,
+            },
+        ],
+        "takeaway_focus": "What decides the answer for a long stay.",
+        "commission_alignment": "Answers the cost question about Lima itself.",
+        "unsupported_requirements": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _validate(payload: dict[str, Any], target_word_count: int = 900):
+    runtime = _runtime()
+    return validate_v3_outline(
+        sanitize_v3_outline(payload),
+        commission=runtime.commission,
+        claim_ids={claim["claim_id"] for claim in runtime.evidence["claims"]},
+        requirement_ids={
+            item["requirement_id"] for item in runtime.evidence["requirements"]
+        },
+        target_word_count=target_word_count,
+    )
+
+
+def test_a_context_only_place_cannot_organize_a_section():
+    drifted = _outline_payload()
+    drifted["sections"][2]["heading"] = "How Medellín compares"
+
+    accepted, diagnostics = _validate(drifted)
+
+    assert accepted is False
+    assert diagnostics["no_context_only_sections"] is False
+    assert diagnostics["context_only_headings"] == ["How Medellín compares"]
+
+
+def test_a_plan_cannot_cite_a_claim_the_evidence_does_not_contain():
+    invented = _outline_payload()
+    invented["sections"][0]["claim_ids"] = ["c99"]
+
+    accepted, diagnostics = _validate(invented)
+
+    assert accepted is False
+    assert diagnostics["unknown_claim_ids"] == ["c99"]
+
+
+def test_a_plan_must_still_be_about_the_primary_subject():
+    unfocused = _outline_payload()
+    for section in unfocused["sections"]:
+        section["heading"] = section["heading"].replace("Lima", "the city")
+        section["purpose"] = section["purpose"].replace("Lima", "the city")
+
+    accepted, diagnostics = _validate(unfocused)
+
+    assert accepted is False
+    assert diagnostics["covers_primary_subject"] is False
+
+
+def test_a_commission_aligned_plan_is_accepted_and_rendered_for_compose():
+    accepted, diagnostics = _validate(_outline_payload())
+
+    assert accepted is True
+    assert diagnostics["unknown_requirement_ids"] == []
+
+    rendered = format_v3_outline_for_prompt(sanitize_v3_outline(_outline_payload()))
+    assert "Evidence claims: c1" in rendered
+    assert "Requirements served: r1" in rendered
+
+
+def test_the_outline_stage_keeps_a_drifted_plan_out_of_compose():
+    drifted = _outline_payload()
+    drifted["sections"][2]["heading"] = "How Medellín compares"
+    llm = FakeLLM(json_response=drifted)
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_outline_stage(_state(), dependencies)
+
+    assert updates["outline_accepted"] is False
+    assert updates["outline"]["sections"] == []
+    assert recorder.recorded[0][0] == "stage_v3_outline"
+    assert recorder.recorded[0][1]["checks"]["no_context_only_sections"] is False
+
+
+def test_the_outline_prompt_carries_the_whole_instruction_stack():
+    llm = FakeLLM(json_response=_outline_payload())
+    dependencies, _recorder = _dependencies(llm)
+
+    run_v3_outline_stage(_state(), dependencies)
+
+    prompt = llm.prompts[0]
+    assert "AUTHORITY ORDER" in prompt
+    assert "VERIFIED EVIDENCE" in prompt
+    assert "APPROVED COMMISSION" in prompt
+    assert "HOUSE STYLE" in prompt
+    assert "Plan the structure only" in prompt
+
+
+def test_compose_writes_from_evidence_records_and_never_from_source_prose():
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "improved_content": "## What Lima costs now\n\nBody.",
+            "commission_alignment_summary": "Answers the cost question.",
+            "improvements_applied": [],
+            "remaining_gaps": [],
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+    state = _state(
+        outline_text=format_v3_outline_for_prompt(
+            sanitize_v3_outline(_outline_payload())
+        ),
+        outline_accepted=True,
+    )
+
+    updates = run_v3_compose_stage(state, dependencies)
+
+    prompt = llm.prompts[0]
+    assert "CLEANED SOURCE MATERIAL" not in prompt
+    assert "SUPPLEMENTAL MATERIAL" not in prompt
+    assert "Never invent a bridge fact" in prompt
+    assert "STYLE DIRECTIVE (REQUIRED)" in prompt
+    assert "Instituto Nacional de Estadística e Informática" in prompt
+    assert updates["rewrite"]["improved_title"] == "What Lima costs now"
+    assert recorder.recorded[0][0] == "stage_v3_compose"
+
+
+def test_compose_does_not_fall_back_to_pasting_the_evidence():
+    llm = FakeLLM(json_response={"improved_title": "", "improved_content": ""})
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_compose_stage(_state(), dependencies)
+
+    rewrite = updates["rewrite"]
+    assert rewrite["improved_content"] == ""
+    assert rewrite["improved_title"] == _fixture()["commission"]["original_title"]


### PR DESCRIPTION
## Why

First slice of PR 6 — making the writer consume the new authority model. The instruction stack (#395), the intake (#396), and the research gate (#397) are in place; this PR gives them the first two writing stages.

## What

**`content/outline_v3.py`** — pure section-plan normalization and the scope guards that make drift cheap to catch:

- a context-only reference may calibrate a fact inside a section, but may never be what a section is *about* — a heading naming one fails the plan
- a section cannot cite a `claim_id` or `requirement_id` the evidence does not contain
- the plan must still be about the commission's primary subject
- plus the structural checks compose depends on: enough sections, unique headings, a sane word budget

**`stages/v3/outline.py`** — plans against the assembled instruction stack. A drifted or unusable plan is discarded and recorded with its diagnostics, exactly as v2 degrades, so a bad plan never becomes prose and never fails the run.

**`stages/v3/compose.py`** — writes from the instruction stack and the evidence records only. There is no cleaned source text and no supplemental material to hand it, because v3 has neither. When the model returns nothing usable, compose falls back to empty prose rather than pasting evidence records into the article: empty is honest, pasted records are not.

**`prompts/editorial_v3.py`** — both prompts. They forbid citing claim or source IDs in the prose, require attribution by the real publication name, and require unsupported points to surface as gaps instead of bridge facts.

## Verification

- full backend suite: 831 collected, all passed (was 823; 8 new tests)
- the stage tests drive real stages through a fake LLM and recorder, including the Lima scope-drift case: a plan with a "How Medellín compares" heading is rejected and never reaches compose
- one test asserts the compose prompt contains no `CLEANED SOURCE MATERIAL` or `SUPPLEMENTAL MATERIAL` block at all
- `black` clean; `flake8` clean apart from `E501` inside prompt literals, matching the existing `prompts/*.py` convention

## Boundaries

No graph wiring yet — nothing calls these stages, and v2's outline and compose are untouched. Grounding, audit/repair, title, and finalize are the next slice; the v3 graph and the mocked Lima end-to-end run follow that. Model routing and pricing are unchanged.