### PR TITLE
Add Prompt2Blog v3 grounding, audit, repair, and title

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -108,3 +108,182 @@ SEO-SAFE RULES:
 STYLE DIRECTIVE (REQUIRED):
 {style_directive}
 """
+
+
+P2B_V3_GROUNDEDNESS_PROMPT = """You are a fact-grounding checker for travel articles.
+
+Goal:
+Find statements in the draft that the evidence records do not support.
+
+Return strict JSON only:
+{{
+  "grounded": true,
+  "assessment": "string",
+  "unsupported_claims": [
+    {{
+      "claim": "string",
+      "reason": "string",
+      "severity": "high|low"
+    }}
+  ]
+}}
+
+What counts as unsupported:
+- Any figure, date, rule, price, duration, capacity, or named entity that no
+  claim in the records states.
+- A claim stated more confidently, more recently, or more broadly than the
+  record it rests on. Check attribution, as-of dates, geography, units, and
+  stated uncertainty against the record itself.
+- A conflict resolved in the prose that the records leave unresolved.
+- Safety, health, legal, or entry guidance the records do not establish.
+- Superlatives and rankings presented as fact.
+
+What does NOT count:
+- General background a well-informed writer would state without a source.
+- Statements the draft already marks as unconfirmed, approximate, or variable.
+- Restatement or paraphrase of something a record does say.
+- Advice framed as judgement rather than fact.
+
+Rules:
+- severity is "high" when a reader could be misled into a booking, spending,
+  legal, or safety decision. Otherwise "low".
+- Quote the claim as it appears in the draft.
+- grounded is true only when there are no high-severity unsupported claims.
+- Do not rewrite the article.
+
+EVIDENCE RECORDS:
+{evidence_records}
+
+DRAFT TITLE:
+{rewritten_title}
+
+DRAFT CONTENT:
+{rewritten_content}
+"""
+
+P2B_V3_QUALITY_AUDIT_PROMPT = """You are a quality auditor for commissioned articles.
+
+Goal:
+Score the draft on commission fidelity, evidence discipline, form fit, and
+reader utility.
+
+Return strict JSON only:
+{{
+  "overall_score": 1,
+  "guideline_coverage_score": 1,
+  "informativeness_score": 1,
+  "originality_score": 1,
+  "brief_adherence_score": 1,
+  "seo_score": 1,
+  "too_close_to_source": false,
+  "word_count_estimate": 0,
+  "constraint_checks": {{
+    "audience_match": false,
+    "tone_match": false
+  }},
+  "required_revisions": ["string"],
+  "quality_summary": "string"
+}}
+
+Scoring rubric:
+- 9-10: publishable.
+- 7-8: acceptable with edits.
+- <=6: requires hard rewrite.
+
+Rules:
+- required_revisions must be specific and actionable.
+- Treat these as failures, not style notes: the article drifts from the
+  approved form; a context-only reference organizes a section or earns a
+  verdict; the core reader question goes unanswered; an exclusion is broken; a
+  statement outruns the evidence record behind it.
+- guideline_coverage_score is fidelity to the approved commission and its
+  article form.
+- Mark too_close_to_source=true when phrasing or structure tracks an evidence
+  record too closely.
+- Judge only audience_match and tone_match. Word count, paragraph length, CTA,
+  and keyword presence are measured deterministically outside this prompt, so
+  do not report them.
+- Score honestly. A draft that merely avoids mistakes is a 7, not a 9.
+
+{instructions}
+
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+
+DRAFT TITLE:
+{rewritten_title}
+
+DRAFT CONTENT:
+{rewritten_content}
+"""
+
+P2B_V3_REPAIR_PROMPT = """You are running a repair pass on a commissioned article.
+
+Goal:
+Fix the prose and structure the auditor flagged, without changing what the
+article is or what it claims.
+
+Return strict JSON only:
+{{
+  "improved_title": "string",
+  "improved_content": "string",
+  "commission_alignment_summary": "string",
+  "improvements_applied": ["string"],
+  "remaining_gaps": ["string"]
+}}
+
+Rules:
+- Resolve each required revision directly.
+- Repair prose and structure only. You may not create a fact, and you may not
+  change the commission: not the form, the primary subject, the scope mode, the
+  reference roles, the requirements, or the exclusions.
+- Never add a fact the evidence records do not contain. Remove or explicitly
+  mark as unconfirmed anything flagged as unsupported.
+- Never promote a context-only reference, add a comparator, or broaden scope to
+  satisfy a revision.
+- Never cite evidence records in the prose: no claim IDs, no source IDs, no
+  numbered references. Attribute only by naming the real publication or body.
+- Keep complete article prose with clear `##` / `###` structure.
+- Where support is missing, state the uncertainty plainly and list it in
+  remaining_gaps.
+
+REQUIRED REVISIONS:
+{required_revisions}
+
+PREVIOUS TITLE:
+{previous_title}
+
+PREVIOUS CONTENT:
+{previous_content}
+
+{instructions}
+
+STYLE DIRECTIVE (REQUIRED):
+{style_directive}
+"""
+
+P2B_V3_TITLE_PROMPT = """You are an expert headline editor.
+
+Goal:
+Write exactly one final title for this commissioned article.
+
+Output rules (strict):
+- Return exactly one line.
+- No quotes, no markdown, no alternatives, no explanation.
+- Keep the original title's intent and subject. It is the author's intent, not
+  a template to copy or a phrase to abandon.
+- Name the primary subject. Never headline a context-only reference.
+- Promise only what the article delivers and the evidence supports.
+
+HEADLINE STANDARD:
+{headline_instructions}
+
+APPROVED COMMISSION SUMMARY:
+{commission_summary}
+
+BASELINE TITLE:
+{previous_title}
+
+FINAL ARTICLE CONTENT:
+{rewritten_content}
+"""

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality_v3.py
@@ -1,0 +1,59 @@
+"""Deterministic v3 quality inputs derived from the commission.
+
+V3 has no writing brief. The measurable constraints the audit needs still
+exist, but they come from the approved commission and the resolved length
+profile, so nothing has to be reconstructed from prose.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .support import _safe_dict, _safe_int, _safe_str
+
+
+def v3_constraint_brief(
+    commission: dict[str, Any],
+    option_context: dict[str, Any],
+) -> dict[str, Any]:
+    """Builds the brief `_build_constraint_checks` measures a v3 draft against.
+
+    Keyword and must-include fields stay empty on purpose: v3 commissions carry
+    no SEO brief, and inventing one here would fail drafts for missing a
+    requirement nobody approved.
+    """
+    length = _safe_dict(_safe_dict(option_context).get("length"))
+    return {
+        "formatting": {
+            "target_word_count": _safe_int(length.get("target_word_count"), default=0),
+            "paragraph_length": _safe_str(length.get("paragraph_length"))
+            or _safe_str(length.get("label")),
+        },
+        "call_to_action": _safe_str(commission.get("call_to_action")),
+        "seo": {"primary_keyword": "", "secondary_keywords": []},
+        "must_include": [],
+    }
+
+
+def v3_commission_summary(commission: dict[str, Any]) -> str:
+    """One compact block of the commission facts a headline must respect."""
+    scope = _safe_dict(commission.get("scope"))
+    references = scope.get("references") or []
+    roles = ", ".join(
+        f"{_safe_str(reference.get('name'))} ({_safe_str(reference.get('role'))})"
+        for reference in references
+    )
+    audience = _safe_dict(commission.get("audience"))
+    return "\n".join(
+        [
+            f"Original title: {_safe_str(commission.get('original_title'))}",
+            f"Location: {_safe_str(commission.get('location'))}",
+            f"Primary subject: {_safe_str(commission.get('primary_subject'))}",
+            f"Form: {_safe_str(commission.get('form_id'))}",
+            f"Scope mode: {_safe_str(scope.get('mode'))}",
+            f"References: {roles}",
+            "Core reader question: "
+            f"{_safe_str(commission.get('core_reader_question'))}",
+            f"Primary reader: {_safe_str(audience.get('primary_reader'))}",
+        ]
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.shared.prompts import ANTI_AI_TELLS_FULL
+
+from ...dependencies import PipelineDependencies
+from ...graph.state import Prompt2BlogV3GraphState
+from ...observability import _append_stage_trace
+from ...policies import is_better_quality
+from ...prompts.editorial_v3 import (
+    P2B_V3_QUALITY_AUDIT_PROMPT,
+    P2B_V3_REPAIR_PROMPT,
+)
+from ...quality import (
+    _build_constraint_checks,
+    _sanitize_quality,
+    _sanitize_rewrite,
+    unchecked_groundedness,
+)
+from ...quality_v3 import v3_constraint_brief
+from ...schemas import REWRITE_SCHEMA
+from ...support import _format_style_directive, _json
+
+
+def _audit_v3_rewrite(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+    rewrite: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], str, str, dict[str, Any]]:
+    prompt = P2B_V3_QUALITY_AUDIT_PROMPT.format(
+        instructions=state["instruction_text"],
+        style_directive=_format_style_directive(state["option_context"]),
+        rewritten_title=rewrite["improved_title"],
+        rewritten_content=rewrite["improved_content"],
+    )
+    parsed, raw_response = dependencies.llm.invoke_json(
+        prompt=prompt,
+        max_tokens=1536,
+        temperature=0.05,
+        model_name=state["audit_model"],
+    )
+    quality = _sanitize_quality(parsed)
+    computed_checks = _build_constraint_checks(
+        rewrite["improved_title"],
+        rewrite["improved_content"],
+        v3_constraint_brief(state["commission"], state["option_context"]),
+    )
+    measurements = {
+        "word_count_estimate",
+        "secondary_keyword_coverage",
+        "must_include_coverage",
+    }
+    groundedness = state.get("groundedness") or unchecked_groundedness()
+    quality_checks = {
+        **quality.get("constraint_checks", {}),
+        **{
+            key: value
+            for key, value in computed_checks.items()
+            if key not in measurements
+        },
+        "claims_grounded": groundedness["grounded"],
+    }
+    quality["constraint_checks"] = quality_checks
+    quality["word_count_estimate"] = computed_checks["word_count_estimate"]
+    quality["secondary_keyword_coverage"] = computed_checks[
+        "secondary_keyword_coverage"
+    ]
+    quality["groundedness"] = groundedness
+    return quality, quality_checks, prompt, raw_response, parsed
+
+
+def run_v3_quality_audit_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    stage = "stage_v3_quality_audit"
+    run_id = state["run_id"]
+    attempt = state.get("repair_attempts", 0)
+    dependencies.recorder.start_stage(run_id, stage)
+
+    rewrite = state["rewrite"]
+    quality, checks, prompt, raw_response, parsed = _audit_v3_rewrite(
+        state,
+        dependencies,
+        rewrite,
+    )
+
+    updates: dict[str, Any] = {
+        "current_stage": stage,
+        "quality": quality,
+        "quality_checks": checks,
+    }
+    if is_better_quality(quality, state.get("best_quality")):
+        updates["best_rewrite"] = rewrite
+        updates["best_quality"] = quality
+        updates["best_quality_checks"] = checks
+
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {"quality": quality, "raw_response": raw_response, "attempt": attempt},
+    )
+    _append_stage_trace(
+        state["trace"],
+        state["include_debug"],
+        stage=stage,
+        model_name=state["audit_model"],
+        input_payload={"attempt": attempt},
+        prompt=prompt,
+        raw_response=raw_response,
+        parsed=parsed,
+        output=quality,
+    )
+    return updates
+
+
+def run_v3_repair_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Repair prose and structure only.
+
+    Repair can never create a fact or change the commission, so an unsupported
+    claim is fixed by removing it or marking it unconfirmed — never by finding
+    new material, which by then would have no evidence record behind it.
+    """
+    stage = "stage_v3_repair"
+    run_id = state["run_id"]
+    rewrite = state["rewrite"]
+    quality = state["quality"]
+    attempt = state.get("repair_attempts", 0) + 1
+    dependencies.recorder.start_stage(run_id, stage)
+
+    groundedness = state.get("groundedness") or unchecked_groundedness()
+    required_revisions = list(quality.get("required_revisions", []))
+    required_revisions.extend(
+        f"Remove or explicitly mark as unconfirmed: {claim['claim']} "
+        f"({claim['reason']})"
+        for claim in groundedness["unsupported_claims"]
+    )
+
+    prompt = P2B_V3_REPAIR_PROMPT.format(
+        required_revisions=_json(required_revisions),
+        previous_title=rewrite["improved_title"],
+        previous_content=rewrite["improved_content"],
+        instructions=state["instruction_text"],
+        style_directive=_format_style_directive(state["option_context"]),
+    )
+    prompt = f"{prompt}\n\n{ANTI_AI_TELLS_FULL}"
+    # Repair rewrites the whole article, so it runs on the writer model.
+    parsed, raw_response = dependencies.llm.invoke_json(
+        prompt=prompt,
+        max_tokens=6144,
+        temperature=0.1,
+        model_name=state["writing_model"],
+        schema=REWRITE_SCHEMA,
+    )
+    repaired = _sanitize_rewrite(
+        parsed,
+        fallback_title=rewrite["improved_title"],
+        fallback_content=rewrite["improved_content"],
+    )
+    repaired["improved_content"] = dependencies.llm.enforce_anti_ai(
+        repaired["improved_content"],
+        model_name=state["writing_model"],
+        max_tokens=6144,
+        context="prompt2blog v3 repair",
+    )
+    _append_stage_trace(
+        state["trace"],
+        state["include_debug"],
+        stage=stage,
+        model_name=state["writing_model"],
+        input_payload={"attempt": attempt},
+        prompt=prompt,
+        raw_response=raw_response,
+        parsed=parsed,
+        output={"rewrite": repaired},
+    )
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {
+            "repair_applied": True,
+            "attempt": attempt,
+            "rewrite": repaired,
+            "required_revisions": required_revisions,
+            "raw_response": raw_response,
+        },
+    )
+    return {
+        "current_stage": stage,
+        "repair_applied": True,
+        "repair_attempts": attempt,
+        "rewrite": repaired,
+    }
+
+
+def run_v3_quality_settle_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Settle on the best-scoring draft the repair loop produced."""
+    stage = "stage_v3_quality_settle"
+    run_id = state["run_id"]
+    dependencies.recorder.start_stage(run_id, stage)
+
+    best_rewrite = state.get("best_rewrite") or state["rewrite"]
+    best_quality = state.get("best_quality") or state["quality"]
+    best_checks = state.get("best_quality_checks") or state["quality_checks"]
+    rolled_back = best_rewrite is not state["rewrite"]
+
+    settlement = {
+        "repair_attempts": state.get("repair_attempts", 0),
+        "repair_applied": state.get("repair_applied", False),
+        "reverted_to_earlier_draft": rolled_back,
+        "final_overall_score": best_quality.get("overall_score"),
+        "last_overall_score": state["quality"].get("overall_score"),
+    }
+    dependencies.recorder.record_stage(run_id, stage, settlement)
+    _append_stage_trace(
+        state["trace"],
+        state["include_debug"],
+        stage=stage,
+        output=settlement,
+    )
+    return {
+        "current_stage": stage,
+        "rewrite": best_rewrite,
+        "quality": best_quality,
+        "quality_checks": best_checks,
+        # The grounding verdict travels with the draft it describes.
+        "groundedness": best_quality.get("groundedness") or state["groundedness"],
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ...dependencies import PipelineDependencies
+from ...graph.state import Prompt2BlogV3GraphState
+from ...observability import _append_stage_trace
+from ...prompts.editorial_v3 import P2B_V3_GROUNDEDNESS_PROMPT
+from ...quality import _sanitize_groundedness, unchecked_groundedness
+
+logger = logging.getLogger(__name__)
+
+
+def check_v3_groundedness(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+    *,
+    stage: str,
+    rewrite: dict[str, Any],
+) -> dict[str, Any]:
+    """Compare one draft against the exact evidence records.
+
+    V2 compared a draft with cleaned source prose, which had already lost
+    publisher, date, and qualification. V3 compares it with the records
+    themselves, so an overstated date or a widened claim is visible.
+    """
+    run_id = state["run_id"]
+    prompt = P2B_V3_GROUNDEDNESS_PROMPT.format(
+        evidence_records=state["evidence"]["records_text"],
+        rewritten_title=rewrite["improved_title"],
+        rewritten_content=rewrite["improved_content"],
+    )
+
+    raw_response = ""
+    try:
+        parsed, raw_response = dependencies.llm.invoke_json(
+            prompt=prompt,
+            max_tokens=2048,
+            temperature=0.0,
+            model_name=state["audit_model"],
+        )
+        groundedness = _sanitize_groundedness(parsed)
+        _append_stage_trace(
+            state["trace"],
+            state["include_debug"],
+            stage=stage,
+            model_name=state["audit_model"],
+            prompt=prompt,
+            raw_response=raw_response,
+            parsed=parsed,
+            output=groundedness,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Prompt2Blog v3 groundedness check failed: %s", exc)
+        groundedness = unchecked_groundedness()
+        _append_stage_trace(
+            state["trace"],
+            state["include_debug"],
+            stage=stage,
+            model_name=state["audit_model"],
+            prompt=prompt,
+            error=str(exc),
+        )
+
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {"groundedness": groundedness, "raw_response": raw_response},
+    )
+    return groundedness
+
+
+def run_v3_groundedness_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    stage = "stage_v3_groundedness"
+    dependencies.recorder.start_stage(state["run_id"], stage)
+    groundedness = check_v3_groundedness(
+        state,
+        dependencies,
+        stage=stage,
+        rewrite=state["rewrite"],
+    )
+    return {"current_stage": stage, "groundedness": groundedness}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/title.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/title.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...content.markdown import _clean_title
+from ...dependencies import PipelineDependencies
+from ...graph.state import Prompt2BlogV3GraphState
+from ...observability import _append_stage_trace
+from ...prompts.editorial_v3 import P2B_V3_TITLE_PROMPT
+from ...quality_v3 import v3_commission_summary
+
+
+# The title is the highest-leverage single string the pipeline emits, so it is
+# written by the writer model rather than the cheaper analysis model.
+def run_v3_title_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Write the headline from the shared standard and the approved commission.
+
+    The original title reaches this stage as author intent, so the headline can
+    keep what the commission was about instead of re-deriving a subject from
+    the finished prose.
+    """
+    stage = "stage_v3_title"
+    run_id = state["run_id"]
+    rewrite = state["rewrite"]
+    dependencies.recorder.start_stage(run_id, stage)
+
+    prompt = P2B_V3_TITLE_PROMPT.format(
+        headline_instructions=state["headline_instructions"],
+        commission_summary=v3_commission_summary(state["commission"]),
+        previous_title=rewrite["improved_title"],
+        rewritten_content=rewrite["improved_content"],
+    )
+    raw_response = dependencies.llm.invoke_text(
+        prompt=prompt,
+        max_tokens=512,
+        temperature=0.1,
+        model_name=state["writing_model"],
+    )
+    final_title = (
+        _clean_title(raw_response)
+        or rewrite["improved_title"]
+        or state["commission"]["original_title"]
+    )
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {"final_title": final_title, "raw_response": raw_response},
+    )
+    _append_stage_trace(
+        state["trace"],
+        state["include_debug"],
+        stage=stage,
+        model_name=state["writing_model"],
+        prompt=prompt,
+        raw_response=raw_response,
+        output={"final_title": final_title},
+    )
+    return {"current_stage": stage, "final_title": final_title}

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -1,0 +1,313 @@
+"""V3 grounding, audit, repair, and title: evidence-bound and commission-bound."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
+from app.features.prompt2blog.dependencies import PipelineDependencies
+from app.features.prompt2blog.intake_v3 import prepare_v3_runtime_request
+from app.features.prompt2blog.quality_v3 import (
+    v3_commission_summary,
+    v3_constraint_brief,
+)
+from app.features.prompt2blog.stages.v3.audit_repair import (
+    run_v3_quality_audit_stage,
+    run_v3_quality_settle_stage,
+    run_v3_repair_stage,
+)
+from app.features.prompt2blog.stages.v3.groundedness import run_v3_groundedness_stage
+from app.features.prompt2blog.stages.v3.title import run_v3_title_stage
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v3.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _supported_evidence() -> dict:
+    evidence = json.loads(json.dumps(_fixture()["evidence_package"]))
+    evidence["claims"].extend(
+        [
+            {
+                "claim_id": "c2",
+                "text": "Current reporting documents Lima's practical tradeoffs.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r2"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+            {
+                "claim_id": "c3",
+                "text": "Comparable earlier reporting shows how those costs moved.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r3"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+        ]
+    )
+    evidence["requirements"] = [
+        {"requirement_id": "r1", "status": "supported", "claim_ids": ["c1"], "gap": ""},
+        {"requirement_id": "r2", "status": "supported", "claim_ids": ["c2"], "gap": ""},
+        {"requirement_id": "r3", "status": "supported", "claim_ids": ["c3"], "gap": ""},
+    ]
+    evidence["gaps"] = []
+    return evidence
+
+
+def _runtime():
+    return prepare_v3_runtime_request(
+        Prompt2BlogV3Request.model_validate(
+            {
+                "schema_version": 3,
+                "commission": _fixture()["commission"],
+                "evidence_package": _supported_evidence(),
+                "profiles": {
+                    "tone_id": "editorial",
+                    "length_id": "medium",
+                    "creativity_level": "medium",
+                },
+            }
+        )
+    )
+
+
+def _rewrite(title: str = "What Lima costs now") -> dict[str, Any]:
+    return {
+        "improved_title": title,
+        "improved_content": "## What Lima costs now\n\nBody about Lima.",
+        "improvements_applied": [],
+        "remaining_gaps": [],
+    }
+
+
+def _state(**overrides) -> dict[str, Any]:
+    runtime = _runtime()
+    state: dict[str, Any] = {
+        "run_id": "v3-run",
+        "commission": runtime.commission,
+        "evidence": runtime.evidence,
+        "instructions": runtime.instructions,
+        "instruction_text": runtime.instructions["instruction_text"],
+        "headline_instructions": runtime.instructions["headline_instructions"],
+        "option_context": runtime.option_context,
+        "writing_model": "test-writer",
+        "audit_model": "test-auditor",
+        "model_name": "test-model",
+        "compose_temperature": 0.4,
+        "include_debug": True,
+        "trace": [],
+        "rewrite": _rewrite(),
+    }
+    state.update(overrides)
+    return state
+
+
+@dataclass
+class FakeRecorder:
+    started: list[str] = field(default_factory=list)
+    recorded: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def start_stage(self, _run_id: str, stage: str) -> None:
+        self.started.append(stage)
+
+    def record_stage(self, _run_id: str, stage: str, payload: dict[str, Any]) -> None:
+        self.recorded.append((stage, payload))
+
+
+@dataclass
+class FakeLLM:
+    json_response: dict[str, Any] = field(default_factory=dict)
+    text_response: str = ""
+    prompts: list[str] = field(default_factory=list)
+
+    def invoke_json(self, *, prompt: str, **_kwargs) -> tuple[dict[str, Any], str]:
+        self.prompts.append(prompt)
+        return self.json_response, json.dumps(self.json_response)
+
+    def invoke_text(self, *, prompt: str, **_kwargs) -> str:
+        self.prompts.append(prompt)
+        return self.text_response
+
+    def enforce_anti_ai(self, text: str, **_kwargs) -> str:
+        return text
+
+
+def _dependencies(llm: FakeLLM) -> tuple[PipelineDependencies, FakeRecorder]:
+    recorder = FakeRecorder()
+    return PipelineDependencies(llm=llm, recorder=recorder), recorder
+
+
+def test_grounding_compares_the_draft_with_the_exact_evidence_records():
+    llm = FakeLLM(
+        json_response={
+            "grounded": False,
+            "assessment": "One figure is not in the records.",
+            "unsupported_claims": [
+                {
+                    "claim": "Rent averages 900 dollars.",
+                    "reason": "No record states a rent figure.",
+                    "severity": "high",
+                }
+            ],
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_groundedness_stage(_state(), dependencies)
+
+    prompt = llm.prompts[0]
+    assert "EVIDENCE RECORDS" in prompt
+    assert "Instituto Nacional de Estadística e Informática" in prompt
+    assert "retrieved 2026-08-25" in prompt
+    assert "CLEANED SOURCE MATERIAL" not in prompt
+    assert updates["groundedness"]["grounded"] is False
+    assert recorder.recorded[0][0] == "stage_v3_groundedness"
+
+
+def test_grounding_failure_degrades_to_unchecked_instead_of_failing_the_run():
+    class ExplodingLLM(FakeLLM):
+        def invoke_json(self, *, prompt: str, **_kwargs):
+            self.prompts.append(prompt)
+            raise RuntimeError("provider down")
+
+    dependencies, _recorder = _dependencies(ExplodingLLM())
+
+    updates = run_v3_groundedness_stage(_state(), dependencies)
+
+    assert updates["groundedness"]["checked"] is False
+
+
+def test_the_audit_judges_commission_fidelity_and_keeps_measured_checks():
+    llm = FakeLLM(
+        json_response={
+            "overall_score": 8,
+            "constraint_checks": {"audience_match": True, "tone_match": True},
+            "required_revisions": ["Answer the core reader question directly."],
+            "quality_summary": "Close, needs one fix.",
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+    state = _state(
+        groundedness={
+            "checked": True,
+            "grounded": True,
+            "unsupported_claims": [],
+            "high_severity_count": 0,
+        }
+    )
+
+    updates = run_v3_quality_audit_stage(state, dependencies)
+
+    prompt = llm.prompts[0]
+    assert "APPROVED COMMISSION" in prompt
+    assert "a context-only reference organizes a section" in prompt
+    assert "ARTICLE TYPE:" not in prompt
+    assert updates["quality_checks"]["claims_grounded"] is True
+    assert updates["quality_checks"]["audience_match"] is True
+    assert updates["best_rewrite"] == state["rewrite"]
+
+
+def test_repair_is_told_it_may_not_create_facts_or_change_the_commission():
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "improved_content": "## What Lima costs now\n\nRepaired body.",
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+    state = _state(
+        quality={"required_revisions": ["Tighten the opening."]},
+        groundedness={
+            "checked": True,
+            "grounded": False,
+            "high_severity_count": 1,
+            "unsupported_claims": [
+                {
+                    "claim": "Rent averages 900 dollars.",
+                    "reason": "No record states a rent figure.",
+                    "severity": "high",
+                }
+            ],
+        },
+    )
+
+    updates = run_v3_repair_stage(state, dependencies)
+
+    prompt = llm.prompts[0]
+    assert "Repair prose and structure only" in prompt
+    assert "you may not change the commission" in " ".join(prompt.split())
+    assert "Never promote a context-only reference" in prompt
+    assert "Remove or explicitly mark as unconfirmed: Rent averages 900 dollars." in (
+        recorder.recorded[0][1]["required_revisions"][1]
+    )
+    assert updates["repair_attempts"] == 1
+
+
+def test_settling_restores_the_best_draft_and_its_own_grounding_verdict():
+    best_rewrite = _rewrite("Best Lima title")
+    best_quality = {
+        "overall_score": 9,
+        "groundedness": {"checked": True, "grounded": True},
+    }
+    dependencies, _recorder = _dependencies(FakeLLM())
+    state = _state(
+        rewrite=_rewrite("Worse Lima title"),
+        quality={"overall_score": 5},
+        quality_checks={},
+        groundedness={"checked": True, "grounded": False},
+        best_rewrite=best_rewrite,
+        best_quality=best_quality,
+        best_quality_checks={"claims_grounded": True},
+    )
+
+    updates = run_v3_quality_settle_stage(state, dependencies)
+
+    assert updates["rewrite"] == best_rewrite
+    assert updates["groundedness"]["grounded"] is True
+
+
+def test_the_title_stage_sees_the_original_title_and_the_headline_standard():
+    llm = FakeLLM(text_response="Is Lima still worth the move?")
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_title_stage(_state(), dependencies)
+
+    prompt = llm.prompts[0]
+    assert _fixture()["commission"]["original_title"] in prompt
+    assert "HEADLINE STANDARD" in prompt
+    assert "Primary subject: Lima" in prompt
+    assert "Never headline a context-only reference" in prompt
+    assert updates["final_title"] == "Is Lima still worth the move?"
+
+
+def test_the_title_falls_back_to_the_commission_rather_than_to_nothing():
+    dependencies, _recorder = _dependencies(FakeLLM(text_response="  "))
+
+    updates = run_v3_title_stage(
+        _state(rewrite={**_rewrite(), "improved_title": ""}), dependencies
+    )
+
+    assert updates["final_title"] == _fixture()["commission"]["original_title"]
+
+
+def test_the_v3_constraint_brief_invents_no_seo_requirement():
+    runtime = _runtime()
+
+    brief = v3_constraint_brief(runtime.commission, runtime.option_context)
+
+    assert brief["seo"] == {"primary_keyword": "", "secondary_keywords": []}
+    assert brief["must_include"] == []
+    assert brief["formatting"]["target_word_count"] >= 0
+    assert "Primary subject: Lima" in v3_commission_summary(runtime.commission)


### PR DESCRIPTION
## Why

Second slice of PR 6. #398 added v3 outline and compose; this PR adds the stages that check and finish the draft, all bound to the same authority model.

## What

- **Grounding** compares the draft with the **exact evidence records** rather than cleaned source prose. V2 compared against text that had already lost publisher, date, and qualification; v3 can therefore catch a claim stated more confidently, more recently, or more broadly than the record behind it. A provider failure still degrades to `unchecked` instead of failing the run.
- **Audit** scores commission fidelity and evidence discipline. Drifting from the approved form, letting a context-only reference organize a section or earn a verdict, leaving the core reader question unanswered, or breaking an exclusion are failures, not style notes. Every measurable check stays deterministic and computed outside the prompt.
- **Repair** may fix prose and structure only. It cannot create a fact and cannot change the commission — an unsupported claim is removed or marked unconfirmed, never researched away, and scope may not be widened to satisfy a revision. Repair stays on the writer model, as decided in the earlier audit.
- **Settle** keeps the best-scoring draft of the repair loop, and carries that draft's own grounding verdict with it.
- **Title** writes from the shared headline standard, the form's headline note, and the original title as author intent. It must name the primary subject and may never headline a context-only reference. It falls back to the commission's original title rather than to nothing.
- **`quality_v3.py`** derives the deterministic constraint brief from the commission and the resolved length profile. Keyword and must-include fields stay empty on purpose: a v3 commission carries no SEO brief, and inventing one would fail drafts for missing a requirement nobody approved.

## Verification

- full backend suite: 839 collected, all passed (was 831; 8 new tests)
- tests drive the real stages through a fake LLM and recorder, and assert on the prompts themselves — that grounding sees the publisher and retrieval date, that the audit prompt has no `ARTICLE TYPE` block, and that repair is told it may not change the commission
- `black` clean; `flake8` clean apart from `E501` inside prompt literals

## Boundaries

Still no graph wiring — nothing calls these stages yet, and every v2 stage is untouched. The v3 graph, the finalize stage, and the mocked Lima end-to-end run are the last slice of PR 6. Model routing and pricing are unchanged.