### PR TITLE
feat(prompt2blog): show the five steps and where the operator stands

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/StepRail.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/StepRail.tsx
@@ -1,0 +1,53 @@
+import type { P2BStep } from '../step-model'
+
+interface StepRailProps {
+  steps: readonly P2BStep[]
+}
+
+const STATE_LABELS: Record<P2BStep['state'], string> = {
+  done: 'Done',
+  current: 'You are here',
+  upcoming: 'Not yet'
+}
+
+/**
+ * Where the operator is in the five steps, and what is left.
+ *
+ * Read-only on purpose. The rail reports position; it never moves the operator,
+ * because every real transition belongs to the control that performs the work.
+ * A rail that could jump ahead of the state would be a second, disagreeing
+ * source of truth about the same run.
+ */
+export function StepRail({ steps }: StepRailProps) {
+  const current = steps.find((step) => step.state === 'current')
+
+  return (
+    <section className="p2b-step-rail" aria-label="Article steps">
+      <ol className="p2b-step-rail-list">
+        {steps.map((step) => (
+          <li
+            key={step.id}
+            className={`p2b-step-rail-item p2b-step-rail-item--${step.state}`}
+            aria-current={step.state === 'current' ? 'step' : undefined}
+          >
+            <span className="p2b-step-rail-number" aria-hidden="true">
+              {step.state === 'done' ? '✓' : step.number}
+            </span>
+            <span className="p2b-step-rail-text">
+              <span className="p2b-step-rail-name">{step.name}</span>
+              <span className="p2b-step-rail-state">{STATE_LABELS[step.state]}</span>
+              {step.summary && (
+                <span className="p2b-step-rail-summary">{step.summary}</span>
+              )}
+            </span>
+          </li>
+        ))}
+      </ol>
+      {current && (
+        <p className="p2b-step-rail-purpose">
+          <strong>Step {current.number}: {current.name}.</strong> {current.purpose}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-drift-v3.json'
+import type { Prompt2BlogCommission, Prompt2BlogEvidencePackage } from '../api'
+import { DEFAULT_COMPOSER_STATE } from './composer.storage'
+import type { P2BFormState } from './composer.types'
+import { currentP2BStep, deriveP2BSteps, P2B_STEP_IDS } from './step-model'
+
+const commission = limaFixture.commission as unknown as Prompt2BlogCommission
+const evidencePackage = limaFixture.evidence_package as unknown as Prompt2BlogEvidencePackage
+
+function state(overrides: Partial<P2BFormState> = {}): P2BFormState {
+  return { ...DEFAULT_COMPOSER_STATE, ...overrides }
+}
+
+function inV3(
+  editorial: Partial<P2BFormState['editorial']> = {},
+  overrides: Partial<P2BFormState> = {}
+): P2BFormState {
+  return state({
+    activeWorkflow: 'editorial_v3',
+    easySetupTitle: commission.original_title,
+    easySetupLocation: commission.location,
+    editorial: {
+      directionOptions: [],
+      selectedOptionId: null,
+      commissionDraft: null,
+      approval: { status: 'not_started' },
+      evidencePackage: null,
+      ...editorial
+    },
+    ...overrides
+  })
+}
+
+describe('deriveP2BSteps', () => {
+  it('always describes the same five steps in the same order', () => {
+    expect(deriveP2BSteps(state()).map(step => step.id)).toEqual([...P2B_STEP_IDS])
+    expect(deriveP2BSteps(state()).map(step => step.number)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('starts an untouched page on step one with nothing done', () => {
+    const steps = deriveP2BSteps(state())
+
+    expect(currentP2BStep(state()).id).toBe('start')
+    expect(steps.filter(step => step.state === 'done')).toHaveLength(0)
+    expect(steps.map(step => step.state)).toEqual([
+      'current',
+      'upcoming',
+      'upcoming',
+      'upcoming',
+      'upcoming'
+    ])
+  })
+
+  it('keeps a typed title and location on step one until the direction prompt exists', () => {
+    // Typing does not start direction work; pressing the button does.
+    const typed = state({
+      easySetupTitle: commission.original_title,
+      easySetupLocation: commission.location
+    })
+
+    expect(currentP2BStep(typed).id).toBe('start')
+    expect(deriveP2BSteps(typed)[0].summary).toBeNull()
+  })
+
+  it('moves to picking a direction once direction work has started', () => {
+    const started = inV3()
+
+    expect(currentP2BStep(started).id).toBe('direction')
+    expect(deriveP2BSteps(started)[0].state).toBe('done')
+    expect(deriveP2BSteps(started)[0].summary).toContain(commission.original_title)
+  })
+
+  it('stays on picking a direction while three options wait to be chosen', () => {
+    expect(currentP2BStep(inV3({ approval: { status: 'awaiting_selection' } })).id).toBe(
+      'direction'
+    )
+  })
+
+  it('recaps the chosen direction in the operator’s words, not as an option id', () => {
+    const approved = inV3({
+      selectedOptionId: 'direction-1',
+      approval: { status: 'approved', commission }
+    })
+
+    expect(deriveP2BSteps(approved)[1].summary).toBe(commission.approved_direction)
+    expect(deriveP2BSteps(approved)[1].summary).not.toContain('direction-1')
+  })
+
+  it('sends an edited commission back to the review step', () => {
+    const edited = inV3({ approval: { status: 'needs_approval' } })
+
+    expect(currentP2BStep(edited).id).toBe('commission')
+    expect(deriveP2BSteps(edited)[1].state).toBe('done')
+  })
+
+  it('sends a draft needing reconfirmation back to the review step', () => {
+    const stale = inV3({
+      approval: { status: 'reconfirmation_required', reason: 'commission_edited' }
+    })
+
+    expect(currentP2BStep(stale).id).toBe('commission')
+  })
+
+  it('moves to gathering facts once a commission is approved', () => {
+    const approved = inV3({ approval: { status: 'approved', commission } })
+
+    expect(currentP2BStep(approved).id).toBe('research')
+    expect(deriveP2BSteps(approved)[2].summary).toBe(commission.primary_subject)
+  })
+
+  it('reaches the writing step once matching research is attached', () => {
+    const ready = inV3({
+      approval: { status: 'approved', commission },
+      evidencePackage
+    })
+    const steps = deriveP2BSteps(ready)
+
+    expect(currentP2BStep(ready).id).toBe('write')
+    expect(steps[3].state).toBe('done')
+    // The Lima fixture carries exactly one of each, so this also pins the
+    // singular wording a one-source package produces.
+    expect(steps[3].summary).toBe('1 source, 1 claim')
+  })
+
+  it('counts sources and claims in plural when there is more than one', () => {
+    const ready = inV3({
+      approval: { status: 'approved', commission },
+      evidencePackage: {
+        ...evidencePackage,
+        sources: [...(evidencePackage.sources ?? []), ...(evidencePackage.sources ?? [])]
+      }
+    })
+
+    expect(deriveP2BSteps(ready)[3].summary).toBe('2 sources, 1 claim')
+  })
+
+  it('does not count research imported against another commission', () => {
+    // A package for a different commission is not this commission's research,
+    // however complete it looks, and the run would be refused anyway.
+    const mismatched = inV3({
+      approval: { status: 'approved', commission },
+      evidencePackage: { ...evidencePackage, commission_fingerprint: 'someone-else' }
+    })
+
+    expect(currentP2BStep(mismatched).id).toBe('research')
+    expect(deriveP2BSteps(mismatched)[3].state).toBe('current')
+  })
+
+  it('never marks the writing step done, because a finished run is not composer state', () => {
+    const ready = inV3({
+      approval: { status: 'approved', commission },
+      evidencePackage
+    })
+
+    expect(deriveP2BSteps(ready)[4].state).toBe('current')
+    expect(deriveP2BSteps(ready).some(step => step.id === 'write' && step.state === 'done')).toBe(
+      false
+    )
+  })
+
+  it('gives every step a name and a reason a non-technical operator can read', () => {
+    for (const step of deriveP2BSteps(state())) {
+      expect(step.name.length).toBeGreaterThan(0)
+      expect(step.purpose.length).toBeGreaterThan(0)
+      expect(step.name).not.toMatch(/_|fingerprint|schema|v3/i)
+    }
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.ts
@@ -1,0 +1,185 @@
+import type { P2BFormState } from './composer.types'
+
+export const P2B_STEP_IDS = [
+  'start',
+  'direction',
+  'commission',
+  'research',
+  'write'
+] as const
+
+export type P2BStepId = (typeof P2B_STEP_IDS)[number]
+
+/** Where the operator stands relative to one step. */
+export type P2BStepState = 'done' | 'current' | 'upcoming'
+
+export interface P2BStep {
+  id: P2BStepId
+  /** 1-based position, shown to the operator. */
+  number: number
+  /** What this step is called in words a non-technical operator reads. */
+  name: string
+  /** Why the step exists, in one sentence. */
+  purpose: string
+  state: P2BStepState
+  /** A finished step's one-line recap, or null while it is not finished. */
+  summary: string | null
+}
+
+interface StepDefinition {
+  id: P2BStepId
+  name: string
+  purpose: string
+}
+
+/**
+ * The five steps, named for someone who has never seen the pipeline.
+ *
+ * "Commission" survives here on purpose rather than being softened into
+ * "assignment": it is the word the finished article's record uses and the word
+ * every document about this pipeline uses, so the page teaches it once instead
+ * of maintaining a second vocabulary.
+ */
+const STEP_DEFINITIONS: readonly StepDefinition[] = [
+  {
+    id: 'start',
+    name: 'Start the article',
+    purpose: 'Name what you are writing and where it is about.'
+  },
+  {
+    id: 'direction',
+    name: 'Pick a direction',
+    purpose:
+      'Your chatbot proposes three ways to write it. You choose the one worth commissioning.'
+  },
+  {
+    id: 'commission',
+    name: 'Review what you locked',
+    purpose:
+      'Choosing a direction locked the commission. Check it now, because research can add facts to it but can never change it.'
+  },
+  {
+    id: 'research',
+    name: 'Gather the facts',
+    purpose:
+      'A second chatbot round trip brings back sourced evidence answering the commission’s questions.'
+  },
+  {
+    id: 'write',
+    name: 'Write it',
+    purpose: 'Set the tone and length, then run the pipeline.'
+  }
+]
+
+function directionWasChosen(state: P2BFormState): boolean {
+  const { status } = state.editorial.approval
+  return (
+    status === 'approved' ||
+    status === 'needs_approval' ||
+    status === 'reconfirmation_required'
+  )
+}
+
+function researchIsAttached(state: P2BFormState): boolean {
+  const { approval, evidencePackage } = state.editorial
+  if (approval.status !== 'approved' || !evidencePackage) return false
+  // Research imported against a different commission is not this commission's
+  // research, however complete it looks.
+  return (
+    evidencePackage.commission_fingerprint ===
+    approval.commission.commission_fingerprint
+  )
+}
+
+function summarizeCommission(state: P2BFormState): string | null {
+  const { approval } = state.editorial
+  if (approval.status !== 'approved') return null
+  return approval.commission.primary_subject || null
+}
+
+/**
+ * The chosen direction in the operator's words rather than `direction-1`.
+ *
+ * Only an approved commission carries the direction statement, so a draft that
+ * is still awaiting re-approval falls back to no recap rather than to an ID
+ * that means nothing to the person reading it.
+ */
+function summarizeDirection(state: P2BFormState): string | null {
+  const { approval } = state.editorial
+  if (approval.status !== 'approved') return null
+  return approval.commission.approved_direction || null
+}
+
+function summarizeResearch(state: P2BFormState): string | null {
+  const evidence = state.editorial.evidencePackage
+  if (!evidence) return null
+  const sources = evidence.sources?.length ?? 0
+  const claims = evidence.claims?.length ?? 0
+  return `${sources} ${sources === 1 ? 'source' : 'sources'}, ${claims} ${
+    claims === 1 ? 'claim' : 'claims'
+  }`
+}
+
+/**
+ * Which of the five steps are finished, and where the operator stands.
+ *
+ * Derived entirely from composer state the page already keeps. Nothing here is
+ * stored, so the indicator cannot drift out of step with the work it describes
+ * — a rail that disagrees with the page is worse than no rail at all.
+ *
+ * Step 3 counts as finished the moment a commission is approved, because that
+ * is what the page does today: choosing a direction card approves it outright.
+ * Making that a stop the operator consciously passes needs a control to pass
+ * it with, which lands together with the step sections rather than ahead of
+ * them.
+ *
+ * Step 5 is never `done` here. Finishing it means a completed run, which lives
+ * in the pipeline's own state, not the composer's.
+ */
+export function deriveP2BSteps(state: P2BFormState): P2BStep[] {
+  const startedDirectionWork = state.activeWorkflow === 'editorial_v3'
+  const titleAndLocation =
+    state.easySetupTitle.trim() !== '' && state.easySetupLocation.trim() !== ''
+
+  const completion: Record<P2BStepId, boolean> = {
+    start: startedDirectionWork && titleAndLocation,
+    direction: startedDirectionWork && directionWasChosen(state),
+    commission: state.editorial.approval.status === 'approved',
+    research: researchIsAttached(state),
+    write: false
+  }
+
+  const summaries: Record<P2BStepId, string | null> = {
+    start: titleAndLocation
+      ? `${state.easySetupTitle.trim()} — ${state.easySetupLocation.trim()}`
+      : null,
+    direction: summarizeDirection(state),
+    commission: summarizeCommission(state),
+    research: summarizeResearch(state),
+    write: null
+  }
+
+  const currentIndex = STEP_DEFINITIONS.findIndex(
+    (definition) => !completion[definition.id]
+  )
+
+  return STEP_DEFINITIONS.map((definition, index) => ({
+    id: definition.id,
+    number: index + 1,
+    name: definition.name,
+    purpose: definition.purpose,
+    state:
+      completion[definition.id] && index < currentIndex
+        ? 'done'
+        : index === currentIndex
+          ? 'current'
+          : 'upcoming',
+    summary: completion[definition.id] ? summaries[definition.id] : null
+  }))
+}
+
+/** The step the operator is standing on. */
+export function currentP2BStep(state: P2BFormState): P2BStep {
+  const steps = deriveP2BSteps(state)
+  return steps.find((step) => step.state === 'current') ?? steps[steps.length - 1]
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { CleanupDetailsModal } from '../cleanup-details/CleanupDetailsModal'
 import { useCleanupDetailsModal } from '../cleanup-details/hooks/useCleanupDetailsModal'
 import { EasySetupPanel } from '../composer/components/EasySetupPanel'
 import { MiddleSectionsFold } from '../composer/components/MiddleSectionsFold'
 import { ModelRoutingPanel } from '../composer/components/ModelRoutingPanel'
+import { StepRail } from '../composer/components/StepRail'
 import { PromptProfilesPanel } from '../composer/components/PromptProfilesPanel'
 import { usePrompt2BlogComposer } from '../composer/hooks/usePrompt2BlogComposer'
+import { deriveP2BSteps } from '../composer/step-model'
 import { PipelinePanel } from '../pipeline-run/components/PipelinePanel'
 import { usePrompt2BlogPipelineRun } from '../pipeline-run/hooks/usePrompt2BlogPipelineRun'
 import '../styles.css'
@@ -24,6 +26,7 @@ export default function Prompt2BlogPage() {
   })
   const [copied, setCopied] = useState(false)
   const { state } = composer
+  const steps = useMemo(() => deriveP2BSteps(state), [state])
 
   const handleCopyJson = useCallback(() => {
     navigator.clipboard
@@ -80,6 +83,7 @@ export default function Prompt2BlogPage() {
       </header>
 
       <main className="p2b-form-container">
+        <StepRail steps={steps} />
         <form className="p2b-form" onSubmit={event => event.preventDefault()}>
           <ModelRoutingPanel
             modelStackId={state.modelStackId}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
@@ -126,3 +126,110 @@
     animation: none;
   }
 }
+
+/* --- Step rail -------------------------------------------------------------
+   Where the operator stands in the five steps. Sits above the form so the
+   shape of the work is visible before any field is. */
+
+.p2b-step-rail {
+  margin: 0 0 var(--space-6);
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface, white);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.p2b-step-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.p2b-step-rail-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  min-width: 0;
+}
+
+.p2b-step-rail-item--current {
+  border-color: var(--p2b-accent);
+  background: var(--p2b-accent-softer);
+}
+
+.p2b-step-rail-item--upcoming {
+  opacity: 0.55;
+}
+
+.p2b-step-rail-number {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 1px solid var(--border);
+  color: var(--ink);
+}
+
+.p2b-step-rail-item--done .p2b-step-rail-number {
+  border-color: var(--p2b-accent);
+  color: var(--p2b-accent);
+}
+
+.p2b-step-rail-item--current .p2b-step-rail-number {
+  background: var(--p2b-accent);
+  border-color: var(--p2b-accent);
+  color: white;
+}
+
+.p2b-step-rail-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.p2b-step-rail-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--ink);
+}
+
+.p2b-step-rail-state {
+  font-size: 0.75rem;
+  color: var(--muted-ink, var(--ink));
+  opacity: 0.7;
+}
+
+.p2b-step-rail-summary {
+  font-size: 0.75rem;
+  color: var(--ink);
+  opacity: 0.75;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.p2b-step-rail-purpose {
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--ink);
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/responsive.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/responsive.css
@@ -99,3 +99,11 @@
     font-size: 1.125rem;
   }
 }
+
+/* The five steps stop reading as a row long before the phone breakpoint; the
+   names wrap into unreadable slivers first. */
+@media (max-width: 900px) {
+  .p2b-step-rail-list {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Why

Walked cold, the page is one long scroll that assumes you already know the
pipeline. Nothing says how many steps there are, which one you are on, or what
the current one is for. The owner's framing: *"I'm scrolling down this page
trying to figure out what to do, what goes next. It's not clear what the steps
are."*

This is the position indicator and nothing else. **The page below it is
unchanged** — same panels, same order, same behaviour. Reordering and splitting
the sections comes next; landing the rail alone keeps that diff readable and
lets the derivation be tested on its own.

## The five steps

| # | On screen | Finished when |
|---|---|---|
| 1 | Start the article | direction work has started from a title and location |
| 2 | Pick a direction | a direction has been chosen |
| 3 | Review what you locked | the commission is approved |
| 4 | Gather the facts | a matching evidence package is attached |
| 5 | Write it | never, from composer state — see below |

## How it derives

`deriveP2BSteps` is a pure function of state the composer already keeps:
`activeWorkflow`, `editorial.approval.status`, and whether an attached evidence
package's fingerprint matches the approved commission. **Nothing new is
stored.** A rail that could drift out of step with the page would be a second,
disagreeing source of truth about the same run.

Research imported against a different commission does not count as this
commission's research, however complete it looks — the run would be refused for
the same reason.

## Two deliberate limits, both worth knowing before review

**Step 3 counts as finished the moment the commission is approved.** That is
what the page does today: clicking a direction card calls
`storeApprovedCommission` itself, so approval happens to the operator rather
than being something they perform. Making step 3 a stop they consciously pass
needs a control to pass it with, and that control lands with the step sections
rather than ahead of them — so the rail is not left pointing at a step with no
way out.

**Step 5 is never `done`.** Finishing it means a completed run, which lives in
the pipeline hook's state, not the composer's.

## Naming

"Commission" stays on screen rather than becoming "assignment". It is the word
the finished article's record uses and the word ADR 0029 and every other
document use; teaching it once at step 3 costs less than maintaining two
vocabularies. Reversible in one PR if a coworker trips on it.

## Verified in the running app

Cleared page:

```
1 Start the article  You are here
2 Pick a direction   Not yet
...
Step 1: Start the article. Name what you are writing and where it is about.
```

After generating the direction prompt:

```
✓ Start the article  Done   A long weekend in Lima — Lima, Peru
2 Pick a direction   You are here
...
Step 2: Pick a direction. Your chatbot proposes three ways to write it.
```

## Verification

- frontend vitest — **821 passed across 165 files** (807 baseline + 14 new)
- `tsc --noEmit`, boundaries, eslint — clean
- `vite build` — passes, pre-existing chunk-size warning only
- backend untouched

## Scope

Additive display. No contract, gate, or authority-model change. The commission
is still approved by a human before research, research still cannot change it,
and an unsupported run still stops.