### PR TITLE
feat(prompt2blog): retire the legacy 42-type inputs from the active UI

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -5,12 +5,10 @@ import type {
   Prompt2BlogDirectionResponse,
   Prompt2BlogEditorialOptionsResponse,
   Prompt2BlogEvidencePackage,
-  Prompt2BlogInputOptionsResponse,
 } from '../../api'
 import type { P2BEditorialComposerState, P2BFormState } from '../composer.types'
 import { reviewDirectionResponseJson, type DirectionImportReview } from '../direction-import'
 import { buildDirectionPrompt } from '../direction-prompt'
-import { reviewEasySetupJson, type EasySetupImportReview } from '../easy-setup-import'
 import { useClipboardCopy } from '../hooks/useClipboardCopy'
 import { CommissionEditor } from './CommissionEditor'
 import { DirectionCards } from './DirectionCards'
@@ -22,10 +20,8 @@ interface EasySetupPanelProps {
   editorialOptions: Prompt2BlogEditorialOptionsResponse | null
   editorialOptionsError: boolean
   editorialOptionsLoading: boolean
-  inputOptions: Prompt2BlogInputOptionsResponse | null
   location: string
   title: string
-  onApply: (patch: Partial<P2BFormState>) => void
   onApplyDirectionResponse: (response: Prompt2BlogDirectionResponse) => void
   onApproveCommission: () => Promise<void>
   onClearDirectionWorkflow: () => void
@@ -45,10 +41,8 @@ export function EasySetupPanel({
   editorialOptions,
   editorialOptionsError,
   editorialOptionsLoading,
-  inputOptions,
   location,
   title,
-  onApply,
   onApplyDirectionResponse,
   onApproveCommission,
   onClearDirectionWorkflow,
@@ -63,9 +57,6 @@ export function EasySetupPanel({
 }: EasySetupPanelProps) {
   const [prompt, setPrompt] = useState<string | null>(null)
   const directionCopy = useClipboardCopy()
-  const [pastedJson, setPastedJson] = useState('')
-  const [review, setReview] = useState<EasySetupImportReview | null>(null)
-  const [appliedCount, setAppliedCount] = useState<number | null>(null)
   const [directionJson, setDirectionJson] = useState('')
   const [directionReview, setDirectionReview] = useState<DirectionImportReview | null>(null)
   const [directionStatus, setDirectionStatus] = useState<string | null>(null)
@@ -118,26 +109,6 @@ export function EasySetupPanel({
     onApplyDirectionResponse(directionReview.response)
     setDirectionReview(null)
     setDirectionStatus('Three directions are ready for approval.')
-  }
-
-  // The review is tied to the exact text it was run against; editing the box
-  // retracts the approval so nothing unchecked can reach the form.
-  const handlePastedJsonChange = (value: string) => {
-    setPastedJson(value)
-    setReview(null)
-    setAppliedCount(null)
-  }
-
-  const handleCheckJson = () => {
-    setAppliedCount(null)
-    setReview(reviewEasySetupJson(pastedJson, inputOptions))
-  }
-
-  const handleApplyJson = () => {
-    if (!review?.patch) return
-    onApply(review.patch)
-    setAppliedCount(Object.keys(review.patch).length)
-    setReview(null)
   }
 
   return (
@@ -314,93 +285,6 @@ export function EasySetupPanel({
             )}
           </>
         )}
-        <details className="p2b-disclosure">
-          <summary>Legacy v2 brief import</summary>
-          <div className="p2b-disclosure-body">
-            <p className="p2b-field-hint">
-              Temporary compatibility path for saved one-shot briefs.
-            </p>
-            <div className="p2b-field">
-              <label htmlFor="p2b-easy-setup-json">Approved JSON</label>
-              <textarea
-                id="p2b-easy-setup-json"
-                className="p2b-textarea"
-                rows={10}
-                placeholder="Paste the JSON the model returned, then check it before applying."
-                value={pastedJson}
-                onChange={event => handlePastedJsonChange(event.target.value)}
-              />
-            </div>
-            <div className="p2b-panel-actions">
-              <button
-                type="button"
-                className="p2b-copy-json-btn"
-                disabled={!pastedJson.trim()}
-                onClick={handleCheckJson}
-              >
-                Check JSON
-              </button>
-              <button
-                type="button"
-                className="p2b-submit-btn"
-                disabled={!review?.patch}
-                onClick={handleApplyJson}
-              >
-                Apply to form
-              </button>
-            </div>
-            {appliedCount !== null && (
-              <p className="p2b-import-applied" role="status">
-                Applied {appliedCount} fields to the form below.
-              </p>
-            )}
-            {review?.direction && (
-              <div className="p2b-import-direction">
-                <span className="p2b-import-direction-label">Direction</span>
-                <p>{review.direction}</p>
-              </div>
-            )}
-            {review !== null && review.issues.length > 0 && (
-              <div className="p2b-import-report p2b-import-report--blocked">
-                <p className="p2b-import-report-title">
-                  {review.issues.length} problem
-                  {review.issues.length === 1 ? '' : 's'} — nothing was applied.
-                </p>
-                <ul className="p2b-import-list">
-                  {review.issues.map(issue => (
-                    <li key={`${issue.field}-${issue.message}`}>
-                      <code>{issue.field}</code> {issue.message}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {review?.patch && (
-              <div className="p2b-import-report">
-                <p className="p2b-import-report-title">
-                  Every value matches the loaded options. Review and apply.
-                </p>
-                {review.corrections.length > 0 && (
-                  <ul className="p2b-import-list p2b-import-list--corrections">
-                    {review.corrections.map(correction => (
-                      <li key={`${correction.field}-${correction.message}`}>
-                        <code>{correction.field}</code> {correction.message}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-                <dl className="p2b-import-rows">
-                  {review.rows.map(row => (
-                    <div key={row.field} className="p2b-import-row">
-                      <dt>{row.field}</dt>
-                      <dd>{row.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              </div>
-            )}
-          </div>
-        </details>
       </div>
     </section>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/MiddleSectionsFold.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/MiddleSectionsFold.tsx
@@ -5,8 +5,8 @@ export function MiddleSectionsFold({ children }: { children: ReactNode }) {
     <details className="p2b-middle-fold">
       <summary className="p2b-middle-fold-summary">
         <div className="p2b-panel-header-text">
-          <h2>Article Details</h2>
-          <p>Core inputs, prompt profiles, SEO, source material, and guidelines.</p>
+          <h2>Writing Profiles</h2>
+          <p>Tone, length, brand voice, and creativity for the approved commission.</p>
         </div>
         <span className="p2b-middle-fold-chevron" aria-hidden="true" />
       </summary>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -375,23 +375,45 @@ describe('Prompt2BlogPage', () => {
     })
   })
 
+  it('no longer offers the legacy 42-type selector or its inputs', async () => {
+    renderPage()
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
+
+    for (const label of [
+      'Article Type',
+      'Article Goal',
+      'Target Reader',
+      'Destination Context',
+      'Editorial Angle (Optional)',
+      'Approved JSON',
+      'Source Block 1',
+      'Secondary Keywords (comma-separated)',
+    ]) {
+      expect(screen.queryByLabelText(label)).not.toBeInTheDocument()
+    }
+    for (const heading of ['Core Inputs', 'SEO + Constraints', 'Source Material', 'Guideline Preview']) {
+      expect(screen.queryByRole('heading', { name: heading })).not.toBeInTheDocument()
+    }
+  })
+
   it('starts with an Easy Set Up block containing Title and Location fields', async () => {
     renderPage()
 
     const easySetupPanel = screen.getByRole('heading', { name: 'Easy Set Up' }).closest('section')
-    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' }).closest('section')
+    const profilesPanel = screen
+      .getByRole('heading', { name: 'Writing Profiles' })
+      .closest('section')
     const modelRoutingPanel = screen.getByRole('heading', { name: 'Run Stack' }).closest('section')
 
     expect(easySetupPanel).toBeInTheDocument()
     expect(modelRoutingPanel?.compareDocumentPosition(easySetupPanel!)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     )
-    expect(easySetupPanel?.compareDocumentPosition(coreInputsPanel!)).toBe(
+    expect(easySetupPanel?.compareDocumentPosition(profilesPanel!)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     )
     expect(within(easySetupPanel!).getByLabelText('Title')).toBeInTheDocument()
     expect(within(easySetupPanel!).getByLabelText('Location')).toBeInTheDocument()
-    expect(within(easySetupPanel!).getByLabelText('Approved JSON')).not.toBeVisible()
     expect(within(easySetupPanel!).queryByLabelText('Direction JSON')).not.toBeInTheDocument()
     expect(
       within(easySetupPanel!).getByRole('button', {
@@ -405,7 +427,7 @@ describe('Prompt2BlogPage', () => {
     renderPage()
 
     // The prompt quotes the loaded option catalogs, so wait for them to arrive.
-    await screen.findByRole('option', { name: 'Destination Guide' })
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
     const confirmSetup = screen.getByRole('button', {
       name: 'Generate direction prompt',
     })
@@ -450,7 +472,7 @@ describe('Prompt2BlogPage', () => {
     restoreClipboard = stubClipboard(writeText)
 
     renderPage()
-    await screen.findByRole('option', { name: 'Destination Guide' })
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
 
     fireEvent.change(screen.getByLabelText('Title'), {
       target: { value: 'A weekend in Lisbon' },
@@ -471,7 +493,7 @@ describe('Prompt2BlogPage', () => {
     restoreClipboard = stubClipboard(vi.fn().mockRejectedValue(new Error('denied')))
 
     renderPage()
-    await screen.findByRole('option', { name: 'Destination Guide' })
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
 
     fireEvent.change(screen.getByLabelText('Title'), {
       target: { value: 'A weekend in Lisbon' },
@@ -483,119 +505,6 @@ describe('Prompt2BlogPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Copy prompt' }))
 
     expect(await screen.findByRole('button', { name: 'Copy failed' })).toBeInTheDocument()
-  })
-
-  it('fills the whole form from an approved JSON brief once it checks out', async () => {
-    renderPage()
-    await screen.findByRole('option', { name: 'Destination Guide' })
-    fireEvent.click(screen.getByText('Legacy v2 brief import'))
-
-    const approved = JSON.stringify({
-      direction: 'A routing piece for a reader who loses their weekend to transit.',
-      title: 'A Weekend in Lisbon',
-      location: 'Lisbon, Portugal',
-      article_type: 'Itinerary Article',
-      article_goal: 'Plan two full days without wasted transit.',
-      target_reader: 'A first-time visitor with 48 hours.',
-      destination_context: 'Lisbon, Portugal, on the Tagus estuary.',
-      angle: 'Neighbourhood-first planning beats landmark ticking.',
-      call_to_action: 'Book the viewpoint slot before arriving.',
-      tone_id: 'balanced',
-      length_id: 'standard',
-      brand_voice_id: 'questurian',
-      creativity_level: 'high',
-      primary_keyword: 'weekend in lisbon',
-      secondary_keywords: ['lisbon itinerary', '48 hours in lisbon'],
-      must_include: ['Tram 28 crowding', 'Airport transfer costs'],
-      negative_instructions: ['No unsourced price claims'],
-      enable_editorial_augmentation: true,
-      source_material: ['RESEARCH NEEDED: current Carris fare'],
-      model_name: 'gemini-2.5-pro',
-      writing_model: 'gemini-2.5-flash',
-    })
-
-    fireEvent.change(screen.getByLabelText('Approved JSON'), {
-      target: { value: approved },
-    })
-    expect(screen.getByRole('button', { name: 'Apply to form' })).toBeDisabled()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Check JSON' }))
-
-    expect(
-      screen.getByText('Every value matches the loaded options. Review and apply.'),
-    ).toBeInTheDocument()
-    expect(screen.getByText('Itinerary Article (id 9)')).toBeInTheDocument()
-    expect(
-      screen.getByText('A routing piece for a reader who loses their weekend to transit.'),
-    ).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Apply to form' }))
-
-    expect(screen.getByLabelText('Article Type')).toHaveValue('9')
-    expect(screen.getByLabelText('Article Goal')).toHaveValue(
-      'Plan two full days without wasted transit.',
-    )
-    expect(screen.getByLabelText('Target Reader')).toHaveValue(
-      'A first-time visitor with 48 hours.',
-    )
-    expect(screen.getByLabelText('Editorial Angle (Optional)')).toHaveValue(
-      'Neighbourhood-first planning beats landmark ticking.',
-    )
-    expect(screen.getByLabelText('Call to Action (Optional)')).toHaveValue(
-      'Book the viewpoint slot before arriving.',
-    )
-    expect(screen.getByLabelText('Tone')).toHaveValue('balanced')
-    expect(screen.getByLabelText('Creativity Level')).toHaveValue('high')
-    expect(screen.getByLabelText('Pipeline preset')).toHaveValue('editorial-premium')
-    expect(screen.getByLabelText('Primary Keyword')).toHaveValue('weekend in lisbon')
-    expect(screen.getByLabelText('Secondary Keywords (comma-separated)')).toHaveValue(
-      'lisbon itinerary, 48 hours in lisbon',
-    )
-    expect(screen.getByLabelText('Must Include (one per line)')).toHaveValue(
-      'Tram 28 crowding\nAirport transfer costs',
-    )
-    expect(screen.getByLabelText('Negative Instructions (one per line)')).toHaveValue(
-      'No unsourced price claims',
-    )
-    expect(screen.getByLabelText('Add editorial extras')).toBeChecked()
-    expect(screen.getByLabelText('Title')).toHaveValue('A Weekend in Lisbon')
-    expect(screen.getByText('Applied 18 fields to the form below.')).toBeInTheDocument()
-  })
-
-  it('blocks applying a brief whose values are not in the loaded options', async () => {
-    renderPage()
-    await screen.findByRole('option', { name: 'Destination Guide' })
-    fireEvent.click(screen.getByText('Legacy v2 brief import'))
-
-    fireEvent.change(screen.getByLabelText('Approved JSON'), {
-      target: { value: '{"article_type": "Destination Guides"}' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Check JSON' }))
-
-    expect(screen.getByText(/nothing was applied/)).toBeInTheDocument()
-    expect(screen.getByText(/Closest match: "Destination Guide"/)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Apply to form' })).toBeDisabled()
-    expect(screen.getByLabelText('Article Goal')).toHaveValue('')
-  })
-
-  it('retracts an approved check as soon as the pasted JSON is edited', async () => {
-    renderPage()
-    await screen.findByRole('option', { name: 'Destination Guide' })
-    fireEvent.click(screen.getByText('Legacy v2 brief import'))
-
-    const box = screen.getByLabelText('Approved JSON')
-    fireEvent.change(box, {
-      target: { value: '{"article_type": "Destination Guides"}' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Check JSON' }))
-    expect(screen.getByText(/nothing was applied/)).toBeInTheDocument()
-
-    fireEvent.change(box, {
-      target: { value: '{"article_type": "Destination Guide"}' },
-    })
-
-    expect(screen.queryByText(/nothing was applied/)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Apply to form' })).toBeDisabled()
   })
 
   it('preserves Easy Set Up values in the composer draft', async () => {
@@ -700,198 +609,6 @@ describe('Prompt2BlogPage', () => {
     expect(editorialExtras).toBeChecked()
   })
 
-  it('folds every middle section behind one Article Details bar', async () => {
-    renderPage()
-
-    const advancedGenerationSummary = await screen.findByText('Advanced generation controls')
-    const advancedGeneration = advancedGenerationSummary.closest('details')
-    const advancedSeoSummary = screen.getByText('Advanced SEO controls')
-    const advancedSeo = advancedSeoSummary.closest('details')
-    const optionalGuidanceSummary = screen.getByText('Optional editorial guidance')
-    const optionalGuidance = optionalGuidanceSummary.closest('details')
-
-    const articleDetailsHeading = screen.getByRole('heading', {
-      name: 'Article Details',
-    })
-    const articleDetails = articleDetailsHeading.closest('details')
-    const middlePanels = [
-      'Core Inputs',
-      'Prompt Profiles',
-      'SEO + Constraints',
-      'Source Material',
-      'Guideline Preview',
-    ].map(title => screen.getByRole('heading', { name: title }).closest('details'))
-
-    expect(screen.getByRole('heading', { name: 'Easy Set Up' }).closest('details')).toBeNull()
-    expect(screen.getByRole('heading', { name: 'Pipeline' }).closest('details')).toBeNull()
-    expect(articleDetails).not.toHaveAttribute('open')
-    middlePanels.forEach(panel => expect(panel).toBe(articleDetails))
-
-    expect(advancedGeneration).not.toHaveAttribute('open')
-    expect(advancedSeo).not.toHaveAttribute('open')
-    expect(optionalGuidance).not.toHaveAttribute('open')
-    for (const label of [
-      'Creativity Level',
-      'Negative Instructions (one per line)',
-      'Add editorial extras',
-    ]) {
-      expect(screen.getByLabelText(label).closest('details')).toBe(advancedGeneration)
-    }
-    expect(screen.getByLabelText('Pipeline preset').closest('details')).toBeNull()
-    expect(screen.queryByLabelText('Audience Profile (Optional)')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Prompt Enhance')).not.toBeInTheDocument()
-    expect(screen.getByLabelText('Secondary Keywords (comma-separated)').closest('details')).toBe(
-      advancedSeo,
-    )
-    expect(screen.getByLabelText('Editorial Angle (Optional)').closest('details')).toBe(
-      optionalGuidance,
-    )
-    expect(screen.getByLabelText('Call to Action (Optional)').closest('details')).toBe(
-      optionalGuidance,
-    )
-
-    fireEvent.click(articleDetailsHeading)
-    fireEvent.click(advancedGenerationSummary)
-    fireEvent.click(advancedSeoSummary)
-    fireEvent.click(optionalGuidanceSummary)
-
-    expect(articleDetails).toHaveAttribute('open')
-    expect(advancedGeneration).toHaveAttribute('open')
-    expect(advancedSeo).toHaveAttribute('open')
-    expect(optionalGuidance).toHaveAttribute('open')
-  })
-
-  it('opens optional editorial guidance when a saved draft uses it', async () => {
-    saveComposerState({
-      ...DEFAULT_COMPOSER_STATE,
-      angle: 'Peru is the better first stop',
-      callToAction: 'Compare fares',
-    })
-
-    renderPage()
-
-    const optionalGuidanceSummary = await screen.findByText('Optional editorial guidance')
-    const optionalGuidance = optionalGuidanceSummary.closest('details')
-
-    expect(optionalGuidance).toHaveAttribute('open')
-    expect(screen.getByLabelText('Editorial Angle (Optional)')).toHaveValue(
-      'Peru is the better first stop',
-    )
-    expect(screen.getByLabelText('Call to Action (Optional)')).toHaveValue('Compare fares')
-  })
-
-  it('preserves optional guidance across toggles and clears it with core inputs', async () => {
-    renderPage()
-
-    const optionalGuidanceSummary = await screen.findByText('Optional editorial guidance')
-    const angle = screen.getByLabelText('Editorial Angle (Optional)')
-    const callToAction = screen.getByLabelText('Call to Action (Optional)')
-
-    fireEvent.click(optionalGuidanceSummary)
-    fireEvent.change(angle, {
-      target: { value: 'Peru is the better first stop' },
-    })
-    fireEvent.change(callToAction, { target: { value: 'Compare fares' } })
-    fireEvent.click(optionalGuidanceSummary)
-    fireEvent.click(optionalGuidanceSummary)
-
-    expect(angle).toHaveValue('Peru is the better first stop')
-    expect(callToAction).toHaveValue('Compare fares')
-
-    const coreInputsPanel = screen.getByRole('heading', { name: 'Core Inputs' }).closest('section')
-    fireEvent.click(within(coreInputsPanel!).getByRole('button', { name: 'Clear section' }))
-
-    expect(angle).toHaveValue('')
-    expect(callToAction).toHaveValue('')
-  })
-
-  it('preserves advanced values across disclosure toggles and clears them by section', async () => {
-    renderPage()
-
-    const advancedGenerationSummary = await screen.findByText('Advanced generation controls')
-    const advancedSeoSummary = screen.getByText('Advanced SEO controls')
-    const negativeInstructions = screen.getByLabelText('Negative Instructions (one per line)')
-    const secondaryKeywords = screen.getByLabelText('Secondary Keywords (comma-separated)')
-
-    fireEvent.click(advancedGenerationSummary)
-    fireEvent.change(negativeInstructions, {
-      target: { value: 'Avoid generic praise' },
-    })
-    fireEvent.click(advancedGenerationSummary)
-    fireEvent.click(advancedGenerationSummary)
-
-    fireEvent.click(advancedSeoSummary)
-    fireEvent.change(secondaryKeywords, {
-      target: { value: 'family hotels, free museums' },
-    })
-    fireEvent.click(advancedSeoSummary)
-    fireEvent.click(advancedSeoSummary)
-
-    expect(negativeInstructions).toHaveValue('Avoid generic praise')
-    expect(secondaryKeywords).toHaveValue('family hotels, free museums')
-
-    const promptProfilesPanel = screen
-      .getByRole('heading', { name: 'Prompt Profiles' })
-      .closest('section')
-    const seoPanel = screen.getByRole('heading', { name: 'SEO + Constraints' }).closest('section')
-
-    fireEvent.click(
-      within(promptProfilesPanel!).getByRole('button', {
-        name: 'Clear section',
-      }),
-    )
-    fireEvent.click(within(seoPanel!).getByRole('button', { name: 'Clear section' }))
-
-    expect(negativeInstructions).toHaveValue('')
-    expect(secondaryKeywords).toHaveValue('')
-  })
-
-  it('sends every model bundled by the selected run stack', async () => {
-    renderPage()
-
-    await waitFor(() => {
-      expect(getPrompt2BlogInputOptionsMock).toHaveBeenCalled()
-    })
-
-    fireEvent.change(screen.getByLabelText('Article Type'), {
-      target: { value: '7' },
-    })
-    fireEvent.change(screen.getByLabelText('Article Goal'), {
-      target: { value: 'Help readers pick the right neighborhoods.' },
-    })
-    fireEvent.change(screen.getByLabelText('Target Reader'), {
-      target: { value: 'First-time visitors' },
-    })
-    fireEvent.change(screen.getByLabelText('Destination Context'), {
-      target: { value: 'Lisbon, Portugal' },
-    })
-    fireEvent.change(screen.getByLabelText('Pipeline preset'), {
-      target: { value: 'best-value' },
-    })
-    fireEvent.change(screen.getByLabelText('Source Block 1'), {
-      target: {
-        value: 'Alfama is historic. Principe Real is calmer and more upscale.',
-      },
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' }))
-
-    await waitFor(() => {
-      expect(startPrompt2BlogRunMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          article_type_id: 7,
-          model_name: 'gemini-3.1-flash-lite',
-          writing_model: 'gemini-3.7-flash',
-          audit_model: 'gemini-3.7-flash',
-          tone_id: 'balanced',
-          length_id: 'standard',
-          enable_editorial_augmentation: false,
-          source_material: ['Alfama is historic. Principe Real is calmer and more upscale.'],
-        }),
-      )
-    })
-  })
-
   it('blocks submission while an editorial v3 direction is unfinished', async () => {
     saveComposerState({
       ...DEFAULT_COMPOSER_STATE,
@@ -988,18 +705,6 @@ describe('Prompt2BlogPage', () => {
 
     expect(screen.getByRole('button', { name: 'Show direction cards' })).toBeDisabled()
     expect(screen.getByLabelText('Direction JSON')).toHaveValue('')
-  })
-
-  it('lets users choose a travel quick pick and shows the selected definition', async () => {
-    renderPage()
-
-    const quickPick = await screen.findByRole('button', {
-      name: 'Itinerary Article',
-    })
-    fireEvent.click(quickPick)
-
-    expect(screen.getByLabelText('Article Type')).toHaveValue('9')
-    expect(screen.getByText('Day-by-day or stop-by-stop planning format.')).toBeInTheDocument()
   })
 
   it('opens cleanup details from the pipeline step', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -2,14 +2,10 @@ import { useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { CleanupDetailsModal } from '../cleanup-details/CleanupDetailsModal'
 import { useCleanupDetailsModal } from '../cleanup-details/hooks/useCleanupDetailsModal'
-import { CoreInputsPanel } from '../composer/components/CoreInputsPanel'
 import { EasySetupPanel } from '../composer/components/EasySetupPanel'
-import { GuidelinePreviewPanel } from '../composer/components/GuidelinePreviewPanel'
 import { MiddleSectionsFold } from '../composer/components/MiddleSectionsFold'
 import { ModelRoutingPanel } from '../composer/components/ModelRoutingPanel'
 import { PromptProfilesPanel } from '../composer/components/PromptProfilesPanel'
-import { SeoConstraintsPanel } from '../composer/components/SeoConstraintsPanel'
-import { SourceMaterialPanel } from '../composer/components/SourceMaterialPanel'
 import { usePrompt2BlogComposer } from '../composer/hooks/usePrompt2BlogComposer'
 import { PipelinePanel } from '../pipeline-run/components/PipelinePanel'
 import { usePrompt2BlogPipelineRun } from '../pipeline-run/hooks/usePrompt2BlogPipelineRun'
@@ -72,8 +68,8 @@ export default function Prompt2BlogPage() {
             <span className="p2b-dot">.</span>
           </h1>
           <p className="p2b-lede">
-            Choose article type, set voice controls, paste source material, and run the full
-            guideline-aware pipeline.
+            Approve one editorial commission, research it, and run the commission-driven
+            pipeline.
           </p>
         </div>
         <div className="p2b-badge-row">
@@ -99,10 +95,8 @@ export default function Prompt2BlogPage() {
             editorialOptions={composer.editorialOptions}
             editorialOptionsError={composer.editorialOptionsError}
             editorialOptionsLoading={composer.editorialOptionsLoading}
-            inputOptions={composer.inputOptions}
             location={state.easySetupLocation}
             title={state.easySetupTitle}
-            onApply={composer.applyFields}
             onApplyDirectionResponse={composer.applyDirectionResponse}
             onApproveCommission={composer.approveCommissionChanges}
             onClearDirectionWorkflow={composer.clearDirectionWorkflow}
@@ -116,26 +110,6 @@ export default function Prompt2BlogPage() {
             onTitleChange={value => composer.updateField('easySetupTitle', value)}
           />
           <MiddleSectionsFold>
-            <CoreInputsPanel
-              angle={state.angle}
-              articleGoal={state.articleGoal}
-              articleTypeId={state.articleTypeId}
-              callToAction={state.callToAction}
-              destinationContext={state.destinationContext}
-              groupedOptions={composer.groupedArticleTypeOptions}
-              quickPicks={composer.articleTypeQuickPicks}
-              selectedArticleType={composer.selectedArticleType}
-              targetReader={state.targetReader}
-              onAngleChange={value => composer.updateField('angle', value)}
-              onArticleGoalChange={value => composer.updateField('articleGoal', value)}
-              onArticleTypeChange={value => composer.updateField('articleTypeId', value)}
-              onCallToActionChange={value => composer.updateField('callToAction', value)}
-              onClear={composer.clearCoreInputs}
-              onDestinationContextChange={value =>
-                composer.updateField('destinationContext', value)
-              }
-              onTargetReaderChange={value => composer.updateField('targetReader', value)}
-            />
             <PromptProfilesPanel
               brandVoiceId={state.brandVoiceId}
               creativityLevel={state.creativityLevel}
@@ -146,26 +120,6 @@ export default function Prompt2BlogPage() {
               toneId={state.toneId}
               onChange={composer.updateField}
               onClear={composer.clearPromptProfiles}
-            />
-            <SeoConstraintsPanel
-              mustInclude={state.mustInclude}
-              primaryKeyword={state.primaryKeyword}
-              secondaryKeywords={state.secondaryKeywords}
-              onClear={composer.clearSeoConstraints}
-              onMustIncludeChange={value => composer.updateField('mustInclude', value)}
-              onPrimaryKeywordChange={value => composer.updateField('primaryKeyword', value)}
-              onSecondaryKeywordsChange={value => composer.updateField('secondaryKeywords', value)}
-            />
-            <SourceMaterialPanel
-              blobs={state.blobs}
-              onAdd={composer.addBlob}
-              onClear={composer.clearSourceMaterial}
-              onRemove={composer.removeBlob}
-              onUpdate={composer.updateBlob}
-            />
-            <GuidelinePreviewPanel
-              loading={composer.guidelineLoading}
-              preview={composer.guidelinePreview}
             />
           </MiddleSectionsFold>
           <PipelinePanel


### PR DESCRIPTION
PR 7E of the Prompt2Blog v3 editorial redesign. The commission flow is now the
whole Prompt2Blog page.

Removed from the page: the 42-type article selector and its travel quick picks,
the guideline preview that reads guidelines by that numeric id, the legacy v2
brief import, the source-material blocks, and the SEO + constraints panel.

Those five went together on purpose. Without an article type the v2 payload is
always null, so the v2 run path is unreachable from the UI; leaving its inputs
on screen would have left the user filling boxes that no longer reach a run.
Writing profiles stay — tone, length, brand voice and creativity are exactly
what the v3 request's `profiles` block carries.

Not removed here: the modules behind those panels, the v2 payload builder, and
the `/run` and `/pipeline-v2` routes. Deleting code and retiring the route is
PR 8, and the shared 42-type table, its routes, guideline files and seeding
scripts stay for URL2Blog and YouTube2Blog regardless.

Nine page tests covering the removed surfaces are deleted and one is added that
pins their absence. Saved legacy drafts are untouched: composer storage already
marks them `reconfirmation_required` rather than erasing them.

Verification: frontend vitest 848 passing across 168 files, tsc clean, eslint
and boundary check clean, vite build passes. Backend untouched.