### PR TITLE
Make every v4 schema demand a value, not just a key

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 from app.core.staff_auth import require_staff, staff_user_id
 
 from ..config import P2B_V4_RESEARCH_STRUCTURE_MODEL
+from ..brief_v4 import BriefIncomplete
 from ..dependencies import PipelineDependencies
 from ..grill_v4 import (
     GRILL_RESEARCH_MAX_TOKENS,
@@ -117,6 +118,21 @@ def _handle(action, *args, **kwargs) -> Any:
     """Turn the intake's own failures into answers a page can act on."""
     try:
         return action(*args, **kwargs)
+    except BriefIncomplete as error:
+        logger.error("Brief incomplete: %s | %s", error.missing, error.raw[:2000])
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error": "brief_incomplete",
+                "message": (
+                    "The brief came back missing "
+                    + ", ".join(error.missing)
+                    + ". Nothing you said caused this — try approving again, or "
+                    "go back to the grill and say more about it."
+                ),
+                "raw": error.raw[:2000],
+            },
+        ) from error
     except GrillUnusableResponse as error:
         # 502, not 400: nothing the operator typed caused this, and the reply
         # travels with it. The first real run died here and left no trace at

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/brief_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/brief_v4.py
@@ -21,13 +21,14 @@ from typing import Any
 
 from .contracts_v4 import ArticleBrief, BriefMaterial, BriefReader, GrillState
 from .grill_v4 import GrillDependencies
+from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
 logger = logging.getLogger(__name__)
 
 BRIEF_STAGE = "stage_v4_brief"
 
