### PR TITLE
fix(prompt2blog): tell the research desk what partial means

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_readiness_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_readiness_v3.py
@@ -22,6 +22,20 @@ from .editorial_catalog import (
 )
 from .evidence_v3 import NormalizedEvidence, NormalizedSource
 
+# Requirement status and claim confidence answer different questions, and a
+# research desk that conflates them stalls on a question it has in fact
+# answered: an issuing authority whose own site blocks automated retrieval held
+# a real run's requirement at `partial` for three rounds while several
+# independent sources agreed on the figure. Kept verbatim in step with the
+# frontend's `REQUIREMENT_STATUS_RULES`; all three prompts must say the same
+# thing.
+REQUIREMENT_STATUS_RULES = """REQUIREMENT STATUS VERSUS CLAIM CONFIDENCE
+These record two different things. Never conflate them.
+- status describes the QUESTION. supported means linked claims answer the requirement's question; partial means part of that question is still unanswered; missing means none of it is answered.
+- confidence describes the ANSWER. high, medium, or low records how well corroborated that answer is.
+- An answer you found and corroborated stays supported even when you could not reach the ideal primary source, the publisher blocks automated retrieval, or you would have preferred more evidence. Record that reservation as claim confidence medium or low and as a source note. Never downgrade the requirement to partial for it.
+- Reserve partial and missing for a genuinely unanswered question. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims."""
+
 ReadinessStatus = Literal["ready", "needs_research"]
 FindingCode = Literal["requirement_gap", "unresolved_conflict", "source_gate"]
 
@@ -257,10 +271,12 @@ ACTIVE TOPIC MODULES
 REPLACEMENT RULES
 - Do not redo or weaken already supported work. Preserve valid existing sources, claims, requirement links, dates, metadata, and resolved conflicts.
 - Add or revise only what is needed to close the listed requirements, conflicts, findings, and source gates.
-- Use partial or missing honestly when the follow-up still cannot close a gap.
+- Set requirement status and claim confidence by the rules below, including for work this follow-up still cannot close.
 - Keep every locked requirement exactly once in requirements, including already supported requirements.
 - Keep source and claim mappings resolvable in both directions. Web and report sources require publisher and URL.
