### PR TITLE
Show the operator what actually went wrong, and never trap them on it

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-errors.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-errors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+/**
+ * What the operator is told when a step fails.
+ *
+ * The server answers a failure with an object -- a message written for a
+ * person, plus the raw model reply. The shared error parser only reads a
+ * string, so every one of those messages was replaced with a generic
+ * fallback: the operator saw "That step could not be completed" while the
+ * server was explaining exactly what went wrong.
+ */
+
+const apiFetch = vi.fn()
+vi.mock('../../../shared/api/client/apiFetch', () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+}))
+
+const { answerQuestion } = await import('./intake.api')
+
+function failWith(body: unknown, status = 502): void {
+  apiFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: async () => body,
+  })
+}
+
+beforeEach(() => apiFetch.mockReset())
+
+describe('a failed intake step', () => {
+  it('shows the message the server actually wrote', async () => {
+    failWith({
+      detail: {
+        error: 'brief_incomplete',
+        message: 'The brief came back missing who it is for.',
+        raw: '{"primary_reader":""}',
+      },
+    })
+
+    await expect(answerQuestion('run-1', 'hello')).rejects.toThrow(
+      'The brief came back missing who it is for.',
+    )
+  })
+
+  it('keeps the raw reply on the error without putting it in the message', async () => {
+    failWith({
+      detail: { error: 'grill_unusable_response', message: 'Try again.', raw: '{"done":false}' },
+    })
+
+    const error = await answerQuestion('run-1', 'hello').catch(caught => caught)
+
+    expect(error.raw).toBe('{"done":false}')
+    expect(error.message).not.toContain('done')
+  })
+
+  it('still reads a plain string detail', async () => {
+    // Most of the app answers this way, and intake must not stop understanding it.
+    failWith({ detail: 'No grill in progress for run r.' }, 404)
+
+    await expect(answerQuestion('run-1', 'hello')).rejects.toThrow(
+      'No grill in progress for run r.',
+    )
+  })
+
+  it('falls back only when there is genuinely nothing to say', async () => {
+    failWith({}, 500)
+
+    await expect(answerQuestion('run-1', 'hello')).rejects.toThrow(
+      'That step could not be completed.',
+    )
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -1,5 +1,4 @@
 import { apiFetch } from '../../../shared/api/client/apiFetch'
-import { parseError } from '../../../shared/api/errors/parse-error'
 import { FEATURE_PREFIX } from '../constants/prompt2blog.constants'
 import type { IntakeState } from './intake.types'
 
@@ -13,6 +12,31 @@ import type { IntakeState } from './intake.types'
 
 const INTAKE = `${FEATURE_PREFIX}/intake`
 
+/**
+ * Read whatever the server actually said.
+ *
+ * The shared `parseError` only reads `detail` when it is a string. Intake
+ * answers a failure with an object -- a message written for a person plus the
+ * raw model reply -- so every one of those messages was being thrown away and
+ * replaced with a generic fallback. The operator saw "That step could not be
+ * completed" while the server was explaining exactly what went wrong.
+ */
+async function readError(response: Response, fallback: string): Promise<Error> {
+  const body = await response.json().catch(() => null)
+  const detail = body?.detail
+
+  if (typeof detail === 'string' && detail) return new Error(detail)
+  if (detail && typeof detail === 'object') {
+    const message = typeof detail.message === 'string' ? detail.message : fallback
+    const error = new Error(message)
+    // Kept on the error so a screen can offer it without the message carrying
+    // a wall of JSON.
+    Object.assign(error, { raw: detail.raw, code: detail.error })
+    return error
+  }
+  return new Error(fallback)
+}
+
 async function post(path: string, body?: unknown): Promise<IntakeState> {
   const response = await apiFetch(path, {
     method: 'POST',
@@ -20,7 +44,7 @@ async function post(path: string, body?: unknown): Promise<IntakeState> {
     body: body === undefined ? undefined : JSON.stringify(body),
   })
   if (!response.ok) {
-    throw await parseError(response, 'That step could not be completed.')
+    throw await readError(response, 'That step could not be completed.')
   }
   return (await response.json()) as IntakeState
 }
@@ -34,7 +58,7 @@ export function openIntake(seed: string): Promise<IntakeState> {
 export async function readIntake(runId: string): Promise<IntakeState> {
   const response = await apiFetch(`${INTAKE}/${runId}`)
   if (!response.ok) {
-    throw await parseError(response, 'Could not read where this article stands.')
+    throw await readError(response, 'Could not read where this article stands.')
   }
   return (await response.json()) as IntakeState
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -44,9 +44,15 @@ export function Prompt2BlogPage() {
 
       <main className="p2b-form-container">
         {intake.error && (
-          <p className="p2b-error" role="alert">
-            {intake.error}
-          </p>
+          <div className="p2b-error" role="alert">
+            <p>{intake.error}</p>
+            {/* A failed step must never be a dead end. The run is remembered
+                so a closed tab can resume, which means a run that cannot move
+                forward would otherwise trap the page on every reload. */}
+            <button type="button" className="p2b-clear-btn" onClick={intake.abandon}>
+              Start over
+            </button>
+          </div>
         )}
 
         {step === 'seed' && <SeedScreen busy={intake.busy} onStart={intake.start} />}
@@ -93,7 +99,7 @@ export function Prompt2BlogPage() {
           />
         )}
 
-        {state && (
+        {state && !intake.error && (
           <div className="p2b-submit-row">
             <button type="button" className="p2b-clear-btn" onClick={intake.abandon}>
               Start something else


### PR DESCRIPTION
`That step could not be completed` is **my own fallback string**, shown because the client threw away the message the server sent.

Intake answers a failure with an object — a sentence written for a person, plus the raw model reply. The shared `parseError` only reads `detail` when it is a **string**, so every one of those messages was discarded.

Both failures fixed this afternoon wrote a careful explanation that nobody ever saw.

## Fixed

Intake reads its own errors. A string detail still works, because most of the app answers that way. An object detail yields its message, and the raw reply rides on the error rather than in the message — so a screen can offer it without showing a wall of JSON to someone who just wanted to write an article.

## And a failed step is no longer a dead end

The run id is remembered so a closed tab can resume. That means a run which cannot move forward traps the page on every reload.

The escape existed but only rendered **when nothing had gone wrong**, which is exactly backwards. "Start over" now appears with the error.

Frontend 716 passing, backend 0 failures, tsc clean, eslint clean, boundaries pass.