### PR TITLE
Stop refusing good questions over their shape

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -62,25 +62,28 @@ GRILL_RESEARCH_MODEL = "gemini-2.5-flash"
 # real run: `{"done": false}` with nothing else is schema-valid and useless,
 # and the model took that gap. A schema that permits what the code refuses is
 # a schema that has not been written down properly.
+# Flat on purpose.
+#
+# This was nested -- `question` as an object carrying `ask`, `recommendation`
+# and `pushback` -- and models kept answering flat instead: `question` as the
+# question string, with `recommendation` beside it at the top level. Twice in a
+# row the reply was a good question with a good recommendation, and it was
+# refused for its shape.
+#
+# There is nothing here worth nesting. A flat object has no structure to get
+# wrong, and shape is not worth losing content over.
 NEXT_TURN_SCHEMA = require_non_empty({
     "type": "object",
     "properties": {
         "done": {"type": "boolean"},
-        "question": {
-            "type": "object",
-            "properties": {
-                "question_id": {"type": "string"},
-                "topic": {"type": "string"},
-                "ask": {"type": "string"},
-                "recommendation": {"type": "string"},
-                "pushback": {"type": "string"},
-            },
-            "required": ["question_id", "topic", "ask", "recommendation"],
-        },
+        "ask": {"type": "string"},
+        "recommendation": {"type": "string"},
+        "pushback": {"type": "string"},
+        "topic": {"type": "string"},
         "consensus": {"type": "string"},
         "location": {"type": "string"},
     },
-    "required": ["done", "question", "consensus"],
+    "required": ["done", "ask", "recommendation", "consensus"],
 })
 
 
@@ -141,9 +144,10 @@ THE INTERVIEW SO FAR:
 
 Decide the single most useful next move.
 
-Output shape (mechanical -- get it right and then forget about it): the reply
-always carries both `question` and `consensus`. Fill the one you are using and
-leave the other empty.
+Output shape (mechanical -- get it right and then forget about it): every
+reply carries `ask`, `recommendation` and `consensus`. When you are asking,
+fill `ask` and `recommendation` and leave `consensus` empty. When you are done,
+fill `consensus` and leave the other two empty.
 
 Now the part that matters:
 - Ask ONE question, and only about something you cannot look up. What they
@@ -169,19 +173,41 @@ Now the part that matters:
 
 
 def _question_from(payload: dict[str, Any], fallback_id: str) -> GrillQuestion | None:
-    raw = _safe_dict(payload.get("question"))
-    ask = _safe_str(raw.get("ask"))
-    recommendation = _safe_str(raw.get("recommendation"))
+    """Read the question, however the model chose to arrange it.
+
+    Flat is what the schema asks for and what models actually produce. Nested
+    under `question` is what an earlier schema asked for, and some will still
+    do it. A bare `question` string with the recommendation beside it is the
+    third arrangement seen in the wild.
+
+    All three carry the same words. Refusing one of them throws away a
+    perfectly good question over punctuation, which is exactly what happened
+    twice on the first live runs.
+    """
+    nested = _safe_dict(payload.get("question"))
+    question_text = payload.get("question")
+    flat_ask = question_text if isinstance(question_text, str) else ""
+
+    ask = (
+        _safe_str(payload.get("ask"))
+        or _safe_str(nested.get("ask"))
+        or _safe_str(flat_ask)
+    )
+    recommendation = _safe_str(payload.get("recommendation")) or _safe_str(
+        nested.get("recommendation")
+    )
     if not ask or not recommendation:
         # A question with no recommendation is a blank box, which is the thing
         # this replaces. Reject it rather than showing it.
         return None
     return GrillQuestion(
-        question_id=_safe_str(raw.get("question_id")) or fallback_id,
-        topic=_safe_str(raw.get("topic")) or "next",
+        question_id=_safe_str(payload.get("question_id"))
+        or _safe_str(nested.get("question_id"))
+        or fallback_id,
+        topic=_safe_str(payload.get("topic")) or _safe_str(nested.get("topic")) or "next",
         ask=ask,
         recommendation=recommendation,
-        pushback=_safe_str(raw.get("pushback")),
+        pushback=_safe_str(payload.get("pushback")) or _safe_str(nested.get("pushback")),
     )
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
@@ -37,6 +37,7 @@ class FakeLLM:
 
 
 def _question(**overrides) -> dict[str, Any]:
