### PR TITLE
feat(prompt2blog): make steps 1 and 2 numbered sections

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -7,12 +7,14 @@ import type {
   Prompt2BlogEvidencePackage,
 } from '../../api'
 import type { P2BEditorialComposerState, P2BFormState } from '../composer.types'
+import type { P2BStep, P2BStepId } from '../step-model'
 import { reviewDirectionResponseJson, type DirectionImportReview } from '../direction-import'
 import { buildDirectionPrompt } from '../direction-prompt'
 import { useClipboardCopy } from '../hooks/useClipboardCopy'
 import { CommissionEditor } from './CommissionEditor'
 import { DirectionCards } from './DirectionCards'
 import { ResearchPanel } from './ResearchPanel'
+import { StepSection } from './StepSection'
 
 interface EasySetupPanelProps {
   activeWorkflow: P2BFormState['activeWorkflow']
@@ -21,6 +23,7 @@ interface EasySetupPanelProps {
   editorialOptionsError: boolean
   editorialOptionsLoading: boolean
   location: string
+  steps: readonly P2BStep[]
   title: string
   onApplyDirectionResponse: (response: Prompt2BlogDirectionResponse) => void
   onApproveCommission: () => Promise<void>
@@ -42,6 +45,7 @@ export function EasySetupPanel({
   editorialOptionsError,
   editorialOptionsLoading,
   location,
+  steps,
   title,
   onApplyDirectionResponse,
   onApproveCommission,
@@ -111,19 +115,18 @@ export function EasySetupPanel({
     setDirectionStatus('Three directions are ready for approval.')
   }
 
+  // deriveP2BSteps always returns all five; a missing one means the page handed
+  // this panel something other than the step model, which is a programming
+  // error rather than a state the operator can reach.
+  const stepFor = (id: P2BStepId): P2BStep => {
+    const step = steps.find(candidate => candidate.id === id)
+    if (!step) throw new Error(`Missing step "${id}" in the step model.`)
+    return step
+  }
+
   return (
-    <section className="p2b-panel">
-      <div className="p2b-panel-header">
-        <div className="p2b-panel-header-text">
-          <h2>Easy Set Up</h2>
-          <p>Compare three editorial directions, then approve the commission.</p>
-        </div>
-      </div>
-      <div className="p2b-panel-body">
-        <div className="p2b-subsection-heading">
-          <h3>Generate a direction prompt</h3>
-          <p>Only the working title and location leave the app at this step.</p>
-        </div>
+    <>
+      <StepSection step={stepFor('start')}>
         <div className="p2b-field-row p2b-field-row--2">
           <div className="p2b-field">
             <label htmlFor="p2b-easy-setup-title">Title</label>
@@ -148,6 +151,9 @@ export function EasySetupPanel({
             />
           </div>
         </div>
+        <p className="p2b-field-hint">
+          Only the working title and location leave the app at this step.
+        </p>
         <div className="p2b-panel-actions">
           <button
             type="button"
@@ -168,6 +174,14 @@ export function EasySetupPanel({
               Retry
             </button>
           </div>
+        )}
+      </StepSection>
+
+      <StepSection step={stepFor('direction')}>
+        {prompt === null && !showDirectionStep && (
+          <p className="p2b-field-hint">
+            Finish step 1 and your direction prompt appears here.
+          </p>
         )}
         {prompt !== null && (
           <div className="p2b-field">
@@ -261,31 +275,32 @@ export function EasySetupPanel({
                 }}
               />
             )}
-            {editorialOptions && editorial.commissionDraft && (
-              <CommissionEditor
-                draft={editorial.commissionDraft}
-                editorialOptions={editorialOptions}
-                isApproved={editorial.approval.status === 'approved'}
-                onApprove={() => {
-                  void onApproveCommission().catch(error =>
-                    setDirectionStatus(error instanceof Error ? error.message : 'Approval failed.'),
-                  )
-                }}
-                onChange={onCommissionChange}
-              />
-            )}
-            {editorialOptions && editorial.approval.status === 'approved' && (
-              <ResearchPanel
-                commission={editorial.approval.commission}
-                editorialOptions={editorialOptions}
-                evidencePackage={editorial.evidencePackage}
-                onClearEvidence={onClearEvidence}
-                onStoreEvidence={onStoreEvidence}
-              />
-            )}
           </>
         )}
-      </div>
-    </section>
+      </StepSection>
+
+      {editorialOptions && editorial.commissionDraft && (
+        <CommissionEditor
+          draft={editorial.commissionDraft}
+          editorialOptions={editorialOptions}
+          isApproved={editorial.approval.status === 'approved'}
+          onApprove={() => {
+            void onApproveCommission().catch(error =>
+              setDirectionStatus(error instanceof Error ? error.message : 'Approval failed.'),
+            )
+          }}
+          onChange={onCommissionChange}
+        />
+      )}
+      {editorialOptions && editorial.approval.status === 'approved' && (
+        <ResearchPanel
+          commission={editorial.approval.commission}
+          editorialOptions={editorialOptions}
+          evidencePackage={editorial.evidencePackage}
+          onClearEvidence={onClearEvidence}
+          onStoreEvidence={onStoreEvidence}
+        />
+      )}
+    </>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/StepSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/StepSection.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import type { P2BStep } from '../step-model'
+
+interface StepSectionProps {
+  step: P2BStep
+  /** Shown on a finished step when the model has no recap of its own. */
+  fallbackSummary?: string
+  children: ReactNode
+}
+
+const TOGGLE_LABELS: Record<P2BStep['state'], { open: string; closed: string }> = {
+  done: { open: 'Hide this step', closed: 'Change this' },
+  current: { open: 'Hide this step', closed: 'Show this step' },
+  upcoming: { open: 'Hide this step', closed: 'Look ahead' }
+}
+
+/**
+ * One numbered step: what it is called, why it exists, and its work.
+ *
+ * The current step is open; finished and upcoming ones are closed but never
+ * disabled. Locking a step an operator has not reached punishes curiosity for
+ * no safety gain — the controls inside already refuse work that is not ready,
+ * and someone who wants to see what is coming should be able to look.
+ */
+export function StepSection({ step, fallbackSummary, children }: StepSectionProps) {
+  // Null means "follow the step". A transition clears the override so the page
+  // resumes opening whatever the operator is actually working on.
+  const [override, setOverride] = useState<boolean | null>(null)
+  useEffect(() => setOverride(null), [step.state])
+
+  const isOpen = override ?? step.state === 'current'
+  const summary = step.summary ?? fallbackSummary ?? null
+
+  return (
+    <section
+      className={`p2b-step-section p2b-step-section--${step.state}${
+        isOpen ? ' p2b-step-section--open' : ''
+      }`}
+      aria-labelledby={`p2b-step-heading-${step.id}`}
+    >
+      <div className="p2b-step-section-header">
+        <span className="p2b-step-section-number" aria-hidden="true">
+          {step.state === 'done' ? '✓' : step.number}
+        </span>
+        <div className="p2b-step-section-heading-text">
+          <h2 id={`p2b-step-heading-${step.id}`}>
+            Step {step.number}: {step.name}
+          </h2>
+          {isOpen ? (
+            <p className="p2b-step-section-purpose">{step.purpose}</p>
+          ) : (
+            summary && <p className="p2b-step-section-summary">{summary}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          className="p2b-step-section-toggle"
+          aria-expanded={isOpen}
+          aria-controls={`p2b-step-body-${step.id}`}
+          onClick={() => setOverride(!isOpen)}
+        >
+          {isOpen ? TOGGLE_LABELS[step.state].open : TOGGLE_LABELS[step.state].closed}
+        </button>
+      </div>
+      <div
+        id={`p2b-step-body-${step.id}`}
+        className="p2b-step-section-body"
+        hidden={!isOpen}
+      >
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -221,6 +221,12 @@ function createDirectionResponseJson() {
   })
 }
 
+function openStep(name: RegExp) {
+  const header = screen.getByRole('heading', { name }).closest('.p2b-step-section-header')
+  const toggle = within(header as HTMLElement).getByRole('button')
+  if (toggle.getAttribute('aria-expanded') === 'false') fireEvent.click(toggle)
+}
+
 describe('Prompt2BlogPage', () => {
   let restoreClipboard: (() => void) | null = null
 
@@ -363,27 +369,69 @@ describe('Prompt2BlogPage', () => {
     }
   })
 
-  it('starts with an Easy Set Up block containing Title and Location fields', async () => {
+  it('opens on step one, holding only Title and Location', async () => {
     renderPage()
 
-    const easySetupPanel = screen.getByRole('heading', { name: 'Easy Set Up' }).closest('section')
+    const startStep = screen
+      .getByRole('heading', { name: /Step 1: Start the article/ })
+      .closest('section')
     const profilesPanel = screen
       .getByRole('heading', { name: 'Writing Profiles' })
       .closest('section')
 
-    expect(easySetupPanel).toBeInTheDocument()
-    expect(easySetupPanel?.compareDocumentPosition(profilesPanel!)).toBe(
+    expect(startStep).toBeInTheDocument()
+    expect(startStep?.compareDocumentPosition(profilesPanel!)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     )
-    expect(within(easySetupPanel!).getByLabelText('Title')).toBeInTheDocument()
-    expect(within(easySetupPanel!).getByLabelText('Location')).toBeInTheDocument()
-    expect(within(easySetupPanel!).queryByLabelText('Direction JSON')).not.toBeInTheDocument()
+    expect(within(startStep!).getByLabelText('Title')).toBeInTheDocument()
+    expect(within(startStep!).getByLabelText('Location')).toBeInTheDocument()
+    expect(within(startStep!).queryByLabelText('Direction JSON')).not.toBeInTheDocument()
     expect(
-      within(easySetupPanel!).getByRole('button', {
+      within(startStep!).getByRole('button', {
         name: 'Generate direction prompt',
       }),
     ).toBeDisabled()
-    expect(within(easySetupPanel!).queryByLabelText('Prompt')).not.toBeInTheDocument()
+    expect(within(startStep!).queryByLabelText('Prompt')).not.toBeInTheDocument()
+  })
+
+  it('presents the numbered steps in order, with only the current one open', async () => {
+    renderPage()
+
+    const headings = screen
+      .getAllByRole('heading', { name: /^Step \d:/ })
+      .map(heading => heading.textContent)
+
+    expect(headings).toEqual([
+      'Step 1: Start the article',
+      'Step 2: Pick a direction',
+    ])
+
+    const startBody = screen
+      .getByRole('heading', { name: /Step 1: Start the article/ })
+      .closest('section')
+      ?.querySelector('.p2b-step-section-body')
+    const directionBody = screen
+      .getByRole('heading', { name: /Step 2: Pick a direction/ })
+      .closest('section')
+      ?.querySelector('.p2b-step-section-body')
+
+    expect(startBody).not.toHaveAttribute('hidden')
+    expect(directionBody).toHaveAttribute('hidden')
+  })
+
+  it('lets an operator look ahead into a step they have not reached', async () => {
+    // Locking a step nobody has reached punishes curiosity for no safety gain:
+    // the controls inside already refuse work that is not ready.
+    renderPage()
+
+    openStep(/Step 2: Pick a direction/)
+
+    expect(
+      screen
+        .getByRole('heading', { name: /Step 2: Pick a direction/ })
+        .closest('section')
+        ?.querySelector('.p2b-step-section-body'),
+    ).not.toHaveAttribute('hidden')
   })
 
   it('puts the work first and the model machinery last', async () => {
@@ -391,14 +439,16 @@ describe('Prompt2BlogPage', () => {
     // cost picker, above the two fields that actually start an article.
     renderPage()
 
-    const easySetupPanel = screen.getByRole('heading', { name: 'Easy Set Up' }).closest('section')
+    const startStep = screen
+      .getByRole('heading', { name: /Step 1: Start the article/ })
+      .closest('section')
     const profilesPanel = screen
       .getByRole('heading', { name: 'Writing Profiles' })
       .closest('section')
     const pipelinePanel = screen.getByRole('heading', { name: 'Pipeline' }).closest('section')
     const advancedPanel = screen.getByRole('heading', { name: 'Advanced' }).closest('section')
 
-    expect(easySetupPanel?.compareDocumentPosition(profilesPanel!)).toBe(
+    expect(startStep?.compareDocumentPosition(profilesPanel!)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     )
     expect(profilesPanel?.compareDocumentPosition(pipelinePanel!)).toBe(
@@ -666,6 +716,7 @@ describe('Prompt2BlogPage', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeDisabled()
 
+    openStep(/Step 2: Pick a direction/)
     fireEvent.click(screen.getByRole('button', { name: 'Clear direction work' }))
     expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeEnabled()
   })
@@ -691,6 +742,7 @@ describe('Prompt2BlogPage', () => {
       target: { value: 'Three days in Lisbon' },
     })
 
+    openStep(/Step 2: Pick a direction/)
     expect(screen.getByRole('button', { name: 'Show direction cards' })).toBeDisabled()
     expect(screen.getByLabelText('Direction JSON')).toHaveValue('')
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -92,6 +92,7 @@ export default function Prompt2BlogPage() {
             editorialOptionsError={composer.editorialOptionsError}
             editorialOptionsLoading={composer.editorialOptionsLoading}
             location={state.easySetupLocation}
+            steps={steps}
             title={state.easySetupTitle}
             onApplyDirectionResponse={composer.applyDirectionResponse}
             onApproveCommission={composer.approveCommissionChanges}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
@@ -233,3 +233,112 @@
   line-height: 1.5;
   color: var(--ink);
 }
+
+/* --- Step sections ---------------------------------------------------------
+   One numbered step: what it is called, why it exists, and its work. The
+   current step is open; finished and upcoming ones are closed but never
+   disabled, so an operator can look ahead or go back without being blocked. */
+
+.p2b-step-section {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface, white);
+  overflow: hidden;
+}
+
+.p2b-step-section--current {
+  border-color: var(--p2b-accent);
+}
+
+.p2b-step-section--upcoming .p2b-step-section-header {
+  opacity: 0.65;
+}
+
+.p2b-step-section-header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-5);
+}
+
+.p2b-step-section--open .p2b-step-section-header {
+  border-bottom: 1px solid var(--border);
+}
+
+.p2b-step-section-number {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  border: 1px solid var(--border);
+  color: var(--ink);
+}
+
+.p2b-step-section--done .p2b-step-section-number {
+  border-color: var(--p2b-accent);
+  color: var(--p2b-accent);
+}
+
+.p2b-step-section--current .p2b-step-section-number {
+  background: var(--p2b-accent);
+  border-color: var(--p2b-accent);
+  color: white;
+}
+
+.p2b-step-section-heading-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.p2b-step-section-heading-text h2 {
+  margin: 0;
+  font-size: 1.125rem;
+  color: var(--ink);
+}
+
+.p2b-step-section-purpose,
+.p2b-step-section-summary {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--ink);
+  opacity: 0.8;
+}
+
+.p2b-step-section-toggle {
+  flex-shrink: 0;
+  font-family: var(--font-body);
+  border: 1px solid var(--border);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: white;
+  color: var(--p2b-accent);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: all var(--transition-base);
+}
+
+.p2b-step-section-toggle:hover {
+  border-color: var(--p2b-accent);
+  background: var(--p2b-accent-softer);
+}
+
+.p2b-step-section-body {
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.p2b-step-section-body[hidden] {
+  display: none;
+}


### PR DESCRIPTION
## Why

`Easy Set Up` held four different jobs behind one heading and three
sub-headings — name the article, get a prompt, import three directions, choose
one — and then rendered the commission editor and research panel inside itself
too. Walked cold, there was no way to tell which part was yours right now.

This is the first half of splitting it into the five steps the rail already
names. **Steps 1 and 2 only.** The commission editor and research panel still
render inline below, unchanged; they become steps 3 and 4 in the next PR, along
with the control that makes step 3 a stop the operator consciously passes.

Splitting this way keeps each diff readable, which is the constraint on this
project.

## `StepSection`

One numbered step: its number, its plain name, why it exists, and its work.

- The **current** step is open.
- **Finished** and **upcoming** steps are closed but **never disabled**.
  Locking a step nobody has reached punishes curiosity for no safety gain — the
  controls inside already refuse work that is not ready. Every closed step
  carries a toggle naming what opening it does: `Change this`, `Look ahead`.
- A finished step shows its recap from the step model in place of its purpose
  line.
- The open/closed override resets whenever the step changes state, so the page
  resumes following whatever the operator is actually working on.

## Where the prompt went

The direction prompt moved from step 1 into step 2. Copying it is the first
half of step 2's chatbot round trip, not the tail of step 1. An operator who
looks ahead into step 2 before finishing step 1 now reads *"Finish step 1 and
your direction prompt appears here"* rather than finding an empty section.

## About the test changes

They are consequences of the split, not new behaviour:

- The `Easy Set Up` heading no longer exists — two layout tests now anchor on
  `Step 1: Start the article`.
- A finished step 2 is closed, so its buttons are inside a `hidden` body. The
  two flow tests reopen it through the toggle, exactly the way an operator
  does. A small `openStep` helper does this.

Three tests are added: step order, only-the-current-step-open, and looking
ahead into an unreached step.

## Verification

- frontend vitest — **826 passed across 165 files** (824 baseline + 2 net new)
- `tsc --noEmit`, boundaries, eslint — clean
- `vite build` — passes, pre-existing chunk-size warning only
- backend untouched

One intermediate full-suite run failed six unrelated files (listicle builder,
image cropper) on 5s timeouts while three dev servers were competing for CPU.
With those stopped the suite passes clean, and the slowest prompt2blog test
runs in 446ms on its own. That matches the load flakiness this suite is already
known for; nothing here changed those files.

**Not verified in the running app** — the dev servers were stopped to get a
clean suite run. The behaviour asserted here (section order, only the current
step open, look-ahead) is covered by the jsdom tests rather than a live check.

## Scope

Presentation only. No contract, gate, or authority-model change. Every existing
control keeps its label and its behaviour.