### PR TITLE
Correct what the handoff says is unmerged and how many issues are open

### DIFF
--- a/apps/ai-blog-writer/docs/handoff-2026-08-31.md
+++ b/apps/ai-blog-writer/docs/handoff-2026-08-31.md
@@ -16,11 +16,15 @@ the code, the commits or the issues.
 | The Claude article account | `apps/ai-blog-writer/docs/claude-article-account.md` |
 | Vocabulary | `apps/ai-blog-writer/CONTEXT.md` |
 
-Open issues **#440 to #448** carry everything outstanding. #440 (token
-accounting) is the one the owner's actual goal depends on.
+Open issues **#440 to #450** carry everything outstanding (eleven, not nine:
+#449 and #450 were filed after this line was first written). #440 (token
+accounting) is the one the owner's actual goal depends on, and #450 is the
+cheapest real win.
 
-Branch `p2b/v4-grill-conversation-and-tolerant-parsing`, ~22 commits ahead of
-`main`, **not merged, no PR opened**. Commit messages are long and explain why.
+Branch `p2b/v4-grill-conversation-and-tolerant-parsing` was ~22 commits ahead of
+`main` when this was written. It **merged as #451 on 2026-09-01** and is in `main`
+now; do not go looking for it as unmerged work. Commit messages are long and
+explain why.
 
 ## The two runs, and what they prove
 


### PR DESCRIPTION
Docs only. Two stale lines in `handoff-2026-08-31.md`.

1. It told the next reader that `p2b/v4-grill-conversation-and-tolerant-parsing` was ~22 commits ahead of main, **not merged, no PR opened**. It merged as #451 on 2026-09-01. That line sends someone hunting for work that is already in main.
2. It said open issues **#440 to #448**. There are eleven, #440 to #450 — #449 and #450 were filed after that line was written, and #450 is the cheapest win on the list.