### PR TITLE
fix(p2b): three fixes found by a real Lima restaurant run

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -123,7 +123,10 @@ def _evidence_body(evidence: NormalizedEvidence) -> str:
         "attribution, no sourcing language, and no note about how it was "
         "obtained. A confirmed premise is simply a fact the article may use; "
         "never mention that it was checked, and never write a sentence about "
-        "what the research established.\n\n"
+        "what the research established. A resolved conflict is the same: the "
+        "resolution is the fact, and the disagreement behind it is internal. "
+        "Write the settled figure as a plain sentence. Never tell the reader "
+        "that two records disagreed, which one was chosen, or why.\n\n"
         f"{evidence.records_text}"
     )
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -219,8 +219,12 @@ Rules:
 - Score honestly. A draft that merely avoids mistakes is a 7, not a 9.
 - MEASURED CHECKS below are counted outside this prompt and are not opinions.
   While any of them is false, overall_score may not exceed 6, and the failure
-  must appear in required_revisions. A draft at a third of its target length is
-  not publishable, whatever else it does well.
+  must appear in required_revisions. Length is a band with two edges: a draft
+  at a third of its target length is not publishable, and neither is one that
+  overruns the band. Never infer which way a length check missed -- when
+  target_word_count_met is FAIL, `word_count_verdict` states the direction and
+  the size of the miss, and your required_revisions must say the same thing it
+  does.
 
 {instructions}
 
@@ -254,6 +258,9 @@ Return strict JSON only:
 
 Rules:
 - Resolve each required revision directly.
+- A revision that states a length change gives the direction and the number of
+  words. Move that way. Never lengthen a draft asked to be cut, or cut one
+  asked to be lengthened.
 - Repair prose and structure only. You may not create a fact, and you may not
   change the commission: not the form, the primary subject, the scope mode, the
   reference roles, the requirements, or the exclusions.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -47,6 +47,24 @@ HARD_CONSTRAINT_CHECK_KEYS = (
     "claims_grounded",
 )
 
+# Keys `_build_constraint_checks` returns that are measurements, not pass/fail
+# verdicts. Every site that merges computed checks over the auditor's own
+# `constraint_checks` has to drop these, or a count lands in a dict whose
+# other values are booleans and reads as a check that failed. The sites used
+# to each carry their own filter -- one by name, one by `_coverage` suffix --
+# which meant a new measurement leaked into whichever list was not updated.
+CONSTRAINT_MEASUREMENT_KEYS = frozenset(
+    {
+        "word_count_estimate",
+        "word_count_delta",
+        "word_count_direction",
+        "word_count_target_min",
+        "word_count_target_max",
+        "secondary_keyword_coverage",
+        "must_include_coverage",
+    }
+)
+
 
 def _extract_narrative_focus(writing_brief: dict[str, Any]) -> str:
     editorial = _safe_str(writing_brief.get("editorial_instructions"))
