### PR TITLE
feat(prompt2blog): let research say a fact is unpublished, and stop asking

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -82,6 +82,15 @@ API → orchestrator → graph → stages → content / quality
   research, the other decides whether a run may start. They must not drift.
 - Readiness findings are derived, never stored. The composer keeps only the
   evidence package and recomputes.
+- A requirement has four verdicts, and only two of them are work: `supported`
+  and `unpublished` are settled, `partial` and `missing` are open.
+  `unpublished` exists because a fact nobody has ever published had no way to be
+  reported — the desk could only say `partial`, which blocked, which sent the
+  operator back to ask again for the same answer at full package cost. It is not
+  a way past the gate: it needs a `gap` naming the authorities, documents and
+  dates checked, and a package with no `supported` requirement at all is still
+  `needs_research` (`nothing_answered`), because an article with no findable
+  facts has nothing to write from.
 
 ## Internal graphs
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -86,7 +86,10 @@ API → orchestrator → graph → stages → content / quality
   and `unpublished` are settled, `partial` and `missing` are open.
   `unpublished` exists because a fact nobody has ever published had no way to be
   reported — the desk could only say `partial`, which blocked, which sent the
-  operator back to ask again for the same answer at full package cost. It is not
+  operator back to ask again for the same answer at full package cost. The
+  writer is told to write around it and never to mention the absence: prose
+  explaining what could not be found reads like a database, not an article. It
+  is not
   a way past the gate: it needs a `gap` naming the authorities, documents and
   dates checked, and a package with no `supported` requirement at all is still
   `needs_research` (`nothing_answered`), because an article with no findable

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v3.py
@@ -65,7 +65,12 @@ EvidenceMaterialType = Literal[
     "other",
 ]
 EvidenceConfidence = Literal["high", "medium", "low"]
-EvidenceRequirementStatus = Literal["supported", "partial", "missing"]
+# `unpublished` is the exit a research desk previously did not have. A question
+# nobody has ever published an answer to — Lima's customs processing minutes, for
+# either terminal — could only be reported as `partial`, which blocked the run and
+# sent the operator back to ask again for a fact that does not exist. It is a
+# finding, not a failure: the article can say the number is unpublished.
+EvidenceRequirementStatus = Literal["supported", "partial", "missing", "unpublished"]
 CreativityLevel = Literal["low", "medium", "high"]
 
 
@@ -208,10 +213,16 @@ class EvidenceRequirement(V3ContractModel):
             raise ValueError("supported requirements must reference at least one claim")
         if self.status == "supported" and self.gap:
             raise ValueError("supported requirements cannot describe a gap")
-        if self.status in {"partial", "missing"} and not self.gap:
-            raise ValueError("partial and missing requirements must describe the gap")
+        if self.status in {"partial", "missing", "unpublished"} and not self.gap:
+            raise ValueError(
+                "partial, missing, and unpublished requirements must describe the gap"
+            )
         if self.status == "missing" and self.claim_ids:
             raise ValueError("missing requirements cannot reference claims")
+        # `unpublished` keeps claims on purpose: "OSITRAN's December 2025 report
+        # measures immigration and baggage and no other step" is a real claim with
+        # a real source, and it is what makes the absence reportable rather than
+        # merely asserted.
         return self
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
@@ -63,10 +63,23 @@ class NormalizedEvidence(NormalizedModel):
     records_text: str
 
     def unresolved_requirement_ids(self) -> list[str]:
+        """Questions more research could still close.
+
+        `unpublished` is deliberately not one of them. The desk already checked
+        and reported that nobody publishes the answer; asking again returns the
+        same sentence and costs another long prompt.
+        """
         return [
             requirement.requirement_id
             for requirement in self.requirements
-            if requirement.status != "supported"
+            if requirement.status not in {"supported", "unpublished"}
+        ]
+
+    def unpublished_requirement_ids(self) -> list[str]:
+        return [
+            requirement.requirement_id
+            for requirement in self.requirements
+            if requirement.status == "unpublished"
         ]
 
     def unresolved_conflict_ids(self) -> list[str]:
@@ -86,6 +99,7 @@ class NormalizedEvidence(NormalizedModel):
                 for requirement in self.requirements
             },
             "unresolved_requirement_ids": self.unresolved_requirement_ids(),
+            "unpublished_requirement_ids": self.unpublished_requirement_ids(),
             "unresolved_conflict_ids": self.unresolved_conflict_ids(),
         }
 
