### PR TITLE
fix(prompt2blog): stop the pipeline panel describing a run that does not exist

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelinePanel.tsx
@@ -29,6 +29,7 @@ export function PipelinePanel({
     canOpenCleanupModal,
     dismissNeedsResearch,
     error,
+    hasStartedRun,
     isLoading,
     loadingLabel,
     needsResearch,
@@ -78,7 +79,7 @@ export function PipelinePanel({
                 step === CLEANUP_STAGE_KEY && canOpenCleanupModal ? onOpenCleanupModal : undefined
               }
               label={PIPELINE_STAGE_LABELS[step]}
-              status={getPipelineStepStatus(step, pipelineStatus, stageOrder)}
+              status={getPipelineStepStatus(step, pipelineStatus, stageOrder, hasStartedRun)}
             />
           ))}
           {pipelineStatus?.stage === 'unknown' && (

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.test.tsx
@@ -75,6 +75,25 @@ describe('usePrompt2BlogPipelineRun submission routing', () => {
     )
     expect(startPrompt2BlogV3RunMock).not.toHaveBeenCalled()
   })
+
+  it('describes the v3 pipeline on an untouched page, and reports no progress', async () => {
+    // Nothing has been filled in, so there is no payload yet. The stage list a
+    // first-time operator reads must still be the pipeline that would actually
+    // run, and it must not claim a step is already running.
+    const { result } = renderRun({ v3Payload: null })
+
+    expect(result.current.pipelineVersion).toBe('v3')
+    expect(result.current.hasStartedRun).toBe(false)
+  })
+
+  it('reports a started run once one is queued', async () => {
+    startPrompt2BlogV3RunMock.mockResolvedValue({ status: 'queued', run_id: 'v3-run' })
+    const { result } = renderRun({ v3Payload })
+
+    act(() => result.current.run())
+
+    await waitFor(() => expect(result.current.hasStartedRun).toBe(true))
+  })
 })
 
 describe('needs_research', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/hooks/usePrompt2BlogPipelineRun.ts
@@ -5,7 +5,10 @@ import {
   type Prompt2BlogV3Request,
 } from '../../api'
 import { CLEANUP_STAGE_KEY } from '../../cleanup-details/cleanup-stage.parser'
-import { PROMPT2BLOG_PIPELINE_STAGES } from '../../types/pipeline.types'
+import {
+  PROMPT2BLOG_PIPELINE_STAGES,
+  PROMPT2BLOG_V3_PIPELINE_STAGES,
+} from '../../types/pipeline.types'
 import type {
   PipelineLogEntry,
   PipelineLogLevel,
@@ -81,14 +84,6 @@ export function usePrompt2BlogPipelineRun({
     reset: resetStartPipeline,
   } = usePrompt2BlogMutation({ v3Payload, v3BlockedReason })
 
-  // Which pipeline's stage list to show. A finished run names its own version;
-  // a run being started is named by the payload that will start it.
-  const pipelineVersion: PipelineVersion = pipelineResult
-    ? pipelineResult.version
-    : v3Payload
-      ? 'v3'
-      : 'v2'
-
   const {
     pipelineStatus,
     pipelineDebugData,
@@ -109,6 +104,24 @@ export function usePrompt2BlogPipelineRun({
     appendPipelineLog,
     isStartingPipeline,
   })
+
+  // Which pipeline's stage list to show. A finished run names its own version.
+  // Nothing else can name one: this app can only start v3 runs, so the list an
+  // operator reads before and during a run is the v3 list. Defaulting to v2
+  // meant every pre-run page described the retired pipeline's stages.
+  //
+  // The exception is a run restored from storage that predates the cutover. It
+  // reports v2 stage names, and reading those against the v3 order would place
+  // every step at -1 and stall the whole list, so it keeps the v2 list.
+  const pipelineVersion: PipelineVersion = useMemo(() => {
+    if (pipelineResult) return pipelineResult.version
+    const stage = pipelineStatus && pipelineStatus.stage !== 'unknown' ? pipelineStatus.stage : null
+    const isLegacyStage =
+      stage !== null
+      && !(PROMPT2BLOG_V3_PIPELINE_STAGES as readonly string[]).includes(stage)
+      && (PROMPT2BLOG_PIPELINE_STAGES as readonly string[]).includes(stage)
+    return isLegacyStage ? 'v2' : 'v3'
+  }, [pipelineResult, pipelineStatus])
 
   const canOpenCleanupModal = useMemo(() => {
     // Cleanup is a v2-only stage; a v3 stage name simply misses the order and
@@ -202,6 +215,9 @@ export function usePrompt2BlogPipelineRun({
   ])
 
   const isLoading = isStartingPipeline || sourceStep === 'pipeline_running'
+  // A `needs_research` answer returns sourceStep to 'edit', which is correct:
+  // nothing was queued, so the stage list goes back to reporting nothing.
+  const hasStartedRun = sourceStep !== 'edit' || isStartingPipeline
 
   return {
     sourceStep,
@@ -214,6 +230,7 @@ export function usePrompt2BlogPipelineRun({
     showPipelineDebug,
     togglePipelineDebug: () => setShowPipelineDebug(prev => !prev),
     isLoading,
+    hasStartedRun,
     loadingLabel,
     error,
     setError,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.test.ts
@@ -16,9 +16,28 @@ function createStatus(overrides: Partial<Prompt2BlogStatusResponse> = {}): Promp
 }
 
 describe('getPipelineStepStatus', () => {
-  it('marks queued as running before status exists', () => {
+  it('marks queued as running once a run has started but has no status yet', () => {
     expect(getPipelineStepStatus('queued', null)).toBe('running')
     expect(getPipelineStepStatus('stage_input_validate', null)).toBe('pending')
+  })
+
+  it('reports nothing at all before a run exists', () => {
+    // An untouched page that shows `queued` as running tells a first-time
+    // operator something is already happening. Nothing is.
+    expect(
+      getPipelineStepStatus('queued', null, PROMPT2BLOG_STAGE_ORDERS.v3, false)
+    ).toBe('pending')
+    expect(
+      getPipelineStepStatus('stage_v3_compose', null, PROMPT2BLOG_STAGE_ORDERS.v3, false)
+    ).toBe('pending')
+  })
+
+  it('still reports a real run when one has started', () => {
+    const status = createStatus({ state: 'running', stage: 'stage_compose' })
+
+    expect(
+      getPipelineStepStatus('stage_compose', status, PROMPT2BLOG_STAGE_ORDERS.v2, true)
+    ).toBe('running')
   })
 
   it('marks previous, current, and future steps during an in-progress run', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/pipeline-status.ts
@@ -47,7 +47,12 @@ export function getPipelineStepStatus(
   step: KnownPrompt2BlogPipelineStage,
   status: Prompt2BlogStatusResponse | null,
   stageOrder: readonly string[] = PROMPT2BLOG_PIPELINE_STAGES,
+  hasStartedRun = true,
 ): PipelineStepStatus {
+  // Before a run exists there is no progress to report. Showing `queued` as
+  // running on an untouched page tells a first-time operator that something is
+  // already happening, and the only honest answer is that nothing is.
+  if (!hasStartedRun) return 'pending'
   if (!status) return step === 'queued' ? 'running' : 'pending'
   return getStepStatus({
     step,


### PR DESCRIPTION
## Why

Found by walking the app cold, logged in, against a real backend — the first
step of the UX work. Two things the pipeline panel said on an untouched page
were simply not true.

**1. The page claimed a run was in progress.** `getPipelineStepStatus` returned
`running` for `queued` whenever status was null — which is also the state of a
page nobody has touched. So the first thing a new operator saw was:

```
01  Queued                    RUNNING
02  Validate inputs           PENDING
...
```

A pipeline that looks mid-flight before you have typed anything.

**2. Those were the wrong pipeline's stages.** `pipelineVersion` fell back to
`'v2'` whenever `v3Payload` was null, which is the entire time before a run is
ready to start. Every pre-run page listed the retired v2 pipeline's seventeen
stage names, so everything an operator read about "what is going to happen"
described a pipeline that can no longer be started from this app.

## What changed

- `getPipelineStepStatus` takes `hasStartedRun` and reports every step as
  `pending` until a run exists. It defaults to `true`, so every existing caller
  and test is untouched.
- `usePrompt2BlogPipelineRun` exposes `hasStartedRun`, derived from
  `sourceStep` and the in-flight start. `needs_research` correctly reports
  false: it returns `sourceStep` to `'edit'` because nothing was queued.
- `pipelineVersion` defaults to v3. The one exception is a run restored from
  storage that predates the cutover — it reports v2 stage names, and reading
  those against the v3 order would place every step at -1 and stall the whole
  list, so that case keeps v2.

## Verified in the running app

Cleared page, before and after:

| | stages listed | showing RUNNING |
|---|---|---|
| before | 17 (v2 names) | 1 (`Queued`) |
| after | 10 (v3 names) | 0 |

## Verification

- frontend vitest — **807 passed across 164 files** (803 baseline + 4 new)
- `tsc --noEmit`, boundaries, eslint — clean
- `vite build` — passes, pre-existing chunk-size warning only
- backend untouched

## Scope

Display truth only. No contract, gate, or authority-model change, and no
change to what a run does.

## Not in this PR

The other things that walk turned up — the run button being live on an empty
page, the model-and-cost picker sitting above the two fields that start the
work, and a direction card silently approving the commission — belong to the
step-model work that follows.