### PR TITLE
feat(prompt2blog): submit approved commissions to the v3 pipeline

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -29,6 +29,7 @@ import {
 } from '../composer.storage'
 import type { P2BFormState } from '../composer.types'
 import { buildPrompt2BlogPayload } from '../prompt-payload'
+import { buildPrompt2BlogV3Payload, v3SubmissionBlockedReason } from '../v3-payload'
 import { approveCommission as fingerprintApprovedCommission } from '../commission'
 import {
   applyValidatedDirectionResponse,
@@ -186,10 +187,11 @@ export function usePrompt2BlogComposer() {
     [articleTypeOptions, state.articleTypeId],
   )
   const payload = useMemo(() => buildPrompt2BlogPayload(state), [state])
-  const submissionBlockedReason =
-    state.activeWorkflow === 'editorial_v3'
-      ? 'Editorial v3 direction work is active. Research import ships next; clear direction work to use legacy v2.'
-      : null
+  const v3Payload = useMemo(() => buildPrompt2BlogV3Payload(state), [state])
+  // An approved commission with attached research runs on v3. Everything else
+  // in the editorial workflow reports what is still missing; a legacy draft
+  // keeps the v2 path and its own validation.
+  const submissionBlockedReason = useMemo(() => v3SubmissionBlockedReason(state), [state])
 
   const startDirectionWorkflow = useCallback(() => {
     setState(startEditorialWorkflow)
@@ -351,6 +353,7 @@ export function usePrompt2BlogComposer() {
     articleTypeQuickPicks,
     selectedArticleType,
     payload,
+    v3Payload,
     submissionBlockedReason,
     startDirectionWorkflow,
     applyDirectionResponse,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../api', () => ({
   getPrompt2BlogResult: vi.fn(),
   getPrompt2BlogStatus: vi.fn(),
   startPrompt2BlogRun: vi.fn(),
+  startPrompt2BlogV3Run: vi.fn(),
 }))
 
 const getPrompt2BlogDebugMock = vi.mocked(prompt2blogApi.getPrompt2BlogDebug)
@@ -26,6 +27,7 @@ const getPrompt2BlogInputOptionsMock = vi.mocked(prompt2blogApi.getPrompt2BlogIn
 const getPrompt2BlogResultMock = vi.mocked(prompt2blogApi.getPrompt2BlogResult)
 const getPrompt2BlogStatusMock = vi.mocked(prompt2blogApi.getPrompt2BlogStatus)
 const startPrompt2BlogRunMock = vi.mocked(prompt2blogApi.startPrompt2BlogRun)
+const startPrompt2BlogV3RunMock = vi.mocked(prompt2blogApi.startPrompt2BlogV3Run)
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -890,7 +892,7 @@ describe('Prompt2BlogPage', () => {
     })
   })
 
