### PR TITLE
docs(prompt2blog): record the v3 contract and drop the unused intake route

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -2,13 +2,36 @@
 
 ## Scope
 
-Owns the `/prompt2blog` feature: option and guideline catalogs, structured
-source preparation, article generation stages, quality gates, editorial
-augmentation, title generation, run recording, and the final Markdown artifact.
+Owns the `/prompt2blog` feature: option and editorial catalogs, the research
+gate, article generation stages, quality gates, title generation, run
+recording, and the final Markdown artifact.
 
 Prompt2Blog remains one feature boundary. Its internal modules separate domain
 logic, application stages, and infrastructure adapters; they are not separate
 bounded contexts.
+
+## Two pipelines, one default
+
+**v3 is the pipeline.** The frontend submits only `POST /pipeline-v3`, with an
+approved commission and a verified evidence package. Everything about the v3
+path is described in ADR 0029.
+
+**v2 is a fallback, not a product surface.** `POST /run` and
+`POST /pipeline-v2` still work and the v2 engine is intact, but nothing in the
+UI calls them. They stay until the owner's controlled real run proves v3 end to
+end; until that gate passes, v2 is the only working way to produce an article
+if v3 turns out to be wrong. Retiring them belongs after that run, not before.
+
+Both artifact keys are read forever: a finished run records exactly one of
+`pipeline_v2` or `pipeline_v3`, and old result pages must keep opening.
+
+## The shared 42-type catalog is not ours
+
+The `article_types` SQLite table, its routes, its guideline Markdown, and its
+seeding scripts belong to URL2Blog and YouTube2Blog as much as to Prompt2Blog.
+The v3 redesign removed Prompt2Blog's *dependency* on them; it deleted nothing
+from the shared catalog and repurposed no row IDs. `options.py` still reads
+them for the v2 fallback. Do not delete or renumber them.
 
 ## Module map
 
@@ -24,10 +47,10 @@ bounded contexts.
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |
-| `stages/` | One operation per persisted pipeline stage |
+| `stages/` | One operation per persisted v2 pipeline stage |
 | `graph/` | Typed graph state and ordered LangGraph execution |
 | `run_recorder.py` | The only adapter that writes lifecycle/status/artifact data |
-| `orchestrator.py` | Thin full-run and runtime-run entrypoints |
+| `orchestrator.py` | Thin v2 full-run and runtime-run entrypoints |
 
 ## Dependency direction
 
@@ -46,16 +69,47 @@ API → orchestrator → graph → stages → content / quality
 
 ## Preserved contracts
 
-- Public REST paths and request/response shapes are unchanged.
-- Persisted stage names are unchanged.
+- Every v2 REST path, request shape and persisted stage name is unchanged.
+  `POST /pipeline-v3` was added; `POST /pipeline-v3/intake` was added and then
+  removed once the run route made it redundant, and it never had a caller.
 - `run_id`, completed artifact structure, Markdown output, debug trace shape,
   and option-file semantics are unchanged.
 - No new canonical top-level `Stage[N]Output` was introduced.
 - Quality Gate repair still performs a second audit before finalization.
+- The `reported-people-scenes-quotations` source gate is implemented twice on
+  purpose — TypeScript in `composer/evidence-import.ts`, Python in
+  `research_readiness_v3.py`. One runs before the user spends money on
+  research, the other decides whether a run may start. They must not drift.
+- Readiness findings are derived, never stored. The composer keeps only the
+  evidence package and recomputes.
 
-## Internal graph
+## Internal graphs
 
-The generation graph exposes these first-class nodes:
+The v3 generation graph, which every real run uses:
+
+1. outline
+2. compose
+3. groundedness
+4. quality audit
+5. repair
+6. quality settle
+7. title
+8. finalize
+
+It is shorter than v2 by design. There is no guideline fetch, no coverage
+check, and no supplement node: research readiness is settled before a run
+starts, and v3 never generates a fact it did not receive. Grounding sits inside
+the repair loop, so a repaired draft is re-checked against the evidence rather
+than trusted. Stage payloads persist as `stage_v3_*`.
+
+Editorial augmentation has no v3 node. `POST /pipeline-v3` refuses
+`enable_editorial_augmentation` with a 400 rather than accepting the flag and
+ignoring it: augmentation is a full-article rewrite of already-audited prose
+and has not been re-verified against the evidence model. Re-enabling it means
+wiring `stages/augmentation.py` plus a v3 re-grounding pass into
+`graph/topology_v3.py` — the reason v2 has `final_verify` at all.
+
+The v2 generation graph, kept for the fallback described above:
 
 1. guideline
 2. coverage
