### PR TITLE
feat(prompt2blog): build the v3 submission payload from approved state

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-drift-v3.json'
+import type { Prompt2BlogCommission, Prompt2BlogEvidencePackage } from '../api'
+import { DEFAULT_COMPOSER_STATE } from './composer.storage'
+import type { P2BFormState } from './composer.types'
+import { buildPrompt2BlogV3Payload, v3SubmissionBlockedReason } from './v3-payload'
+
+const commission = limaFixture.commission as unknown as Prompt2BlogCommission
+const evidencePackage = limaFixture.evidence_package as unknown as Prompt2BlogEvidencePackage
+
+function approvedState(overrides: Partial<P2BFormState> = {}): P2BFormState {
+  return {
+    ...DEFAULT_COMPOSER_STATE,
+    activeWorkflow: 'editorial_v3',
+    easySetupTitle: commission.original_title,
+    easySetupLocation: commission.location,
+    toneId: 'balanced',
+    lengthId: 'standard',
+    brandVoiceId: 'questurian',
+    editorial: {
+      directionOptions: [],
+      selectedOptionId: 'direction-1',
+      commissionDraft: null,
+      approval: { status: 'approved', commission },
+      evidencePackage,
+    },
+    ...overrides,
+  }
+}
+
+describe('v3SubmissionBlockedReason', () => {
+  it('does not speak for a legacy v2 draft', () => {
+    expect(v3SubmissionBlockedReason({ ...approvedState(), activeWorkflow: 'legacy_v2' })).toBeNull()
+  })
+
+  it('allows an approved commission with matching research', () => {
+    expect(v3SubmissionBlockedReason(approvedState())).toBeNull()
+  })
+
+  it('allows a run whose research still has open gaps, because the gate is the backend’s', () => {
+    // The Lima fixture leaves r2 missing on purpose. Submitting returns
+    // `needs_research` with a follow-up prompt, which the user has to see.
+    expect(
+      evidencePackage.requirements.some(requirement => requirement.status !== 'supported'),
+    ).toBe(true)
+    expect(v3SubmissionBlockedReason(approvedState())).toBeNull()
+  })
+
+  it('names each unapproved stage of the direction flow', () => {
+    const reasonFor = (approval: P2BFormState['editorial']['approval']) =>
+      v3SubmissionBlockedReason(
+        approvedState({ editorial: { ...approvedState().editorial, approval } }),
+      )
+
+    expect(reasonFor({ status: 'not_started' })).toMatch(/approve a commission/)
+    expect(reasonFor({ status: 'awaiting_selection' })).toMatch(/Choose one of the three/)
+    expect(reasonFor({ status: 'needs_approval' })).toMatch(/Approve the commission/)
+    expect(reasonFor({ status: 'reconfirmation_required', reason: 'legacy_draft' })).toMatch(
+      /Reconfirm it/,
+    )
+    expect(reasonFor({ status: 'reconfirmation_required', reason: 'commission_edited' })).toMatch(
+      /Approve it again/,
+    )
+    expect(
+      reasonFor({ status: 'reconfirmation_required', reason: 'title_or_location_changed' }),
+    ).toMatch(/Generate directions again/)
+  })
+
+  it('blocks when no research is attached', () => {
+    expect(
+      v3SubmissionBlockedReason(
+        approvedState({ editorial: { ...approvedState().editorial, evidencePackage: null } }),
+      ),
+    ).toMatch(/Import the research package/)
+  })
+
+  it('blocks research belonging to a different commission', () => {
+    expect(
+      v3SubmissionBlockedReason(
+        approvedState({
+          editorial: {
+            ...approvedState().editorial,
+            evidencePackage: { ...evidencePackage, commission_fingerprint: 'other' },
+          },
+        }),
+      ),
+    ).toMatch(/different commission/)
+  })
+
+  it('blocks research that answers a different requirement set', () => {
+    expect(
+      v3SubmissionBlockedReason(
+        approvedState({
+          editorial: {
+            ...approvedState().editorial,
+            evidencePackage: {
+              ...evidencePackage,
+              requirements: evidencePackage.requirements.slice(1),
+            },
+          },
+        }),
+      ),
+    ).toMatch(/exact requirements/)
+  })
+
+  it('blocks a missing tone or length', () => {
+    expect(v3SubmissionBlockedReason(approvedState({ toneId: '' }))).toMatch(/Tone and length/)
+    expect(v3SubmissionBlockedReason(approvedState({ lengthId: '' }))).toMatch(/Tone and length/)
+  })
+
+  it('blocks editorial extras rather than silently dropping them', () => {
+    expect(v3SubmissionBlockedReason(approvedState({ enableEditorialAugmentation: true }))).toMatch(
+      /Editorial extras are not available/,
+    )
+  })
+})
+
+describe('buildPrompt2BlogV3Payload', () => {
+  it('returns null for a legacy v2 draft', () => {
+    expect(
+      buildPrompt2BlogV3Payload({ ...approvedState(), activeWorkflow: 'legacy_v2' }),
+    ).toBeNull()
+  })
+
+  it('returns null whenever a blocker is reported', () => {
+    expect(buildPrompt2BlogV3Payload(approvedState({ toneId: '' }))).toBeNull()
+    expect(
+      buildPrompt2BlogV3Payload(approvedState({ enableEditorialAugmentation: true })),
+    ).toBeNull()
+  })
+
+  it('sends the approved commission and evidence package whole', () => {
+    const payload = buildPrompt2BlogV3Payload(approvedState())
+
+    expect(payload?.commission).toEqual(commission)
+    expect(payload?.evidence_package).toEqual(evidencePackage)
+    expect(payload?.schema_version).toBe(3)
+  })
+
+  it('carries the writing profiles and model routing the composer holds', () => {
+    const payload = buildPrompt2BlogV3Payload(approvedState({ creativityLevel: 'low' }))
+
+    expect(payload?.profiles).toEqual({
+      tone_id: 'balanced',
+      length_id: 'standard',
+      brand_voice_id: 'questurian',
+      creativity_level: 'low',
+    })
+    expect(payload?.model_routing).toEqual({
+      model_name: DEFAULT_COMPOSER_STATE.modelName,
+      writing_model: DEFAULT_COMPOSER_STATE.writingModel,
+      audit_model: DEFAULT_COMPOSER_STATE.auditModel,
+      model_stack_id: DEFAULT_COMPOSER_STATE.modelStackId,
+    })
+  })
+
+  it('sends a null brand voice rather than an empty id the backend would reject', () => {
+    expect(buildPrompt2BlogV3Payload(approvedState({ brandVoiceId: '' }))?.profiles.brand_voice_id)
+      .toBeNull()
+  })
+
+  it('never asks v3 for editorial augmentation', () => {
+    expect(buildPrompt2BlogV3Payload(approvedState())?.enable_editorial_augmentation).toBe(false)
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.ts
@@ -1,0 +1,102 @@
+import type { Prompt2BlogV3Request } from '../api'
+import type { P2BFormState } from './composer.types'
+
+const APPROVAL_BLOCKERS: Record<string, string> = {
+  not_started: 'Generate three directions and approve a commission before running.',
+  awaiting_selection: 'Choose one of the three directions before running.',
+  needs_approval: 'Approve the commission before running.',
+}
+
+const RECONFIRMATION_BLOCKERS: Record<string, string> = {
+  legacy_draft: 'This saved draft predates the commission flow. Reconfirm it before running.',
+  commission_edited: 'The commission changed. Approve it again before running.',
+  title_or_location_changed:
+    'The title or location changed. Generate directions again before running.',
+}
+
+/**
+ * Why this commission cannot be submitted to the v3 pipeline yet, in the words
+ * the composer shows the user. Returns null when it can be.
+ *
+ * Research readiness is deliberately absent from this list. The gate is the
+ * backend's to run, it costs no writer-model token to reach, and its answer is
+ * `needs_research` with a follow-up prompt attached — a result the user needs
+ * to see, not a button this side should have disabled.
+ */
+export function v3SubmissionBlockedReason(state: P2BFormState): string | null {
+  if (state.activeWorkflow !== 'editorial_v3') return null
+
+  const { approval, evidencePackage } = state.editorial
+  if (approval.status === 'reconfirmation_required') {
+    return RECONFIRMATION_BLOCKERS[approval.reason]
+  }
+  if (approval.status !== 'approved') {
+    return APPROVAL_BLOCKERS[approval.status]
+  }
+  if (!evidencePackage) {
+    return 'Import the research package for this commission before running.'
+  }
+  if (evidencePackage.commission_fingerprint !== approval.commission.commission_fingerprint) {
+    return 'The attached research belongs to a different commission.'
+  }
+
+  const commissionRequirements = approval.commission.requirements.map(
+    requirement => requirement.requirement_id,
+  )
+  const evidenceRequirements = evidencePackage.requirements.map(
+    requirement => requirement.requirement_id,
+  )
+  const sameRequirements =
+    commissionRequirements.length === evidenceRequirements.length &&
+    commissionRequirements.every(requirementId => evidenceRequirements.includes(requirementId))
+  if (!sameRequirements) {
+    return 'The attached research does not answer this commission’s exact requirements.'
+  }
+
+  if (!state.toneId || !state.lengthId) return 'Tone and length are required.'
+
+  // v3 refuses this flag with a 400 rather than accepting it and ignoring it:
+  // augmentation rewrites audited prose and has not been re-verified against
+  // the evidence model. Say so here instead of dropping the user's choice.
+  if (state.enableEditorialAugmentation) {
+    return 'Editorial extras are not available on the v3 pipeline. Turn them off to run.'
+  }
+
+  return null
+}
+
+/**
+ * Builds the v3 request from an approved commission and its attached research.
+ *
+ * Nothing here flattens the commission or the evidence into v2 shapes. Both
+ * travel whole, which is the point of the migration: the run has to be able to
+ * show later what it was commissioned to write and what it was given to write
+ * it from.
+ */
+export function buildPrompt2BlogV3Payload(state: P2BFormState): Prompt2BlogV3Request | null {
+  if (v3SubmissionBlockedReason(state) !== null) return null
+  if (state.activeWorkflow !== 'editorial_v3') return null
+
+  const { approval, evidencePackage } = state.editorial
+  if (approval.status !== 'approved' || !evidencePackage) return null
+
+  return {
+    schema_version: 3,
+    commission: approval.commission,
+    evidence_package: evidencePackage,
+    profiles: {
+      tone_id: state.toneId,
+      length_id: state.lengthId,
+      brand_voice_id: state.brandVoiceId || null,
+      creativity_level: state.creativityLevel,
+    },
+    model_routing: {
+      model_name: state.modelName,
+      writing_model: state.writingModel,
+      audit_model: state.auditModel,
+      model_stack_id: state.modelStackId,
+    },
+    include_debug: true,
+    enable_editorial_augmentation: false,
+  }
+}


### PR DESCRIPTION
PR 7B of the Prompt2Blog v3 editorial redesign. Pure functions plus tests; no
caller yet, so behavior is unchanged.

- `buildPrompt2BlogV3Payload` turns an approved commission and its attached
  evidence into a `Prompt2BlogV3Request`. Both travel whole — nothing is
  flattened into v2 `source_material`, which is the bug this migration exists
  to remove.
- `v3SubmissionBlockedReason` reports, in the words the composer shows, why a
  commission cannot be submitted: unapproved or reconfirmation-required
  approval, missing research, research belonging to another commission,
  research answering a different requirement set, missing tone or length.

Two deliberate calls:

1. Research readiness is NOT a submission blocker. The gate is the backend's,
   reaching it spends no writer-model token, and its answer is `needs_research`
   with a follow-up prompt attached — a result the user has to see, not a
   button this side should have disabled. The Lima fixture leaves a requirement
   missing on purpose and a test pins that it still submits.
2. `enable_editorial_augmentation` is reported as a blocker rather than
   silently sent as false. v3 refuses the flag with a 400 instead of accepting
   and ignoring it; dropping the user's toggle on the client would reintroduce
   exactly the silence the backend refused.

Verification: frontend vitest 841 passing across 165 files, tsc clean, eslint
and boundary check clean.