+    """The flat shape the schema asks for and models actually produce."""
     payload = {
         "question_id": "q1",
         "topic": "what should this do for the reader",
@@ -57,7 +58,7 @@ def _deps(responses: list[dict[str, Any]], digest: str = "Lima has a food reputa
 def test_the_grill_looks_things_up_before_it_asks_anything():
     # G2. This is what keeps the grill short -- not a question limit. A grill
     # that asks what it could have looked up is a form with extra steps.
-    deps = _deps([{"done": False, "question": _question()}])
+    deps = _deps([{"done": False, **_question()}])
 
     state = start_grill("run-1", SEED, deps)
 
@@ -79,7 +80,7 @@ def test_research_failure_leaves_the_grill_working_but_ungrounded():
 
 def test_every_question_carries_a_recommended_answer():
     # G1. Nobody faces a blank: correcting is easy where composing is not.
-    state = start_grill("run-1", SEED, _deps([{"done": False, "question": _question()}]))
+    state = start_grill("run-1", SEED, _deps([{"done": False, **_question()}]))
 
     assert state.pending is not None
     assert state.pending.recommendation.startswith("My recommendation:")
@@ -94,8 +95,8 @@ def test_a_question_without_a_recommendation_is_refused_rather_than_shown():
     # Twice, because one unusable reply is now retried rather than fatal.
     deps = _deps(
         [
-            {"done": False, "question": _question(recommendation="")},
-            {"done": False, "question": _question(recommendation="")},
+            {"done": False, **_question(recommendation="")},
+            {"done": False, **_question(recommendation="")},
         ]
     )
 
@@ -110,8 +111,8 @@ def test_the_grill_asks_one_question_at_a_time_shaped_by_the_last():
     # are a fixed list wearing a conversation's clothes.
     deps = _deps(
         [
-            {"done": False, "question": _question()},
-            {"done": False, "question": _question(question_id="q2", ask="Who is reading it?")},
+            {"done": False, **_question()},
+            {"done": False, **_question(question_id="q2", ask="Who is reading it?")},
         ]
     )
 
@@ -130,8 +131,8 @@ def test_the_answer_is_kept_exactly_as_it_was_typed():
     typed = "I was there 4 days last year. mostly ate. the ceviche place in Surquillo market was better than any of the fancy ones"
     deps = _deps(
         [
-            {"done": False, "question": _question()},
-            {"done": False, "question": _question(question_id="q2")},
+            {"done": False, **_question()},
+            {"done": False, **_question(question_id="q2")},
         ]
     )
 
@@ -144,7 +145,7 @@ def test_the_grill_pushes_back_when_an_answer_contradicts_the_seed():
     # G4. It does not just collect the answer; it makes the conflict resolve.
     deps = _deps(
         [
-            {"done": False, "question": _question()},
+            {"done": False, **_question()},
             {
                 "done": False,
                 "question": _question(
@@ -166,7 +167,7 @@ def test_the_grill_stops_at_agreement_rather_than_at_a_count():
     # themselves gets eight.
     deps = _deps(
         [
-            {"done": False, "question": _question()},
+            {"done": False, **_question()},
             {"done": True, "consensus": "A first-timer's guide for someone with a Lima layover."},
         ]
     )
@@ -186,8 +187,8 @@ def test_claiming_to_be_done_without_saying_what_was_agreed_is_not_agreement():
     """
     deps = _deps(
         [
-            {"done": False, "question": _question()},
-            {"done": True, "consensus": "", "question": _question(question_id="q2")},
+            {"done": False, **_question()},
+            {"done": True, "consensus": "", **_question(question_id="q2")},
         ]
     )
 
@@ -198,13 +199,13 @@ def test_claiming_to_be_done_without_saying_what_was_agreed_is_not_agreement():
 
 
 def test_location_is_extracted_rather_than_typed_into_a_box():
-    deps = _deps([{"done": False, "question": _question(), "location": "Lima, Peru"}])
+    deps = _deps([{"done": False, **_question(), "location": "Lima, Peru"}])
 
     assert start_grill("run-1", SEED, deps).location == "Lima, Peru"
 
 
 def test_an_ambiguous_line_leaves_the_location_for_a_question():
-    deps = _deps([{"done": False, "question": _question(), "location": ""}])
+    deps = _deps([{"done": False, **_question(), "location": ""}])
 
     assert start_grill("run-1", "a weekend in the valley", deps).location == ""
 
@@ -212,7 +213,7 @@ def test_an_ambiguous_line_leaves_the_location_for_a_question():
 def test_an_agreed_grill_will_not_take_another_answer():
     deps = _deps(
         [
-            {"done": False, "question": _question()},
+            {"done": False, **_question()},
             {"done": True, "consensus": "Settled."},
         ]
     )
@@ -231,9 +232,9 @@ def test_reopening_keeps_what_was_learned_and_drops_the_agreement():
     """
     deps = _deps(
         [
-            {"done": False, "question": _question()},
+            {"done": False, **_question()},
             {"done": True, "consensus": "Settled."},
-            {"done": False, "question": _question(question_id="q3", ask="What changed?")},
+            {"done": False, **_question(question_id="q3", ask="What changed?")},
         ]
     )
     agreed = answer_grill(start_grill("run-1", SEED, deps), "guide", deps)
@@ -247,7 +248,7 @@ def test_reopening_keeps_what_was_learned_and_drops_the_agreement():
 
 
 def test_an_empty_answer_is_refused():
-    deps = _deps([{"done": False, "question": _question()}])
+    deps = _deps([{"done": False, **_question()}])
     state = start_grill("run-1", SEED, deps)
 
     with pytest.raises(ValueError, match="cannot be empty"):
@@ -263,8 +264,8 @@ def test_the_stage_record_is_readable_on_its_own():
     """
     deps = _deps(
         [
-            {"done": False, "question": _question()},
-            {"done": False, "question": _question(question_id="q2")},
+            {"done": False, **_question()},
+            {"done": False, **_question(question_id="q2")},
         ]
     )
     state = answer_grill(start_grill("run-1", SEED, deps), "guide, with a pitch", deps)
@@ -316,7 +317,7 @@ def test_a_reply_with_no_question_and_no_consensus_is_retried_once():
     schema-valid and useless -- and one unusable reply ended the run before it
     had started.
     """
-    deps = _deps([{"done": False}, {"done": False, "question": _question()}])
+    deps = _deps([{"done": False}, {"done": False, **_question()}])
 
     state = start_grill("run-1", SEED, deps)
 
@@ -345,7 +346,12 @@ def test_the_schema_demands_what_the_code_demands():
     # written down properly.
     from app.features.prompt2blog.grill_v4 import NEXT_TURN_SCHEMA
 
-    assert set(NEXT_TURN_SCHEMA["required"]) == {"done", "question", "consensus"}
+    assert set(NEXT_TURN_SCHEMA["required"]) == {
+        "done",
+        "ask",
+        "recommendation",
+        "consensus",
+    }
 
 
 def test_the_prompt_says_to_return_both_and_leave_one_empty():
@@ -363,8 +369,8 @@ def test_the_prompt_says_to_return_both_and_leave_one_empty():
 
     # The rule still holds; it just lives with the output shape rather than in
     # the list of rules about how to interview well.
-    assert "always carries both `question` and `consensus`" in flat
-    assert "Fill the one you are using and leave the other empty." in flat
+    assert "every reply carries `ask`, `recommendation` and `consensus`" in flat
+    assert "leave `consensus` empty" in flat
 
 
 def test_the_format_rule_is_not_mixed_into_the_interviewing_rules():
@@ -409,3 +415,59 @@ def test_the_grill_runs_on_its_own_named_model():
     # Judgement, not extraction. A low temperature proposes the safe question
     # rather than the useful one.
     assert P2B_V4_GRILL_TEMPERATURE >= 0.5
+
+
+def test_a_good_question_is_not_refused_for_its_shape():
+    """This cost two live runs.
+
+    The model returned `question` as the question string with `recommendation`
+    beside it at the top level, while the schema wanted them nested. The words
+    were right both times and were thrown away over punctuation.
+    """
+    as_the_model_sent_it = {
+        "done": False,
+        "question": "What will be the main focus of your article?",
+        "recommendation": "A personal guide focusing on Lima's food culture.",
+        "location": "Lima, Peru",
+    }
+    deps = _deps([as_the_model_sent_it])
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert state.pending is not None
+    assert state.pending.ask == "What will be the main focus of your article?"
+    assert state.pending.recommendation.startswith("A personal guide")
+    assert state.location == "Lima, Peru"
+
+
+def test_the_nested_shape_still_works():
+    # An earlier schema asked for this, and some models will keep producing it.
+    deps = _deps(
+        [
+            {
+                "done": False,
+                "question": {
+                    "question_id": "q1",
+                    "topic": "focus",
+                    "ask": "Guide, or the case?",
+                    "recommendation": "A guide with a point of view.",
+                },
+            }
+        ]
+    )
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert state.pending is not None
+    assert state.pending.ask == "Guide, or the case?"
+
+
+def test_the_schema_has_nothing_left_to_nest():
+    # A flat object has no structure to get wrong.
+    from app.features.prompt2blog.grill_v4 import NEXT_TURN_SCHEMA
+
+    assert set(NEXT_TURN_SCHEMA["required"]) == {"done", "ask", "recommendation", "consensus"}
+    assert all(
+        spec.get("type") in {"string", "boolean"}
+        for spec in NEXT_TURN_SCHEMA["properties"].values()
+    )


### PR DESCRIPTION
Two live runs in a row returned **a good question with a good recommendation** and were thrown away, because `question` came back as a string with `recommendation` beside it while the schema wanted them nested in an object.

```json
{
  "question": "To show why Lima is worth the stay, we'll need a specific focus.
                Are you building this around your own recent trip eating through
                the city, or do you have interviews lined up with locals?",
  "recommendation": "This is based on your own recent travels and personal
                      experiences exploring Lima's food and neighborhoods.",
  "done": false
}
```

The words were right both times. The refusal was mine.

## Flat, because there was never anything to nest

`ask`, `recommendation`, `pushback`, `consensus` — a flat object has no structure to get wrong.

The parser accepts all three arrangements seen so far: flat, nested under `question`, and `question` as a bare string with the recommendation alongside.

**Being strict about arrangement when the content is right is pure loss.** The schema exists so the model knows what to send, not so the parser can reject what arrived.

## The evidence trail earned its keep

The failure carried the raw reply onto the run, and reading it took a minute. The same failure a day earlier left nothing behind and could only be guessed at.

Backend 0 failures, eslint clean.