@@ -67,8 +121,8 @@ The generation graph exposes these first-class nodes:
 8. title
 9. finalize
 
-The full-run graph prepends source preparation. Individual stages continue to
-record their existing `stage_*` payloads through `RunRecorder`.
+The v2 full-run graph prepends source preparation. Individual stages continue
+to record their existing `stage_*` payloads through `RunRecorder`.
 
 `RunRecorder` snapshots the token tracker's cumulative totals on `start_stage`
 and writes the delta into each stage payload as `stage_usage`, which is also

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -150,30 +150,6 @@ async def start_full_run(
     return JSONResponse({"message": "Prompt2Blog full run queued", "run_id": run_id})
 
 
-@router.post("/pipeline-v3/intake")
-async def prepare_pipeline_v3(
-    request: Prompt2BlogV3Request,
-    staff_user=Depends(require_staff),
-) -> JSONResponse:
-    """Validate an approved commission, gate it on research, assemble its input.
-
-    Intake is synchronous and starts nothing. Insufficient research terminates
-    here as `needs_research` — a product state, not a failure — before any
-    writing work exists to spend a token on.
-    """
-    try:
-        result = v3_intake_result(request)
-    except (RuntimeError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-
-    message = (
-        "Prompt2Blog v3 run input assembled"
-        if result["status"] == "ready"
-        else "Prompt2Blog v3 commission needs more research"
-    )
-    return JSONResponse({"message": message, **result})
-
-
 @router.post("/pipeline-v3")
 async def start_pipeline_v3(
     request: Prompt2BlogV3Request,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/routes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/routes.py
@@ -49,13 +49,6 @@ async def start_pipeline_v2(
     return await _runs_api.start_pipeline_v2(request, background_tasks, staff_user)
 
 
-async def prepare_pipeline_v3(
-    request: Prompt2BlogV3Request,
-    staff_user=None,
-):
-    return await _runs_api.prepare_pipeline_v3(request, staff_user)
-
-
 async def start_pipeline_v3(
     request: Prompt2BlogV3Request,
     background_tasks,
@@ -108,7 +101,6 @@ __all__ = [
     "get_editorial_options",
     "get_article_type_guideline_preview",
     "start_pipeline_v2",
-    "prepare_pipeline_v3",
     "start_pipeline_v3",
     "start_full_run",
     "get_status",

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
@@ -8,16 +8,16 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 from pydantic import ValidationError
 
 import app.features.prompt2blog.routes as prompt2blog_routes
 from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
 from app.features.prompt2blog.intake_v3 import (
     prepare_v3_runtime_request,
+    v3_intake_result,
     v3_run_input_artifact,
 )
-from tests.prompt2blog_test_support import response_payload
 
 FIXTURE_PATH = (
     Path(__file__).parents[3]
@@ -90,13 +90,8 @@ def _request(**overrides) -> Prompt2BlogV3Request:
 
 
 def _intake(payload: dict) -> dict:
-    return response_payload(
-        asyncio.run(
-            prompt2blog_routes.prepare_pipeline_v3(
-                Prompt2BlogV3Request.model_validate(payload)
-            )
-        )
-    )
+    """Runs the gate-and-assemble step `/pipeline-v3` runs before queueing."""
+    return v3_intake_result(Prompt2BlogV3Request.model_validate(payload))
 
 
 def test_intake_returns_a_versioned_run_input_for_the_approved_commission():
@@ -105,7 +100,6 @@ def test_intake_returns_a_versioned_run_input_for_the_approved_commission():
     payload = _intake(_ready_payload())
     run_input = payload["run_input"]
 
-    assert payload["message"] == "Prompt2Blog v3 run input assembled"
     assert run_input["schema_version"] == 3
     assert run_input["instruction_schema_version"] == 3
     assert (
@@ -160,8 +154,23 @@ def test_intake_rejects_an_unknown_writing_profile_by_name():
     payload = _ready_payload()
     payload["profiles"]["tone_id"] = "not-a-tone"
 
-    with pytest.raises(HTTPException) as excinfo:
+    with pytest.raises(RuntimeError, match="tone_id"):
         _intake(payload)
+
+
+def test_the_run_route_reports_an_unknown_writing_profile_as_a_bad_request():
+    """The route is where an unresolvable profile becomes a 400 rather than a 500."""
+    payload = _ready_payload()
+    payload["profiles"]["tone_id"] = "not-a-tone"
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            prompt2blog_routes.start_pipeline_v3(
+                Prompt2BlogV3Request.model_validate(payload),
+                BackgroundTasks(),
+                None,
+            )
+        )
 
     assert excinfo.value.status_code == 400
     assert "tone_id" in str(excinfo.value.detail)

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
@@ -2,21 +2,19 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from copy import deepcopy
 from pathlib import Path
 
 import app.features.prompt2blog.llm as prompt2blog_llm
 from app.features.prompt2blog.graph.state import Prompt2BlogV3GraphState
-import app.features.prompt2blog.routes as prompt2blog_routes
 from app.features.prompt2blog.contracts_v3 import Prompt2BlogV3Request
 from app.features.prompt2blog.evidence_v3 import normalize_evidence
+from app.features.prompt2blog.intake_v3 import v3_intake_result
 from app.features.prompt2blog.research_readiness_v3 import (
     assess_research_readiness,
     build_follow_up_research_prompt,
 )
-from tests.prompt2blog_test_support import response_payload
 
 FIXTURE_PATH = (
     Path(__file__).parents[3]
@@ -170,12 +168,9 @@ def test_intake_terminates_as_needs_research_without_calling_a_model(monkeypatch
                 prompt2blog_llm, attribute, fail_on_model_call, raising=False
             )
 
-    payload = response_payload(
-        asyncio.run(prompt2blog_routes.prepare_pipeline_v3(_request()))
-    )
+    payload = v3_intake_result(_request())
 
     assert payload["status"] == "needs_research"
-    assert payload["message"] == "Prompt2Blog v3 commission needs more research"
     assert "run_input" not in payload
     assert [item["requirement_id"] for item in payload["unresolved_requirements"]] == [
         "r2",
@@ -189,13 +184,7 @@ def test_intake_terminates_as_needs_research_without_calling_a_model(monkeypatch
 
 
 def test_ready_research_reaches_run_input_instead_of_the_gate():
-    payload = response_payload(
-        asyncio.run(
-            prompt2blog_routes.prepare_pipeline_v3(
-                _request(evidence=_supported_evidence())
-            )
-        )
-    )
+    payload = v3_intake_result(_request(evidence=_supported_evidence()))
 
     assert payload["status"] == "ready"
     assert payload["run_input"]["form_id"] == "analysis"

--- a/apps/ai-blog-writer/docs/adr/0029-prompt2blog-v3-commission-pipeline.md
+++ b/apps/ai-blog-writer/docs/adr/0029-prompt2blog-v3-commission-pipeline.md
@@ -1,0 +1,86 @@
+# Prompt2Blog v3 runs an approved commission against verified evidence
+
+## Context
+
+ADR 0024 made every Prompt2Blog generation step a first-class LangGraph node.
+It did not change what the pipeline was asked to write, and that was the real
+defect. One Easy Setup call chose the editorial direction, the article type,
+the audience, the requirements and the research prompt at the same time. The
+chosen type from a 42-row shared catalog then became structural authority, the
+operator's original title never reached the run, coverage found gaps research
+had not filled, and a supplement stage generated the missing material because
+its prompt simultaneously forbade invention and demanded every hard constraint
+be met.
+
+The audited Lima run is the case: a Lima-centred analysis became a three-city
+comparison, grounding failed, two repair attempts settled back to a weaker
+draft, and the receipt was 312,555 tokens across 24 calls.
+
+## Decision
+
+Prompt2Blog runs on a v3 pipeline whose authority model is explicit.
+
+**The commission is the controlling document.** A human picks one of three
+AI-proposed editorial directions, edits it if they want, and approves it. The
+approved commission fixes the original title, the location, the article form,
+zero to four topic modules, the audience, the primary subject, the scope mode
+and every reference's role, the requirements, and the exclusions. It carries a
+fingerprint of its own contents.
+
+**Research answers the commission and can never change it.** The research
+prompt is generated from the approved commission and locks it as read-only.
+The returned evidence package is validated deterministically: sources carry
+publisher, URL and dates; claims map to sources and requirements in both
+directions; every commission requirement appears exactly once. Evidence is
+stored against the fingerprint it was researched for and dropped the moment the
+commission changes.
+
+**Insufficient research stops the run instead of starting one.**
+`POST /pipeline-v3` runs a deterministic readiness gate before queueing
+anything and returns `needs_research` on a 200 with the findings, the open
+requirements, the unresolved conflicts, the unmet source gates, and a follow-up
+research prompt that closes exactly those. It is a product state, not a
+failure: nothing is queued and no writer-model token is spent reaching it.
+
+**There is no supplemental-fact generation stage.** v3 writes from the evidence
+it was given or it does not write.
+
+The persisted v3 stage contract, versioning ADR 0024's rather than reusing it:
+
+| Stage | Records |
+| --- | --- |
+| `pipeline_input_v3` | The versioned run input: fingerprint, form, modules, audience, scope mode, requirement ids, precedence, evidence receipt, profiles, routing |
+| `stage_v3_outline` | The section plan and any requirement it could not support |
+| `stage_v3_compose` | The draft and its alignment summary |
+| `stage_v3_groundedness` | Every claim checked against the exact evidence records |
+| `stage_v3_quality_audit` | Commission fidelity, informativeness, originality, brief adherence, SEO |
+| `stage_v3_repair` | A repaired draft, forbidden from adding facts or widening scope |
+| `stage_v3_quality_settle` | The best-scoring draft of the attempts |
+| `stage_v3_title` | The headline, generated against the original title and the commission |
+| `stage_v3_finalize` | `pipeline_v3`: the commission, form, instruction meta, evidence receipt, quality review and run cost |
+
+Grounding sits inside the repair loop, so a repaired draft is re-checked
+against the evidence rather than trusted.
+
+The 15 article forms, 10 topic modules, audience tags and house/headline rules
+are file-backed with stable string ids, owned by Prompt2Blog. The shared
+42-row `article_types` table keeps every row and id for URL2Blog and
+YouTube2Blog.
+
+## Consequences
+
+- The article's subject, shape and scope are decided once, by a person, before
+  any money is spent on research or writing.
+- A run that cannot be supported costs nothing rather than costing a repair
+  loop.
+- A finished run can be audited from its artifact alone: the commission it
+  answers and the evidence it used are both in `pipeline_v3`.
+- Two pipelines exist. `pipeline_v2` artifacts stay readable and stageable
+  forever, and `POST /run` and `POST /pipeline-v2` remain until the owner's
+  controlled real run proves v3 end to end.
+- `enable_editorial_augmentation` is refused with a 400 on v3 rather than
+  accepted and ignored. It rewrites audited prose and has not been re-verified
+  against the evidence model.
+- The `reported-people-scenes-quotations` source gate is implemented in both
+  TypeScript and Python on purpose — one runs before research is commissioned,
+  the other decides whether a run may start. They must not drift.

--- a/apps/ai-blog-writer/docs/api-changelog.md
+++ b/apps/ai-blog-writer/docs/api-changelog.md
@@ -1,5 +1,33 @@
 # API Changelog
 
+## 2026-08-25
+
+### Added
+- Prompt2Blog v3, the commission-driven pipeline (ADR 0029):
+  - `POST /prompt2blog/pipeline-v3` — queue a run from an approved commission
+    and its verified evidence package, or answer `needs_research` on a 200
+    without queueing anything.
+  - `GET /prompt2blog/editorial-options` — the 15 article forms, 10 topic
+    modules, audience tags, scope modes and reference roles.
+- `GET /prompt2blog/result/{run_id}` and `/debug/{run_id}` expose a
+  `pipeline_v3` artifact and `stage_v3_*` stages, and attach the LangGraph
+  trace to whichever artifact key a run recorded.
+
+### Changed
+- The Prompt2Blog UI submits only `pipeline-v3`. `POST /prompt2blog/run` and
+  `POST /prompt2blog/pipeline-v2` still work and are unchanged, but have no UI
+  caller; they remain as a fallback until v3 is proven on a controlled real run.
+- `POST /prompt2blog/pipeline-v3` refuses `enable_editorial_augmentation` with
+  a 400 rather than accepting the flag and ignoring it.
+- `pipeline_v2` result artifacts stay readable and stageable. Nothing about the
+  shared 42-row `article_types` catalog, its routes, its guideline files or its
+  seeding scripts changed; URL2Blog and YouTube2Blog still own them.
+
+### Removed
+- `POST /prompt2blog/pipeline-v3/intake`, added earlier in this series as a
+  validate-and-assemble preview and made redundant by `POST /pipeline-v3`
+  answering `needs_research` itself. It never had a caller.
+
 ## 2026-02-24
 
 ### Added

--- a/apps/ai-blog-writer/docs/routes.md
+++ b/apps/ai-blog-writer/docs/routes.md
@@ -40,17 +40,38 @@ Comprehensive route list for this workspace.
 
 | Method | Path | Description |
 |---|---|---|
-| POST | `/prompt2blog/pipeline-v2` | Queue the structured Prompt2Blog run (full LangGraph path) |
-| POST | `/prompt2blog/run` | Queue the one-click Prompt2Blog run (same structured schema as `pipeline-v2`) |
-| GET | `/prompt2blog/input-options` | Load input dropdown catalogs (`article_types`, `tones`, `lengths`, `brand_voices`, defaults) |
-| GET | `/prompt2blog/article-types/{article_type_id}/guideline-preview` | Preview resolved guideline + title guideline markdown for selected article type |
+| POST | `/prompt2blog/pipeline-v3` | Queue a commission-driven run, or return `needs_research` |
+| GET | `/prompt2blog/editorial-options` | Load the v3 catalogs (forms, topic modules, audience tags, scope modes, reference roles) |
+| GET | `/prompt2blog/input-options` | Load writing-profile catalogs (`tones`, `lengths`, `brand_voices`, defaults; also still carries legacy `article_types`) |
 | GET | `/prompt2blog/status/{run_id}` | Get run status |
 | GET | `/prompt2blog/result/{run_id}` | Get run output (`markdown` + `artifact`) |
 | GET | `/prompt2blog/articles` | List completed Prompt2Blog articles |
 | POST | `/prompt2blog/articles/{run_id}/sync` | Mark article as synced to Payload |
 | GET | `/prompt2blog/articles/{run_id}/sync` | Get Payload sync status for article |
+| POST | `/prompt2blog/pipeline-v2` | Legacy fallback: queue the structured v2 run. No UI caller. |
+| POST | `/prompt2blog/run` | Legacy fallback: one-click v2 run (same schema as `pipeline-v2`). No UI caller. |
+| GET | `/prompt2blog/article-types/{article_type_id}/guideline-preview` | Legacy: resolved guideline + title guideline markdown for a shared 42-type id |
 
-Structured Prompt2Blog run input now uses:
+`POST /prompt2blog/pipeline-v3` takes an approved commission and its verified
+evidence package:
+- `commission` (required): fingerprint, original title, location, approved
+  direction, `form_id`, up to four `topic_module_ids`, audience, primary
+  subject, scope mode and reference roles, requirements, exclusions
+- `evidence_package` (required): sources, claims, per-requirement status,
+  conflicts, gaps — its fingerprint must match the commission's, and its
+  requirements must match the commission's exactly
+- `profiles` (required): `tone_id`, `length_id`, optional `brand_voice_id`,
+  `creativity_level`
+- `model_routing`, `include_debug` (optional)
+- `enable_editorial_augmentation` is refused with a 400. See ADR 0029.
+
+It answers with either `{"status": "queued", "run_id"}` or, on a 200,
+`{"status": "needs_research", findings, unresolved_requirements,
+unresolved_conflict_ids, missing_source_requirements,
+follow_up_research_prompt}`. `needs_research` queues nothing and spends no
+writer-model token; it is a result to show, not an error.
+
+Legacy v2 run input (unchanged, still accepted on the two fallback routes):
 - `article_type_id` (required), `source_material` (required array of raw text blocks)
 - `article_goal`, `target_reader`, `destination_context` (required)
 - `tone_id`, `length_id` (required; loaded from `/prompt2blog/input-options`)


### PR DESCRIPTION
PR 8C of the Prompt2Blog v3 editorial redesign, and the last code PR.

Removed `POST /prompt2blog/pipeline-v3/intake`. It landed in #396 as a
synchronous validate-and-assemble preview, at a point when there was no
terminal state for insufficient research and queueing would have left stuck
runs on main. #400 gave `POST /pipeline-v3` its own `needs_research` answer,
which made intake redundant, and no client ever called it. Its two test suites
now drive `v3_intake_result` directly — the function both paths share — so the
gate-and-assemble coverage is unchanged, and the "unresolvable profile is a
400, not a 500" case moved onto the run route where that translation now lives.

Documentation:
- ADR 0029 records the v3 authority model and the persisted `stage_v3_*`
  contract, deliberately versioning ADR 0024's v2 contract rather than reusing
  it. It states why there is no supplemental-fact stage, why grounding sits
  inside the repair loop, and why augmentation is refused.
- `prompt2blog/CONTEXT.md` gains "Two pipelines, one default" and "The shared
  42-type catalog is not ours", both v3 and v2 graphs, and the two invariants a
  future change is most likely to break: the source gate implemented in both TS
  and Python must not drift, and readiness findings stay derived, never stored.
- `docs/routes.md` leads with the v3 route and marks the v2 routes as fallbacks
  with no UI caller.
- `docs/api-changelog.md` gains a 2026-08-25 entry.

The v2 engine and its two routes stay. The owner's controlled real run of v3
has not happened; until it does, v2 is the only working way to produce an
article if v3 turns out to be wrong. Retiring it belongs after that gate.

Verification: backend pytest 848 passing, black and flake8 clean on every
touched file. Frontend untouched.