### PR TITLE
Give the grill a better model, and stop taxing it with bookkeeping

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -34,6 +34,21 @@ P2B_V3_TITLE_MODEL = "claude-sonnet-5-medium"
 # compose.
 P2B_V4_RESEARCH_STRUCTURE_MODEL = "claude-sonnet-5-medium"
 
+# Who runs the interview.
+#
+# The spec chose a flash model for being "short, conversational". In practice
+# the grill is the one place a weak model is most expensive: it decides what
+# the article is, every later stage inherits that, and it is about six calls --
+# so the cheapest thing in the pipeline to make good.
+#
+# Change this one line to move it. Anything in VERTEX_TOKEN_RATES works.
+P2B_V4_GRILL_MODEL = "gemini-3.1-pro-preview"
+
+# Higher than the pipeline default. This call is judgement, not extraction: at
+# a low temperature it proposes the safe question rather than the useful one,
+# and the whole value of the grill is the sharp question nobody expected.
+P2B_V4_GRILL_TEMPERATURE = 0.6
+
 EDITORIAL_COMPONENT_LABELS = {
     "pull_quote": "Pull Quote",
     "in_the_know_box": "In The Know",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -30,7 +30,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
-from .config import DEFAULT_MODEL
+from .config import P2B_V4_GRILL_MODEL, P2B_V4_GRILL_TEMPERATURE
 from .contracts_v4 import GrillQuestion, GrillState, GrillTurn
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
@@ -98,7 +98,7 @@ class GrillDependencies:
     # Returns (digest, source_urls, total_tokens). Separate from `llm` because
     # this one reaches the web and the other does not.
     research: Callable[[str], tuple[str, list[str], int | None]]
-    model_name: str = DEFAULT_MODEL
+    model_name: str = P2B_V4_GRILL_MODEL
 
 
 def research_seed(dependencies: GrillDependencies, seed: str) -> tuple[str, list[str], int | None]:
@@ -141,7 +141,11 @@ THE INTERVIEW SO FAR:
 
 Decide the single most useful next move.
 
-Rules:
+Output shape (mechanical -- get it right and then forget about it): the reply
+always carries both `question` and `consensus`. Fill the one you are using and
+leave the other empty.
+
+Now the part that matters:
 - Ask ONE question, and only about something you cannot look up. What they
   want, who it is for, what they personally have, what would make it a
   failure. Never ask them to confirm a fact.
@@ -155,10 +159,6 @@ Rules:
   means it is a research-led piece.
 - Set `location` when their line names a place clearly enough to act on. Leave
   it empty only when it is genuinely ambiguous.
-- ALWAYS return both `question` and `consensus`. When you are asking, fill
-  `question` and leave `consensus` an empty string. When you are done, fill
-  `consensus` and leave the question's `ask` and `recommendation` empty. Never
-  return neither.
 - Set `done` true and write `consensus` when you could brief a writer from
   what you have: what the piece is, who reads it, what it should make them do,
   what it is built on, what it must name, and what would make it a failure.
@@ -237,7 +237,7 @@ def _advance_once(
         model_name=dependencies.model_name,
         schema=NEXT_TURN_SCHEMA,
         max_tokens=2_048,
-        temperature=0.3,
+        temperature=P2B_V4_GRILL_TEMPERATURE,
     )
     payload = _safe_dict(parsed)
     location = _safe_str(payload.get("location")) or state.location

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
@@ -361,5 +361,51 @@ def test_the_prompt_says_to_return_both_and_leave_one_empty():
     )
     flat = " ".join(prompt.split())
 
-    assert "ALWAYS return both `question` and `consensus`" in flat
-    assert "Never return neither." in flat
+    # The rule still holds; it just lives with the output shape rather than in
+    # the list of rules about how to interview well.
+    assert "always carries both `question` and `consensus`" in flat
+    assert "Fill the one you are using and leave the other empty." in flat
+
+
+def test_the_format_rule_is_not_mixed_into_the_interviewing_rules():
+    """A formatting instruction in the list of rules about how to interview
+    well taxes every question with bookkeeping.
+
+    Adding "always return both fields, leave one empty" to that list visibly
+    weakened the recommendations on the next live run: the model was juggling
+    an empty-string chore alongside deciding what to ask.
+    """
+    prompt = build_next_turn_prompt(
+        GrillState(
+            run_id="r",
+            seed=SEED,
+            status="asking",
+            pending=GrillQuestion(
+                question_id="q1", topic="t", ask="a", recommendation="r"
+            ),
+        )
+    )
+
+    shape = prompt.index("Output shape")
+    rules = prompt.index("Now the part that matters")
+    assert shape < rules, "the mechanical part comes first and is done with"
+    assert "ALWAYS return both" not in prompt
+
+
+def test_the_grill_runs_on_its_own_named_model():
+    """One line to change, and not the pipeline default.
+
+    The grill decides what the article is and every later stage inherits that,
+    across about six calls -- the cheapest place in the pipeline to spend on a
+    better model.
+    """
+    from app.features.prompt2blog.config import (
+        P2B_V4_GRILL_MODEL,
+        P2B_V4_GRILL_TEMPERATURE,
+    )
+    from app.features.prompt2blog.pricing import VERTEX_TOKEN_RATES
+
+    assert P2B_V4_GRILL_MODEL in VERTEX_TOKEN_RATES, "an unpriced model hides its cost"
+    # Judgement, not extraction. A low temperature proposes the safe question
+    # rather than the useful one.
+    assert P2B_V4_GRILL_TEMPERATURE >= 0.5


### PR DESCRIPTION
The grill's recommendations got **visibly weaker between two live runs**, and the cause was my prompt edit, not the model.

## What I broke

Fixing the crash in #434 put this into the list of rules about how to interview well:

> ALWAYS return both `question` and `consensus`. When you are asking, fill `question` and leave `consensus` an empty string.

So on every turn the model was juggling an empty-string chore alongside deciding what to ask. That is the kind of added compliance load that makes a model hedge.

The rule still holds. It now sits **with the output shape**, labelled mechanical, ahead of "Now the part that matters".

## The grill gets its own model

`P2B_V4_GRILL_MODEL` — one line to change, no longer the pipeline default.

The spec picked a flash model for being "short, conversational", which reads as a cost decision. But the grill is where a weak model is *most* expensive: it decides what the article is, every later stage inherits that, and it is about six calls. It is the cheapest thing in the pipeline to make good.

A test asserts the chosen model is in the price table, because an unpriced model hides its own cost on the receipt.

## Temperature 0.3 → 0.6

This call is judgement, not extraction. At a low temperature it proposes the safe question rather than the useful one — and the sharp question nobody expected is the entire value of the grill.

Backend 0 failures, eslint clean.