### PR TITLE
Prompt2Blog v4 stage 0: the voice, the house rules, and the analysis form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@
   6. Run `pnpm generate:types`.
 - Never run destructive Payload migrations against existing local data without first checking row counts for critical tables: `locations`, `articles`, `media_assets`, `media_sets`, `users`, `visitor_profiles`, and `visitor_auth_*`.
 - Keep migration verification token-light: redirect noisy command output to `/tmp`, inspect with `tail`, `rg`, `git diff --stat`, and `git diff --numstat`, and only print narrow snippets around intended schema changes.
+- **Prompt2Blog is being rebuilt as v4. Read the decision records before touching it.**
+  - `apps/ai-blog-writer/docs/adr/0030-prompt2blog-v4-grill-and-brief.md` — an interview replaces the commission form; the Article Brief is the vision and is never consumed; one gate blocks before writing and nothing blocks after.
+  - `apps/ai-blog-writer/docs/adr/0031-prompt2blog-run-begins-at-the-seed.md` — a run is created when the seed is typed; v3 and v2 are **deleted, not deprecated**. Do not restore a fallback intake path, and do not add backward compatibility for old runs — the clean break is deliberate.
+  - `apps/ai-blog-writer/docs/adr/0032-one-questurian-voice.md` — one voice file plus one short mechanical-rules file. The six tone profiles are removed, and URL2Blog and YouTube2Blog are switched off until they are rebuilt on this foundation. Do not re-add a tone dropdown or copy the voice rules into another pipeline.
+  - Vocabulary is in `apps/ai-blog-writer/CONTEXT.md` — Seed, Grill, Article Brief, Work Order, Questurian Voice. **Article Brief** is not the listicle pipeline's Writer Brief and not the itinerary Generation Brief; the glossary says so explicitly.
+  - Build order and its hard sequencing constraints: https://claude.ai/code/artifact/9e3322ab-0da7-4a3d-a2c2-b83dd8ae17f6
 - Skills do not expand the user's authorization. Review, audit, explain, and plan requests remain read-only even when a skill suggests scaffolding or writes.
 - For Stripe work, do not generate or scaffold an app during review, and do not replace or initialize an existing app unless the user explicitly requests that change.
 - Get explicit user approval before accepting terms of service, installing or executing newly downloaded skills or code, provisioning external resources, uploading or publishing an app, changing live Stripe configuration, or initiating any financial transaction.

--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -321,6 +321,43 @@ Rule: a stop carries at most 4 Tour Picks (hard cap, enforced at the schema) and
 Related terms: Itinerary Autobuild (does not pick tours; tours are structured data, not AI prose — ADR 0013).
 Do not confuse with: the `tour-agency` stop (a manual, free-typed itinerary block); Tour Picks ride on an attraction stop and reference Tour records.
 
+### Seed
+
+Definition: the one line an operator types to start a Prompt2Blog article, in place of the v3 title-and-location pair. It is the spark, not a promise: it is kept on the [[Article Brief]] as provenance and is not binding on anything downstream. Creating a run happens here (ADR 0031), before any question is asked.
+Related terms: Grill, Article Brief, Run.
+Do not confuse with: the v3 `original_title`, which was locked on entry and handed to five stages as a promise nobody examined.
+
+### Grill
+
+Definition: the interview that replaces the Prompt2Blog commission form. It researches the seed before asking anything, asks one question at a time with a recommended answer attached to each, pushes back when an answer contradicts the seed or an earlier answer, and stops when the operator agrees with a played-back summary rather than at a question count.
+Rule: the grill is the single exit from every dead end — a refuted premise, a thin dossier, or a brief the operator no longer wants all return here, carrying what was learned. Re-entering revises the brief on the same run and discards downstream work that depended on what changed.
+Rule: first-hand material the operator supplies is recorded verbatim, never paraphrased, because first-hand material is excused from fact-checking by design and a paraphrase would create an unverifiable claim nothing downstream can catch.
+Related terms: Seed, Article Brief, Work Order.
+Do not confuse with: the v3 direction cards (removed in ADR 0030), which offered three model-written variants of a direction nobody had established.
+
+### Article Brief
+
+Definition: the vision for one Prompt2Blog article, produced by the [[Grill]] and approved by the operator. Carries the seed as provenance, the reader outcome, the form, the reader, the spine, what the piece must name, the material by kind (first-hand, interview, research), and a fails-if line naming what failure looks like.
+Rule: the brief is never consumed. It rides the whole run and the finished article is judged against it, including against its fails-if line.
+Rule: the brief is not hand-editable. Changing it means talking to the grill again; typed text would be an untracked instruction injected into every stage downstream.
+Related terms: Grill, Work Order, Questurian Voice.
+Do not confuse with: **Writer Brief** (the listicle blurb pipeline's per-blurb writer payload) or **Generation Brief** (the itinerary autobuild input). Three different objects; only this one is the article's vision. Inside Prompt2Blog "the brief" means the Article Brief.
+
+### Work Order
+
+Definition: the research plan derived from the [[Article Brief]] — the brief's translation into separately checkable questions. Holds premises, requirements, scope and a fingerprint. The eight editorial fields it held in v3 now live on the brief.
+Rule: requirements are split into load-bearing and texture. A missing texture answer costs a flourish; a missing load-bearing one costs the piece.
+Rule: the operator cuts it before research runs. Cutting a load-bearing question is permitted and is answered once with what the article can no longer claim, then obeyed.
+Related terms: Article Brief, Grounded Research.
+Do not confuse with: the Article Brief. The brief persists to the end; the work order persists only until research answers it.
+
+### Questurian Voice
+
+Definition: the single file describing what a Questurian article is like — treats the reader as an adult with a decision to make, isn't selling anything, warmth is attention rather than adjectives, has a view and says it, never talks about itself. Paired with a separate, much shorter file of mechanical rules (price and date format, no fabricated experiences, sentence-case headings, no in-article attribution).
+Rule: there is one voice. The six tone profiles are removed (ADR 0032); per-article variation comes from the Article Brief.
+Related terms: Article Brief, Anti-AI block.
+Do not confuse with: the v3 `questurian-default` brand-voice file, which was a rulebook of prohibitions rather than a description of a voice.
+
 ## Relationships
 
 - A **Run** has one **PipelineMeta** and many **StageResults**, finalized into one **PipelineArtifact**.

--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
@@ -420,22 +420,50 @@ def _usage_from(payload: dict[str, Any]) -> dict[str, Optional[int]]:
     }
 
 