-- Preserve exact material_type so source-gate readiness stays deterministic."""
+- Preserve exact material_type so source-gate readiness stays deterministic.
+
+{REQUIREMENT_STATUS_RULES}"""
 
 
 def needs_research_payload(

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
@@ -14,6 +14,7 @@ from app.features.prompt2blog.intake_v3 import v3_intake_result
 from app.features.prompt2blog.research_readiness_v3 import (
     assess_research_readiness,
     build_follow_up_research_prompt,
+    REQUIREMENT_STATUS_RULES,
 )
 
 FIXTURE_PATH = (
@@ -154,6 +155,26 @@ def test_the_follow_up_prompt_targets_only_unresolved_work():
     assert "- r2 — " in prompt
     assert "- r3 — " in prompt
     assert "- r1 — " not in prompt
+
+
+def test_the_follow_up_prompt_separates_requirement_status_from_claim_confidence():
+    """An unreachable primary source is a confidence reservation, not a gap.
+
+    Conflating the two is what held a real run's requirement at ``partial``
+    across three research rounds while several independent sources agreed on
+    the answer, so the prompt has to draw the line explicitly.
+    """
+    request = _request()
+    evidence, readiness = _assess(request)
+
+    prompt = build_follow_up_research_prompt(request.commission, evidence, readiness)
+
+    assert REQUIREMENT_STATUS_RULES in prompt
+    assert "status describes the QUESTION" in prompt
+    assert "confidence describes the ANSWER" in prompt
+    assert "the publisher blocks automated retrieval" in prompt
+    assert "Never downgrade the requirement to partial for it." in prompt
+    assert "Use partial or missing honestly" not in prompt
 
 
 def test_intake_terminates_as_needs_research_without_calling_a_model(monkeypatch):

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '../api'
 import type { EvidenceReadinessFinding } from './evidence-import'
 import { buildFollowUpResearchPrompt } from './follow-up-research-prompt'
+import { REQUIREMENT_STATUS_RULES } from './research-prompt'
 
 const fingerprint =
   'd1c2c9e041513d1d2b54261f8be5a1a3904a206b9daddf5e392c81b9e7cdcf48'
@@ -234,5 +235,20 @@ describe('buildFollowUpResearchPrompt', () => {
     expect(prompt).toContain(
       '"material_type": "web|report|transcript|interview-responses|first-person-notes|evaluation-notes|other"'
     )
+  })
+
+  it('carries the same status-versus-confidence rules as the initial prompt', () => {
+    const prompt = buildFollowUpResearchPrompt(
+      commission,
+      incompleteEvidence,
+      [],
+      catalog
+    )
+
+    expect(prompt).toContain(REQUIREMENT_STATUS_RULES)
+    expect(prompt).toContain(
+      'Set requirement status and claim confidence by the rules below, including for work this follow-up still cannot close.'
+    )
+    expect(prompt).not.toContain('Use partial or missing honestly')
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.ts
@@ -7,7 +7,10 @@ import {
   evidenceSatisfiesSourceRequirement,
   type EvidenceReadinessFinding
 } from './evidence-import'
-import { formatEvidencePackageContract } from './research-prompt'
+import {
+  formatEvidencePackageContract,
+  REQUIREMENT_STATUS_RULES
+} from './research-prompt'
 
 function formatActiveModules(
   commission: Prompt2BlogCommission,
@@ -148,10 +151,12 @@ ${formatActiveModules(commission, catalog)}
 REPLACEMENT RULES
 - Do not redo or weaken already supported work. Preserve valid existing sources, claims, requirement links, dates, metadata, and resolved conflicts.
 - Add or revise only what is needed to close the listed requirements, conflicts, findings, and source gates.
-- Use partial or missing honestly when the follow-up still cannot close a gap.
+- Set requirement status and claim confidence by the rules below, including for work this follow-up still cannot close.
 - Keep every locked requirement exactly once in requirements, including already supported requirements.
 - Keep source/claim mappings bidirectional and resolvable. Web and report sources require publisher and URL.
 - Preserve exact material_type so source-gate readiness remains deterministic.
+
+${REQUIREMENT_STATUS_RULES}
 
 OUTPUT
 Return one bare JSON object and nothing else. No Markdown fence, preamble, commentary, or trailing note. Use exactly the shown keys and empty arrays rather than omitted collections. Return the entire replacement package with the locked fingerprint; return no commission object or editorial-authority fields.

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.test.ts
@@ -93,11 +93,33 @@ describe('buildResearchPrompt', () => {
     expect(prompt).toContain(
       '"material_type": "web|report|transcript|interview-responses|first-person-notes|evaluation-notes|other"'
     )
-    expect(prompt).toContain('Use partial or missing honestly')
+    expect(prompt).toContain(
+      'Set requirement status and claim confidence by the rules below.'
+    )
     expect(prompt).toContain(
       'Every commission requirement ID must appear exactly once'
     )
     expect(prompt).not.toContain('"commission": {')
+  })
+
+  it('separates requirement status from claim confidence so an unreachable primary source cannot stall the loop', () => {
+    const prompt = buildResearchPrompt(commission, catalog)
+
+    expect(prompt).toContain('REQUIREMENT STATUS VERSUS CLAIM CONFIDENCE')
+    expect(prompt).toContain('status describes the QUESTION')
+    expect(prompt).toContain('confidence describes the ANSWER')
+    expect(prompt).toContain(
+      'the publisher blocks automated retrieval, or you would have preferred more evidence'
+    )
+    expect(prompt).toContain(
+      'Never downgrade the requirement to partial for it.'
+    )
+    expect(prompt).toContain(
+      'Reserve partial and missing for a genuinely unanswered question.'
+    )
+    expect(prompt).toContain(
+      'otherwise say exactly which part of the question is still unanswered'
+    )
   })
 
   it('includes only active module metadata and the active form source gate', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.ts
@@ -42,6 +42,25 @@ function activeResearchGuidance(
   }
 }
 
+/**
+ * Requirement status and claim confidence answer different questions, and a
+ * research desk that conflates them stalls on a question it has in fact
+ * answered. The real run that motivated this block held a requirement at
+ * `partial` for three rounds because the issuing authority's own site blocks
+ * automated retrieval, even though several independent sources agreed on the
+ * figure. An unreachable primary source is a confidence reservation, not an
+ * unanswered question.
+ *
+ * Shared verbatim with the follow-up prompt and mirrored in the backend's
+ * `build_follow_up_research_prompt`; all three must say the same thing.
+ */
+export const REQUIREMENT_STATUS_RULES = `REQUIREMENT STATUS VERSUS CLAIM CONFIDENCE
+These record two different things. Never conflate them.
+- status describes the QUESTION. supported means linked claims answer the requirement's question; partial means part of that question is still unanswered; missing means none of it is answered.
+- confidence describes the ANSWER. high, medium, or low records how well corroborated that answer is.
+- An answer you found and corroborated stays supported even when you could not reach the ideal primary source, the publisher blocks automated retrieval, or you would have preferred more evidence. Record that reservation as claim confidence medium or low and as a source note. Never downgrade the requirement to partial for it.
+- Reserve partial and missing for a genuinely unanswered question. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims.`
+
 /** Exact bare response shape shared by initial and follow-up research prompts. */
 export function formatEvidencePackageContract(fingerprint: string): string {
   return `{
@@ -75,7 +94,7 @@ export function formatEvidencePackageContract(fingerprint: string): string {
       "requirement_id": "r1",
       "status": "supported|partial|missing",
       "claim_ids": ["c1"],
-      "gap": "Empty only when fully supported; otherwise say exactly what is missing"
+      "gap": "Empty only when the question is answered; otherwise say exactly which part of the question is still unanswered"
     }
   ],
   "conflicts": [
@@ -131,10 +150,12 @@ RESEARCH DISCIPLINE
 - Prefer primary, official, attributable, current sources; preserve publisher, URL, dates, source type, material type, and useful notes.
 - Use separate source and claim IDs. Every claim must cite existing source IDs and one or more locked requirement IDs.
 - Record volatile facts with an as-of date. Explain conflicts instead of choosing silently.
-- Use partial or missing honestly. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims.
+- Set requirement status and claim confidence by the rules below.
 - Every commission requirement ID must appear exactly once in requirements. Do not invent requirement IDs.
 - Web and report material requires publisher and URL. Every source requires at least one useful note.
 - For transcript, interview-response, first-person-note, evaluation-note, or other operator-supplied material, publisher, URL, and published_at may be JSON null.
+
+${REQUIREMENT_STATUS_RULES}
 
 OUTPUT
 Return one bare JSON object and nothing else. No Markdown fence, preamble, commentary, or trailing note. Use exactly the shown keys; use empty arrays rather than omitting collections. Return no commission object or editorial-authority fields.


### PR DESCRIPTION
## Why

The owner's first real run stalled here. A Lima commission's requirement `r2`
stayed `partial` across three research rounds and 28 sources. The answer was
never missing — several independent, mostly-2026 sources agreed on both fee
figures. The research agent withheld `supported` because it could not fetch
Migraciones' own TUPA schedule, since gob.pe blocks automated retrieval.

No number of follow-up prompts unblocks a site that blocks bots, so the loop
could not converge. The only exit offered was hand-editing the evidence JSON,
which is precisely the manual work this pipeline exists to remove. That is a
design defect, not a user error.

## What was actually wrong

The evidence contract already carries `confidence: high|medium|low` per claim
for exactly this kind of reservation. No prompt ever told the agent that
requirement status and claim confidence answer different questions, and
`Use partial or missing honestly` left the conflation wide open. The agent read
"I could not reach the ideal source" as "the question is unanswered".

## What changed

`REQUIREMENT_STATUS_RULES` is stated once in `research-prompt.ts`, shared by the
follow-up prompt, and mirrored verbatim in the backend's
`build_follow_up_research_prompt`:

- `status` describes the **question** — supported / partial / missing.
- `confidence` describes the **answer** — how well corroborated it is.
- An answer found and corroborated stays `supported` even when the ideal
  primary source is unreachable or the publisher blocks automated retrieval.
  That reservation is recorded as claim confidence medium or low plus a source
  note — never as a downgrade to `partial`.
- `partial` and `missing` are reserved for a genuinely unanswered question.

The `gap` field description now asks which part of the question is still
unanswered rather than what is missing.

The two follow-up prompt builders (frontend and backend) were already duplicated
before this change. They stay duplicated; both now carry the same wording and
both are tested for it. Deduplicating them is not in scope here.

## Scope

Prompt wording and its tests only. No contract change, no gate logic change, no
UI change. The authority model is untouched: the commission is still approved
before research, research still cannot change it, and an unsupported run still
stops.

## Verification

- backend pytest — exit 0 (summary line swallowed as usual)
- frontend vitest — **801 passed across 164 files** (799 baseline + 2 new tests)
- `tsc --noEmit` — clean
- boundaries + eslint — clean
- `black --check` and `flake8` on touched Python — clean
- `vite build` — passes, pre-existing chunk-size warning only

## Follow-ups, not in this PR

- A copy button for the attached evidence package (next PR).
- The UX rework: step rail, one step at a time, plain words.
- "Accept as answered" per requirement — deliberately parked until an article
  ships, since it changes what the readiness gate means.