### PR TITLE
feat(prompt2blog): say what this pipeline is good at, before it costs anything

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ArticleFitGuide.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ArticleFitGuide.tsx
@@ -123,20 +123,25 @@ export function ArticleFitGuide() {
               </div>
 
               <section>
-                <h4>You can still have a point of view</h4>
+                <h4>One thing per question</h4>
                 <p>
-                  The article can argue that Lima is worth it. Just make the questions you send to
-                  research ones somebody could look up — the judgment goes on top of the facts,
-                  not instead of them.
+                  "What housing, food, and transport cost" is three questions wearing one coat. If
+                  research finds two of them, the whole question comes back{' '}
+                  <strong>Partly answered</strong> and you pay for another round to close the
+                  third. Ask one thing at a time.
                 </p>
               </section>
 
               <section>
                 <h4>Why it matters</h4>
                 <p>
-                  Every question that comes back unanswered sends you to your chatbot for another
-                  round, and each round is a long prompt. Two sharp questions beat five loose
-                  ones. You can add or remove questions in step 3, before any research happens.
+                  Every question that comes back unanswered or partly answered sends you to your
+                  chatbot for another round, and each round is a long prompt. Two sharp questions
+                  beat five loose ones.
+                </p>
+                <p>
+                  Trim them in step 3, <strong>before</strong> you research. Once research is
+                  attached, changing the commission drops it and the research starts over.
                 </p>
               </section>
             </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ArticleFitGuide.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ArticleFitGuide.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const WORKS_WELL = [
+  'What a month in Lima costs',
+  'How to get from the airport into the city',
+  'What changed at the new terminal this year',
+]
+
+const TAKES_MORE_ROUNDS = [
+  'Is Lima worth it?',
+  'The best neighborhood in Lima',
+  'Why Lima beats Medellín',
+]
+
+/**
+ * What this pipeline is good at, before the operator has spent anything.
+ *
+ * A fact-gathering pipeline refuses to write until its research questions have
+ * answers, so an idea whose central question is a matter of taste costs several
+ * chatbot round trips and can still end unanswered. That is expensive to learn
+ * by doing. It sits behind a control rather than in the step body because it is
+ * read once and then known.
+ */
+export function ArticleFitGuide() {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  // Every close returns focus to the control that opened it, Escape included:
+  // the element focus was sitting on is the one being unmounted, so without
+  // this a keyboard operator is dropped back to the top of the document.
+  const close = useCallback(() => {
+    setOpen(false)
+    triggerRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    closeRef.current?.focus()
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [close, open])
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="p2b-guide-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+      >
+        <span className="p2b-guide-trigger-mark" aria-hidden="true">
+          i
+        </span>
+        What kind of article works here?
+      </button>
+
+      {open && createPortal(
+        <div
+          className="p2b-modal-overlay"
+          onClick={event => event.target === event.currentTarget && close()}
+        >
+          <div
+            className="p2b-modal p2b-modal--guide"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="p2b-article-fit-heading"
+          >
+            <div className="p2b-modal__header">
+              <div>
+                <p className="p2b-modal__eyebrow">Before you start</p>
+                <h3 id="p2b-article-fit-heading">What kind of article works here</h3>
+                <p className="p2b-modal__lede">
+                  This pipeline gathers facts. It will not write anything until its research
+                  questions have answers, so the idea you pick decides how much work it takes.
+                </p>
+              </div>
+              <button
+                ref={closeRef}
+                type="button"
+                className="p2b-modal__close"
+                onClick={close}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <div className="p2b-modal__body p2b-guide-body">
+              <section>
+                <h4>The test</h4>
+                <p className="p2b-guide-test">
+                  Could two people look it up and get the same answer?
+                </p>
+                <p>
+                  If yes, it is a good research question. If it depends on how you feel about it,
+                  research comes back empty and you go another round with your chatbot.
+                </p>
+              </section>
+
+              <div className="p2b-guide-columns">
+                <section>
+                  <h4>Finishes fast</h4>
+                  <ul>
+                    {WORKS_WELL.map(example => (
+                      <li key={example}>{example}</li>
+                    ))}
+                  </ul>
+                </section>
+                <section>
+                  <h4>Takes more rounds</h4>
+                  <ul>
+                    {TAKES_MORE_ROUNDS.map(example => (
+                      <li key={example}>{example}</li>
+                    ))}
+                  </ul>
+                </section>
+              </div>
+
+              <section>
+                <h4>You can still have a point of view</h4>
+                <p>
+                  The article can argue that Lima is worth it. Just make the questions you send to
+                  research ones somebody could look up — the judgment goes on top of the facts,
+                  not instead of them.
+                </p>
+              </section>
+
+              <section>
+                <h4>Why it matters</h4>
+                <p>
+                  Every question that comes back unanswered sends you to your chatbot for another
+                  round, and each round is a long prompt. Two sharp questions beat five loose
+                  ones. You can add or remove questions in step 3, before any research happens.
+                </p>
+              </section>
+            </div>
+          </div>
+        </div>,
+        // Step 1 collapses by setting `hidden` on its body, and a fixed overlay
+        // rendered inside that subtree disappears with it. The dialog belongs to
+        // the page, not to the step that opened it.
+        document.body,
+      )}
+    </>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/EasySetupPanel.tsx
@@ -11,6 +11,7 @@ import type { P2BStep, P2BStepId } from '../step-model'
 import { reviewDirectionResponseJson, type DirectionImportReview } from '../direction-import'
 import { buildDirectionPrompt } from '../direction-prompt'
 import { useClipboardCopy } from '../hooks/useClipboardCopy'
+import { ArticleFitGuide } from './ArticleFitGuide'
 import { CommissionEditor } from './CommissionEditor'
 import { ChatbotRoundTrip } from './ChatbotRoundTrip'
 import { DirectionCards } from './DirectionCards'
@@ -135,6 +136,7 @@ export function EasySetupPanel({
   return (
     <>
       <StepSection step={stepFor('start')}>
+        <ArticleFitGuide />
         <div className="p2b-field-row p2b-field-row--2">
           <div className="p2b-field">
             <label htmlFor="p2b-easy-setup-title">Title</label>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/article-fit-guide.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/article-fit-guide.test.tsx
@@ -1,0 +1,70 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ArticleFitGuide } from './ArticleFitGuide'
+
+afterEach(cleanup)
+
+const openGuide = () =>
+  fireEvent.click(screen.getByRole('button', { name: /What kind of article works here/i }))
+
+describe('ArticleFitGuide', () => {
+  it('stays out of the way until it is asked for', () => {
+    render(<ArticleFitGuide />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('answers what the pipeline is good at, in one test the operator can apply', () => {
+    render(<ArticleFitGuide />)
+    openGuide()
+
+    const dialog = screen.getByRole('dialog', { name: 'What kind of article works here' })
+    expect(dialog).toHaveTextContent('Could two people look it up and get the same answer?')
+    expect(dialog).toHaveTextContent('What a month in Lima costs')
+    expect(dialog).toHaveTextContent('Is Lima worth it?')
+  })
+
+  it('says an opinion piece is still allowed, so the rule is not read as a ban', () => {
+    render(<ArticleFitGuide />)
+    openGuide()
+
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'The article can argue that Lima is worth it.',
+    )
+  })
+
+  it('closes on Escape and hands focus back to the control that opened it', () => {
+    render(<ArticleFitGuide />)
+    openGuide()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /What kind of article works here/i })).toHaveFocus()
+  })
+
+  it('escapes a collapsed step, which hides its own body', () => {
+    render(
+      <div hidden>
+        <ArticleFitGuide />
+      </div>,
+    )
+    fireEvent.click(document.querySelector('.p2b-guide-trigger') as HTMLButtonElement)
+
+    // A fixed overlay rendered inside a `hidden` subtree is invisible, and step
+    // 1 collapses exactly that way.
+    const dialog = document.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog?.closest('[hidden]')).toBeNull()
+  })
+
+  it('closes on the close button', () => {
+    render(<ArticleFitGuide />)
+    openGuide()
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/article-fit-guide.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/article-fit-guide.test.tsx
@@ -26,12 +26,23 @@ describe('ArticleFitGuide', () => {
     expect(dialog).toHaveTextContent('Is Lima worth it?')
   })
 
-  it('says an opinion piece is still allowed, so the rule is not read as a ban', () => {
+  it('names the compound question, which is what actually returns Partly answered', () => {
     render(<ArticleFitGuide />)
     openGuide()
 
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveTextContent('is three questions wearing one coat')
+    expect(dialog).toHaveTextContent('Ask one thing at a time.')
+  })
+
+  it('says when trimming questions is free and when it costs the research', () => {
+    render(<ArticleFitGuide />)
+    openGuide()
+
+    // Editing an approved commission changes its fingerprint, and evidence that
+    // names another fingerprint is dropped rather than carried over.
     expect(screen.getByRole('dialog')).toHaveTextContent(
-      'The article can argue that Lima is worth it.',
+      'Once research is attached, changing the commission drops it and the research starts over.',
     )
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/cleanup-modal.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/cleanup-modal.css
@@ -276,3 +276,60 @@
   color: #64748b;
 }
 
+
+/* The article-fit guide is read, not scanned for data, so it is narrower than
+   the cleanup report and its body reads as prose rather than cards. */
+.p2b-modal--guide {
+  width: min(640px, 100%);
+}
+
+.p2b-guide-body {
+  gap: var(--space-5);
+  color: var(--ink);
+  line-height: 1.6;
+}
+
+.p2b-guide-body h4 {
+  margin: 0 0 var(--space-2);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.p2b-guide-body p {
+  margin: 0 0 var(--space-2);
+}
+
+.p2b-guide-body p:last-child {
+  margin-bottom: 0;
+}
+
+.p2b-guide-test {
+  padding-left: var(--space-4);
+  border-left: 3px solid var(--p2b-accent);
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+}
+
+.p2b-guide-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-5);
+}
+
+.p2b-guide-body ul {
+  margin: 0;
+  padding-left: var(--space-4);
+}
+
+.p2b-guide-body li + li {
+  margin-top: var(--space-1);
+}
+
+@media (max-width: 560px) {
+  .p2b-guide-columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/layout.css
@@ -407,3 +407,36 @@
   line-height: calc(1.5rem - 2px);
   text-align: center;
 }
+
+/* Quiet by default: this is read once, on the first article, and then known. */
+.p2b-guide-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.p2b-guide-trigger:hover,
+.p2b-guide-trigger:focus-visible {
+  color: var(--p2b-accent-hover);
+}
+
+.p2b-guide-trigger-mark {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 1.125rem;
+  height: 1.125rem;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: calc(1.125rem - 2px);
+  text-align: center;
+}


### PR DESCRIPTION
Not in the original plan. It came out of the owner using the app: the pipeline
is a **fact-gathering** pipeline, and nothing on screen says so.

## Why

Step 1 asks for a title and a location. It does not say that this pipeline
refuses to write until its research questions have answers — so an idea whose
central question is a matter of taste ("Is Lima worth it?") comes back
unanswered and costs another chatbot round trip every time.

Measured on a real commission: the first research prompt is ~7,000 characters,
and the follow-up is ~8,800 and **grows each round**, because the whole current
evidence package is pasted back in. On a chat subscription that is real, felt
cost. Right now you find that out on round three, after you have spent it.

## What this adds

A quiet `i` control at the top of step 1 that opens a short guide:

- **One test the operator can apply** — could two people look it up and get the
  same answer?
- **Examples on both sides**, so the rule is concrete rather than abstract.
- **That an opinionated article is still allowed.** The judgment goes on top of
  researched facts, not instead of them. Without this the guide reads as a ban
  on having a point of view, which is wrong and would push people off the tool.
- **Why it matters in the currency they feel** — rounds with their chatbot —
  plus the lever most operators never find: research questions can be trimmed in
  step 3, before any research happens.

Behind a control rather than in the step body because it is read once, on the
first article, and then known. Wall-of-text guidance above the title field would
be scrolled past by everyone who has already read it.

## Two things worth reviewing

- **The dialog renders through a portal.** Step 1 collapses by setting `hidden`
  on its own body, and a fixed overlay rendered inside that subtree vanishes
  with it. Caught live, not in tests — the first version was invisible when
  opened from a collapsed step. There is a regression test.
- **Escape restores focus to the trigger**, same as the close button. The first
  version dropped keyboard users at the top of the document.

Reuses the existing `p2b-modal*` shell from the cleanup modal.

## Verification

```
vitest (full)  850 passing / 169 files
tsc --noEmit   clean
eslint         clean (features/prompt2blog, --max-warnings=0)
vite build     passes (pre-existing chunk-size warning only)
```

Checked live in the running app: opened from a collapsed step 1, rendered over
the page, closed on the close button.

No backend change, no pipeline change, no gate change.

## Related, deliberately not here

The follow-up round trip returns a **complete replacement** evidence package
rather than a patch, which is why its cost does not shrink as you get closer to
done. That is a real design cost and a separate job — see the discussion of a
per-question follow-up and of Fix B ("Accept as answered"), which is already
parked in the plan until a first article ships.