### PR TITLE
Give the intake screens styles, and put the way out where it can be seen

### DIFF
--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -17,6 +17,14 @@ import { useIntake } from '../intake/useIntake'
  * voice, a creativity level and a direction card before it would do anything,
  * and never once asked what the article was for.
  */
+const STEP_LABELS: Record<string, string> = {
+  seed: 'Starting',
+  grill: 'A few questions',
+  brief: 'The brief',
+  work_order: 'The research plan',
+  research: 'What we found',
+}
+
 export function Prompt2BlogPage() {
   const intake = useIntake()
   const state = intake.state
@@ -43,15 +51,21 @@ export function Prompt2BlogPage() {
       </header>
 
       <main className="p2b-form-container">
+        {state && (
+          // Always here, at the top, whatever has or has not gone wrong. The
+          // run is remembered so a closed tab can resume, which means a run
+          // that cannot move forward would trap the page on every reload.
+          <div className="p2b-intake-bar">
+            <span className="p2b-intake-step">{STEP_LABELS[step]}</span>
+            <button type="button" onClick={intake.abandon}>
+              Start over
+            </button>
+          </div>
+        )}
+
         {intake.error && (
           <div className="p2b-error" role="alert">
             <p>{intake.error}</p>
-            {/* A failed step must never be a dead end. The run is remembered
-                so a closed tab can resume, which means a run that cannot move
-                forward would otherwise trap the page on every reload. */}
-            <button type="button" className="p2b-clear-btn" onClick={intake.abandon}>
-              Start over
-            </button>
           </div>
         )}
 
@@ -99,13 +113,6 @@ export function Prompt2BlogPage() {
           />
         )}
 
-        {state && !intake.error && (
-          <div className="p2b-submit-row">
-            <button type="button" className="p2b-clear-btn" onClick={intake.abandon}>
-              Start something else
-            </button>
-          </div>
-        )}
       </main>
     </div>
   )

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles.css
@@ -1,4 +1,5 @@
 @import './styles/layout.css';
