### PR TITLE
Prompt2Blog: tell operators what to do next

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/StepSection.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/StepSection.tsx
@@ -47,7 +47,14 @@ export function StepSection({ step, fallbackSummary, children }: StepSectionProp
             Step {step.number}: {step.name}
           </h2>
           {isOpen ? (
-            <p className="p2b-step-section-purpose">{step.purpose}</p>
+            <>
+              <p className="p2b-step-section-purpose">{step.purpose}</p>
+              {step.state === 'current' && (
+                <p className="p2b-step-section-next-action">
+                  <strong>Do this next:</strong> {step.nextAction}
+                </p>
+              )}
+            </>
           ) : (
             summary && <p className="p2b-step-section-summary">{summary}</p>
           )}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-match.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-match.ts
@@ -1,0 +1,28 @@
+import type { Prompt2BlogCommission, Prompt2BlogEvidencePackage } from '../api'
+
+export type EvidenceCommissionMatch =
+  | 'matches'
+  | 'different_commission'
+  | 'different_requirements'
+
+/** Whether attached evidence belongs to, and answers, this exact commission. */
+export function compareEvidenceToCommission(
+  commission: Prompt2BlogCommission,
+  evidencePackage: Prompt2BlogEvidencePackage
+): EvidenceCommissionMatch {
+  if (evidencePackage.commission_fingerprint !== commission.commission_fingerprint) {
+    return 'different_commission'
+  }
+
+  const commissionRequirements = commission.requirements.map(
+    requirement => requirement.requirement_id
+  )
+  const evidenceRequirements = evidencePackage.requirements.map(
+    requirement => requirement.requirement_id
+  )
+  const sameRequirements =
+    commissionRequirements.length === evidenceRequirements.length &&
+    commissionRequirements.every(requirementId => evidenceRequirements.includes(requirementId))
+
+  return sameRequirements ? 'matches' : 'different_requirements'
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/hooks/usePrompt2BlogComposer.ts
@@ -22,7 +22,10 @@ import {
 } from '../composer.storage'
 import type { P2BFormState } from '../composer.types'
 import { findDefaultOption } from '../option-defaults'
-import { buildPrompt2BlogV3Payload, v3SubmissionBlockedReason } from '../v3-payload'
+import {
+  buildPrompt2BlogV3Payload,
+  prompt2BlogSubmissionBlockedReason,
+} from '../v3-payload'
 import { approveCommission as fingerprintApprovedCommission } from '../commission'
 import {
   applyValidatedDirectionResponse,
@@ -133,7 +136,10 @@ export function usePrompt2BlogComposer() {
   // An approved commission with attached research runs on v3. Everything else
   // in the editorial workflow reports what is still missing; a legacy draft
   // keeps the v2 path and its own validation.
-  const submissionBlockedReason = useMemo(() => v3SubmissionBlockedReason(state), [state])
+  const submissionBlockedReason = useMemo(
+    () => prompt2BlogSubmissionBlockedReason(state),
+    [state],
+  )
 
   const startDirectionWorkflow = useCallback(() => {
     setState(startEditorialWorkflow)

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-guidance.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-guidance.ts
@@ -1,0 +1,25 @@
+/**
+ * Operator instructions shared by the step display and submission gate.
+ *
+ * Keeping the words here matters: the open step and disabled run button must
+ * never point at different next actions for the same composer state.
+ */
+export const P2B_NEXT_ACTION = {
+  start: 'Enter a working title and location, then generate the direction prompt.',
+  direction:
+    'Copy the direction prompt into your chatbot, then paste its answer here.',
+  chooseDirection: 'Choose one of the three directions.',
+  commission:
+    'Read the locked commission, change anything that is wrong, then confirm it.',
+  changedCommission: 'Review the changed commission, then approve it.',
+  savedCommission: 'Review this saved commission, then approve it again.',
+  editedCommission: 'Review the changed commission, then approve it again.',
+  changedIdentity: 'Generate a new direction prompt for the changed title or location.',
+  research:
+    'Copy the research prompt into your chatbot, then paste and attach its evidence package.',
+  mismatchedResearch: 'Clear the attached research, then gather facts for this commission.',
+  incompleteResearch:
+    'Replace the attached research with answers to this commission’s exact questions.',
+  write: 'Choose the tone and length, then run the pipeline.',
+  chooseProfiles: 'Choose a tone and length.',
+} as const

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.test.ts
@@ -68,14 +68,16 @@ describe('deriveP2BSteps', () => {
     const started = inV3()
 
     expect(currentP2BStep(started).id).toBe('direction')
+    expect(currentP2BStep(started).nextAction).toMatch(/Copy the direction prompt/)
     expect(deriveP2BSteps(started)[0].state).toBe('done')
     expect(deriveP2BSteps(started)[0].summary).toContain(commission.original_title)
   })
 
   it('stays on picking a direction while three options wait to be chosen', () => {
-    expect(currentP2BStep(inV3({ approval: { status: 'awaiting_selection' } })).id).toBe(
-      'direction'
-    )
+    const current = currentP2BStep(inV3({ approval: { status: 'awaiting_selection' } }))
+
+    expect(current.id).toBe('direction')
+    expect(current.nextAction).toBe('Choose one of the three directions.')
   })
 
   it('recaps the chosen direction in the operator’s words, not as an option id', () => {
@@ -103,12 +105,22 @@ describe('deriveP2BSteps', () => {
     expect(currentP2BStep(stale).id).toBe('commission')
   })
 
+  it('sends a changed title or location back to the step holding the regenerate button', () => {
+    const retitled = inV3({
+      approval: { status: 'reconfirmation_required', reason: 'title_or_location_changed' }
+    })
+
+    expect(currentP2BStep(retitled).id).toBe('start')
+    expect(currentP2BStep(retitled).nextAction).toMatch(/Generate a new direction prompt/)
+  })
+
   it('stops on the review step when a direction card approved a commission for you', () => {
     // Clicking a card approves outright. That says a click happened, not that
     // a human read what got locked, so the step stays open until they say so.
     const approved = inV3({ approval: { status: 'approved', commission } })
 
     expect(currentP2BStep(approved).id).toBe('commission')
+    expect(currentP2BStep(approved).nextAction).toMatch(/Read the locked commission/)
     expect(deriveP2BSteps(approved)[2].state).toBe('current')
   })
 
@@ -119,6 +131,7 @@ describe('deriveP2BSteps', () => {
     })
 
     expect(currentP2BStep(reviewed).id).toBe('research')
+    expect(currentP2BStep(reviewed).nextAction).toMatch(/Copy the research prompt/)
     expect(deriveP2BSteps(reviewed)[2].summary).toBe(commission.primary_subject)
   })
 
@@ -172,6 +185,20 @@ describe('deriveP2BSteps', () => {
     expect(deriveP2BSteps(mismatched)[3].state).toBe('current')
   })
 
+  it('keeps research open when the attached package answers different questions', () => {
+    const mismatched = inV3({
+      approval: { status: 'approved', commission },
+      reviewedCommissionFingerprint: commission.commission_fingerprint,
+      evidencePackage: {
+        ...evidencePackage,
+        requirements: evidencePackage.requirements.slice(1)
+      }
+    })
+
+    expect(currentP2BStep(mismatched).id).toBe('research')
+    expect(currentP2BStep(mismatched).nextAction).toMatch(/exact questions/)
+  })
+
   it('never marks the writing step done, because a finished run is not composer state', () => {
     const ready = inV3({
       approval: { status: 'approved', commission },
@@ -185,11 +212,13 @@ describe('deriveP2BSteps', () => {
     )
   })
 
-  it('gives every step a name and a reason a non-technical operator can read', () => {
+  it('gives every step a name, reason, and next action a non-technical operator can read', () => {
     for (const step of deriveP2BSteps(state())) {
       expect(step.name.length).toBeGreaterThan(0)
       expect(step.purpose.length).toBeGreaterThan(0)
+      expect(step.nextAction.length).toBeGreaterThan(0)
       expect(step.name).not.toMatch(/_|fingerprint|schema|v3/i)
+      expect(step.nextAction).not.toMatch(/_|fingerprint|schema|v3/i)
     }
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/step-model.ts
@@ -1,4 +1,7 @@
 import type { P2BFormState } from './composer.types'
+import { compareEvidenceToCommission } from './evidence-match'
+import { P2B_NEXT_ACTION } from './step-guidance'
+import { prompt2BlogSubmissionBlockedReason } from './v3-payload'
 
 export const P2B_STEP_IDS = [
   'start',
@@ -21,6 +24,8 @@ export interface P2BStep {
   name: string
   /** Why the step exists, in one sentence. */
   purpose: string
+  /** What the operator should do here, in one sentence. */
+  nextAction: string
   state: P2BStepState
   /** A finished step's one-line recap, or null while it is not finished. */
   summary: string | null
@@ -30,6 +35,7 @@ interface StepDefinition {
   id: P2BStepId
   name: string
   purpose: string
+  nextAction: string
 }
 
 /**
@@ -44,30 +50,35 @@ const STEP_DEFINITIONS: readonly StepDefinition[] = [
   {
     id: 'start',
     name: 'Start the article',
-    purpose: 'Name what you are writing and where it is about.'
+    purpose: 'Name what you are writing and where it is about.',
+    nextAction: P2B_NEXT_ACTION.start
   },
   {
     id: 'direction',
     name: 'Pick a direction',
     purpose:
-      'Your chatbot proposes three ways to write it. You choose the one worth commissioning.'
+      'Your chatbot proposes three ways to write it. You choose the one worth commissioning.',
+    nextAction: P2B_NEXT_ACTION.direction
   },
   {
     id: 'commission',
     name: 'Review what you locked',
     purpose:
-      'Choosing a direction locked the commission. Check it now, because research can add facts to it but can never change it.'
+      'Choosing a direction locked the commission. Check it now, because research can add facts to it but can never change it.',
+    nextAction: P2B_NEXT_ACTION.commission
   },
   {
     id: 'research',
     name: 'Gather the facts',
     purpose:
-      'A second chatbot round trip brings back sourced evidence answering the commission’s questions.'
+      'A second chatbot round trip brings back sourced evidence answering the commission’s questions.',
+    nextAction: P2B_NEXT_ACTION.research
   },
   {
     id: 'write',
     name: 'Write it',
-    purpose: 'Set the tone and length, then run the pipeline.'
+    purpose: 'Set the tone and length, then run the pipeline.',
+    nextAction: P2B_NEXT_ACTION.write
   }
 ]
 
@@ -83,12 +94,9 @@ function directionWasChosen(state: P2BFormState): boolean {
 function researchIsAttached(state: P2BFormState): boolean {
   const { approval, evidencePackage } = state.editorial
   if (approval.status !== 'approved' || !evidencePackage) return false
-  // Research imported against a different commission is not this commission's
-  // research, however complete it looks.
-  return (
-    evidencePackage.commission_fingerprint ===
-    approval.commission.commission_fingerprint
-  )
+  // Research for a different commission or set of questions is not finished,
+  // however complete the package looks on its own.
+  return compareEvidenceToCommission(approval.commission, evidencePackage) === 'matches'
 }
 
 function commissionWasReviewed(state: P2BFormState): boolean {
@@ -145,11 +153,14 @@ function summarizeResearch(state: P2BFormState): string | null {
  */
 export function deriveP2BSteps(state: P2BFormState): P2BStep[] {
   const startedDirectionWork = state.activeWorkflow === 'editorial_v3'
+  const identityChanged =
+    state.editorial.approval.status === 'reconfirmation_required' &&
+    state.editorial.approval.reason === 'title_or_location_changed'
   const titleAndLocation =
     state.easySetupTitle.trim() !== '' && state.easySetupLocation.trim() !== ''
 
   const completion: Record<P2BStepId, boolean> = {
-    start: startedDirectionWork && titleAndLocation,
+    start: startedDirectionWork && titleAndLocation && !identityChanged,
     direction: startedDirectionWork && directionWasChosen(state),
     commission: commissionWasReviewed(state),
     research: researchIsAttached(state),
@@ -169,12 +180,18 @@ export function deriveP2BSteps(state: P2BFormState): P2BStep[] {
   const currentIndex = STEP_DEFINITIONS.findIndex(
     (definition) => !completion[definition.id]
   )
+  const blockedReason = prompt2BlogSubmissionBlockedReason(state)
 
   return STEP_DEFINITIONS.map((definition, index) => ({
     id: definition.id,
     number: index + 1,
     name: definition.name,
     purpose: definition.purpose,
+    // The run blocker knows the exact unfinished state. Use that sharper
+    // instruction on the current step; look-ahead steps keep their stable
+    // overview so they still make sense out of sequence.
+    nextAction:
+      index === currentIndex && blockedReason ? blockedReason : definition.nextAction,
     state:
       completion[definition.id] && index < currentIndex
         ? 'done'

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
@@ -3,7 +3,11 @@ import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-
 import type { Prompt2BlogCommission, Prompt2BlogEvidencePackage } from '../api'
 import { DEFAULT_COMPOSER_STATE } from './composer.storage'
 import type { P2BFormState } from './composer.types'
-import { buildPrompt2BlogV3Payload, v3SubmissionBlockedReason } from './v3-payload'
+import {
+  buildPrompt2BlogV3Payload,
+  prompt2BlogSubmissionBlockedReason,
+  v3SubmissionBlockedReason,
+} from './v3-payload'
 
 const commission = limaFixture.commission as unknown as Prompt2BlogCommission
 const evidencePackage = limaFixture.evidence_package as unknown as Prompt2BlogEvidencePackage
@@ -53,18 +57,31 @@ describe('v3SubmissionBlockedReason', () => {
         approvedState({ editorial: { ...approvedState().editorial, approval } }),
       )
 
-    expect(reasonFor({ status: 'not_started' })).toMatch(/approve a commission/)
+    expect(reasonFor({ status: 'not_started' })).toMatch(/Copy the direction prompt/)
     expect(reasonFor({ status: 'awaiting_selection' })).toMatch(/Choose one of the three/)
-    expect(reasonFor({ status: 'needs_approval' })).toMatch(/Approve the commission/)
+    expect(reasonFor({ status: 'needs_approval' })).toMatch(/approve it/)
     expect(reasonFor({ status: 'reconfirmation_required', reason: 'legacy_draft' })).toMatch(
-      /Reconfirm it/,
+      /approve it again/,
     )
     expect(reasonFor({ status: 'reconfirmation_required', reason: 'commission_edited' })).toMatch(
-      /Approve it again/,
+      /approve it again/,
     )
     expect(
       reasonFor({ status: 'reconfirmation_required', reason: 'title_or_location_changed' }),
-    ).toMatch(/Generate directions again/)
+    ).toMatch(/Generate a new direction prompt/)
+  })
+
+  it('keeps a card-approved commission stopped until the operator reviews it', () => {
+    expect(
+      v3SubmissionBlockedReason(
+        approvedState({
+          editorial: {
+            ...approvedState().editorial,
+            reviewedCommissionFingerprint: null,
+          },
+        }),
+      ),
+    ).toMatch(/Read the locked commission/)
   })
 
   it('blocks when no research is attached', () => {
@@ -72,7 +89,7 @@ describe('v3SubmissionBlockedReason', () => {
       v3SubmissionBlockedReason(
         approvedState({ editorial: { ...approvedState().editorial, evidencePackage: null } }),
       ),
-    ).toMatch(/Import the research package/)
+    ).toMatch(/Copy the research prompt/)
   })
 
   it('blocks research belonging to a different commission', () => {
@@ -85,7 +102,7 @@ describe('v3SubmissionBlockedReason', () => {
           },
         }),
       ),
-    ).toMatch(/different commission/)
+    ).toMatch(/Clear the attached research/)
   })
 
   it('blocks research that answers a different requirement set', () => {
@@ -101,14 +118,22 @@ describe('v3SubmissionBlockedReason', () => {
           },
         }),
       ),
-    ).toMatch(/exact requirements/)
+    ).toMatch(/exact questions/)
   })
 
   it('blocks a missing tone or length', () => {
-    expect(v3SubmissionBlockedReason(approvedState({ toneId: '' }))).toMatch(/Tone and length/)
-    expect(v3SubmissionBlockedReason(approvedState({ lengthId: '' }))).toMatch(/Tone and length/)
+    expect(v3SubmissionBlockedReason(approvedState({ toneId: '' }))).toMatch(/tone and length/)
+    expect(v3SubmissionBlockedReason(approvedState({ lengthId: '' }))).toMatch(/tone and length/)
   })
 
+})
+
+describe('prompt2BlogSubmissionBlockedReason', () => {
+  it('points an untouched page to the first step', () => {
+    expect(
+      prompt2BlogSubmissionBlockedReason({ ...approvedState(), activeWorkflow: 'legacy_v2' }),
+    ).toMatch(/Enter a working title and location/)
+  })
 })
 
 describe('buildPrompt2BlogV3Payload', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.ts
@@ -1,17 +1,24 @@
 import type { Prompt2BlogV3Request } from '../api'
 import type { P2BFormState } from './composer.types'
+import { compareEvidenceToCommission } from './evidence-match'
+import { P2B_NEXT_ACTION } from './step-guidance'
 
 const APPROVAL_BLOCKERS: Record<string, string> = {
-  not_started: 'Generate three directions and approve a commission before running.',
-  awaiting_selection: 'Choose one of the three directions before running.',
-  needs_approval: 'Approve the commission before running.',
+  not_started: P2B_NEXT_ACTION.direction,
+  awaiting_selection: P2B_NEXT_ACTION.chooseDirection,
+  needs_approval: P2B_NEXT_ACTION.changedCommission,
 }
 
 const RECONFIRMATION_BLOCKERS: Record<string, string> = {
-  legacy_draft: 'This saved draft predates the commission flow. Reconfirm it before running.',
-  commission_edited: 'The commission changed. Approve it again before running.',
-  title_or_location_changed:
-    'The title or location changed. Generate directions again before running.',
+  legacy_draft: P2B_NEXT_ACTION.savedCommission,
+  commission_edited: P2B_NEXT_ACTION.editedCommission,
+  title_or_location_changed: P2B_NEXT_ACTION.changedIdentity,
+}
+
+/** What must happen before the page can build a v3 run. */
+export function prompt2BlogSubmissionBlockedReason(state: P2BFormState): string | null {
+  if (state.activeWorkflow !== 'editorial_v3') return P2B_NEXT_ACTION.start
+  return v3SubmissionBlockedReason(state)
 }
 
 /**
@@ -33,27 +40,23 @@ export function v3SubmissionBlockedReason(state: P2BFormState): string | null {
   if (approval.status !== 'approved') {
     return APPROVAL_BLOCKERS[approval.status]
   }
+  if (
+    state.editorial.reviewedCommissionFingerprint !== approval.commission.commission_fingerprint
+  ) {
+    return P2B_NEXT_ACTION.commission
+  }
   if (!evidencePackage) {
-    return 'Import the research package for this commission before running.'
+    return P2B_NEXT_ACTION.research
   }
-  if (evidencePackage.commission_fingerprint !== approval.commission.commission_fingerprint) {
-    return 'The attached research belongs to a different commission.'
+  const evidenceMatch = compareEvidenceToCommission(approval.commission, evidencePackage)
+  if (evidenceMatch === 'different_commission') {
+    return P2B_NEXT_ACTION.mismatchedResearch
   }
-
-  const commissionRequirements = approval.commission.requirements.map(
-    requirement => requirement.requirement_id,
-  )
-  const evidenceRequirements = evidencePackage.requirements.map(
-    requirement => requirement.requirement_id,
-  )
-  const sameRequirements =
-    commissionRequirements.length === evidenceRequirements.length &&
-    commissionRequirements.every(requirementId => evidenceRequirements.includes(requirementId))
-  if (!sameRequirements) {
-    return 'The attached research does not answer this commission’s exact requirements.'
+  if (evidenceMatch === 'different_requirements') {
+    return P2B_NEXT_ACTION.incompleteResearch
   }
 
-  if (!state.toneId || !state.lengthId) return 'Tone and length are required.'
+  if (!state.toneId || !state.lengthId) return P2B_NEXT_ACTION.chooseProfiles
 
   return null
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -399,6 +399,10 @@ describe('Prompt2BlogPage', () => {
       }),
     ).toBeDisabled()
     expect(within(startStep!).queryByLabelText('Prompt')).not.toBeInTheDocument()
+    expect(
+      within(startStep!).getByText(/Enter a working title and location/),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeDisabled()
   })
 
   it('presents the numbered steps in order, with only the current one open', async () => {
@@ -435,12 +439,12 @@ describe('Prompt2BlogPage', () => {
 
     openStep(/Step 2: Pick a direction/)
 
-    expect(
-      screen
-        .getByRole('heading', { name: /Step 2: Pick a direction/ })
-        .closest('section')
-        ?.querySelector('.p2b-step-section-body'),
-    ).not.toHaveAttribute('hidden')
+    const directionStep = screen
+      .getByRole('heading', { name: /Step 2: Pick a direction/ })
+      .closest('section')
+
+    expect(directionStep?.querySelector('.p2b-step-section-body')).not.toHaveAttribute('hidden')
+    expect(within(directionStep!).queryByText(/Do this next/)).not.toBeInTheDocument()
   })
 
   it('puts the work first and the model machinery last', async () => {
@@ -675,7 +679,7 @@ describe('Prompt2BlogPage', () => {
     })
     expect(runButton).toBeDisabled()
     expect(screen.getByRole('status')).toHaveTextContent(
-      'Choose one of the three directions before running.',
+      'Choose one of the three directions.',
     )
     fireEvent.click(runButton)
     expect(startPrompt2BlogV3RunMock).not.toHaveBeenCalled()
@@ -727,7 +731,10 @@ describe('Prompt2BlogPage', () => {
 
     openStep(/Step 2: Pick a direction/)
     fireEvent.click(screen.getByRole('button', { name: 'Clear direction work' }))
-    expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Run Prompt2Blog Pipeline' })).toBeDisabled()
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Enter a working title and location, then generate the direction prompt.',
+    )
   })
 
   it('makes approval by direction card a stop the operator passes deliberately', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
@@ -234,6 +234,10 @@
   color: var(--ink);
 }
 
+.p2b-step-section-next-action strong {
+  color: var(--p2b-accent);
+}
+
 /* --- Step sections ---------------------------------------------------------
    One numbered step: what it is called, why it exists, and its work. The
    current step is open; finished and upcoming ones are closed but never
@@ -305,11 +309,16 @@
 }
 
 .p2b-step-section-purpose,
-.p2b-step-section-summary {
+.p2b-step-section-summary,
+.p2b-step-section-next-action {
   margin: 0;
   font-size: 0.875rem;
   line-height: 1.5;
   color: var(--ink);
+}
+
+.p2b-step-section-purpose,
+.p2b-step-section-summary {
   opacity: 0.8;
 }
 


### PR DESCRIPTION
## Why

Each open step explains why it exists, but it still leaves a new operator to infer the next action. The disabled run button also described why a run could not start instead of pointing back to the control that resolves it.

## What changed

- Adds one plain Do this next instruction to the current open step.
- Reuses one guidance catalog for step copy and run-button blockers.
- Keeps peek-ahead and reopened steps from falsely calling their work next.
- Disables the run button on a cold page and points to step 1.
- Keeps a card-approved commission stopped until its deliberate review is confirmed.
- Keeps stage position aligned when title/location changes or attached research answers the wrong question set.

## Running-page verification

Walked localhost against real Payload auth:

- Cold page opens step 1 with its purpose and Enter a working title and location next action.
- Run button is disabled and repeats the same action.
- Looking ahead into step 2 shows its purpose and preview body, but no false Do this next command.
- Generating a prompt opens step 2 with Copy the direction prompt.
- Importing valid directions changes it to Choose one of the three directions.
- Choosing one opens step 3 with Read the locked commission; run remains disabled.
- Confirming opens step 4 with Copy the research prompt; run remains disabled.

## Verification

- Focused Prompt2Blog tests: 53 passed
- Full frontend suite: 831 passed across 165 files before final review fixes
- TypeScript, boundaries, ESLint: clean
- Vite build: passed; pre-existing chunk warning only
- Backend pytest: passed
- Two-axis code review: clean after fixes
- CI: all 5 jobs green on final commit

## Scope

Phase 3 PR 6 only. No round-trip strip or plain-language research-result rewrite from PRs 7-8.