### PR TITLE
fix(abw): strip colons from useId before using it as a DOM id

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockSettingsModal.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/homepageFeaturedContent/HomepageBlockSettingsModal.tsx
@@ -20,7 +20,7 @@ export default function HomepageBlockSettingsModal({
   footer,
   children
 }: Props) {
-  const titleId = useId()
+  const titleId = useId().replace(/:/g, '')
 
   useEffect(() => {
     if (!isOpen) return

--- a/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/ItineraryMomentFields.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listicleItineraries/builder/components/ItineraryMomentFields.tsx
@@ -81,7 +81,7 @@ function MomentBadgePicker({
   onSelect: (next: MomentOption | undefined) => void
 }) {
   const [isOpen, setIsOpen] = useState(false)
-  const listboxId = useId()
+  const listboxId = useId().replace(/:/g, '')
   const pickerRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([])

--- a/apps/ai-blog-writer/apps/frontend/src/shared/builder/components/FieldInfoHint.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/shared/builder/components/FieldInfoHint.tsx
@@ -5,7 +5,7 @@ type FieldInfoHintProps = {
 }
 
 export function FieldInfoHint({ text }: FieldInfoHintProps) {
-  const tooltipId = useId()
+  const tooltipId = useId().replace(/:/g, '')
 
   return (
     <span


### PR DESCRIPTION
## What

React's `useId()` returns `:r3:`. Three components wrote that value straight into a DOM `id` attribute. Any CSS-selector match against such an element makes jsdom/nwsapi build a selector containing an unescaped `:`, which is invalid.

Symptom: `BuilderStopsPanel.test.tsx` failed with

```
SyntaxError: 'ul#:r3: .stl-moment-picker__menu input:focus-visible' is not a valid selector
```

Only in a full run — it needs an earlier test file to have loaded the stylesheet that carries the `:focus-visible` rule, so the file passed in isolation and looked like a flake.

## Fix

Apply the sanitize idiom already used in `CommissionEditor.tsx` (`useId().replace(/:/g, '')`) to the three remaining sites:

- `ItineraryMomentFields.tsx` — listbox id (the one that failed)
- `HomepageBlockSettingsModal.tsx` — `aria-labelledby` target
- `FieldInfoHint.tsx` — `aria-describedby` target

Ids stay unique; the aria wiring is unchanged.

## Verification

```
vitest (full, --pool=forks --singleFork)  171 files / 928 tests passed
tsc --noEmit                              clean
```

Before this change the same command reported 1 failed / 920 passed.