### PR TITLE
Stop the grill dying silently on its first call

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -27,6 +27,7 @@ from ..grill_v4 import (
     GRILL_RESEARCH_MAX_TOKENS,
     GRILL_RESEARCH_MODEL,
     GrillDependencies,
+    GrillUnusableResponse,
 )
 from ..intake_v4 import (
     IntakeServices,
@@ -116,6 +117,23 @@ def _handle(action, *args, **kwargs) -> Any:
     """Turn the intake's own failures into answers a page can act on."""
     try:
         return action(*args, **kwargs)
+    except GrillUnusableResponse as error:
+        # 502, not 400: nothing the operator typed caused this, and the reply
+        # travels with it. The first real run died here and left no trace at
+        # all, which made the one failure that most needed explaining the one
+        # with no evidence.
+        logger.error("Grill returned an unusable response: %s", error.raw[:2000])
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "grill_unusable_response",
+                "message": (
+                    "The interviewer did not come back with a question. This is "
+                    "not something you did. Try again."
+                ),
+                "raw": error.raw[:2000],
+            },
+        ) from error
     except RunTokenCeilingReached as error:
         # Not a server fault and not a retry: the run is over its ceiling and
         # says what it spent.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 
 GRILL_STAGE = "stage_v4_grill"
 
+
+def _json_or_repr(payload: Any) -> str:
+    try:
+        return json.dumps(payload)
+    except Exception:  # pragma: no cover -- diagnostics only
+        return repr(payload)
+
 # Enough for a dense digest of a city. The helper's own default is 1024, which
 # truncates silently -- the Lima dossier was 12,000 characters.
 GRILL_RESEARCH_MAX_TOKENS = 4_096
@@ -49,6 +56,11 @@ GRILL_RESEARCH_MAX_TOKENS = 4_096
 GRILL_RESEARCH_MODEL = "gemini-2.5-flash"
 
 
+# `question` and `consensus` are both required, and the prompt says to leave
+# the unused one empty. Making only `done` required is what broke the first
+# real run: `{"done": false}` with nothing else is schema-valid and useless,
+# and the model took that gap. A schema that permits what the code refuses is
+# a schema that has not been written down properly.
 NEXT_TURN_SCHEMA = {
     "type": "object",
     "properties": {
@@ -67,7 +79,7 @@ NEXT_TURN_SCHEMA = {
         "consensus": {"type": "string"},
         "location": {"type": "string"},
     },
-    "required": ["done"],
+    "required": ["done", "question", "consensus"],
 }
 
 
@@ -142,6 +154,10 @@ Rules:
   means it is a research-led piece.
 - Set `location` when their line names a place clearly enough to act on. Leave
   it empty only when it is genuinely ambiguous.
+- ALWAYS return both `question` and `consensus`. When you are asking, fill
+  `question` and leave `consensus` an empty string. When you are done, fill
+  `consensus` and leave the question's `ask` and `recommendation` empty. Never
+  return neither.
 - Set `done` true and write `consensus` when you could brief a writer from
   what you have: what the piece is, who reads it, what it should make them do,
   what it is built on, what it must name, and what would make it a failure.
@@ -168,6 +184,21 @@ def _question_from(payload: dict[str, Any], fallback_id: str) -> GrillQuestion |
     )
 
 
