### PR TITLE
Run the Prompt2Blog v3 pipeline end to end

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -20,6 +20,7 @@ bounded contexts.
 | `evidence_v3.py`, `instructions_v3.py` | V3 evidence normalization and the layered instruction stack |
 | `research_readiness_v3.py`, `intake_v3.py` | The v3 research gate, its `needs_research` result, and v3 run input |
 | `stages/v3/`, `prompts/editorial_v3.py`, `content/outline_v3.py` | V3 writing stages, their prompts, and pure section-plan scope guards |
+| `orchestrator_v3.py`, `graph/topology_v3.py` | The v3 run entrypoint and its shorter generation topology |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -14,10 +14,16 @@ from app.shared.writer_models import resolve_writer_model
 
 from ..config import DEFAULT_MODEL, FEATURE_NAME
 from ..contracts_v3 import Prompt2BlogV3Request
-from ..intake_v3 import v3_intake_result
+from ..intake_v3 import (
+    prepare_v3_runtime_request,
+    v3_intake_result,
+    v3_run_input_artifact,
+)
 from ..models import Prompt2BlogInputRequest
 from ..observability import _read_langgraph_trace
+from ..models import PipelineV3RuntimeRequest
 from ..orchestrator import run_full_pipeline
+from ..orchestrator_v3 import run_pipeline_v3
 from ..run_recorder import RunRecorder
 from ..support import _clean_string_list, _safe_str
 
