### PR TITLE
feat(prompt2blog): make locking a commission something the operator does

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.test.ts
@@ -78,7 +78,8 @@ function state(overrides: Partial<P2BFormState> = {}): P2BFormState {
       selectedOptionId: null,
       commissionDraft: null,
       approval: { status: 'not_started' },
-      evidencePackage: null
+      evidencePackage: null,
+      reviewedCommissionFingerprint: null
     },
     easySetupTitle: APP_TITLE,
     easySetupLocation: APP_LOCATION,
@@ -120,6 +121,7 @@ describe('commission state', () => {
     expect(next.activeWorkflow).toBe('editorial_v3')
     expect(next.editorial).toEqual({
       directionOptions: [],
+      reviewedCommissionFingerprint: null,
       selectedOptionId: null,
       commissionDraft: null,
       approval: { status: 'not_started' },
@@ -244,6 +246,7 @@ describe('commission state', () => {
     expect(next.activeWorkflow).toBe('legacy_v2')
     expect(next.editorial).toEqual({
       directionOptions: [],
+      reviewedCommissionFingerprint: null,
       selectedOptionId: null,
       commissionDraft: null,
       approval: { status: 'not_started' },

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/commission-state.ts
@@ -23,7 +23,8 @@ function emptyEditorialState(): P2BEditorialComposerState {
     selectedOptionId: null,
     commissionDraft: null,
     approval: { status: 'not_started' },
-    evidencePackage: null
+    evidencePackage: null,
+    reviewedCommissionFingerprint: null
   }
 }
 
@@ -87,6 +88,7 @@ export function applyValidatedDirectionResponse(
       selectedOptionId: null,
       commissionDraft: null,
       approval: { status: 'awaiting_selection' },
+      reviewedCommissionFingerprint: null,
       evidencePackage: null
     }
   }
@@ -126,9 +128,18 @@ export function selectDirectionOption(
 }
 
 /** Records a fully fingerprinted snapshot without computing its fingerprint. */
+/**
+ * Approves a commission, and records whether a human deliberately reviewed it.
+ *
+ * `reviewed` is false for the implicit approval a direction card performs, and
+ * true when the operator presses the editor's own approve button or confirms
+ * the review step. The distinction is the whole point: without it, approval by
+ * card click is indistinguishable from approval a person actually read.
+ */
 export function approveCommission(
   state: P2BFormState,
-  commission: Prompt2BlogCommission
+  commission: Prompt2BlogCommission,
+  { reviewed = false }: { reviewed?: boolean } = {}
 ): P2BFormState {
   if (!state.editorial.commissionDraft) {
     throw new Error('A commission draft must be selected before approval.')
@@ -163,7 +174,23 @@ export function approveCommission(
       evidencePackage: retainedEvidencePackage(state.editorial.evidencePackage, {
         status: 'approved',
         commission
-      })
+      }),
+      reviewedCommissionFingerprint: reviewed
+        ? commission.commission_fingerprint
+        : null
+    }
+  }
+}
+
+/** Records that the operator read what a direction card locked for them. */
+export function markCommissionReviewed(state: P2BFormState): P2BFormState {
+  const { approval } = state.editorial
+  if (approval.status !== 'approved') return state
+  return {
+    ...state,
+    editorial: {
+      ...state.editorial,
+      reviewedCommissionFingerprint: approval.commission.commission_fingerprint
     }
   }
 }
@@ -190,7 +217,9 @@ export function editCommissionDraft(
         status: 'reconfirmation_required',
         reason: 'commission_edited'
       },
-      evidencePackage: null
+      evidencePackage: null,
+      // An edited commission is not the one that was read.
+      reviewedCommissionFingerprint: null
     }
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -30,6 +30,7 @@ interface EasySetupPanelProps {
   onClearDirectionWorkflow: () => void
   onClearEvidence: () => void
   onCommissionChange: (draft: Prompt2BlogCommissionDraft) => void
+  onConfirmCommissionReview: () => void
   onLocationChange: (value: string) => void
   onRetryEditorialOptions: () => void
   onSelectDirection: (optionId: Prompt2BlogDirectionOptionId) => Promise<void>
@@ -52,6 +53,7 @@ export function EasySetupPanel({
   onClearDirectionWorkflow,
   onClearEvidence,
   onCommissionChange,
+  onConfirmCommissionReview,
   onLocationChange,
   onRetryEditorialOptions,
   onSelectDirection,
@@ -118,6 +120,11 @@ export function EasySetupPanel({
   // deriveP2BSteps always returns all five; a missing one means the page handed
   // this panel something other than the step model, which is a programming
   // error rather than a state the operator can reach.
+  const awaitingReview =
+    editorial.approval.status === 'approved'
+    && editorial.reviewedCommissionFingerprint
+      !== editorial.approval.commission.commission_fingerprint
+
   const stepFor = (id: P2BStepId): P2BStep => {
     const step = steps.find(candidate => candidate.id === id)
     if (!step) throw new Error(`Missing step "${id}" in the step model.`)
@@ -279,28 +286,64 @@ export function EasySetupPanel({
         )}
       </StepSection>
 
-      {editorialOptions && editorial.commissionDraft && (
-        <CommissionEditor
-          draft={editorial.commissionDraft}
-          editorialOptions={editorialOptions}
-          isApproved={editorial.approval.status === 'approved'}
-          onApprove={() => {
-            void onApproveCommission().catch(error =>
-              setDirectionStatus(error instanceof Error ? error.message : 'Approval failed.'),
-            )
-          }}
-          onChange={onCommissionChange}
-        />
-      )}
-      {editorialOptions && editorial.approval.status === 'approved' && (
-        <ResearchPanel
-          commission={editorial.approval.commission}
-          editorialOptions={editorialOptions}
-          evidencePackage={editorial.evidencePackage}
-          onClearEvidence={onClearEvidence}
-          onStoreEvidence={onStoreEvidence}
-        />
-      )}
+      <StepSection step={stepFor('commission')}>
+        {!editorial.commissionDraft && (
+          <p className="p2b-field-hint">
+            Choose a direction in step 2 and what you commissioned appears here.
+          </p>
+        )}
+        {editorialOptions && editorial.commissionDraft && (
+          <>
+            {awaitingReview && (
+              <div className="p2b-commission-alert" role="status">
+                <span>
+                  Choosing that direction locked this commission. Research can add facts to
+                  it, but nothing after this point can change what the article is. Read it,
+                  change anything that is wrong, then confirm.
+                </span>
+              </div>
+            )}
+            <CommissionEditor
+              draft={editorial.commissionDraft}
+              editorialOptions={editorialOptions}
+              isApproved={editorial.approval.status === 'approved'}
+              onApprove={() => {
+                void onApproveCommission().catch(error =>
+                  setDirectionStatus(error instanceof Error ? error.message : 'Approval failed.'),
+                )
+              }}
+              onChange={onCommissionChange}
+            />
+            {awaitingReview && (
+              <div className="p2b-panel-actions">
+                <button
+                  type="button"
+                  className="p2b-submit-btn"
+                  onClick={onConfirmCommissionReview}
+                >
+                  This is right — go to research
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </StepSection>
+
+      <StepSection step={stepFor('research')}>
+        {editorialOptions && editorial.approval.status === 'approved' ? (
+          <ResearchPanel
+            commission={editorial.approval.commission}
+            editorialOptions={editorialOptions}
+            evidencePackage={editorial.evidencePackage}
+            onClearEvidence={onClearEvidence}
+            onStoreEvidence={onStoreEvidence}
+          />
+        ) : (
+          <p className="p2b-field-hint">
+            Confirm the commission in step 3 and its research prompt appears here.
+          </p>
+        )}
+      </StepSection>
     </>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.test.ts
@@ -194,6 +194,7 @@ describe('loadSavedComposerState', () => {
         commissionDraft: withoutFingerprint(APPROVED_COMMISSION),
         approval: { status: 'approved', commission: APPROVED_COMMISSION },
         evidencePackage: null,
+        reviewedCommissionFingerprint: null,
       },
     })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -98,6 +98,7 @@ export const DEFAULT_EDITORIAL_STATE: P2BEditorialComposerState = {
   commissionDraft: null,
   approval: { status: 'not_started' },
   evidencePackage: null,
+  reviewedCommissionFingerprint: null,
 }
 
 export const DEFAULT_COMPOSER_STATE: P2BFormState = {
@@ -352,6 +353,13 @@ function normalizeEditorialState(value: unknown): P2BEditorialComposerState {
     commissionDraft,
     approval,
     evidencePackage: normalizeEvidencePackage(candidate.evidencePackage, approval),
+    // A review belongs to one exact commission. A saved value that names any
+    // other one is not a review of what is approved now, so it does not load.
+    reviewedCommissionFingerprint:
+      approval.status === 'approved'
+      && candidate.reviewedCommissionFingerprint === approval.commission.commission_fingerprint
+        ? approval.commission.commission_fingerprint
+        : null,
   }
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.types.ts
@@ -32,6 +32,16 @@ export interface P2BEditorialComposerState {
    * commission they describe.
    */
   evidencePackage: Prompt2BlogEvidencePackage | null
+  /**
+   * The commission the operator has confirmed they read, by fingerprint.
+   *
+   * Choosing a direction card approves a commission outright, so approval on
+   * its own says nothing about whether a human looked at what was locked. This
+   * records that they did. Storing the fingerprint rather than a flag means a
+   * commission that changes cannot inherit the old one's review: the value no
+   * longer matches, and the step reopens on its own.
+   */
+  reviewedCommissionFingerprint: string | null
 }
 
 export interface P2BFormState {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -27,6 +27,7 @@ import { approveCommission as fingerprintApprovedCommission } from '../commissio
 import {
   applyValidatedDirectionResponse,
   approveCommission as storeApprovedCommission,
+  markCommissionReviewed,
   clearDirectionWorkflow as resetDirectionWorkflow,
   clearEvidencePackage,
   storeEvidencePackage,
@@ -69,6 +70,8 @@ export function usePrompt2BlogComposer() {
                 status: 'reconfirmation_required',
                 reason: 'title_or_location_changed',
               },
+              // A retitled article is not the commission that was read.
+              reviewedCommissionFingerprint: null,
               evidencePackage: null,
             },
           }
@@ -172,9 +175,17 @@ export function usePrompt2BlogComposer() {
     const draft = state.editorial.commissionDraft
     const commission = await fingerprintApprovedCommission(draft, editorialOptions)
     setState(prev =>
-      prev.editorial.commissionDraft !== draft ? prev : storeApprovedCommission(prev, commission),
+      prev.editorial.commissionDraft !== draft
+        ? prev
+        : // Pressing approve is itself the deliberate read that the review step
+          // asks for, so it does not ask again.
+          storeApprovedCommission(prev, commission, { reviewed: true }),
     )
   }, [editorialOptions, state.editorial.commissionDraft])
+
+  const confirmCommissionReview = useCallback(() => {
+    setState(markCommissionReviewed)
+  }, [])
 
   const storeEvidence = useCallback((evidencePackage: Prompt2BlogEvidencePackage) => {
     setState(prev => storeEvidencePackage(prev, evidencePackage))
@@ -245,6 +256,7 @@ export function usePrompt2BlogComposer() {
     selectDirectionOption,
     updateCommissionDraft,
     approveCommissionChanges,
+    confirmCommissionReview,
     storeEvidence,
     clearEvidence,
     clearDirectionWorkflow,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.test.ts
@@ -26,6 +26,7 @@ function inV3(
       commissionDraft: null,
       approval: { status: 'not_started' },
       evidencePackage: null,
+      reviewedCommissionFingerprint: null,
       ...editorial
     },
     ...overrides
@@ -102,17 +103,39 @@ describe('deriveP2BSteps', () => {
     expect(currentP2BStep(stale).id).toBe('commission')
   })
 
-  it('moves to gathering facts once a commission is approved', () => {
+  it('stops on the review step when a direction card approved a commission for you', () => {
+    // Clicking a card approves outright. That says a click happened, not that
+    // a human read what got locked, so the step stays open until they say so.
     const approved = inV3({ approval: { status: 'approved', commission } })
 
-    expect(currentP2BStep(approved).id).toBe('research')
-    expect(deriveP2BSteps(approved)[2].summary).toBe(commission.primary_subject)
+    expect(currentP2BStep(approved).id).toBe('commission')
+    expect(deriveP2BSteps(approved)[2].state).toBe('current')
+  })
+
+  it('moves to gathering facts once the operator confirms the commission', () => {
+    const reviewed = inV3({
+      approval: { status: 'approved', commission },
+      reviewedCommissionFingerprint: commission.commission_fingerprint
+    })
+
+    expect(currentP2BStep(reviewed).id).toBe('research')
+    expect(deriveP2BSteps(reviewed)[2].summary).toBe(commission.primary_subject)
+  })
+
+  it('ignores a review that names a different commission', () => {
+    const stale = inV3({
+      approval: { status: 'approved', commission },
+      reviewedCommissionFingerprint: 'a-commission-that-was-edited-away'
+    })
+
+    expect(currentP2BStep(stale).id).toBe('commission')
   })
 
   it('reaches the writing step once matching research is attached', () => {
     const ready = inV3({
       approval: { status: 'approved', commission },
-      evidencePackage
+      evidencePackage,
+      reviewedCommissionFingerprint: commission.commission_fingerprint
     })
     const steps = deriveP2BSteps(ready)
 
@@ -126,6 +149,7 @@ describe('deriveP2BSteps', () => {
   it('counts sources and claims in plural when there is more than one', () => {
     const ready = inV3({
       approval: { status: 'approved', commission },
+      reviewedCommissionFingerprint: commission.commission_fingerprint,
       evidencePackage: {
         ...evidencePackage,
         sources: [...(evidencePackage.sources ?? []), ...(evidencePackage.sources ?? [])]
@@ -140,6 +164,7 @@ describe('deriveP2BSteps', () => {
     // however complete it looks, and the run would be refused anyway.
     const mismatched = inV3({
       approval: { status: 'approved', commission },
+      reviewedCommissionFingerprint: commission.commission_fingerprint,
       evidencePackage: { ...evidencePackage, commission_fingerprint: 'someone-else' }
     })
 
@@ -150,7 +175,8 @@ describe('deriveP2BSteps', () => {
   it('never marks the writing step done, because a finished run is not composer state', () => {
     const ready = inV3({
       approval: { status: 'approved', commission },
-      evidencePackage
+      evidencePackage,
+      reviewedCommissionFingerprint: commission.commission_fingerprint
     })
 
     expect(deriveP2BSteps(ready)[4].state).toBe('current')

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.ts
@@ -91,6 +91,14 @@ function researchIsAttached(state: P2BFormState): boolean {
   )
 }
 
+function commissionWasReviewed(state: P2BFormState): boolean {
+  const { approval, reviewedCommissionFingerprint } = state.editorial
+  if (approval.status !== 'approved') return false
+  return (
+    reviewedCommissionFingerprint === approval.commission.commission_fingerprint
+  )
+}
+
 function summarizeCommission(state: P2BFormState): string | null {
   const { approval } = state.editorial
   if (approval.status !== 'approved') return null
@@ -123,15 +131,14 @@ function summarizeResearch(state: P2BFormState): string | null {
 /**
  * Which of the five steps are finished, and where the operator stands.
  *
- * Derived entirely from composer state the page already keeps. Nothing here is
- * stored, so the indicator cannot drift out of step with the work it describes
- * — a rail that disagrees with the page is worse than no rail at all.
+ * Derived entirely from composer state the page already keeps, so the
+ * indicator cannot drift out of step with the work it describes — a rail that
+ * disagrees with the page is worse than no rail at all.
  *
- * Step 3 counts as finished the moment a commission is approved, because that
- * is what the page does today: choosing a direction card approves it outright.
- * Making that a stop the operator consciously passes needs a control to pass
- * it with, which lands together with the step sections rather than ahead of
- * them.
+ * Step 3 needs more than an approved commission. Choosing a direction card
+ * approves one outright, so approval alone says only that a click happened,
+ * not that a human read what got locked. It is finished when the operator has
+ * confirmed this exact commission by fingerprint.
  *
  * Step 5 is never `done` here. Finishing it means a completed run, which lives
  * in the pipeline's own state, not the composer's.
@@ -144,7 +151,7 @@ export function deriveP2BSteps(state: P2BFormState): P2BStep[] {
   const completion: Record<P2BStepId, boolean> = {
     start: startedDirectionWork && titleAndLocation,
     direction: startedDirectionWork && directionWasChosen(state),
-    commission: state.editorial.approval.status === 'approved',
+    commission: commissionWasReviewed(state),
     research: researchIsAttached(state),
     write: false
   }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
@@ -23,6 +23,7 @@ function approvedState(overrides: Partial<P2BFormState> = {}): P2BFormState {
       commissionDraft: null,
       approval: { status: 'approved', commission },
       evidencePackage,
+      reviewedCommissionFingerprint: commission.commission_fingerprint,
     },
     ...overrides,
   }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -221,6 +221,13 @@ function createDirectionResponseJson() {
   })
 }
 
+function stepBody(name: RegExp): Element | null | undefined {
+  return screen
+    .getByRole('heading', { name })
+    .closest('section')
+    ?.querySelector('.p2b-step-section-body')
+}
+
 function openStep(name: RegExp) {
   const header = screen.getByRole('heading', { name }).closest('.p2b-step-section-header')
   const toggle = within(header as HTMLElement).getByRole('button')
@@ -404,6 +411,8 @@ describe('Prompt2BlogPage', () => {
     expect(headings).toEqual([
       'Step 1: Start the article',
       'Step 2: Pick a direction',
+      'Step 3: Review what you locked',
+      'Step 4: Gather the facts',
     ])
 
     const startBody = screen
@@ -719,6 +728,83 @@ describe('Prompt2BlogPage', () => {
     openStep(/Step 2: Pick a direction/)
     fireEvent.click(screen.getByRole('button', { name: 'Clear direction work' }))
     expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeEnabled()
+  })
+
+  it('makes approval by direction card a stop the operator passes deliberately', async () => {
+    renderPage()
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'A weekend in Lisbon' },
+    })
+    fireEvent.change(screen.getByLabelText('Location'), {
+      target: { value: 'Lisbon, Portugal' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Generate direction prompt' }))
+    fireEvent.change(screen.getByLabelText('Direction JSON'), {
+      target: { value: createDirectionResponseJson() },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Check directions' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Show direction cards' }))
+    fireEvent.click(screen.getAllByRole('radio')[0])
+
+    // The card locked a commission without the operator ever saying so. Step 3
+    // is where they are told that, and step 4 stays closed behind it.
+    expect(await screen.findByText(/Choosing that direction locked this commission/)).toBeInTheDocument()
+    expect(stepBody(/Step 3: Review what you locked/)).not.toHaveAttribute('hidden')
+    expect(stepBody(/Step 4: Gather the facts/)).toHaveAttribute('hidden')
+
+    fireEvent.click(screen.getByRole('button', { name: 'This is right — go to research' }))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'This is right — go to research' }),
+      ).not.toBeInTheDocument(),
+    )
+    // Confirming is what opens the research step, not approval on its own.
+    expect(stepBody(/Step 4: Gather the facts/)).not.toHaveAttribute('hidden')
+    expect(stepBody(/Step 3: Review what you locked/)).toHaveAttribute('hidden')
+    expect(screen.getByLabelText('Research prompt')).toBeInTheDocument()
+  })
+
+  it('reopens the review step when the commission changes after being confirmed', async () => {
+    renderPage()
+    await waitFor(() => expect(getPrompt2BlogEditorialOptionsMock).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'A weekend in Lisbon' },
+    })
+    fireEvent.change(screen.getByLabelText('Location'), {
+      target: { value: 'Lisbon, Portugal' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Generate direction prompt' }))
+    fireEvent.change(screen.getByLabelText('Direction JSON'), {
+      target: { value: createDirectionResponseJson() },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Check directions' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Show direction cards' }))
+    fireEvent.click(screen.getAllByRole('radio')[0])
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'This is right — go to research' }),
+    )
+
+    fireEvent.change(screen.getByLabelText('Primary subject'), {
+      target: { value: 'Historic Lisbon' },
+    })
+
+    // Editing retracts approval, so what was read is no longer what is locked.
+    expect(screen.getByText('Needs approval')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Research prompt')).not.toBeInTheDocument()
+    expect(stepBody(/Step 3: Review what you locked/)).not.toHaveAttribute('hidden')
+
+    // Pressing approve is itself the deliberate read, so it does not ask twice.
+    fireEvent.click(screen.getByRole('button', { name: 'Approve commission' }))
+    expect(await screen.findByText('Approved')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'This is right — go to research' }),
+    ).not.toBeInTheDocument()
+    expect(stepBody(/Step 4: Gather the facts/)).not.toHaveAttribute('hidden')
+    expect(screen.getByLabelText('Research prompt')).toBeInTheDocument()
   })
 
   it('retracts a checked direction response when title identity changes', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -99,6 +99,7 @@ export default function Prompt2BlogPage() {
             onClearDirectionWorkflow={composer.clearDirectionWorkflow}
             onClearEvidence={composer.clearEvidence}
             onCommissionChange={composer.updateCommissionDraft}
+            onConfirmCommissionReview={composer.confirmCommissionReview}
             onLocationChange={value => composer.updateField('easySetupLocation', value)}
             onRetryEditorialOptions={composer.retryEditorialOptions}
             onSelectDirection={composer.selectDirectionOption}


### PR DESCRIPTION
## Why

Found by walking the app cold. Clicking a direction card calls
`storeApprovedCommission` itself, so **the commission was locked by a click on
a card** — approval happened to the operator rather than being something they
performed, and nothing marked the moment it happened.

That matters more here than it would elsewhere. The commission is the thing
research can never change and an unsupported run stops against. It is the whole
reason the v3 redesign happened. Having it locked invisibly is the one place
the UI was quietly undercutting the authority model it exists to serve.

## What changed

Steps 3 and 4 become sections, and **step 3 becomes a real stop**:

- A commission approved by a card click opens the review step with what it
  locked, plainly: *"Choosing that direction locked this commission. Research
  can add facts to it, but nothing after this point can change what the article
  is. Read it, change anything that is wrong, then confirm."*
- One control passes it: **This is right — go to research**.
- Step 4 stays closed behind it.
- Pressing the editor's own **Approve commission** counts as that read and does
  not ask twice — it is already a deliberate act.

Nothing is locked away: an operator can still `Look ahead` into step 4, as with
every other step. What changed is where the page points them.

## The state

`reviewedCommissionFingerprint: string | null` on the editorial composer state
— **a fingerprint, not a flag**. A commission that changes cannot inherit the
old one's review: the value stops matching and the step reopens on its own.

Cleared by editing the draft, retitling the article, and importing new
directions. The storage loader refuses a saved value naming anything other than
what is approved right now, so a stale review cannot survive a reload.

`approveCommission` takes `{ reviewed }` — false for the card's implicit
approval, true for the editor's explicit one. Without that distinction the two
are indistinguishable, which is the bug.

## Verified in the running app, end to end

Selecting a direction card:

```
✓ Start the article       Done   A long weekend in Lima — Lima, Peru
✓ Pick a direction        Done   Explain the immigration paperwork…
3 Review what you locked  You are here
4 Gather the facts        Not yet
```

with `This is right — go to research` present and step 4's body `hidden`. After
confirming, step 4 opens and every other section collapses.

## One thing the live check caught in my own test

My first version asserted `getByLabelText('Research prompt')).toBeInTheDocument()`
after confirming. That would have passed *before* confirming too — a collapsed
step's body is hidden but still in the DOM, so the assertion proved nothing.
The tests now assert on the section body's `hidden` state in both directions.

## Verification

- frontend vitest — **830 passed across 165 files** (826 baseline + 4 new)
- `tsc --noEmit`, boundaries, eslint — clean
- `vite build` — passes, pre-existing chunk-size warning only
- backend untouched

Existing tests that changed did so because approval alone no longer finishes
step 3; each now says which behaviour it is pinning.

## Scope

The authority model is unchanged and slightly better served: a human still
approves before research, research still cannot change the commission, an
unsupported run still stops. This only makes the human's part visible.