@@ -135,12 +153,28 @@ def _build_constraint_checks(
     paragraph_length_pref = _safe_str(formatting.get("paragraph_length"))
     target_word_count = _safe_int(formatting.get("target_word_count"), default=0)
 
+    # The check carries which way it missed, not just that it missed. As a bare
+    # boolean it told the auditor "wrong length" and left the direction to be
+    # guessed; on the Lima restaurant run the guess was "too short" against a
+    # draft 363 words over the ceiling, and both repair passes made the article
+    # longer still. `word_count_delta` is the distance outside the accepted
+    # band, signed: positive is over the ceiling, negative is under the floor.
     target_word_count_met = True
+    word_count_delta = 0
+    word_count_direction = "within"
+    word_count_target_min = 0
+    word_count_target_max = 0
     if target_word_count > 0:
         tolerance = max(100, int(target_word_count * 0.1))
-        target_word_count_met = (
-            target_word_count - tolerance <= word_count <= target_word_count + tolerance
-        )
+        word_count_target_min = target_word_count - tolerance
+        word_count_target_max = target_word_count + tolerance
+        if word_count < word_count_target_min:
+            word_count_delta = word_count - word_count_target_min
+            word_count_direction = "under"
+        elif word_count > word_count_target_max:
+            word_count_delta = word_count - word_count_target_max
+            word_count_direction = "over"
+        target_word_count_met = word_count_direction == "within"
 
     avg_sentences = _estimate_paragraph_sentence_average(content)
     paragraph_length_met = True
@@ -203,6 +237,10 @@ def _build_constraint_checks(
         "must_include_covered": must_include_coverage >= MUST_INCLUDE_COVERAGE_THRESHOLD,
         "must_include_coverage": round(must_include_coverage, 3),
         "target_word_count_met": target_word_count_met,
+        "word_count_delta": word_count_delta,
+        "word_count_direction": word_count_direction,
+        "word_count_target_min": word_count_target_min,
+        "word_count_target_max": word_count_target_max,
         "paragraph_length_met": paragraph_length_met,
         "cta_present": cta_present,
         "primary_keyword_present": primary_keyword_present,
@@ -210,6 +248,79 @@ def _build_constraint_checks(
         "secondary_keyword_coverage": round(secondary_keyword_coverage, 3),
         "word_count_estimate": word_count,
     }
+
+
+def word_count_revision_instruction(checks: dict[str, Any]) -> str | None:
+    """The length revision, stated in words, or None when the length is fine.
+
+    Repair used to receive whatever sentence the auditor wrote about length.
+    The auditor was reading a boolean, so it could only guess a direction, and
+    a wrong guess costs a full writing-model call plus the minutes it takes.
+    This sentence is computed from the same counts the check is, so it cannot
+    disagree with the check that triggered it.
+    """
+    if _safe_bool(checks.get("target_word_count_met"), default=True):
+        return None
+
+    direction = _safe_str(checks.get("word_count_direction"))
+    delta = _safe_int(checks.get("word_count_delta"), default=0)
+    word_count = _safe_int(checks.get("word_count_estimate"), default=0)
+    lower = _safe_int(checks.get("word_count_target_min"), default=0)
+    upper = _safe_int(checks.get("word_count_target_max"), default=0)
+    if direction not in {"over", "under"} or not delta or upper <= 0:
+        return None
+
+    # Rounded to the nearest ten. A writer asked for "363 words" treats the
+    # number as a target to hit exactly and pads or truncates to reach it.
+    amount = max(10, abs(delta) // 10 * 10)
+    band = f"{lower}-{upper} words"
+    if direction == "over":
+        return (
+            f"Length: the draft is {word_count} words, roughly {abs(delta)} over the "
+            f"{band} required for this article. Cut about {amount} words. Tighten "
+            "prose, remove repetition and merge overlapping passages. Do not drop "
+            "a required subject, a section, or a sourced fact to make the count."
+        )
+    return (
+        f"Length: the draft is {word_count} words, roughly {abs(delta)} under the "
+        f"{band} required for this article. Add about {amount} words by developing "
+        "material the draft already covers. Never add a fact the evidence records "
+        "do not contain, and do not pad with restatement."
+    )
+
+
+# Words that mark a revision as being about how long the article is. Used to
+# drop the auditor's own length sentence when the deterministic one exists:
+# two length instructions in one list can point opposite ways, and that is the
+# bug this whole path was built to remove.
+_LENGTH_REVISION_TERMS = (
+    "word count",
+    "word target",
+    "length",
+    "expand",
+    "lengthen",
+    "shorten",
+    "trim",
+    "condense",
+    "too short",
+    "too long",
+    "target_word_count",
+)
+
+
+def drop_length_revisions(revisions: list[str]) -> list[str]:
+    """Remove revisions about length, keeping everything else in order.
+
+    Only called when a computed length instruction is taking their place. The
+    auditor is shown the direction now, but being shown it is not the same as
+    obeying it, and a list holding both "cut about 360 words" and "expand the
+    draft" leaves the repair model to pick. It picked wrong once already.
+    """
+    return [
+        revision
+        for revision in revisions
+        if not any(term in revision.lower() for term in _LENGTH_REVISION_TERMS)
+    ]
 
 
 def _sanitize_coverage(parsed: dict[str, Any]) -> dict[str, Any]:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/audit_repair.py
@@ -12,6 +12,7 @@ from ..prompts.quality import P2B_QUALITY_AUDIT_PROMPT, P2B_REPAIR_PROMPT
 from ..policies import is_better_quality
 from ..schemas import REWRITE_SCHEMA
 from ..quality import (
+    CONSTRAINT_MEASUREMENT_KEYS,
     _build_constraint_checks,
     _sanitize_quality,
     _sanitize_rewrite,
@@ -54,18 +55,13 @@ def _audit_rewrite(
     # The auditor supplies the semantic checks; everything measurable is
     # computed here and wins. Non-boolean measurements are reported alongside
     # the checks rather than inside them.
-    measurements = {
-        "word_count_estimate",
-        "secondary_keyword_coverage",
-        "must_include_coverage",
-    }
     groundedness = state.get("groundedness") or unchecked_groundedness()
     quality_checks = {
         **quality.get("constraint_checks", {}),
         **{
             key: value
             for key, value in computed_checks.items()
-            if key not in measurements
+            if key not in CONSTRAINT_MEASUREMENT_KEYS
         },
         "claims_grounded": groundedness["grounded"],
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/final_verify.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/final_verify.py
@@ -6,7 +6,7 @@ from typing import Any
 from ..dependencies import PipelineDependencies
 from ..graph.state import Prompt2BlogGraphState
 from ..observability import _append_stage_trace
-from ..quality import _build_constraint_checks
+from ..quality import CONSTRAINT_MEASUREMENT_KEYS, _build_constraint_checks
 from .groundedness import check_groundedness
 
 logger = logging.getLogger(__name__)
@@ -55,17 +55,12 @@ def run_final_verify_stage(
         rewrite["improved_content"],
         state["writing_brief"],
     )
-    measurements = {
-        "word_count_estimate",
-        "secondary_keyword_coverage",
-        "must_include_coverage",
-    }
     quality_checks = {
         **state["quality_checks"],
         **{
             key: value
             for key, value in final_checks.items()
-            if key not in measurements
+            if key not in CONSTRAINT_MEASUREMENT_KEYS
         },
         "claims_grounded": groundedness["grounded"],
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/finalize.py
@@ -7,7 +7,7 @@ from ..dependencies import PipelineDependencies
 from ..graph.state import Prompt2BlogGraphState
 from ..policies import evaluate_readiness
 from ..pricing import Prompt2BlogTokenUsageTracker
-from ..quality import _build_constraint_checks
+from ..quality import CONSTRAINT_MEASUREMENT_KEYS, _build_constraint_checks
 from ..support import _safe_dict, _safe_str
 
 
@@ -44,7 +44,7 @@ def run_finalize_stage(
         **{
             key: value
             for key, value in final_checks.items()
-            if not key.endswith("_coverage") and key != "word_count_estimate"
+            if key not in CONSTRAINT_MEASUREMENT_KEYS
         },
     }
     # Readiness is one shared decision (see policies.evaluate_readiness), not a

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -13,10 +13,13 @@ from ...prompts.editorial_v3 import (
     P2B_V3_REPAIR_PROMPT,
 )
 from ...quality import (
+    CONSTRAINT_MEASUREMENT_KEYS,
     _build_constraint_checks,
     _sanitize_quality,
     _sanitize_rewrite,
+    drop_length_revisions,
     unchecked_groundedness,
+    word_count_revision_instruction,
 )
 from ...quality_v3 import v3_constraint_brief
 from ...schemas import REWRITE_SCHEMA
@@ -28,6 +31,11 @@ from ...support import _format_style_directive, _json
 # while `target_word_count_met` was false at 388 words against a 1400 target:
 # the auditor could not have known, because the checks it was being scored
 # beside were merged into its answer after it had given one.
+#
+# The later Lima restaurant run failed the same check from the other side --
+# 1903 words against a 1260-1540 band -- and the auditor, reading a bare
+# boolean, wrote "expand the draft". Both repair passes obeyed and both were
+# discarded by keep-best. Hence the direction travels with the check.
 def _measured_checks_block(checks: dict[str, Any]) -> str:
     reported = {key: value for key, value in checks.items() if isinstance(value, bool)}
     if not reported:
@@ -39,6 +47,19 @@ def _measured_checks_block(checks: dict[str, Any]) -> str:
     word_count = checks.get("word_count_estimate")
     if word_count is not None:
         lines.append(f"- word_count_estimate: {word_count}")
+    # A failed length check without its direction is a coin flip for the
+    # auditor, and it called the Lima run wrong: it read "too short" off a
+    # draft 363 words over the ceiling and told repair to expand.
+    if checks.get("target_word_count_met") is False:
+        direction = checks.get("word_count_direction")
+        delta = checks.get("word_count_delta")
+        lower = checks.get("word_count_target_min")
+        upper = checks.get("word_count_target_max")
+        if direction in {"over", "under"} and delta:
+            lines.append(
+                f"- word_count_verdict: {direction.upper()} the required "
+                f"{lower}-{upper} word band by {abs(int(delta))} words"
+            )
     return "\n".join(lines)
 
 
@@ -66,23 +87,31 @@ def _audit_v3_rewrite(
         model_name=state["audit_model"],
     )
     quality = _sanitize_quality(parsed)
-    measurements = {
-        "word_count_estimate",
-        "secondary_keyword_coverage",
-        "must_include_coverage",
-    }
     groundedness = state.get("groundedness") or unchecked_groundedness()
     quality_checks = {
         **quality.get("constraint_checks", {}),
         **{
             key: value
             for key, value in computed_checks.items()
-            if key not in measurements
+            if key not in CONSTRAINT_MEASUREMENT_KEYS
         },
         "claims_grounded": groundedness["grounded"],
     }
     quality["constraint_checks"] = quality_checks
     quality["word_count_estimate"] = computed_checks["word_count_estimate"]
+    # Repair reads this to state the length revision in words. It travels on
+    # `quality` rather than in `constraint_checks`, which holds only verdicts.
+    quality["word_count_check"] = {
+        key: computed_checks[key]
+        for key in (
+            "target_word_count_met",
+            "word_count_estimate",
+            "word_count_delta",
+            "word_count_direction",
+            "word_count_target_min",
+            "word_count_target_max",
+        )
+    }
     quality["secondary_keyword_coverage"] = computed_checks[
         "secondary_keyword_coverage"
     ]
@@ -154,6 +183,22 @@ def run_v3_repair_stage(
 
     groundedness = state.get("groundedness") or unchecked_groundedness()
     required_revisions = list(quality.get("required_revisions", []))
+    # First, and computed rather than written by the auditor: a length miss is
+    # the one revision the auditor cannot get wrong twice, because the counts
+    # that failed the check are the counts that phrase the instruction.
+    #
+    # The auditor's own length sentence is dropped rather than kept alongside
+    # it. The auditor is shown the direction now, but a list carrying both
+    # "cut about 360 words" and "expand the draft" would leave repair to pick
+    # between them, which is the original bug wearing a smaller hat.
+    length_revision = word_count_revision_instruction(
+        quality.get("word_count_check") or {}
+    )
+    if length_revision:
+        required_revisions = [
+            length_revision,
+            *drop_length_revisions(required_revisions),
+        ]
     required_revisions.extend(
         f"Remove or explicitly mark as unconfirmed: {claim['claim']} "
         f"({claim['reason']})"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
@@ -7,7 +7,7 @@ from ...dependencies import PipelineDependencies
 from ...graph.state import Prompt2BlogV3GraphState
 from ...policies import evaluate_readiness
 from ...pricing import Prompt2BlogTokenUsageTracker
-from ...quality import _build_constraint_checks
+from ...quality import CONSTRAINT_MEASUREMENT_KEYS, _build_constraint_checks
 from ...quality_v3 import v3_constraint_brief
 from ...support import _safe_dict, _safe_str
 
@@ -45,7 +45,7 @@ def run_v3_finalize_stage(
         **{
             key: value
             for key, value in final_checks.items()
-            if not key.endswith("_coverage") and key != "word_count_estimate"
+            if key not in CONSTRAINT_MEASUREMENT_KEYS
         },
     }
     verdict = evaluate_readiness(
@@ -122,6 +122,20 @@ def run_v3_finalize_stage(
             "constraint_checks": settled_checks,
             "readiness_blockers": list(verdict.blockers),
             "word_count_estimate": final_checks["word_count_estimate"],
+            # A length blocker on its own tells the operator nothing about
+            # which way the article missed, which is the only thing they can
+            # act on.
+            "word_count_check": {
+                key: final_checks[key]
+                for key in (
+                    "target_word_count_met",
+                    "word_count_estimate",
+                    "word_count_delta",
+                    "word_count_direction",
+                    "word_count_target_min",
+                    "word_count_target_max",
+                )
+            },
             "repair_applied": state.get("repair_applied", False),
             "repair_attempts": state.get("repair_attempts", 0),
             "groundedness": state["groundedness"],

--- a/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
@@ -102,6 +102,15 @@ not an average," "no official figures exist for," "there is no public data \
 on," "figures could not be verified," and any sentence whose job is to tell \
 the reader how much to trust the previous one. Where research could not \
 establish something, write around it: never narrate the gap. \
+Saying it about the subject instead of about yourself is the same sentence. \
+Cut: "does not publish," "has not disclosed," "is not public information," \
+"is not publicly available," "could not be confirmed," and any other way of \
+telling the reader that a fact was looked for and not found. Write what the \
+subject does do, or say nothing. \
+Never let the vocabulary of the research reach the page either: no "sampled" \
+booking flows or menus, no "data points," no "sample size," no "evidence \
+records," and no grading your own confidence in a number ("an estimate rather \
+than a guaranteed bill"). Give the number plainly or leave it out. \
 Naming the source is the same disclaimer wearing a press badge. Cut: \
 "sources report," "travel sources," "outlets anticipate," "one outlet," \
 "the publication noted," "the report cited," "according to," "reports \

--- a/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
@@ -134,6 +134,113 @@ _SOURCE_ATTRIBUTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 
+# Sentences that report on the research instead of on the subject.
+#
+# The house rule already says it in words -- write around an unpublished fact,
+# never announce it -- and a real Lima restaurant run shipped seven of these
+# anyway ("Central does not publish its individual course names, so the
+# specific dishes served on a given date are not public information"). The
+# quality audit caught one of the seven, vaguely. An instruction the writer
+# ignores is not a check, so this is the half that does not depend on the
+# model having listened.
+#
+# The reader came for the subject. What a researcher could or could not
+# establish about it is the pipeline's business, and "sampled booking flow" is
+# internal vocabulary that should never reach a travel article at all.
+#
+# Kept deliberately narrow. A false positive costs a repair call on correct
+# prose and the repair prompt tells the writer to delete the sentence, so an
+# over-broad pattern removes facts a reader needs. Three near misses were cut
+# for that reason: "release" ("the venue does not release tickets until 10am"),
+# "not available online" and "not publicly listed" ("reservations are not
+# available online, so call the counter") all mean booking, not research, in a
+# travel article far more often than they mean a gap in the evidence. The
+# research sense of each is already carried by publish, disclose, "not public
+# information" and "not publicly available".
+_RESEARCH_META_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"\b(?:do(?:es)?|did|will)\s+not\s+"
+            r"(?:publish|disclose|make\s+public)\b",
+            re.I,
+        ),
+        "the prose reports what the subject withholds instead of what it does",
+    ),
+    (
+        re.compile(
+            r"\b(?:has|have|had)\s+not\s+"
+            r"(?:published|disclosed|made\s+public)\b",
+            re.I,
+        ),
+        "the prose reports what the subject withholds instead of what it does",
+    ),
+    (
+        re.compile(
+            r"\bnot\s+(?:public\s+information|publicly\s+"
+            r"(?:available|published|disclosed))\b",
+            re.I,
+        ),
+        "the prose narrates a gap in the research",
+    ),
+    (
+        re.compile(
+            r"\bno\s+(?:public\s+(?:data|record|records|information|listing|"
+            r"figure|figures)|published\s+(?:data|figure|figures|price|prices)|"
+            r"official\s+(?:figure|figures|data))\b",
+            re.I,
+        ),
+        "the prose narrates a gap in the research",
+    ),
+    (
+        re.compile(
+            r"\b(?:could|can|would)\s*not\s+be\s+"
+            r"(?:confirmed|verified|established|determined|found)\b",
+            re.I,
+        ),
+        "the prose narrates a gap in the research",
+    ),
+    (
+        re.compile(
+            r"\bat\s+(?:the\s+)?time\s+of\s+(?:writing|research|publication)\b"
+            r"|\bas\s+of\s+this\s+writing\b",
+            re.I,
+        ),
+        "the claim is dated as a shield rather than because the reader needs it",
+    ),
+    (
+        re.compile(
+            r"\bsampled\s+(?:booking|checkout|reservation|reservations|pricing|"
+            r"price|prices|menu|menus|listing|listings|flow|flows|itinerary|"
+            r"rate|rates)\b"
+            r"|\bsample\s+size\b"
+            r"|\bdata\s+points?\b"
+            r"|\b(?:evidence|source)\s+records?\b",
+            re.I,
+        ),
+        "internal research vocabulary has reached the reader",
+    ),
+    (
+        re.compile(
+            r"\b(?:an?\s+)?estimate\s+rather\s+than\b"
+            r"|\brather\s+than\s+an?\s+(?:guaranteed|confirmed|final)\b",
+            re.I,
+        ),
+        "the prose grades its own confidence in the number",
+    ),
+)
+
+
+def _research_meta(line: str) -> list[str]:
+    for pattern in _NON_PROSE_SPANS:
+        line = pattern.sub(" ", line)
+    found: list[str] = []
+    for pattern, reason in _RESEARCH_META_PATTERNS:
+        match = pattern.search(line)
+        if match:
+            found.append(f"{match.group(0).strip()} ({reason})")
+    return found
+
+
 def _source_attributions(line: str) -> list[str]:
     for pattern in _NON_PROSE_SPANS:
         line = pattern.sub(" ", line)
@@ -235,6 +342,12 @@ def validate_anti_ai_tells_markdown(text: str) -> AntiAiValidationResult:
                 f"Line {line_number}: attribution belongs in the evidence "
                 f"record, not the prose: {'; '.join(attributions)}"
             )
+        research_meta = _research_meta(line)
+        if research_meta:
+            errors.append(
+                f"Line {line_number}: write around what the research could not "
+                f"establish, never announce it: {'; '.join(research_meta)}"
+            )
         for pattern in _COMMA_AS_DASH_ASIDE_PATTERNS:
             match = pattern.search(line)
             if match:
@@ -257,7 +370,13 @@ def build_anti_ai_repair_prompt(content: str, errors: list[str]) -> str:
         "the word in place. Fix sourcing language by stating the fact as a "
         "plain sentence and deleting the publication, not by swapping in "
         "another attribution verb; if the fact cannot stand without a source "
-        "named in the sentence, delete the sentence.\n\n"
+        "named in the sentence, delete the sentence.\n"
+        "Fix a sentence that reports on the research by deleting it, or by "
+        "replacing it with what the article does know. \"Central does not "
+        "publish its course names\" becomes a sentence about what Central "
+        "does serve, or it goes. Never soften it into \"course names vary\" "
+        "or \"the menu changes often\": the reader is still being told about "
+        "an absence. Never name the research itself in the prose.\n\n"
         f"Validation errors:\n{error_lines}\n\n"
         "Previous output:\n"
         "<<<CONTENT>>>\n"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 from app.features.prompt2blog.quality import (
+    CONSTRAINT_MEASUREMENT_KEYS,
     NEUTRAL_QUALITY_SCORE,
     _build_constraint_checks,
     _contains_phrase,
     _sanitize_quality,
     _should_run_repair,
+    word_count_revision_instruction,
 )
 
 
@@ -149,3 +151,78 @@ def test_cta_check_reads_a_configured_call_to_action():
         )["cta_present"]
         is True
     )
+
+
+def _long_draft(word_count: int) -> str:
+    """A draft of exactly ``word_count`` countable words."""
+    return "## Section\n\n" + " ".join(["word"] * (word_count - 1))
+
+
+def test_word_count_check_reports_which_side_of_the_band_it_missed():
+    brief = _brief(formatting={"paragraph_length": "", "target_word_count": 1400})
+
+    # Band is 1260-1540: target 1400 with a max(100, 10%) = 140 tolerance.
+    over = _build_constraint_checks("T", _long_draft(1903), brief)
+    assert over["target_word_count_met"] is False
+    assert over["word_count_direction"] == "over"
+    assert over["word_count_delta"] == 363
+    assert (over["word_count_target_min"], over["word_count_target_max"]) == (1260, 1540)
+
+    under = _build_constraint_checks("T", _long_draft(388), brief)
+    assert under["word_count_direction"] == "under"
+    assert under["word_count_delta"] == -872
+
+    inside = _build_constraint_checks("T", _long_draft(1400), brief)
+    assert inside["target_word_count_met"] is True
+    assert inside["word_count_direction"] == "within"
+    assert inside["word_count_delta"] == 0
+
+
+def test_no_target_word_count_reports_no_direction():
+    checks = _build_constraint_checks("T", _long_draft(400), _brief())
+
+    assert checks["target_word_count_met"] is True
+    assert checks["word_count_direction"] == "within"
+    assert checks["word_count_target_max"] == 0
+
+
+def test_length_revision_states_the_direction_rather_than_leaving_it_to_a_model():
+    brief = _brief(formatting={"paragraph_length": "", "target_word_count": 1400})
+
+    over = word_count_revision_instruction(
+        _build_constraint_checks("T", _long_draft(1903), brief)
+    )
+    assert over is not None
+    assert "Cut about 360 words" in over
+    assert "1260-1540 words" in over
+    assert "Add about" not in over
+
+    under = word_count_revision_instruction(
+        _build_constraint_checks("T", _long_draft(388), brief)
+    )
+    assert under is not None
+    assert "Add about 870 words" in under
+    assert "Cut about" not in under
+
+    assert (
+        word_count_revision_instruction(
+            _build_constraint_checks("T", _long_draft(1400), brief)
+        )
+        is None
+    )
+
+
+def test_length_measurements_never_land_among_the_pass_fail_verdicts():
+    checks = _build_constraint_checks(
+        "T",
+        _long_draft(1903),
+        _brief(formatting={"paragraph_length": "", "target_word_count": 1400}),
+    )
+    verdicts = {
+        key: value
+        for key, value in checks.items()
+        if key not in CONSTRAINT_MEASUREMENT_KEYS
+    }
+
+    # A count sitting in a dict of booleans reads as a check that failed.
+    assert all(isinstance(value, bool) for value in verdicts.values())

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -198,3 +198,20 @@ def test_the_writer_is_told_not_to_narrate_the_premise_check():
         in evidence_layer.body
     )
     assert "never mention that it was checked" in evidence_layer.body
+
+
+def test_the_writer_is_told_not_to_narrate_a_resolved_conflict():
+    """The premise line's twin, and the same failure shape.
+
+    Conflict resolution sends the operator's own decision to the writer, and
+    on the run that proved the feature the auditor caught the writer narrating
+    the disagreement itself. The reader wants the settled figure, not the
+    argument that produced it.
+    """
+    instructions = assemble_v3_instructions(_request())
+    evidence_layer = next(
+        layer for layer in instructions.layers if layer.layer == "evidence"
+    )
+
+    assert "A resolved conflict is the same" in evidence_layer.body
+    assert "Never tell the reader that two records disagreed" in evidence_layer.body

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -384,3 +384,173 @@ def test_the_audit_still_measures_the_checks_it_reports():
     assert updates["quality_checks"]["target_word_count_met"] is False
     # Judged checks stay the auditor's; measured checks stay the code's.
     assert updates["quality_checks"]["tone_match"] is False
+
+
+def test_repair_is_told_to_cut_when_the_draft_overruns_its_length_band():
+    """The Lima restaurant run's dead end, as a test.
+
+    The auditor read `target_word_count_met: false` off a 1903-word draft
+    against a 1260-1540 band, guessed "too short", and told repair to expand.
+    Both repair passes obeyed and both were discarded. The direction now
+    travels with the check, so repair cannot be sent the wrong way.
+    """
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "improved_content": "## What Lima costs now\n\nRepaired body.",
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+    state = _state(
+        quality={
+            "required_revisions": [],
+            "word_count_check": {
+                "target_word_count_met": False,
+                "word_count_estimate": 1903,
+                "word_count_delta": 363,
+                "word_count_direction": "over",
+                "word_count_target_min": 1260,
+                "word_count_target_max": 1540,
+            },
+        },
+        groundedness={
+            "checked": True,
+            "grounded": True,
+            "high_severity_count": 0,
+            "unsupported_claims": [],
+        },
+    )
+
+    run_v3_repair_stage(state, dependencies)
+
+    length_revision = recorder.recorded[0][1]["required_revisions"][0]
+    assert "Cut about 360 words" in length_revision
+    assert "1260-1540 words" in length_revision
+    assert length_revision in llm.prompts[0]
+    assert "Never lengthen a draft asked to be cut" in llm.prompts[0]
+
+
+def test_repair_gets_no_length_revision_when_the_draft_is_within_its_band():
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "improved_content": "## What Lima costs now\n\nRepaired body.",
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+    state = _state(
+        quality={
+            "required_revisions": ["Tighten the opening."],
+            "word_count_check": {
+                "target_word_count_met": True,
+                "word_count_estimate": 1400,
+                "word_count_delta": 0,
+                "word_count_direction": "within",
+                "word_count_target_min": 1260,
+                "word_count_target_max": 1540,
+            },
+        },
+        groundedness={
+            "checked": True,
+            "grounded": True,
+            "high_severity_count": 0,
+            "unsupported_claims": [],
+        },
+    )
+
+    run_v3_repair_stage(state, dependencies)
+
+    assert recorder.recorded[0][1]["required_revisions"] == ["Tighten the opening."]
+
+
+def test_audit_is_shown_the_direction_of_a_length_miss_not_just_the_failure():
+    from app.features.prompt2blog.stages.v3.audit_repair import _measured_checks_block
+
+    block = _measured_checks_block(
+        {
+            "target_word_count_met": False,
+            "cta_present": True,
+            "word_count_estimate": 1903,
+            "word_count_delta": 363,
+            "word_count_direction": "over",
+            "word_count_target_min": 1260,
+            "word_count_target_max": 1540,
+        }
+    )
+
+    assert "target_word_count_met: FAIL" in block
+    assert "word_count_verdict: OVER the required 1260-1540 word band by 363 words" in (
+        block
+    )
+
+
+def test_the_auditors_own_length_sentence_is_replaced_not_kept_beside():
+    """Two length instructions pointing opposite ways is the original bug.
+
+    The auditor is shown the direction now, but shown is not obeyed. If it
+    still writes "expand the draft" against a draft that must be cut, repair
+    must not be handed both and left to choose.
+    """
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "improved_content": "## What Lima costs now\n\nRepaired body.",
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+    state = _state(
+        quality={
+            "required_revisions": [
+                "Expand the draft to fulfill the required Long length profile.",
+                "Name a price for each restaurant.",
+            ],
+            "word_count_check": {
+                "target_word_count_met": False,
+                "word_count_estimate": 1903,
+                "word_count_delta": 363,
+                "word_count_direction": "over",
+                "word_count_target_min": 1260,
+                "word_count_target_max": 1540,
+            },
+        },
+        groundedness={
+            "checked": True,
+            "grounded": True,
+            "high_severity_count": 0,
+            "unsupported_claims": [],
+        },
+    )
+
+    run_v3_repair_stage(state, dependencies)
+
+    revisions = recorder.recorded[0][1]["required_revisions"]
+    assert "Cut about 360 words" in revisions[0]
+    # The unrelated revision survives; only the contradicting one is dropped.
+    assert "Name a price for each restaurant." in revisions
+    assert not any("Expand the draft" in revision for revision in revisions)
+
+
+def test_an_auditor_revision_about_length_survives_when_the_length_is_fine():
+    """Nothing is dropped unless a computed instruction is replacing it."""
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "improved_content": "## What Lima costs now\n\nRepaired body.",
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+    state = _state(
+        quality={"required_revisions": ["Shorten the opening paragraph."]},
+        groundedness={
+            "checked": True,
+            "grounded": True,
+            "high_severity_count": 0,
+            "unsupported_claims": [],
+        },
+    )
+
+    run_v3_repair_stage(state, dependencies)
+
+    assert recorder.recorded[0][1]["required_revisions"] == [
+        "Shorten the opening paragraph."
+    ]

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_anti_ai_disclaimers.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_anti_ai_disclaimers.py
@@ -55,3 +55,62 @@ def test_the_rule_spares_a_named_actor_in_the_story():
     for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
         assert "A named person or institution who acts in the story stays" in rules
         assert "the outlet that wrote it up does not" in rules
+
+
+def test_the_rule_bans_reporting_the_gap_as_the_subjects_silence():
+    # "There is no public data on X" and "X does not publish it" are the same
+    # sentence pointed at a different noun. The first was already banned.
+    for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
+        assert "does not publish," in rules
+        assert "has not disclosed," in rules
+        assert "is not public information," in rules
+        assert "Write what the subject does do, or say nothing." in rules
+
+
+def test_the_rule_keeps_research_vocabulary_off_the_page():
+    # "Merito's sampled booking flow uses a S/551 guarantee" shipped to a
+    # reader. None of these words describe the restaurant.
+    for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
+        assert '"sampled" booking flows or menus' in rules
+        assert '"data points,"' in rules
+        assert '"evidence records,"' in rules
+        assert '"an estimate rather than a guaranteed bill"' in rules
+
+
+def test_every_phrase_the_validator_rejects_is_named_in_the_prompt():
+    """The check and the instruction must not drift apart.
+
+    The validator is shared: url2blog, youtube2blog and editor_assist all run
+    it, but their writers only ever see this block. A pattern enforced here
+    and unstated there costs every one of them a repair call for a rule they
+    were never given.
+    """
+    from app.shared.text.normalize import validate_anti_ai_tells_markdown
+
+    # One sentence per research-meta pattern the validator carries.
+    rejected = (
+        "Central does not publish the course names.",
+        "Kjolle has not disclosed the autumn menu.",
+        "The price is not publicly available.",
+        "There is no public data on the counter seats.",
+        "The closing time could not be confirmed.",
+        "At the time of writing the room seats forty.",
+        "Two data points put the bill near S/500.",
+        "The number is an estimate rather than a guaranteed bill.",
+    )
+    for sentence in rejected:
+        assert not validate_anti_ai_tells_markdown(sentence).valid, sentence
+
+    # And the prompt has to say so, in both variants, before a writer is
+    # judged against it.
+    for rules in (ANTI_AI_TELLS_FULL, ANTI_AI_TELLS_BLURB):
+        for phrase in (
+            "does not publish",
+            "has not disclosed",
+            "is not public information",
+            "is not publicly available",
+            "could not be confirmed",
+            "at the time of writing",
+            "data points",
+        ):
+            assert phrase in rules, phrase

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
@@ -241,3 +241,82 @@ class TestSourceAttributionIsNotProse:
         )
         assert "deleting the publication" in prompt
         assert "another attribution verb" in prompt
+
+
+class TestResearchMetaIsNotReaderFacing:
+    """The reader came for the subject, not for a report on the research.
+
+    Every FLAGGED sentence below is verbatim, or near verbatim, from the Lima
+    restaurant run's shipped article. Seven of these reached the reader. The
+    quality audit flagged one, vaguely, and the house rule forbidding them
+    was already in the writer's prompt and had been ignored.
+    """
+
+    FLAGGED = (
+        "Central does not publish its individual course names, so the specific "
+        "dishes served on a given date are not public information.",
+        "Maido does not publish which courses are currently being served.",
+        "Merito's sampled booking flow uses a S/551 guarantee per person.",
+        "The number is an estimate rather than a guaranteed bill.",
+        "Kjolle has not disclosed the autumn menu.",
+        "The tasting price is not publicly available.",
+        "No official figures exist for the wait at either counter.",
+        "There is no public data on the counter seats.",
+        "The closing time could not be confirmed.",
+        "At the time of writing the room seats forty.",
+        "Two data points put the bill near S/500.",
+    )
+
+    # These must stay clean, or the rule costs a repair call on correct prose.
+    ALLOWED = (
+        "Central seats twenty eight and charges S/551 for the tasting menu.",
+        # "sampled" is an ordinary verb in a food article. Only the research
+        # noun phrase it forms in "sampled booking flow" is the tell.
+        "We sampled the ceviche at three counters in Barranco.",
+        "Maido publishes its menu on the day of service.",
+        "The guarantee covers the tasting menu and the pairing.",
+        "Book the 1pm seating; the room fills by Thursday.",
+        "The kitchen opens at noon and stops seating at half past two.",
+        # "release" means putting seats on sale, not publishing research.
+        "The venue does not release tickets until 10am on the day.",
+        "The museum will not release the autumn schedule until August.",
+        # How a reader books is the article doing its job, not a research gap.
+        "Reservations are not available online, so call the counter before noon.",
+        "Rooms are not available online during Fiestas Patrias.",
+        "Tables are not publicly listed; the concierge holds them.",
+    )
+
+    @staticmethod
+    def _research_meta_errors(text: str) -> list[str]:
+        return [
+            error
+            for error in validate_anti_ai_tells_markdown(text).errors
+            if "write around what the research could not establish" in error
+        ]
+
+    def test_research_meta_sentences_fail_validation(self):
+        for sentence in self.FLAGGED:
+            assert self._research_meta_errors(sentence), sentence
+
+    def test_ordinary_prose_about_the_subject_stays_clean(self):
+        for sentence in self.ALLOWED:
+            assert not self._research_meta_errors(sentence), sentence
+
+    def test_the_error_names_the_offending_phrase(self):
+        errors = self._research_meta_errors(self.FLAGGED[0])
+        assert "does not publish" in errors[0]
+        assert "not public information" in errors[0]
+
+    def test_a_link_target_is_not_prose(self):
+        clean = "Book at [Central](https://example.com/no-public-data) early."
+        assert not self._research_meta_errors(clean)
+
+    def test_the_repair_prompt_says_to_delete_not_soften(self):
+        # Softening is how this rule gets defeated: "course names vary" is the
+        # same absence, told at one remove.
+        prompt = build_anti_ai_repair_prompt(
+            self.FLAGGED[0],
+            ["Line 1: write around what the research could not establish"],
+        )
+        assert "reports on the research by deleting it" in prompt
+        assert "Never soften it" in prompt

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.test.ts
@@ -459,6 +459,59 @@ describe('direction warnings never block an import', () => {
     expect(reviewWithLength(value, 700).warnings).toEqual([])
   })
 
+  it('says when a direction asks too many questions for the length', () => {
+    /*
+     * The Lima restaurant run: six requirements against a 1400 word target,
+     * whose measured ceiling is 1540. Six questions are worth about 2100
+     * words. It was over length before a word was written, and nothing said
+     * so until two repair passes had been spent trying to cut it back.
+     */
+    const value = response()
+    value.options[0].requirements = Array.from({ length: 6 }, (_unused, index) => ({
+      requirement_id: `r${index + 1}`,
+      question: `What does item ${index + 1} cost a visitor today?`,
+      assumption_ids: ['a1']
+    }))
+
+    const result = reviewWithLength(value, 1400)
+
+    expect(result.issues).toEqual([])
+    expect(result.response).not.toBeNull()
+    const tooMany = result.warnings.filter(warning =>
+      warning.message.includes('Asks 6 questions')
+    )
+    expect(tooMany).toHaveLength(1)
+    expect(tooMany[0].label).toBe('Direction 1')
+    expect(tooMany[0].message).toContain('2100 words of material')
+    expect(tooMany[0].message).toContain('1540 word ceiling')
+    expect(tooMany[0].message).toContain('about 4 questions')
+  })
+
+  it('never fires the too-few and too-many warnings on one direction', () => {
+    // Both are derived from the same 350-words-a-question figure, so a length
+    // that made both true would be arithmetic telling the operator nothing.
+    for (const targetWordCount of [700, 1000, 1400, 2000, 4000]) {
+      for (const questionCount of [1, 3, 4, 6, 9, 14]) {
+        const value = response()
+        value.options[0].requirements = Array.from(
+          { length: questionCount },
+          (_unused, index) => ({
+            requirement_id: `r${index + 1}`,
+            question: `What does item ${index + 1} cost a visitor today?`,
+            assumption_ids: ['a1']
+          })
+        )
+        const messages = reviewWithLength(value, targetWordCount)
+          .warnings.filter(warning => warning.label === 'Direction 1')
+          .map(warning => warning.message)
+
+        expect(
+          messages.filter(message => /^Asks \d+ questions? for an article/.test(message))
+        ).not.toHaveLength(2)
+      }
+    }
+  })
+
   it('flags a question that asks more than one thing', () => {
     const value = response()
     value.options[0].requirements = [

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-import.ts
@@ -4,7 +4,13 @@ import {
   type Prompt2BlogDirectionResponse,
   type Prompt2BlogEditorialOptionsResponse
 } from '../api'
-import { todayIso } from './direction-prompt'
+import {
+  WORDS_PER_RESEARCH_QUESTION,
+  lengthCeilingWords,
+  researchQuestionCeilingForLength,
+  researchQuestionsForLength,
+  todayIso
+} from './direction-prompt'
 
 export type DirectionImportIssue = {
   path: string
@@ -545,8 +551,6 @@ function validateDistinctOptions(
   }
 }
 
-/** Words a single answered research question is worth, in finished prose. */
-const WORDS_PER_RESEARCH_QUESTION = 350
 
 /**
  * Nouns that describe an article instead of naming its subject.
@@ -641,9 +645,15 @@ function collectDirectionWarnings(
   asOfDate: string
 ): DirectionWarning[] {
   const warnings: DirectionWarning[] = []
-  const needed = targetWordCount
-    ? Math.min(8, Math.max(3, Math.round(targetWordCount / WORDS_PER_RESEARCH_QUESTION)))
-    : 0
+  /*
+   * Both bounds come from the prompt builder rather than being recomputed
+   * here. The warning has to say what the generated prompt asked for; two
+   * copies of the arithmetic would eventually disagree, and the operator
+   * would be told off for following the instructions this app wrote.
+   */
+  const needed = targetWordCount ? researchQuestionsForLength(targetWordCount) : 0
+  const affordable = researchQuestionCeilingForLength(targetWordCount)
+  const ceiling = lengthCeilingWords(targetWordCount)
 
   options.forEach((option, index) => {
     if (!isObject(option)) return
@@ -657,6 +667,32 @@ function collectDirectionWarnings(
           `Asks ${requirements.length} question${requirements.length === 1 ? '' : 's'} ` +
           `for an article of about ${targetWordCount} words. ${needed} or more is ` +
           'what that length needs. Fewer questions means a shorter, thinner article.'
+      })
+    }
+
+    /*
+     * The mirror of the too-few warning, and the same class of failure as the
+     * premise checks below: a contradiction visible for free here, otherwise
+     * paid for after the run.
+     *
+     * A commission with six requirements against a 1540 word ceiling carries
+     * 2100 words of material. It was over length before a word was written.
+     * The real run found out 28 minutes later, when the length check failed
+     * and two repair passes were spent trying to cut it back.
+     *
+     * Advisory, not blocking, exactly like the too-few warning: 350 words a
+     * question is an average, and a thin question is genuinely cheaper.
+     */
+    if (affordable && requirements.length > affordable) {
+      const material = requirements.length * WORDS_PER_RESEARCH_QUESTION
+      warnings.push({
+        label,
+        message:
+          `Asks ${requirements.length} questions for an article of about ` +
+          `${targetWordCount} words. That is roughly ${material} words of ` +
+          `material against a ${ceiling} word ceiling, so the article cannot ` +
+          `be written to length as commissioned. Cut to about ${affordable} ` +
+          'questions, or raise the length.'
       })
     }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.test.ts
@@ -3,6 +3,7 @@ import type { Prompt2BlogEditorialOptionsResponse } from '../api'
 import type { Prompt2BlogInputOption } from '../api'
 import {
   buildDirectionPrompt,
+  researchQuestionCeilingForLength,
   researchQuestionsForLength
 } from './direction-prompt'
 
@@ -145,6 +146,46 @@ describe('buildDirectionPrompt', () => {
     expect(researchQuestionsForLength(0)).toBe(3)
   })
 
+  it('caps the research questions at what the length can absorb', () => {
+    /*
+     * The floor alone only pushed one way. The Lima restaurant run came back
+     * with six questions against a 1400 word target -- about 2100 words of
+     * material for a 1540 word ceiling -- and the article was over length
+     * before a word was written.
+     */
+    expect(researchQuestionCeilingForLength(1400)).toBe(4)
+    expect(researchQuestionCeilingForLength(4000)).toBe(12)
+    // The ceiling can never sit below the floor at any length.
+    expect(researchQuestionCeilingForLength(700)).toBe(
+      researchQuestionsForLength(700)
+    )
+    // No length chosen means no measured band and so no ceiling.
+    expect(researchQuestionCeilingForLength(0)).toBe(0)
+
+    const prompt = buildDirectionPrompt(
+      'Where to eat in Lima right now',
+      'Lima, Peru',
+      catalog,
+      longLength
+    )
+    expect(prompt).toContain('cannot be written to length')
+    /*
+     * The ceiling has to appear in the output contract and the schema
+     * examples, not only in the rules prose. This prompt already lost that
+     * argument once: see 'refuses to teach one question by example' below,
+     * where the rule said "at least one", the example said "one", and the
+     * example won.
+     */
+    const uncapped = prompt.match(/at least 4(?! and at most)/g) ?? []
+    expect(uncapped).toEqual([])
+    expect(prompt).toContain(
+      'needs at least 4 and at most 4 requirements, numbered from r1'
+    )
+    expect(prompt).toContain(
+      '"requirements": ["at least 4 and at most 4, same shape as above"]'
+    )
+  })
+
   it('tells the chooser the working title is a promise it must keep', () => {
     const prompt = buildDirectionPrompt(
       'Where to eat in Lima right now',
@@ -155,7 +196,9 @@ describe('buildDirectionPrompt', () => {
 
     expect(prompt).toContain('THE TITLE IS A PROMISE')
     expect(prompt).toContain('A title containing "right now" is not automatically news.')
-    expect(prompt).toContain('needs at least 4 required research questions')
+    expect(prompt).toContain(
+      'needs at least 4 and at most 4 required research questions'
+    )
     expect(prompt).toContain('"requirement_id": "r4"')
   })
 
@@ -178,7 +221,9 @@ describe('buildDirectionPrompt', () => {
   it('still builds a usable prompt when no length has been chosen', () => {
     const prompt = buildDirectionPrompt('A weekend in Lisbon', 'Lisbon, Portugal', catalog, null)
 
+    // No length chosen means no measured band, so there is no ceiling to state.
     expect(prompt).toContain('needs at least 3 required research questions')
+    expect(prompt).not.toContain('at most')
   })
 
   it('tells the direction model what day it is', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/direction-prompt.ts
@@ -53,7 +53,51 @@ function formatForms(
  */
 export function researchQuestionsForLength(targetWordCount: number): number {
   if (!Number.isFinite(targetWordCount) || targetWordCount <= 0) return 3
-  return Math.min(8, Math.max(3, Math.round(targetWordCount / 350)))
+  return Math.min(
+    8,
+    Math.max(3, Math.round(targetWordCount / WORDS_PER_RESEARCH_QUESTION))
+  )
+}
+
+/** Words a single answered research question is worth, in finished prose. */
+export const WORDS_PER_RESEARCH_QUESTION = 350
+
+/**
+ * The most research questions a target length can absorb.
+ *
+ * The floor above stops a thin article. This is the same arithmetic run
+ * against the ceiling the pipeline actually measures a draft against -- the
+ * target plus `max(100, 10%)`, matching `_build_constraint_checks` in the
+ * backend -- and it stops the opposite failure. A commission carrying six
+ * questions against a 1540 word ceiling is worth about 2100 words of prose:
+ * it cannot be written to length, and the run finds out only after the
+ * writing model has been paid for twice.
+ *
+ * Never below `researchQuestionsForLength`, so the floor and the ceiling
+ * cannot contradict each other at any length.
+ *
+ * Known limit of that clamp: below roughly 1200 words the raw ceiling falls
+ * under the floor of 3, so it is clamped up and this function reports a count
+ * its own arithmetic says will not fit (a 700 word target gets 3 questions,
+ * worth about 1050 words, against an 800 word ceiling). Short commissions are
+ * therefore never warned about. Either 350 words a question is too blunt at
+ * that end, or the floor of 3 is doing something the arithmetic does not
+ * describe; the evidence for the ceiling comes from long articles, so this is
+ * left honest rather than guessed at.
+ */
+export function researchQuestionCeilingForLength(targetWordCount: number): number {
+  if (!Number.isFinite(targetWordCount) || targetWordCount <= 0) return 0
+  const ceiling = targetWordCount + Math.max(100, Math.round(targetWordCount * 0.1))
+  return Math.max(
+    researchQuestionsForLength(targetWordCount),
+    Math.floor(ceiling / WORDS_PER_RESEARCH_QUESTION)
+  )
+}
+
+/** The measured length band's upper edge, for messages that name it. */
+export function lengthCeilingWords(targetWordCount: number): number {
+  if (!Number.isFinite(targetWordCount) || targetWordCount <= 0) return 0
+  return targetWordCount + Math.max(100, Math.round(targetWordCount * 0.1))
 }
 
 /**
@@ -83,6 +127,16 @@ export function buildDirectionPrompt(
   settledFalse: readonly SettledFalsePremise[] = []
 ): string {
   const questionCount = researchQuestionsForLength(length?.target_word_count ?? 0)
+  /*
+   * No chosen length means no measured band, so there is nothing to state a
+   * ceiling against. Saying "at most 0" would be worse than saying nothing.
+   */
+  const questionCeiling = researchQuestionCeilingForLength(
+    length?.target_word_count ?? 0
+  )
+  const questionRange = questionCeiling
+    ? `at least ${questionCount} and at most ${questionCeiling}`
+    : `at least ${questionCount}`
   /*
    * Carried back from a run the gate stopped. Without it the operator returns
    * to this step with nothing but their own memory of what was refuted, and
@@ -125,10 +179,10 @@ The original title is what a reader sees before they read anything. Every option
 Read the USE WHEN and DO NOT USE WHEN lines under every form before choosing one. Pick the form that keeps the promise, not the form the title's mood suggests. A title containing "right now" is not automatically news.
 
 RESEARCH QUESTIONS
-Every option needs at least ${questionCount} required research questions.
+Every option needs ${questionRange} required research questions.
 - One question asks one thing. Split anything joined by "and" into separate questions, because one unanswerable half currently blocks the whole article.
 - No question may depend on another question's answer. "Which restaurants made the list" followed by "what do those restaurants charge" is a chain: nobody can research the second until the first comes back, so a first question that fails silently deletes the rest. Ask each question against something the premise or the subject already names.
-- Questions must be answerable by looking something up, and together they must cover enough ground to fill the target length. A single question yields a single section.
+- Questions must be answerable by looking something up, and together they must cover enough ground to fill the target length without overrunning it. A single question yields a single section of roughly ${WORDS_PER_RESEARCH_QUESTION} words, so more questions than the range above commissions an article that cannot be written to length. Ask fewer, better questions rather than covering everything.
 - Name things. A question about "the current shift in the dining scene" cannot be researched; "which restaurants opened in Barranco in 2026" can, and "what does a tasting menu cost in Barranco in 2026" is a second question that stands without waiting for the first.
 
 EDITORIAL RULES
@@ -144,7 +198,7 @@ EDITORIAL RULES
 - Make options materially distinct in direction, reader question, and outcome. They may share an article form when the editorial takes remain genuinely different.
 
 OUTPUT
-Return one JSON object and nothing else. No Markdown fence, preamble, or trailing note. Echo original_title and location exactly, character for character. Return exactly three options. Use the three fixed option_id values in the shown order. Every object must contain exactly the shown keys. Every option needs at least ${questionCount} requirements, numbered from r1 upward, and at least one premise, numbered from a1 upward. Every id in assumption_ids must name a premise declared by that same option.
+Return one JSON object and nothing else. No Markdown fence, preamble, or trailing note. Echo original_title and location exactly, character for character. Return exactly three options. Use the three fixed option_id values in the shown order. Every object must contain exactly the shown keys. Every option needs ${questionRange} requirements, numbered from r1 upward, and at least one premise, numbered from a1 upward. Every id in assumption_ids must name a premise declared by that same option.
 
 {
   "schema_version": 3,
@@ -192,7 +246,7 @@ ${requirementSample}
         "references": [{ "name": "...", "role": "primary_subject" }]
       },
       "premise": ["at least 1, same shape as above"],
-      "requirements": ["at least ${questionCount}, same shape as above"],
+      "requirements": ["${questionRange}, same shape as above"],
       "exclusions": ["..."],
       "rationale": "..."
     },
@@ -210,7 +264,7 @@ ${requirementSample}
         "references": [{ "name": "...", "role": "primary_subject" }]
       },
       "premise": ["at least 1, same shape as above"],
-      "requirements": ["at least ${questionCount}, same shape as above"],
+      "requirements": ["${questionRange}, same shape as above"],
       "exclusions": ["..."],
       "rationale": "..."
     }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -336,6 +336,16 @@ export type Prompt2BlogV3PipelinePayload = {
     constraint_checks: Record<string, boolean | number>
     readiness_blockers: string[]
     word_count_estimate: number
+    /** Optional: runs stored before this field existed do not carry it. */
+    word_count_check?: {
+      target_word_count_met: boolean
+      word_count_estimate: number
+      /** Words outside the accepted band: positive over, negative under. */
+      word_count_delta: number
+      word_count_direction: 'within' | 'over' | 'under'
+      word_count_target_min: number
+      word_count_target_max: number
+    }
     repair_applied: boolean
     repair_attempts: number
     groundedness: Prompt2BlogGroundedness


### PR DESCRIPTION
All three were found watching run `835e8a30` produce a usable article only because keep-best reverted both repair passes.

## 1. The word count check reports a direction

It was a bare boolean, so the audit model was told "wrong length" and left to guess which way. It guessed **too short** against a draft **363 words over** the ceiling and told repair to expand. Both repair passes made the article longer and both were discarded — two writing-model calls and about half the run's 28 minutes.

| draft | words | band |
|---|---|---|
| compose | 1886 | 1260–1540 |
| repair #1 | 2631 | further out |
| repair #2 | 2577 | further out |
| kept (reverted to compose) | 1903 | still out |

The check now carries the miss and its direction, and the repair instruction is **computed from the same counts that failed the check** rather than written by a model, so the two cannot disagree:

> Length: the draft is 1903 words, roughly 363 over the 1260-1540 words required for this article. Cut about 360 words…

The auditor's own length sentence is dropped when the computed one replaces it. A list holding both "cut about 360 words" and "expand the draft" is the original bug wearing a smaller hat.

The actual source of the "expand" bias turned out to be the audit prompt itself, which illustrated the rule with only the too-short case. It now names both edges.

Also folds three hand-written "which keys are measurements" filters into one shared set. They were already written differently in each place, so a new measurement would have leaked into whichever list nobody updated.

## 2. Direction time warns when a commission cannot fit its length

The run's commission carried 6 requirements against a 1540 word ceiling. At the pipeline's own ~350 words a question that is 2100 words of material — impossible before a word was written, and nothing said so until after the spend.

The generated prompt now asks for a range rather than an open-ended "at least N" — in the output contract and the schema examples as well as the rules prose. That last part matters: this file's own test already documents the precedence failure ("The rule said 'at least one'; the example said 'one', and the example won"), so a cap stated only in prose would have been ignored.

The import step also warns when an option comes back over. Advisory, like the existing too-few warning. Both bounds now come from one function, so the warning cannot scold an operator for following instructions this app wrote.

**Known limit, documented not fixed:** below ~1200 words the raw ceiling falls under the floor of 3 and is clamped up, so short commissions are never warned. The evidence for the 350-words-a-question figure comes from long articles; guessing at the short end seemed worse than writing down that it is unresolved.

## 3. Research-meta sentences are caught deterministically

Seven reached the reader:

> "Central does not publish its individual course names, so the specific dishes served on a given date are not public information."

> "Mérito's **sampled booking flow** uses a S/551 guarantee…"

The house rule already existed in the writer's prompt and was ignored, so this is the half that does not depend on the model having listened. It lives in the **shared** validator, so url2blog / youtube2blog / editor_assist inherit it, and the matching rule was added to the **shared prompt block** so no writer is judged against an instruction it never saw. A test now asserts every phrase the validator rejects is named in the prompt, so the two cannot drift apart.

Patterns are deliberately narrow. A false positive costs a repair call on correct prose *and* the repair prompt says to delete the sentence, so an over-broad pattern removes facts the reader needs. `release`, `not available online` and `not publicly listed` were all cut after they flagged ordinary booking prose ("the venue does not release tickets until 10am", "reservations are not available online, so call the counter"). Those now sit in the test file as cases that must stay clean.

Also: the writer is told not to narrate a resolved conflict, matching the existing rule about not narrating the premise check.

## Verification

- backend pytest: green
- frontend vitest: **931/931** (was 921) — run with `--no-file-parallelism`, the parallel flake is known and unrelated
- tsc, eslint: clean
- flake8: unchanged at its 3 pre-existing E402s

## What this does not prove

Fixes 1 and 2 are both about giving a model better information. The tests prove the information is now correct and internally consistent; they cannot prove the model acts on it. That needs a real run. Likewise the Fix 3 phrase list comes from one article's seven failures — a future run will phrase one in a way these patterns miss.
