### PR TITLE
Prompt2Blog: teach the chatbot round trip

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ChatbotRoundTrip.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ChatbotRoundTrip.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ChatbotRoundTrip } from './ChatbotRoundTrip'
+
+describe('ChatbotRoundTrip', () => {
+  it('teaches the copy-out and paste-in sequence in order', () => {
+    render(<ChatbotRoundTrip />)
+
+    const steps = within(screen.getByRole('list', { name: 'Chatbot round trip' }))
+      .getAllByRole('listitem')
+      .map(item => item.textContent)
+
+    expect(steps).toEqual([
+      '1Copy prompt',
+      '2Paste into your chatbot',
+      '3Paste the answer here',
+    ])
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ChatbotRoundTrip.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ChatbotRoundTrip.tsx
@@ -1,0 +1,21 @@
+const ROUND_TRIP_STEPS = [
+  'Copy prompt',
+  'Paste into your chatbot',
+  'Paste the answer here',
+] as const
+
+/** The same copy-out / paste-in handoff taught in direction and research. */
+export function ChatbotRoundTrip() {
+  return (
+    <ol className="p2b-round-trip" aria-label="Chatbot round trip">
+      {ROUND_TRIP_STEPS.map((label, index) => (
+        <li key={label}>
+          <span className="p2b-round-trip-number" aria-hidden="true">
+            {index + 1}
+          </span>
+          <strong>{label}</strong>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -12,6 +12,7 @@ import { reviewDirectionResponseJson, type DirectionImportReview } from '../dire
 import { buildDirectionPrompt } from '../direction-prompt'
 import { useClipboardCopy } from '../hooks/useClipboardCopy'
 import { CommissionEditor } from './CommissionEditor'
+import { ChatbotRoundTrip } from './ChatbotRoundTrip'
 import { DirectionCards } from './DirectionCards'
 import { ResearchPanel } from './ResearchPanel'
 import { StepSection } from './StepSection'
@@ -185,6 +186,7 @@ export function EasySetupPanel({
       </StepSection>
 
       <StepSection step={stepFor('direction')}>
+        <ChatbotRoundTrip />
         {prompt === null && !showDirectionStep && (
           <p className="p2b-field-hint">
             Finish step 1 and your direction prompt appears here.
@@ -330,6 +332,7 @@ export function EasySetupPanel({
       </StepSection>
 
       <StepSection step={stepFor('research')}>
+        <ChatbotRoundTrip />
         {editorialOptions && editorial.approval.status === 'approved' ? (
           <ResearchPanel
             commission={editorial.approval.commission}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -432,6 +432,27 @@ describe('Prompt2BlogPage', () => {
     expect(directionBody).toHaveAttribute('hidden')
   })
 
+  it('teaches the same chatbot round trip in direction and research', async () => {
+    renderPage()
+
+    const directionStep = screen
+      .getByRole('heading', { name: /Step 2: Pick a direction/ })
+      .closest('section')
+    const researchStep = screen
+      .getByRole('heading', { name: /Step 4: Gather the facts/ })
+      .closest('section')
+
+    for (const step of [directionStep, researchStep]) {
+      const roundTrip = within(step!).getByRole('list', {
+        name: 'Chatbot round trip',
+        hidden: true,
+      })
+      expect(within(roundTrip).getByText('Copy prompt')).toBeInTheDocument()
+      expect(within(roundTrip).getByText('Paste into your chatbot')).toBeInTheDocument()
+      expect(within(roundTrip).getByText('Paste the answer here')).toBeInTheDocument()
+    }
+  })
+
   it('lets an operator look ahead into a step they have not reached', async () => {
     // Locking a step nobody has reached punishes curiosity for no safety gain:
     // the controls inside already refuse work that is not ready.

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
@@ -351,3 +351,59 @@
 .p2b-step-section-body[hidden] {
   display: none;
 }
+
+/* One repeated transfer slip teaches both chatbot round trips. Numbering and
+   arrows describe real movement out of the app and back, not decoration. */
+.p2b-round-trip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  background: var(--surface, white);
+  list-style: none;
+}
+
+.p2b-round-trip li {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-3) var(--space-4);
+  color: var(--ink);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.p2b-round-trip li + li {
+  border-left: 1px solid var(--border);
+}
+
+.p2b-round-trip li:not(:last-child)::after {
+  content: '→';
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  right: -0.7rem;
+  width: 1.4rem;
+  background: var(--surface, white);
+  color: var(--p2b-accent);
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: center;
+  transform: translateY(-50%);
+}
+
+.p2b-round-trip-number {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 1px solid var(--p2b-accent);
+  border-radius: 50%;
+  color: var(--p2b-accent-hover);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: calc(1.5rem - 2px);
+  text-align: center;
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/responsive.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/responsive.css
@@ -52,6 +52,23 @@
     justify-self: start;
   }
 
+  .p2b-round-trip {
+    grid-template-columns: 1fr;
+  }
+
+  .p2b-round-trip li + li {
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+
+  .p2b-round-trip li:not(:last-child)::after {
+    content: '↓';
+    top: auto;
+    right: 50%;
+    bottom: -0.7rem;
+    transform: translateX(50%);
+  }
+
   .p2b-input,
   .p2b-textarea,
   .p2b-select {


### PR DESCRIPTION
## Why

Steps 2 and 4 both leave the app and return, but neither presented that as an expected workflow. A first-time operator met a large prompt and JSON box with no shared mental model, so the handoff could read like an error.

## What changed

One shared transfer strip appears in both steps:

1. Copy prompt
2. Paste into your chatbot
3. Paste the answer here

The same zero-prop component and styles teach it once. Desktop uses three joined stations; mobile stacks them with downward arrows. Existing Prompt2Blog blue, ink, border, and surface tokens remain unchanged.

## Running-page verification

- Step 4 showed the strip immediately above its research prompt.
- The same component exists in step 2, including peek-ahead.
- Desktop rendered one horizontal three-station transfer.
- 390px viewport rendered one vertical sequence with downward arrows.
- Viewport override was reset after checking.

## Verification

- Focused tests: 21 passed
- Full frontend suite: 836 passed across 166 files
- TypeScript, boundaries, ESLint: clean
- Vite build: passed; pre-existing chunk warning only
- Backend pytest: passed
- Two-axis review: clean after CSS fallback fix

## Scope

Phase 3 PR 7 only. No workflow/state changes and no PR 8 terminology rewrite.