### PR TITLE
feat(prompt2blog): say the gate in words an operator knows

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PlainResearchFindings.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PlainResearchFindings.tsx
@@ -7,7 +7,7 @@ import {
 
 type PlainResearchFinding = {
   code: ResearchFindingCode
-  requirement_ids: string[]
+  requirement_ids: readonly string[]
   message: string
 }
 
@@ -16,25 +16,55 @@ interface PlainResearchFindingsProps {
   questions: readonly ResearchQuestion[]
 }
 
+/**
+ * The two backend messages that are pure ids are dropped: the source-gate
+ * message names the form id and the gate id, and the requirement-gap fallback
+ * repeats an id the question label already says in words.
+ */
+function plainFindingLine(
+  finding: PlainResearchFinding,
+  questions: readonly ResearchQuestion[],
+): { label: string; detail: string } {
+  const parts: string[] = []
+  if (finding.requirement_ids.length > 0) {
+    parts.push(
+      finding.requirement_ids
+        .map(requirementId => researchQuestionLabel(requirementId, questions))
+        .join('; '),
+    )
+  }
+  const messageIsAnId =
+    finding.code === 'source_gate' ||
+    /^Requirement r\d+ is incomplete\.$/i.test(finding.message)
+  if (!messageIsAnId) parts.push(finding.message)
+  return {
+    label: researchFindingLabel(finding.code),
+    detail: parts.map(part => ` — ${part}`).join(''),
+  }
+}
+
 /** Gate findings in words an operator can act on, without backend ids. */
 export function PlainResearchFindings({ findings, questions }: PlainResearchFindingsProps) {
+  // Two source-gate findings differ only by the gate id we deliberately hide,
+  // so without this they read as the same sentence printed twice.
+  const lines = findings.map(finding => plainFindingLine(finding, questions))
+  const seen = new Set<string>()
+
   return (
     <ul className="p2b-import-list">
-      {findings.map(finding => {
-        const showMessage =
-          finding.code !== 'source_gate' &&
-          !/^Requirement r\d+ is incomplete\.$/i.test(finding.message)
-        const questionLabels = finding.requirement_ids.map(requirementId =>
-          researchQuestionLabel(requirementId, questions),
-        )
-        return (
-          <li key={`${finding.code}-${finding.message}`}>
-            <strong>{researchFindingLabel(finding.code)}</strong>
-            {questionLabels.length > 0 && ` — ${questionLabels.join('; ')}`}
-            {showMessage && ` — ${finding.message}`}
+      {lines
+        .filter(line => {
+          const key = `${line.label}${line.detail}`
+          if (seen.has(key)) return false
+          seen.add(key)
+          return true
+        })
+        .map(line => (
+          <li key={`${line.label}${line.detail}`}>
+            <strong>{line.label}</strong>
+            {line.detail}
           </li>
-        )
-      })}
+        ))}
     </ul>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PlainResearchFindings.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PlainResearchFindings.tsx
@@ -1,0 +1,40 @@
+import {
+  researchFindingLabel,
+  researchQuestionLabel,
+  type ResearchFindingCode,
+  type ResearchQuestion,
+} from '../research-language'
+
+type PlainResearchFinding = {
+  code: ResearchFindingCode
+  requirement_ids: string[]
+  message: string
+}
+
+interface PlainResearchFindingsProps {
+  findings: readonly PlainResearchFinding[]
+  questions: readonly ResearchQuestion[]
+}
+
+/** Gate findings in words an operator can act on, without backend ids. */
+export function PlainResearchFindings({ findings, questions }: PlainResearchFindingsProps) {
+  return (
+    <ul className="p2b-import-list">
+      {findings.map(finding => {
+        const showMessage =
+          finding.code !== 'source_gate' &&
+          !/^Requirement r\d+ is incomplete\.$/i.test(finding.message)
+        const questionLabels = finding.requirement_ids.map(requirementId =>
+          researchQuestionLabel(requirementId, questions),
+        )
+        return (
+          <li key={`${finding.code}-${finding.message}`}>
+            <strong>{researchFindingLabel(finding.code)}</strong>
+            {questionLabels.length > 0 && ` — ${questionLabels.join('; ')}`}
+            {showMessage && ` — ${finding.message}`}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
@@ -12,6 +12,13 @@ import {
 import { buildFollowUpResearchPrompt } from '../follow-up-research-prompt'
 import { buildResearchPrompt } from '../research-prompt'
 import { useClipboardCopy } from '../hooks/useClipboardCopy'
+import {
+  plainEvidenceIssue,
+  researchNotReadyMessage,
+  researchQuestionLabel,
+  researchStatusLabel,
+} from '../research-language'
+import { PlainResearchFindings } from './PlainResearchFindings'
 
 interface ResearchPanelProps {
   commission: Prompt2BlogCommission
@@ -19,12 +26,6 @@ interface ResearchPanelProps {
   evidencePackage: Prompt2BlogEvidencePackage | null
   onClearEvidence: () => void
   onStoreEvidence: (evidencePackage: Prompt2BlogEvidencePackage) => void
-}
-
-const STATUS_LABELS: Record<string, string> = {
-  supported: 'Supported',
-  partial: 'Partial',
-  missing: 'Missing',
 }
 
 export function ResearchPanel({
@@ -75,6 +76,10 @@ export function ResearchPanel({
         : null,
     [commission, editorialOptions, evidencePackage, findings],
   )
+
+  const unansweredQuestionCount =
+    evidencePackage?.requirements.filter(requirement => requirement.status !== 'supported').length
+    ?? 0
 
   const handleEvidenceJsonChange = (value: string) => {
     setEvidenceJson(value)
@@ -177,11 +182,15 @@ export function ResearchPanel({
             Evidence JSON is blocked — nothing was attached.
           </p>
           <ul className="p2b-import-list">
-            {review.issues.map(issue => (
-              <li key={`${issue.path}-${issue.message}`}>
-                <code>{issue.path}</code> {issue.message}
-              </li>
-            ))}
+            {review.issues.map(issue => {
+              const plainIssue = plainEvidenceIssue(issue.path, issue.message)
+              return (
+                <li key={`${issue.path}-${issue.message}`}>
+                  {plainIssue.label && <code>{plainIssue.label}</code>}{' '}
+                  {plainIssue.message}
+                </li>
+              )
+            })}
           </ul>
         </div>
       )}
@@ -203,8 +212,10 @@ export function ResearchPanel({
           <ul className="p2b-requirement-list">
             {evidencePackage.requirements.map(requirement => (
               <li key={requirement.requirement_id} className="p2b-requirement-row">
-                <code>{requirement.requirement_id}</code>{' '}
-                {STATUS_LABELS[requirement.status] ?? requirement.status}
+                <strong>
+                  {researchQuestionLabel(requirement.requirement_id, commission.requirements)}
+                </strong>{' '}
+                {researchStatusLabel(requirement.status)}
                 {requirement.gap ? ` — ${requirement.gap}` : ''}
               </li>
             ))}
@@ -212,20 +223,14 @@ export function ResearchPanel({
           {findings.length > 0 ? (
             <>
               <p className="p2b-import-report-title">
-                {findings.length} readiness {findings.length === 1 ? 'gap' : 'gaps'} remain. The
-                run stays blocked until research closes them.
+                {researchNotReadyMessage(unansweredQuestionCount)}
               </p>
-              <ul className="p2b-import-list">
-                {findings.map(finding => (
-                  <li key={`${finding.code}-${finding.message}`}>
-                    <code>{finding.code}</code> {finding.message}
-                  </li>
-                ))}
-              </ul>
+              <PlainResearchFindings findings={findings} questions={commission.requirements} />
             </>
           ) : (
             <p className="p2b-field-hint">
-              Every locked requirement is supported and no conflict or source gate is open.
+              Every question is answered, and the evidence has no unresolved disagreement or
+              missing first-hand source.
             </p>
           )}
           {followUpPrompt !== null && (

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/plain-research-findings.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/plain-research-findings.test.tsx
@@ -1,0 +1,65 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PlainResearchFindings } from './PlainResearchFindings'
+
+afterEach(cleanup)
+
+const questions = [
+  { requirement_id: 'r1', question: 'What do current costs show?' },
+  { requirement_id: 'r2', question: 'Which tradeoffs change the value judgment?' },
+]
+
+describe('PlainResearchFindings', () => {
+  it('reads one source-gate line, not the same sentence twice', () => {
+    render(
+      <PlainResearchFindings
+        findings={[
+          {
+            code: 'source_gate',
+            requirement_ids: [],
+            message: 'The city-guide form still needs attributable-responses.',
+          },
+          {
+            code: 'source_gate',
+            requirement_ids: [],
+            message: 'The city-guide form still needs on-the-ground-observation.',
+          },
+        ]}
+        questions={questions}
+      />
+    )
+
+    expect(
+      screen.getAllByText('This kind of article needs a first-hand source')
+    ).toHaveLength(1)
+    expect(screen.queryByText(/attributable-responses/)).toBeNull()
+  })
+
+  it('drops the id-only gap message but keeps a real one', () => {
+    render(
+      <PlainResearchFindings
+        findings={[
+          {
+            code: 'requirement_gap',
+            requirement_ids: ['r1'],
+            message: 'Requirement r1 is incomplete.',
+          },
+          {
+            code: 'requirement_gap',
+            requirement_ids: ['r2'],
+            message: 'No evidence covers the livability tradeoffs.',
+          },
+        ]}
+        questions={questions}
+      />
+    )
+
+    expect(screen.getByText(/Question 1: What do current costs show\?$/)).toBeInTheDocument()
+    expect(screen.queryByText(/Requirement r1 is incomplete/)).toBeNull()
+    expect(
+      screen.getByText(/No evidence covers the livability tradeoffs\./)
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
@@ -166,6 +166,10 @@ describe('ResearchPanel', () => {
     pasteEvidence(evidence({ commission_fingerprint: 'a'.repeat(64) }))
 
     expect(screen.getByText(/nothing was attached/i)).toBeInTheDocument()
+    expect(
+      screen.getByText('This research belongs to a different commission.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('commission_fingerprint')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Attach research' })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Attach research' }))
@@ -200,7 +204,14 @@ describe('ResearchPanel', () => {
       })
     )
 
-    expect(screen.getByText(/1 readiness gap remain/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Not ready yet — 1 question still needs an answer. Nothing ran and nothing was charged.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getAllByText(/Question 1: What do current costs show\?/).length).toBeGreaterThan(0)
+    expect(screen.getByText('Still unanswered')).toBeInTheDocument()
+    expect(screen.queryByText('requirement_gap')).not.toBeInTheDocument()
     // The gap reads more than once on purpose: as the requirement's status, as
     // the finding that blocks the run, and inside the follow-up prompt.
     expect(
@@ -215,9 +226,7 @@ describe('ResearchPanel', () => {
   it('hides the follow-up prompt once research is ready', () => {
     renderPanel(evidence())
 
-    expect(
-      screen.getByText(/Every locked requirement is supported/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Every question is answered/i)).toBeInTheDocument()
     expect(
       screen.queryByLabelText('Follow-up research prompt')
     ).not.toBeInTheDocument()

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.test.ts
@@ -24,6 +24,10 @@ describe('research language', () => {
     )
   })
 
+  it('still names a finding code it has never seen', () => {
+    expect(researchFindingLabel('some_future_gate')).toBe('Still needs attention')
+  })
+
   it('keeps a half-answered question distinct from an unanswered one', () => {
     expect(researchStatusLabel('supported')).toBe('Answered')
     expect(researchStatusLabel('partial')).toBe('Partly answered')

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  plainEvidenceIssue,
+  researchFindingLabel,
+  researchNotReadyMessage,
+  researchQuestionLabel,
+  researchStatusLabel,
+} from './research-language'
+
+describe('research language', () => {
+  it('turns requirement ids into the actual numbered question', () => {
+    expect(
+      researchQuestionLabel('r2', [
+        { requirement_id: 'r2', question: 'Which tradeoffs change the value judgment?' },
+      ])
+    ).toBe('Question 2: Which tradeoffs change the value judgment?')
+  })
+
+  it('names gate findings without backend codes', () => {
+    expect(researchFindingLabel('requirement_gap')).toBe('Still unanswered')
+    expect(researchFindingLabel('unresolved_conflict')).toBe('Two sources disagree')
+    expect(researchFindingLabel('source_gate')).toBe(
+      'This kind of article needs a first-hand source'
+    )
+  })
+
+  it('keeps a half-answered question distinct from an unanswered one', () => {
+    expect(researchStatusLabel('supported')).toBe('Answered')
+    expect(researchStatusLabel('partial')).toBe('Partly answered')
+    expect(researchStatusLabel('missing')).toBe('Still unanswered')
+  })
+
+  it('states that an incomplete run spent nothing', () => {
+    expect(researchNotReadyMessage(2)).toBe(
+      'Not ready yet — 2 questions still need answers. Nothing ran and nothing was charged.'
+    )
+  })
+
+  it('hides the internal fingerprint field name', () => {
+    expect(plainEvidenceIssue('commission_fingerprint', 'Must match.')).toEqual({
+      label: null,
+      message: 'This research belongs to a different commission.',
+    })
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.ts
@@ -14,8 +14,12 @@ const FINDING_LABELS: Record<ResearchFindingCode, string> = {
   source_gate: 'This kind of article needs a first-hand source',
 }
 
-export function researchFindingLabel(code: ResearchFindingCode): string {
-  return FINDING_LABELS[code]
+/**
+ * Falls back rather than rendering an empty label: a finding code this build
+ * has never heard of still has to say that it stopped the run.
+ */
+export function researchFindingLabel(code: string): string {
+  return FINDING_LABELS[code as ResearchFindingCode] ?? 'Still needs attention'
 }
 
 const STATUS_LABELS: Record<string, string> = {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.ts
@@ -1,0 +1,70 @@
+export type ResearchFindingCode =
+  | 'requirement_gap'
+  | 'unresolved_conflict'
+  | 'source_gate'
+
+export type ResearchQuestion = {
+  requirement_id: string
+  question: string
+}
+
+const FINDING_LABELS: Record<ResearchFindingCode, string> = {
+  requirement_gap: 'Still unanswered',
+  unresolved_conflict: 'Two sources disagree',
+  source_gate: 'This kind of article needs a first-hand source',
+}
+
+export function researchFindingLabel(code: ResearchFindingCode): string {
+  return FINDING_LABELS[code]
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  supported: 'Answered',
+  partial: 'Partly answered',
+  missing: 'Still unanswered',
+}
+
+/**
+ * `partial` and `missing` both block the run, but they are different jobs for
+ * the operator — one answer needs finishing, the other needs starting — so
+ * they keep different words.
+ */
+export function researchStatusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status
+}
+
+export function researchQuestionLabel(
+  requirementId: string,
+  questions: readonly ResearchQuestion[]
+): string {
+  const question = questions.find(item => item.requirement_id === requirementId)?.question
+  const number = /^r(\d+)$/i.exec(requirementId)?.[1]
+
+  if (number && question) return `Question ${number}: ${question}`
+  if (question) return `Question: ${question}`
+  if (number) return `Question ${number}`
+  return 'Article question'
+}
+
+export function researchNotReadyMessage(questionCount: number): string {
+  if (questionCount === 1) {
+    return 'Not ready yet — 1 question still needs an answer. Nothing ran and nothing was charged.'
+  }
+  if (questionCount > 1) {
+    return `Not ready yet — ${questionCount} questions still need answers. Nothing ran and nothing was charged.`
+  }
+  return 'Not ready yet — the research still needs attention. Nothing ran and nothing was charged.'
+}
+
+export function plainEvidenceIssue(path: string, message: string): {
+  label: string | null
+  message: string
+} {
+  if (path.split('.').includes('commission_fingerprint')) {
+    return {
+      label: null,
+      message: 'This research belongs to a different commission.',
+    }
+  }
+  return { label: path, message }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/NeedsResearchResult.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/NeedsResearchResult.tsx
@@ -1,16 +1,12 @@
 import type { Prompt2BlogV3NeedsResearchResponse } from '../../api'
+import { PlainResearchFindings } from '../../composer/components/PlainResearchFindings'
 import { useClipboardCopy } from '../../composer/hooks/useClipboardCopy'
+import { researchNotReadyMessage, researchQuestionLabel } from '../../composer/research-language'
 
 interface NeedsResearchResultProps {
   result: Prompt2BlogV3NeedsResearchResponse
   onBackToResearch: () => void
   onDismiss: () => void
-}
-
-const FINDING_LABELS: Record<string, string> = {
-  requirement_gap: 'Requirement gap',
-  unresolved_conflict: 'Unresolved conflict',
-  source_gate: 'Source gate',
 }
 
 /**
@@ -32,26 +28,26 @@ export function NeedsResearchResult({
   return (
     <div className="p2b-import-report p2b-import-report--blocked" role="status">
       <p className="p2b-import-report-title">
-        The run did not start: this commission’s research is incomplete. Nothing was queued and
-        no article was written.
+        {researchNotReadyMessage(result.unresolved_requirements.length)}
       </p>
 
-      <ul className="p2b-import-list">
-        {result.findings.map(finding => (
-          <li key={`${finding.code}-${finding.message}`}>
-            <code>{FINDING_LABELS[finding.code] ?? finding.code}</code> {finding.message}
-            {finding.requirement_ids.length > 0 && ` (${finding.requirement_ids.join(', ')})`}
-          </li>
-        ))}
-      </ul>
+      <PlainResearchFindings
+        findings={result.findings}
+        questions={result.unresolved_requirements}
+      />
 
       {result.unresolved_requirements.length > 0 && (
         <>
-          <p className="p2b-import-report-title">Requirements still open</p>
+          <p className="p2b-import-report-title">Questions still open</p>
           <ul className="p2b-requirement-list">
             {result.unresolved_requirements.map(requirement => (
               <li key={requirement.requirement_id} className="p2b-requirement-row">
-                <code>{requirement.requirement_id}</code> {requirement.question}
+                <strong>
+                  {researchQuestionLabel(
+                    requirement.requirement_id,
+                    result.unresolved_requirements
+                  )}
+                </strong>
                 {requirement.gap ? ` — ${requirement.gap}` : ''}
               </li>
             ))}
@@ -61,14 +57,14 @@ export function NeedsResearchResult({
 
       {result.unresolved_conflict_ids.length > 0 && (
         <p className="p2b-field-hint">
-          Unresolved conflicts: {result.unresolved_conflict_ids.join(', ')}
+          Two sources disagree. The follow-up prompt asks your chatbot to resolve them.
         </p>
       )}
 
       {result.missing_source_requirements.length > 0 && (
         <p className="p2b-field-hint">
-          This article form still needs {result.missing_source_requirements.join(', ')}. Meet it
-          with genuine matching material — never a simulated interview, scene, or quotation.
+          This kind of article needs a first-hand source. Add genuine matching material — never a
+          simulated interview, scene, or quotation.
         </p>
       )}
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/needs-research-result.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/needs-research-result.test.tsx
@@ -1,8 +1,11 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Prompt2BlogV3NeedsResearchResponse } from '../../api'
 import { NeedsResearchResult } from './NeedsResearchResult'
+
+afterEach(cleanup)
 
 const result: Prompt2BlogV3NeedsResearchResponse = {
   status: 'needs_research',
@@ -32,12 +35,14 @@ const result: Prompt2BlogV3NeedsResearchResponse = {
 }
 
 describe('NeedsResearchResult', () => {
-  it('states plainly that nothing was queued and no article was written', () => {
+  it('states plainly that nothing ran or was charged', () => {
     render(
       <NeedsResearchResult result={result} onBackToResearch={() => {}} onDismiss={() => {}} />,
     )
 
-    expect(screen.getByRole('status').textContent).toMatch(/Nothing was queued/)
+    expect(screen.getByText(
+      'Not ready yet — 1 question still needs an answer. Nothing ran and nothing was charged.',
+    )).toBeInTheDocument()
   })
 
   it('lists every reason the gate stopped the run', () => {
@@ -46,9 +51,17 @@ describe('NeedsResearchResult', () => {
     )
 
     expect(screen.getByText(/No evidence covers the livability tradeoffs/)).toBeTruthy()
-    expect(screen.getAllByText(/attributable-responses/).length).toBeGreaterThan(0)
-    expect(screen.getByText(/Which quality-of-life tradeoffs/)).toBeTruthy()
-    expect(screen.getByText(/Unresolved conflicts: k1/)).toBeTruthy()
+    expect(screen.getByText('Still unanswered')).toBeTruthy()
+    expect(
+      screen.getAllByText(/Question 2: Which quality-of-life tradeoffs change the value judgment\?/)
+        .length,
+    ).toBeGreaterThan(0)
+    expect(screen.getAllByText(/This kind of article needs a first-hand source/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/Two sources disagree/)).toBeTruthy()
+    expect(screen.queryByText(/attributable-responses/)).toBeNull()
+    expect(screen.queryByText(/Unresolved conflicts: k1/)).toBeNull()
+    expect(screen.queryByText('requirement_gap')).toBeNull()
+    expect(screen.queryByText('source_gate')).toBeNull()
   })
 
   it('offers the follow-up prompt and a route back into research', () => {


### PR DESCRIPTION
Phase 3, PR 8 of the Prompt2Blog UX plan — the last PR before the coworker gate.

## Why

The research gate spoke its own field names out loud. An operator who has never
read the schema saw `r2`, `requirement_gap`, `source_gate`,
`commission_fingerprint`, and this sentence:

> N readiness gaps remain. The run stays blocked until research closes them.

The owner named that sentence specifically: a non-technical operator reads
"blocked" as "I broke it". Nothing on screen said the opposite — that the gate
is the normal path, that the run never started, and that nothing was charged.

## What changed

- **New `composer/research-language.ts`** — one pure module holding every one of
  these strings, so the composer panel and the run result cannot drift apart.
  Unit-tested on its own.
- **`r2` → "Question 2: <the requirement's actual question>"**, looked up from
  the commission's own requirements. Falls back gracefully when the id is not in
  the list.
- **Finding codes get words**: `requirement_gap` → "Still unanswered",
  `unresolved_conflict` → "Two sources disagree", `source_gate` → "This kind of
  article needs a first-hand source".
- **`commission_fingerprint` is never shown.** A package pasted from a different
  commission now says "This research belongs to a different commission."
- **The blocked line says what happened and what it cost**: "Not ready yet — 1
  question still needs an answer. Nothing ran and nothing was charged."
- **`partial` and `missing` stay apart** — "Partly answered" vs "Still
  unanswered". Same verdict from the gate, different job for the operator.
- **`PlainResearchFindings`** renders findings for both surfaces and suppresses
  the two backend messages that are pure ids: the source-gate message
  (`The <form_id> form still needs <gate_id>.`) and the
  `Requirement rN is incomplete.` fallback, which the question label already
  says better. Real gap text from research is always shown.

Wording only. No gate logic, no payload shape, no backend change.

## Deliberately not in this PR

- **`CommissionEditor` still shows `requirement_id` as an editable field.** It is
  a real identifier the operator can set there, not a leak into a report. Out of
  the plan's scope for PR 8 (`ResearchPanel` and `NeedsResearchResult`).
- **"Evidence JSON is blocked — nothing was attached."** and the raw field paths
  on other validation issues stay. Only the fingerprint path was named in the
  plan, and those paths are actionable when you are staring at pasted JSON.
- The **run button being enabled on a cold page** (named in #411) is still open.

## Found in review of this PR, fixed in the second commit

- **An unknown finding code rendered an empty label.** The lookup lost the old
  `?? finding.code` fallback. It now reads "Still needs attention", so a code
  this build has never seen still says that it stopped the run.
- **Two source-gate findings printed the same sentence twice.** They differ only
  by the gate id this PR deliberately hides, so a form with two unmet source
  requirements read as one duplicated line. Identical lines are collapsed.

## Verification

Dev servers stopped, per the flakiness noted in the handoff.

```
vitest (full)  844 passing / 168 files
tsc --noEmit   clean
eslint         clean (features/prompt2blog, --max-warnings=0)
vite build     passes (pre-existing chunk-size warning only)
```

No Python touched, so pytest was not run locally; CI covers it.

**Not yet live-checked.** Verifying this needs the app up and a human login.