-  it('blocks legacy submission while an editorial v3 direction is active', async () => {
+  it('blocks submission while an editorial v3 direction is unfinished', async () => {
     saveComposerState({
       ...DEFAULT_COMPOSER_STATE,
       activeWorkflow: 'editorial_v3',
@@ -908,10 +910,11 @@ describe('Prompt2BlogPage', () => {
     })
     expect(runButton).toBeDisabled()
     expect(screen.getByRole('status')).toHaveTextContent(
-      'Editorial v3 direction work is active. Research import ships next',
+      'Choose one of the three directions before running.',
     )
     fireEvent.click(runButton)
     expect(startPrompt2BlogRunMock).not.toHaveBeenCalled()
+    expect(startPrompt2BlogV3RunMock).not.toHaveBeenCalled()
   })
 
   it('imports three directions, approves an editable commission, and can return to legacy', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -17,7 +17,11 @@ import '../styles.css'
 
 export default function Prompt2BlogPage() {
   const composer = usePrompt2BlogComposer()
-  const pipeline = usePrompt2BlogPipelineRun(composer.payload)
+  const pipeline = usePrompt2BlogPipelineRun({
+    v2Payload: composer.payload,
+    v3Payload: composer.v3Payload,
+    v3BlockedReason: composer.submissionBlockedReason,
+  })
   const cleanupModal = useCleanupDetailsModal({
     pipelineRunId: pipeline.pipelineRunId,
     pipelineDebugData: pipeline.pipelineDebugData,
@@ -27,8 +31,10 @@ export default function Prompt2BlogPage() {
   const { state } = composer
 
   const handleCopyJson = useCallback(() => {
+    // Copy whichever request this draft would actually send.
+    const submittedPayload = composer.v3Payload ?? composer.payload
     navigator.clipboard
-      .writeText(JSON.stringify(composer.payload, null, 2))
+      .writeText(JSON.stringify(submittedPayload, null, 2))
       .then(() => {
         setCopied(true)
         setTimeout(() => setCopied(false), 2000)
@@ -36,12 +42,20 @@ export default function Prompt2BlogPage() {
       .catch(() => {
         pipeline.setError('Unable to copy JSON to clipboard.')
       })
-  }, [composer.payload, pipeline])
+  }, [composer.payload, composer.v3Payload, pipeline])
 
   const handleResetRun = useCallback(() => {
     cleanupModal.close()
     pipeline.reset()
   }, [cleanupModal, pipeline])
+
+  // The research step is already on the page; a stopped run needs the user
+  // taken back to the box that accepts a replacement package, not a new screen.
+  const handleBackToResearch = useCallback(() => {
+    const evidenceField = document.getElementById('p2b-evidence-json')
+    evidenceField?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    if (evidenceField instanceof HTMLTextAreaElement) evidenceField.focus()
+  }, [])
 
   const handleClear = useCallback(() => {
     composer.clearAll()
@@ -156,6 +170,7 @@ export default function Prompt2BlogPage() {
           </MiddleSectionsFold>
           <PipelinePanel
             run={pipeline}
+            onBackToResearch={handleBackToResearch}
             onOpenCleanupModal={() => void cleanupModal.open()}
             onReset={handleResetRun}
             submissionBlockedReason={composer.submissionBlockedReason}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/NeedsResearchResult.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/NeedsResearchResult.tsx
@@ -1,0 +1,105 @@
+import type { Prompt2BlogV3NeedsResearchResponse } from '../../api'
+import { useClipboardCopy } from '../../composer/hooks/useClipboardCopy'
+
+interface NeedsResearchResultProps {
+  result: Prompt2BlogV3NeedsResearchResponse
+  onBackToResearch: () => void
+  onDismiss: () => void
+}
+
+const FINDING_LABELS: Record<string, string> = {
+  requirement_gap: 'Requirement gap',
+  unresolved_conflict: 'Unresolved conflict',
+  source_gate: 'Source gate',
+}
+
+/**
+ * The terminal result of a run that never started.
+ *
+ * Insufficient research is a product state, not a failure: the commission was
+ * valid, the deterministic gate ran before any writing work existed, and no
+ * writer-model token was spent. What it produces is a list of exactly what is
+ * missing and the prompt that closes it, so the route out of here is more
+ * research — never a retry of the same run.
+ */
+export function NeedsResearchResult({
+  result,
+  onBackToResearch,
+  onDismiss,
+}: NeedsResearchResultProps) {
+  const followUpCopy = useClipboardCopy()
+
+  return (
+    <div className="p2b-import-report p2b-import-report--blocked" role="status">
+      <p className="p2b-import-report-title">
+        The run did not start: this commission’s research is incomplete. Nothing was queued and
+        no article was written.
+      </p>
+
+      <ul className="p2b-import-list">
+        {result.findings.map(finding => (
+          <li key={`${finding.code}-${finding.message}`}>
+            <code>{FINDING_LABELS[finding.code] ?? finding.code}</code> {finding.message}
+            {finding.requirement_ids.length > 0 && ` (${finding.requirement_ids.join(', ')})`}
+          </li>
+        ))}
+      </ul>
+
+      {result.unresolved_requirements.length > 0 && (
+        <>
+          <p className="p2b-import-report-title">Requirements still open</p>
+          <ul className="p2b-requirement-list">
+            {result.unresolved_requirements.map(requirement => (
+              <li key={requirement.requirement_id} className="p2b-requirement-row">
+                <code>{requirement.requirement_id}</code> {requirement.question}
+                {requirement.gap ? ` — ${requirement.gap}` : ''}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {result.unresolved_conflict_ids.length > 0 && (
+        <p className="p2b-field-hint">
+          Unresolved conflicts: {result.unresolved_conflict_ids.join(', ')}
+        </p>
+      )}
+
+      {result.missing_source_requirements.length > 0 && (
+        <p className="p2b-field-hint">
+          This article form still needs {result.missing_source_requirements.join(', ')}. Meet it
+          with genuine matching material — never a simulated interview, scene, or quotation.
+        </p>
+      )}
+
+      <div className="p2b-field">
+        <div className="p2b-field-label-row">
+          <label htmlFor="p2b-needs-research-prompt">Follow-up research prompt</label>
+          <button
+            type="button"
+            className="p2b-inline-copy-btn"
+            onClick={() => followUpCopy.copy(result.follow_up_research_prompt)}
+          >
+            {followUpCopy.label}
+          </button>
+        </div>
+        <textarea
+          id="p2b-needs-research-prompt"
+          className="p2b-textarea"
+          rows={10}
+          readOnly
+          value={result.follow_up_research_prompt}
+        />
+      </div>
+
+      <div className="p2b-panel-actions">
+        <button type="button" className="p2b-submit-btn" onClick={onBackToResearch}>
+          Back to research
+        </button>
+        <button type="button" className="p2b-clear-btn" onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
@@ -1,13 +1,18 @@
 import type { usePrompt2BlogPipelineRun } from '../hooks/usePrompt2BlogPipelineRun'
 import { CLEANUP_STAGE_KEY } from '../../cleanup-details/cleanup-stage.parser'
 import type { PipelineStepStatus } from '../pipeline-run.types'
-import { PROMPT2BLOG_PIPELINE_STAGES } from '../../types/pipeline.types'
-import { getPipelineStepStatus, PIPELINE_STAGE_LABELS } from '../pipeline-status'
+import {
+  getPipelineStepStatus,
+  PIPELINE_STAGE_LABELS,
+  PROMPT2BLOG_STAGE_ORDERS,
+} from '../pipeline-status'
+import { NeedsResearchResult } from './NeedsResearchResult'
 import { PipelineResult } from './PipelineResult'
 import { PipelineV3Result } from './PipelineV3Result'
 
 interface PipelinePanelProps {
   run: ReturnType<typeof usePrompt2BlogPipelineRun>
+  onBackToResearch: () => void
   onOpenCleanupModal: () => void
   onReset: () => void
   submissionBlockedReason?: string | null
@@ -15,24 +20,29 @@ interface PipelinePanelProps {
 
 export function PipelinePanel({
   run,
+  onBackToResearch,
   onOpenCleanupModal,
   onReset,
   submissionBlockedReason,
 }: PipelinePanelProps) {
   const {
     canOpenCleanupModal,
+    dismissNeedsResearch,
     error,
     isLoading,
     loadingLabel,
+    needsResearch,
     pipelineDebugData,
     pipelineLogs,
     pipelineResult,
     pipelineStatus,
+    pipelineVersion,
     showPipelineDebug,
     sourceStep,
     stageArticleUrl,
     togglePipelineDebug,
   } = run
+  const stageOrder = PROMPT2BLOG_STAGE_ORDERS[pipelineVersion]
 
   return (
     <section className="p2b-panel">
@@ -61,14 +71,14 @@ export function PipelinePanel({
         )}
 
         <div className="p2b-progress-grid">
-          {PROMPT2BLOG_PIPELINE_STAGES.map(step => (
+          {stageOrder.map(step => (
             <PipelineStageItem
               key={step}
               action={
                 step === CLEANUP_STAGE_KEY && canOpenCleanupModal ? onOpenCleanupModal : undefined
               }
               label={PIPELINE_STAGE_LABELS[step]}
-              status={getPipelineStepStatus(step, pipelineStatus)}
+              status={getPipelineStepStatus(step, pipelineStatus, stageOrder)}
             />
           ))}
           {pipelineStatus?.stage === 'unknown' && (
@@ -89,6 +99,14 @@ export function PipelinePanel({
                 .join('\n')}
             </pre>
           </div>
+        )}
+
+        {needsResearch && (
+          <NeedsResearchResult
+            result={needsResearch}
+            onBackToResearch={onBackToResearch}
+            onDismiss={dismissNeedsResearch}
+          />
         )}
 
         {sourceStep === 'pipeline_complete' && pipelineResult && (

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/needs-research-result.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/needs-research-result.test.tsx
@@ -1,0 +1,78 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { Prompt2BlogV3NeedsResearchResponse } from '../../api'
+import { NeedsResearchResult } from './NeedsResearchResult'
+
+const result: Prompt2BlogV3NeedsResearchResponse = {
+  status: 'needs_research',
+  commission_fingerprint: 'abc',
+  findings: [
+    {
+      code: 'requirement_gap',
+      requirement_ids: ['r2'],
+      message: 'No evidence covers the livability tradeoffs.',
+    },
+    {
+      code: 'source_gate',
+      requirement_ids: [],
+      message: 'The interview-qa form still needs attributable-responses.',
+    },
+  ],
+  unresolved_requirements: [
+    {
+      requirement_id: 'r2',
+      question: 'Which quality-of-life tradeoffs change the value judgment?',
+      gap: 'Nothing current was found.',
+    },
+  ],
+  unresolved_conflict_ids: ['k1'],
+  missing_source_requirements: ['attributable-responses'],
+  follow_up_research_prompt: 'Close r2 without changing the commission.',
+}
+
+describe('NeedsResearchResult', () => {
+  it('states plainly that nothing was queued and no article was written', () => {
+    render(
+      <NeedsResearchResult result={result} onBackToResearch={() => {}} onDismiss={() => {}} />,
+    )
+
+    expect(screen.getByRole('status').textContent).toMatch(/Nothing was queued/)
+  })
+
+  it('lists every reason the gate stopped the run', () => {
+    render(
+      <NeedsResearchResult result={result} onBackToResearch={() => {}} onDismiss={() => {}} />,
+    )
+
+    expect(screen.getByText(/No evidence covers the livability tradeoffs/)).toBeTruthy()
+    expect(screen.getAllByText(/attributable-responses/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/Which quality-of-life tradeoffs/)).toBeTruthy()
+    expect(screen.getByText(/Unresolved conflicts: k1/)).toBeTruthy()
+  })
+
+  it('offers the follow-up prompt and a route back into research', () => {
+    const onBackToResearch = vi.fn()
+    render(
+      <NeedsResearchResult
+        result={result}
+        onBackToResearch={onBackToResearch}
+        onDismiss={() => {}}
+      />,
+    )
+
+    expect(screen.getByLabelText('Follow-up research prompt')).toHaveValue(
+      'Close r2 without changing the commission.',
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Back to research' }))
+    expect(onBackToResearch).toHaveBeenCalledOnce()
+  })
+
+  it('offers no retry of the same run, because the same run would stop again', () => {
+    render(
+      <NeedsResearchResult result={result} onBackToResearch={() => {}} onDismiss={() => {}} />,
+    )
+
+    expect(screen.queryByRole('button', { name: /Retry|Run again/ })).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogMutation.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogMutation.ts
@@ -1,18 +1,56 @@
 import { useMutation } from '@tanstack/react-query'
 import {
   startPrompt2BlogRun,
+  startPrompt2BlogV3Run,
   type Prompt2BlogRunRequest,
-  type Prompt2BlogRunResponse,
+  type Prompt2BlogV3NeedsResearchResponse,
+  type Prompt2BlogV3Request,
 } from '../../api'
 import { validatePipelinePayload } from '../validate-pipeline-payload'
 
-export function usePrompt2BlogMutation(payload: Prompt2BlogRunRequest | null) {
-  return useMutation<Prompt2BlogRunResponse, Error, void>({
+/**
+ * How a start attempt ended. `needs_research` is not a failure: the commission
+ * was valid, the deterministic gate ran, and it found evidence that cannot
+ * support the article. Nothing was queued and no writer-model token was spent,
+ * so it is a result the UI has to show rather than an error to throw.
+ */
+export type Prompt2BlogStartOutcome =
+  | { kind: 'queued'; runId: string }
+  | { kind: 'needs_research'; payload: Prompt2BlogV3NeedsResearchResponse }
+
+type Prompt2BlogMutationPayloads = {
+  v2Payload: Prompt2BlogRunRequest | null
+  v3Payload: Prompt2BlogV3Request | null
+  v3BlockedReason?: string | null
+}
+
+/**
+ * An approved v3 commission takes the v3 route; everything else stays on v2.
+ * The two payloads are mutually exclusive by construction — `buildPrompt2BlogV3Payload`
+ * returns null unless the composer is in the editorial workflow, and
+ * `buildPrompt2BlogPayload` returns null when it is.
+ */
+export function usePrompt2BlogMutation({
+  v2Payload,
+  v3Payload,
+  v3BlockedReason,
+}: Prompt2BlogMutationPayloads) {
+  return useMutation<Prompt2BlogStartOutcome, Error, void>({
     mutationFn: async () => {
-      const validationError = validatePipelinePayload(payload)
+      if (v3Payload) {
+        const response = await startPrompt2BlogV3Run(v3Payload)
+        return response.status === 'queued'
+          ? { kind: 'queued', runId: response.run_id }
+          : { kind: 'needs_research', payload: response }
+      }
+
+      if (v3BlockedReason) throw new Error(v3BlockedReason)
+
+      const validationError = validatePipelinePayload(v2Payload)
       if (validationError) throw new Error(validationError)
-      if (!payload) throw new Error('Article type is required.')
-      return startPrompt2BlogRun(payload)
+      if (!v2Payload) throw new Error('Article type is required.')
+      const response = await startPrompt2BlogRun(v2Payload)
+      return { kind: 'queued', runId: response.run_id }
     },
   })
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.test.tsx
@@ -1,0 +1,149 @@
+/* @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import limaFixture from '../../../../../../../data/fixtures/prompt2blog/lima-scope-drift-v3.json'
+import * as prompt2blogApi from '../../api'
+import type { Prompt2BlogRunRequest, Prompt2BlogV3Request } from '../../api'
+import { usePrompt2BlogPipelineRun } from './usePrompt2BlogPipelineRun'
+
+vi.mock('../../api', () => ({
+  PROMPT2BLOG_PIPELINE_STAGES: [],
+  getPrompt2BlogDebug: vi.fn(),
+  getPrompt2BlogResult: vi.fn(),
+  getPrompt2BlogStatus: vi.fn(),
+  startPrompt2BlogRun: vi.fn(),
+  startPrompt2BlogV3Run: vi.fn(),
+}))
+
+const startPrompt2BlogRunMock = vi.mocked(prompt2blogApi.startPrompt2BlogRun)
+const startPrompt2BlogV3RunMock = vi.mocked(prompt2blogApi.startPrompt2BlogV3Run)
+
+const v3Payload = {
+  schema_version: 3,
+  commission: limaFixture.commission,
+  evidence_package: limaFixture.evidence_package,
+  profiles: { tone_id: 'balanced', length_id: 'standard' },
+} as unknown as Prompt2BlogV3Request
+
+const v2Payload = {
+  article_type_id: 7,
+  source_material: ['Something to write from.'],
+  article_goal: 'Goal',
+  target_reader: 'Reader',
+  destination_context: 'Lima, Peru',
+  tone_id: 'balanced',
+  length_id: 'standard',
+} as Prompt2BlogRunRequest
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+function renderRun(options: Parameters<typeof usePrompt2BlogPipelineRun>[0]) {
+  return renderHook(() => usePrompt2BlogPipelineRun(options), { wrapper })
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  // The lifecycle polls status as soon as a run is queued; a resolved pending
+  // status keeps the poll quiet without exercising terminal handling here.
+  vi.mocked(prompt2blogApi.getPrompt2BlogStatus).mockResolvedValue({
+    run_id: 'run',
+    feature: 'prompt2blog',
+    state: 'running',
+    stage: 'queued',
+    error: null,
+    updated_at: '2026-08-25T00:00:00Z',
+  })
+})
+
+describe('usePrompt2BlogPipelineRun submission routing', () => {
+  it('sends an approved commission to the v3 route and never to v2', async () => {
+    startPrompt2BlogV3RunMock.mockResolvedValue({ status: 'queued', run_id: 'v3-run' })
+    const { result } = renderRun({ v2Payload: null, v3Payload })
+
+    expect(result.current.pipelineVersion).toBe('v3')
+    act(() => result.current.run())
+
+    await waitFor(() => expect(result.current.pipelineRunId).toBe('v3-run'))
+    expect(startPrompt2BlogV3RunMock).toHaveBeenCalledWith(v3Payload)
+    expect(startPrompt2BlogRunMock).not.toHaveBeenCalled()
+    expect(result.current.sourceStep).toBe('pipeline_running')
+  })
+
+  it('keeps a legacy draft on the v2 route', async () => {
+    startPrompt2BlogRunMock.mockResolvedValue({ message: 'queued', run_id: 'v2-run' })
+    const { result } = renderRun({ v2Payload, v3Payload: null })
+
+    expect(result.current.pipelineVersion).toBe('v2')
+    act(() => result.current.run())
+
+    await waitFor(() => expect(result.current.pipelineRunId).toBe('v2-run'))
+    expect(startPrompt2BlogRunMock).toHaveBeenCalledWith(v2Payload)
+    expect(startPrompt2BlogV3RunMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to v2 when v3 work is incomplete', async () => {
+    const { result } = renderRun({
+      v2Payload,
+      v3Payload: null,
+      v3BlockedReason: 'Approve the commission before running.',
+    })
+
+    act(() => result.current.run())
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Approve the commission before running.'),
+    )
+    expect(startPrompt2BlogRunMock).not.toHaveBeenCalled()
+    expect(startPrompt2BlogV3RunMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('needs_research', () => {
+  const needsResearch = {
+    status: 'needs_research' as const,
+    commission_fingerprint: limaFixture.commission.commission_fingerprint,
+    findings: [
+      {
+        code: 'requirement_gap' as const,
+        requirement_ids: ['r2'],
+        message: 'No evidence covers the tradeoffs.',
+      },
+    ],
+    unresolved_requirements: [
+      { requirement_id: 'r2', question: 'Which tradeoffs?', gap: 'Nothing found.' },
+    ],
+    unresolved_conflict_ids: [],
+    missing_source_requirements: [],
+    follow_up_research_prompt: 'Close r2.',
+  }
+
+  it('is a result, not a failure: nothing is queued and no run starts', async () => {
+    startPrompt2BlogV3RunMock.mockResolvedValue(needsResearch)
+    const { result } = renderRun({ v2Payload: null, v3Payload })
+
+    act(() => result.current.run())
+
+    await waitFor(() => expect(result.current.needsResearch).toEqual(needsResearch))
+    expect(result.current.pipelineRunId).toBeNull()
+    expect(result.current.sourceStep).toBe('edit')
+    expect(result.current.error).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('clears on dismiss and on a fresh run', async () => {
+    startPrompt2BlogV3RunMock.mockResolvedValue(needsResearch)
+    const { result } = renderRun({ v2Payload: null, v3Payload })
+
+    act(() => result.current.run())
+    await waitFor(() => expect(result.current.needsResearch).not.toBeNull())
+
+    act(() => result.current.dismissNeedsResearch())
+    expect(result.current.needsResearch).toBeNull()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
@@ -2,18 +2,31 @@ import { useCallback, useMemo, useState } from 'react'
 import { buildStageArticleUrl } from '../../../blogArticles'
 import {
   type Prompt2BlogRunRequest,
+  type Prompt2BlogV3NeedsResearchResponse,
+  type Prompt2BlogV3Request,
 } from '../../api'
 import { CLEANUP_STAGE_KEY } from '../../cleanup-details/cleanup-stage.parser'
 import { PROMPT2BLOG_PIPELINE_STAGES } from '../../types/pipeline.types'
 import type {
   PipelineLogEntry,
   PipelineLogLevel,
+  PipelineVersion,
 } from '../pipeline-run.types'
 import { usePersistedPipelineRunState } from './usePersistedPipelineRunState'
 import { usePrompt2BlogMutation } from './usePrompt2BlogMutation'
 import { usePrompt2BlogRunLifecycle } from './usePrompt2BlogRunLifecycle'
 
-export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null) {
+type Prompt2BlogPipelineRunOptions = {
+  v2Payload: Prompt2BlogRunRequest | null
+  v3Payload: Prompt2BlogV3Request | null
+  v3BlockedReason?: string | null
+}
+
+export function usePrompt2BlogPipelineRun({
+  v2Payload,
+  v3Payload,
+  v3BlockedReason,
+}: Prompt2BlogPipelineRunOptions) {
   const {
     savedRun,
     sourceStep,
@@ -26,6 +39,9 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
   } = usePersistedPipelineRunState()
   const [pipelineLogs, setPipelineLogs] = useState<PipelineLogEntry[]>([])
   const [showPipelineDebug, setShowPipelineDebug] = useState(false)
+  const [needsResearch, setNeedsResearch] = useState<Prompt2BlogV3NeedsResearchResponse | null>(
+    null,
+  )
 
   const appendPipelineLog = useCallback((message: string, level: PipelineLogLevel = 'info') => {
     setPipelineLogs(prev => [
@@ -66,7 +82,15 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
     isPending: isStartingPipeline,
     mutate: startPipeline,
     reset: resetStartPipeline,
-  } = usePrompt2BlogMutation(payload)
+  } = usePrompt2BlogMutation({ v2Payload, v3Payload, v3BlockedReason })
+
+  // Which pipeline's stage list to show. A finished run names its own version;
+  // a run being started is named by the payload that will start it.
+  const pipelineVersion: PipelineVersion = pipelineResult
+    ? pipelineResult.version
+    : v3Payload
+      ? 'v3'
+      : 'v2'
 
   const {
     pipelineStatus,
@@ -111,13 +135,28 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
     setLoadingLabel('Starting final article pipeline...')
     setPipelineLogs([])
     setShowPipelineDebug(false)
+    setNeedsResearch(null)
 
     startPipeline(undefined, {
-      onSuccess: (startResponse) => {
+      onSuccess: (outcome) => {
         resetStartPipeline()
-        appendPipelineLog(`Pipeline started. Run ID: ${startResponse.run_id}`)
+        if (outcome.kind === 'needs_research') {
+          // The gate stopped before any writing work existed. Stay on the edit
+          // step so the research panel is still there to take a replacement
+          // package.
+          setNeedsResearch(outcome.payload)
+          appendPipelineLog(
+            `Run not started: research is incomplete (${outcome.payload.findings.length} finding${
+              outcome.payload.findings.length === 1 ? '' : 's'
+            }).`,
+          )
+          setLoadingLabel('')
+          setSourceStep('edit')
+          return
+        }
+        appendPipelineLog(`Pipeline started. Run ID: ${outcome.runId}`)
         setLoadingLabel('Running final article pipeline...')
-        setPipelineRunId(startResponse.run_id)
+        setPipelineRunId(outcome.runId)
         setSourceStep('pipeline_running')
       },
       onError: (err) => {
@@ -151,6 +190,7 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
     clearLifecycleState()
     setPipelineLogs([])
     setShowPipelineDebug(false)
+    setNeedsResearch(null)
     resetStatusError()
     clearPersistedRunState()
   }, [
@@ -182,6 +222,9 @@ export function usePrompt2BlogPipelineRun(payload: Prompt2BlogRunRequest | null)
     setError,
     stageArticleUrl,
     canOpenCleanupModal,
+    needsResearch,
+    dismissNeedsResearch: () => setNeedsResearch(null),
+    pipelineVersion,
     run,
     reset,
   }


### PR DESCRIPTION
PR 7D of the Prompt2Blog v3 editorial redesign. This is the cutover: an
approved commission with attached research now runs on v3.

- `usePrompt2BlogMutation` takes both payloads and returns a start outcome. An
  approved v3 commission takes the v3 route; everything else stays on v2. The
  two payloads are mutually exclusive by construction — each builder returns
  null when the other workflow is active.
- The v2 fence in the composer is replaced, not removed. Where it used to say
  "research import ships next", it now reports exactly what is still missing:
  no direction chosen, commission unapproved, research not imported, research
  belonging to another commission, and so on. An unfinished v3 draft still
  cannot reach a v2 run — a test pins that it falls through to neither route.
- `needs_research` gets a result screen. It is not an error: the commission was
  valid, the deterministic gate ran before any writing work existed, and no
  writer-model token was spent. The screen lists every finding, the open
  requirements, unresolved conflicts and missing source gates, carries the
  follow-up research prompt with a copy button, and routes back to the evidence
  box that takes a replacement package. It deliberately offers no retry: the
  same run would stop at the same gate.
- Progress renders the stage list of whichever pipeline is running, via
  `PROMPT2BLOG_STAGE_ORDERS`.
- "Copy JSON" copies whichever request the draft would actually send.

Verification: frontend vitest 856 passing across 168 files, tsc clean, eslint
and boundary check clean, vite build passes with the pre-existing chunk-size
warning only. Backend untouched.