-BRIEF_SCHEMA = {
+BRIEF_SCHEMA = require_non_empty({
     "type": "object",
     "properties": {
         "form_id": {"type": "string"},
@@ -60,7 +61,7 @@ BRIEF_SCHEMA = {
         "spine",
         "fails_if",
     ],
-}
+})
 
 
 def build_brief_prompt(state: GrillState) -> str:
@@ -134,17 +135,79 @@ def brief_fingerprint(payload: dict[str, Any]) -> str:
     return "bf-" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
 
 
+class BriefIncomplete(RuntimeError):
+    """The brief writer left something out that the brief cannot do without.
+
+    Carries what it did return. A run that fails here has already paid for the
+    grill, so the operator should get a sentence about what is missing rather
+    than a Pydantic traceback about string length.
+    """
+
+    def __init__(self, missing: list[str], raw: str) -> None:
+        super().__init__(
+            "The brief came back missing: " + ", ".join(missing) + "."
+        )
+        self.missing = missing
+        self.raw = raw
+
+
+# What a brief cannot be assembled without. Empty is the failure mode that
+# actually happens -- the key is present and the value is "" -- so this checks
+# the value, not the key.
+REQUIRED_BRIEF_FIELDS = (
+    ("form_id", "the kind of article"),
+    ("primary_reader", "who it is for"),
+    ("reader_question", "the question it answers"),
+    ("outcome", "what it should make them do"),
+    ("spine", "what it is built on"),
+    ("fails_if", "what would make it a failure"),
+)
+
+
+def _missing_fields(payload: dict[str, Any]) -> list[str]:
+    return [
+        label
+        for key, label in REQUIRED_BRIEF_FIELDS
+        if not _safe_str(payload.get(key))
+    ]
+
+
 def build_brief(
     state: GrillState,
     dependencies: GrillDependencies,
     *,
     location: str | None = None,
 ) -> ArticleBrief:
-    """Assemble the brief an agreed grill earned."""
+    """Assemble the brief an agreed grill earned.
+
+    Retried once. The grill has already been paid for by this point, and a
+    single thin reply should not cost the operator the whole conversation.
+    """
     if state.status != "agreed":
         raise ValueError("A brief can only be built from a grill that reached agreement.")
 
-    parsed, _raw = dependencies.llm.invoke_json(
+    attempts: list[str] = []
+    for attempt in range(2):
+        try:
+            return _build_brief_once(state, dependencies, location=location)
+        except BriefIncomplete as error:
+            attempts.append(error.raw)
+            logger.warning(
+                "Brief came back incomplete (attempt %s), missing %s",
+                attempt + 1,
+                ", ".join(error.missing),
+            )
+            last = error
+    raise BriefIncomplete(last.missing, "\n---\n".join(attempts))
+
+
+def _build_brief_once(
+    state: GrillState,
+    dependencies: GrillDependencies,
+    *,
+    location: str | None = None,
+) -> ArticleBrief:
+    parsed, raw = dependencies.llm.invoke_json(
         prompt=build_brief_prompt(state),
         model_name=dependencies.model_name,
         schema=BRIEF_SCHEMA,
@@ -152,6 +215,13 @@ def build_brief(
         temperature=0.2,
     )
     payload = _safe_dict(parsed)
+
+    missing = _missing_fields(payload)
+    if missing:
+        # Checked here rather than left to Pydantic, so the operator is told
+        # what is missing in words instead of being shown a string-length
+        # validation error for a field they have never heard of.
+        raise BriefIncomplete(missing, raw or json.dumps(payload))
 
     resolved_location = _safe_str(location or state.location)
     if not resolved_location:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Protocol
 
 from .config import DEFAULT_MODEL
 from .contracts_v4 import GrillQuestion, GrillState, GrillTurn
+from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ GRILL_RESEARCH_MODEL = "gemini-2.5-flash"
 # real run: `{"done": false}` with nothing else is schema-valid and useless,
 # and the model took that gap. A schema that permits what the code refuses is
 # a schema that has not been written down properly.
-NEXT_TURN_SCHEMA = {
+NEXT_TURN_SCHEMA = require_non_empty({
     "type": "object",
     "properties": {
         "done": {"type": "boolean"},
@@ -80,7 +81,7 @@ NEXT_TURN_SCHEMA = {
         "location": {"type": "string"},
     },
     "required": ["done", "question", "consensus"],
-}
+})
 
 
 class GrillLLM(Protocol):

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -32,6 +32,7 @@ from .contracts_v4 import (
     Prompt2BlogWorkOrder,
     WorkOrderRequirement,
 )
+from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
 logger = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ STRUCTURE_MAX_TOKENS = 16_384
 GATHER_MODEL = "gemini-2.5-flash"
 
 
-EVIDENCE_SCHEMA = {
+EVIDENCE_SCHEMA = require_non_empty({
     "type": "object",
     "properties": {
         "sources": {
@@ -103,7 +104,7 @@ EVIDENCE_SCHEMA = {
         "gaps": {"type": "array", "items": {"type": "object"}},
     },
     "required": ["sources", "claims", "requirements"],
-}
+})
 
 
 @dataclass

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schema_guards.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schema_guards.py
@@ -1,0 +1,50 @@
+"""Making a schema demand what the code demands.
+
+`required` in JSON Schema means the key is present. It does not mean the value
+is useful: an empty string satisfies it completely.
+
+That gap has now broken two live runs in the same afternoon. The grill returned
+`{"done": false}` with no question and the code died; the brief returned
+`primary_reader: ""` and Pydantic -- which does insist on a real value -- threw
+a validation error at the operator mid-flow.
+
+Both times the model was obeying the schema it was given. The schema was the
+thing that was wrong, and it was wrong in the same way in four places, so this
+fixes the shape rather than the instances.
+
+Applied at definition, so a schema written later gets it without anyone
+remembering to.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def require_non_empty(schema: dict[str, Any]) -> dict[str, Any]:
+    """Give every required string in ``schema`` a minimum length of one.
+
+    Recurses into nested objects and array items. Leaves an already-declared
+    `minLength` alone, so a field that wants a longer floor keeps it.
+    """
+    _harden(schema)
+    return schema
+
+
+def _harden(node: Any, required: frozenset[str] = frozenset()) -> None:
+    if not isinstance(node, dict):
+        return
+
+    properties = node.get("properties")
+    own_required = frozenset(node.get("required") or ())
+    if isinstance(properties, dict):
+        for name, spec in properties.items():
+            if not isinstance(spec, dict):
+                continue
+            if spec.get("type") == "string" and name in own_required:
+                spec.setdefault("minLength", 1)
+            _harden(spec, own_required)
+
+    items = node.get("items")
+    if isinstance(items, dict):
+        _harden(items)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -33,13 +33,14 @@ from .contracts_v4 import (
     WorkOrderScope,
 )
 from .grill_v4 import GrillDependencies
+from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
 logger = logging.getLogger(__name__)
 
 WORK_ORDER_STAGE = "stage_v4_work_order"
 
-WORK_ORDER_SCHEMA = {
+WORK_ORDER_SCHEMA = require_non_empty({
     "type": "object",
     "properties": {
         "primary_subject": {"type": "string"},
@@ -81,7 +82,7 @@ WORK_ORDER_SCHEMA = {
         },
     },
     "required": ["primary_subject", "scope_mode", "references", "requirements"],
-}
+})
 
 
 @dataclass(frozen=True)

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_build.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_build.py
@@ -207,3 +207,72 @@ def test_the_stage_record_shows_material_back_for_approval():
 
     assert record["material"] == [{"kind": "firsthand", "statement": FIRSTHAND}]
     assert record["fails_if"] == "reads like a tourist board"
+
+
+# --- what the first real run hit at the brief step -------------------------
+
+
+def test_required_strings_cannot_be_empty_in_the_schema():
+    """`required` means the key exists, not that the value is useful.
+
+    The first real run returned `primary_reader: ""`, which satisfied the
+    schema completely and then failed Pydantic's own minimum -- a validation
+    error about string length shown to someone who had just approved a brief.
+    """
+    from app.features.prompt2blog.brief_v4 import BRIEF_SCHEMA
+
+    reader = BRIEF_SCHEMA["properties"]["primary_reader"]
+    assert reader["minLength"] == 1
+
+
+def test_every_v4_schema_got_the_same_guard():
+    # It was wrong in the same way in four places, so it is fixed as a shape
+    # rather than as four instances.
+    from app.features.prompt2blog.grill_v4 import NEXT_TURN_SCHEMA
+    from app.features.prompt2blog.research_v4 import EVIDENCE_SCHEMA
+    from app.features.prompt2blog.work_order_v4 import WORK_ORDER_SCHEMA
+
+    assert NEXT_TURN_SCHEMA["properties"]["consensus"]["minLength"] == 1
+    assert WORK_ORDER_SCHEMA["properties"]["primary_subject"]["minLength"] == 1
+    assert (
+        EVIDENCE_SCHEMA["properties"]["sources"]["items"]["properties"]["title"][
+            "minLength"
+        ]
+        == 1
+    )
+
+
+def test_an_empty_field_is_asked_about_again_before_giving_up():
+    from app.features.prompt2blog.brief_v4 import BriefIncomplete
+
+    thin = _payload(primary_reader="")
+    deps = GrillDependencies(
+        llm=FakeLLM(thin), research=lambda _s: ("", [], None)
+    )
+
+    with pytest.raises(BriefIncomplete) as error:
+        build_brief(_agreed(), deps)
+
+    assert len(deps.llm.prompts) == 2, "it should have asked again"
+    assert "who it is for" in error.value.missing
+
+
+def test_the_failure_says_what_is_missing_in_words():
+    """Not a string-length error for a field nobody has heard of.
+
+    The run has already paid for the grill by this point, so the operator is
+    owed a sentence rather than a traceback.
+    """
+    from app.features.prompt2blog.brief_v4 import BriefIncomplete
+
+    deps = GrillDependencies(
+        llm=FakeLLM(_payload(spine="", fails_if="")),
+        research=lambda _s: ("", [], None),
+    )
+
+    with pytest.raises(BriefIncomplete) as error:
+        build_brief(_agreed(), deps)
+
+    assert "what it is built on" in str(error.value)
+    assert "what would make it a failure" in str(error.value)
+    assert error.value.raw, "what came back has to travel with the failure"


### PR DESCRIPTION
Second live failure, **same cause as the first**.

`required` in JSON Schema means the key is present. It does not mean the value is useful — an empty string satisfies it completely.

- The grill returned `{"done": false}` with no question → fixed in #434.
- The brief returned `primary_reader: ""`, which passed the schema and then failed Pydantic's own minimum. Someone who had just approved a brief was shown a string-length validation error about a field they have never heard of.

Both times **the model obeyed the schema it was given.** The schema was wrong.

## Fixed as a shape, not as instances

`require_non_empty` gives every required string a minimum length of one, recursing into nested objects and array items, applied at definition so a schema written later gets it without anyone remembering to.

**Thirty-two required strings across four schemas accepted `""` until now.** I fixed one yesterday and left three carrying the identical gap — I should have treated the first failure as a class.

## The brief stops failing in Pydantic's words

It checks its own required fields first and names what is missing in English — "who it is for", "what it is built on" — retries once, and carries what came back.

The grill has already been paid for by that point. A single thin reply should not cost the whole conversation, and the operator is owed a sentence rather than a traceback.

Backend 0 failures, eslint clean.