+class GrillUnusableResponse(RuntimeError):
+    """The grill answered with something it cannot act on.
+
+    Carries the raw response. The first real run died on exactly this and left
+    nothing behind -- no stage row, no log line -- so the one moment that most
+    needs explaining was the one moment with no evidence.
+    """
+
+    def __init__(self, raw: str) -> None:
+        super().__init__(
+            "The grill returned neither a usable question nor a consensus."
+        )
+        self.raw = raw
+
+
 def advance_grill(
     state: GrillState,
     dependencies: GrillDependencies,
@@ -176,8 +207,31 @@ def advance_grill(
 
     Returns a state that is either asking one more question or agreed. The
     caller records it; nothing is written here.
+
+    Retried once. The writing stages deliberately do not retry a schema call,
+    because each attempt there is a full article rewrite -- but this is a flash
+    model deciding one question, and one unusable reply should not end a run
+    before it has started.
     """
-    parsed, _raw = dependencies.llm.invoke_json(
+    attempts: list[str] = []
+    for attempt in range(2):
+        try:
+            return _advance_once(state, dependencies)
+        except GrillUnusableResponse as error:
+            attempts.append(error.raw)
+            logger.warning(
+                "Grill returned an unusable response (attempt %s): %s",
+                attempt + 1,
+                error.raw[:500],
+            )
+    raise GrillUnusableResponse("\n---\n".join(attempts))
+
+
+def _advance_once(
+    state: GrillState,
+    dependencies: GrillDependencies,
+) -> GrillState:
+    parsed, raw = dependencies.llm.invoke_json(
         prompt=build_next_turn_prompt(state),
         model_name=dependencies.model_name,
         schema=NEXT_TURN_SCHEMA,
@@ -204,7 +258,7 @@ def advance_grill(
 
     question = _question_from(payload, fallback_id=f"q{len(state.turns) + 1}")
     if question is None:
-        raise ValueError("The grill returned neither a usable question nor a consensus.")
+        raise GrillUnusableResponse(raw or _json_or_repr(payload))
     return state.model_copy(
         update={"status": "asking", "pending": question, "location": location}
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -31,6 +31,7 @@ from .contracts_v4 import ArticleBrief, GrillState, Prompt2BlogWorkOrder
 from .grill_v4 import (
     GRILL_STAGE,
     GrillDependencies,
+    GrillUnusableResponse,
     answer_grill,
     grill_stage_record,
     reopen_grill,
@@ -151,7 +152,21 @@ def begin_intake(
     run_id = str(uuid4())
     services.recorder.queue(run_id, owner_staff_id)
     logger.info("Prompt2Blog intake opened", extra={"run_id": run_id, "feature": FEATURE_NAME})
-    return _write_grill(services, start_grill(run_id, cleaned, services.dependencies))
+    try:
+        return _write_grill(
+            services, start_grill(run_id, cleaned, services.dependencies)
+        )
+    except GrillUnusableResponse as error:
+        # The run already exists, so it must be able to say why it is empty. A
+        # run with no stages and no explanation is the worst thing to hand
+        # someone who is trying to work out what happened.
+        _record(
+            services,
+            run_id,
+            GRILL_STAGE,
+            {"status": "failed", "seed": cleaned, "unusable_response": error.raw[:4000]},
+        )
+        raise
 
 
 def answer_intake(run_id: str, answer: str, services: IntakeServices) -> GrillState:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
@@ -91,9 +91,17 @@ def test_a_question_without_a_recommendation_is_refused_rather_than_shown():
     A question with no proposal attached is exactly the form field the grill
     exists to remove, so it is rejected rather than rendered.
     """
-    deps = _deps([{"done": False, "question": _question(recommendation="")}])
+    # Twice, because one unusable reply is now retried rather than fatal.
+    deps = _deps(
+        [
+            {"done": False, "question": _question(recommendation="")},
+            {"done": False, "question": _question(recommendation="")},
+        ]
+    )
 
-    with pytest.raises(ValueError, match="neither a usable question nor a consensus"):
+    from app.features.prompt2blog.grill_v4 import GrillUnusableResponse
+
+    with pytest.raises(GrillUnusableResponse):
         start_grill("run-1", SEED, deps)
 
 
@@ -296,3 +304,62 @@ def test_the_prompt_forbids_asking_for_credentials():
 
     assert "never about credentials" in prompt.lower()
     assert "what they HAVE" in prompt
+
+
+# --- what the first real run hit ------------------------------------------
+
+
+def test_a_reply_with_no_question_and_no_consensus_is_retried_once():
+    """The first real run died here.
+
+    The schema required only `done`, so `{"done": false}` with nothing else was
+    schema-valid and useless -- and one unusable reply ended the run before it
+    had started.
+    """
+    deps = _deps([{"done": False}, {"done": False, "question": _question()}])
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert state.pending is not None
+    assert len(deps.llm.prompts) == 2, "it should have asked again"
+
+
+def test_two_unusable_replies_carry_what_came_back():
+    """A failure with no evidence is the worst kind.
+
+    The first one left no stage row and no log line, so the one moment that
+    most needed explaining was the one with nothing to look at.
+    """
+    from app.features.prompt2blog.grill_v4 import GrillUnusableResponse
+
+    deps = _deps([{"done": False}, {"done": True, "consensus": ""}])
+
+    with pytest.raises(GrillUnusableResponse) as error:
+        start_grill("run-1", SEED, deps)
+
+    assert error.value.raw, "the raw reply has to travel with the failure"
+
+
+def test_the_schema_demands_what_the_code_demands():
+    # A schema that permits what the code refuses is a schema that was not
+    # written down properly.
+    from app.features.prompt2blog.grill_v4 import NEXT_TURN_SCHEMA
+
+    assert set(NEXT_TURN_SCHEMA["required"]) == {"done", "question", "consensus"}
+
+
+def test_the_prompt_says_to_return_both_and_leave_one_empty():
+    prompt = build_next_turn_prompt(
+        GrillState(
+            run_id="r",
+            seed=SEED,
+            status="asking",
+            pending=GrillQuestion(
+                question_id="q1", topic="t", ask="a", recommendation="r"
+            ),
+        )
+    )
+    flat = " ".join(prompt.split())
+
+    assert "ALWAYS return both `question` and `consensus`" in flat
+    assert "Never return neither." in flat


### PR DESCRIPTION
The first real v4 run failed with `The grill returned neither a usable question nor a consensus` and **left nothing behind** — no stage row, no log line, no record of what the model said. The run exists with zero stages.

That is the worst part of it, and it is fixed first: the failure that most needed explaining was the one with no evidence.

## The cause, visible by reading

The schema required only `done`. So `{"done": false}` with no question attached was schema-valid and useless — the code refused what the schema permitted, and the model took the gap.

Both `question` and `consensus` are required now, and the prompt says to fill one and leave the other empty rather than leaving "return something usable" implied.

## Why it was fatal rather than annoying

No retry. That reasoning was copied from the writing stages, where each schema attempt is a full article rewrite — correct there, wrong here. This is a flash model deciding one question at the very start of a run, and one unusable reply should not end a run before it has begun.

One retry now.

## The evidence trail

When it still cannot be used, the raw reply travels with the failure:

- onto the run, as a `failed` grill stage carrying the response
- into the error log
- back to the caller as a **502** with the response attached

502 rather than 400 because nothing the operator typed caused it, and "this is not something you did" is more useful than a validation error for a validation nobody failed.

## What I still cannot tell you

**What the model actually returned on that first run.** None of this existed yet. The next failure will say.

Backend 0 failures, eslint clean.