@@ -35,6 +41,17 @@ def _run_full_pipeline_background(
         # The orchestrator records the active failed stage and logs the exception.
         # Re-raising from a Starlette background task only adds an unhandled-task
         # error after the HTTP response has already been sent.
+        return
+
+
+def _run_pipeline_v3_background(
+    run_id: str,
+    request: PipelineV3RuntimeRequest,
+) -> None:
+    """Keep background-task failures contained after the graph records them."""
+    try:
+        run_pipeline_v3(run_id, request)
+    except Exception:  # noqa: BLE001
         return
 
 
@@ -157,6 +174,51 @@ async def prepare_pipeline_v3(
     return JSONResponse({"message": message, **result})
 
 
+@router.post("/pipeline-v3")
+async def start_pipeline_v3(
+    request: Prompt2BlogV3Request,
+    background_tasks: BackgroundTasks,
+    staff_user=Depends(require_staff),
+) -> JSONResponse:
+    """Start a v3 run, or stop at the research gate without starting one.
+
+    `needs_research` is returned synchronously and queues nothing: a commission
+    whose evidence cannot support it has no run to make.
+    """
+    try:
+        readiness_result = v3_intake_result(request)
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    if readiness_result["status"] != "ready":
+        return JSONResponse(
+            {
+                "message": "Prompt2Blog v3 commission needs more research",
+                **readiness_result,
+            }
+        )
+
+    if request.enable_editorial_augmentation:
+        raise HTTPException(
+            status_code=400,
+            detail=("Editorial augmentation is not available on the v3 pipeline yet."),
+        )
+
+    runtime = prepare_v3_runtime_request(request)
+    run_id = str(uuid4())
+    recorder = RunRecorder()
+    recorder.queue(run_id, staff_user_id(staff_user))
+    recorder.record_stage(run_id, "pipeline_input_v3", v3_run_input_artifact(runtime))
+    background_tasks.add_task(_run_pipeline_v3_background, run_id, runtime)
+    return JSONResponse(
+        {
+            "message": "Prompt2Blog pipeline v3 queued",
+            "status": "queued",
+            "run_id": run_id,
+        }
+    )
+
+
 @router.get("/status/{run_id}")
 async def get_status(run_id: str) -> JSONResponse:
     """Get status for a Prompt2Blog pipeline run."""
@@ -217,6 +279,16 @@ async def debug_run(run_id: str) -> JSONResponse:
         "stage_title",
         "stage_finalize",
         "pipeline_v2",
+        "pipeline_input_v3",
+        "stage_v3_outline",
+        "stage_v3_compose",
+        "stage_v3_groundedness",
+        "stage_v3_quality_audit",
+        "stage_v3_repair",
+        "stage_v3_quality_settle",
+        "stage_v3_title",
+        "stage_v3_finalize",
+        "pipeline_v3",
         "langgraph_trace",
     ]:
         stage_data = read_stage_result(run_id, stage_name)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -83,9 +83,17 @@ class Prompt2BlogV3GraphState(TypedDict, total=False):
     trace: list[dict[str, Any]]
     readiness: dict[str, Any]
     outline: dict[str, Any]
+    outline_accepted: bool
+    outline_text: str
     rewrite: dict[str, Any]
     groundedness: dict[str, Any]
     quality: dict[str, Any]
+    quality_checks: dict[str, Any]
+    repair_applied: bool
+    repair_attempts: int
+    best_rewrite: dict[str, Any]
+    best_quality: dict[str, Any]
+    best_quality_checks: dict[str, Any]
     final_title: str
     final_markdown: str
     response_payload: dict[str, Any]

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/topology_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/topology_v3.py
@@ -1,0 +1,58 @@
+"""Prompt2Blog v3 graph topology.
+
+Shorter than v2 by design. There is no guideline fetch, no coverage check, and
+no supplement node: research readiness is settled before a run starts, and v3
+never generates a fact it did not receive.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..policies import route_quality_gate
+from .state import Prompt2BlogV3GraphState
+
+V3_GENERATION_NODES = (
+    "outline",
+    "compose",
+    "groundedness",
+    "quality_audit",
+    "repair",
+    "quality_settle",
+    "title",
+    "finalize",
+)
+
+
+def build_prompt2blog_v3_graph(nodes: dict[str, Any]) -> Any:
+    """Compile the v3 generation topology."""
+    from langgraph.graph import END, START, StateGraph
+
+    missing = set(V3_GENERATION_NODES) - nodes.keys()
+    unexpected = nodes.keys() - set(V3_GENERATION_NODES)
+    if missing or unexpected:
+        raise ValueError(
+            "Invalid Prompt2Blog v3 node registry; "
+            f"missing={sorted(missing)}, unexpected={sorted(unexpected)}"
+        )
+
+    builder = StateGraph(Prompt2BlogV3GraphState)
+    for name, node in nodes.items():
+        builder.add_node(name, node)
+
+    builder.add_edge(START, "outline")
+    builder.add_edge("outline", "compose")
+    # Grounding runs before the audit and inside the repair loop, so a repaired
+    # draft is re-checked against the evidence rather than trusted.
+    builder.add_edge("compose", "groundedness")
+    builder.add_edge("groundedness", "quality_audit")
+    builder.add_conditional_edges(
+        "quality_audit",
+        route_quality_gate,
+        {"repair": "repair", "settle": "quality_settle"},
+    )
+    builder.add_edge("repair", "groundedness")
+    builder.add_edge("quality_settle", "title")
+    builder.add_edge("title", "finalize")
+    builder.add_edge("finalize", END)
+    return builder

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator_v3.py
@@ -1,0 +1,145 @@
+"""Prompt2Blog v3 run entrypoint.
+
+Thin by design: the commission, the evidence, and the instruction stack are all
+assembled before a run starts, so the orchestrator only has to build the
+initial state and execute the v3 graph.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from .config import (
+    DEFAULT_MODEL,
+    P2B_AUDIT_MODEL,
+    P2B_COMPOSE_MODEL,
+    PROMPT2BLOG_CREATIVITY_TEMPERATURES,
+    PROMPT2BLOG_DEFAULT_COMPOSE_TEMPERATURE,
+)
+from .dependencies import PipelineDependencies
+from .graph.runner import GraphNode, run_prompt2blog_stage_graph
+from .graph.state import Prompt2BlogV3GraphState
+from .graph.topology_v3 import build_prompt2blog_v3_graph
+from .models import PipelineV3RuntimeRequest
+from .stages.v3.audit_repair import (
+    run_v3_quality_audit_stage,
+    run_v3_quality_settle_stage,
+    run_v3_repair_stage,
+)
+from .stages.v3.compose import run_v3_compose_stage
+from .stages.v3.finalize import run_v3_finalize_stage
+from .stages.v3.groundedness import run_v3_groundedness_stage
+from .stages.v3.outline import run_v3_outline_stage
+from .stages.v3.title import run_v3_title_stage
+from .support import _safe_dict, _safe_str
+
+logger = logging.getLogger(__name__)
+
+V3StageFunction = Callable[
+    [Prompt2BlogV3GraphState, PipelineDependencies],
+    dict[str, Any],
+]
+
+
+def _initial_v3_state(
+    run_id: str,
+    request: PipelineV3RuntimeRequest,
+    dependencies: PipelineDependencies,
+) -> Prompt2BlogV3GraphState:
+    instructions = _safe_dict(request.instructions)
+    creativity_level = _safe_str(
+        _safe_dict(request.option_context).get("creativity_level")
+    ).lower()
+    return {
+        "run_id": run_id,
+        "request": request,
+        "commission": request.commission,
+        "evidence": request.evidence,
+        "instructions": instructions,
+        "instruction_text": _safe_str(instructions.get("instruction_text")),
+        "headline_instructions": _safe_str(instructions.get("headline_instructions")),
+        "option_context": _safe_dict(request.option_context),
+        "model_name": request.model_name or DEFAULT_MODEL,
+        "writing_model": dependencies.resolve_writer_model(
+            request.writing_model,
+            default=P2B_COMPOSE_MODEL,
+        ),
+        "audit_model": dependencies.resolve_writer_model(
+            request.audit_model,
+            default=P2B_AUDIT_MODEL,
+        ),
+        "model_stack_id": request.model_stack_id,
+        "compose_temperature": PROMPT2BLOG_CREATIVITY_TEMPERATURES.get(
+            creativity_level,
+            PROMPT2BLOG_DEFAULT_COMPOSE_TEMPERATURE,
+        ),
+        "include_debug": request.include_debug,
+        "enable_editorial_augmentation": request.enable_editorial_augmentation,
+        "current_stage": "stage_v3_outline",
+        "repair_attempts": 0,
+        "repair_applied": False,
+        "outline_accepted": False,
+        "outline_text": "",
+        "trace": [],
+    }
+
+
+def _node(
+    stage: V3StageFunction,
+    dependencies: PipelineDependencies,
+) -> GraphNode:
+    def run(state: Prompt2BlogV3GraphState) -> dict[str, Any]:
+        updates = stage(state, dependencies)
+        updates["trace"] = state["trace"]
+        return updates
+
+    return run
+
+
+def _v3_nodes(
+    dependencies: PipelineDependencies,
+) -> list[tuple[str, GraphNode]]:
+    stages: list[tuple[str, V3StageFunction]] = [
+        ("outline", run_v3_outline_stage),
+        ("compose", run_v3_compose_stage),
+        ("groundedness", run_v3_groundedness_stage),
+        ("quality_audit", run_v3_quality_audit_stage),
+        ("repair", run_v3_repair_stage),
+        ("quality_settle", run_v3_quality_settle_stage),
+        ("title", run_v3_title_stage),
+        ("finalize", run_v3_finalize_stage),
+    ]
+    return [(name, _node(stage, dependencies)) for name, stage in stages]
+
+
+def run_pipeline_v3(
+    run_id: str,
+    request: PipelineV3RuntimeRequest,
+    dependencies: PipelineDependencies | None = None,
+) -> Prompt2BlogV3GraphState:
+    dependencies = dependencies or PipelineDependencies()
+    initial_state = _initial_v3_state(run_id, request, dependencies)
+    try:
+        return run_prompt2blog_stage_graph(
+            run_id=run_id,
+            trace_name="prompt2blog.pipeline_v3",
+            initial_state=initial_state,
+            nodes=_v3_nodes(dependencies),
+            recorder=dependencies.recorder,
+            build_graph=build_prompt2blog_v3_graph,
+        )
+    except Exception as exc:
+        logger.exception("Prompt2Blog pipeline-v3 failed", extra={"run_id": run_id})
+        dependencies.recorder.fail(
+            run_id,
+            dependencies.recorder.active_stage(run_id),
+            exc,
+            debug_data=(
+                {"pipeline_trace": initial_state["trace"]}
+                if request.include_debug
+                else None
+            ),
+        )
+        raise

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/routes.py
@@ -18,6 +18,7 @@ from .models import (  # noqa: F401
     SynthesizeResponse,
 )
 from .orchestrator import run_full_pipeline, run_pipeline_v2
+from .orchestrator_v3 import run_pipeline_v3  # noqa: F401
 
 
 async def synthesize_sources(req: SynthesizeRequest) -> SynthesizeResponse:
@@ -53,6 +54,14 @@ async def prepare_pipeline_v3(
     staff_user=None,
 ):
     return await _runs_api.prepare_pipeline_v3(request, staff_user)
+
+
+async def start_pipeline_v3(
+    request: Prompt2BlogV3Request,
+    background_tasks,
+    staff_user=None,
+):
+    return await _runs_api.start_pipeline_v3(request, background_tasks, staff_user)
 
 
 async def start_full_run(
@@ -100,6 +109,7 @@ __all__ = [
     "get_article_type_guideline_preview",
     "start_pipeline_v2",
     "prepare_pipeline_v3",
+    "start_pipeline_v3",
     "start_full_run",
     "get_status",
     "get_result",
@@ -109,5 +119,6 @@ __all__ = [
     "mark_article_as_synced",
     "get_sync_status",
     "run_pipeline_v2",
+    "run_pipeline_v3",
     "run_full_pipeline",
 ]

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...content.markdown import _build_markdown
+from ...dependencies import PipelineDependencies
+from ...graph.state import Prompt2BlogV3GraphState
+from ...policies import evaluate_readiness
+from ...pricing import Prompt2BlogTokenUsageTracker
+from ...quality import _build_constraint_checks
+from ...quality_v3 import v3_constraint_brief
+from ...support import _safe_dict, _safe_str
+
+
+def run_v3_finalize_stage(
+    state: Prompt2BlogV3GraphState,
+    dependencies: PipelineDependencies,
+) -> dict[str, Any]:
+    """Persist the finished article with the commission it answers.
+
+    The artifact keeps the commission, the form and modules, the audience, the
+    evidence receipt, and the readiness outcome, so a finished run can be
+    audited later without replaying it or trusting the prose.
+    """
+    stage = "stage_v3_finalize"
+    run_id = state["run_id"]
+    rewrite = state["rewrite"]
+    quality = state["quality"]
+    quality_checks = state["quality_checks"]
+    commission = state["commission"]
+    instructions = state["instructions"]
+    evidence = state["evidence"]
+    dependencies.recorder.start_stage(run_id, stage)
+
+    final_title = dependencies.normalize_dashes(state["final_title"])
+    final_content = rewrite["improved_content"]
+    final_markdown = _build_markdown(final_title, final_content)
+    final_checks = _build_constraint_checks(
+        final_title,
+        final_content,
+        v3_constraint_brief(commission, state["option_context"]),
+    )
+    settled_checks = {
+        **quality_checks,
+        **{
+            key: value
+            for key, value in final_checks.items()
+            if not key.endswith("_coverage") and key != "word_count_estimate"
+        },
+    }
+    verdict = evaluate_readiness(
+        quality=quality,
+        checks=settled_checks,
+        groundedness=state["groundedness"],
+    )
+    pipeline_status = "ready_for_staging" if verdict.ready else "needs_revision"
+
+    dependencies.recorder.record_stage(
+        run_id,
+        stage,
+        {
+            "pipeline_status": pipeline_status,
+            "readiness_blockers": list(verdict.blockers),
+            "final_title": final_title,
+            "word_count_estimate": final_checks["word_count_estimate"],
+            "constraint_checks": final_checks,
+        },
+    )
+
+    usage_summary = getattr(dependencies.llm, "usage_summary", None)
+    usage_kwargs = {
+        "stack_id": state.get("model_stack_id"),
+        "worker_model": state["model_name"],
+        "writing_model": state["writing_model"],
+        "audit_model": state["audit_model"],
+    }
+    run_cost = (
+        usage_summary(**usage_kwargs)
+        if callable(usage_summary)
+        else Prompt2BlogTokenUsageTracker().summary(**usage_kwargs)
+    )
+    instruction_meta = _safe_dict(instructions.get("instruction_meta"))
+
+    response_payload: dict[str, Any] = {
+        "message": "Prompt2Blog pipeline v3 completed",
+        "run_id": run_id,
+        "schema_version": 3,
+        "status": "completed",
+        "pipeline_status": pipeline_status,
+        "readiness_blockers": list(verdict.blockers),
+        "commission": commission,
+        "form": {
+            "id": instruction_meta.get("form_id"),
+            "label": instruction_meta.get("form_label"),
+        },
+        "instruction_meta": instruction_meta,
+        "evidence_receipt": instruction_meta.get("evidence_receipt", {}),
+        "improved_article": {"title": final_title, "content": final_content},
+        "final_markdown": final_markdown,
+        "run_cost": run_cost,
+        "input_profiles": {
+            "tone": _safe_dict(state["option_context"].get("tone")),
+            "length": _safe_dict(state["option_context"].get("length")),
+            "brand_voice": _safe_dict(state["option_context"].get("brand_voice")),
+            "creativity_level": _safe_str(
+                state["option_context"].get("creativity_level")
+            ),
+        },
+        "quality_review": {
+            "alignment_summary": rewrite["guideline_alignment_summary"],
+            "improvements_applied": rewrite["improvements_applied"],
+            "remaining_gaps": rewrite["remaining_gaps"],
+            "quality_summary": quality["quality_summary"],
+            "quality_scores": {
+                "overall": quality["overall_score"],
+                "commission_fidelity": quality["guideline_coverage_score"],
+                "informativeness": quality["informativeness_score"],
+                "originality": quality["originality_score"],
+                "brief_adherence": quality["brief_adherence_score"],
+                "seo": quality["seo_score"],
+            },
+            "constraint_checks": settled_checks,
+            "readiness_blockers": list(verdict.blockers),
+            "word_count_estimate": final_checks["word_count_estimate"],
+            "repair_applied": state.get("repair_applied", False),
+            "repair_attempts": state.get("repair_attempts", 0),
+            "groundedness": state["groundedness"],
+            "outline_accepted": state.get("outline_accepted", False),
+            "outline_section_count": len(
+                _safe_dict(state.get("outline")).get("sections") or []
+            ),
+            "outline_unsupported_requirements": _safe_dict(state.get("outline")).get(
+                "unsupported_requirements", []
+            ),
+            "model_used": state["model_name"],
+            "stage_model_overrides": {
+                "stage_v3_outline": state["writing_model"],
+                "stage_v3_compose": state["writing_model"],
+                "stage_v3_repair": state["writing_model"],
+                "stage_v3_title": state["writing_model"],
+                "stage_v3_quality_audit": state["audit_model"],
+                "stage_v3_groundedness": state["audit_model"],
+            },
+        },
+    }
+    if state["include_debug"]:
+        response_payload["debug"] = {
+            "pipeline_input": {
+                "commission_fingerprint": commission["commission_fingerprint"],
+                "form_id": commission["form_id"],
+                "topic_module_ids": list(commission["topic_module_ids"]),
+                "model_name": state["model_name"],
+                "writing_model": state["writing_model"],
+                "audit_model": state["audit_model"],
+                "model_stack_id": state.get("model_stack_id"),
+                "include_debug": state["include_debug"],
+                "input_profiles": state["option_context"],
+            },
+            "instruction_text": instructions.get("instruction_text", ""),
+            "evidence_records": evidence.get("records_text", ""),
+            "pipeline_trace": state["trace"],
+        }
+
+    dependencies.recorder.record_stage(run_id, "pipeline_v3", response_payload)
+    dependencies.recorder.record_artifact(
+        run_id,
+        {
+            "markdown": final_markdown,
+            "pipeline_v3": response_payload,
+            "stages": {
+                "stage_v3_outline": state.get("outline", {}),
+                "stage_v3_compose": rewrite,
+                "stage_v3_groundedness": state["groundedness"],
+                "stage_v3_quality_audit": quality,
+                "stage_v3_title": {"final_title": final_title},
+            },
+        },
+    )
+    dependencies.recorder.complete(run_id)
+    return {
+        "current_stage": stage,
+        "rewrite": rewrite,
+        "final_title": final_title,
+        "final_markdown": final_markdown,
+        "response_payload": response_payload,
+        "completed": True,
+    }

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
@@ -1,0 +1,379 @@
+"""The Lima regression through the whole mocked v3 graph."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+import app.features.prompt2blog.api.runs as runs_api
+import app.features.prompt2blog.routes as prompt2blog_routes
+from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
+from app.features.prompt2blog.dependencies import PipelineDependencies
+from app.features.prompt2blog.intake_v3 import prepare_v3_runtime_request
+from app.features.prompt2blog.orchestrator_v3 import run_pipeline_v3
+from app.features.prompt2blog.run_recorder import RunRecorder
+from tests.prompt2blog_test_support import response_payload
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v3.json"
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _supported_evidence() -> dict:
+    evidence = deepcopy(_fixture()["evidence_package"])
+    evidence["claims"].extend(
+        [
+            {
+                "claim_id": "c2",
+                "text": "Current reporting documents Lima's practical tradeoffs.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r2"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+            {
+                "claim_id": "c3",
+                "text": "Comparable earlier reporting shows how those costs moved.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r3"],
+                "as_of": "2026-07-01",
+                "confidence": "medium",
+            },
+        ]
+    )
+    evidence["requirements"] = [
+        {"requirement_id": "r1", "status": "supported", "claim_ids": ["c1"], "gap": ""},
+        {"requirement_id": "r2", "status": "supported", "claim_ids": ["c2"], "gap": ""},
+        {"requirement_id": "r3", "status": "supported", "claim_ids": ["c3"], "gap": ""},
+    ]
+    evidence["gaps"] = []
+    return evidence
+
+
+def _request(**overrides) -> Prompt2BlogV3Request:
+    payload = {
+        "schema_version": 3,
+        "commission": _fixture()["commission"],
+        "evidence_package": _supported_evidence(),
+        "profiles": {
+            "tone_id": "editorial",
+            "length_id": "medium",
+            "creativity_level": "medium",
+        },
+        "model_routing": {
+            "model_name": "test-model",
+            "writing_model": "gemini-2.5-flash",
+            "audit_model": "gemini-2.5-flash",
+        },
+    }
+    payload.update(overrides)
+    return Prompt2BlogV3Request.model_validate(payload)
+
+
+OUTLINE = {
+    "working_title": "What Lima costs now",
+    "direct_answer_focus": "Whether Lima still offers long-stay value.",
+    "sections": [
+        {
+            "heading": "What Lima costs now",
+            "purpose": "Establish the current cost baseline for Lima.",
+            "claim_ids": ["c1"],
+            "requirement_ids": ["r1"],
+            "target_words": 300,
+        },
+        {
+            "heading": "The tradeoffs behind the price",
+            "purpose": "Show the practical tradeoffs a Lima resident meets.",
+            "claim_ids": ["c2"],
+            "requirement_ids": ["r2"],
+            "target_words": 300,
+        },
+        {
+            "heading": "How the Lima picture changed",
+            "purpose": "Compare the current baseline with earlier reporting.",
+            "claim_ids": ["c3"],
+            "requirement_ids": ["r3"],
+            "target_words": 300,
+        },
+    ],
+    "takeaway_focus": "What decides the answer for a long stay.",
+    "commission_alignment": "Answers the cost question about Lima itself.",
+    "unsupported_requirements": [],
+}
+
+
+def _section(heading: str, sentence: str) -> str:
+    # The audit's word-count check is deterministic and measured on the real
+    # text, so the mocked draft has to be a real medium-length article.
+    paragraphs = [" ".join([sentence] * 4) for _ in range(6)]
+    return f"## {heading}\n\n" + "\n\n".join(paragraphs)
+
+
+DRAFT = {
+    "improved_title": "What Lima costs now",
+    "improved_content": "\n\n".join(
+        [
+            _section(
+                "What Lima costs now",
+                "Official price reporting gives a current baseline for routine "
+                "costs in Lima.",
+            ),
+            _section(
+                "The tradeoffs behind the price",
+                "The same reporting shows the practical tradeoffs a Lima "
+                "resident meets each month.",
+            ),
+            _section(
+                "How the Lima picture changed",
+                "Earlier reporting shows how those Lima costs moved over the "
+                "period covered.",
+            ),
+        ]
+    ),
+    "commission_alignment_summary": "Answers the cost question about Lima.",
+    "improvements_applied": ["Grounded every section in a claim."],
+    "remaining_gaps": [],
+}
+
+
+@dataclass
+class RecordingRecorder:
+    stages: dict[str, Any] = field(default_factory=dict)
+    order: list[str] = field(default_factory=list)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    completed: list[str] = field(default_factory=list)
+    active: str = ""
+
+    def start_stage(self, _run_id: str, stage: str) -> None:
+        self.order.append(stage)
+        self.active = stage
+
+    def record_stage(self, _run_id: str, stage: str, payload: dict[str, Any]) -> None:
+        self.stages[stage] = payload
+
+    def record_artifact(self, _run_id: str, artifact: dict[str, Any]) -> None:
+        self.artifacts.append(artifact)
+
+    def complete(self, run_id: str) -> None:
+        self.completed.append(run_id)
+
+    def fail(self, *_args, **_kwargs) -> None:
+        raise AssertionError("the mocked v3 run must not fail")
+
+    def active_stage(self, _run_id: str) -> str:
+        return self.active
+
+
+@dataclass
+class ScriptedLLM:
+    quality_scores: list[int]
+    prompts: list[tuple[str, str]] = field(default_factory=list)
+    grounded: bool = True
+
+    def invoke_json(self, *, prompt: str, **_kwargs) -> tuple[dict[str, Any], str]:
+        if "planning an article before it is written" in prompt:
+            self.prompts.append(("outline", prompt))
+            return OUTLINE, json.dumps(OUTLINE)
+        if "fact-grounding checker" in prompt:
+            self.prompts.append(("groundedness", prompt))
+            payload = {
+                "grounded": self.grounded,
+                "assessment": "Checked against the records.",
+                "unsupported_claims": (
+                    []
+                    if self.grounded
+                    else [
+                        {
+                            "claim": "Rent averages 900 dollars.",
+                            "reason": "No record states a rent figure.",
+                            "severity": "high",
+                        }
+                    ]
+                ),
+            }
+            return payload, json.dumps(payload)
+        if "quality auditor" in prompt:
+            self.prompts.append(("audit", prompt))
+            score = (
+                self.quality_scores.pop(0)
+                if len(self.quality_scores) > 1
+                else self.quality_scores[0]
+            )
+            payload = {
+                "overall_score": score,
+                "guideline_coverage_score": score,
+                "informativeness_score": score,
+                "originality_score": score,
+                "brief_adherence_score": score,
+                "seo_score": score,
+                "too_close_to_source": False,
+                "constraint_checks": {"audience_match": True, "tone_match": True},
+                "required_revisions": [] if score >= 8 else ["Tighten the opening."],
+                "quality_summary": "Scored by the scripted auditor.",
+            }
+            return payload, json.dumps(payload)
+        if "repair pass" in prompt:
+            self.prompts.append(("repair", prompt))
+            return DRAFT, json.dumps(DRAFT)
+        self.prompts.append(("compose", prompt))
+        return DRAFT, json.dumps(DRAFT)
+
+    def invoke_text(self, *, prompt: str, **_kwargs) -> str:
+        self.prompts.append(("title", prompt))
+        return "Is Lima still worth a long stay?"
+
+    def enforce_anti_ai(self, text: str, **_kwargs) -> str:
+        return text
+
+
+def _run(**llm_kwargs) -> tuple[dict[str, Any], RecordingRecorder, ScriptedLLM]:
+    llm = ScriptedLLM(**llm_kwargs)
+    recorder = RecordingRecorder()
+    runtime = prepare_v3_runtime_request(_request())
+    state = run_pipeline_v3(
+        "lima-v3-run",
+        runtime,
+        PipelineDependencies(llm=llm, recorder=recorder),
+    )
+    return state, recorder, llm
+
+
+def test_the_lima_commission_runs_end_to_end_through_the_v3_graph():
+    state, recorder, _llm = _run(quality_scores=[9])
+
+    assert state["completed"] is True
+    assert recorder.order == [
+        "stage_v3_outline",
+        "stage_v3_compose",
+        "stage_v3_groundedness",
+        "stage_v3_quality_audit",
+        "stage_v3_quality_settle",
+        "stage_v3_title",
+        "stage_v3_finalize",
+    ]
+    payload = recorder.stages["pipeline_v3"]
+    assert payload["pipeline_status"] == "ready_for_staging"
+    assert payload["form"]["id"] == "analysis"
+    assert payload["commission"]["primary_subject"] == "Lima"
+    assert payload["evidence_receipt"]["requirement_status"] == {
+        "r1": "supported",
+        "r2": "supported",
+        "r3": "supported",
+    }
+    assert state["final_title"] == "Is Lima still worth a long stay?"
+
+
+def test_the_v3_run_never_reaches_a_guideline_or_supplement_stage():
+    _state, recorder, _llm = _run(quality_scores=[9])
+
+    assert "stage_guideline_fetch" not in recorder.order
+    assert "stage_coverage_check" not in recorder.order
+    assert "stage_supplement" not in recorder.order
+    assert "pipeline_v2" not in recorder.stages
+
+
+def test_context_only_cities_never_become_the_article_structure():
+    _state, recorder, llm = _run(quality_scores=[9])
+
+    artifact = recorder.artifacts[0]
+    markdown = artifact["markdown"]
+    headings = [line for line in markdown.splitlines() if line.startswith("##")]
+    assert headings
+    assert all("Medellín" not in heading for heading in headings)
+    assert all("Buenos Aires" not in heading for heading in headings)
+    # The scope rule still travelled with every writing prompt.
+    outline_prompt = next(prompt for kind, prompt in llm.prompts if kind == "outline")
+    assert "context-only reference may calibrate a fact" in " ".join(
+        outline_prompt.split()
+    )
+
+
+def test_a_low_score_spends_a_repair_pass_and_re_checks_grounding():
+    _state, recorder, llm = _run(quality_scores=[5, 9])
+
+    assert recorder.order.count("stage_v3_repair") == 1
+    assert recorder.order.count("stage_v3_groundedness") == 2
+    assert recorder.order.count("stage_v3_quality_audit") == 2
+    repair_prompt = next(prompt for kind, prompt in llm.prompts if kind == "repair")
+    assert "you may not change the commission" in " ".join(repair_prompt.split())
+
+
+def test_the_route_queues_a_run_only_when_research_is_ready(monkeypatch):
+    queued: dict[str, Any] = {}
+
+    class FakeRecorder:
+        def queue(self, run_id: str, _user_id) -> None:
+            queued["run_id"] = run_id
+
+        def record_stage(self, _run_id: str, stage: str, payload: dict) -> None:
+            queued[stage] = payload
+
+    monkeypatch.setattr(runs_api, "RunRecorder", FakeRecorder)
+    background = BackgroundTasks()
+
+    payload = response_payload(
+        asyncio.run(prompt2blog_routes.start_pipeline_v3(_request(), background, None))
+    )
+
+    assert payload["status"] == "queued"
+    assert payload["run_id"] == queued["run_id"]
+    assert queued["pipeline_input_v3"]["form_id"] == "analysis"
+    assert len(background.tasks) == 1
+
+
+def test_the_route_returns_needs_research_without_queueing_anything(monkeypatch):
+    def fail_if_used(*_args, **_kwargs):
+        raise AssertionError("needs_research must not create a run")
+
+    monkeypatch.setattr(runs_api, "RunRecorder", fail_if_used)
+    background = BackgroundTasks()
+
+    payload = response_payload(
+        asyncio.run(
+            prompt2blog_routes.start_pipeline_v3(
+                _request(evidence_package=_fixture()["evidence_package"]),
+                background,
+                None,
+            )
+        )
+    )
+
+    assert payload["status"] == "needs_research"
+    assert "run_id" not in payload
+    assert background.tasks == []
+
+
+def test_editorial_augmentation_is_refused_rather_than_silently_ignored():
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            prompt2blog_routes.start_pipeline_v3(
+                _request(enable_editorial_augmentation=True),
+                BackgroundTasks(),
+                None,
+            )
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "not available on the v3 pipeline" in str(excinfo.value.detail)
+
+
+def test_the_default_recorder_is_untouched_by_the_v3_entrypoint():
+    # The v3 orchestrator must keep using the one adapter that writes runs.
+    assert isinstance(PipelineDependencies().recorder, RunRecorder)
+    assert uuid4()


### PR DESCRIPTION
## Why

Final slice of PR 6. #398 and #399 added the v3 writing stages; this PR wires them into a graph, gives them a run entrypoint, and proves the Lima commission survives a complete run.

## What

- **`stages/v3/finalize.py`** persists the finished article together with the commission it answers: form and modules, audience, the evidence receipt, readiness outcome, per-stage model attribution, and the run cost. A finished run can be audited later without replaying it or trusting the prose.
- **`graph/topology_v3.py`** — the v3 topology, deliberately shorter than v2: no guideline fetch, no coverage check, no supplement node. Readiness is settled before a run starts, and v3 never generates a fact it did not receive. Grounding still sits inside the repair loop, so a repaired draft is re-checked rather than trusted.
- **`orchestrator_v3.py`** and **`POST /prompt2blog/pipeline-v3`** — the route queues a run only when research is ready; `needs_research` comes back synchronously and creates nothing, because a commission whose evidence cannot support it has no run to make.
- Editorial augmentation is **refused with a 400** on v3 rather than accepted and ignored — it is a full-article generation call that has not been re-verified against the evidence model yet.
- The debug endpoint now reads the v3 stages alongside the v2 ones.

## Verification

- full backend suite: 847 collected, all passed (was 839; 8 new tests)
- the Lima commission runs end to end through the real LangGraph graph with a scripted LLM: stage order asserted, `ready_for_staging`, evidence receipt intact, and no `Medellín` or `Buenos Aires` heading in the shipped markdown
- a low audit score spends exactly one repair pass and re-runs grounding afterwards
- one test asserts the run never touches `stage_guideline_fetch`, `stage_coverage_check`, or `stage_supplement`
- route tests assert a ready commission queues exactly one background task, and that `needs_research` constructs no recorder at all
- `black` and `flake8` clean on every touched file

## Boundaries

V2 is untouched — its topology, orchestrator, routes, stages, and `pipeline_v2` artifacts all behave exactly as before, and both paths coexist. No UI submits to v3 yet; that cutover, the `needs_research` result screen, and staging by form label are PR 7. Model routing and pricing are unchanged.