@@ -166,9 +180,18 @@ def _records_text(
     for requirement in requirements:
         claim_ids = ", ".join(requirement.claim_ids) or "none"
         gap = f" | gap: {requirement.gap}" if requirement.gap else ""
+        # The status word alone left the writer to guess what `unpublished`
+        # licensed. Spelled out here, the groundedness check can match a
+        # sentence about the absence to this record.
+        status = (
+            "unpublished (searched for and no one publishes an answer; "
+            "the article may state this absence)"
+            if requirement.status == "unpublished"
+            else requirement.status
+        )
         lines.append(
             f"- {requirement.requirement_id} | {requirement.question} "
-            f"| status: {requirement.status} | claims: {claim_ids}{gap}"
+            f"| status: {status} | claims: {claim_ids}{gap}"
         )
 
     lines.append("")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
@@ -181,11 +181,11 @@ def _records_text(
         claim_ids = ", ".join(requirement.claim_ids) or "none"
         gap = f" | gap: {requirement.gap}" if requirement.gap else ""
         # The status word alone left the writer to guess what `unpublished`
-        # licensed. Spelled out here, the groundedness check can match a
-        # sentence about the absence to this record.
+        # means for the draft. Spelled out here, because the one thing it must
+        # never produce is prose explaining what could not be found.
         status = (
             "unpublished (searched for and no one publishes an answer; "
-            "the article may state this absence)"
+            "write around it and never mention the absence)"
             if requirement.status == "unpublished"
             else requirement.status
         )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -111,7 +111,11 @@ def _evidence_body(evidence: NormalizedEvidence) -> str:
         "These records are the only permitted source of fact. Use them exactly: "
         "preserve attribution, dates, units, geography, and stated uncertainty. "
         "An unsupported requirement stays a visible gap; never invent a bridge "
-        "fact to close it.\n\n"
+        "fact to close it. A requirement marked unpublished was searched for and "
+        "no one publishes an answer: that absence is itself a fact this article "
+        "may state plainly, in the reader's terms and only where it matters to "
+        "them. Never present an unpublished figure as unknown to you alone, and "
+        "never estimate one.\n\n"
         f"{evidence.records_text}"
     )
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -111,11 +111,10 @@ def _evidence_body(evidence: NormalizedEvidence) -> str:
         "These records are the only permitted source of fact. Use them exactly: "
         "preserve attribution, dates, units, geography, and stated uncertainty. "
         "An unsupported requirement stays a visible gap; never invent a bridge "
-        "fact to close it. A requirement marked unpublished was searched for and "
-        "no one publishes an answer: that absence is itself a fact this article "
-        "may state plainly, in the reader's terms and only where it matters to "
-        "them. Never present an unpublished figure as unknown to you alone, and "
-        "never estimate one.\n\n"
+        "fact to close it. A requirement marked unpublished was searched for "
+        "and no one publishes an answer. Leave it out and write around it. Do "
+        "not tell the reader the figure is unpublished, do not explain what "
+        "could not be found, and never estimate the number.\n\n"
         f"{evidence.records_text}"
     )
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_readiness_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_readiness_v3.py
@@ -31,13 +31,19 @@ from .evidence_v3 import NormalizedEvidence, NormalizedSource
 # thing.
 REQUIREMENT_STATUS_RULES = """REQUIREMENT STATUS VERSUS CLAIM CONFIDENCE
 These record two different things. Never conflate them.
-- status describes the QUESTION. supported means linked claims answer the requirement's question; partial means part of that question is still unanswered; missing means none of it is answered.
+- status describes the QUESTION. supported means linked claims answer the requirement's question; partial means part of that question is still unanswered; missing means none of it is answered; unpublished means you searched and no one has published an answer for anyone to find.
 - confidence describes the ANSWER. high, medium, or low records how well corroborated that answer is.
 - An answer you found and corroborated stays supported even when you could not reach the ideal primary source, the publisher blocks automated retrieval, or you would have preferred more evidence. Record that reservation as claim confidence medium or low and as a source note. Never downgrade the requirement to partial for it.
-- Reserve partial and missing for a genuinely unanswered question. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims."""
+- Reserve partial and missing for a question more research could still close. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims.
+- Use unpublished only after real searching, and only when the fact itself is unpublished rather than merely hard for you to reach. Name in gap exactly which authorities, documents, and dates you checked. Where a source states the limit of what it measures, record that as a claim and link it. unpublished does not block the run and will not be sent back to you, so a careless unpublished silently costs the article a fact."""
 
 ReadinessStatus = Literal["ready", "needs_research"]
-FindingCode = Literal["requirement_gap", "unresolved_conflict", "source_gate"]
+FindingCode = Literal[
+    "requirement_gap",
+    "unresolved_conflict",
+    "source_gate",
+    "nothing_answered",
+]
 
 _ATTRIBUTABLE_VOICE = {"transcript", "interview-responses"}
 
@@ -56,6 +62,7 @@ class ResearchReadiness(ReadinessModel):
     status: ReadinessStatus
     findings: list[ReadinessFinding]
     unresolved_requirement_ids: list[str]
+    unpublished_requirement_ids: list[str]
     unresolved_conflict_ids: list[str]
     missing_source_requirements: list[str]
 
@@ -109,7 +116,9 @@ def assess_research_readiness(
 
     findings: list[ReadinessFinding] = []
     for requirement in evidence.requirements:
-        if requirement.status == "supported":
+        # `unpublished` is a reported result, not a gap to chase. It is still
+        # visible to the operator through `unpublished_requirement_ids`.
+        if requirement.status in {"supported", "unpublished"}:
             continue
         findings.append(
             ReadinessFinding(
@@ -143,6 +152,24 @@ def assess_research_readiness(
             )
         )
 
+    # Backstop against a research desk that escapes the gate by declaring every
+    # question unpublished: an article where nothing at all was findable has
+    # nothing to write.
+    if evidence.requirements and not any(
+        requirement.status == "supported" for requirement in evidence.requirements
+    ):
+        findings.append(
+            ReadinessFinding(
+                code="nothing_answered",
+                requirement_ids=[
+                    requirement.requirement_id for requirement in evidence.requirements
+                ],
+                message=(
+                    "No question was answered, so there is nothing to write from."
+                ),
+            )
+        )
+
     missing_gates = [
         requirement
         for requirement in form.source_requirements
@@ -161,6 +188,7 @@ def assess_research_readiness(
         status="needs_research" if findings else "ready",
         findings=findings,
         unresolved_requirement_ids=evidence.unresolved_requirement_ids(),
+        unpublished_requirement_ids=evidence.unpublished_requirement_ids(),
         unresolved_conflict_ids=evidence.unresolved_conflict_ids(),
         missing_source_requirements=list(missing_gates),
     )
@@ -183,6 +211,30 @@ def build_follow_up_research_prompt(
         unresolved_ids.update(finding.requirement_ids)
     for gap in evidence.gaps:
         unresolved_ids.update(gap["requirement_ids"])
+    # Findings and reported gaps can both name a question the desk already
+    # established as unpublished. Re-asking it returns the same sentence and
+    # costs another full-package round, so it never reaches the prompt.
+    unpublished_ids = set(readiness.unpublished_requirement_ids)
+    unresolved_ids -= unpublished_ids
+
+    unpublished_gaps = {
+        requirement.requirement_id: requirement.gap
+        for requirement in evidence.requirements
+        if requirement.status == "unpublished"
+    }
+    unpublished_lines = (
+        "\n".join(
+            f"- {requirement.requirement_id} — {requirement.question}"
+            + (
+                f" [what was checked: {unpublished_gaps[requirement.requirement_id]}]"
+                if unpublished_gaps.get(requirement.requirement_id)
+                else ""
+            )
+            for requirement in commission.requirements
+            if requirement.requirement_id in unpublished_ids
+        )
+        or "- None."
+    )
 
     requirement_lines = (
         "\n".join(
@@ -255,6 +307,10 @@ CURRENT EVIDENCE RECORDS
 UNRESOLVED REQUIREMENTS ONLY
 {requirement_lines}
 
+ALREADY ESTABLISHED AS UNPUBLISHED
+{unpublished_lines}
+Keep these exactly as unpublished with their existing gap text. Do not search them again and do not downgrade them to partial or missing.
+
 UNRESOLVED CONFLICTS ONLY
 {conflict_lines}
 
@@ -307,6 +363,14 @@ def needs_research_payload(
                 "gap": gaps_by_requirement.get(requirement_id, ""),
             }
             for requirement_id in readiness.unresolved_requirement_ids
+        ],
+        "unpublished_requirements": [
+            {
+                "requirement_id": requirement_id,
+                "question": questions[requirement_id],
+                "gap": gaps_by_requirement.get(requirement_id, ""),
+            }
+            for requirement_id in readiness.unpublished_requirement_ids
         ],
         "unresolved_conflict_ids": list(readiness.unresolved_conflict_ids),
         "missing_source_requirements": list(readiness.missing_source_requirements),

--- a/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
@@ -92,6 +92,23 @@ fairly, genuinely, truly, really, simply, just, of course, indeed. Cut "it's \
 worth noting that," "it's important to remember," and any meta-commentary \
 about the writing itself."""
 
