### PR TITLE
feat(prompt2blog): copy the attached evidence package

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
@@ -39,6 +39,11 @@ export function ResearchPanel({
   const [status, setStatus] = useState<string | null>(null)
   const researchCopy = useClipboardCopy()
   const followUpCopy = useClipboardCopy()
+  // The attached package is the one thing on this page a user needs *out* of
+  // the app: to keep it, to hand it to someone, or to carry it into a fresh
+  // chat. Without this the only copy of it is buried inside the follow-up
+  // prompt textarea.
+  const evidenceCopy = useClipboardCopy('Copy evidence package')
 
   const fingerprint = commission.commission_fingerprint
 
@@ -182,10 +187,19 @@ export function ResearchPanel({
       )}
       {evidencePackage && (
         <div className="p2b-import-report">
-          <p className="p2b-import-report-title">
-            {evidencePackage.sources?.length ?? 0} sources and{' '}
-            {evidencePackage.claims?.length ?? 0} claims are attached to this commission.
-          </p>
+          <div className="p2b-field-label-row">
+            <p className="p2b-import-report-title">
+              {evidencePackage.sources?.length ?? 0} sources and{' '}
+              {evidencePackage.claims?.length ?? 0} claims are attached to this commission.
+            </p>
+            <button
+              type="button"
+              className="p2b-inline-copy-btn"
+              onClick={() => evidenceCopy.copy(JSON.stringify(evidencePackage, null, 2))}
+            >
+              {evidenceCopy.label}
+            </button>
+          </div>
           <ul className="p2b-requirement-list">
             {evidencePackage.requirements.map(requirement => (
               <li key={requirement.requirement_id} className="p2b-requirement-row">

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
@@ -223,6 +223,31 @@ describe('ResearchPanel', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('copies the attached evidence package so it never has to be dug out of a prompt', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    const attached = evidence()
+    renderPanel(attached)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Copy evidence package' })
+    )
+
+    expect(writeText).toHaveBeenCalledWith(JSON.stringify(attached, null, 2))
+    expect(
+      await screen.findByRole('button', { name: 'Copied!' })
+    ).toBeInTheDocument()
+    vi.unstubAllGlobals()
+  })
+
+  it('offers nothing to copy before research is attached', () => {
+    renderPanel(null)
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy evidence package' })
+    ).not.toBeInTheDocument()
+  })
+
   it('removes attached research without touching the commission', () => {
     const { onClearEvidence } = renderPanel(evidence())
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/useClipboardCopy.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/useClipboardCopy.ts
@@ -2,18 +2,22 @@ import { useCallback, useEffect, useState } from 'react'
 
 export type ClipboardCopyStatus = 'idle' | 'copied' | 'error'
 
-const COPY_LABELS: Record<ClipboardCopyStatus, string> = {
-  idle: 'Copy prompt',
+const RESOLVED_LABELS: Record<Exclude<ClipboardCopyStatus, 'idle'>, string> = {
   copied: 'Copied!',
   error: 'Copy failed',
 }
 
 /**
- * One clipboard affordance for every prompt the composer hands to a chatbot.
- * Clipboard access is missing outside secure contexts, so the button has to
- * say so rather than silently doing nothing.
+ * One clipboard affordance for every prompt the composer hands to a chatbot,
+ * and for the evidence package it hands back. Clipboard access is missing
+ * outside secure contexts, so the button has to say so rather than silently
+ * doing nothing.
+ *
+ * `idleLabel` names what is being copied. Most callers copy a prompt and take
+ * the default; the evidence package is the one thing on this page a user
+ * needs out of the app rather than into a chatbot, so it says so.
  */
-export function useClipboardCopy() {
+export function useClipboardCopy(idleLabel = 'Copy prompt') {
   const [status, setStatus] = useState<ClipboardCopyStatus>('idle')
 
   useEffect(() => {
@@ -34,5 +38,10 @@ export function useClipboardCopy() {
 
   const reset = useCallback(() => setStatus('idle'), [])
 
-  return { status, label: COPY_LABELS[status], copy, reset }
+  return {
+    status,
+    label: status === 'idle' ? idleLabel : RESOLVED_LABELS[status],
+    copy,
+    reset,
+  }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/forms.css
@@ -350,6 +350,12 @@
   gap: var(--space-3);
 }
 
+/* The label row also carries a report paragraph next to its copy button; the
+   button must not be squeezed by it. */
+.p2b-field-label-row .p2b-inline-copy-btn {
+  flex-shrink: 0;
+}
+
 .p2b-field-row {
   display: grid;
   gap: var(--space-4);


### PR DESCRIPTION
## Why

The evidence package is the one artifact on this page a user needs **out** of
the app rather than into a chatbot — to keep it, to hand it to someone, or to
carry it into a fresh chat.

Until now the only copy of it on screen lived inside the follow-up prompt
textarea, embedded under `CURRENT EVIDENCE PACKAGE`. Getting your own research
back meant hand-selecting a fragment out of a much longer prompt. Plain
oversight, surfaced by the owner's first real run.

## What changed

- A `Copy evidence package` button on the attached-package report, beside the
  sources-and-claims count.
- `useClipboardCopy` now takes its idle label as an argument. Every existing
  caller copies a prompt and keeps the default `Copy prompt`, so no other
  button changes.
- One CSS guard so the button is not squeezed by the report paragraph sharing
  its row.

## Scope

Additive. No contract, gate, or authority-model change. The button appears only
when a package is attached.

## Verification

- frontend vitest — **803 passed across 164 files** (801 baseline + 2 new)
- `tsc --noEmit` — clean
- boundaries + eslint — clean
- `vite build` — passes, pre-existing chunk-size warning only
- backend untouched, so no pytest run for this change

## Context

Second of the two quick wins agreed with the owner before the UX rework. The
first was #409 (`partial` versus claim confidence). Next up is the step model
and step rail.