+@import './styles/intake.css';
 @import './styles/forms.css';
 @import './styles/pipeline.css';
 @import './styles/cleanup-modal.css';

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1,0 +1,376 @@
+/*
+ * The intake screens: seed, grill, brief, work order, research.
+ *
+ * These shipped with no styles at all — the components were written against
+ * class names that existed in no stylesheet, so the whole flow rendered as raw
+ * HTML and the controls were unfindable.
+ *
+ * Built on the existing tokens rather than new ones. This is one page of an
+ * app that already has a look; it should not arrive with its own.
+ *
+ * The shape is a single reading column, because the grill is a conversation
+ * and a conversation is read top to bottom. One question is on screen at a
+ * time on purpose.
+ */
+
+.p2b-intake {
+  max-width: 42rem;
+  margin: 0 auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6) clamp(var(--space-4), 4vw, var(--space-7));
+  box-shadow: 0 2px 16px var(--shadow-soft);
+}
+
+.p2b-intake .p2b-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 var(--space-3);
+}
+
+/* ---------- the conversation so far ---------- */
+
+.p2b-transcript {
+  list-style: none;
+  margin: 0 0 var(--space-6);
+  padding: 0 0 var(--space-5);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.p2b-transcript-ask {
+  margin: 0 0 var(--space-1);
+  color: var(--muted);
+  font-size: 0.9375rem;
+}
+
+/* What you said, kept word for word. Set apart because it is the one thing on
+   this page nobody rewrote. */
+.p2b-transcript-answer {
+  margin: 0;
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--p2b-accent-soft);
+  color: var(--ink);
+}
+
+/* ---------- the question ---------- */
+
+.p2b-question {
+  font-size: 1.25rem;
+  line-height: 1.45;
+  color: var(--ink);
+  margin: 0 0 var(--space-5);
+  text-wrap: pretty;
+}
+
+/* Shown above the question it exists to resolve, so the contradiction reads
+   as the reason for asking rather than as a complaint. */
+.p2b-pushback {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--accent-softer);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+}
+
+.p2b-consensus {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--ink);
+  margin: 0 0 var(--space-5);
+  text-wrap: pretty;
+}
+
+.p2b-note {
+  margin: var(--space-4) 0 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.p2b-muted {
+  color: var(--muted);
+}
+
+/* ---------- the brief ---------- */
+
+.p2b-brief {
+  margin: 0 0 var(--space-5);
+  display: grid;
+  grid-template-columns: minmax(9rem, auto) 1fr;
+  gap: var(--space-2) var(--space-5);
+  align-items: baseline;
+}
+
+.p2b-brief dt {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.p2b-brief dd {
+  margin: 0;
+  color: var(--ink);
+}
+
+.p2b-fails-if {
+  color: var(--accent);
+}
+
+@media (max-width: 34rem) {
+  .p2b-brief {
+    grid-template-columns: 1fr;
+    gap: 0 0;
+  }
+  .p2b-brief dd {
+    margin: 0 0 var(--space-3);
+  }
+}
+
+.p2b-material {
+  margin: var(--space-5) 0 0;
+  padding: var(--space-4);
+  background: var(--cream-dark);
+  border-radius: var(--radius-md);
+}
+
+.p2b-material .p2b-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--muted);
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.p2b-material ul {
+  margin: 0;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.p2b-material-kind {
+  display: inline-block;
+  margin-right: var(--space-2);
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: var(--sage-soft);
+  color: var(--sage);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ---------- the research plan ---------- */
+
+.p2b-questions {
+  list-style: none;
+  margin: 0 0 var(--space-5);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.p2b-questions li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.p2b-questions label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  cursor: pointer;
+}
+
+/* A struck question is still readable. It was a real decision and the operator
+   may want to put it back. */
+.p2b-struck .p2b-question-text {
+  text-decoration: line-through;
+  color: var(--muted-light);
+}
+
+.p2b-kind {
+  flex-shrink: 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.p2b-kind-core {
+  color: var(--accent);
+}
+
+/* Said once, after the fact. Not a warning to acknowledge — the cut already
+   happened. */
+.p2b-cut-warnings {
+  margin: var(--space-4) 0 0;
+  padding: var(--space-4) var(--space-5);
+  background: var(--accent-softer);
+  border-radius: var(--radius-md);
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.p2b-blocked {
+  margin: var(--space-4) 0 0;
+  padding: var(--space-4) var(--space-5);
+  background: var(--error-soft);
+  border-radius: var(--radius-md);
+  color: var(--ink);
+  font-size: 0.9375rem;
+}
+
+.p2b-blocked ul {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-5);
+}
+
+.p2b-research-summary {
+  color: var(--muted);
+  margin: 0 0 var(--space-4);
+}
+
+/* ---------- controls ---------- */
+
+.p2b-intake .p2b-field {
+  display: block;
+  margin: 0 0 var(--space-4);
+}
+
+.p2b-intake .p2b-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+.p2b-intake textarea,
+.p2b-intake input[type='text'] {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--cream);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.p2b-intake textarea:focus,
+.p2b-intake input[type='text']:focus {
+  outline: 2px solid var(--p2b-accent);
+  outline-offset: 1px;
+  border-color: var(--p2b-accent);
+}
+
+.p2b-intake-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+}
+
+.p2b-intake-actions button {
+  padding: var(--space-3) var(--space-5);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--p2b-accent);
+  color: white;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-base);
+}
+
+.p2b-intake-actions button:hover:not(:disabled) {
+  background: var(--p2b-accent-hover);
+}
+
+.p2b-intake-actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.p2b-intake-actions .p2b-secondary {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border-strong);
+}
+
+.p2b-intake-actions .p2b-secondary:hover:not(:disabled) {
+  background: var(--cream-dark);
+  color: var(--ink);
+}
+
+/* ---------- getting out ---------- */
+
+/* Always on screen, next to the step indicator, because a run that cannot move
+   forward would otherwise trap the page on every reload. It was previously at
+   the very bottom and only rendered when nothing had gone wrong, which is
+   exactly backwards. */
+.p2b-intake-bar {
+  max-width: 42rem;
+  margin: 0 auto var(--space-4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.p2b-intake-step {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.p2b-intake-bar button {
+  background: none;
+  border: none;
+  padding: var(--space-2) 0;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.875rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.p2b-intake-bar button:hover {
+  color: var(--accent);
+}
+
+.p2b-error {
+  max-width: 42rem;
+  margin: 0 auto var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--error-soft);
+  border-left: 3px solid var(--error);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--ink);
+}
+
+.p2b-error p {
+  margin: 0 0 var(--space-3);
+}


### PR DESCRIPTION
**The four intake screens shipped with no CSS at all.** Every class they use — `p2b-intake`, `p2b-question`, `p2b-transcript`, `p2b-intake-actions` — existed in no stylesheet.

I wrote components against class names I never defined, and never looked at the rendered result. The whole flow has been raw unstyled HTML.

## Which is why the reset could not be found

It was a grey pill at the very bottom of an unstyled page, below the fold — and it only rendered **when nothing had gone wrong**, which is exactly backwards for the one control whose job is escaping a run that will not move.

It is now a bar at the top, beside which step you are on, present whatever has or has not happened. It says "Start over", because that is what it does.

## The styles

Built on the tokens the app already has rather than new ones — this is one page of an app with a look, and it should not arrive with its own.

A single reading column, because the grill is a conversation and one question is on screen at a time on purpose.

Two details that are decisions rather than decoration:

- **A struck research question stays readable** rather than disappearing. Striking it was a real decision and the operator may want to reverse it.
- **What the operator typed is set apart** from what the machine said. It is the one thing on the page nobody rewrote.

Frontend 716 passing, tsc clean, eslint clean, boundaries pass.