+_BANNED_DISCLAIMERS = """\
+Banned disclaimers. State what you know as a plain fact and stop. Do not \
+caveat a fact, attribute it defensively, date it as a shield, or explain how \
+it was established. "Customs took twenty five minutes" is the whole sentence. \
+Cut: "based on my own experience," "anecdotally," "at the time of writing," \
+"your experience may vary," "this is one traveller's experience," "this is \
+not an average," "no official figures exist for," "there is no public data \
+on," "figures could not be verified," and any sentence whose job is to tell \
+the reader how much to trust the previous one. Where research could not \
+establish something, write around it: never narrate the gap. \
+This bans hedging, not first person. In a piece written in first person, \
+"I waited twenty five minutes at customs" is the fact, told plainly, and it \
+stays. A date or a season belongs in the prose when the reader needs it to \
+act — a closure, a season, a change to the place itself — never as armour \
+around a claim. Accuracy is settled before the writing starts; it is not the \
+reader's problem."""
+
 _BANNED_ADJ_STACKING = """\
 Banned adjective stacking. No three-adjective lists ("warm, unfussy, and \
 inviting"). Pick one adjective and make it earn its place, or replace the \
@@ -177,35 +194,41 @@ competent writing on the internet, it is AI prose. The fix is almost always \
 more specificity and less symmetry."""
 
 
-ANTI_AI_TELLS_FULL = "\n\n".join([
-    PRECEDENCE_HEADER,
-    _BANNED_CONSTRUCTIONS,
-    _BANNED_PERSONIFICATIONS,
-    _NO_DASH_SUBSTITUTION,
-    _RHYTHM,
-    _SPECIFICITY_SOFTENED,
-    _BANNED_HEDGES,
-    _SUMMARY_PATTERNS,
-    _BANNED_ADJ_STACKING,
-    _SUPERLATIVE_WITHOUT_ANCHOR,
-    _DICTION,
-    _VOICE,
-    _FINAL_TEST,
-])
+ANTI_AI_TELLS_FULL = "\n\n".join(
+    [
+        PRECEDENCE_HEADER,
+        _BANNED_CONSTRUCTIONS,
+        _BANNED_PERSONIFICATIONS,
+        _NO_DASH_SUBSTITUTION,
+        _RHYTHM,
+        _SPECIFICITY_SOFTENED,
+        _BANNED_HEDGES,
+        _BANNED_DISCLAIMERS,
+        _SUMMARY_PATTERNS,
+        _BANNED_ADJ_STACKING,
+        _SUPERLATIVE_WITHOUT_ANCHOR,
+        _DICTION,
+        _VOICE,
+        _FINAL_TEST,
+    ]
+)
 
 
-ANTI_AI_TELLS_BLURB = "\n\n".join([
-    PRECEDENCE_HEADER,
-    _BANNED_CONSTRUCTIONS,
-    _BANNED_PERSONIFICATIONS,
-    _NO_DASH_SUBSTITUTION,
-    _BLURB_TRIADS,
-    _BLURB_RHYTHM,
-    _BLURB_NO_UNIFORM_KICKERS,
-    _SPECIFICITY_SOFTENED,
-    _BANNED_HEDGES,
-    _BANNED_ADJ_STACKING,
-    _SUPERLATIVE_WITHOUT_ANCHOR,
-    _DICTION,
-    _VOICE,
-])
+ANTI_AI_TELLS_BLURB = "\n\n".join(
+    [
+        PRECEDENCE_HEADER,
+        _BANNED_CONSTRUCTIONS,
+        _BANNED_PERSONIFICATIONS,
+        _NO_DASH_SUBSTITUTION,
+        _BLURB_TRIADS,
+        _BLURB_RHYTHM,
+        _BLURB_NO_UNIFORM_KICKERS,
+        _SPECIFICITY_SOFTENED,
+        _BANNED_HEDGES,
+        _BANNED_DISCLAIMERS,
+        _BANNED_ADJ_STACKING,
+        _SUPERLATIVE_WITHOUT_ANCHOR,
+        _DICTION,
+        _VOICE,
+    ]
+)

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_editorial_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_editorial_contracts.py
@@ -120,6 +120,39 @@ def test_evidence_rejects_inconsistent_claim_requirement_mapping():
         EvidencePackage.model_validate(payload)
 
 
