### PR TITLE
feat(prompt2blog): add v3 run contracts and start client

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -242,9 +242,13 @@ async def get_result(run_id: str) -> JSONResponse:
     trace_payload = _read_langgraph_trace(run_id)
     artifact = output["artifact"]
     if trace_payload and isinstance(artifact, dict):
-        pipeline_payload = artifact.get("pipeline_v2")
-        if isinstance(pipeline_payload, dict):
-            pipeline_payload.update(trace_payload)
+        # A run records exactly one of these keys, named for the pipeline
+        # version that produced it. Both are checked so a v3 result carries its
+        # trace link in the same place a v2 result always has.
+        for artifact_key in ("pipeline_v2", "pipeline_v3"):
+            pipeline_payload = artifact.get(artifact_key)
+            if isinstance(pipeline_payload, dict):
+                pipeline_payload.update(trace_payload)
 
     response_payload: dict[str, Any] = {
         "run_id": run_id,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_run_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_run_routes.py
@@ -60,6 +60,35 @@ def test_result_route_preserves_legacy_v2_artifact_shape(monkeypatch):
     assert payload == expected
 
 
+def test_result_route_attaches_the_trace_to_a_v3_artifact(monkeypatch):
+    """A v3 run must surface its trace where a v2 run always has."""
+    artifact = {"pipeline_v3": {"run_id": "v3-run", "status": "completed"}}
+    monkeypatch.setattr(
+        runs_api,
+        "read_status",
+        lambda _run_id: {"feature": "prompt2blog", "state": "completed"},
+    )
+    monkeypatch.setattr(
+        runs_api,
+        "read_output",
+        lambda _run_id: {"markdown": "# Lima", "artifact": artifact},
+    )
+    monkeypatch.setattr(
+        runs_api,
+        "_read_langgraph_trace",
+        lambda _run_id: {"langsmith_trace_url": "https://trace.example/v3-run"},
+    )
+
+    payload = response_payload(asyncio.run(prompt2blog_routes.get_result("v3-run")))
+
+    assert (
+        payload["artifact"]["pipeline_v3"]["langsmith_trace_url"]
+        == "https://trace.example/v3-run"
+    )
+    assert payload["langsmith_trace_url"] == "https://trace.example/v3-run"
+    assert "pipeline_v2" not in payload["artifact"]
+
+
 def test_start_pipeline_v2_queues_background_task(
     empty_prompt2blog_storage, monkeypatch
 ):

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
@@ -42,6 +42,8 @@ export type {
   Prompt2BlogArticleTypeOption,
   Prompt2BlogDebugResponse,
   Prompt2BlogDebugStages,
+  Prompt2BlogEvidenceReceipt,
+  Prompt2BlogGroundedness,
   Prompt2BlogGuidelinePreviewResponse,
   Prompt2BlogInputOption,
   Prompt2BlogInputOptionsResponse,
@@ -49,13 +51,29 @@ export type {
   Prompt2BlogPipelinePayload,
   Prompt2BlogPipelineStage,
   Prompt2BlogResultResponse,
+  Prompt2BlogRunArtifact,
+  Prompt2BlogRunCost,
   Prompt2BlogRunRequest,
   Prompt2BlogRunResponse,
   Prompt2BlogStageTrace,
   Prompt2BlogStatusResponse,
+  Prompt2BlogV3InstructionMeta,
+  Prompt2BlogV3NeedsResearchResponse,
+  Prompt2BlogV3PipelinePayload,
+  Prompt2BlogV3QueuedResponse,
+  Prompt2BlogV3ReadinessFinding,
+  Prompt2BlogV3ReadinessFindingCode,
+  Prompt2BlogV3StartResponse,
   Prompt2BlogWriterModel,
+  KnownPrompt2BlogPipelineStage,
+  KnownPrompt2BlogV2PipelineStage,
+  KnownPrompt2BlogV3PipelineStage,
 } from './types/pipeline.types'
-export { PROMPT2BLOG_PIPELINE_STAGES } from './types/pipeline.types'
+export {
+  PROMPT2BLOG_KNOWN_PIPELINE_STAGES,
+  PROMPT2BLOG_PIPELINE_STAGES,
+  PROMPT2BLOG_V3_PIPELINE_STAGES,
+} from './types/pipeline.types'
 
 export { fetchArticleTypeGuidelinesById, fetchArticleTypes } from './api/article-types.api'
 export { deleteArticle, fetchArticles } from './api/articles.api'
@@ -68,6 +86,7 @@ export {
   getPrompt2BlogResult,
   getPrompt2BlogStatus,
   startPrompt2BlogRun,
+  startPrompt2BlogV3Run,
 } from './api/pipeline.api'
 export { getArticleSyncStatus, markArticleSynced } from './api/sync.api'
 export type { CreateArticlePayload, Location, MediaAsset } from '../staging/api'

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import legacyRequestFixture from '../../../../../../data/fixtures/prompt2blog/legacy-v2-request.json'
 import legacyResultFixture from '../../../../../../data/fixtures/prompt2blog/legacy-v2-result.json'
+import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-drift-v3.json'
 import type { Prompt2BlogRunRequest } from '../types/pipeline.types'
+import type { Prompt2BlogV3Request } from '../types/editorial.types'
 import {
   getPrompt2BlogResult,
   normalizePrompt2BlogStatusResponse,
   startPrompt2BlogRun,
+  startPrompt2BlogV3Run,
 } from './pipeline.api'
 
 const mockFetch = vi.fn()
@@ -53,6 +56,29 @@ describe('normalizePrompt2BlogStatusResponse', () => {
         'fallback-run',
       ).stage,
     ).toBe('queued')
+  })
+
+  it('keeps a v3 stage name recognized rather than unknown', () => {
+    expect(
+      normalizePrompt2BlogStatusResponse(
+        {
+          run_id: 'run-123',
+          feature: 'prompt2blog',
+          state: 'running',
+          stage: 'stage_v3_compose',
+          error: null,
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+        'fallback-run',
+      ),
+    ).toEqual({
+      run_id: 'run-123',
+      feature: 'prompt2blog',
+      state: 'running',
+      stage: 'stage_v3_compose',
+      error: null,
+      updated_at: '2026-01-01T00:00:00Z',
+    })
   })
 
   it('normalizes unknown stage to a visible unknown state', () => {
@@ -113,5 +139,79 @@ describe('legacy v2 API contracts', () => {
     await expect(getPrompt2BlogResult('legacy-v2-run')).resolves.toEqual(
       legacyResultFixture,
     )
+  })
+})
+
+describe('startPrompt2BlogV3Run', () => {
+  const v3Request = {
+    schema_version: 3,
+    commission: limaFixture.commission,
+    evidence_package: limaFixture.evidence_package,
+    profiles: { tone_id: 'editorial-analysis', length_id: 'long' },
+  } as unknown as Prompt2BlogV3Request
+
+  it('posts the v3 request to the v3 route', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: 'queued', status: 'queued', run_id: 'v3-run' }),
+    })
+
+    await expect(startPrompt2BlogV3Run(v3Request)).resolves.toEqual({
+      message: 'queued',
+      status: 'queued',
+      run_id: 'v3-run',
+    })
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://localhost:4003/prompt2blog/pipeline-v3')
+    expect(JSON.parse(init.body as string)).toEqual(v3Request)
+  })
+
+  it('returns needs_research as a result rather than throwing', async () => {
+    const needsResearch = {
+      message: 'Prompt2Blog v3 commission needs more research',
+      status: 'needs_research',
+      commission_fingerprint: limaFixture.commission.commission_fingerprint,
+      findings: [{ code: 'requirement_gap', requirement_ids: ['r2'], message: 'No evidence.' }],
+      unresolved_requirements: [{ requirement_id: 'r2', question: 'Which tradeoffs?', gap: 'None.' }],
+      unresolved_conflict_ids: [],
+      missing_source_requirements: [],
+      follow_up_research_prompt: 'Close r2.',
+    }
+    mockFetch.mockResolvedValue({ ok: true, json: async () => needsResearch })
+
+    await expect(startPrompt2BlogV3Run(v3Request)).resolves.toEqual(needsResearch)
+  })
+
+  it('rejects a start response that names neither outcome', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ run_id: 'v3-run' }) })
+
+    await expect(startPrompt2BlogV3Run(v3Request)).rejects.toThrow(
+      'unrecognized start response',
+    )
+  })
+
+  it('rejects a queued response with no run id to poll', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ status: 'queued' }) })
+
+    await expect(startPrompt2BlogV3Run(v3Request)).rejects.toThrow(
+      'unrecognized start response',
+    )
+  })
+})
+
+describe('v3 result artifacts', () => {
+  it('reads a v3 artifact without disturbing the legacy key', async () => {
+    const v3Result = {
+      run_id: 'v3-run',
+      markdown: '# Lima',
+      artifact: { pipeline_v3: { run_id: 'v3-run', status: 'completed' } },
+    }
+    mockFetch.mockResolvedValue({ ok: true, json: async () => v3Result })
+
+    const result = await getPrompt2BlogResult('v3-run')
+
+    expect(result.artifact.pipeline_v3).toBeDefined()
+    expect(result.artifact.pipeline_v2).toBeUndefined()
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.ts
@@ -10,8 +10,10 @@ import type {
   Prompt2BlogRunRequest,
   Prompt2BlogRunResponse,
   Prompt2BlogStatusResponse,
+  Prompt2BlogV3StartResponse,
 } from '../types/pipeline.types'
-import { PROMPT2BLOG_PIPELINE_STAGES } from '../types/pipeline.types'
+import type { Prompt2BlogV3Request } from '../types/editorial.types'
+import { PROMPT2BLOG_KNOWN_PIPELINE_STAGES } from '../types/pipeline.types'
 import { finalizeStatusResponse, normalizePipelineStatus } from '../../pipelineRuns'
 
 export function normalizePrompt2BlogStatusResponse(
@@ -20,7 +22,7 @@ export function normalizePrompt2BlogStatusResponse(
 ): Prompt2BlogStatusResponse {
   const normalized = normalizePipelineStatus({
     value,
-    stages: PROMPT2BLOG_PIPELINE_STAGES,
+    stages: PROMPT2BLOG_KNOWN_PIPELINE_STAGES,
     unknownStage: 'unknown' satisfies Prompt2BlogPipelineStage,
     rawStageField: 'raw_stage',
     defaults: {
@@ -50,6 +52,34 @@ export async function startPrompt2BlogRun(
   }
 
   return response.json()
+}
+
+/**
+ * Starts a v3 run, or reports the research that has to happen first.
+ *
+ * `needs_research` arrives on a 200: the commission was valid and the gate ran,
+ * it just found evidence that cannot support the article. Nothing was queued,
+ * so it is a result to show, not an error to throw.
+ */
+export async function startPrompt2BlogV3Run(
+  payload: Prompt2BlogV3Request,
+): Promise<Prompt2BlogV3StartResponse> {
+  const response = await apiFetch(`${FEATURE_PREFIX}/pipeline-v3`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    throw await parseError(response, 'Prompt2Blog v3 run failed to start')
+  }
+
+  const body = (await response.json()) as Prompt2BlogV3StartResponse
+  if (body?.status === 'queued' && typeof body.run_id === 'string' && body.run_id) {
+    return body
+  }
+  if (body?.status === 'needs_research') return body
+  throw new Error('Prompt2Blog v3 returned an unrecognized start response.')
 }
 
 export async function getPrompt2BlogInputOptions(): Promise<Prompt2BlogInputOptionsResponse> {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
@@ -4,7 +4,7 @@ import {
   type Prompt2BlogRunRequest,
 } from '../../api'
 import { CLEANUP_STAGE_KEY } from '../../cleanup-details/cleanup-stage.parser'
-import { PROMPT2BLOG_PIPELINE_STAGES, type KnownPrompt2BlogPipelineStage } from '../../types/pipeline.types'
+import { PROMPT2BLOG_PIPELINE_STAGES } from '../../types/pipeline.types'
 import type {
   PipelineLogEntry,
   PipelineLogLevel,
@@ -79,9 +79,12 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
   })
 
   const canOpenCleanupModal = useMemo(() => {
-    const cleanupStageIndex = PROMPT2BLOG_PIPELINE_STAGES.indexOf(CLEANUP_STAGE_KEY)
+    // Cleanup is a v2-only stage; a v3 stage name simply misses the order and
+    // reads as -1, which is what "no cleanup to show" already means here.
+    const v2StageOrder: readonly string[] = PROMPT2BLOG_PIPELINE_STAGES
+    const cleanupStageIndex = v2StageOrder.indexOf(CLEANUP_STAGE_KEY)
     const currentStageIndex = pipelineStatus && pipelineStatus.stage !== 'unknown'
-      ? PROMPT2BLOG_PIPELINE_STAGES.indexOf(pipelineStatus.stage as KnownPrompt2BlogPipelineStage)
+      ? v2StageOrder.indexOf(pipelineStatus.stage)
       : -1
     return Boolean(
       pipelineRunId

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Prompt2BlogPipelineStage, Prompt2BlogStatusResponse } from '../api'
-import { getPipelineStepStatus } from './pipeline-status'
+import { PROMPT2BLOG_V3_PIPELINE_STAGES } from '../types/pipeline.types'
+import { getPipelineStepStatus, PIPELINE_STAGE_LABELS, PROMPT2BLOG_STAGE_ORDERS } from './pipeline-status'
 
 function createStatus(overrides: Partial<Prompt2BlogStatusResponse> = {}): Prompt2BlogStatusResponse {
   return {
@@ -56,5 +57,28 @@ describe('getPipelineStepStatus', () => {
 
     expect(getPipelineStepStatus('queued', status)).toBe('pending')
     expect(getPipelineStepStatus('stage_input_validate', status)).toBe('pending')
+  })
+})
+
+describe('v3 stage progress', () => {
+  it('reads v3 progress against the v3 order', () => {
+    const status = createStatus({ state: 'running', stage: 'stage_v3_groundedness' })
+    const v3 = PROMPT2BLOG_STAGE_ORDERS.v3
+
+    expect(getPipelineStepStatus('stage_v3_compose', status, v3)).toBe('done')
+    expect(getPipelineStepStatus('stage_v3_groundedness', status, v3)).toBe('running')
+    expect(getPipelineStepStatus('stage_v3_title', status, v3)).toBe('pending')
+  })
+
+  it('stalls a v3 stage read against the v2 order, which is why the order is passed', () => {
+    const status = createStatus({ state: 'running', stage: 'stage_v3_groundedness' })
+
+    expect(getPipelineStepStatus('stage_v3_groundedness', status)).toBe('pending')
+  })
+
+  it('labels every v3 stage', () => {
+    for (const stage of PROMPT2BLOG_V3_PIPELINE_STAGES) {
+      expect(PIPELINE_STAGE_LABELS[stage]).toBeTruthy()
+    }
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.ts
@@ -1,5 +1,6 @@
 import {
   PROMPT2BLOG_PIPELINE_STAGES,
+  PROMPT2BLOG_V3_PIPELINE_STAGES,
   type KnownPrompt2BlogPipelineStage,
   type Prompt2BlogPipelineStage,
   type Prompt2BlogStatusResponse,
@@ -25,18 +26,37 @@ export const PIPELINE_STAGE_LABELS: Record<Prompt2BlogPipelineStage, string> = {
   stage_final_verify: 'Re-check the article being shipped',
   stage_title: 'Generate final title',
   stage_finalize: 'Finalize markdown output',
+  stage_v3_outline: 'Plan sections against the commission',
+  stage_v3_compose: 'Compose the draft from the evidence',
+  stage_v3_groundedness: 'Check every claim against the evidence',
+  stage_v3_quality_audit: 'Audit commission fidelity and constraints',
+  stage_v3_repair: 'Repair pass (if needed)',
+  stage_v3_quality_settle: 'Settle on the best-scoring draft',
+  stage_v3_title: 'Generate the headline',
+  stage_v3_finalize: 'Finalize markdown output',
   complete: 'Complete',
   unknown: 'Unknown pipeline stage',
 }
 
+/**
+ * Progress is read against one version's stage order. Passing the v2 order a
+ * v3 stage name (or the reverse) would place every step at index -1 and stall
+ * the whole progress list, so callers pass the order the run is actually using.
+ */
 export function getPipelineStepStatus(
   step: KnownPrompt2BlogPipelineStage,
   status: Prompt2BlogStatusResponse | null,
+  stageOrder: readonly string[] = PROMPT2BLOG_PIPELINE_STAGES,
 ): PipelineStepStatus {
   if (!status) return step === 'queued' ? 'running' : 'pending'
   return getStepStatus({
     step,
     status,
-    stageOrder: PROMPT2BLOG_PIPELINE_STAGES,
+    stageOrder,
   })
 }
+
+export const PROMPT2BLOG_STAGE_ORDERS = {
+  v2: PROMPT2BLOG_PIPELINE_STAGES,
+  v3: PROMPT2BLOG_V3_PIPELINE_STAGES,
+} as const satisfies Record<'v2' | 'v3', readonly KnownPrompt2BlogPipelineStage[]>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -1,3 +1,12 @@
+import type {
+  Prompt2BlogArticleFormId,
+  Prompt2BlogAudienceTagId,
+  Prompt2BlogCommission,
+  Prompt2BlogEvidenceRequirementStatus,
+  Prompt2BlogSourceRequirement,
+  Prompt2BlogTopicModuleId,
+} from './editorial.types'
+
 export type Prompt2BlogModelName =
   | 'gemini-3.7-flash'
   | 'gemini-3.5-flash'
@@ -116,7 +125,40 @@ export const PROMPT2BLOG_PIPELINE_STAGES = [
   'complete',
 ] as const
 
-export type KnownPrompt2BlogPipelineStage = typeof PROMPT2BLOG_PIPELINE_STAGES[number]
+/**
+ * The v3 graph is shorter than v2 by design: research readiness is settled
+ * before a run starts, so there is no guideline fetch, coverage check, or
+ * supplement stage to show.
+ */
+export const PROMPT2BLOG_V3_PIPELINE_STAGES = [
+  'queued',
+  'stage_v3_outline',
+  'stage_v3_compose',
+  'stage_v3_groundedness',
+  'stage_v3_quality_audit',
+  'stage_v3_repair',
+  'stage_v3_quality_settle',
+  'stage_v3_title',
+  'stage_v3_finalize',
+  'complete',
+] as const
+
+export type KnownPrompt2BlogV2PipelineStage = typeof PROMPT2BLOG_PIPELINE_STAGES[number]
+export type KnownPrompt2BlogV3PipelineStage = typeof PROMPT2BLOG_V3_PIPELINE_STAGES[number]
+
+/**
+ * Every stage name the status endpoint may legitimately report, across both
+ * pipeline versions. Status normalization matches against this so a v3 run
+ * does not render as `unknown` while it is working.
+ */
+export const PROMPT2BLOG_KNOWN_PIPELINE_STAGES = [
+  ...PROMPT2BLOG_PIPELINE_STAGES,
+  ...PROMPT2BLOG_V3_PIPELINE_STAGES,
+] as const
+
+export type KnownPrompt2BlogPipelineStage =
+  | KnownPrompt2BlogV2PipelineStage
+  | KnownPrompt2BlogV3PipelineStage
 export type Prompt2BlogPipelineStage = KnownPrompt2BlogPipelineStage | 'unknown'
 
 export type Prompt2BlogStatusResponse = {
@@ -139,6 +181,60 @@ export type Prompt2BlogStageTrace = {
   output?: unknown
   skipped?: boolean
   error?: string
+}
+
+export type Prompt2BlogGroundedness = {
+  checked: boolean
+  grounded: boolean
+  assessment: string
+  unsupported_claims: Array<{
+    claim: string
+    reason: string
+    severity: 'high' | 'low'
+  }>
+  high_severity_count: number
+}
+
+export type Prompt2BlogRunCost = {
+  stack_id: string
+  models: {
+    worker: string
+    writer: string
+    judge: string
+  }
+  input_tokens: number
+  output_tokens: number
+  // Billed at the output rate, and included in output_tokens.
+  reasoning_tokens?: number
+  cached_input_tokens: number
+  total_tokens: number
+  successful_calls: number
+  measured_calls: number
+  measurement_status: 'complete' | 'partial' | 'unavailable'
+  estimated_cost_usd: number | null
+  currency: 'USD'
+  by_model: Array<{
+    model: string
+    input_tokens: number
+    output_tokens: number
+    reasoning_tokens?: number
+    cached_input_tokens: number
+    total_tokens: number
+    calls: number
+    estimated_cost_usd: number | null
+  }>
+  // Sorted by total tokens descending. Absent on runs recorded before
+  // per-stage attribution existed.
+  by_stage?: Array<{
+    stage: string
+    input_tokens: number
+    output_tokens: number
+    reasoning_tokens: number
+    cached_input_tokens: number
+    total_tokens: number
+    calls: number
+  }>
+  pricing_note: string
 }
 
 export type Prompt2BlogPipelinePayload = {
@@ -171,47 +267,7 @@ export type Prompt2BlogPipelinePayload = {
     content: string
   }
   final_markdown: string
-  run_cost?: {
-    stack_id: string
-    models: {
-      worker: string
-      writer: string
-      judge: string
-    }
-    input_tokens: number
-    output_tokens: number
-    // Billed at the output rate, and included in output_tokens.
-    reasoning_tokens?: number
-    cached_input_tokens: number
-    total_tokens: number
-    successful_calls: number
-    measured_calls: number
-    measurement_status: 'complete' | 'partial' | 'unavailable'
-    estimated_cost_usd: number | null
-    currency: 'USD'
-    by_model: Array<{
-      model: string
-      input_tokens: number
-      output_tokens: number
-      reasoning_tokens?: number
-      cached_input_tokens: number
-      total_tokens: number
-      calls: number
-      estimated_cost_usd: number | null
-    }>
-    // Sorted by total tokens descending. Absent on runs recorded before
-    // per-stage attribution existed.
-    by_stage?: Array<{
-      stage: string
-      input_tokens: number
-      output_tokens: number
-      reasoning_tokens: number
-      cached_input_tokens: number
-      total_tokens: number
-      calls: number
-    }>
-    pricing_note: string
-  }
+  run_cost?: Prompt2BlogRunCost
   quality_review: {
     alignment_summary: string
     improvements_applied: string[]
@@ -237,17 +293,7 @@ export type Prompt2BlogPipelinePayload = {
       claims_grounded: boolean
     }
     readiness_blockers?: string[]
-    groundedness: {
-      checked: boolean
-      grounded: boolean
-      assessment: string
-      unsupported_claims: Array<{
-        claim: string
-        reason: string
-        severity: 'high' | 'low'
-      }>
-      high_severity_count: number
-    }
+    groundedness: Prompt2BlogGroundedness
     secondary_keyword_coverage: number
     must_include_coverage: number
     word_count_estimate: number
@@ -285,15 +331,155 @@ export type Prompt2BlogPipelinePayload = {
   }
 }
 
+/**
+ * The v3 result artifact. It is deliberately not a superset of the v2 payload:
+ * v3 has no article type, no guideline meta, no SEO brief, and no editorial
+ * augmentation, and it carries the approved commission and the evidence
+ * receipt that v2 had no place to put.
+ */
+export type Prompt2BlogV3PipelinePayload = {
+  message: string
+  run_id: string
+  schema_version: 3
+  status: 'completed'
+  langsmith_trace_url?: string
+  langsmith_trace_run_id?: string
+  pipeline_status: 'ready_for_staging' | 'needs_revision'
+  readiness_blockers: string[]
+  commission: Prompt2BlogCommission
+  form: {
+    id: Prompt2BlogArticleFormId | null
+    label: string | null
+  }
+  instruction_meta: Prompt2BlogV3InstructionMeta
+  evidence_receipt: Prompt2BlogEvidenceReceipt
+  improved_article: {
+    title: string
+    content: string
+  }
+  final_markdown: string
+  run_cost?: Prompt2BlogRunCost
+  input_profiles?: {
+    tone?: Record<string, unknown>
+    length?: Record<string, unknown>
+    brand_voice?: Record<string, unknown>
+    creativity_level?: string
+  }
+  quality_review: {
+    alignment_summary: string
+    improvements_applied: string[]
+    remaining_gaps: string[]
+    quality_summary: string
+    quality_scores: {
+      overall: number
+      // The v3 name for what v2 called guideline coverage: how faithfully the
+      // draft answers the approved commission.
+      commission_fidelity: number
+      informativeness: number
+      originality: number
+      brief_adherence: number
+      seo: number
+    }
+    constraint_checks: Record<string, boolean | number>
+    readiness_blockers: string[]
+    word_count_estimate: number
+    repair_applied: boolean
+    repair_attempts: number
+    groundedness: Prompt2BlogGroundedness
+    outline_accepted: boolean
+    outline_section_count: number
+    outline_unsupported_requirements: string[]
+    model_used: string
+    stage_model_overrides?: Record<string, string>
+  }
+  debug?: {
+    pipeline_input: Record<string, unknown>
+    instruction_text: string
+    evidence_records: string
+    pipeline_trace?: Prompt2BlogStageTrace[]
+  }
+}
+
+export type Prompt2BlogV3InstructionMeta = {
+  schema_version?: number
+  form_id?: Prompt2BlogArticleFormId
+  form_label?: string
+  source_requirements?: string[]
+  topic_module_ids?: Prompt2BlogTopicModuleId[]
+  audience_tag_ids?: Prompt2BlogAudienceTagId[]
+  house_rules_id?: string
+  headline_rules_id?: string
+  precedence?: string[]
+  commission_fingerprint?: string
+  evidence_receipt?: Prompt2BlogEvidenceReceipt
+}
+
+export type Prompt2BlogEvidenceReceipt = {
+  source_ids?: string[]
+  claim_ids?: string[]
+  requirement_status?: Record<string, Prompt2BlogEvidenceRequirementStatus>
+  unresolved_requirement_ids?: string[]
+  unresolved_conflict_ids?: string[]
+}
+
+export type Prompt2BlogV3ReadinessFindingCode =
+  | 'requirement_gap'
+  | 'unresolved_conflict'
+  | 'source_gate'
+
+export type Prompt2BlogV3ReadinessFinding = {
+  code: Prompt2BlogV3ReadinessFindingCode
+  requirement_ids: string[]
+  message: string
+}
+
+/**
+ * `needs_research` is a product state, not an error. The run was never queued,
+ * no writer-model token was spent, and the payload carries the prompt that
+ * closes exactly the gaps the deterministic gate found.
+ */
+export type Prompt2BlogV3NeedsResearchResponse = {
+  message?: string
+  status: 'needs_research'
+  commission_fingerprint: string
+  findings: Prompt2BlogV3ReadinessFinding[]
+  unresolved_requirements: Array<{
+    requirement_id: string
+    question: string
+    gap: string
+  }>
+  unresolved_conflict_ids: string[]
+  missing_source_requirements: Prompt2BlogSourceRequirement[]
+  follow_up_research_prompt: string
+}
+
+export type Prompt2BlogV3QueuedResponse = {
+  message?: string
+  status: 'queued'
+  run_id: string
+}
+
+export type Prompt2BlogV3StartResponse =
+  | Prompt2BlogV3QueuedResponse
+  | Prompt2BlogV3NeedsResearchResponse
+
+/**
+ * A run artifact carries exactly one pipeline payload, under the key naming
+ * the version that produced it. Legacy runs keep `pipeline_v2` forever; both
+ * keys stay optional so old result pages continue to open.
+ */
+export type Prompt2BlogRunArtifact = {
+  pipeline_v2?: Prompt2BlogPipelinePayload
+  pipeline_v3?: Prompt2BlogV3PipelinePayload
+  stages?: Record<string, unknown>
+}
+
 export type Prompt2BlogResultResponse = {
   run_id: string
   langsmith_trace_url?: string
   langsmith_trace_run_id?: string
   markdown: string
-  artifact: {
-    pipeline_v2?: Prompt2BlogPipelinePayload
-    stages?: Record<string, unknown>
-  }
+  artifact: Prompt2BlogRunArtifact
 }
 
 export type Prompt2BlogDebugResponse = {
@@ -303,10 +489,7 @@ export type Prompt2BlogDebugResponse = {
   output:
     | {
         markdown: string
-        artifact: {
-          pipeline_v2?: Prompt2BlogPipelinePayload
-          stages?: Record<string, unknown>
-        }
+        artifact: Prompt2BlogRunArtifact
       }
     | null
 }


### PR DESCRIPTION
PR 7A of the Prompt2Blog v3 editorial redesign. Adds the frontend surface a
v3 run needs, with no behavior change: nothing calls the new client yet.

- `PROMPT2BLOG_V3_PIPELINE_STAGES` and labels for the eight v3 stage names.
- `PROMPT2BLOG_KNOWN_PIPELINE_STAGES` so status polling recognizes a v3 stage
  instead of rendering it as `unknown`.
- `getPipelineStepStatus` now takes the stage order to read progress against.
  A v3 stage name read against the v2 order sits at index -1 and stalls the
  whole list, so the order is explicit rather than assumed.
- `Prompt2BlogV3PipelinePayload` for the `pipeline_v3` artifact, plus the
  discriminated `queued` / `needs_research` start response.
- `startPrompt2BlogV3Run`, which returns `needs_research` as a result rather
  than throwing: it arrives on a 200, nothing was queued, and it is a product
  state the UI has to show.
- `Prompt2BlogRunArtifact` keeps `pipeline_v2` and `pipeline_v3` both optional,
  so legacy result pages keep opening.
- Extracted `Prompt2BlogRunCost` and `Prompt2BlogGroundedness` so the v3
  payload reuses them instead of restating them.
- Backend: `/result/{run_id}` now attaches the LangGraph trace to a
  `pipeline_v3` artifact as well as `pipeline_v2`.

Deliberate: the v3 payload is not a superset of v2. It has no article type, no
guideline meta, no SEO brief and no augmentation fields, and it carries the
commission and evidence receipt v2 had nowhere to put. Modelling it as one
widened type would have made every v2-only field optional and lost that.

Verification: backend pytest 848 passing, frontend vitest 826 passing across
164 files, tsc clean, eslint and boundary check clean, vite build passes with
the pre-existing chunk-size warning only.