-def _canonical_model(payload: dict[str, Any], alias: str) -> str:
-    """The model that actually answered, not the alias that was asked for.
+def _usage_number(entry: dict[str, Any], key: str) -> float:
+    value = entry.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    return float(value)
 
-    Worth carrying into cost attribution: 'sonnet' is a moving target, so a
-    per-stage spend record keyed on the alias would not say what it paid for.
+
+def _canonical_model(payload: dict[str, Any], alias: str) -> str:
+    """The model that did the work, not the first one the CLI happened to list.
+
+    ``modelUsage`` is a map, not a single entry. A real call routinely lists a
+    small helper model alongside the one that answered, and the key order is
+    the CLI's own -- not a ranking. Reading ``next(iter(...))`` therefore
+    stamped whole runs with the helper's name: every Claude call in this repo's
+    run history is recorded as ``claude-haiku-4-5``, including articles drafted
+    on Opus at high effort. The prices were right and the model names were
+    fiction, which is the worst shape for a spend record to be in.
+
+    Generated output is what separates the two: the helper emits tens of
+    tokens, the model that wrote the article emits thousands. Reported cost
+    breaks a tie when no entry declared its output. Ties keep the CLI's own
+    order, so the choice is deterministic for a given payload.
     """
     model_usage = payload.get("modelUsage")
-    if isinstance(model_usage, dict) and model_usage:
-        first_key = next(iter(model_usage))
-        entry = model_usage[first_key]
-        if isinstance(entry, dict):
-            canonical = entry.get("canonicalModel")
-            if isinstance(canonical, str) and canonical.strip():
-                return canonical.strip()
-        return str(first_key)
-    return alias
+    if not isinstance(model_usage, dict) or not model_usage:
+        return alias
+
+    best_key: Any = None
+    best_rank = (-1.0, -1.0)
+    for key, entry in model_usage.items():
+        row = entry if isinstance(entry, dict) else {}
+        rank = (_usage_number(row, "outputTokens"), _usage_number(row, "costUSD"))
+        if rank > best_rank:
+            best_rank = rank
+            best_key = key
+    if best_key is None:
+        best_key = next(iter(model_usage))
+
+    entry = model_usage[best_key]
+    if isinstance(entry, dict):
+        canonical = entry.get("canonicalModel")
+        if isinstance(canonical, str) and canonical.strip():
+            return canonical.strip()
+    return str(best_key)
 
 
 def _invoke(

--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/prompt2blog_credential.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/prompt2blog_credential.py
@@ -52,21 +52,33 @@ def save_credential(*, label: str, token: str) -> dict[str, Any]:
     cleaned_token = token.strip()
     if not cleaned_label or not cleaned_token:
         raise Prompt2BlogCredentialError("Account label and token are required.")
+    if any(character.isspace() for character in cleaned_token):
+        raise Prompt2BlogCredentialError(
+            "That does not look like a Claude setup token: it contains a space "
+            "or a line break."
+        )
 
-    args = [
-        SECURITY_CLI,
-        "add-generic-password",
-        "-a",
-        SLOT_ID,
-        "-s",
-        KEYCHAIN_SERVICE,
-        "-U",
-        "-w",
-    ]
+    # `add-generic-password -w` with no value does not read the password from
+    # stdin -- it PROMPTS for it, twice, on the controlling terminal. A piped
+    # token is therefore either ignored (the item is written with an empty
+    # secret) or never consumed at all, and the call sits until it times out.
+    # Under uvicorn, started from a terminal, it is the second one.
+    #
+    # `security -i` reads the whole command from stdin instead: no prompt, a
+    # real exit code, and the token still never appears in argv, so it cannot
+    # be read out of `ps` -- which is why the prompt was being used at all.
+    args = [SECURITY_CLI, "-i"]
+    command = (
+        "add-generic-password"
+        f" -a {SLOT_ID}"
+        f" -s {KEYCHAIN_SERVICE}"
+        " -U"
+        f" -w {cleaned_token}\n"
+    )
     try:
         completed = subprocess.run(
             args,
-            input=cleaned_token + "\n",
+            input=command,
             capture_output=True,
             text=True,
             timeout=KEYCHAIN_TIMEOUT_SECONDS,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -3,9 +3,10 @@ from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.core import (
+    read_all_stage_results,
     read_output,
     read_stage_result,
     read_status,
@@ -28,6 +29,7 @@ from utils.llm_model_policy import (
 
 from ..config import DEFAULT_MODEL, FEATURE_NAME
 from ..contracts_v3 import Prompt2BlogV3Request
+from ..drafts_view import build_drafts_report, render_drafts_page
 from ..intake_v3 import (
     prepare_v3_runtime_request,
     v3_intake_result,
@@ -401,6 +403,37 @@ async def get_result(run_id: str) -> JSONResponse:
     }
     response_payload.update(trace_payload)
     return JSONResponse(response_payload)
+
+
+@router.get("/drafts/{run_id}", response_class=HTMLResponse)
+async def drafts_page(run_id: str) -> HTMLResponse:
+    """Every draft this run produced, as a page an operator can read.
+
+    HTML rather than JSON because the answer is prose being compared to other
+    prose: which version shipped, how long each one was, and what the audit
+    said about it. The same page the `scripts/p2b-drafts.py` CLI writes, from
+    the same renderer.
+
+    Read-only, and it reads rows `/debug/{run_id}` already returns, so it adds
+    no exposure beyond that endpoint.
+    """
+    status = read_status(run_id)
+    if not status or status.get("feature") != FEATURE_NAME:
+        raise HTTPException(status_code=404, detail="Run not found.")
+
+    output = read_output(run_id)
+    report = build_drafts_report(
+        run_id=run_id,
+        status=status,
+        stages=read_all_stage_results(run_id),
+        markdown=(output or {}).get("markdown", ""),
+    )
+    if not report["drafts"]:
+        raise HTTPException(
+            status_code=404,
+            detail="This run has no drafts yet; it may still be composing.",
+        )
+    return HTMLResponse(render_drafts_page(report))
 
 
 @router.get("/debug/{run_id}")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -14,11 +14,16 @@ P2B_COMPOSE_MODEL = "gemini-3.1-pro-preview"
 # Used only when an older client does not send its selected stack's audit model.
 P2B_AUDIT_MODEL = "gemini-3.7-flash"
 
-# V3 gives bounded, structured jobs to Sonnet at medium effort. Opus stays on
-# the two stages where prose quality has the largest editing-cost impact:
-# compose and repair. These are fixed independently from the selectable writer
-# and audit roles so choosing a premium prose model cannot silently promote
-# every small pipeline call to the same effort tier.
+# Defaults for the three roles a route does not have to name. V3 gives bounded,
+# structured jobs to Sonnet at medium effort, and Opus stays on the two stages
+# where prose quality has the largest editing-cost impact: compose and repair.
+#
+# These were pinned rather than defaulted until routes could name them, which
+# meant a route could only move two of the six calls a run makes. They are
+# still separate from the writer and audit roles: the reason for pinning them
+# was that a premium prose model must not silently promote every small call to
+# the same effort tier, and a route that has to name each one cannot do that by
+# accident.
 P2B_V3_OUTLINE_MODEL = "claude-sonnet-5-medium"
 P2B_V3_GROUNDEDNESS_MODEL = "claude-sonnet-5-medium"
 P2B_V3_TITLE_MODEL = "claude-sonnet-5-medium"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v3.py
@@ -379,9 +379,27 @@ class Prompt2BlogWritingProfiles(V3ContractModel):
 
 
 class Prompt2BlogModelRouting(V3ContractModel):
+    """Which model answers for each role a v3 run actually calls.
+
+    Outline, groundedness and title used to be pinned in ``config.py`` and
+    unreachable from a request, so a route could only move the writer and the
+    judge -- two of the six calls a run makes. They are declared per route now,
+    and they are still separate fields rather than "same as the writer": the
+    reason they were pinned was to stop a premium prose model silently
+    promoting every small call to the same tier, and a route that has to name
+    them cannot do that by accident.
+
+    All optional. A request that omits one gets the ``P2B_V3_*_MODEL`` default,
+    so an older client keeps the routing it has always had.
+    """
+
     model_name: str | None = None
     writing_model: str | None = None
+    repair_model: str | None = None
     audit_model: str | None = None
+    outline_model: str | None = None
+    groundedness_model: str | None = None
+    title_model: str | None = None
     model_stack_id: str | None = None
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/drafts_view.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/drafts_view.py
@@ -1,0 +1,434 @@
+"""Every draft a run produced, rendered as one readable page.
+
+A run keeps each version of the article -- what compose wrote, what repair
+rewrote, and the one that shipped -- but they sit inside three different stage
+rows as JSON, so comparing them meant querying sqlite by hand. Run 25178bce
+shipped the *longer* of two drafts and nothing in the UI said so.
+
+Deliberately dependency-free: only the standard library, no imports from the
+rest of this app. The API route feeds it rows it has already read, and
+`scripts/p2b-drafts.py` loads this file directly to render the same page
+offline, so there is one renderer rather than two that drift.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Any
+
+# The pipeline's own word counter, from `support.py::_tokenize_words`. It
+# counts runs of letters and digits, so "day-by-day" is 3 words and "US$1,090"
+# is 3. Reproduced rather than imported to keep this module standalone; it is
+# shown beside a plain word count because the gap between the two is what
+# failed run 25178bce, whose repaired draft was 991 words and was rejected at
+# a counted 1004 against a 1000 ceiling.
+PIPELINE_TOKEN = re.compile(r"[a-z0-9']+")
+
+STAGE_LABELS = {
+    "stage_compose": "First draft",
+    "stage_v3_compose": "First draft",
+    "stage_repair": "Repaired draft",
+    "stage_v3_repair": "Repaired draft",
+    "stage_supplement": "Supplemented draft",
+    "stage_editorial_augmentation": "Augmented draft",
+    "stage_final_verify": "Verified draft",
+}
+
+# Short enough to be a paragraph of boilerplate rather than an article.
+MIN_DRAFT_CHARS = 400
+
+
+def pipeline_words(text: str) -> int:
+    return len(PIPELINE_TOKEN.findall(text.lower()))
+
+
+def plain_words(text: str) -> int:
+    return len(text.split())
+
+
+def band_side(count: int, low: Any, high: Any) -> str:
+    """``over`` / ``under`` / ``""`` for a count against the accepted band."""
+    if isinstance(high, int) and high and count > high:
+        return "over"
+    if isinstance(low, int) and low and count < low:
+        return "under"
+    return ""
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip().lower()
+
+
+def _safe_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _draft_text(data: Any) -> tuple[str, str]:
+    """The (title, content) a stage payload carries, if it carries an article."""
+    data = _safe_dict(data)
+    rewrite = data.get("rewrite")
+    if isinstance(rewrite, dict):
+        content = rewrite.get("improved_content")
+        if isinstance(content, str) and len(content) > MIN_DRAFT_CHARS:
+            title = rewrite.get("improved_title")
+            return (title if isinstance(title, str) else ""), content
+    for key in ("content", "markdown", "article"):
+        value = data.get(key)
+        if isinstance(value, str) and len(value) > MIN_DRAFT_CHARS:
+            return "", value
+    return "", ""
+
+
+def _inline(text: str) -> str:
+    escaped = html.escape(text)
+    escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+    escaped = re.sub(r"(?<!\*)\*(?!\s)(.+?)(?<!\s)\*(?!\*)", r"<em>\1</em>", escaped)
+    return escaped
+
+
+def markdown_to_html(text: str) -> str:
+    """Enough markdown to read a draft: headings, lists, bold, italics.
+
+    Not a markdown implementation. The drafts this renders are pipeline output,
+    which is headings and paragraphs, and a real parser would be a dependency
+    this module exists to avoid.
+    """
+    out: list[str] = []
+    in_list = False
+    for raw_line in text.split("\n"):
+        line = raw_line.rstrip()
+        if not line.strip():
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            continue
+        bullet = re.match(r"^\s*[-*]\s+(.*)$", line)
+        if bullet:
+            if not in_list:
+                out.append("<ul>")
+                in_list = True
+            out.append(f"<li>{_inline(bullet.group(1))}</li>")
+            continue
+        if in_list:
+            out.append("</ul>")
+            in_list = False
+        heading = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if heading:
+            level = min(len(heading.group(1)) + 1, 6)
+            out.append(f"<h{level}>{_inline(heading.group(2))}</h{level}>")
+        else:
+            out.append(f"<p>{_inline(line)}</p>")
+    if in_list:
+        out.append("</ul>")
+    return "\n".join(out)
+
+
+def build_drafts_report(
+    *,
+    run_id: str,
+    status: dict[str, Any] | None,
+    stages: dict[str, Any],
+    markdown: str,
+) -> dict[str, Any]:
+    """Collect every draft in a run, newest last, with the shipped one marked.
+
+    ``stages`` is what ``read_all_stage_results`` returns: stage name to the
+    stored envelope, in the order the stages were written.
+    """
+    drafts: list[dict[str, Any]] = []
+    payloads: dict[str, Any] = {}
+    for stage_name, envelope in stages.items():
+        envelope = _safe_dict(envelope)
+        data = _safe_dict(envelope.get("data") or envelope)
+        payloads[stage_name] = data
+        title, content = _draft_text(data)
+        if not content:
+            continue
+        created = str(envelope.get("created_at") or "")
+        drafts.append(
+            {
+                "stage": stage_name,
+                "label": STAGE_LABELS.get(stage_name, stage_name),
+                "at": created[11:19],
+                "title": title,
+                "content": content,
+                "is_shipped": False,
+            }
+        )
+
+    if markdown:
+        body = re.sub(r"^#\s+.*\n+", "", markdown, count=1)
+        shipped = _normalize(body)
+        for draft in drafts:
+            draft["is_shipped"] = _normalize(draft["content"]) == shipped
+        drafts.append(
+            {
+                "stage": "final",
+                "label": "Shipped article",
+                "at": "",
+                "title": markdown.split("\n", 1)[0].lstrip("# ").strip(),
+                "content": body,
+                "is_shipped": False,
+            }
+        )
+
+    for draft in drafts:
+        draft["words"] = plain_words(draft["content"])
+        draft["pipeline_words"] = pipeline_words(draft["content"])
+
+    audit = payloads.get("stage_v3_quality_audit") or payloads.get(
+        "stage_quality_audit"
+    )
+    settle = payloads.get("stage_v3_quality_settle") or payloads.get(
+        "stage_quality_settle"
+    )
+    finalize = payloads.get("stage_v3_finalize") or payloads.get("stage_finalize")
+    audit = _safe_dict(audit)
+    settle = _safe_dict(settle)
+
+    return {
+        "run_id": run_id,
+        "status": _safe_dict(status),
+        "drafts": drafts,
+        "finalize": _safe_dict(finalize),
+        "quality": _safe_dict(audit.get("quality")),
+        "repair_decision": _safe_dict(
+            audit.get("repair_decision") or settle.get("repair_decision")
+        ),
+        "settle": settle,
+        "routing": _safe_dict(
+            _safe_dict(payloads.get("pipeline_input_v3")).get("model_routing")
+        ),
+        "ledger": _safe_dict(payloads.get("usage_ledger")),
+    }
+
+
+def _chip(label: str, value: str, tone: str = "") -> str:
+    return (
+        f'<div class="chip {tone}"><span class="chip-label">{html.escape(label)}'
+        f'</span><span class="chip-value">{html.escape(value)}</span></div>'
+    )
+
+
+def _table(rows: list[tuple[str, str]]) -> str:
+    return "".join(
+        f"<tr><td>{html.escape(str(key))}</td><td>{html.escape(str(value))}</td></tr>"
+        for key, value in rows
+    )
+
+
+def render_drafts_page(report: dict[str, Any]) -> str:
+    """The whole page, self-contained: no scripts fetched, no styles fetched."""
+    drafts = report["drafts"]
+    quality = report["quality"]
+    finalize = report["finalize"]
+    settle = report["settle"]
+    decision = report["repair_decision"]
+    ledger = report["ledger"]
+
+    checks = _safe_dict(finalize.get("constraint_checks")) or _safe_dict(
+        quality.get("constraint_checks")
+    )
+    failing = [key for key, value in checks.items() if value is False]
+    blockers = finalize.get("readiness_blockers") or []
+    status = (
+        finalize.get("pipeline_status")
+        or report["status"].get("status")
+        or "unknown"
+    )
+
+    stage_rows = ledger.get("by_stage") or []
+    totals = _safe_dict(ledger.get("totals"))
+    total_cost = sum(
+        row.get("cost_usd") or 0.0
+        for row in stage_rows
+        if isinstance(row, dict) and isinstance(row.get("cost_usd"), (int, float))
+    )
+
+    chips = [
+        _chip("Verdict", str(status), "good" if status == "ready_for_staging" else "bad"),
+        _chip("Drafts", str(len([d for d in drafts if d["stage"] != "final"]))),
+        _chip("Metered cost", f"${total_cost:,.2f}" if total_cost else "n/a"),
+        _chip("Tokens", f"{totals.get('total_tokens', 0):,}"),
+        _chip("Repair attempts", str(settle.get("repair_attempts", 0))),
+    ]
+    if settle.get("reverted_to_earlier_draft"):
+        chips.append(_chip("Kept draft", "reverted to an earlier one", "warn"))
+
+    band_min = checks.get("word_count_target_min")
+    band_max = checks.get("word_count_target_max")
+    band = f"{band_min}–{band_max}" if band_min and band_max else "not set"
+
+    tabs: list[str] = []
+    panes: list[str] = []
+    for index, draft in enumerate(drafts):
+        marks = []
+        if draft["is_shipped"]:
+            marks.append('<span class="tag ship">shipped</span>')
+        # Two verdicts, because they can disagree: the gate reads the pipeline
+        # counter, which on the Lima run failed a draft whose actual words were
+        # inside the band. When they split, the draft says so.
+        counter_side = band_side(draft["pipeline_words"], band_min, band_max)
+        if counter_side:
+            marks.append(f'<span class="tag over">counter: {counter_side} band</span>')
+            if not band_side(draft["words"], band_min, band_max):
+                marks.append('<span class="tag ok">words in band</span>')
+        delta = draft["pipeline_words"] - draft["words"]
+        title_html = (
+            f'<p class="meta">Title: {html.escape(draft["title"])}</p>'
+            if draft["title"]
+            else ""
+        )
+        tabs.append(
+            f'<button class="tab{" active" if index == 0 else ""}"'
+            f' data-pane="{index}">{html.escape(draft["label"])}'
+            f'<span class="tab-count">{draft["words"]} words</span></button>'
+        )
+        panes.append(
+            f'<section class="pane{" active" if index == 0 else ""}" id="pane-{index}">'
+            f'<header class="pane-head"><h2>{html.escape(draft["label"])}'
+            f'{"".join(marks)}</h2>'
+            f'<p class="meta"><b>{draft["words"]}</b> words &middot; pipeline counter'
+            f' says <b>{draft["pipeline_words"]}</b>'
+            f'{f" (+{delta})" if delta else ""} &middot; band {html.escape(band)}'
+            f'{" &middot; " + draft["at"] if draft["at"] else ""}</p>'
+            f"{title_html}</header>"
+            f'<article class="prose">{markdown_to_html(draft["content"])}</article>'
+            "</section>"
+        )
+
+    revisions = quality.get("required_revisions") or []
+    revision_html = "".join(f"<li>{html.escape(str(item))}</li>" for item in revisions)
+
+    decision_html = ""
+    if decision:
+        decision_html = (
+            '<p class="meta">Repair gate: <b>'
+            f'{html.escape(str(decision.get("route", "")))}</b> — '
+            f'{html.escape(str(decision.get("reason", "")))}, '
+            f'{decision.get("attempts_used", 0)} of '
+            f'{decision.get("attempts_allowed", 0)} attempts, '
+            f'{decision.get("tokens_spent") or 0:,} of '
+            f'{decision.get("token_budget", 0):,} tokens spent.</p>'
+        )
+
+    heading = drafts[0]["title"] if drafts and drafts[0]["title"] else "Prompt2Blog run"
+    ledger_rows = "".join(
+        f'<tr><td>{html.escape(str(row.get("stage", "")))}</td>'
+        f'<td>{row.get("total_tokens", 0):,}</td>'
+        f'<td>{("$%.4f" % row["cost_usd"]) if isinstance(row.get("cost_usd"), (int, float)) else "—"}</td></tr>'
+        for row in stage_rows
+        if isinstance(row, dict)
+    )
+
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Drafts — {html.escape(report["run_id"][:8])}</title>
+<style>
+  :root {{
+    --bg:#f7f5f1; --panel:#fffdfa; --ink:#1d1b18; --muted:#6b6660;
+    --line:#e2ddd4; --accent:#3b5bdb; --bad:#b3261e; --good:#1a7f4b; --warn:#a8620a;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{ --bg:#161513; --panel:#1e1d1a; --ink:#eae7e1; --muted:#a09a92;
+      --line:#302e2a; --accent:#8ea2ff; --bad:#ff8a80; --good:#7ddba3;
+      --warn:#e0a458; }}
+  }}
+  * {{ box-sizing:border-box; }}
+  body {{ margin:0; background:var(--bg); color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,sans-serif; }}
+  header.top {{ padding:24px 32px 16px; border-bottom:1px solid var(--line); }}
+  h1 {{ font-size:20px; margin:0 0 4px; }}
+  .runid {{ font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    color:var(--muted); font-size:13px; }}
+  .chips {{ display:flex; flex-wrap:wrap; gap:8px; margin-top:14px; }}
+  .chip {{ background:var(--panel); border:1px solid var(--line); border-radius:8px;
+    padding:6px 10px; display:flex; gap:8px; align-items:baseline; font-size:13px; }}
+  .chip-label {{ color:var(--muted); }}
+  .chip-value {{ font-weight:600; }}
+  .chip.bad .chip-value {{ color:var(--bad); }}
+  .chip.good .chip-value {{ color:var(--good); }}
+  .chip.warn .chip-value {{ color:var(--warn); }}
+  .wrap {{ display:grid; grid-template-columns:minmax(0,1fr) 300px; gap:24px;
+    padding:24px 32px 64px; align-items:start; }}
+  @media (max-width:1000px) {{ .wrap {{ grid-template-columns:1fr; }} }}
+  .tabs {{ display:flex; flex-wrap:wrap; gap:6px; margin-bottom:16px; }}
+  .tab {{ background:var(--panel); border:1px solid var(--line); border-radius:8px;
+    padding:8px 12px; cursor:pointer; color:var(--ink); font:inherit; font-size:14px;
+    display:flex; gap:8px; align-items:baseline; }}
+  .tab.active {{ border-color:var(--accent); box-shadow:inset 0 -2px 0 var(--accent); }}
+  .tab-count {{ color:var(--muted); font-size:12px; }}
+  .pane {{ display:none; background:var(--panel); border:1px solid var(--line);
+    border-radius:12px; padding:24px 28px; }}
+  .pane.active {{ display:block; }}
+  .pane-head h2 {{ font-size:17px; margin:0 0 6px; display:flex; gap:8px;
+    align-items:center; flex-wrap:wrap; }}
+  .meta {{ color:var(--muted); font-size:13px; margin:0 0 4px; }}
+  .tag {{ font-size:11px; text-transform:uppercase; letter-spacing:.06em;
+    border-radius:999px; padding:2px 8px; font-weight:700; }}
+  .tag.ship {{ background:var(--good); color:#fff; }}
+  .tag.over {{ background:var(--warn); color:#fff; }}
+  .tag.ok {{ background:transparent; color:var(--good);
+    border:1px solid var(--good); }}
+  .prose {{ max-width:70ch; margin-top:20px; border-top:1px solid var(--line);
+    padding-top:20px; }}
+  .prose h2 {{ font-size:19px; margin:28px 0 8px; }}
+  .prose h3 {{ font-size:16px; margin:22px 0 6px; }}
+  .prose p {{ margin:0 0 14px; }}
+  aside section {{ background:var(--panel); border:1px solid var(--line);
+    border-radius:12px; padding:16px 18px; margin-bottom:16px; }}
+  aside h3 {{ font-size:13px; text-transform:uppercase; letter-spacing:.07em;
+    color:var(--muted); margin:0 0 10px; }}
+  table {{ width:100%; border-collapse:collapse; font-size:13px; }}
+  td {{ padding:4px 0; border-bottom:1px solid var(--line); vertical-align:top; }}
+  td:first-child {{ color:var(--muted); padding-right:10px; }}
+  td:last-child {{ text-align:right; font-variant-numeric:tabular-nums; }}
+  ul.revisions {{ margin:0; padding-left:18px; font-size:13px; }}
+  ul.revisions li {{ margin-bottom:6px; }}
+  .fail {{ color:var(--bad); font-weight:600; }}
+</style></head>
+<body>
+<header class="top">
+  <h1>{html.escape(str(heading))}</h1>
+  <div class="runid">{html.escape(report["run_id"])}</div>
+  <div class="chips">{"".join(chips)}</div>
+</header>
+<div class="wrap">
+  <main>
+    <div class="tabs">{"".join(tabs)}</div>
+    {"".join(panes)}
+  </main>
+  <aside>
+    <section>
+      <h3>Audit</h3>
+      <p class="meta">Overall score <b>{quality.get("overall_score", "—")}</b>{
+        "<br>Failing: <span class='fail'>" + html.escape(", ".join(failing)) + "</span>"
+        if failing else ""}</p>
+      {decision_html}
+      {"<ul class='revisions'>" + revision_html + "</ul>" if revision_html else ""}
+      {"<p class='meta'>Blockers: " + html.escape(", ".join(map(str, blockers))) + "</p>"
+       if blockers else ""}
+    </section>
+    <section><h3>Checks</h3><table>{_table(sorted(checks.items()))}</table></section>
+    <section><h3>Spend by stage</h3><table>{ledger_rows}</table></section>
+    <section><h3>Routing</h3><table>{_table(list(report["routing"].items()))}</table></section>
+  </aside>
+</div>
+<script>
+  document.querySelectorAll('.tab').forEach(function (tab) {{
+    tab.addEventListener('click', function () {{
+      document.querySelectorAll('.tab').forEach(function (other) {{
+        other.classList.remove('active');
+      }});
+      document.querySelectorAll('.pane').forEach(function (pane) {{
+        pane.classList.remove('active');
+      }});
+      tab.classList.add('active');
+      document.getElementById('pane-' + tab.dataset.pane).classList.add('active');
+    }});
+  }});
+</script>
+</body></html>
+"""

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -82,6 +82,7 @@ class Prompt2BlogV3GraphState(TypedDict, total=False):
     model_name: str
     outline_model: str
     writing_model: str
+    repair_model: str
     groundedness_model: str
     audit_model: str
     title_model: str

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v3.py
@@ -87,7 +87,11 @@ def prepare_v3_runtime_request(
         enable_editorial_augmentation=request.enable_editorial_augmentation,
         model_name=request.model_routing.model_name,
         writing_model=request.model_routing.writing_model,
+        repair_model=request.model_routing.repair_model,
         audit_model=request.model_routing.audit_model,
+        outline_model=request.model_routing.outline_model,
+        groundedness_model=request.model_routing.groundedness_model,
+        title_model=request.model_routing.title_model,
         model_stack_id=request.model_routing.model_stack_id,
     )
 
@@ -124,7 +128,11 @@ def v3_run_input_artifact(runtime: PipelineV3RuntimeRequest) -> dict[str, Any]:
         "model_routing": {
             "model_name": runtime.model_name,
             "writing_model": runtime.writing_model,
+            "repair_model": runtime.repair_model,
             "audit_model": runtime.audit_model,
+            "outline_model": runtime.outline_model,
+            "groundedness_model": runtime.groundedness_model,
+            "title_model": runtime.title_model,
             "model_stack_id": runtime.model_stack_id,
         },
         "include_debug": runtime.include_debug,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/models.py
@@ -68,6 +68,15 @@ class PipelineV3RuntimeRequest(BaseModel):
     model_name: str | None = None
     writing_model: str | None = None
     audit_model: str | None = None
+    # Repair defaults to the writing model rather than a constant: it rewrites
+    # the same prose, so following the writer is the right default. A route
+    # names it only to spend different effort on the rescue than on the draft.
+    repair_model: str | None = None
+    # The three roles v2 pins and v3 lets a route name. Optional, so a request
+    # that omits them gets the `P2B_V3_*_MODEL` defaults and routes as before.
+    outline_model: str | None = None
+    groundedness_model: str | None = None
+    title_model: str | None = None
     model_stack_id: str | None = None
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator_v3.py
@@ -106,19 +106,38 @@ def _initial_v3_state(
         "stage_contexts": _safe_dict(instructions.get("stage_contexts")),
         "option_context": _safe_dict(request.option_context),
         "model_name": request.model_name or DEFAULT_MODEL,
-        "outline_model": dependencies.resolve_writer_model(P2B_V3_OUTLINE_MODEL),
+        # Every role a v3 run calls is now routable. The three that used to be
+        # pinned still default to the same constants, so a request that names
+        # none of them runs exactly as it did before.
+        "outline_model": dependencies.resolve_writer_model(
+            request.outline_model,
+            default=P2B_V3_OUTLINE_MODEL,
+        ),
         "writing_model": dependencies.resolve_writer_model(
             request.writing_model,
             default=P2B_COMPOSE_MODEL,
+        ),
+        # Defaults to whatever the writer resolved to, so a route that says
+        # nothing about repair keeps drafting and repairing on one model.
+        "repair_model": dependencies.resolve_writer_model(
+            request.repair_model,
+            default=dependencies.resolve_writer_model(
+                request.writing_model,
+                default=P2B_COMPOSE_MODEL,
+            ),
         ),
         "audit_model": dependencies.resolve_writer_model(
             request.audit_model,
             default=P2B_AUDIT_MODEL,
         ),
         "groundedness_model": dependencies.resolve_writer_model(
-            P2B_V3_GROUNDEDNESS_MODEL
+            request.groundedness_model,
+            default=P2B_V3_GROUNDEDNESS_MODEL,
         ),
-        "title_model": dependencies.resolve_writer_model(P2B_V3_TITLE_MODEL),
+        "title_model": dependencies.resolve_writer_model(
+            request.title_model,
+            default=P2B_V3_TITLE_MODEL,
+        ),
         "model_stack_id": request.model_stack_id,
         "compose_temperature": PROMPT2BLOG_CREATIVITY_TEMPERATURES.get(
             creativity_level,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -486,19 +486,41 @@ class Prompt2BlogTokenUsageTracker:
         ]
 
     def _stage_rows(self) -> list[dict[str, Any]]:
+        # `by_attempt` has carried a per-row price since it was written and this
+        # has not, so a receipt could say what one attempt of repair cost but
+        # never what repair cost -- the exact number anyone deciding whether a
+        # stage is worth its budget wants. Priced the same way, including the
+        # abstention: a stage holding even one call the provider would not
+        # price reports no cost rather than a total that quietly omits it.
         rows: dict[str, dict[str, Any]] = {}
         for entry in self.calls:
             row = rows.setdefault(
                 entry["stage"],
-                {"stage": entry["stage"], **_empty_usage(), "attempts": 0},
+                {
+                    "stage": entry["stage"],
+                    **_empty_usage(),
+                    "attempts": 0,
+                    "cost_usd": 0.0,
+                    "unpriced_calls": 0,
+                },
             )
             for token_key in TOKEN_KEYS:
                 row[token_key] += entry[token_key]
             row["calls"] += 1
+            if entry["cost_usd"] is None:
+                row["unpriced_calls"] += 1
+            else:
+                row["cost_usd"] += entry["cost_usd"]
         for stage, attempts in self.stage_attempts.items():
             row = rows.setdefault(
                 stage,
-                {"stage": stage, **_empty_usage(), "attempts": 0},
+                {
+                    "stage": stage,
+                    **_empty_usage(),
+                    "attempts": 0,
+                    "cost_usd": 0.0,
+                    "unpriced_calls": 0,
+                },
             )
             row["attempts"] = attempts
         for stage, row in rows.items():
@@ -513,10 +535,22 @@ class Prompt2BlogTokenUsageTracker:
                 )
         # Sorted by spend so the stages worth capping or de-thinking are the
         # ones read first.
-        return sorted(
-            rows.values(),
-            key=lambda row: (-row["total_tokens"], row["stage"]),
-        )
+        return [
+            {
+                **{
+                    key: value
+                    for key, value in row.items()
+                    if key not in ("cost_usd", "unpriced_calls")
+                },
+                "cost_usd": (
+                    round(row["cost_usd"], 6) if not row["unpriced_calls"] else None
+                ),
+            }
+            for row in sorted(
+                rows.values(),
+                key=lambda row: (-row["total_tokens"], row["stage"]),
+            )
+        ]
 
     def summary(
         self,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -229,12 +229,20 @@ def run_v3_repair_stage(
         instructions=stage_context_text(state["stage_contexts"], "repair_lock"),
         style_directive=_format_style_directive(state["option_context"]),
     )
-    # Repair rewrites the whole article, so it runs on the writer model.
+    # Repair rewrites the whole article, so it runs on a prose model -- the
+    # writer's, unless the route named a different one.
+    #
+    # Worth being separable from the draft: the two are not the same job. The
+    # draft writes into an open space; repair is handed a list of required
+    # revisions and has to satisfy them without breaking the rest, which is the
+    # kind of work more reasoning effort actually pays for. It is also the
+    # cheaper place to spend it, because it only runs on a draft that failed.
+    repair_model = state.get("repair_model") or state["writing_model"]
     parsed, raw_response = dependencies.llm.invoke_json(
         prompt=prompt,
         max_tokens=6144,
         temperature=0.1,
-        model_name=state["writing_model"],
+        model_name=repair_model,
         schema=REWRITE_SCHEMA,
     )
     repaired = _sanitize_rewrite(
@@ -242,9 +250,11 @@ def run_v3_repair_stage(
         fallback_title=rewrite["improved_title"],
         fallback_content=rewrite["improved_content"],
     )
+    # The same model that just wrote this text: the enforcement pass is another
+    # rewrite of it, not a separate judgement.
     repaired["improved_content"] = dependencies.llm.enforce_anti_ai(
         repaired["improved_content"],
-        model_name=state["writing_model"],
+        model_name=repair_model,
         max_tokens=6144,
         context="prompt2blog v3 repair",
     )
@@ -252,7 +262,7 @@ def run_v3_repair_stage(
         state["trace"],
         state["include_debug"],
         stage=stage,
-        model_name=state["writing_model"],
+        model_name=repair_model,
         input_payload={"attempt": attempt},
         prompt=prompt,
         raw_response=raw_response,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.shared.writer_models import temperature_is_honored
+
 from ...content.markdown import _build_markdown
 from ...dependencies import PipelineDependencies
 from ...graph.state import Prompt2BlogV3GraphState
@@ -155,11 +157,26 @@ def run_v3_finalize_stage(
             "outline_unsupported_requirements": _safe_dict(state.get("outline")).get(
                 "unsupported_requirements", []
             ),
-            "model_used": state["model_name"],
+            # The model that produced this review. It used to report the
+            # worker model, which v3 never calls at all -- so a review written
+            # by the audit model was filed under a Gemini name that had no part
+            # in it.
+            "model_used": state["audit_model"],
+            # Whether the creativity control reached the stage that writes
+            # prose. It sets `compose_temperature`, and the subscription CLI
+            # has no temperature flag, so on a Claude-written draft the setting
+            # is accepted and dropped. Recorded rather than hidden: a reader
+            # comparing two drafts should not have to guess whether the dial
+            # was connected.
+            "creativity": {
+                "level": _safe_dict(state["option_context"]).get("creativity_level"),
+                "compose_temperature": state["compose_temperature"],
+                "applied_to_compose": temperature_is_honored(state["writing_model"]),
+            },
             "stage_model_overrides": {
                 "stage_v3_outline": state["outline_model"],
                 "stage_v3_compose": state["writing_model"],
-                "stage_v3_repair": state["writing_model"],
+                "stage_v3_repair": state["repair_model"],
                 "stage_v3_title": state["title_model"],
                 "stage_v3_quality_audit": state["audit_model"],
                 "stage_v3_groundedness": state["groundedness_model"],
@@ -175,6 +192,7 @@ def run_v3_finalize_stage(
                 "model_name": state["model_name"],
                 "outline_model": state["outline_model"],
                 "writing_model": state["writing_model"],
+                "repair_model": state["repair_model"],
                 "groundedness_model": state["groundedness_model"],
                 "audit_model": state["audit_model"],
                 "title_model": state["title_model"],

--- a/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/prompts/anti_ai_tells.py
@@ -25,6 +25,11 @@ not apply to a single 90-140 word paragraph.
 
 Both are written to be appended *after* any per-article-type guideline, with the
 precedence statement asserting they override conflicting instructions above.
+
+Two families in `_BANNED_CONSTRUCTIONS` are named as shapes rather than listed
+as strings (ADR 0030). A literal list only catches the variants someone thought
+to write down; naming the shape catches the ones they did not. Do not expand
+either family back into individual entries.
 """
 
 PRECEDENCE_HEADER = (
@@ -34,35 +39,41 @@ PRECEDENCE_HEADER = (
 
 
 _BANNED_CONSTRUCTIONS = """\
-Banned constructions. Do not use any of these:
-- "quietly [adjective]" (quietly radical, quietly confident, quietly stunning, quietly devastating)
-- "what happens when X meets Y" or "where X meets Y" or "what happens between X and Y" or "the space between X and Y" — any phrasing that names an abstract interaction between two ingredients, techniques, or cultures instead of describing the result ("refining what happens between Japanese technique and an Amazonian ingredient"). Describe the result, not the interaction.
-- "X territory" as a closer (special-occasion territory, dangerous territory)
-- "It's not just X, it's Y"
-- "more than just a [noun]"
+Banned constructions. Two shapes account for most of these. Learn the shape, \
+not the list: a variant is banned even when it is not written out below.
+
+THE CONTRASTIVE PIVOT — defining a thing by what it is not, or balancing it \
+against a counter-claim in the same breath. "It's not just X, it's Y." "More \
+than just a [noun]." "A working kitchen rather than a monument." "Not X, but \
+Y." "More X than Y." Bare "X, not Y" where Y is abstract or metaphorical ("its \
+own cuisine, not a hyphenated footnote"). "Feels both X and Y." "Deceptively \
+simple." The shape itself is the tell — rewording the metaphor does not fix \
+it. State the thing directly and drop the negation.
+
+THE KICKER THAT IMPLIES A PAYOFF — a closer that gestures at a reason instead \
+of giving it, leaving the reader to fill in the blank. "The line forms early \
+for a reason." "The seating to chase." "Lower-key than the price suggests." \
+"...which is why the 1pm seating fills first." "Special-occasion territory." \
+State the actual reason, name the thing plainly, or cut the sentence.
+
+Also banned, individually:
+- "quietly [adjective]" (quietly radical, quietly confident, quietly stunning)
+- "what happens when X meets Y" or "where X meets Y" or "the space between X and Y" — any phrasing that names an abstract interaction between two ingredients, techniques, or cultures instead of describing the result. Describe the result, not the interaction.
 - "in a world where..."
 - "the [noun] is [verb]-ing" sweeping openers (the city is changing, the menu is evolving)
-- "feels both X and Y" or "reads as both X and Y"
 - "a masterclass in"
 - "punches above its weight"
 - "the kind of [noun] that..."
-- "deceptively simple"
 - "effortlessly [adjective]"
-- "the most X you can Y" or "the X-est you can Y" superlative-of-experience ("the most committed expression of Nikkei you can sit down to," "the tightest fish you can eat in the city," "the smartest pairing you can order"). The shape sounds writerly and commits to nothing concrete. State what the place actually does, or cut the claim.
+- "the most X you can Y" or "the X-est you can Y" superlative-of-experience ("the tightest fish you can eat in the city"). The shape sounds writerly and commits to nothing concrete. State what the place actually does, or cut the claim.
 - "set the bar," "raise the bar," "move the needle"
 - "speaks volumes," "speaks to"
 - "at its core," "at the heart of"
 - "testament to"
-- "X rather than Y" contrastive pivots ("a working kitchen rather than a monument," "a find rather than a scene"). Also any "not X, but Y" or "more X than Y" pivot used to flip an expectation.
-- Bare "X, not Y" contrastive where Y is an abstract or metaphorical noun phrase ("its own cuisine, not a hyphenated footnote"; "a kitchen, not a stage"). The shape itself is the tell — rewording the metaphor does not fix it. State X directly and drop the negation.
-- "for a reason" as a closing kicker ("reservations open weeks ahead for a reason," "the line forms early for a reason"). The phrase signals an unstated payoff the reader is supposed to fill in — state the actual reason or cut the sentence.
-- "the [noun] to chase / to beat / to want / to know" as a kicker noun phrase ("the seating to chase," "the table to want"). Name the thing plainly.
-- "[adj]-er than [noun] suggests / implies / lets on" comparative tells ("lower-key than the price suggests," "smaller than the reputation lets on"). They are kickers in disguise — cut the comparative frame.
-- "X, which is why Y" causal pivots used to justify a recommendation ("low-key for the price tag, which is why the 1pm seating..."). State the recommendation directly.
-- Compound mood adjectives of the form "[noun]-forward" or "[noun]-led" used to describe a room or program ("art-forward," "produce-forward," "vinyl-led"). Name the thing instead.
-- Strained-clever metaphors that sound good on first read and empty on second ("build the case that X deserves its own shelf," "earn its seat at the table," "writes its own chapter"). If you cannot say the thing literally, do not say it figuratively.
-- Two-clause aphoristic closer with abstract nouns — short balanced clauses joined by semicolon, "and," or a comma, with both clauses ending in an abstract or metaphorical noun ("Lunch is the calmer way in; dinner is the full argument." / "The room is the draw, and the food is the proof."). The parallel-with-abstract-noun shape is a strong signal even when each clause would be fine alone. Cut the symmetry or rewrite as two sentences with different shapes.
-- Clipped imperative sign-offs as a closer, whether they end the paragraph or trail a compound sentence as the second clause ("Book weeks out, ideally more." / "Reserve early." / "Go hungry." / "Book months ahead, and treat it as the centerpiece of the trip."). Covers Book, Reserve, Order, Skip, Arrive, Sit, Come, Bring, Go, Stay, Treat. Either fold the practical note into a full sentence earlier, or drop it.
+- Compound mood adjectives of the form "[noun]-forward" or "[noun]-led" used to describe a room or program ("art-forward," "produce-forward"). Name the thing instead.
+- Strained-clever metaphors that sound good on first read and empty on second ("earn its seat at the table," "writes its own chapter"). If you cannot say the thing literally, do not say it figuratively.
+- Two-clause aphoristic closer with abstract nouns — short balanced clauses joined by semicolon, "and," or a comma, with both clauses ending in an abstract or metaphorical noun ("The room is the draw, and the food is the proof."). The parallel-with-abstract-noun shape is a strong signal even when each clause would be fine alone. Cut the symmetry or rewrite as two sentences with different shapes.
+- Clipped imperative sign-offs as a closer, whether they end the paragraph or trail a compound sentence as the second clause ("Book weeks out, ideally more." / "Go hungry."). Covers Book, Reserve, Order, Skip, Arrive, Sit, Come, Bring, Go, Stay, Treat. Either fold the practical note into a full sentence earlier, or drop it.
 - Any sentence ending in a tidy summary that restates the paragraph."""
 
 _BANNED_PERSONIFICATIONS = """\
@@ -92,33 +103,30 @@ fairly, genuinely, truly, really, simply, just, of course, indeed. Cut "it's \
 worth noting that," "it's important to remember," and any meta-commentary \
 about the writing itself."""
 
+# Every phrase the shared validator rejects has to be named here, or a writer
+# is judged against a rule it was never given (see
+# test_every_phrase_the_validator_rejects_is_named_in_the_prompt). That
+# coupling, not verbosity, is why this block is long: it is a phrase list with
+# prose around it. Restructured into four named moves rather than shortened.
 _BANNED_DISCLAIMERS = """\
-Banned disclaimers. State what you know as a plain fact and stop. Do not \
+Banned disclaimers. Never write about the enquiry. The reader is here for the \
+place, not for how we found out about it. State what you know as a plain fact \
+and stop: "Customs took twenty five minutes" is the whole sentence. Do not \
 caveat a fact, attribute it defensively, date it as a shield, or explain how \
-it was established. "Customs took twenty five minutes" is the whole sentence. \
-Cut: "based on my own experience," "anecdotally," "at the time of writing," \
-"your experience may vary," "this is one traveller's experience," "this is \
-not an average," "no official figures exist for," "there is no public data \
-on," "figures could not be verified," and any sentence whose job is to tell \
-the reader how much to trust the previous one. Where research could not \
-establish something, write around it: never narrate the gap. \
-Saying it about the subject instead of about yourself is the same sentence. \
-Cut: "does not publish," "has not disclosed," "is not public information," \
-"is not publicly available," "could not be confirmed," and any other way of \
-telling the reader that a fact was looked for and not found. Write what the \
-subject does do, or say nothing. \
-Never let the vocabulary of the research reach the page either: no "sampled" \
-booking flows or menus, no "data points," no "sample size," no "evidence \
-records," and no grading your own confidence in a number ("an estimate rather \
-than a guaranteed bill"). Give the number plainly or leave it out. \
-Naming the source is the same disclaimer wearing a press badge. Cut: \
-"sources report," "travel sources," "outlets anticipate," "one outlet," \
-"the publication noted," "the report cited," "according to," "reports \
-suggest," and every other construction whose job is to put a publication \
-between you and the claim. A named person or institution who acts in the \
-story stays; the outlet that wrote it up does not. \
-This bans hedging, not first person. In a piece written in first person, \
-"I waited twenty five minutes at customs" is the fact, told plainly, and it \
+it was established.
+
+Four moves are banned, in every wording.
+
+1. Telling the reader how much to trust a claim. Cut: "based on my own experience," "anecdotally," "at the time of writing," "your experience may vary," "this is one traveller's experience," "this is not an average," and any sentence whose job is to tell the reader how much to trust the previous one.
+
+2. Narrating a gap. Cut: "no official figures exist for," "there is no public data on," "figures could not be verified," "does not publish," "has not disclosed," "is not public information," "is not publicly available," "could not be confirmed." Where research could not establish something, write around it: never narrate the gap. Write what the subject does do, or say nothing.
+
+3. Letting the vocabulary of the research onto the page. No "sampled" booking flows or menus, no "data points," no "sample size," no "evidence records," and no grading your own confidence in a number ("an estimate rather than a guaranteed bill"). Give the number plainly or leave it out.
+
+4. Putting a publication between you and the claim. Cut: "sources report," "travel sources," "outlets anticipate," "one outlet," "the publication noted," "the report cited," "according to," "reports suggest." A named person or institution who acts in the story stays; the outlet that wrote it up does not.
+
+This bans hedging, not first person. In a piece written in first person, "I \
+waited twenty five minutes at customs" is the fact, told plainly, and it \
 stays. A date or a season belongs in the prose when the reader needs it to \
 act — a closure, a season, a change to the place itself — never as armour \
 around a claim. Accuracy is settled before the writing starts; it is not the \
@@ -136,21 +144,19 @@ Diction rules. Prefer short Anglo-Saxon words over Latinate ones — "use" not \
 (when not literal)."""
 
 _NO_DASH_SUBSTITUTION = """\
-Do not substitute em-dash cadence with comma-bracketed asides. If you would \
-have written "X — Y — Z" before the no-em-dash rule, do not write "X, Y, Z" \
-instead. Comma-bracketed adverbials like "arguing, convincingly, that" or \
-"the room is warm, and quietly so, throughout" are em dashes in disguise — \
-rewrite the sentence into two shorter sentences, or drop the aside entirely. \
-A comma should join clauses or list items, not impersonate a dash.
-Do not substitute a hyphen either. "The room is warm - and quietly so" is the \
-same dash wearing a different hat, and a spaced hyphen reads as a typewriter \
-artefact rather than punctuation anyone chose. Hyphens do not bracket asides and they do not break sentences.
-Do not use hyphenated compounds at all. "Two-bedroom apartments", \
-"a long-stay visa", "a well-known, family-run spot" -- each is correct \
-English on its own, but a run of them through an article is one of the \
-clearest signals the text was generated. Rephrase instead: "apartments with \
-two bedrooms", "a visa for long stays", "a spot the family runs, and people \
-know it". Proper names keep their hyphens; nothing else does."""
+No em dashes, and no substitutes for them. A comma-bracketed aside is an em \
+dash in disguise: if you would have written "X — Y — Z", do not write "X, Y, \
+Z" instead. Asides like "arguing, convincingly, that" or "the room is warm, \
+and quietly so, throughout" get rewritten as two shorter sentences or dropped. \
+A comma joins clauses or list items; it does not impersonate a dash. A spaced \
+hyphen is the same dash in another hat and reads as a typewriter artefact.
+
+Do not use hyphenated compounds at all. "Two-bedroom apartments", "a long-stay \
+visa", "a well-known, family-run spot" — each is correct English on its own, \
+but a run of them through an article is one of the clearest signals the text \
+was generated. Rephrase: "apartments with two bedrooms", "a visa for long \
+stays", "a spot the family runs, and people know it". Proper names keep their \
+hyphens; nothing else does."""
 
 _VOICE = """\
 Voice rules. Write from a single point of view with an opinion. If the writing \

--- a/apps/ai-blog-writer/apps/backend/app/shared/writer_models.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/writer_models.py
@@ -63,3 +63,29 @@ def resolve_writer_model(
     raise ValueError(
         "Invalid writing model. Allowed values: " + ", ".join(WRITER_MODEL_OPTIONS)
     )
+
+
+def temperature_is_honored(model_name: str | None) -> bool:
+    """Whether a sampling temperature actually reaches the model that answers.
+
+    The Claude Code CLI has no temperature flag, so ``ClaudeCliTextLLM`` accepts
+    the value and drops it. Every other transport here -- Vertex, the Anthropic
+    API -- passes it through. That makes the creativity control real on some
+    runs and inert on others, with nothing on the receipt saying which, so a
+    reader comparing two drafts cannot tell whether the setting was part of the
+    difference.
+
+    Asked of the resolved model name rather than of the LLM object, because the
+    callers that need the answer -- the run record, the composer UI -- are
+    deciding what to say about a stage before or after the call, not holding
+    the adapter that made it.
+    """
+    from utils.llm_model_policy import (
+        CLAUDE_PROVIDER_SUBSCRIPTION_CLI,
+        claude_provider,
+        is_claude_model,
+    )
+
+    if not is_claude_model(model_name):
+        return True
+    return claude_provider() != CLAUDE_PROVIDER_SUBSCRIPTION_CLI

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
@@ -1,38 +1,38 @@
 ---
 id: analysis
 label: Analysis
-summary: Examines why a development or condition matters and reaches an evidence-led judgment.
+summary: Answers a real question about a place and commits to the answer.
 order: 2
 ---
 
 ## Use when
 
-Use when the commission asks why something is happening, whether a proposition still holds, or what several verified signals mean together. Analysis needs a clear primary subject, a bounded question, and enough evidence to support interpretation rather than description alone.
+Use when the reader has a question with a real answer and wants it settled — is Lisbon actually getting more expensive, has the diving recovered, is the night train worth it over the flight. The grill establishes this: the operator was asked whether they wanted a guide or wanted to make the case, and said the case. Analysis needs one subject, one bounded question, and enough evidence to answer it rather than describe around it.
 
 ## Do not use when
 
-Do not use to disguise unsupported opinion, summarize a destination, or compare multiple co-equal subjects without an approved head-to-head scope. Use News Report for a timely event without substantial interpretation, Explainer for neutral understanding, or Comparison when comparison is the organizing promise.
+Do not use when the operator asked for a guide, an orientation, or a plan — this form is unreachable except through the grill's own question, and a model may not select it from a title. Use News Report for a timely event, Explainer where the reader needs understanding rather than a verdict, or Comparison when weighing two subjects is the promise.
 
 ## Reader promise
 
-Give readers a defensible answer to the core question. Show the strongest evidence, competing explanations, meaningful limits, and consequences. Distinguish observed facts from the article’s interpretation.
+Answer the question the reader actually has, and commit to the answer. Say what the answer costs them — what it changes about where they go, what they book, what they pay. A reader who finishes this should be able to act, not merely to summarise both sides.
 
 ## Required evidence
 
-Require current, relevant evidence for every load-bearing claim and enough context to judge change over time. Define the baseline, period, geography, and measurement behind terms such as affordable, safer, popular, or declining. Context-only places may calibrate a point but cannot become co-subjects, substitute evidence, or organizing sections. Surface conflicting indicators instead of averaging them into certainty.
+Require current, relevant evidence for every load-bearing claim, and enough context to judge change over time. Define the baseline, period, geography and measurement behind words like affordable, safer, busier or declining. Where indicators genuinely conflict, say which one you believe and why, rather than averaging them into a shrug. Context-only places may calibrate a point but never become co-subjects or sections.
 
 ## Allowed structures
 
-1. Direct answer, evidence by factor, counterevidence, qualified conclusion.
-2. What changed, causes, who experiences the change, implications.
-3. Claim under test, evidence for, evidence against, judgment and limits.
+1. The answer, then what makes it true, then what would change it.
+2. What changed, why it changed, and who it changes things for.
+3. The common belief, what the evidence actually shows, and what to do about it.
 
-Organize around the approved question and primary subject, not around sources or incidental comparators.
+Organise around the question and the subject, never around the research that answered it. No section may take scope, limits, method, or the state of the evidence as its subject.
 
 ## Failure modes
 
-Avoid thesis drift, cherry-picking, vague trend language, causal claims from correlation, and conclusions stronger than the evidence. Do not broaden a Lima-centered affordability analysis into a Lima-versus-Medellín-versus-Buenos Aires comparison unless the commission explicitly approves head-to-head scope.
+Avoid thesis drift, cherry-picking, vague trend language, and causal claims from correlation. Do not hedge the answer into uselessness — a qualified answer names the one thing that qualifies it, in a clause, and moves on. Do not widen a single-city question into a three-city comparison. Do not write about the enquiry: the reader came for the place, not for how we found out.
 
 ## Headline note
 
-Frame the tested proposition or central finding. Questions are acceptable when the article gives a clear answer. Do not promise certainty the evidence cannot support.
+Name the finding, not the investigation. "Lima's best food is at the market" is a headline; "What the evidence says about Lima's food scene" is a filing label. A question is acceptable only when the article answers it plainly.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/voice/house-rules.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/voice/house-rules.md
@@ -1,0 +1,37 @@
+---
+id: house-rules
+label: House rules
+description: The mechanical rules that cannot be inferred from the voice.
+default: true
+order: 2
+---
+
+# House rules
+
+These are conventions, not character. The voice document says what Questurian
+is like; this says how it sets things down. Where the two seem to conflict, the
+voice wins — nothing here is worth a sentence that reads wrong.
+
+**Address.** "You" is the reader making the decision, and it is the default
+address. Never "we" for the publication: state the recommendation instead of
+announcing that you are making one.
+
+**Experience.** Never invent a trip, meal, walk, conversation or visit. First
+person is available only for material the brief records as first-hand, and only
+in the words it records.
+
+**Numbers and dates.** Give a price with its currency and an as-of frame — "COP
+38,000 (about USD 9) as of March 2026". Write dates in full. Give opening hours
+as sourced, with the day range. Do not round a number the source did not round.
+
+**Names.** Use the local proper name on first mention with an English gloss
+where it helps, then the local name alone, transliterated the same way
+throughout.
+
+**Attribution.** An unconfirmed detail is cut, never attributed. No "sources
+report", no "according to", no "the publication noted". Attribution belongs in
+the evidence record and never in the article.
+
+**Headings and structure.** Sentence case, no terminal punctuation, no stacked
+gerunds. No one-sentence sections. Lists only for genuinely parallel items,
+never to chop up an argument.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/voice/questurian-voice.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/voice/questurian-voice.md
@@ -1,0 +1,49 @@
+---
+id: questurian-voice
+label: Questurian Voice
+description: What Questurian is like. The only voice; there is no tone layer (ADR 0032).
+default: true
+order: 1
+---
+
+# The Questurian voice
+
+**It treats you as an adult with a decision to make.** Not a tourist to be
+delighted, not a beginner to be managed. It assumes you can take the real
+answer, including when the real answer is inconvenient, expensive or dull.
+
+**It isn't selling anything.** Not the destination, not the trip, not itself. It
+has no stake in whether you go. That is why it can tell you a place is a
+four-hour round trip for a view that is fogged in most mornings.
+
+**Its warmth is attention.** There are no warm words in a Questurian article and
+it still reads as generous, because someone went to the trouble of finding out
+the thing that actually matters — that one neighbourhood is flat and the other
+is built on a slope, and what that does to your walk home with the groceries.
+Care is the warmth. Adjectives are not.
+
+**It is interested without being impressed.** Places deserve attention; none of
+them are miracles. It never gushes, never performs enthusiasm it doesn't have,
+and never tells you somewhere is special instead of showing you why you'd go.
+
+**It would rather tell you the annoying true thing than the pleasant vague one.**
+A caveat that costs the reader something is worth more than three sentences of
+reassurance.
+
+**It has a view and says it.** It won't rank things for the sake of it, but it
+never hides behind even-handedness either. Where there's a call to make, it
+makes it and says what the call costs.
+
+**It doesn't make you wait.** No warming up, no scene-setting before the point,
+no restating the heading. It respects that you came for something.
+
+**It knows the difference between what it knows and what it's guessing** — and
+leaves the second thing out. It never hedges, never armours a claim, never asks
+you to grade its confidence.
+
+**It never talks about itself.** Not about its research, not about how it knows
+something, not about what it couldn't find out. The reader is here for the
+place, not the process.
+
+**It is never generic.** A paragraph that could sit in any publication's article
+about any city is not Questurian.

--- a/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_claude_cli_writer.py
@@ -609,3 +609,41 @@ def test_transport_errors_surface_as_writer_model_errors(
             tool_description="d",
             input_schema=SCHEMA,
         )
+
+
+def test_canonical_model_names_the_model_that_did_the_work():
+    """`modelUsage` lists helpers beside the writer, in the CLI's own order.
+
+    Reading the first key stamped whole runs with the helper's name -- every
+    Claude call in this repo's run history is recorded as `claude-haiku-4-5`,
+    including drafts written by Opus. Output tokens are what tell them apart.
+    """
+    payload = {
+        "modelUsage": {
+            "claude-haiku-4-5-20251001": {
+                "canonicalModel": "claude-haiku-4-5",
+                "outputTokens": 27,
+                "costUSD": 0.0004,
+            },
+            "claude-opus-5": {
+                "canonicalModel": "claude-opus-5",
+                "outputTokens": 5_937,
+                "costUSD": 0.292,
+            },
+        }
+    }
+
+    assert cli_writer._canonical_model(payload, "opus") == "claude-opus-5"
+
+
+def test_canonical_model_falls_back_to_cost_then_to_the_alias():
+    by_cost = {
+        "helper": {"canonicalModel": "claude-haiku-4-5", "costUSD": 0.001},
+        "writer": {"canonicalModel": "claude-sonnet-5", "costUSD": 0.44},
+    }
+
+    assert cli_writer._canonical_model(by_cost, "sonnet") == "sonnet"
+    assert cli_writer._canonical_model({"modelUsage": by_cost}, "sonnet") == (
+        "claude-sonnet-5"
+    )
+    assert cli_writer._canonical_model({"modelUsage": {}}, "sonnet") == "sonnet"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_credential.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_credential.py
@@ -1,3 +1,4 @@
+import pytest
 import sqlite3
 import subprocess
 
@@ -24,17 +25,17 @@ def test_save_credential_keeps_token_out_of_command_and_database(tmp_path, monke
         token=secret,
     )
 
-    assert observed["args"] == [
-        "/usr/bin/security",
-        "add-generic-password",
-        "-a",
-        "prompt2blog",
-        "-s",
-        "com.questurian.prompt2blog.claude",
-        "-U",
-        "-w",
-    ]
-    assert observed["kwargs"]["input"] == secret + "\n"
+    # The token travels on stdin as part of a `security -i` command line, so it
+    # never reaches argv. It must not be handed to the interactive `-w` prompt:
+    # that prompt reads the terminal, not stdin, and the call hangs there.
+    assert observed["args"] == ["/usr/bin/security", "-i"]
+    assert observed["kwargs"]["input"] == (
+        "add-generic-password"
+        " -a prompt2blog"
+        " -s com.questurian.prompt2blog.claude"
+        " -U"
+        f" -w {secret}\n"
+    )
     assert secret not in " ".join(observed["args"])
     assert status["configured"] is True
     assert status["label"] == "Article account"
@@ -93,3 +94,24 @@ def test_load_credential_reads_keychain_and_redacts_its_representation(
     assert credential.label == "Article account"
     assert credential.token == secret
     assert secret not in repr(credential)
+
+
+def test_save_credential_rejects_a_token_with_whitespace(tmp_path, monkeypatch):
+    """A pasted token that wrapped would silently truncate the stdin command."""
+    import app.core.database as database
+    from app.features.claude_connection import prompt2blog_credential
+
+    monkeypatch.setattr(database, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "pipeline.db")
+    database.ensure_core_tables()
+
+    def fail_run(args, **kwargs):
+        raise AssertionError("security must not be called for a malformed token")
+
+    monkeypatch.setattr(prompt2blog_credential.subprocess, "run", fail_run)
+
+    with pytest.raises(prompt2blog_credential.Prompt2BlogCredentialError):
+        prompt2blog_credential.save_credential(
+            label="Article account",
+            token="sk-ant-oat01-AAA BBB",
+        )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_drafts_view.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_drafts_view.py
@@ -1,0 +1,194 @@
+"""The drafts page: every version of an article a run produced.
+
+The case that motivates it is run 25178bce, where repair produced a shorter
+draft, the keep-best comparison scored it no higher than the one it replaced,
+and the *earlier* draft shipped. Nothing in the run record said so at a glance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import write_status, write_stage_result
+from app.features.prompt2blog.api import runs as runs_api
+from app.features.prompt2blog.drafts_view import (
+    band_side,
+    build_drafts_report,
+    markdown_to_html,
+    pipeline_words,
+    plain_words,
+    render_drafts_page,
+)
+from tests.prompt2blog_test_support import seed_completed_prompt2blog_run
+
+pytest_plugins = ["tests.prompt2blog_test_fixtures"]
+
+FIRST_DRAFT = "## Lima\n\n" + "word " * 600
+REPAIRED_DRAFT = "## Lima\n\n" + "word " * 400
+
+
+def _stages() -> dict[str, dict]:
+    return {
+        "stage_v3_compose": {
+            "created_at": "2026-08-29T13:04:14+00:00",
+            "data": {"rewrite": {"improved_title": "Lima", "improved_content": FIRST_DRAFT}},
+        },
+        "stage_v3_repair": {
+            "created_at": "2026-08-29T13:06:33+00:00",
+            "data": {"rewrite": {"improved_title": "Lima", "improved_content": REPAIRED_DRAFT}},
+        },
+        "stage_v3_quality_audit": {
+            "created_at": "2026-08-29T13:06:47+00:00",
+            "data": {
+                "quality": {
+                    "overall_score": 6,
+                    "required_revisions": ["Trim the draft"],
+                    "constraint_checks": {"target_word_count_met": False},
+                },
+                "repair_decision": {
+                    "route": "settle",
+                    "reason": "attempt_limit_reached",
+                    "attempts_used": 1,
+                    "attempts_allowed": 1,
+                    "tokens_spent": 119366,
+                    "token_budget": 320000,
+                },
+            },
+        },
+        "stage_v3_quality_settle": {
+            "created_at": "2026-08-29T13:06:47+00:00",
+            "data": {"repair_attempts": 1, "reverted_to_earlier_draft": True},
+        },
+        "stage_v3_finalize": {
+            "created_at": "2026-08-29T13:06:55+00:00",
+            "data": {
+                "pipeline_status": "needs_revision",
+                "readiness_blockers": ["target_word_count_met"],
+                "constraint_checks": {
+                    "target_word_count_met": False,
+                    "word_count_target_min": 800,
+                    "word_count_target_max": 1000,
+                },
+            },
+        },
+    }
+
+
+def test_report_marks_the_draft_that_actually_shipped():
+    report = build_drafts_report(
+        run_id="run-1",
+        status={"feature": "prompt2blog"},
+        stages=_stages(),
+        markdown="# Lima\n\n" + FIRST_DRAFT,
+    )
+
+    labels = [draft["label"] for draft in report["drafts"]]
+    assert labels == ["First draft", "Repaired draft", "Shipped article"]
+
+    shipped = [draft["label"] for draft in report["drafts"] if draft["is_shipped"]]
+    # The compose draft, not the repair that replaced and then lost to it.
+    assert shipped == ["First draft"]
+
+
+def test_repaired_draft_is_kept_even_when_it_was_discarded():
+    """A discarded draft is the whole reason to open this page."""
+    report = build_drafts_report(
+        run_id="run-1",
+        status={},
+        stages=_stages(),
+        markdown="# Lima\n\n" + FIRST_DRAFT,
+    )
+
+    repaired = next(d for d in report["drafts"] if d["label"] == "Repaired draft")
+    assert repaired["words"] == plain_words(REPAIRED_DRAFT)
+    assert repaired["is_shipped"] is False
+
+
+def test_page_reports_both_word_counts_and_the_revert():
+    report = build_drafts_report(
+        run_id="run-1",
+        status={},
+        stages=_stages(),
+        markdown="# Lima\n\n" + FIRST_DRAFT,
+    )
+    page = render_drafts_page(report)
+
+    assert "reverted to an earlier one" in page
+    assert "pipeline counter says" in page
+    assert "Trim the draft" in page
+    assert "attempt_limit_reached" in page
+
+
+def test_pipeline_counter_can_disagree_with_a_word_count():
+    """The counter splits on punctuation, which is what failed run 25178bce."""
+    text = "day-by-day US$1,090"
+
+    assert plain_words(text) == 2
+    assert pipeline_words(text) == 6
+
+
+def test_band_side_reports_which_way_a_count_missed():
+    assert band_side(1004, 800, 1000) == "over"
+    assert band_side(700, 800, 1000) == "under"
+    assert band_side(900, 800, 1000) == ""
+    # No band configured is not a failure.
+    assert band_side(900, 0, 0) == ""
+
+
+def test_markdown_rendering_escapes_html_in_a_draft():
+    rendered = markdown_to_html("## <script>alert(1)</script>\n\nBody **bold**")
+
+    assert "<script>" not in rendered
+    assert "&lt;script&gt;" in rendered
+    assert "<strong>bold</strong>" in rendered
+
+
+def test_drafts_route_renders_html_for_a_run(empty_prompt2blog_storage):
+    run_id = f"p2b-{uuid4()}"
+    seed_completed_prompt2blog_run(run_id)
+    write_stage_result(
+        run_id,
+        "stage_v3_compose",
+        {
+            "created_at": "2026-08-29T13:04:14+00:00",
+            "data": {"rewrite": {"improved_title": "Lima", "improved_content": FIRST_DRAFT}},
+        },
+    )
+
+    response = asyncio.run(runs_api.drafts_page(run_id))
+
+    assert response.status_code == 200
+    assert response.media_type == "text/html"
+    assert "First draft" in response.body.decode("utf-8")
+
+
+def test_drafts_route_404s_for_an_unknown_run(empty_prompt2blog_storage):
+    with pytest.raises(HTTPException) as raised:
+        asyncio.run(runs_api.drafts_page("no-such-run"))
+
+    assert raised.value.status_code == 404
+
+
+def test_drafts_route_404s_when_a_run_has_no_draft_yet(empty_prompt2blog_storage):
+    """A run that failed before composing holds no article to show."""
+    run_id = f"p2b-{uuid4()}"
+    write_status(
+        run_id,
+        {
+            "run_id": run_id,
+            "state": "failed",
+            "stage": "stage_v3_outline",
+            "error": "stopped early",
+            "updated_at": "2026-08-29T00:00:00Z",
+        },
+        feature="prompt2blog",
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        asyncio.run(runs_api.drafts_page(run_id))
+
+    assert raised.value.status_code == 404

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_pricing.py
@@ -459,3 +459,43 @@ def test_a_provider_without_a_price_is_unaffected_by_the_fold(monkeypatch):
     )
 
     assert summary["by_model"][0]["cost_basis"] == "rate-table"
+
+
+def test_stage_rows_carry_the_price_of_the_stage():
+    """`by_attempt` could always say what one attempt cost; `by_stage` could not.
+
+    A stage that ran twice is exactly where the question gets asked, so the
+    two repair calls have to add up rather than come back as a token count
+    with no price beside it.
+    """
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.begin_stage("stage_v3_repair")
+    tracker.record(
+        "claude-opus-5",
+        {"input_tokens": 1_000, "output_tokens": 500, "measured_cost_usd": 0.40},
+    )
+    tracker.record(
+        "claude-opus-5",
+        {"input_tokens": 800, "output_tokens": 200, "measured_cost_usd": 0.25},
+    )
+
+    rows = {row["stage"]: row for row in tracker.ledger()["by_stage"]}
+
+    assert rows["stage_v3_repair"]["cost_usd"] == 0.65
+    assert rows["stage_v3_repair"]["calls"] == 2
+
+
+def test_a_stage_holding_an_unpriced_call_reports_no_price():
+    """A partial total reads as a total. Abstaining is the honest answer."""
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.begin_stage("stage_v3_compose")
+    tracker.record(
+        "claude-opus-5",
+        {"input_tokens": 1_000, "output_tokens": 500, "measured_cost_usd": 0.40},
+    )
+    tracker.record("mystery-model", {"input_tokens": 10, "output_tokens": 5})
+
+    rows = {row["stage"]: row for row in tracker.ledger()["by_stage"]}
+
+    assert rows["stage_v3_compose"]["cost_usd"] is None
+    assert rows["stage_v3_compose"]["calls"] == 2

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_stage_attribution.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_stage_attribution.py
@@ -113,6 +113,7 @@ def test_a_stage_is_not_charged_for_what_earlier_stages_spent():
             "total_tokens": 3_000,
             "calls": 1,
             "attempts": 1,
+            "cost_usd": 0.00825,
         },
         {
             "stage": "stage_outline",
@@ -123,6 +124,7 @@ def test_a_stage_is_not_charged_for_what_earlier_stages_spent():
             "total_tokens": 500,
             "calls": 1,
             "attempts": 1,
+            "cost_usd": 0.000675,
         },
     ]
 
@@ -234,6 +236,9 @@ def test_a_stage_with_no_llm_call_gets_a_zero_row():
             "total_tokens": 0,
             "calls": 0,
             "attempts": 1,
+            # A stage that made no call spent nothing, which is a price and
+            # not an absence of one.
+            "cost_usd": 0.0,
         }
     ]
 
@@ -328,6 +333,7 @@ def test_pipeline_dependencies_wires_the_recorder_to_the_usage_tracker():
             "total_tokens": 80,
             "calls": 1,
             "attempts": 1,
+            "cost_usd": 0.00012,
         }
     ]
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
@@ -23,6 +23,7 @@ from app.features.prompt2blog.intake_v3 import prepare_v3_runtime_request
 from app.features.prompt2blog.orchestrator_v3 import run_pipeline_v3
 from app.features.prompt2blog.run_recorder import RunRecorder
 from tests.prompt2blog_test_support import response_payload
+from utils import llm_model_policy
 
 FIXTURE_PATH = (
     Path(__file__).parents[3]
@@ -342,6 +343,167 @@ def test_balanced_route_reserves_opus_for_drafting_and_repair():
         "repair": ["claude-opus-5-high"],
         "title": ["claude-sonnet-5-medium"],
     }
+
+    # The receipt has to name the same models the run used. `model_used` under
+    # the quality review reported the worker model, which v3 never calls, so a
+    # review written by Sonnet was filed under a Gemini name.
+    review = recorder.stages["pipeline_v3"]["quality_review"]
+    assert review["model_used"] == "claude-sonnet-5-high"
+    assert review["stage_model_overrides"]["stage_v3_compose"] == "claude-opus-5-high"
+
+
+def test_a_route_can_move_the_checking_stages_off_claude():
+    """The Gemini-checked route: Claude drafts and repairs, Gemini checks.
+
+    Outline, groundedness and title were pinned in `config.py` and unreachable
+    from a request, so a route could only move two of the six calls a run
+    makes. The point of moving them is not only metered spend -- it is that a
+    Claude draft graded by a Claude judge is marked by a model that shares its
+    blind spots.
+    """
+    request = _request(
+        model_routing={
+            "model_name": "gemini-3.1-flash-lite",
+            "writing_model": "claude-opus-5-high",
+            "audit_model": "gemini-3.1-pro-preview",
+            "outline_model": "gemini-3.1-pro-preview",
+            "groundedness_model": "gemini-3.1-pro-preview",
+            "title_model": "gemini-3.7-flash",
+            "model_stack_id": "gemini-checked-high",
+        }
+    )
+    llm = ScriptedLLM(quality_scores=[6, 9])
+    recorder = RecordingRecorder()
+
+    run_pipeline_v3(
+        "gemini-checked-run",
+        prepare_v3_runtime_request(request),
+        PipelineDependencies(llm=llm, recorder=recorder),
+    )
+
+    assert llm.models == {
+        "outline": ["gemini-3.1-pro-preview"],
+        "compose": ["claude-opus-5-high"],
+        "groundedness": ["gemini-3.1-pro-preview", "gemini-3.1-pro-preview"],
+        "audit": ["gemini-3.1-pro-preview", "gemini-3.1-pro-preview"],
+        "repair": ["claude-opus-5-high"],
+        "title": ["gemini-3.7-flash"],
+    }
+
+
+def test_a_route_can_repair_at_a_different_effort_than_it_drafts():
+    """Max effort where it is conditional, not where it is unavoidable.
+
+    Repair only fires on a draft that failed, and the run buys exactly one
+    attempt, so this is the single call whose strength decides whether a weak
+    draft is rescued or handed back. Max on the draft would be paid on every
+    run, including the ones that were going to pass.
+    """
+    request = _request(
+        model_routing={
+            "model_name": "gemini-3.1-flash-lite",
+            "writing_model": "claude-opus-5-high",
+            "repair_model": "claude-opus-5-max",
+            "audit_model": "gemini-3.1-pro-preview",
+            "outline_model": "gemini-3.1-pro-preview",
+            "groundedness_model": "gemini-3.1-pro-preview",
+            "title_model": "gemini-3.7-flash",
+            "model_stack_id": "gemini-checked-max-repair",
+        }
+    )
+    llm = ScriptedLLM(quality_scores=[6, 9])
+    recorder = RecordingRecorder()
+
+    run_pipeline_v3(
+        "max-repair-run",
+        prepare_v3_runtime_request(request),
+        PipelineDependencies(llm=llm, recorder=recorder),
+    )
+
+    assert llm.models["compose"] == ["claude-opus-5-high"]
+    assert llm.models["repair"] == ["claude-opus-5-max"]
+    # The receipt has to name the model that did the rewrite, not the writer it
+    # would have inherited.
+    overrides = recorder.stages["pipeline_v3"]["quality_review"][
+        "stage_model_overrides"
+    ]
+    assert overrides["stage_v3_repair"] == "claude-opus-5-max"
+    assert overrides["stage_v3_compose"] == "claude-opus-5-high"
+
+
+def test_repair_follows_the_writer_when_a_route_does_not_name_it():
+    request = _request(
+        model_routing={
+            "model_name": "gemini-3.1-flash-lite",
+            "writing_model": "claude-opus-5-high",
+            "audit_model": "claude-sonnet-5-high",
+            "model_stack_id": "opus-led-high",
+        }
+    )
+    llm = ScriptedLLM(quality_scores=[6, 9])
+
+    run_pipeline_v3(
+        "inherited-repair-run",
+        prepare_v3_runtime_request(request),
+        PipelineDependencies(llm=llm, recorder=RecordingRecorder()),
+    )
+
+    assert llm.models["repair"] == ["claude-opus-5-high"]
+
+
+def test_a_request_that_names_no_checking_models_keeps_the_pinned_defaults():
+    """An older client sends three roles, not six, and must route as it always did."""
+    request = _request(
+        model_routing={
+            "model_name": "gemini-3.1-flash-lite",
+            "writing_model": "claude-opus-5-high",
+            "audit_model": "claude-sonnet-5-high",
+            "model_stack_id": "opus-led-high",
+        }
+    )
+    llm = ScriptedLLM(quality_scores=[9])
+
+    run_pipeline_v3(
+        "legacy-routing-run",
+        prepare_v3_runtime_request(request),
+        PipelineDependencies(llm=llm, recorder=RecordingRecorder()),
+    )
+
+    assert llm.models["outline"] == ["claude-sonnet-5-medium"]
+    assert llm.models["groundedness"] == ["claude-sonnet-5-medium"]
+    assert llm.models["title"] == ["claude-sonnet-5-medium"]
+
+
+def test_a_claude_written_draft_says_the_creativity_dial_did_not_reach_it(monkeypatch):
+    """The control sets a temperature, and the Claude plan transport has none.
+
+    Silently dropping it is what made two drafts at different creativity levels
+    indistinguishable with nothing on the run saying why.
+    """
+    monkeypatch.setattr(llm_model_policy, "anthropic_models_enabled", lambda: False)
+    monkeypatch.setattr(
+        llm_model_policy, "claude_subscription_models_enabled", lambda: True
+    )
+    request = _request(
+        model_routing={
+            "model_name": "gemini-3.1-flash-lite",
+            "writing_model": "claude-opus-5-high",
+            "audit_model": "claude-sonnet-5-high",
+            "model_stack_id": "opus-led-high",
+        }
+    )
+    recorder = RecordingRecorder()
+
+    run_pipeline_v3(
+        "creativity-honesty-run",
+        prepare_v3_runtime_request(request),
+        PipelineDependencies(llm=ScriptedLLM(quality_scores=[9]), recorder=recorder),
+    )
+
+    creativity = recorder.stages["pipeline_v3"]["quality_review"]["creativity"]
+    assert creativity["applied_to_compose"] is False
+    assert creativity["level"] == "medium"
+    assert creativity["compose_temperature"] == 0.2
 
 
 def test_the_v3_run_never_reaches_a_guideline_or_supplement_stage():

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_writer_model_capabilities.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_writer_model_capabilities.py
@@ -1,0 +1,39 @@
+"""What a writer model's transport can and cannot be told to do."""
+
+from app.shared.writer_models import temperature_is_honored
+from utils import llm_model_policy
+
+
+def test_gemini_models_honour_temperature(monkeypatch):
+    monkeypatch.setattr(llm_model_policy, "anthropic_models_enabled", lambda: False)
+    monkeypatch.setattr(
+        llm_model_policy, "claude_subscription_models_enabled", lambda: False
+    )
+
+    assert temperature_is_honored("gemini-3.1-pro-preview") is True
+
+
+def test_a_claude_model_served_by_the_subscription_cli_does_not(monkeypatch):
+    """The CLI has no temperature flag, so the creativity control is inert.
+
+    This is the state every current article route is in, which is why the run
+    record and the composer have to be able to say so rather than show a dial
+    that reaches nothing.
+    """
+    monkeypatch.setattr(llm_model_policy, "anthropic_models_enabled", lambda: False)
+    monkeypatch.setattr(
+        llm_model_policy, "claude_subscription_models_enabled", lambda: True
+    )
+
+    assert temperature_is_honored("claude-opus-5-high") is False
+    # The substitution path is unaffected: a Gemini name is still a Gemini call.
+    assert temperature_is_honored("gemini-3.7-flash") is True
+
+
+def test_the_anthropic_api_path_honours_temperature_again(monkeypatch):
+    monkeypatch.setattr(llm_model_policy, "anthropic_models_enabled", lambda: True)
+    monkeypatch.setattr(
+        llm_model_policy, "claude_subscription_models_enabled", lambda: True
+    )
+
+    assert temperature_is_honored("claude-opus-5-high") is True

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api.ts
@@ -87,6 +87,7 @@ export {
   getPrompt2BlogResult,
   getPrompt2BlogResumePlan,
   getPrompt2BlogStatus,
+  openPrompt2BlogDrafts,
   resumePrompt2BlogRun,
   startPrompt2BlogV3Run,
 } from './api/pipeline.api'

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/api/pipeline.api.ts
@@ -134,6 +134,31 @@ export async function fetchResult(runId: string): Promise<Prompt2BlogResultRespo
   return getPrompt2BlogResult(runId)
 }
 
+/**
+ * Opens the run's drafts page — every version of the article the run produced.
+ *
+ * Fetched and handed to the browser as a blob rather than linked directly at
+ * the backend URL. A plain `<a href>` is a top-level navigation, so it carries
+ * no `X-API-Key`; the link would work in local development, where no key is
+ * set, and 401 anywhere it is. Going through `apiFetch` means the page opens
+ * under whatever credentials the rest of the app already uses.
+ *
+ * The blob URL is revoked on a timer rather than immediately: revoking it
+ * before the new tab has finished loading leaves the operator staring at a
+ * blank page.
+ */
+export async function openPrompt2BlogDrafts(runId: string): Promise<void> {
+  const response = await apiFetch(`${FEATURE_PREFIX}/drafts/${runId}`)
+
+  if (!response.ok) {
+    throw await parseError(response, 'Could not open the drafts for this run')
+  }
+
+  const url = URL.createObjectURL(await response.blob())
+  window.open(url, '_blank', 'noopener')
+  window.setTimeout(() => URL.revokeObjectURL(url), 60_000)
+}
+
 export async function getPrompt2BlogDebug(runId: string): Promise<Prompt2BlogDebugResponse> {
   const response = await apiFetch(`${FEATURE_PREFIX}/debug/${runId}`)
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/ModelRoutingPanel.tsx
@@ -1,6 +1,7 @@
 import {
   DEFAULT_PROMPT2BLOG_MODEL_STACK_ID,
-  PROMPT2BLOG_FIXED_STAGE_MODELS,
+  type Prompt2BlogModelStackId,
+  PROMPT2BLOG_ROUTE_GROUPS,
   resolvePrompt2BlogModelStack,
 } from '../../constants/prompt2blog.constants'
 import {
@@ -11,8 +12,15 @@ import {
 } from '../../constants/prompt2blog-pricing'
 import { Panel } from './Panel'
 
-export function ModelRoutingPanel() {
-  const selectedStack = resolvePrompt2BlogModelStack(DEFAULT_PROMPT2BLOG_MODEL_STACK_ID)
+export function ModelRoutingPanel({
+  modelStackId = DEFAULT_PROMPT2BLOG_MODEL_STACK_ID,
+  onChange,
+}: {
+  modelStackId?: Prompt2BlogModelStackId
+  /** Omitted on a read-only render; the panel then shows the route in use. */
+  onChange?: (value: Prompt2BlogModelStackId) => void
+} = {}) {
+  const selectedStack = resolvePrompt2BlogModelStack(modelStackId)
   const priceEstimate = estimatePrompt2BlogStackPrice(selectedStack)
   const planRoleNames = priceEstimate.planRoles
     .map(role => PROMPT2BLOG_ROLE_LABELS[role])
@@ -20,12 +28,35 @@ export function ModelRoutingPanel() {
 
   return <Panel
     title="Article system"
-    description="One fixed route balances writing quality, fact checking, and Claude plan usage."
+    description="Who writes the draft, and who checks it. Both routes write on Claude Opus."
   >
     <div className="p2b-field p2b-stack-picker">
-      <strong>Questurian balanced article route</strong>
+      {onChange ? (
+        <>
+          <label htmlFor="p2b-model-stack">Article route</label>
+          <select
+            id="p2b-model-stack"
+            className="p2b-select"
+            value={selectedStack.id}
+            onChange={event =>
+              onChange(event.target.value as Prompt2BlogModelStackId)
+            }
+          >
+            {PROMPT2BLOG_ROUTE_GROUPS.map(group => (
+              <optgroup key={group.label} label={group.label}>
+                {group.ids.map(id => {
+                  const stack = resolvePrompt2BlogModelStack(id)
+                  return <option key={id} value={id}>{stack.shortLabel}</option>
+                })}
+              </optgroup>
+            ))}
+          </select>
+        </>
+      ) : (
+        <strong>{selectedStack.label}</strong>
+      )}
       <p className="p2b-stack-description">{selectedStack.description}</p>
-      <p className="p2b-stack-guidance">Fixed for every new run. No model choice required.</p>
+      <p className="p2b-stack-guidance">{selectedStack.guidance}</p>
     </div>
     <div
       className="p2b-stack-cost"
@@ -58,9 +89,10 @@ export function ModelRoutingPanel() {
       <details className="p2b-stack-cost-method">
         <summary>How this estimate works</summary>
         <p>
-          Comparison estimate: 80% input and 20% output tokens, weighted across
-          4 worker, 5 writer, and 2 judge responsibilities. Actual cost changes
-          with source length, retries, caching, and optional stages.
+          Comparison estimate: 80% input and 20% output tokens, weighted by the
+          share of a run each role actually spent — 41% writer, 22% judge, 22%
+          fact checker, 9% planner, 7% headline, measured on a finished run.
+          Actual cost changes with source length, repairs, and caching.
         </p>
         <p>
           Standard global Vertex rates checked August 24, 2026. Gemini 3.7 Flash
@@ -78,14 +110,14 @@ export function ModelRoutingPanel() {
       <summary>See model assignments</summary>
       <div className="p2b-stack-receipt" aria-label={`${selectedStack.label} model assignments`}>
         <StackAssignment
-          label={PROMPT2BLOG_ROLE_LABELS.modelName}
-          model={selectedStack.modelName}
-          stages="Cleanup · synthesis · coverage · gap filling"
-        />
-        <StackAssignment
           label={PROMPT2BLOG_ROLE_LABELS.writingModel}
           model={selectedStack.writingModel}
-          stages="Draft · repair"
+          stages="First draft"
+        />
+        <StackAssignment
+          label={PROMPT2BLOG_ROLE_LABELS.repairModel}
+          model={selectedStack.repairModel}
+          stages="Rewrite of a draft that failed the audit"
         />
         <StackAssignment
           label={PROMPT2BLOG_ROLE_LABELS.auditModel}
@@ -93,9 +125,19 @@ export function ModelRoutingPanel() {
           stages="Quality audit"
         />
         <StackAssignment
-          label="Pipeline checks"
-          model={PROMPT2BLOG_FIXED_STAGE_MODELS.groundedness}
-          stages="Outline · groundedness · title"
+          label={PROMPT2BLOG_ROLE_LABELS.groundednessModel}
+          model={selectedStack.groundednessModel}
+          stages="Claims checked against the evidence"
+        />
+        <StackAssignment
+          label={PROMPT2BLOG_ROLE_LABELS.outlineModel}
+          model={selectedStack.outlineModel}
+          stages="Section plan"
+        />
+        <StackAssignment
+          label={PROMPT2BLOG_ROLE_LABELS.titleModel}
+          model={selectedStack.titleModel}
+          stages="Headline"
         />
       </div>
     </details>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/PromptProfilesPanel.tsx
@@ -1,4 +1,8 @@
 import type { Prompt2BlogInputOption, Prompt2BlogInputOptionsResponse } from '../../api'
+import {
+  creativityReachesWriter,
+  DEFAULT_PROMPT2BLOG_MODEL_STACK_ID,
+} from '../../constants/prompt2blog.constants'
 import type { P2BFormState } from '../composer.types'
 import { Panel } from './Panel'
 
@@ -21,6 +25,9 @@ interface PromptProfilesPanelProps {
 }
 
 export function PromptProfilesPanel(props: PromptProfilesPanelProps) {
+  const creativityAppliesToWriter = creativityReachesWriter(
+    DEFAULT_PROMPT2BLOG_MODEL_STACK_ID,
+  )
   return <Panel
     title="Writing Profiles"
     description="Tone, brand voice, and creativity for the approved commission."
@@ -37,7 +44,14 @@ export function PromptProfilesPanel(props: PromptProfilesPanelProps) {
           <span className="p2b-disclosure-summary-hint">Creativity and optional steering</span>
         </summary>
         <div className="p2b-disclosure-body">
-          <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select></div>
+          <div className="p2b-field"><label htmlFor="p2b-creativity">Creativity Level</label><select id="p2b-creativity" className="p2b-select" value={props.creativityLevel} onChange={event => props.onChange('creativityLevel', resolveCreativityLevel(event.target.value))}>{CREATIVITY_LEVELS.map(level => <option key={level} value={level}>{level[0].toUpperCase()}{level.slice(1)}</option>)}</select>{creativityAppliesToWriter ? null : (
+            <p className="p2b-field-hint" data-testid="p2b-creativity-inert">
+              Not applied on the current article route. Creativity sets the
+              writing model's sampling temperature, and the Claude plan
+              transport has no temperature control, so this setting is recorded
+              on the run but does not change the draft.
+            </p>
+          )}</div>
         </div>
       </details>
   </Panel>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/creativity-inert-notice.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/components/creativity-inert-notice.test.tsx
@@ -1,0 +1,55 @@
+/* @vitest-environment jsdom */
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  creativityReachesWriter,
+  PROMPT2BLOG_MODEL_STACKS,
+} from '../../constants/prompt2blog.constants'
+import { PromptProfilesPanel } from './PromptProfilesPanel'
+
+afterEach(cleanup)
+
+const noop = () => {}
+
+describe('creativity control honesty', () => {
+  it('says so when the setting does not reach the writing model', () => {
+    // Every current route writes on Claude, and the Claude plan transport has
+    // no temperature flag, so the dial is inert on every run today.
+    expect(PROMPT2BLOG_MODEL_STACKS.every(stack => !creativityReachesWriter(stack.id)))
+      .toBe(true)
+
+    render(
+      <PromptProfilesPanel
+        brandVoiceId="questurian-default"
+        creativityLevel="medium"
+        inputOptions={null}
+        lengthId="long"
+        toneId="practical"
+        onChange={noop}
+        onClear={noop}
+      />,
+    )
+
+    expect(screen.getByTestId('p2b-creativity-inert')).toHaveTextContent(
+      /does not change the draft/i,
+    )
+  })
+
+  it('reports the dial as connected for a writer that honours temperature', () => {
+    // Guards the direction of the check: this must start passing again by
+    // itself if a Gemini writer is ever selected, not stay stuck on a warning.
+    const geminiWritingStack = {
+      ...PROMPT2BLOG_MODEL_STACKS[0],
+      id: 'gemini-writer-probe' as (typeof PROMPT2BLOG_MODEL_STACKS)[number]['id'],
+      writingModel:
+        'gemini-3.1-pro-preview' as (typeof PROMPT2BLOG_MODEL_STACKS)[number]['writingModel'],
+    }
+    PROMPT2BLOG_MODEL_STACKS.push(geminiWritingStack)
+    try {
+      expect(creativityReachesWriter('gemini-writer-probe')).toBe(true)
+    } finally {
+      PROMPT2BLOG_MODEL_STACKS.pop()
+    }
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/composer.storage.ts
@@ -3,6 +3,7 @@ import {
   resolvePrompt2BlogModelStack,
   resolvePrompt2BlogModelName,
   resolvePrompt2BlogWriterModel,
+  resolveOfferedStackId,
 } from '../constants/prompt2blog.constants'
 import type {
   P2BCommissionApproval,
@@ -439,9 +440,11 @@ export function loadSavedComposerState(): P2BFormState {
       editorial,
       easySetupLocation: readString(parsed.easySetupLocation),
       easySetupTitle: readString(parsed.easySetupTitle),
-      // Model selection was removed. Old drafts may still carry a premium
-      // stack, but every resumed/new run now uses the one supported route.
-      modelStackId: DEFAULT_MODEL_STACK.id,
+      // The route is a real choice again, so a saved draft keeps the one it
+      // was saved with -- but only if the picker still offers it. A draft
+      // naming a retired stack falls back to the default rather than pinning
+      // the user to a route they cannot see or switch away from.
+      modelStackId: resolveOfferedStackId(parsed.modelStackId),
       modelName: resolvePrompt2BlogModelName(DEFAULT_MODEL_STACK.modelName),
       writingModel: resolvePrompt2BlogWriterModel(DEFAULT_MODEL_STACK.writingModel),
       auditModel: resolvePrompt2BlogWriterModel(DEFAULT_MODEL_STACK.auditModel),

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.test.ts
@@ -3,6 +3,7 @@ import limaFixture from '../../../../../../data/fixtures/prompt2blog/lima-scope-
 import type { Prompt2BlogCommission, Prompt2BlogEvidencePackage } from '../api'
 import { DEFAULT_COMPOSER_STATE } from './composer.storage'
 import type { P2BFormState } from './composer.types'
+import { resolvePrompt2BlogModelStack } from '../constants/prompt2blog.constants'
 import {
   buildPrompt2BlogV3Payload,
   prompt2BlogSubmissionBlockedReason,
@@ -165,11 +166,18 @@ describe('buildPrompt2BlogV3Payload', () => {
       brand_voice_id: 'questurian',
       creativity_level: 'low',
     })
+    // Read off the stack the draft names, not off mirrored copies in composer
+    // state: state carried three of the six roles, so the two could disagree.
+    const stack = resolvePrompt2BlogModelStack(DEFAULT_COMPOSER_STATE.modelStackId)
     expect(payload?.model_routing).toEqual({
-      model_name: DEFAULT_COMPOSER_STATE.modelName,
-      writing_model: DEFAULT_COMPOSER_STATE.writingModel,
-      audit_model: DEFAULT_COMPOSER_STATE.auditModel,
-      model_stack_id: DEFAULT_COMPOSER_STATE.modelStackId,
+      model_name: stack.modelName,
+      writing_model: stack.writingModel,
+      repair_model: stack.repairModel,
+      audit_model: stack.auditModel,
+      outline_model: stack.outlineModel,
+      groundedness_model: stack.groundednessModel,
+      title_model: stack.titleModel,
+      model_stack_id: stack.id,
     })
   })
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/composer/v3-payload.ts
@@ -1,4 +1,5 @@
 import type { Prompt2BlogV3Request } from '../api'
+import { resolvePrompt2BlogModelStack } from '../constants/prompt2blog.constants'
 import type { P2BFormState } from './composer.types'
 import { compareEvidenceToCommission } from './evidence-match'
 import { P2B_NEXT_ACTION } from './step-guidance'
@@ -76,6 +77,8 @@ export function buildPrompt2BlogV3Payload(state: P2BFormState): Prompt2BlogV3Req
   const { approval, evidencePackage } = state.editorial
   if (approval.status !== 'approved' || !evidencePackage) return null
 
+  const stack = resolvePrompt2BlogModelStack(state.modelStackId)
+
   return {
     schema_version: 3,
     commission: approval.commission,
@@ -86,11 +89,20 @@ export function buildPrompt2BlogV3Payload(state: P2BFormState): Prompt2BlogV3Req
       brand_voice_id: state.brandVoiceId || null,
       creativity_level: state.creativityLevel,
     },
+    // Read off the stack, not off the mirrored copies in composer state.
+    // State carried three of the six roles while the routing panel read the
+    // stack directly, so a draft saved under one stack id could submit another
+    // stack's models -- the same shape of drift as a receipt naming a model
+    // that did not run. The stack id is the choice; everything else follows.
     model_routing: {
-      model_name: state.modelName,
-      writing_model: state.writingModel,
-      audit_model: state.auditModel,
-      model_stack_id: state.modelStackId,
+      model_name: stack.modelName,
+      writing_model: stack.writingModel,
+      repair_model: stack.repairModel,
+      audit_model: stack.auditModel,
+      outline_model: stack.outlineModel,
+      groundedness_model: stack.groundednessModel,
+      title_model: stack.titleModel,
+      model_stack_id: stack.id,
     },
     include_debug: true,
     // v3 refuses this flag with a 400 rather than accepting it and ignoring

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.test.ts
@@ -7,14 +7,15 @@ import {
   type Prompt2BlogModelStackShape
 } from './prompt2blog-pricing'
 
+const stackById = (id: string) =>
+  PROMPT2BLOG_MODEL_STACKS.find(stack => stack.id === id)!
+
 describe('estimatePrompt2BlogStackPrice', () => {
   it('keeps input and output rates visible instead of hiding their difference', () => {
-    const stack = PROMPT2BLOG_MODEL_STACKS.find(stack => stack.id === 'opus-led-medium')!
+    const estimate = estimatePrompt2BlogStackPrice(stackById('gemini-checked-high'))
 
-    const estimate = estimatePrompt2BlogStackPrice(stack)
-
-    expect(formatPerMillionRate(estimate.inputPerMillion)).toBe('$0.25')
-    expect(formatPerMillionRate(estimate.outputPerMillion)).toBe('$1.50')
+    expect(formatPerMillionRate(estimate.inputPerMillion)).toBe('$1.85')
+    expect(formatPerMillionRate(estimate.outputPerMillion)).toBe('$11.04')
   })
 
   // The estimator used to throw on any model with no rate, which crashed the
@@ -31,9 +32,12 @@ describe('estimatePrompt2BlogStackPrice', () => {
     // Claude calls draw a plan allowance, so there is no dollar-per-million
     // figure that could be quoted honestly.
     const claudeWriter: Prompt2BlogModelStackShape = {
-      modelName: 'gemini-3.7-flash',
       writingModel: 'claude-opus-4-8',
-      auditModel: 'gemini-3.7-flash'
+      repairModel: 'gemini-3.7-flash',
+      auditModel: 'gemini-3.7-flash',
+      groundednessModel: 'gemini-3.7-flash',
+      outlineModel: 'gemini-3.7-flash',
+      titleModel: 'gemini-3.7-flash'
     }
 
     const estimate = estimatePrompt2BlogStackPrice(claudeWriter)
@@ -47,27 +51,52 @@ describe('estimatePrompt2BlogStackPrice', () => {
   })
 
   it('reports no rate at all when every role is on the plan', () => {
-    const allClaude: Prompt2BlogModelStackShape = {
-      modelName: 'claude-sonnet-5',
-      writingModel: 'claude-opus-4-8',
-      auditModel: 'claude-sonnet-5'
-    }
-
-    const estimate = estimatePrompt2BlogStackPrice(allClaude)
+    // Which is what every Claude-led route now is. The worker model used to
+    // carry a Gemini rate into this answer, so a route whose every real call
+    // draws plan allowance still advertised a dollar figure.
+    const estimate = estimatePrompt2BlogStackPrice(stackById('opus-led-medium'))
 
     expect(estimate.mixedPerMillion).toBeNull()
     expect(formatPerMillionRate(estimate.mixedPerMillion)).toBe('—')
-    expect(estimate.planRoles).toHaveLength(3)
+    expect(estimate.planRoles).toHaveLength(6)
   })
 
-  it('prices Claude-led stacks from their Flash-Lite worker only', () => {
-    const led = PROMPT2BLOG_MODEL_STACKS.find(stack => stack.id === 'opus-led-high')!
+  it('prices the Gemini-checked route from its four checking roles', () => {
+    const estimate = estimatePrompt2BlogStackPrice(stackById('gemini-checked-high'))
 
-    const estimate = estimatePrompt2BlogStackPrice(led)
+    // Only the draft and the repair stay on the plan.
+    expect(estimate.planRoles).toEqual(['writingModel', 'repairModel'])
+    expect(estimate.mixedPerMillion).toBeCloseTo(3.69, 2)
+  })
 
-    expect(estimate.planRoles).toEqual(['writingModel', 'auditModel'])
-    expect(formatPerMillionRate(estimate.inputPerMillion)).toBe('$0.25')
-    expect(formatPerMillionRate(estimate.outputPerMillion)).toBe('$1.50')
+  it('prices the max-repair route identically, because only effort changed', () => {
+    // Both prose stages stay on the plan either way, so the metered half of
+    // the route is the same four Gemini calls. What the split costs is plan
+    // allowance on the runs that actually repair, which no per-token rate can
+    // express -- so the rate must not imply the two routes differ in dollars.
+    const high = estimatePrompt2BlogStackPrice(stackById('gemini-checked-high'))
+    const maxRepair = estimatePrompt2BlogStackPrice(
+      stackById('gemini-checked-max-repair'),
+    )
+
+    expect(maxRepair.mixedPerMillion).toBeCloseTo(high.mixedPerMillion!, 6)
+    expect(maxRepair.planRoles).toEqual(['writingModel', 'repairModel'])
+  })
+
+  it('never prices the research worker, which v3 does not call', () => {
+    // `state["model_name"]` reaches the run record and nothing else. It used to
+    // carry the heaviest weight in this estimate.
+    const workerOnlyDifference: Prompt2BlogModelStackShape = {
+      writingModel: 'claude-opus-4-8',
+      repairModel: 'claude-opus-4-8',
+      auditModel: 'claude-sonnet-5',
+      groundednessModel: 'claude-sonnet-5',
+      outlineModel: 'claude-sonnet-5',
+      titleModel: 'claude-sonnet-5'
+    }
+
+    expect(estimatePrompt2BlogStackPrice(workerOnlyDifference).mixedPerMillion)
+      .toBeNull()
   })
 
   it('does not mistake a Gemini model for a plan model', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-pricing.ts
@@ -3,13 +3,25 @@ interface VertexTokenRate {
   output: number
 }
 
-export type Prompt2BlogRoleKey = 'modelName' | 'writingModel' | 'auditModel'
+export type Prompt2BlogRoleKey =
+  | 'writingModel'
+  | 'repairModel'
+  | 'auditModel'
+  | 'groundednessModel'
+  | 'outlineModel'
+  | 'titleModel'
 
 /**
- * Just the three role assignments. Narrower than `Prompt2BlogModelStack` on
- * purpose: pricing reads model names and nothing else, and the role unions
- * differ per role (only the writer union carries Claude names today), so a
- * plain string map is what this function actually needs.
+ * Just the role assignments a v3 run actually calls. Narrower than
+ * `Prompt2BlogModelStack` on purpose: pricing reads model names and nothing
+ * else, and the role unions differ per role, so a plain string map is what this
+ * function actually needs.
+ *
+ * `modelName` -- the research worker -- is deliberately absent. V3 never calls
+ * it; `state["model_name"]` reaches nothing but the run record. It used to
+ * carry the single heaviest weight here, so the headline rate was four
+ * elevenths a price for work that never happened, and the three checking roles
+ * that do run were not priced at all.
  */
 export type Prompt2BlogModelStackShape = Record<Prompt2BlogRoleKey, string>
 
@@ -45,16 +57,33 @@ const VERTEX_TOKEN_RATES: Record<string, VertexTokenRate> = {
   'gemini-3.1-flash-lite': { input: 0.25, output: 1.5 },
 }
 
+/**
+ * Share of a run's tokens, measured rather than guessed.
+ *
+ * Taken from the Medellin run (250,222 tokens): compose 44,309, repair 57,116,
+ * audit 55,913, groundedness 54,887, outline 21,478, title 16,519.
+ *
+ * Repair is weighted as though it always fires, which on a passing draft it
+ * does not. That overstates a repair-heavy route rather than flattering it --
+ * the safer direction for a number an operator compares routes with. These are
+ * a comparison basis, not a forecast of one run.
+ */
 const ROLE_WEIGHTS: ReadonlyArray<{ key: Prompt2BlogRoleKey; weight: number }> = [
-  { key: 'modelName', weight: 4 },
-  { key: 'writingModel', weight: 5 },
-  { key: 'auditModel', weight: 2 },
+  { key: 'writingModel', weight: 18 },
+  { key: 'repairModel', weight: 23 },
+  { key: 'auditModel', weight: 22 },
+  { key: 'groundednessModel', weight: 22 },
+  { key: 'outlineModel', weight: 9 },
+  { key: 'titleModel', weight: 7 },
 ] as const
 
 export const PROMPT2BLOG_ROLE_LABELS: Record<Prompt2BlogRoleKey, string> = {
-  modelName: 'Research worker',
   writingModel: 'Article writer',
+  repairModel: 'Repair pass',
   auditModel: 'Quality judge',
+  groundednessModel: 'Fact checker',
+  outlineModel: 'Section planner',
+  titleModel: 'Headline writer',
 }
 
 const INPUT_TOKEN_SHARE = 0.8

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-stacks.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog-stacks.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   PROMPT2BLOG_MODEL_STACKS,
+  PROMPT2BLOG_OFFERED_STACK_IDS,
+  PROMPT2BLOG_ROUTE_GROUPS,
   PROMPT2BLOG_STACK_FAMILY_ORDER,
   DEFAULT_PROMPT2BLOG_MODEL_STACK_ID,
+  resolveOfferedStackId,
   resolvePrompt2BlogModelStack,
   resolvePrompt2BlogWriterModel
 } from './prompt2blog.constants'
@@ -10,11 +13,17 @@ import { isPlanAllowanceModel } from './prompt2blog-pricing'
 
 const CLAUDE_STACKS = PROMPT2BLOG_MODEL_STACKS
 
+const CLAUDE_LED_STACKS = PROMPT2BLOG_MODEL_STACKS.filter(
+  stack => stack.family !== 'checked'
+)
+
 describe('Claude-writer run stacks', () => {
-  it('uses only Flash-Lite for metered work', () => {
-    for (const stack of CLAUDE_STACKS) {
-      expect(stack.modelName).toBe('gemini-3.1-flash-lite')
+  it('keeps every checking role on the plan for the Claude-led stacks', () => {
+    for (const stack of CLAUDE_LED_STACKS) {
       expect(isPlanAllowanceModel(stack.auditModel)).toBe(true)
+      expect(isPlanAllowanceModel(stack.groundednessModel)).toBe(true)
+      expect(isPlanAllowanceModel(stack.outlineModel)).toBe(true)
+      expect(isPlanAllowanceModel(stack.titleModel)).toBe(true)
     }
   })
 
@@ -27,10 +36,15 @@ describe('Claude-writer run stacks', () => {
       'sonnet-led-medium',
       'sonnet-led-high',
       'sonnet-led-xhigh',
-      'sonnet-led-max'
+      'sonnet-led-max',
+      'gemini-checked-high',
+      'gemini-checked-max',
+      'gemini-checked-max-repair',
+      'flash-checked-high',
+      'flash-checked-max-repair'
     ])
     expect(PROMPT2BLOG_MODEL_STACKS.some(stack => stack.id.includes('low'))).toBe(false)
-    expect(PROMPT2BLOG_MODEL_STACKS).toHaveLength(8)
+    expect(PROMPT2BLOG_MODEL_STACKS).toHaveLength(13)
   })
 
   it('gives every stack a family the picker knows how to group', () => {
@@ -40,7 +54,7 @@ describe('Claude-writer run stacks', () => {
   })
 
   it('groups Opus before Sonnet and orders each by increasing effort', () => {
-    expect(PROMPT2BLOG_STACK_FAMILY_ORDER).toEqual(['opus', 'sonnet'])
+    expect(PROMPT2BLOG_STACK_FAMILY_ORDER).toEqual(['opus', 'sonnet', 'checked'])
     expect(PROMPT2BLOG_MODEL_STACKS.map(stack => stack.family)).toEqual([
       'opus',
       'opus',
@@ -49,8 +63,118 @@ describe('Claude-writer run stacks', () => {
       'sonnet',
       'sonnet',
       'sonnet',
-      'sonnet'
+      'sonnet',
+      'checked',
+      'checked',
+      'checked',
+      'checked',
+      'checked'
     ])
+  })
+
+  it('keeps Claude on the two stages that write prose, and nowhere else', () => {
+    // The point of the route. Claude drafts and repairs; every stage that
+    // reads, checks or scores is a Gemini call, so the judge is not from the
+    // family that wrote what it is judging -- and the checking stages, which
+    // are more than half a run's tokens, stop drawing plan allowance.
+    const checked = resolvePrompt2BlogModelStack('gemini-checked-high')
+
+    expect(isPlanAllowanceModel(checked.writingModel)).toBe(true)
+    expect(isPlanAllowanceModel(checked.auditModel)).toBe(false)
+    expect(isPlanAllowanceModel(checked.groundednessModel)).toBe(false)
+    expect(isPlanAllowanceModel(checked.outlineModel)).toBe(false)
+    expect(isPlanAllowanceModel(checked.titleModel)).toBe(false)
+  })
+
+  it('offers exactly the routes the picker shows, default first', () => {
+    expect(PROMPT2BLOG_OFFERED_STACK_IDS).toEqual([
+      'opus-led-high',
+      'gemini-checked-high',
+      'gemini-checked-max-repair',
+      'flash-checked-high',
+      'flash-checked-max-repair'
+    ])
+    expect(PROMPT2BLOG_OFFERED_STACK_IDS[0]).toBe(DEFAULT_PROMPT2BLOG_MODEL_STACK_ID)
+  })
+
+  it('groups the picker by who checks the draft, and offers nothing outside a group', () => {
+    // Effort is the second-order choice inside a group. Five flat options asked
+    // the operator to compare two unrelated axes at once.
+    expect(PROMPT2BLOG_ROUTE_GROUPS.map(group => group.label)).toEqual([
+      'Claude checks its own draft',
+      'Gemini Pro checks — independent reader',
+      'Gemini Flash checks — cheapest'
+    ])
+    // Derived from the groups, so the picker and the validator cannot disagree.
+    expect(PROMPT2BLOG_OFFERED_STACK_IDS).toEqual(
+      PROMPT2BLOG_ROUTE_GROUPS.flatMap(group => group.ids)
+    )
+    for (const id of PROMPT2BLOG_OFFERED_STACK_IDS) {
+      expect(resolvePrompt2BlogModelStack(id).id).toBe(id)
+      expect(resolveOfferedStackId(id)).toBe(id)
+    }
+  })
+
+  it('gives every offered route a short option label distinct from its full name', () => {
+    // The group heading already says who checks, so the option text must not
+    // repeat it -- but the full label still has to name the whole route where
+    // there is no heading, like a receipt's aria label.
+    for (const id of PROMPT2BLOG_OFFERED_STACK_IDS) {
+      const stack = resolvePrompt2BlogModelStack(id)
+      expect(stack.shortLabel.length).toBeGreaterThan(0)
+      expect(stack.shortLabel).not.toContain('checked')
+    }
+  })
+
+  it('checks on Flash for the cheapest route, and never drafts on it', () => {
+    const flash = resolvePrompt2BlogModelStack('flash-checked-high')
+
+    expect(flash.writingModel).toBe('claude-opus-5-high')
+    expect(flash.repairModel).toBe('claude-opus-5-high')
+    expect(flash.auditModel).toBe('gemini-3.7-flash')
+    expect(flash.groundednessModel).toBe('gemini-3.7-flash')
+    expect(flash.outlineModel).toBe('gemini-3.7-flash')
+    expect(flash.titleModel).toBe('gemini-3.7-flash')
+  })
+
+  it('names the weaker checker as a tradeoff rather than only as a saving', () => {
+    // A cheaper judge is likelier to pass a claim the evidence does not
+    // support, and that is the one failure a reader cannot see.
+    for (const id of ['flash-checked-high', 'flash-checked-max-repair'] as const) {
+      expect(resolvePrompt2BlogModelStack(id).guidance).toMatch(/weaker|fact-read/i)
+    }
+  })
+
+  it('spends max effort on the rescue, not on every draft', () => {
+    // Repair only fires on a draft that failed, and the run gets one attempt,
+    // so this is the single call whose strength decides rescue or hand-back.
+    // Max on the draft would be paid on runs that were going to pass.
+    const split = resolvePrompt2BlogModelStack('gemini-checked-max-repair')
+
+    expect(split.writingModel).toBe('claude-opus-5-high')
+    expect(split.repairModel).toBe('claude-opus-5-max')
+  })
+
+  it('repairs on the writing model unless a route says otherwise', () => {
+    const splitEffort = ['gemini-checked-max-repair', 'flash-checked-max-repair']
+    for (const stack of PROMPT2BLOG_MODEL_STACKS) {
+      if (splitEffort.includes(stack.id)) continue
+      expect(stack.repairModel).toBe(stack.writingModel)
+    }
+    for (const id of splitEffort) {
+      const stack = resolvePrompt2BlogModelStack(id)
+      expect(stack.writingModel).toBe('claude-opus-5-high')
+      expect(stack.repairModel).toBe('claude-opus-5-max')
+    }
+  })
+
+  it('falls a stored route that is no longer offered back to the default', () => {
+    // The six unoffered stacks stay defined so an old run record is readable.
+    // Restoring one into live state would pin the user to a route the picker
+    // cannot show.
+    expect(resolveOfferedStackId('gemini-checked-high')).toBe('gemini-checked-high')
+    expect(resolveOfferedStackId('opus-led-max')).toBe(DEFAULT_PROMPT2BLOG_MODEL_STACK_ID)
+    expect(resolveOfferedStackId(undefined)).toBe(DEFAULT_PROMPT2BLOG_MODEL_STACK_ID)
   })
 
   it('has a unique id per stack', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/constants/prompt2blog.constants.ts
@@ -15,16 +15,24 @@ export type Prompt2BlogModelStackId =
   | 'sonnet-led-high'
   | 'sonnet-led-xhigh'
   | 'sonnet-led-max'
+  | 'gemini-checked-high'
+  | 'gemini-checked-max'
+  | 'gemini-checked-max-repair'
+  | 'flash-checked-high'
+  | 'flash-checked-max-repair'
 
 /**
  * Stack family used by the picker. Opus-led stacks reserve Opus for prose and
- * use Sonnet for judgment; Flash-Lite remains the cheap research worker.
+ * use Sonnet for judgment. `checked` stacks keep Claude only on the two stages
+ * that write prose and hand every checking stage to Gemini, so the model that
+ * grades the draft is not from the same family that wrote it.
  */
-export type Prompt2BlogStackFamily = 'opus' | 'sonnet'
+export type Prompt2BlogStackFamily = 'opus' | 'sonnet' | 'checked'
 
 export const PROMPT2BLOG_STACK_FAMILY_LABELS: Record<Prompt2BlogStackFamily, string> = {
   opus: 'Claude Opus',
-  sonnet: 'Claude Sonnet'
+  sonnet: 'Claude Sonnet',
+  checked: 'Claude writes, Gemini checks'
 }
 
 export interface Prompt2BlogModelStack {
@@ -45,9 +53,32 @@ export interface Prompt2BlogModelStack {
    * Marks the stack offered as the starting point. Exactly one carries it.
    */
   recommended?: boolean
+  /**
+   * The option text in the picker. Short because the group heading above it
+   * already says who checks the draft; `label` stays long because it names the
+   * whole route in receipts and aria labels, where there is no heading.
+   */
+  shortLabel: string
   modelName: Prompt2BlogModelName
   writingModel: Prompt2BlogWriterModel
+  /**
+   * Repair rewrites the whole article, so it is a prose model like the writer
+   * -- but it is not the same job. The draft writes into an open space; repair
+   * is handed a list of required revisions and has to satisfy them without
+   * breaking the rest. A route can therefore spend a different effort tier on
+   * the rescue than on the draft.
+   */
+  repairModel: Prompt2BlogWriterModel
   auditModel: Prompt2BlogWriterModel
+  /**
+   * The three roles that used to be pinned in the backend and unreachable from
+   * a request. Declared per stack now, so a route can move six calls instead of
+   * two. Named explicitly rather than inherited from the writer: inheriting is
+   * what would let a premium prose model promote every small call to its tier.
+   */
+  outlineModel: Prompt2BlogWriterModel
+  groundednessModel: Prompt2BlogWriterModel
+  titleModel: Prompt2BlogWriterModel
 }
 
 type Prompt2BlogStackEffort = 'medium' | 'high' | 'xhigh' | 'max'
@@ -65,6 +96,18 @@ const STACK_GUIDANCE: Record<Prompt2BlogStackEffort, string> = {
   max: 'Aims for the smallest editing burden. Slowest, and the one to reach for when the draft matters.'
 }
 
+/**
+ * What the three checking roles were pinned to before routes could name them,
+ * and what the backend still falls back to when a request omits them. Every
+ * Claude-led stack spreads this so its routing is written down rather than
+ * implied by an omission.
+ */
+export const PROMPT2BLOG_FIXED_STAGE_MODELS = {
+  outlineModel: 'claude-sonnet-5-medium',
+  groundednessModel: 'claude-sonnet-5-medium',
+  titleModel: 'claude-sonnet-5-medium'
+} as const
+
 export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
   // Claude owns writing, repair, and judgment. Flash-Lite does only worker
   // tasks, keeping metered spend low. Low effort is intentionally unavailable.
@@ -72,6 +115,7 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
     id: `opus-led-${effort}` as Prompt2BlogModelStackId,
     family: 'opus' as const,
     label: `Opus · ${effort === 'xhigh' ? 'XHigh' : effort[0].toUpperCase() + effort.slice(1)}`,
+    shortLabel: `Opus · ${effort === 'xhigh' ? 'XHigh' : effort[0].toUpperCase() + effort.slice(1)} effort`,
     priceTier: 'Plan + $',
     speedTier: 'Slowest' as const,
     description: `Claude Opus at ${effort} effort writes and repairs; Claude Sonnet at ${effort} judges; fixed medium-effort Sonnet handles planning, fact checks, and titles.`,
@@ -79,31 +123,196 @@ export const PROMPT2BLOG_MODEL_STACKS: Prompt2BlogModelStack[] = [
     recommended: effort === 'high',
     modelName: 'gemini-3.1-flash-lite' as const,
     writingModel: `claude-opus-5-${effort}` as Prompt2BlogWriterModel,
-    auditModel: `claude-sonnet-5-${effort}` as Prompt2BlogWriterModel
+    repairModel: `claude-opus-5-${effort}` as Prompt2BlogWriterModel,
+    auditModel: `claude-sonnet-5-${effort}` as Prompt2BlogWriterModel,
+    ...PROMPT2BLOG_FIXED_STAGE_MODELS
   })),
   ...(['medium', 'high', 'xhigh', 'max'] as const).map(effort => ({
     id: `sonnet-led-${effort}` as Prompt2BlogModelStackId,
     family: 'sonnet' as const,
     label: `Sonnet · ${effort === 'xhigh' ? 'XHigh' : effort[0].toUpperCase() + effort.slice(1)}`,
+    shortLabel: `Sonnet · ${effort === 'xhigh' ? 'XHigh' : effort[0].toUpperCase() + effort.slice(1)} effort`,
     priceTier: 'Plan + $',
     speedTier: effort === 'medium' ? ('Fast' as const) : ('Moderate' as const),
     description: `Claude Sonnet at ${effort} effort writes, repairs, and judges; Gemini Flash-Lite is reserved for cheap research work.`,
     guidance: STACK_GUIDANCE[effort],
     modelName: 'gemini-3.1-flash-lite' as const,
     writingModel: `claude-sonnet-5-${effort}` as Prompt2BlogWriterModel,
-    auditModel: `claude-sonnet-5-${effort}` as Prompt2BlogWriterModel
+    repairModel: `claude-sonnet-5-${effort}` as Prompt2BlogWriterModel,
+    auditModel: `claude-sonnet-5-${effort}` as Prompt2BlogWriterModel,
+    ...PROMPT2BLOG_FIXED_STAGE_MODELS
+  })),
+  // Claude only where the output is prose a reader will judge: the draft and
+  // the repair. Everything that reads, checks or scores is Gemini Pro.
+  //
+  // Two reasons, and the second matters more than the first. Metered spend is
+  // the obvious one -- outline, groundedness and the audit are 53% of a run's
+  // tokens (measured on the Medellin run: 21k outline, 55k groundedness, 56k
+  // audit of 250k) and none of them produce a sentence anyone reads. The one
+  // worth the swap is independence: a Claude draft graded by a Claude judge is
+  // marked by a model that shares its blind spots, and the Medellin audit
+  // passed prose its own family had written while missing nothing a different
+  // reader would have caught. Titles go to Flash: it is one line from an
+  // article the run already holds.
+  ...(['high', 'max'] as const).map(effort => ({
+    id: `gemini-checked-${effort}` as Prompt2BlogModelStackId,
+    family: 'checked' as const,
+    label: `Opus · ${effort === 'max' ? 'Max' : 'High'} · Gemini-checked`,
+    shortLabel: `Opus · ${effort === 'max' ? 'Max' : 'High'} effort`,
+    priceTier: 'Plan + $$',
+    speedTier: 'Slow' as const,
+    description: `Claude Opus at ${effort} effort writes and repairs; Gemini 3.1 Pro plans, fact checks, and grades the draft; Gemini 3.7 Flash writes the title.`,
+    guidance:
+      'The one to try when Claude-graded drafts keep passing an audit you disagree with. A judge from a different family finds different faults, and the checking stages stop drawing Claude plan usage.',
+    modelName: 'gemini-3.1-flash-lite' as const,
+    writingModel: `claude-opus-5-${effort}` as Prompt2BlogWriterModel,
+    repairModel: `claude-opus-5-${effort}` as Prompt2BlogWriterModel,
+    auditModel: 'gemini-3.1-pro-preview' as Prompt2BlogWriterModel,
+    outlineModel: 'gemini-3.1-pro-preview' as Prompt2BlogWriterModel,
+    groundednessModel: 'gemini-3.1-pro-preview' as Prompt2BlogWriterModel,
+    titleModel: 'gemini-3.7-flash' as Prompt2BlogWriterModel
+  })),
+  // Max effort where it is conditional, not where it is unavoidable.
+  //
+  // Max on the draft is paid on every run, including the ones that would have
+  // passed anyway. Repair only fires on a draft that failed the audit, and the
+  // run gets exactly one attempt -- so this is the single call whose strength
+  // decides whether a weak draft is rescued or handed back as needs_revision.
+  // It is also the better-shaped job for reasoning effort: repair is handed a
+  // list of required revisions and has to satisfy them without breaking the
+  // rest, while the draft is writing into an open space.
+  //
+  // What this cannot fix: repair may not change the commission and the outline
+  // is already settled, so max effort here only helps inside the shape the
+  // draft chose. A structurally wrong article needs the effort on the draft.
+  {
+    id: 'gemini-checked-max-repair' as Prompt2BlogModelStackId,
+    family: 'checked' as const,
+    label: 'Opus · Max repair · Gemini-checked',
+    shortLabel: 'Opus · High draft, Max repair',
+    priceTier: 'Plan + $$',
+    speedTier: 'Slow' as const,
+    description:
+      'Claude Opus at high effort writes; a failed draft is repaired at max effort; Gemini 3.1 Pro plans, fact checks, and grades; Gemini 3.7 Flash writes the title.',
+    guidance:
+      'The one to try when drafts come back close but failing on a listed set of fixes. Spends the heaviest effort only on runs that needed rescuing, and nothing extra on runs that passed.',
+    modelName: 'gemini-3.1-flash-lite' as const,
+    writingModel: 'claude-opus-5-high' as Prompt2BlogWriterModel,
+    repairModel: 'claude-opus-5-max' as Prompt2BlogWriterModel,
+    auditModel: 'gemini-3.1-pro-preview' as Prompt2BlogWriterModel,
+    outlineModel: 'gemini-3.1-pro-preview' as Prompt2BlogWriterModel,
+    groundednessModel: 'gemini-3.1-pro-preview' as Prompt2BlogWriterModel,
+    titleModel: 'gemini-3.7-flash' as Prompt2BlogWriterModel
+  },
+  // The cheapest route that still writes on Opus: Flash does every check.
+  //
+  // Flash is roughly a third of Pro's rate, so the metered half of a run drops
+  // from about $3.69 to $1.35 per 1M mixed tokens. What is being traded is
+  // judgement, and the stage to watch is groundedness: a weaker reader is more
+  // likely to wave through a claim the evidence does not actually support,
+  // which is the one failure a reader cannot see and an editor cannot catch
+  // from the prose. Use it for drafts you will fact-read yourself.
+  ...(['high', 'max-repair'] as const).map(variant => ({
+    id: `flash-checked-${variant}` as Prompt2BlogModelStackId,
+    family: 'checked' as const,
+    label: `Opus · ${variant === 'max-repair' ? 'Max repair' : 'High'} · Flash-checked`,
+    shortLabel:
+      variant === 'max-repair' ? 'Opus · High draft, Max repair' : 'Opus · High effort',
+    priceTier: 'Plan + $',
+    speedTier: 'Moderate' as const,
+    description:
+      variant === 'max-repair'
+        ? 'Claude Opus at high effort writes; a failed draft is repaired at max effort; Gemini 3.7 Flash plans, fact checks, grades, and writes the title.'
+        : 'Claude Opus at high effort writes and repairs; Gemini 3.7 Flash plans, fact checks, grades, and writes the title.',
+    guidance:
+      variant === 'max-repair'
+        ? 'The cheapest metered route that still spends heavily on rescuing a failed draft. Read the fact checks yourself: Flash is the weaker reader of the two Gemini options.'
+        : 'The cheapest route on this list. Good for drafts you plan to fact-read yourself, since a weaker checker is likelier to pass a claim the evidence does not support.',
+    modelName: 'gemini-3.1-flash-lite' as const,
+    writingModel: 'claude-opus-5-high' as Prompt2BlogWriterModel,
+    repairModel: (variant === 'max-repair'
+      ? 'claude-opus-5-max'
+      : 'claude-opus-5-high') as Prompt2BlogWriterModel,
+    auditModel: 'gemini-3.7-flash' as Prompt2BlogWriterModel,
+    outlineModel: 'gemini-3.7-flash' as Prompt2BlogWriterModel,
+    groundednessModel: 'gemini-3.7-flash' as Prompt2BlogWriterModel,
+    titleModel: 'gemini-3.7-flash' as Prompt2BlogWriterModel
   }))
 ]
 
-export const PROMPT2BLOG_STACK_FAMILY_ORDER: Prompt2BlogStackFamily[] = ['opus', 'sonnet']
+export const PROMPT2BLOG_STACK_FAMILY_ORDER: Prompt2BlogStackFamily[] = ['opus', 'sonnet', 'checked']
 
 export const DEFAULT_PROMPT2BLOG_MODEL_STACK_ID: Prompt2BlogModelStackId = 'opus-led-high'
 
-export const PROMPT2BLOG_FIXED_STAGE_MODELS = {
-  outline: 'claude-sonnet-5-medium',
-  groundedness: 'claude-sonnet-5-medium',
-  title: 'claude-sonnet-5-medium',
-} as const
+/**
+ * Whether the creativity control reaches the stage that writes the article.
+ *
+ * Creativity sets the sampling temperature for the composing stage. Claude
+ * models are served here by the Claude Code CLI, which has no temperature
+ * flag, so the value is accepted and dropped -- the dial is connected on a
+ * Gemini-written draft and inert on a Claude-written one. Derived from the
+ * stack rather than hardcoded so it stops warning by itself if a writer that
+ * honours temperature is ever selected again.
+ */
+/**
+ * The routes offered in the picker, in the order they are shown.
+ *
+ * Two, not the whole eight-stack matrix. The matrix was closed deliberately --
+ * picking an effort tier off a price label produced drafts that needed
+ * rewriting -- and reopening it would undo that. The one axis worth a decision
+ * is who checks the draft. The other six stacks stay defined so a saved run
+ * that names one is still readable; they are just not offered.
+ */
+/**
+ * The picker's groups, in the order they are shown.
+ *
+ * Grouped by who checks the draft, because that is the decision. Effort is the
+ * second-order choice inside a group, and putting five flat options in one list
+ * asked the operator to compare two unrelated axes at once.
+ *
+ * Not the whole eleven-stack matrix: the matrix was closed deliberately --
+ * picking an effort tier off a price label produced drafts that needed
+ * rewriting. The unoffered stacks stay defined so an old run record is
+ * readable; they are just not choices.
+ */
+export const PROMPT2BLOG_ROUTE_GROUPS: ReadonlyArray<{
+  label: string
+  ids: Prompt2BlogModelStackId[]
+}> = [
+  {
+    label: 'Claude checks its own draft',
+    ids: ['opus-led-high']
+  },
+  {
+    label: 'Gemini Pro checks — independent reader',
+    ids: ['gemini-checked-high', 'gemini-checked-max-repair']
+  },
+  {
+    label: 'Gemini Flash checks — cheapest',
+    ids: ['flash-checked-high', 'flash-checked-max-repair']
+  }
+]
+
+/** Flattened from the groups, so the two cannot disagree about what is offered. */
+export const PROMPT2BLOG_OFFERED_STACK_IDS: Prompt2BlogModelStackId[] =
+  PROMPT2BLOG_ROUTE_GROUPS.flatMap(group => group.ids)
+
+/**
+ * A stack id from storage, narrowed to one the picker can actually show.
+ *
+ * A saved draft naming a route that is no longer offered falls back to the
+ * default rather than resurrecting a stack the picker cannot display or the
+ * user cannot switch away from.
+ */
+export function resolveOfferedStackId(value?: unknown): Prompt2BlogModelStackId {
+  return PROMPT2BLOG_OFFERED_STACK_IDS.includes(value as Prompt2BlogModelStackId)
+    ? (value as Prompt2BlogModelStackId)
+    : DEFAULT_PROMPT2BLOG_MODEL_STACK_ID
+}
+
+export function creativityReachesWriter(value?: string): boolean {
+  return !resolvePrompt2BlogModelStack(value).writingModel.startsWith('claude-')
+}
 
 export function resolvePrompt2BlogModelStack(value?: string): Prompt2BlogModelStack {
   return (

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.test.tsx
@@ -694,24 +694,99 @@ describe('Prompt2BlogPage', () => {
     expect(screen.getByLabelText('Location')).toHaveValue('Lisbon, Portugal')
   })
 
-  it('shows one fixed article system with no model selector', async () => {
+  it('shows the default route as fully plan-funded, and names every stage', async () => {
     renderPage()
 
-    expect(await screen.findByText('Questurian balanced article route')).toBeInTheDocument()
-    expect(screen.queryByLabelText('Pipeline preset')).toBeNull()
-    const receipt = screen.getByLabelText('Opus · High model assignments')
+    const route = await screen.findByLabelText('Article route')
+    expect(route).toHaveValue('opus-led-high')
 
-    expect(within(receipt).getByText('Research worker')).toBeInTheDocument()
+    const receipt = screen.getByLabelText('Opus · High model assignments')
+    // The research worker is gone from this list: v3 never calls it, and
+    // showing it implied a Gemini model was doing work it never did.
+    expect(within(receipt).queryByText('Research worker')).toBeNull()
     expect(within(receipt).getByText('Article writer')).toBeInTheDocument()
-    expect(within(receipt).getByText('Quality judge')).toBeInTheDocument()
-    expect(within(receipt).getByText('Gemini 3.1 Flash Lite')).toBeInTheDocument()
-    expect(within(receipt).getByText('Claude Opus 5 high')).toBeInTheDocument()
+    expect(within(receipt).getByText('Repair pass')).toBeInTheDocument()
+    expect(within(receipt).getByText('Fact checker')).toBeInTheDocument()
+    // Draft and repair, both on the writer's model here.
+    expect(within(receipt).getAllByText('Claude Opus 5 high')).toHaveLength(2)
     expect(within(receipt).getByText('Claude Sonnet 5 high')).toBeInTheDocument()
-    expect(within(receipt).getByText('Claude Sonnet 5 medium')).toBeInTheDocument()
+    // Outline, groundedness and title all sit on the same model here.
+    expect(within(receipt).getAllByText('Claude Sonnet 5 medium')).toHaveLength(3)
+
+    // Every call this route makes draws plan allowance, so there is no
+    // dollar-per-million figure to quote. It used to show one, priced off a
+    // worker model the pipeline never calls.
     const pricing = screen.getByLabelText('Opus · High estimated pricing')
-    expect(within(pricing).getByText('$0.50')).toBeInTheDocument()
-    expect(within(pricing).getByText('Input $0.25 / 1M')).toBeInTheDocument()
-    expect(within(pricing).getByText('Output $1.50 / 1M')).toBeInTheDocument()
+    expect(within(pricing).getByText('Included in your Claude plan')).toBeInTheDocument()
+  })
+
+  it('offers a route that keeps Claude on prose and moves the checks to Gemini', async () => {
+    renderPage()
+
+    const route = await screen.findByLabelText('Article route')
+    fireEvent.change(route, { target: { value: 'gemini-checked-high' } })
+
+    const receipt = screen.getByLabelText(
+      'Opus · High · Gemini-checked model assignments',
+    )
+    // Claude still drafts and repairs; nothing else is Claude.
+    expect(within(receipt).getAllByText('Claude Opus 5 high')).toHaveLength(2)
+    expect(within(receipt).queryByText(/Claude Sonnet/)).toBeNull()
+    expect(within(receipt).getAllByText('Gemini 3.1 Pro Preview')).toHaveLength(3)
+    expect(within(receipt).getByText('Gemini 3.7 Flash')).toBeInTheDocument()
+
+    const pricing = screen.getByLabelText(
+      'Opus · High · Gemini-checked estimated pricing',
+    )
+    expect(within(pricing).getByText('Input $1.85 / 1M')).toBeInTheDocument()
+    expect(within(pricing).getByText('Output $11.04 / 1M')).toBeInTheDocument()
+  })
+
+  it('offers a route that spends max effort on the repair but not the draft', async () => {
+    renderPage()
+
+    const route = await screen.findByLabelText('Article route')
+    fireEvent.change(route, { target: { value: 'gemini-checked-max-repair' } })
+
+    const receipt = screen.getByLabelText(
+      'Opus · Max repair · Gemini-checked model assignments',
+    )
+    // The two prose stages differ by effort tier, which is the whole route.
+    expect(within(receipt).getByText('Claude Opus 5 high')).toBeInTheDocument()
+    expect(within(receipt).getByText('Claude Opus 5 max')).toBeInTheDocument()
+    expect(within(receipt).getAllByText('Gemini 3.1 Pro Preview')).toHaveLength(3)
+  })
+
+  it('groups the routes by who checks the draft', async () => {
+    renderPage()
+
+    const route = await screen.findByLabelText('Article route')
+    const groups = within(route).getAllByRole('group')
+
+    expect(groups.map(group => group.getAttribute('label'))).toEqual([
+      'Claude checks its own draft',
+      'Gemini Pro checks — independent reader',
+      'Gemini Flash checks — cheapest'
+    ])
+    // The heading carries the checker, so the option text carries only effort.
+    expect(within(groups[2]!).getByRole('option', { name: 'Opus · High effort' }))
+      .toBeInTheDocument()
+  })
+
+  it('offers a Flash-checked route that costs a third of the Pro one', async () => {
+    renderPage()
+
+    const route = await screen.findByLabelText('Article route')
+    fireEvent.change(route, { target: { value: 'flash-checked-high' } })
+
+    const receipt = screen.getByLabelText('Opus · High · Flash-checked model assignments')
+    // Opus still writes and repairs. Every check is Flash.
+    expect(within(receipt).getAllByText('Claude Opus 5 high')).toHaveLength(2)
+    expect(within(receipt).getAllByText('Gemini 3.7 Flash')).toHaveLength(4)
+
+    const pricing = screen.getByLabelText('Opus · High · Flash-checked estimated pricing')
+    expect(within(pricing).getByText('Input $0.75 / 1M')).toBeInTheDocument()
+    expect(within(pricing).getByText('Output $3.75 / 1M')).toBeInTheDocument()
   })
 
   it('blocks submission while an editorial v3 direction is unfinished', async () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -147,7 +147,10 @@ export default function Prompt2BlogPage() {
             title="Advanced"
             description="See how the fixed article system works and what it costs."
           >
-            <ModelRoutingPanel />
+            <ModelRoutingPanel
+              modelStackId={state.modelStackId}
+              onChange={value => composer.updateField('modelStackId', value)}
+            />
           </FoldedSection>
 
           <div className="p2b-submit-row">

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineV3Result.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/PipelineV3Result.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import payloadLogoUrl from '../../../../assets/payload-logo.svg?url'
+import { openPrompt2BlogDrafts } from '../../api'
 import type {
   Prompt2BlogRepairDecision,
   Prompt2BlogV3PipelinePayload,
@@ -58,6 +60,22 @@ export function PipelineV3Result({
   const requirementIds = Object.keys(requirementStatus)
   const repairDecision = result.quality_review.repair_decision
   const repairNote = repairDecision ? repairDecisionNote(repairDecision) : null
+  const [draftsError, setDraftsError] = useState<string | null>(null)
+
+  // The finished article is one of several the run wrote, and which one
+  // shipped is a decision worth being able to check: a repair that scores no
+  // better than the draft it replaced is discarded, so the article here can be
+  // the *earlier* one. The drafts page shows all of them side by side.
+  async function showDrafts() {
+    setDraftsError(null)
+    try {
+      await openPrompt2BlogDrafts(result.run_id)
+    } catch (error) {
+      setDraftsError(
+        error instanceof Error ? error.message : 'Could not open the drafts.',
+      )
+    }
+  }
 
   return (
     <div className="p2b-final-result">
@@ -74,6 +92,9 @@ export function PipelineV3Result({
             Stage in Payload Editor
           </Link>
         )}
+        <button type="button" className="p2b-synthesize-btn" onClick={showDrafts}>
+          Read all drafts
+        </button>
         {result.langsmith_trace_url && (
           <a
             href={result.langsmith_trace_url}
@@ -88,6 +109,11 @@ export function PipelineV3Result({
           View Saved Articles
         </Link>
       </div>
+      {draftsError && (
+        <p className="p2b-error" role="alert">
+          {draftsError}
+        </p>
+      )}
       {result.run_cost && <RunCostReceipt cost={result.run_cost} />}
       <p>
         <strong>Status:</strong> {result.pipeline_status}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/pipeline-result.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/pipeline-result.test.tsx
@@ -1,7 +1,16 @@
 /* @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+const openDrafts = vi.hoisted(() => vi.fn())
+vi.mock('../../api/pipeline.api', async () => ({
+  ...(await vi.importActual<typeof import('../../api/pipeline.api')>(
+    '../../api/pipeline.api',
+  )),
+  openPrompt2BlogDrafts: openDrafts,
+}))
 import legacyResultFixture from '../../../../../../../data/fixtures/prompt2blog/legacy-v2-result.json'
 import type { Prompt2BlogPipelinePayload, Prompt2BlogV3PipelinePayload } from '../../api'
 import { PipelineResult } from './PipelineResult'
@@ -156,5 +165,41 @@ describe('PipelineV3Result', () => {
     expect(screen.getByText('needs_revision')).toBeTruthy()
     expect(screen.getByText('claims_grounded')).toBeTruthy()
     expect(screen.queryByRole('link', { name: /Stage in Payload Editor/ })).toBeNull()
+  })
+
+  it('opens the run\'s other drafts, so a discarded repair can still be read', async () => {
+    openDrafts.mockResolvedValueOnce(undefined)
+    renderResult(
+      <PipelineV3Result
+        debugData={null}
+        result={v3Payload}
+        showDebug={false}
+        stageArticleUrl={null}
+        onToggleDebug={() => {}}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Read all drafts' }))
+
+    expect(openDrafts).toHaveBeenCalledWith('v3-run')
+  })
+
+  it('says so in the panel when the drafts cannot be opened', async () => {
+    openDrafts.mockRejectedValueOnce(new Error('Run not found.'))
+    renderResult(
+      <PipelineV3Result
+        debugData={null}
+        result={v3Payload}
+        showDebug={false}
+        stageArticleUrl={null}
+        onToggleDebug={() => {}}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Read all drafts' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe('Run not found.')
+    })
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/editorial.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/editorial.types.ts
@@ -249,7 +249,11 @@ export type Prompt2BlogWritingProfiles = {
 export type Prompt2BlogModelRouting = {
   model_name?: string | null
   writing_model?: string | null
+  repair_model?: string | null
   audit_model?: string | null
+  outline_model?: string | null
+  groundedness_model?: string | null
+  title_model?: string | null
   model_stack_id?: string | null
 }
 

--- a/apps/ai-blog-writer/docs/adr/0030-prompt2blog-v4-grill-and-brief.md
+++ b/apps/ai-blog-writer/docs/adr/0030-prompt2blog-v4-grill-and-brief.md
@@ -1,0 +1,119 @@
+# Prompt2Blog v4 replaces the commission form with an interview
+
+## Context
+
+ADR 0029 made the commission the controlling document and put a human in front
+of it: three AI-proposed directions, pick one, edit it, approve. The failure
+that followed is not that the human was absent. It is what they were asked to
+do. Choosing between three directions a model wrote from one typed line is a
+choice between lookalikes, and nothing in the flow ever asked what the article
+was for.
+
+The audited Lima run passed every measure the system owns — grounding clean,
+audit scores of 8 and 9 throughout — and was unreadable. Its outline built the
+shape the `analysis` form offers straight off the menu: claim under test,
+evidence for, evidence against, judgment and limits. It shipped with a section
+called Scope limits and a sentence beginning "the figures come from 5,268
+tourists surveyed", about one of the great food cities on earth, containing no
+food. The form had been selected by a model reading a title. `analysis` has
+been selected three times and produced three failures.
+
+Two jobs were being done and only one was ever written down: establishing what
+is true, and making something worth reading. The rigour behind the first is the
+best thing in the system. The second had no object, no stage and no measure.
+
+The people using this are travellers, creators and researchers writing about
+places they may never have been. A form is a literacy test: it only works if
+you already know what belongs in each field.
+
+## Decision
+
+Prompt2Blog runs on a v4 pipeline. `schema_version` is 4, the v3 request
+contract is not extended, and no v3 or v2 path survives (ADR 0031).
+
+**An interview replaces the form.** Before asking anything the grill researches
+the seed, so it never asks what it could look up. Every question carries a
+recommended answer, so nobody faces a blank; one question at a time, each shaped
+by the last; it pushes back when an answer contradicts the seed or an earlier
+answer; and it stops at agreement rather than at a question count. The three
+direction cards are removed: direction is settled by the interview, so variants
+would differ only in trivia.
+
+**The Article Brief is the vision and is never consumed.** It carries the seed
+(kept as provenance, no longer binding), the reader outcome, the form, the
+reader, the spine, what the piece must name, the material by kind, and the one
+line saying what failure looks like. Spine, must-name and fails-if are new;
+nothing in v3 holds them. The brief rides the whole run and the finished article
+is judged against it, including against its fails-if line — the measure the
+system never had.
+
+**The work order is the brief's translation, not a second brief.** The direction
+step keeps its real job — turning "the market food beats the famous restaurants"
+into separately checkable questions — and loses the job of inventing the
+article. Eight fields move out to the brief; four stay: premises, requirements,
+scope, fingerprint. Requirements are split into load-bearing and texture, which
+v3 cannot tell apart and blocks on equally. `exclusions` is removed: a negative
+instruction is a topic waiting to happen, and "do not claim a transformation"
+became a section called Scope limits.
+
+**The operator cuts the work order, and is told what it costs.** Six research
+questions in plain English; strike two, add one. Cutting a load-bearing question
+is permitted and is answered once, plainly, with what the article can no longer
+claim. It is a real decision, so it is allowed to be wrong.
+
+**First-hand material is recorded verbatim.** Material the operator supplies
+from their own experience enters the record as their exact words, never a
+model's paraphrase, and is visible in the brief they approve. First-hand
+material is excused from fact-checking by design, so a paraphrase would create
+an unverifiable claim that nothing downstream can catch.
+
+**One gate blocks, before writing. Nothing blocks after.** Research that cannot
+support the piece — including a dossier containing nothing a reader would enjoy,
+which is a real gap and reported as one — stops the run and returns the
+operator to the grill. Once prose exists the `ready_for_staging` /
+`needs_revision` stamp is advisory and never blocks: a run stamped
+`needs_revision` for being forty-one words long is savable in one click, and
+failures are worth keeping because that is how the next failure gets diagnosed.
+
+**The grill is the single exit from every dead end.** A refuted premise, a thin
+dossier, or a brief the operator no longer wants all return to the same place,
+carrying what was learned. Re-entering revises the brief on the same run and
+discards whatever downstream work depended on what changed — usually the
+research, because changing the spine means the old research answered the old
+questions. The brief is not hand-editable: a typed brief is untracked text
+injected into every stage downstream.
+
+**Length stops gating.** A 4% overage is not a failure an editor would
+recognise. A large miss is reported as the symptom it is — thin research
+against the target — and a truncated response is distinguished from a short
+article, because output is capped and a cut-off response is a transport failure.
+
+**Repair is scoped to the section the audit named.** v3 regenerated all 1,041
+words to trim forty, at 47 cents and nearly half the run. The outline already
+defines the sections.
+
+The article graph is unchanged: outline, compose, groundedness, quality audit,
+repair, quality settle, title, finalize.
+
+## Consequences
+
+- The question that decides everything — what is this article for — is asked in
+  plain English and answered by a person in seconds, instead of being inferred
+  silently by a model from one typed line.
+- The system gains a measure of whether an article is any good. It had none.
+- `analysis` is rewritten as travel journalism with a thesis rather than
+  dropped, and becomes reachable only through the grill's own question about
+  whether the operator wants to make a case. A model reading a title can no
+  longer select it, which is the only way it was ever selected.
+- The blanket ban on hyphenated compounds stays strict on purpose. It produces
+  broken English — "day by day itinerary" — and that is now a forcing function:
+  a missing hyphen is a visible signal that no human has read the piece yet. It
+  depends on every article being read before it goes anywhere, so this decision
+  and the advisory stamp hold each other up.
+- The anti-AI block runs once, at compose, and the separate enforcement pass is
+  dropped for Prompt2Blog only (ADR 0032). Prevention beats surgery: a model
+  that understands the sentence avoids the pattern while writing it.
+- Cutting a load-bearing research question can produce a worse article on
+  purpose. That is accepted; the alternative makes the cut meaningless.
+- Runs will exist that never reach an article. A run is now something the
+  operator started, not something that was written (ADR 0031).

--- a/apps/ai-blog-writer/docs/adr/0031-prompt2blog-run-begins-at-the-seed.md
+++ b/apps/ai-blog-writer/docs/adr/0031-prompt2blog-run-begins-at-the-seed.md
@@ -1,0 +1,71 @@
+# A Prompt2Blog run begins at the seed, and v3 and v2 are deleted
+
+## Context
+
+In v3 a run is created when writing starts. Everything before it — the direction
+round trip, the commission approval, the research round trip — happens in the
+browser, and both model calls are made by the operator pasting a generated
+prompt into their own chatbot and pasting the result back. Nothing about that
+work is recorded anywhere the system can see.
+
+That arrangement made three things impossible at once. The cost receipt could
+not account for research, because research was not a system event. An
+interrupted intake could not be resumed, because there was nothing to resume.
+And the object the whole v4 design turns on — the Article Brief — had no home
+until the moment it was already finished.
+
+ADR 0029 kept `POST /run` and `POST /pipeline-v2` alive "until the owner's
+controlled real run proves v3 end to end". That run never happened. The
+condition is circular: v2 cannot retire until a run proves v3, and no run gets
+made while two systems need maintaining. v4 replaces v3's intake entirely, so
+leaving both in place would mean three ways to start an article.
+
+## Decision
+
+**The run is created when the operator types the seed.** The grill, the Article
+Brief, the work order and both research passes are recorded as stages on that
+run, in the same store and the same stage vocabulary as the writing stages.
+
+Three things follow for free. The token ledger already follows runs, so moving
+research and the grill in-app does not need separate accounting to stay visible
+on the receipt. The resume machinery already restores a run from its last
+completed stage, so an abandoned grill is resumable by the mechanism that
+already exists. And the brief has a durable home from the first keystroke rather
+than living in a browser tab.
+
+**A run is what the operator started, not what got written.** Runs that never
+reach an article are normal and are kept.
+
+**A hard per-run token ceiling refuses to continue, and shows its number.** The
+grill stops at agreement rather than at a question count, and research is now
+grounded web search; neither has an upper bound. The ceiling exists so that a
+bug which asks forty questions costs a defined amount and then stops, and it is
+visible so a ceiling set wrong is obvious rather than mysterious.
+
+**v3 and v2 are deleted, not deprecated.** The routes, the engines, the v3
+contracts and the clipboard composer all go. There is no fallback intake path
+and no backward compatibility: v4 is the only way to start an article.
+
+**Existing Prompt2Blog rows are backed up once, then cleared.** The whole
+pipeline database is copied to a dated file at cutover before any deletion. The
+Lima run and the Medellín run are the only evidence of what failure and success
+look like and the v4 design is built on both, so they are preserved as
+reference material even though nothing will read them programmatically again.
+
+## Consequences
+
+- The receipt covers the whole run for the first time. Research stops being
+  free-to-the-system work paid for out of the operator's own chatbot
+  subscription, and starts being a cost the run reports.
+- Every article started after the cutover is a v4 run. Nothing before it opens.
+  This is deliberate and was chosen over preserving history.
+- Resume gains a new class of entry point: a run whose furthest completed stage
+  is a grill turn. The stage-name-to-node mapping has to cover intake stages,
+  not only graph nodes.
+- A run row no longer implies an article. Any query that assumed otherwise —
+  listings, counts, the drafts view — has to say which kind it wants.
+- The per-run ceiling can stop a legitimate long run. That is preferred to an
+  unbounded one, and the number is tunable in one place.
+- Deleting v2 removes the only path that could still produce an article if v4
+  breaks. This is accepted: keeping it is what prevented v3 from ever being
+  proven.

--- a/apps/ai-blog-writer/docs/adr/0032-one-questurian-voice.md
+++ b/apps/ai-blog-writer/docs/adr/0032-one-questurian-voice.md
@@ -1,0 +1,65 @@
+# Questurian has one voice; tones are removed and the sibling pipelines are retired
+
+## Context
+
+Prompt2Blog sends the writer two documents about voice through two channels: a
+tone profile chosen from six, and a brand voice chosen from three. They
+contradict each other, and the defaults contradict each other hardest. The
+default tone, Practical, says "the writer is invisible, no first person, no
+visible judgment, no personality, do not rank options against each other or
+build a thesis." The Questurian voice says it has a view and says it, and never
+hides behind even-handedness. Both are sent on every run.
+
+The file named for the house voice is not a voice document at all. It is a
+rulebook: a banned-lexicon list, price and date formatting, point-of-view rules,
+a required takeaways section, hedging rules. Across all the writing instruction
+in the system there are 41 prohibitions and not one sentence describing what a
+good piece is. That is why bans could never fix the register — the model was
+told which doors were locked and never which room to be in.
+
+The tone files are shared. `app/shared/tone_profiles.py` reads
+`data/prompt2blog/tones`, and URL2Blog and YouTube2Blog both serve it. The
+anti-AI block and its enforcement pass are likewise shared, used by nine
+YouTube2Blog stages, the itinerary composers (ADR 0021) and editor_assist.
+
+## Decision
+
+**There is one Questurian voice, in one file, and it describes what Questurian
+is rather than what it must not do.** The six tone profiles are removed. A
+publication has one voice; six selectable personalities are six chances to
+contradict it, and the variation between articles now comes from the Article
+Brief, which knows who is reading and what the piece is for.
+
+**The mechanical rules survive as a separate, much shorter file.** Price format
+with an as-of frame, dates in full, no fabricated trips or meals, sentence-case
+headings, no in-article attribution. These cannot be inferred from character and
+have to be stated. Most of the old rulebook does not survive: the banned-lexicon
+list in particular duplicates ground the anti-AI block covers better. Two files,
+because the voice will be edited by feel and the rules by fact.
+
+**The anti-AI enforcement pass is dropped for Prompt2Blog only.** The rules run
+once, at compose. Every other consumer keeps the enforcement pass, because they
+do not receive the compose-prompt rework that replaces it and would otherwise
+lose a backstop and gain nothing. Edits to the rule text itself are shared.
+
+**URL2Blog and YouTube2Blog are switched off, not left to break.** Removing the
+shared tone list and changing the shared voice rules leaves them looking
+completely usable while failing mid-run or, worse, quietly producing worse
+articles. They are removed from the navigation and return an explicit retired
+response.
+
+## Consequences
+
+- The outline stage receives a house voice for the first time. It has never been
+  told which publication it works for, and this is the largest single change in
+  the v4 writing path.
+- Prompt2Blog is the only article pipeline in service until the others are
+  rebuilt onto this foundation. That was chosen over keeping them alive with
+  copied voice files, which would silently diverge the moment the voice improved.
+- The house rules are no longer uniform across pipelines. This reverses an
+  earlier deliberate choice to keep them in one shared place, and is scoped to
+  the enforcement pass rather than the rule text to keep the divergence small.
+- The tone dropdown disappears from the composer. Any stored run referencing a
+  `tone_id` is unreadable, which is already true under ADR 0031.
+- Voice quality becomes editable by a person in one file, in English, without
+  touching code.

--- a/apps/ai-blog-writer/scripts/p2b-drafts.py
+++ b/apps/ai-blog-writer/scripts/p2b-drafts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Read every draft a Prompt2Blog run produced, in one page.
+
+The same page the UI's "Read all drafts" button opens, written to a file
+instead. Useful when the backend is not running, or for keeping a copy of a
+run to compare against a later one.
+
+The renderer itself lives in the backend
+(`app/features/prompt2blog/drafts_view.py`) and is loaded straight from that
+file, so this script and the API can never drift into two different pages.
+That module imports nothing but the standard library, which is what makes
+loading it here safe -- no FastAPI, no app config, no .env.
+
+Read-only against the database. Writes one HTML file.
+
+    python3 scripts/p2b-drafts.py                # newest prompt2blog run
+    python3 scripts/p2b-drafts.py <run_id>       # a full id or any prefix
+    python3 scripts/p2b-drafts.py --list         # recent runs
+    python3 scripts/p2b-drafts.py <run_id> --open
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sqlite3
+import subprocess
+import sys
+import webbrowser
+from pathlib import Path
+from types import ModuleType
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+REPO_DB = APP_ROOT / "data" / "pipeline.db"
+RENDERER = (
+    APP_ROOT
+    / "apps"
+    / "backend"
+    / "app"
+    / "features"
+    / "prompt2blog"
+    / "drafts_view.py"
+)
+# `data/runs/` is already gitignored, so a generated page never reaches a diff.
+OUT_DIR = APP_ROOT / "data" / "runs"
+
+
+def load_renderer() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("p2b_drafts_view", RENDERER)
+    if spec is None or spec.loader is None:
+        sys.exit(f"Could not load the renderer at {RENDERER}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    if not db_path.exists():
+        sys.exit(f"No database at {db_path}")
+    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def list_runs(connection: sqlite3.Connection, limit: int) -> None:
+    rows = connection.execute(
+        "SELECT run_id, status, stage, created_at FROM runs"
+        " WHERE feature = 'prompt2blog' ORDER BY created_at DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+    for row in rows:
+        print(
+            f"{row['run_id']}  {row['created_at'][:19]}  "
+            f"{row['status']:<10} {row['stage']}"
+        )
+
+
+def resolve_run_id(connection: sqlite3.Connection, value: str | None) -> str:
+    if not value:
+        row = connection.execute(
+            "SELECT run_id FROM runs WHERE feature = 'prompt2blog'"
+            " ORDER BY created_at DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            sys.exit("No prompt2blog runs yet.")
+        return str(row["run_id"])
+
+    row = connection.execute(
+        "SELECT run_id FROM runs WHERE run_id LIKE ? ORDER BY created_at DESC",
+        (value + "%",),
+    ).fetchone()
+    if row is None:
+        sys.exit(f"No run matching {value}")
+    return str(row["run_id"])
+
+
+def read_run(connection: sqlite3.Connection, run_id: str) -> tuple[dict, dict, str]:
+    """The three things the renderer needs: status row, stages, final markdown."""
+    run = connection.execute(
+        "SELECT * FROM runs WHERE run_id = ?", (run_id,)
+    ).fetchone()
+    if run is None:
+        sys.exit(f"No run {run_id}")
+
+    stages: dict[str, object] = {}
+    for row in connection.execute(
+        "SELECT stage, data FROM stages WHERE run_id = ? ORDER BY created_at",
+        (run_id,),
+    ):
+        try:
+            stages[row["stage"]] = json.loads(row["data"])
+        except json.JSONDecodeError:
+            continue
+
+    output = connection.execute(
+        "SELECT markdown FROM outputs WHERE run_id = ?", (run_id,)
+    ).fetchone()
+    return dict(run), stages, (output["markdown"] if output else "")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_id", nargs="?", help="run id or prefix (default: newest)")
+    parser.add_argument("--list", action="store_true", help="list recent runs")
+    parser.add_argument("--limit", type=int, default=15)
+    parser.add_argument("--db", type=Path, default=REPO_DB)
+    parser.add_argument("--out", type=Path, help="where to write the html")
+    parser.add_argument("--open", action="store_true", help="open in a browser")
+    args = parser.parse_args()
+
+    connection = connect(args.db)
+    if args.list:
+        list_runs(connection, args.limit)
+        return
+
+    view = load_renderer()
+    run_id = resolve_run_id(connection, args.run_id)
+    status, stages, markdown = read_run(connection, run_id)
+
+    report = view.build_drafts_report(
+        run_id=run_id,
+        status=status,
+        stages=stages,
+        markdown=markdown,
+    )
+    if not report["drafts"]:
+        sys.exit(f"Run {run_id} holds no drafts (it may have failed early).")
+
+    out = args.out or OUT_DIR / f"drafts-{run_id[:8]}.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(view.render_drafts_page(report), encoding="utf-8")
+    print(out)
+
+    if args.open:
+        try:
+            subprocess.run(["open", str(out)], check=False)
+        except OSError:
+            webbrowser.open(out.as_uri())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stage 0 of the Prompt2Blog v4 rebuild — words, not wiring. Nothing reads the new files yet; that lands with the v4 contracts and the outline change.

Also carries a piece of pre-existing uncommitted work that was sitting on `main`, committed separately below.

## Why this exists

The Lima run passed every measure the system owns — grounding clean, audit 8s and 9s — and was unreadable. It shipped a section called *Scope limits* and a sentence beginning "the figures come from 5,268 tourists surveyed", about one of the great food cities on earth, containing no food.

The diagnosis: across 1,580 words of writing instruction there were **41 prohibitions and not one sentence describing what a good piece is.** Bans could never fix the register, because the model was told which doors were locked and never which room to be in.

## What is in here

**`00daeed0` — model routing.** Outline, groundedness and title were pinned in `config.py` and unreachable from a request, so a route could only move two of the six calls a run makes. All six are routable now, each defaulting to the constant it used to be pinned to. Repair becomes separately routable from the draft, which are not the same job. Two receipt bugs go with it: `model_used` reported the worker model — which v3 never calls — so audit-model reviews were filed under a Gemini name that had no part in them; and the creativity dial sets a temperature the Claude subscription CLI has no flag for, so it was accepted and dropped in silence. The run now records whether it reached the writer, and the composer says so.

This commit also adds `drafts_view.py`, `scripts/p2b-drafts.py` and three test files that **had never been `git add`ed** — `api/runs.py` imported a module that existed only on one machine.

**`13f580a1` — stage 0 proper.**

- **The house voice, which existed nowhere.** Two files now: `voice/questurian-voice.md` describing what Questurian is like, and `voice/house-rules.md` for the mechanical conventions that cannot be inferred from character. Six rules survived out of the old 422-word rulebook. Precedence is inverted from the old file — the voice wins, because no convention is worth a sentence that reads wrong.
- **The `analysis` form, rewritten** as travel journalism with a thesis. It went 0 for 3. Its allowed structures literally offered *"claim under test, evidence for, evidence against, judgment and limits"* — the shape the Lima outline built straight off the menu — and its "meaningful limits" language is what became *Scope limits*. It keeps its job and loses the text that was wrong for the job.
- **The anti-AI block names two shapes** — the contrastive pivot, and the kicker that implies an unstated payoff — in place of ten literal entries, because a list only catches the variants someone thought to write down. Down 19%.
- **ADRs 0030, 0031, 0032**, vocabulary in `CONTEXT.md`, and a pointer from `AGENTS.md` so a future session finds them without being told.

## One thing the plan got wrong

The plan called for cutting the disclaimers block from 538 tokens to ~150. Doing that failed eight tests, and **the tests are right.** One asserts that every phrase the shared validator rejects is named in the prompt — url2blog, youtube2blog and editor_assist all run that validator, but their writers only ever see this block, so a rule enforced here and unstated there costs each of them a repair call for something they were never told.

It is a phrase list with prose around it, not padding. Restructured into four named moves and left long, with a comment in the file explaining the coupling so nobody optimises it again. It can shrink once the outline fix lands in stage 5 and the article stops discussing its own research.

## Tests

`main` has 2 failing tests, both v2 route tests. This branch has the same 2 and no others — verified by running the full suite against `HEAD` separately rather than assuming. They are deleted along with v2 in stage 1 rather than fixed.

The previously-untracked tests pass.

## Next

Stage 1, the clean break: #424.