+def test_unpublished_requirement_must_record_what_was_checked():
+    # The gap is the only thing that makes this verdict checkable by a human:
+    # which authorities, which documents, which dates.
+    payload = json.loads(FIXTURE_PATH.read_text())["evidence_package"]
+    payload["requirements"][1] = {
+        "requirement_id": "r2",
+        "status": "unpublished",
+        "claim_ids": [],
+        "gap": "",
+    }
+
+    with pytest.raises(ValidationError, match="must describe the gap"):
+        EvidencePackage.model_validate(payload)
+
+
+def test_unpublished_requirement_may_cite_the_claims_that_prove_the_absence():
+    # "The regulator measures these two steps and no others" is a real claim
+    # with a real source, and it is what separates an established absence from
+    # a research desk that simply gave up.
+    payload = json.loads(FIXTURE_PATH.read_text())["evidence_package"]
+    payload["claims"][0]["requirement_ids"] = ["r1", "r2"]
+    payload["requirements"][1] = {
+        "requirement_id": "r2",
+        "status": "unpublished",
+        "claim_ids": [payload["claims"][0]["claim_id"]],
+        "gap": "Checked the regulator, the operator, and the customs authority.",
+    }
+
+    package = EvidencePackage.model_validate(payload)
+
+    assert package.requirements[1].status == "unpublished"
+
+
 def test_v3_request_requires_matching_fingerprint_and_requirement_set():
     fixture = json.loads(FIXTURE_PATH.read_text())
     payload = {

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
@@ -218,3 +218,122 @@ def test_v3_has_no_supplemental_fact_surface():
     assert "supplemental_content" not in Prompt2BlogV3GraphState.__annotations__
     assert "coverage" not in Prompt2BlogV3GraphState.__annotations__
     assert "readiness" in Prompt2BlogV3GraphState.__annotations__
+
+
+def _unpublished_evidence() -> dict:
+    """One question nobody has ever published an answer to.
+
+    The real case: OSITRAN publishes Lima immigration and baggage minutes and
+    measures no other step, so the customs figure exists nowhere for either
+    terminal. Before `unpublished` this could only be reported as `partial`,
+    which blocked the run and sent the operator back to ask again.
+    """
+    evidence = _supported_evidence()
+    # c3 answered r3; this question is the one nobody publishes, so the only
+    # claim left on it records what the sources say they do not measure.
+    evidence["claims"] = [
+        claim for claim in evidence["claims"] if claim["claim_id"] != "c3"
+    ]
+    evidence["claims"].append(
+        {
+            "claim_id": "c4",
+            "text": (
+                "The regulator's December 2025 measurement covers immigration and "
+                "baggage delivery and no other passenger step."
+            ),
+            "source_ids": ["s1"],
+            "requirement_ids": ["r3"],
+            "as_of": "2025-12-01",
+            "confidence": "high",
+        }
+    )
+    evidence["requirements"][2] = {
+        "requirement_id": "r3",
+        "status": "unpublished",
+        "claim_ids": ["c4"],
+        "gap": (
+            "Checked the regulator's December 2025 report, the operator's 2025 "
+            "service statistics, and the customs authority's published releases. "
+            "None of them measures this step, for either terminal."
+        ),
+    }
+    return evidence
+
+
+def test_an_unpublished_question_does_not_block_the_run():
+    evidence, readiness = _assess(_request(evidence=_unpublished_evidence()))
+
+    assert readiness.status == "ready"
+    assert readiness.findings == []
+    assert readiness.unresolved_requirement_ids == []
+    assert readiness.unpublished_requirement_ids == ["r3"]
+    assert evidence.receipt()["unpublished_requirement_ids"] == ["r3"]
+
+
+def test_an_unpublished_question_reaches_the_writer_as_a_reportable_absence():
+    evidence, _readiness = _assess(_request(evidence=_unpublished_evidence()))
+
+    records = evidence.records_text
+    assert "the article may state this absence" in records
+    assert "None of them measures this step" in records
+
+
+def test_a_follow_up_never_re_asks_an_unpublished_question():
+    evidence_package = _unpublished_evidence()
+    # A still-open question keeps the run blocked, and a reported gap names the
+    # unpublished one as well — the exact shape that used to drag it back into
+    # the prompt round after round.
+    evidence_package["requirements"][1] = {
+        "requirement_id": "r2",
+        "status": "partial",
+        "claim_ids": ["c2"],
+        "gap": "The second half of this question is still unanswered.",
+    }
+    evidence_package["gaps"] = [
+        {
+            "gap_id": "g1",
+            "requirement_ids": ["r2", "r3"],
+            "summary": "Outstanding research.",
+        }
+    ]
+    request = _request(evidence=evidence_package)
+    evidence, readiness = _assess(request)
+
+    assert readiness.status == "needs_research"
+    assert readiness.unresolved_requirement_ids == ["r2"]
+
+    prompt = build_follow_up_research_prompt(request.commission, evidence, readiness)
+    unresolved_block = prompt.split("UNRESOLVED REQUIREMENTS ONLY")[1].split(
+        "ALREADY ESTABLISHED AS UNPUBLISHED"
+    )[0]
+    assert "r2" in unresolved_block
+    assert "r3" not in unresolved_block
+    assert "Do not search them again" in prompt
+    assert "None of them measures this step" in prompt
+
+
+def test_a_package_with_nothing_answered_still_blocks():
+    # The escape hatch a lazy research desk would otherwise have: declare every
+    # question unpublished and the gate opens on an article with no facts.
+    evidence_package = _supported_evidence()
+    evidence_package["requirements"] = [
+        {
+            "requirement_id": requirement["requirement_id"],
+            "status": "unpublished",
+            "claim_ids": [],
+            "gap": "Checked every authority that could publish this.",
+        }
+        for requirement in evidence_package["requirements"]
+    ]
+    evidence_package["claims"] = []
+    evidence_package["conflicts"] = []
+
+    _evidence, readiness = _assess(_request(evidence=evidence_package))
+
+    assert readiness.status == "needs_research"
+    assert [finding.code for finding in readiness.findings] == ["nothing_answered"]
+
+
+def test_the_status_rules_define_the_unpublished_verdict():
+    assert "unpublished means you searched" in REQUIREMENT_STATUS_RULES
+    assert "only after real searching" in REQUIREMENT_STATUS_RULES

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_research_readiness.py
@@ -270,11 +270,11 @@ def test_an_unpublished_question_does_not_block_the_run():
     assert evidence.receipt()["unpublished_requirement_ids"] == ["r3"]
 
 
-def test_an_unpublished_question_reaches_the_writer_as_a_reportable_absence():
+def test_an_unpublished_question_reaches_the_writer_as_a_gap_to_write_around():
     evidence, _readiness = _assess(_request(evidence=_unpublished_evidence()))
 
     records = evidence.records_text
-    assert "the article may state this absence" in records
+    assert "write around it and never mention the absence" in records
     assert "None of them measures this step" in records
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_anti_ai_disclaimers.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_anti_ai_disclaimers.py
@@ -1,0 +1,35 @@
+"""Provenance belongs in the evidence record, not in the sentence.
+
+The rule these tests pin came from a real reading of the output: an article
+that keeps explaining how confident to be reads like a database, not like a
+person. The fix is not less accuracy — accuracy is settled before the writing
+starts — it is that the reader never sees the working.
+"""
+
+from app.shared.prompts.anti_ai_tells import (
+    ANTI_AI_TELLS_BLURB,
+    ANTI_AI_TELLS_FULL,
+)
+
+
+def test_both_voice_variants_ban_defensive_caveats():
+    for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
+        assert "Banned disclaimers" in rules
+        assert "based on my own experience" in rules
+        assert "your experience may vary" in rules
+        assert "this is not an average" in rules
+
+
+def test_the_rule_bans_narrating_a_research_gap():
+    for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
+        assert "no official figures exist for" in rules
+        assert "never narrate the gap" in rules
+
+
+def test_the_rule_spares_first_person_writing():
+    # Personal essays and travelogues are first person by form, and an operator
+    # answering a question from their own trip is a fact like any other. Banning
+    # the hedge must not ban the voice.
+    for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
+        assert "This bans hedging, not first person." in rules
+        assert "I waited twenty five minutes at customs" in rules

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ResearchPanel.tsx
@@ -16,6 +16,7 @@ import {
   plainEvidenceIssue,
   researchNotReadyMessage,
   researchQuestionLabel,
+  researchReadyMessage,
   researchStatusLabel,
 } from '../research-language'
 import { PlainResearchFindings } from './PlainResearchFindings'
@@ -77,9 +78,18 @@ export function ResearchPanel({
     [commission, editorialOptions, evidencePackage, findings],
   )
 
+  // A question established as unpublished is not waiting on anyone. Counting it
+  // as unanswered would tell the operator to go and find a number that no one
+  // has ever published.
   const unansweredQuestionCount =
-    evidencePackage?.requirements.filter(requirement => requirement.status !== 'supported').length
-    ?? 0
+    evidencePackage?.requirements.filter(
+      requirement =>
+        requirement.status !== 'supported' && requirement.status !== 'unpublished',
+    ).length ?? 0
+
+  const unpublishedQuestionCount =
+    evidencePackage?.requirements.filter(requirement => requirement.status === 'unpublished')
+      .length ?? 0
 
   const handleEvidenceJsonChange = (value: string) => {
     setEvidenceJson(value)
@@ -228,10 +238,7 @@ export function ResearchPanel({
               <PlainResearchFindings findings={findings} questions={commission.requirements} />
             </>
           ) : (
-            <p className="p2b-field-hint">
-              Every question is answered, and the evidence has no unresolved disagreement or
-              missing first-hand source.
-            </p>
+            <p className="p2b-field-hint">{researchReadyMessage(unpublishedQuestionCount)}</p>
           )}
           {followUpPrompt !== null && (
             <div className="p2b-field">

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/research-panel.test.tsx
@@ -54,7 +54,9 @@ const editorialOptions: Prompt2BlogEditorialOptionsResponse = {
   ]
 }
 
-function makeCommission(): Prompt2BlogCommission {
+function makeCommission(
+  extraRequirements?: Array<{ requirement_id: string; question: string }>
+): Prompt2BlogCommission {
   const draft = {
     schema_version: 3 as const,
     original_title: "Is Lima still South America's bargain expat capital?",
@@ -73,9 +75,12 @@ function makeCommission(): Prompt2BlogCommission {
       mode: 'single_subject' as const,
       references: [{ name: 'Lima', role: 'primary_subject' as const }]
     },
-    requirements: [
-      { requirement_id: 'r1', question: 'What do current costs show?' }
-    ],
+    requirements: extraRequirements
+      ? [
+          { requirement_id: 'r1', question: 'What do current costs show?' },
+          ...extraRequirements
+        ]
+      : [{ requirement_id: 'r1', question: 'What do current costs show?' }],
     exclusions: [],
     call_to_action: null
   }
@@ -127,13 +132,14 @@ function renderPanel(
   handlers: {
     onStoreEvidence?: (value: Prompt2BlogEvidencePackage) => void
     onClearEvidence?: () => void
-  } = {}
+  } = {},
+  activeCommission: Prompt2BlogCommission = commission
 ) {
   const onStoreEvidence = handlers.onStoreEvidence ?? vi.fn()
   const onClearEvidence = handlers.onClearEvidence ?? vi.fn()
   render(
     <ResearchPanel
-      commission={commission}
+      commission={activeCommission}
       editorialOptions={editorialOptions}
       evidencePackage={evidencePackage}
       onClearEvidence={onClearEvidence}
@@ -230,6 +236,47 @@ describe('ResearchPanel', () => {
     expect(
       screen.queryByLabelText('Follow-up research prompt')
     ).not.toBeInTheDocument()
+  })
+
+  it('treats an unpublished question as settled, not as one to go back for', () => {
+    const twoQuestions = makeCommission([
+      { requirement_id: 'r2', question: 'How long is the customs queue?' }
+    ])
+
+    renderPanel(
+      {
+        ...evidence(),
+        commission_fingerprint: twoQuestions.commission_fingerprint,
+        requirements: [
+          {
+            requirement_id: 'r1',
+            status: 'supported',
+            claim_ids: ['c1'],
+            gap: ''
+          },
+          {
+            requirement_id: 'r2',
+            status: 'unpublished',
+            claim_ids: [],
+            gap: 'Checked the regulator and the operator. Neither publishes it.'
+          }
+        ],
+        gaps: []
+      },
+      {},
+      twoQuestions
+    )
+
+    expect(
+      screen.getByText(/Nobody publishes this — it was checked/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Not ready yet/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText('Follow-up research prompt')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/no published answer anywhere/)
+    ).toBeInTheDocument()
   })
 
   it('copies the attached evidence package so it never has to be dug out of a prompt', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.test.ts
@@ -181,6 +181,70 @@ describe('reviewEvidencePackageJson', () => {
     ])
   })
 
+  it('lets an unpublished question through the gate with the record of what was checked', () => {
+    // The Lima block: no agency publishes a customs-processing figure, for
+    // either terminal, so `partial` sent the operator back to ask forever.
+    const value = evidence()
+    value.requirements[1] = {
+      requirement_id: 'r2',
+      status: 'unpublished',
+      claim_ids: [],
+      gap: 'Checked the regulator, the operator, and the customs authority. None publishes it.'
+    }
+    value.gaps = []
+
+    const result = review(value)
+
+    expect(result.issues).toEqual([])
+    expect(result.readinessFindings).toEqual([])
+  })
+
+  it('refuses an unpublished question that does not say what was checked', () => {
+    const value = evidence()
+    value.requirements[1] = {
+      requirement_id: 'r2',
+      status: 'unpublished',
+      claim_ids: [],
+      gap: '   '
+    }
+
+    expect(review(value).issues).toContainEqual({
+      path: 'requirements[1]',
+      message:
+        'Unpublished requirements need a non-empty gap naming what was checked.'
+    })
+  })
+
+  it('still blocks a package where nothing at all came back answered', () => {
+    // Otherwise a research desk escapes the gate by declaring every question
+    // unpublished, and the article is written from nothing.
+    const value = evidence()
+    value.claims = []
+    value.requirements = [
+      {
+        requirement_id: 'r1',
+        status: 'unpublished',
+        claim_ids: [],
+        gap: 'Checked every authority that could publish this.'
+      },
+      {
+        requirement_id: 'r2',
+        status: 'unpublished',
+        claim_ids: [],
+        gap: 'Checked every authority that could publish this.'
+      }
+    ]
+    value.gaps = []
+
+    expect(review(value).readinessFindings).toEqual([
+      {
+        code: 'nothing_answered',
+        requirement_ids: ['r1', 'r2'],
+        message: 'No question was answered, so there is nothing to write from.'
+      }
+    ])
+  })
+
   it('requires one bare exact evidence object with the approved fingerprint', () => {
     const fenced = reviewEvidencePackageJson(
       `\`\`\`json\n${JSON.stringify(evidence())}\n\`\`\``,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/evidence-import.ts
@@ -12,7 +12,11 @@ export type EvidenceImportIssue = {
 }
 
 export type EvidenceReadinessFinding = {
-  code: 'requirement_gap' | 'unresolved_conflict' | 'source_gate'
+  code:
+    | 'requirement_gap'
+    | 'unresolved_conflict'
+    | 'source_gate'
+    | 'nothing_answered'
   requirement_ids: string[]
   message: string
 }
@@ -47,7 +51,12 @@ const MATERIAL_TYPES = new Set([
   'other'
 ])
 const CONFIDENCE_LEVELS = new Set(['high', 'medium', 'low'])
-const REQUIREMENT_STATUSES = new Set(['supported', 'partial', 'missing'])
+const REQUIREMENT_STATUSES = new Set([
+  'supported',
+  'partial',
+  'missing',
+  'unpublished'
+])
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -416,6 +425,17 @@ function validateRequirement(
       message: 'Missing requirements need no claims and a non-empty gap.'
     })
   }
+  // The gap is what makes an unpublished verdict checkable: it has to name the
+  // authorities, documents and dates that were searched. Claims are allowed and
+  // wanted, because a source stating the limit of what it measures is the best
+  // evidence that the figure is unpublished rather than merely unfound.
+  if (status === 'unpublished' && !gap.trim()) {
+    issues.push({
+      path,
+      message:
+        'Unpublished requirements need a non-empty gap naming what was checked.'
+    })
+  }
   return idIsValid && typeof value.requirement_id === 'string'
     ? { requirementId: value.requirement_id, status, claimIds, gap }
     : null
@@ -580,6 +600,8 @@ function buildReadinessFindings(
 ): EvidenceReadinessFinding[] {
   const findings: EvidenceReadinessFinding[] = []
   for (const requirement of evidencePackage.requirements) {
+    // `unpublished` is a reported result, not a gap to chase. More rounds
+    // return the same sentence, so it must not hold the run.
     if (requirement.status === 'partial' || requirement.status === 'missing') {
       findings.push({
         code: 'requirement_gap',
@@ -606,6 +628,23 @@ function buildReadinessFindings(
       code: 'unresolved_conflict',
       requirement_ids: requirementIds,
       message: conflict.summary
+    })
+  }
+  // Backstop against a research desk that escapes the gate by declaring every
+  // question unpublished: an article where nothing at all was findable has
+  // nothing to write. Mirrors the backend's `nothing_answered` finding.
+  if (
+    evidencePackage.requirements.length > 0 &&
+    !evidencePackage.requirements.some(
+      (requirement) => requirement.status === 'supported'
+    )
+  ) {
+    findings.push({
+      code: 'nothing_answered',
+      requirement_ids: evidencePackage.requirements.map(
+        (requirement) => requirement.requirement_id
+      ),
+      message: 'No question was answered, so there is nothing to write from.'
     })
   }
   findings.push(...sourceGateFindings(evidencePackage, commission, catalog))

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.test.ts
@@ -237,6 +237,48 @@ describe('buildFollowUpResearchPrompt', () => {
     )
   })
 
+  it('never re-asks a question already established as unpublished', () => {
+    // A reported gap and a readiness finding both named r2 here. Before this,
+    // either one dragged a settled question back into the next round, and the
+    // round returned the same sentence at full package cost.
+    const evidencePackage: Prompt2BlogEvidencePackage = {
+      ...incompleteEvidence,
+      requirements: [
+        incompleteEvidence.requirements[0],
+        {
+          requirement_id: 'r2',
+          status: 'unpublished',
+          claim_ids: [],
+          gap: 'Checked the regulator and the operator. Neither measures it.'
+        }
+      ]
+    }
+    const findings: EvidenceReadinessFinding[] = [
+      {
+        code: 'source_gate',
+        message: 'Feature lacks attributable people.',
+        requirement_ids: ['r2']
+      }
+    ]
+
+    const prompt = buildFollowUpResearchPrompt(
+      commission,
+      evidencePackage,
+      findings,
+      catalog
+    )
+
+    expect(prompt).not.toBeNull()
+    const unresolved = prompt!
+      .split('UNRESOLVED REQUIREMENTS ONLY')[1]
+      .split('ALREADY ESTABLISHED AS UNPUBLISHED')[0]
+    expect(unresolved).not.toContain('r2')
+    expect(prompt).toContain(
+      '- r2 — Which people and scenes show lived context? [what was checked: Checked the regulator and the operator. Neither measures it.]'
+    )
+    expect(prompt).toContain('Do not search them again')
+  })
+
   it('carries the same status-versus-confidence rules as the initial prompt', () => {
     const prompt = buildFollowUpResearchPrompt(
       commission,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/follow-up-research-prompt.ts
@@ -61,6 +61,21 @@ export function buildFollowUpResearchPrompt(
       unresolvedRequirementIds.add(requirementId)
     )
   }
+  // Reported gaps and findings can both name a question the desk already
+  // established as unpublished. Re-asking it returns the same sentence and
+  // costs another full-package round, so it never reaches the prompt.
+  const unpublishedRequirements = evidencePackage.requirements.filter(
+    (requirement) => requirement.status === 'unpublished'
+  )
+  for (const requirement of unpublishedRequirements) {
+    unresolvedRequirementIds.delete(requirement.requirement_id)
+  }
+  const unpublishedGaps = new Map(
+    unpublishedRequirements.map((requirement) => [
+      requirement.requirement_id,
+      requirement.gap
+    ])
+  )
 
   const unresolvedRequirements = commission.requirements.filter((requirement) =>
     unresolvedRequirementIds.has(requirement.requirement_id)
@@ -93,6 +108,19 @@ export function buildFollowUpResearchPrompt(
         )
         .join('\n')
     : '- None beyond source-gate or conflict work below.'
+  const unpublishedLines = unpublishedRequirements.length
+    ? commission.requirements
+        .filter((requirement) =>
+          unpublishedGaps.has(requirement.requirement_id)
+        )
+        .map((requirement) => {
+          const checked = unpublishedGaps.get(requirement.requirement_id)?.trim()
+          return `- ${requirement.requirement_id} — ${requirement.question}${
+            checked ? ` [what was checked: ${checked}]` : ''
+          }`
+        })
+        .join('\n')
+    : '- None.'
   const conflictLines = unresolvedConflicts.length
     ? unresolvedConflicts
         .map((conflict) => `- ${conflict.conflict_id} — ${conflict.summary}`)
@@ -134,6 +162,10 @@ ${JSON.stringify(evidencePackage, null, 2)}
 
 UNRESOLVED REQUIREMENTS ONLY
 ${requirementLines}
+
+ALREADY ESTABLISHED AS UNPUBLISHED
+${unpublishedLines}
+Keep these exactly as unpublished with their existing gap text. Do not search them again and do not downgrade them to partial or missing.
 
 UNRESOLVED CONFLICTS ONLY
 ${conflictLines}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.test.ts
@@ -4,6 +4,7 @@ import {
   researchFindingLabel,
   researchNotReadyMessage,
   researchQuestionLabel,
+  researchReadyMessage,
   researchStatusLabel,
 } from './research-language'
 
@@ -45,5 +46,25 @@ describe('research language', () => {
       label: null,
       message: 'This research belongs to a different commission.',
     })
+  })
+})
+
+describe('the unpublished verdict in plain words', () => {
+  it('says the question is settled rather than outstanding', () => {
+    expect(researchStatusLabel('unpublished')).toBe(
+      'Nobody publishes this — it was checked'
+    )
+  })
+
+  it('names the backstop finding without a schema word', () => {
+    expect(researchFindingLabel('nothing_answered')).toBe(
+      'Nothing came back answered'
+    )
+  })
+
+  it('does not claim every question was answered when one is unpublished', () => {
+    expect(researchReadyMessage(0)).toContain('Every question is answered')
+    expect(researchReadyMessage(1)).toContain('no published answer anywhere')
+    expect(researchReadyMessage(3)).toContain('3 of them')
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-language.ts
@@ -2,6 +2,7 @@ export type ResearchFindingCode =
   | 'requirement_gap'
   | 'unresolved_conflict'
   | 'source_gate'
+  | 'nothing_answered'
 
 export type ResearchQuestion = {
   requirement_id: string
@@ -12,6 +13,7 @@ const FINDING_LABELS: Record<ResearchFindingCode, string> = {
   requirement_gap: 'Still unanswered',
   unresolved_conflict: 'Two sources disagree',
   source_gate: 'This kind of article needs a first-hand source',
+  nothing_answered: 'Nothing came back answered',
 }
 
 /**
@@ -26,12 +28,15 @@ const STATUS_LABELS: Record<string, string> = {
   supported: 'Answered',
   partial: 'Partly answered',
   missing: 'Still unanswered',
+  unpublished: 'Nobody publishes this — it was checked',
 }
 
 /**
  * `partial` and `missing` both block the run, but they are different jobs for
  * the operator — one answer needs finishing, the other needs starting — so
- * they keep different words.
+ * they keep different words. `unpublished` blocks nothing: it is a result, and
+ * the words have to say so or the operator will go looking for the answer
+ * again.
  */
 export function researchStatusLabel(status: string): string {
   return STATUS_LABELS[status] ?? status
@@ -71,4 +76,22 @@ export function plainEvidenceIssue(path: string, message: string): {
     }
   }
   return { label: path, message }
+}
+
+/**
+ * The all-clear line. A question settled as unpublished is not an answer, and
+ * saying "every question is answered" over the top of one is the kind of
+ * sentence that sends an operator back to research something that does not
+ * exist.
+ */
+export function researchReadyMessage(unpublishedCount: number): string {
+  const clean =
+    'Every question is answered, and nothing is left disagreeing or missing a first-hand source.'
+  if (unpublishedCount === 1) {
+    return 'Every question is settled. One of them has no published answer anywhere — the article can say so.'
+  }
+  if (unpublishedCount > 1) {
+    return `Every question is settled. ${unpublishedCount} of them have no published answer anywhere — the article can say so.`
+  }
+  return clean
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.test.ts
@@ -115,11 +115,26 @@ describe('buildResearchPrompt', () => {
       'Never downgrade the requirement to partial for it.'
     )
     expect(prompt).toContain(
-      'Reserve partial and missing for a genuinely unanswered question.'
+      'Reserve partial and missing for a question more research could still close.'
     )
     expect(prompt).toContain(
       'otherwise say exactly which part of the question is still unanswered'
     )
+  })
+
+  it('offers the unpublished verdict and demands the search record with it', () => {
+    const prompt = buildResearchPrompt(commission, catalog)
+
+    expect(prompt).toContain(
+      'unpublished means you searched and no one has published an answer'
+    )
+    expect(prompt).toContain(
+      'Use unpublished only after real searching, and only when the fact itself is unpublished'
+    )
+    expect(prompt).toContain(
+      'Name in gap exactly which authorities, documents, and dates you checked.'
+    )
+    expect(prompt).toContain('"status": "supported|partial|missing|unpublished"')
   })
 
   it('includes only active module metadata and the active form source gate', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/research-prompt.ts
@@ -56,10 +56,11 @@ function activeResearchGuidance(
  */
 export const REQUIREMENT_STATUS_RULES = `REQUIREMENT STATUS VERSUS CLAIM CONFIDENCE
 These record two different things. Never conflate them.
-- status describes the QUESTION. supported means linked claims answer the requirement's question; partial means part of that question is still unanswered; missing means none of it is answered.
+- status describes the QUESTION. supported means linked claims answer the requirement's question; partial means part of that question is still unanswered; missing means none of it is answered; unpublished means you searched and no one has published an answer for anyone to find.
 - confidence describes the ANSWER. high, medium, or low records how well corroborated that answer is.
 - An answer you found and corroborated stays supported even when you could not reach the ideal primary source, the publisher blocks automated retrieval, or you would have preferred more evidence. Record that reservation as claim confidence medium or low and as a source note. Never downgrade the requirement to partial for it.
-- Reserve partial and missing for a genuinely unanswered question. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims.`
+- Reserve partial and missing for a question more research could still close. Do not pad weak evidence, infer missing facts, or mark a requirement supported without linked claims.
+- Use unpublished only after real searching, and only when the fact itself is unpublished rather than merely hard for you to reach. Name in gap exactly which authorities, documents, and dates you checked. Where a source states the limit of what it measures, record that as a claim and link it. unpublished does not block the run and will not be sent back to you, so a careless unpublished silently costs the article a fact.`
 
 /** Exact bare response shape shared by initial and follow-up research prompts. */
 export function formatEvidencePackageContract(fingerprint: string): string {
@@ -92,9 +93,9 @@ export function formatEvidencePackageContract(fingerprint: string): string {
   "requirements": [
     {
       "requirement_id": "r1",
-      "status": "supported|partial|missing",
+      "status": "supported|partial|missing|unpublished",
       "claim_ids": ["c1"],
-      "gap": "Empty only when the question is answered; otherwise say exactly which part of the question is still unanswered"
+      "gap": "Empty only when the question is answered; otherwise say exactly which part of the question is still unanswered, or for unpublished exactly which authorities, documents, and dates you checked"
     }
   ],
   "conflicts": [

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/NeedsResearchResult.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/NeedsResearchResult.tsx
@@ -55,6 +55,28 @@ export function NeedsResearchResult({
         </>
       )}
 
+      {(result.unpublished_requirements?.length ?? 0) > 0 && (
+        <>
+          {/* Shown next to the open questions so the operator does not send the
+              follow-up prompt back out looking for a figure that was already
+              established as unpublished. */}
+          <p className="p2b-import-report-title">Nobody publishes these — already checked</p>
+          <ul className="p2b-requirement-list">
+            {(result.unpublished_requirements ?? []).map(requirement => (
+              <li key={requirement.requirement_id} className="p2b-requirement-row">
+                <strong>
+                  {researchQuestionLabel(
+                    requirement.requirement_id,
+                    result.unpublished_requirements ?? []
+                  )}
+                </strong>
+                {requirement.gap ? ` — ${requirement.gap}` : ''}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
       {result.unresolved_conflict_ids.length > 0 && (
         <p className="p2b-field-hint">
           Two sources disagree. The follow-up prompt asks your chatbot to resolve them.

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineV3Result.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineV3Result.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import payloadLogoUrl from '../../../../assets/payload-logo.svg?url'
 import type { Prompt2BlogV3PipelinePayload } from '../../api'
+import { researchStatusLabel } from '../../composer/research-language'
 import { RunCostReceipt } from './RunCostReceipt'
 
 interface PipelineV3ResultProps {
@@ -9,12 +10,6 @@ interface PipelineV3ResultProps {
   showDebug: boolean
   stageArticleUrl: string | null
   onToggleDebug: () => void
-}
-
-const REQUIREMENT_STATUS_LABELS: Record<string, string> = {
-  supported: 'Supported',
-  partial: 'Partial',
-  missing: 'Missing',
 }
 
 /**
@@ -101,8 +96,7 @@ export function PipelineV3Result({
             {requirementIds.map(requirementId => (
               <li key={requirementId} className="p2b-requirement-row">
                 <code>{requirementId}</code>{' '}
-                {REQUIREMENT_STATUS_LABELS[requirementStatus[requirementId]]
-                  ?? requirementStatus[requirementId]}
+                {researchStatusLabel(requirementStatus[requirementId])}
               </li>
             ))}
           </ul>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/needs-research-result.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/needs-research-result.test.tsx
@@ -45,6 +45,37 @@ describe('NeedsResearchResult', () => {
     )).toBeInTheDocument()
   })
 
+  it('shows what was already established as unpublished so it is not chased again', () => {
+    render(
+      <NeedsResearchResult
+        result={{
+          ...result,
+          unpublished_requirements: [
+            {
+              requirement_id: 'r3',
+              question: 'How long does customs take?',
+              gap: 'Checked the regulator and the operator. Neither measures it.',
+            },
+          ],
+        }}
+        onBackToResearch={() => {}}
+        onDismiss={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Nobody publishes these — already checked')).toBeInTheDocument()
+    expect(screen.getAllByText(/Question 3: How long does customs take\?/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/Neither measures it/)).toBeTruthy()
+  })
+
+  it('leaves the unpublished list out entirely when there is none', () => {
+    render(
+      <NeedsResearchResult result={result} onBackToResearch={() => {}} onDismiss={() => {}} />,
+    )
+
+    expect(screen.queryByText(/already checked/)).not.toBeInTheDocument()
+  })
+
   it('lists every reason the gate stopped the run', () => {
     render(
       <NeedsResearchResult result={result} onBackToResearch={() => {}} onDismiss={() => {}} />,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/pipeline-result.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/pipeline-result.test.tsx
@@ -73,7 +73,7 @@ describe('PipelineV3Result', () => {
     expect(screen.getByText(/Is Lima still South America/)).toBeTruthy()
     expect(screen.getByText(/2 sources and 1 claims/)).toBeTruthy()
     expect(screen.getByText('r1')).toBeTruthy()
-    expect(screen.getByText(/Supported/)).toBeTruthy()
+    expect(screen.getByText(/Answered/)).toBeTruthy()
   })
 
   it('names what held a run back rather than only reporting the status', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/editorial.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/editorial.types.ts
@@ -58,7 +58,17 @@ export type Prompt2BlogEvidenceMaterialType =
 
 export type Prompt2BlogEvidenceConfidence = 'high' | 'medium' | 'low'
 
-export type Prompt2BlogEvidenceRequirementStatus = 'supported' | 'partial' | 'missing'
+/**
+ * `unpublished` is the exit the research desk did not have. A question nobody
+ * has ever published an answer to could only be reported as `partial`, which
+ * blocked the run and sent the operator back to ask again for a fact that does
+ * not exist. It is a finding the article can report, not a gap to chase.
+ */
+export type Prompt2BlogEvidenceRequirementStatus =
+  | 'supported'
+  | 'partial'
+  | 'missing'
+  | 'unpublished'
 
 export type Prompt2BlogCreativityLevel = 'low' | 'medium' | 'high'
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -372,6 +372,7 @@ export type Prompt2BlogEvidenceReceipt = {
   claim_ids?: string[]
   requirement_status?: Record<string, Prompt2BlogEvidenceRequirementStatus>
   unresolved_requirement_ids?: string[]
+  unpublished_requirement_ids?: string[]
   unresolved_conflict_ids?: string[]
 }
 
@@ -379,6 +380,7 @@ export type Prompt2BlogV3ReadinessFindingCode =
   | 'requirement_gap'
   | 'unresolved_conflict'
   | 'source_gate'
+  | 'nothing_answered'
 
 export type Prompt2BlogV3ReadinessFinding = {
   code: Prompt2BlogV3ReadinessFindingCode
@@ -397,6 +399,11 @@ export type Prompt2BlogV3NeedsResearchResponse = {
   commission_fingerprint: string
   findings: Prompt2BlogV3ReadinessFinding[]
   unresolved_requirements: Array<{
+    requirement_id: string
+    question: string
+    gap: string
+  }>
+  unpublished_requirements?: Array<{
     requirement_id: string
     question: string
     gap: string

--- a/apps/ai-blog-writer/docs/api-changelog.md
+++ b/apps/ai-blog-writer/docs/api-changelog.md
@@ -14,6 +14,14 @@
   trace to whichever artifact key a run recorded.
 
 ### Changed
+- `POST /prompt2blog/pipeline-v3` accepts a fourth evidence requirement status,
+  `unpublished`: a question the research desk searched for and no one has
+  published an answer to. It does not hold the run, it is never re-asked by the
+  follow-up research prompt, and it reaches the writer as a reportable absence.
+  It requires a `gap` naming what was checked, and a package where no
+  requirement is `supported` still answers `needs_research`. The
+  `needs_research` body gained `unpublished_requirements`, and the finished-run
+  evidence receipt gained `unpublished_requirement_ids`.
 - The Prompt2Blog UI submits only `pipeline-v3`. `POST /prompt2blog/run` and
   `POST /prompt2blog/pipeline-v2` still work and are unchanged, but have no UI
   caller; they remain as a fallback until v3 is proven on a controlled real run.


### PR DESCRIPTION
## The bug

A research question had three possible answers: `supported`, `partial`, `missing`. There was no way to report **"I searched, and no one has ever published this."**

So a research desk that had established the absence could only say `partial`. `partial` blocks the run. The operator asks again. The same answer comes back. The loop had no exit, and every round rebuilds the whole evidence package at full prompt cost.

Found on the first real run: Lima's new Jorge Chávez terminal, one year on. Immigration and baggage came back with hard numbers. The customs step came back empty, because no agency publishes a minutes figure for it — for either terminal. The research desk reported that honestly twice, and twice it was treated as a failure to retry.

## The fix

A fourth verdict, `unpublished`. It does not hold the run, the follow-up prompt never re-asks it, and the writer is told to write around the gap.

It is not a way past the gate:

- it requires a `gap` naming which authorities, documents and dates were checked;
- claims are allowed and wanted — a source stating the limit of what it measures is what separates an established absence from a desk that gave up;
- a package where **nothing** is `supported` still answers `needs_research` (`nothing_answered`), because an article with no findable facts has nothing to write from.

The `REQUIREMENT STATUS VERSUS CLAIM CONFIDENCE` block stays byte-identical across the initial prompt, the follow-up prompt and the backend, and a test asserts it.

## What the reader never sees

The first version of this told the writer the absence was a fact the article could state. That produces "no agency publishes customs processing times for Lima's airport" in the middle of a travel piece. The owner called it, and they were right: over-transparency is one of the loudest signals a human did not write the text.

Two commits follow from that:

- the writer is now told to write around an unpublished question and never mention it;
- a **Banned disclaimers** rule joins the shared voice rules, so every ABW pipeline stops explaining itself to the reader. It bans hedging, not first person — "I waited twenty five minutes at customs" is the fact, told plainly, and it stays. A date reaches the prose only when the reader needs it to act on something, never as armour around a claim.

## On screen

`unpublished` reads as **"Nobody publishes this — it was checked"**. The panel stops counting it as an open question, the "not ready" banner does not fire for it, and the blocked-run result lists what was already established so nobody chases it again. The finished-run receipt now uses the same plain labels as the rest of the app instead of its own `Supported / Partial / Missing` map.

## Verification

Live, against the running backend on 4003: a package with one `partial` question and one `unpublished` question returns `needs_research` naming **only** the partial one, reports the unpublished one separately, and the follow-up prompt carries "do not search them again". No writer call, nothing charged.

```
backend pytest    all pass (includes 8 new tests)
frontend vitest   217 passing across prompt2blog (7 new)
tsc --noEmit      clean
eslint            clean (features/prompt2blog, --max-warnings=0)
black / flake8    clean on touched Python
```

## Not in this PR

- **"Can you answer this yourself?"** — the operator answering an unpublished question from their own experience, which becomes first-hand evidence. That is the next PR and it is the bigger win.
- Splitting questions that ask three things at once. `r1` asked about immigration, baggage **and** exit; two came back green and the third took the article down with it.
- The plain-English sweep: the panel still says "20 sources and 18 claims are attached to this commission."