### PR TITLE
feat(prompt2blog): read and render v3 run results

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
@@ -4,6 +4,7 @@ import type { PipelineStepStatus } from '../pipeline-run.types'
 import { PROMPT2BLOG_PIPELINE_STAGES } from '../../types/pipeline.types'
 import { getPipelineStepStatus, PIPELINE_STAGE_LABELS } from '../pipeline-status'
 import { PipelineResult } from './PipelineResult'
+import { PipelineV3Result } from './PipelineV3Result'
 
 interface PipelinePanelProps {
   run: ReturnType<typeof usePrompt2BlogPipelineRun>
@@ -91,13 +92,23 @@ export function PipelinePanel({
         )}
 
         {sourceStep === 'pipeline_complete' && pipelineResult && (
-          <PipelineResult
-            debugData={pipelineDebugData}
-            result={pipelineResult}
-            showDebug={showPipelineDebug}
-            stageArticleUrl={stageArticleUrl}
-            onToggleDebug={togglePipelineDebug}
-          />
+          pipelineResult.version === 'v3' ? (
+            <PipelineV3Result
+              debugData={pipelineDebugData}
+              result={pipelineResult.payload}
+              showDebug={showPipelineDebug}
+              stageArticleUrl={stageArticleUrl}
+              onToggleDebug={togglePipelineDebug}
+            />
+          ) : (
+            <PipelineResult
+              debugData={pipelineDebugData}
+              result={pipelineResult.payload}
+              showDebug={showPipelineDebug}
+              stageArticleUrl={stageArticleUrl}
+              onToggleDebug={togglePipelineDebug}
+            />
+          )
         )}
       </div>
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineV3Result.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineV3Result.tsx
@@ -1,0 +1,130 @@
+import { Link } from 'react-router-dom'
+import payloadLogoUrl from '../../../../assets/payload-logo.svg?url'
+import type { Prompt2BlogV3PipelinePayload } from '../../api'
+import { RunCostReceipt } from './RunCostReceipt'
+
+interface PipelineV3ResultProps {
+  debugData: Record<string, unknown> | null
+  result: Prompt2BlogV3PipelinePayload
+  showDebug: boolean
+  stageArticleUrl: string | null
+  onToggleDebug: () => void
+}
+
+const REQUIREMENT_STATUS_LABELS: Record<string, string> = {
+  supported: 'Supported',
+  partial: 'Partial',
+  missing: 'Missing',
+}
+
+/**
+ * The v3 result. It reports the commission the article answers and the
+ * evidence it was written from, because that is what makes a finished v3 run
+ * auditable without replaying it or trusting the prose.
+ */
+export function PipelineV3Result({
+  debugData,
+  result,
+  showDebug,
+  stageArticleUrl,
+  onToggleDebug,
+}: PipelineV3ResultProps) {
+  const requirementStatus = result.evidence_receipt?.requirement_status ?? {}
+  const requirementIds = Object.keys(requirementStatus)
+
+  return (
+    <div className="p2b-final-result">
+      <h3>Final Article Ready</h3>
+      <div className="p2b-panel-actions" style={{ marginBottom: '1rem' }}>
+        {stageArticleUrl && (
+          <Link to={stageArticleUrl} className="p2b-synthesize-btn payload-action-btn">
+            <img
+              src={payloadLogoUrl}
+              alt=""
+              aria-hidden="true"
+              className="payload-action-btn-icon"
+            />
+            Stage in Payload Editor
+          </Link>
+        )}
+        {result.langsmith_trace_url && (
+          <a
+            href={result.langsmith_trace_url}
+            target="_blank"
+            rel="noreferrer"
+            className="p2b-synthesize-btn"
+          >
+            View LangSmith Trace
+          </a>
+        )}
+        <Link to="/prompt2blog/articles" className="p2b-rerun-btn">
+          View Saved Articles
+        </Link>
+      </div>
+      {result.run_cost && <RunCostReceipt cost={result.run_cost} />}
+      <p>
+        <strong>Status:</strong> {result.pipeline_status}
+      </p>
+      {result.readiness_blockers.length > 0 && (
+        <p>
+          <strong>Held back by:</strong> {result.readiness_blockers.join(', ')}
+        </p>
+      )}
+      <p>
+        <strong>Article Form:</strong> {result.form.label || result.form.id || 'Unknown'}
+      </p>
+      <p>
+        <strong>Commission:</strong> {result.commission.approved_direction}
+      </p>
+      <p>
+        <strong>Primary Subject:</strong> {result.commission.primary_subject}
+      </p>
+      <p>
+        <strong>Model Used:</strong> {result.quality_review.model_used}
+      </p>
+      <p>
+        <strong>Title:</strong> {result.improved_article.title}
+      </p>
+      <p>
+        <strong>Original Title:</strong> {result.commission.original_title}
+      </p>
+      <p>
+        <strong>Quality Summary:</strong> {result.quality_review.quality_summary}
+      </p>
+      {requirementIds.length > 0 && (
+        <div className="p2b-import-report">
+          <p className="p2b-import-report-title">
+            {result.evidence_receipt.source_ids?.length ?? 0} sources and{' '}
+            {result.evidence_receipt.claim_ids?.length ?? 0} claims backed this article.
+          </p>
+          <ul className="p2b-requirement-list">
+            {requirementIds.map(requirementId => (
+              <li key={requirementId} className="p2b-requirement-row">
+                <code>{requirementId}</code>{' '}
+                {REQUIREMENT_STATUS_LABELS[requirementStatus[requirementId]]
+                  ?? requirementStatus[requirementId]}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="p2b-synthesized-text">
+        {result.final_markdown.split('\n').map((line, index) => (
+          <p key={index}>{line || ' '}</p>
+        ))}
+      </div>
+      {debugData && (
+        <div className="p2b-final-debug">
+          <button type="button" className="p2b-rerun-btn" onClick={onToggleDebug}>
+            {showDebug ? 'Hide' : 'Show'} Pipeline Debug
+          </button>
+          {showDebug && (
+            <div className="p2b-raw-json">
+              <pre>{JSON.stringify(debugData, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/pipeline-result.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/pipeline-result.test.tsx
@@ -1,0 +1,98 @@
+/* @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import legacyResultFixture from '../../../../../../../data/fixtures/prompt2blog/legacy-v2-result.json'
+import type { Prompt2BlogPipelinePayload, Prompt2BlogV3PipelinePayload } from '../../api'
+import { PipelineResult } from './PipelineResult'
+import { PipelineV3Result } from './PipelineV3Result'
+
+const legacyPayload = legacyResultFixture.artifact
+  .pipeline_v2 as unknown as Prompt2BlogPipelinePayload
+
+const v3Payload = {
+  message: 'Prompt2Blog pipeline v3 completed',
+  run_id: 'v3-run',
+  schema_version: 3,
+  status: 'completed',
+  pipeline_status: 'ready_for_staging',
+  readiness_blockers: [],
+  commission: {
+    original_title: "Is Lima still South America's bargain expat capital?",
+    approved_direction: 'Assess whether Lima still offers strong long-stay value.',
+    primary_subject: 'Lima',
+  },
+  form: { id: 'analysis', label: 'Analysis' },
+  instruction_meta: { form_label: 'Analysis' },
+  evidence_receipt: {
+    source_ids: ['s1', 's2'],
+    claim_ids: ['c1'],
+    requirement_status: { r1: 'supported', r2: 'partial' },
+  },
+  improved_article: { title: 'Lima, still worth the money', content: 'Body' },
+  final_markdown: '# Lima, still worth the money',
+  quality_review: { quality_summary: 'Grounded and on commission.', model_used: 'claude-opus-5' },
+} as unknown as Prompt2BlogV3PipelinePayload
+
+function renderResult(node: React.ReactNode) {
+  return render(<MemoryRouter>{node}</MemoryRouter>)
+}
+
+describe('PipelineResult (legacy v2)', () => {
+  it('still opens a v2 artifact recorded before v3 existed', () => {
+    renderResult(
+      <PipelineResult
+        debugData={null}
+        result={legacyPayload}
+        showDebug={false}
+        stageArticleUrl="/prompt2blog/stage-article?run_id=legacy-v2-run"
+        onToggleDebug={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Final Article Ready')).toBeTruthy()
+    expect(screen.getByText('In-depth Analysis')).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Stage in Payload Editor/ })).toBeTruthy()
+  })
+})
+
+describe('PipelineV3Result', () => {
+  it('reports the commission and the evidence the article was written from', () => {
+    renderResult(
+      <PipelineV3Result
+        debugData={null}
+        result={v3Payload}
+        showDebug={false}
+        stageArticleUrl="/prompt2blog/stage-article?run_id=v3-run"
+        onToggleDebug={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Analysis')).toBeTruthy()
+    expect(screen.getByText('Lima')).toBeTruthy()
+    expect(screen.getByText(/Is Lima still South America/)).toBeTruthy()
+    expect(screen.getByText(/2 sources and 1 claims/)).toBeTruthy()
+    expect(screen.getByText('r1')).toBeTruthy()
+    expect(screen.getByText(/Supported/)).toBeTruthy()
+  })
+
+  it('names what held a run back rather than only reporting the status', () => {
+    renderResult(
+      <PipelineV3Result
+        debugData={null}
+        result={{
+          ...v3Payload,
+          pipeline_status: 'needs_revision',
+          readiness_blockers: ['claims_grounded'],
+        }}
+        showDebug={false}
+        stageArticleUrl={null}
+        onToggleDebug={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('needs_revision')).toBeTruthy()
+    expect(screen.getByText('claims_grounded')).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /Stage in Payload Editor/ })).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePersistedPipelineRunState.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePersistedPipelineRunState.ts
@@ -5,16 +5,16 @@ import {
   saveRunState,
 } from '../pipeline-run.storage'
 import type {
+  PersistedPipelineResult,
   PersistedRunState,
   SourceStep,
 } from '../pipeline-run.types'
-import type { Prompt2BlogPipelinePayload } from '../../api'
 
 export function usePersistedPipelineRunState() {
   const savedRun = useRef(loadSavedRunState())
   const [sourceStep, setSourceStep] = useState<SourceStep>(savedRun.current.sourceStep)
   const [pipelineRunId, setPipelineRunId] = useState<string | null>(savedRun.current.pipelineRunId)
-  const [pipelineResult, setPipelineResult] = useState<Prompt2BlogPipelinePayload | null>(
+  const [pipelineResult, setPipelineResult] = useState<PersistedPipelineResult | null>(
     savedRun.current.pipelineResult,
   )
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
@@ -41,13 +41,24 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
 
   const stageArticleUrl = useMemo(() => {
     if (!pipelineResult) return null
-    const runId = pipelineResult.run_id || pipelineRunId
+    const { payload } = pipelineResult
+    const runId = payload.run_id || pipelineRunId
     if (!runId) return null
+
+    // Staging keeps one `article_type` slot. v2 fills it with the shared
+    // 42-type name; v3 fills it with the approved article form's label, which
+    // is the equivalent editorial shape under the new model. Old staging URLs
+    // keep working because the slot and the route are unchanged.
+    const articleType = pipelineResult.version === 'v3'
+      ? pipelineResult.payload.form.label
+        || pipelineResult.payload.instruction_meta.form_label
+        || ''
+      : pipelineResult.payload.article_type.name
 
     return buildStageArticleUrl('prompt2blog', {
       run_id: runId,
-      title: pipelineResult.improved_article.title,
-      article_type: pipelineResult.article_type.name,
+      title: payload.improved_article.title,
+      article_type: articleType,
     })
   }, [pipelineResult, pipelineRunId])
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogRunLifecycle.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogRunLifecycle.ts
@@ -12,10 +12,14 @@ import {
   getPrompt2BlogStatus,
   type Prompt2BlogDebugStages,
   type Prompt2BlogStatusResponse,
-  type Prompt2BlogPipelinePayload,
 } from '../../api'
 import { PIPELINE_STAGE_LABELS } from '../pipeline-status'
-import type { PersistedRunState, PipelineLogLevel, SourceStep } from '../pipeline-run.types'
+import type {
+  PersistedPipelineResult,
+  PersistedRunState,
+  PipelineLogLevel,
+  SourceStep,
+} from '../pipeline-run.types'
 import { loadPrompt2BlogTerminalArtifacts } from './loadPrompt2BlogTerminalArtifacts'
 
 type AppendPipelineLog = (message: string, level?: PipelineLogLevel) => void
@@ -25,7 +29,7 @@ type UsePrompt2BlogRunLifecycleOptions = {
   sourceStep: SourceStep
   setSourceStep: Dispatch<SetStateAction<SourceStep>>
   pipelineRunId: string | null
-  setPipelineResult: Dispatch<SetStateAction<Prompt2BlogPipelinePayload | null>>
+  setPipelineResult: Dispatch<SetStateAction<PersistedPipelineResult | null>>
   appendPipelineLog: AppendPipelineLog
   isStartingPipeline: boolean
 }
@@ -121,9 +125,18 @@ export function usePrompt2BlogRunLifecycle({
     if (status.state === 'completed') {
       const { result, debugPayload } = await loadPrompt2BlogTerminalArtifacts(pipelineRunId)
       if (isCancelled()) return
-      if (result.artifact?.pipeline_v2) {
-        setPipelineResult(result.artifact.pipeline_v2)
-        const traceUrl = result.artifact.pipeline_v2.langsmith_trace_url || result.langsmith_trace_url
+      // A run records exactly one payload, under the key naming the pipeline
+      // that produced it. v3 is checked first so a new run does not have to
+      // fall through the legacy branch, and v2 stays supported forever.
+      const terminalResult: PersistedPipelineResult | null = result.artifact?.pipeline_v3
+        ? { version: 'v3', payload: result.artifact.pipeline_v3 }
+        : result.artifact?.pipeline_v2
+          ? { version: 'v2', payload: result.artifact.pipeline_v2 }
+          : null
+      if (terminalResult) {
+        setPipelineResult(terminalResult)
+        const traceUrl =
+          terminalResult.payload.langsmith_trace_url || result.langsmith_trace_url
         if (traceUrl) appendPipelineLog(`LangSmith trace available: ${traceUrl}`)
       } else {
         setError('Pipeline finished but no final payload was returned.')

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-run.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-run.storage.test.ts
@@ -7,7 +7,7 @@ import {
   saveRunState,
 } from './pipeline-run.storage'
 import type { PersistedRunState } from './pipeline-run.types'
-import type { Prompt2BlogPipelinePayload } from '../api'
+import type { Prompt2BlogPipelinePayload, Prompt2BlogV3PipelinePayload } from '../api'
 
 function buildPipelineResult(): Prompt2BlogPipelinePayload {
   return {
@@ -34,11 +34,35 @@ function buildPipelineResult(): Prompt2BlogPipelinePayload {
   } as unknown as Prompt2BlogPipelinePayload
 }
 
+function buildV3PipelineResult(): Prompt2BlogV3PipelinePayload {
+  return {
+    message: 'ok',
+    run_id: 'run-3',
+    schema_version: 3,
+    status: 'completed',
+    pipeline_status: 'ready_for_staging',
+    readiness_blockers: [],
+    commission: { original_title: 'Is Lima still a bargain?', form_id: 'analysis' },
+    form: { id: 'analysis', label: 'Analysis' },
+    instruction_meta: { form_label: 'Analysis' },
+    evidence_receipt: { source_ids: ['s1'], claim_ids: ['c1'] },
+    improved_article: { title: 'Title', content: 'Content' },
+    final_markdown: '# Lima',
+    quality_review: { quality_summary: 'Good' },
+    debug: {
+      pipeline_input: {},
+      instruction_text: 'x'.repeat(64),
+      evidence_records: 'y'.repeat(64),
+      pipeline_trace: [{ stage: 'stage_v3_compose', prompt: 'x'.repeat(64) }],
+    },
+  } as unknown as Prompt2BlogV3PipelinePayload
+}
+
 function completedRun(): PersistedRunState {
   return {
     sourceStep: 'pipeline_complete',
     pipelineRunId: 'run-1',
-    pipelineResult: buildPipelineResult(),
+    pipelineResult: { version: 'v2', payload: buildPipelineResult() },
   }
 }
 
@@ -60,8 +84,10 @@ describe('saveRunState', () => {
 
     const persisted = readPersisted()
     const pipelineResult = persisted.pipelineResult as Record<string, unknown>
-    expect(pipelineResult).not.toHaveProperty('debug')
-    expect(pipelineResult.final_markdown).toBe('# Title')
+    const payload = pipelineResult.payload as Record<string, unknown>
+    expect(pipelineResult.version).toBe('v2')
+    expect(payload).not.toHaveProperty('debug')
+    expect(payload.final_markdown).toBe('# Title')
     expect(localStorage.getItem(RUN_STORAGE_KEY)).not.toContain('pipeline_trace')
   })
 
@@ -71,7 +97,7 @@ describe('saveRunState', () => {
     const loaded = loadSavedRunState()
     expect(loaded.sourceStep).toBe('pipeline_complete')
     expect(loaded.pipelineRunId).toBe('run-1')
-    expect(loaded.pipelineResult?.final_markdown).toBe('# Title')
+    expect(loaded.pipelineResult?.payload.final_markdown).toBe('# Title')
   })
 
   it('leaves a running pipeline resumable when the result exceeds the quota', () => {
@@ -83,7 +109,7 @@ describe('saveRunState', () => {
     saveRunState({
       sourceStep: 'pipeline_running',
       pipelineRunId: 'run-1',
-      pipelineResult: buildPipelineResult(),
+      pipelineResult: { version: 'v2', payload: buildPipelineResult() },
     })
 
     const persisted = readPersisted()
@@ -112,5 +138,60 @@ describe('saveRunState', () => {
 
     expect(() => saveRunState(completedRun())).not.toThrow()
     expect(() => clearRunState()).not.toThrow()
+  })
+})
+
+describe('loadSavedRunState across pipeline versions', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('adopts an untagged entry written before v3 existed as a v2 run', () => {
+    // A completed run sitting in a tab across the upgrade must still open.
+    localStorage.setItem(
+      RUN_STORAGE_KEY,
+      JSON.stringify({
+        sourceStep: 'pipeline_complete',
+        pipelineRunId: 'run-1',
+        pipelineResult: buildPipelineResult(),
+      }),
+    )
+
+    const loaded = loadSavedRunState()
+
+    expect(loaded.sourceStep).toBe('pipeline_complete')
+    expect(loaded.pipelineResult?.version).toBe('v2')
+    expect(loaded.pipelineResult?.payload.final_markdown).toBe('# Title')
+  })
+
+  it('round-trips a v3 run without its debug payload', () => {
+    saveRunState({
+      sourceStep: 'pipeline_complete',
+      pipelineRunId: 'run-3',
+      pipelineResult: { version: 'v3', payload: buildV3PipelineResult() },
+    })
+
+    expect(localStorage.getItem(RUN_STORAGE_KEY)).not.toContain('pipeline_trace')
+
+    const loaded = loadSavedRunState()
+    expect(loaded.pipelineResult?.version).toBe('v3')
+    expect(loaded.pipelineResult?.payload.final_markdown).toBe('# Lima')
+  })
+
+  it('discards a result that carries no quality review either way', () => {
+    localStorage.setItem(
+      RUN_STORAGE_KEY,
+      JSON.stringify({
+        sourceStep: 'pipeline_complete',
+        pipelineRunId: 'run-1',
+        pipelineResult: { version: 'v3', payload: { run_id: 'run-1' } },
+      }),
+    )
+
+    expect(loadSavedRunState()).toEqual({
+      sourceStep: 'edit',
+      pipelineRunId: null,
+      pipelineResult: null,
+    })
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-run.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-run.storage.ts
@@ -1,5 +1,4 @@
-import type { Prompt2BlogPipelinePayload } from '../api'
-import type { PersistedRunState } from './pipeline-run.types'
+import type { PersistedPipelineResult, PersistedRunState } from './pipeline-run.types'
 
 export const RUN_STORAGE_KEY = 'p2b-run-state'
 
@@ -9,11 +8,11 @@ export const RUN_STORAGE_KEY = 'p2b-run-state'
 // it — the debug panel reads the separate /debug endpoint — so it is dropped
 // before persisting.
 function stripDebugPayload(
-  pipelineResult: Prompt2BlogPipelinePayload | null,
-): Prompt2BlogPipelinePayload | null {
+  pipelineResult: PersistedPipelineResult | null,
+): PersistedPipelineResult | null {
   if (!pipelineResult) return null
-  const { debug: _debug, ...persistable } = pipelineResult
-  return persistable
+  const { debug: _debug, ...persistable } = pipelineResult.payload
+  return { version: pipelineResult.version, payload: persistable } as PersistedPipelineResult
 }
 
 function writeRunState(state: PersistedRunState): boolean {
@@ -52,6 +51,29 @@ export function saveRunState(state: PersistedRunState): void {
   clearRunState()
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Reads a persisted result in either the tagged shape or the untagged v2 shape
+ * written before v3 existed. An untagged entry is a v2 run by definition, so it
+ * is adopted rather than discarded: a completed run in a still-open tab must
+ * survive the upgrade.
+ */
+function normalizePersistedResult(value: unknown): PersistedPipelineResult | null {
+  if (!isRecord(value)) return null
+
+  if (value.version === 'v2' || value.version === 'v3') {
+    const payload = value.payload
+    if (!isRecord(payload) || !payload.quality_review) return null
+    return { version: value.version, payload } as PersistedPipelineResult
+  }
+
+  if (!value.quality_review) return null
+  return { version: 'v2', payload: value } as PersistedPipelineResult
+}
+
 export function loadSavedRunState(): PersistedRunState {
   const fallback: PersistedRunState = {
     sourceStep: 'edit',
@@ -63,11 +85,7 @@ export function loadSavedRunState(): PersistedRunState {
     if (!raw) return fallback
     const parsed = JSON.parse(raw) as Partial<PersistedRunState>
     const pipelineRunId = typeof parsed.pipelineRunId === 'string' ? parsed.pipelineRunId : null
-    const pipelineResult =
-      parsed.pipelineResult && typeof parsed.pipelineResult === 'object'
-      && (parsed.pipelineResult as { quality_review?: unknown }).quality_review
-        ? parsed.pipelineResult as Prompt2BlogPipelinePayload
-        : null
+    const pipelineResult = normalizePersistedResult(parsed.pipelineResult)
     const sourceStep =
       parsed.sourceStep === 'pipeline_running' && pipelineRunId
         ? 'pipeline_running'

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-run.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-run.types.ts
@@ -1,14 +1,24 @@
-import type { Prompt2BlogPipelinePayload } from '../api'
+import type { Prompt2BlogPipelinePayload, Prompt2BlogV3PipelinePayload } from '../api'
 import type { PipelineStepState } from '../../pipelineRuns'
 
 export type SourceStep = 'edit' | 'pipeline_running' | 'pipeline_complete'
 export type PipelineStepStatus = PipelineStepState
 export type PipelineLogLevel = 'info' | 'error'
+export type PipelineVersion = 'v2' | 'v3'
+
+/**
+ * A finished run tagged with the pipeline that produced it. The two payloads
+ * are different shapes, not one shape with optional halves, so the tag is what
+ * lets a v2 result from last month and a v3 result from today both render.
+ */
+export type PersistedPipelineResult =
+  | { version: 'v2'; payload: Prompt2BlogPipelinePayload }
+  | { version: 'v3'; payload: Prompt2BlogV3PipelinePayload }
 
 export interface PersistedRunState {
   sourceStep: SourceStep
   pipelineRunId: string | null
-  pipelineResult: Prompt2BlogPipelinePayload | null
+  pipelineResult: PersistedPipelineResult | null
 }
 
 export interface PipelineLogEntry {

--- a/apps/ai-blog-writer/data/fixtures/prompt2blog/legacy-v2-result.json
+++ b/apps/ai-blog-writer/data/fixtures/prompt2blog/legacy-v2-result.json
@@ -19,7 +19,11 @@
         "title": "Is Lima still South America's bargain expat capital?",
         "content": "Legacy article body."
       },
-      "final_markdown": "# Is Lima still South America's bargain expat capital?\n\nLegacy article body."
+      "final_markdown": "# Is Lima still South America's bargain expat capital?\n\nLegacy article body.",
+      "quality_review": {
+        "quality_summary": "Legacy quality summary.",
+        "model_used": "gemini-2.5-pro"
+      }
     },
     "stages": {
       "stage_finalize": {


### PR DESCRIPTION
PR 7C of the Prompt2Blog v3 editorial redesign. The run state can now hold a
result from either pipeline. Submission is unchanged — the composer still posts
v2 — so this PR adds the reading half of the cutover only.

- `PersistedRunState.pipelineResult` becomes a version-tagged union. The two
  payloads are different shapes, not one shape with optional halves, so the tag
  is what lets a v2 result and a v3 result both render.
- `loadSavedRunState` adopts an untagged entry written before v3 existed as a
  v2 run rather than discarding it: a completed run sitting in an open tab has
  to survive the upgrade.
- The terminal handler reads `pipeline_v3` first, then `pipeline_v2`. A run
  records exactly one of them.
- New `PipelineV3Result` reports the commission the article answers, the
  approved form, the original title, and the evidence receipt — what makes a
  finished v3 run auditable without replaying it. `PipelineResult` is untouched
  and still renders legacy artifacts.
- Staging: a v3 run fills the existing `article_type` URL slot with the
  approved article form's label. The slot, the route and old staging URLs are
  unchanged.

One fixture change: `legacy-v2-result.json` gains a two-field `quality_review`.
The frozen artifact could not previously be rendered by the component that has
always required it, so it could not prove the acceptance requirement it exists
for — that old result pages still open. Both fixture consumers compare against
the fixture itself, so the added key changes no assertion.

Verification: backend pytest 848 passing, frontend vitest 847 passing across
166 files, tsc clean, eslint and boundary check clean, vite build passes.