### PR TITLE
Run the research searches at the same time (#450, part one)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -119,6 +119,20 @@ P2B_RUN_TOKEN_BUDGET = 320_000
 # in one place, so a ceiling set wrong is obvious rather than mysterious.
 P2B_RUN_TOKEN_CEILING = 650_000
 
+# How many grounded searches research may have in flight at once.
+#
+# One question per search, and nothing in question four depends on question
+# three, so the sequential loop was only ever the simplest thing to write. On
+# run 76b36468 it cost roughly six minutes of a twenty-and-a-half minute
+# research pass; concurrently that is about the slowest single search.
+#
+# Bounded rather than unbounded because the grounded-search rate limits are
+# unknown and a run fans out as many searches as the work order has questions.
+# Four is a deliberate first guess: enough to collapse most of the wait, small
+# enough that a rate limit shows up as slow rather than as a wall of failures.
+# Lower it here if searches start coming back empty.
+P2B_V4_GATHER_CONCURRENCY = 4
+
 # How many times one run may be resumed after a failure. A resume costs the
 # stages that had not run yet, so a stage that fails for a reason resuming
 # cannot fix -- a commission the model keeps refusing, a permanently dead

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -368,7 +368,7 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
         )
 
     record_progress({"phase": "structuring", "done": len(notes), "total": len(notes),
-                     "current_question": ""})
+                     "last_question_back": ""})
     try:
         evidence = structure_research(work_order, notes, services.research)
     except ResearchUnusable as error:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import date
 from typing import Any, Callable, get_args
@@ -41,6 +42,7 @@ from .contracts_v4 import (
     Prompt2BlogWorkOrder,
     WorkOrderRequirement,
 )
+from .config import P2B_V4_GATHER_CONCURRENCY
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
@@ -659,30 +661,45 @@ def gather_research(
     dependencies: ResearchDependencies,
     on_progress: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, GatheredNotes]:
-    """One grounded pass per question, texture included.
+    """One grounded pass per question, texture included, all at once.
 
     Texture is researched to the identical standard: a scene we cannot source
     is still cut, so it has to be sourced like anything else.
 
-    `on_progress` is called before each search with what is about to be asked.
-    Ten sequential web searches take five to ten minutes and the screen used to
-    say nothing at all for the whole of it, which reads as a hung request.
+    The searches run concurrently because they are independent -- nothing in
+    question four depends on question three -- and sequentially they were about
+    six minutes of run 76b36468's twenty-and-a-half minute research pass. Same
+    prompts, same model, same results; only the waiting changes.
+
+    Bounded at `P2B_V4_GATHER_CONCURRENCY`, because grounded-search rate limits
+    are unknown and the number of questions is set by the work order rather
+    than by us.
+
+    `on_progress` reports **completions**, not position: it fires once when the
+    searches start and once each time one comes back. It cannot say what is
+    being searched now, because several are, so it names the last question to
+    come back instead.
     """
-    notes: dict[str, GatheredNotes] = {}
-    total = len(work_order.requirements)
-    for index, requirement in enumerate(work_order.requirements, start=1):
-        if on_progress is not None:
-            try:
-                on_progress(
-                    {
-                        "phase": "gathering",
-                        "done": index - 1,
-                        "total": total,
-                        "current_question": requirement.question,
-                    }
-                )
-            except Exception as exc:  # pragma: no cover -- telemetry only
-                logger.warning("Research progress write failed: %s", exc)
+    requirements = list(work_order.requirements)
+    total = len(requirements)
+
+    def _emit(phase: str, done: int, last_question_back: str) -> None:
+        if on_progress is None:
+            return
+        try:
+            on_progress(
+                {
+                    "phase": phase,
+                    "done": done,
+                    "total": total,
+                    "last_question_back": last_question_back,
+                }
+            )
+        except Exception as exc:  # pragma: no cover -- telemetry only
+            logger.warning("Research progress write failed: %s", exc)
+
+    def _gather_one(requirement: WorkOrderRequirement) -> GatheredNotes:
+        """Never raises: a hole is survivable, a dead run is not."""
         prompt = build_gather_prompt(brief, requirement)
         try:
             text, urls, tokens = dependencies.gather(prompt, GATHER_MODEL)
@@ -691,24 +708,41 @@ def gather_research(
                 "Gather failed for %s: %s", requirement.requirement_id, exc
             )
             text, urls, tokens = "", [], None
-        notes[requirement.requirement_id] = GatheredNotes(
+        return GatheredNotes(
             text=_safe_str(text), source_urls=list(urls or []), tokens=tokens
         )
-    if on_progress is not None:
-        try:
-            # Structuring is one call and the longest single wait in the run,
-            # so it gets its own phase rather than looking like a stall after
-            # the last search.
-            on_progress(
-                {
-                    "phase": "structuring",
-                    "done": total,
-                    "total": total,
-                    "current_question": "",
-                }
-            )
-        except Exception as exc:  # pragma: no cover -- telemetry only
-            logger.warning("Research progress write failed: %s", exc)
+
+    gathered: dict[str, GatheredNotes] = {}
+    if requirements:
+        # Only once there is something to wait for. A work order with no
+        # questions cannot reach here through the contract, and an empty
+        # "0 of 0" on the screen would be worse than silence if it did.
+        _emit("gathering", 0, "")
+        workers = max(1, min(P2B_V4_GATHER_CONCURRENCY, total))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            pending = {
+                pool.submit(_gather_one, requirement): requirement
+                for requirement in requirements
+            }
+            # Consumed on this thread, so `on_progress` -- which writes a stage
+            # row -- is never called from a worker and needs no lock.
+            for done, future in enumerate(as_completed(pending), start=1):
+                requirement = pending[future]
+                gathered[requirement.requirement_id] = future.result()
+                _emit("gathering", done, requirement.question)
+
+    # Rebuilt in work-order order rather than completion order, so the notes,
+    # the structure prompt built from them and anything diffing two runs do not
+    # change shape with the weather.
+    notes = {
+        requirement.requirement_id: gathered[requirement.requirement_id]
+        for requirement in requirements
+        if requirement.requirement_id in gathered
+    }
+
+    # Structuring is one call and the longest single wait in the run, so it gets
+    # its own phase rather than looking like a stall after the last search.
+    _emit("structuring", total, "")
     return notes
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
@@ -11,6 +11,8 @@ re-run. Do not read a green run here as "research works".
 
 from __future__ import annotations
 
+import threading
+import time
 from datetime import date
 from typing import Any
 
@@ -30,6 +32,7 @@ from app.features.prompt2blog.contracts_v4 import (
     WorkOrderRequirement,
     WorkOrderScope,
 )
+from app.features.prompt2blog.config import P2B_V4_GATHER_CONCURRENCY
 from app.features.prompt2blog.coverage_v4 import assess_coverage
 from app.features.prompt2blog.research_v4 import (
     GATHER_MODEL,
@@ -181,8 +184,11 @@ def test_texture_is_researched_like_anything_else():
 
     gather_research(_brief(), _work_order(), deps)
 
-    texture_prompt = deps.gather.calls[1][0]
-    assert "Huaca Pucllana" in texture_prompt
+    # Found rather than indexed: the searches run concurrently, so which one
+    # was recorded second is the network's business.
+    texture_prompt = next(
+        prompt for prompt, _model in deps.gather.calls if "Huaca Pucllana" in prompt
+    )
     assert "with sources" in texture_prompt
 
 
@@ -202,6 +208,117 @@ def test_the_gather_prompt_asks_for_more_than_the_question():
 
     assert "Do not discard it because it was not the question." in flat
     assert "a reader would find interesting" in flat
+
+
+# --- the searches run together -------------------------------------------
+
+
+def _wide_work_order(count: int) -> Prompt2BlogWorkOrder:
+    """More questions than the concurrency bound, so the bound is observable."""
+    return _work_order(
+        requirements=[
+            WorkOrderRequirement(
+                requirement_id=f"r{index}",
+                question=f"Question {index}?",
+                kind="load_bearing",
+            )
+            for index in range(1, count + 1)
+        ]
+    )
+
+
+def test_the_searches_actually_run_at_the_same_time():
+    """The whole point of the change, and the only test that can prove it.
+
+    Both gathers wait on a barrier that only opens when both have arrived. Run
+    sequentially the first one waits alone and the barrier times out, so this
+    fails loudly rather than silently passing on a fast machine.
+    """
+    barrier = threading.Barrier(2, timeout=10)
+
+    def _gather(_prompt: str, _model: str):
+        barrier.wait()
+        return "notes", [], 10
+
+    notes = gather_research(
+        _brief(),
+        _work_order(),
+        ResearchDependencies(gather=_gather, structure_llm=object()),
+    )
+
+    # The text, not the keys. A timed-out barrier raises inside the worker,
+    # `_gather_one` turns that into an empty hole, and the keys are present
+    # either way -- so asserting on the keys alone would pass sequentially.
+    assert notes["r1"].text == "notes"
+    assert notes["r2"].text == "notes"
+
+
+def test_no_more_searches_run_at_once_than_the_bound_allows():
+    """Grounded-search rate limits are unknown, so the fan-out is bounded."""
+    lock = threading.Lock()
+    live = 0
+    peak = 0
+
+    def _gather(_prompt: str, _model: str):
+        nonlocal live, peak
+        with lock:
+            live += 1
+            peak = max(peak, live)
+        time.sleep(0.02)
+        with lock:
+            live -= 1
+        return "notes", [], 10
+
+    gather_research(
+        _brief(),
+        _wide_work_order(P2B_V4_GATHER_CONCURRENCY + 4),
+        ResearchDependencies(gather=_gather, structure_llm=object()),
+    )
+
+    assert peak <= P2B_V4_GATHER_CONCURRENCY
+    # And it really did fan out, rather than passing by staying sequential.
+    assert peak > 1
+
+
+def test_the_notes_keep_work_order_order_whatever_the_network_does():
+    """The structure prompt is built from these notes.
+
+    Ordering them by whichever search returned first would make the prompt --
+    and so the dossier, and so any diff between two runs -- depend on the
+    weather.
+    """
+    def _gather(prompt: str, _model: str):
+        # The last question comes back first.
+        if "Question 3" in prompt:
+            return "third", [], 10
+        time.sleep(0.05)
+        return "other", [], 10
+
+    notes = gather_research(
+        _brief(),
+        _wide_work_order(3),
+        ResearchDependencies(gather=_gather, structure_llm=object()),
+    )
+
+    assert list(notes) == ["r1", "r2", "r3"]
+
+
+def test_one_search_failing_does_not_take_the_others_down_with_it():
+    """Concurrency must not turn one hole into a dead run."""
+    def _gather(prompt: str, _model: str):
+        if "Question 2" in prompt:
+            raise RuntimeError("no network")
+        return "notes", [], 10
+
+    notes = gather_research(
+        _brief(),
+        _wide_work_order(3),
+        ResearchDependencies(gather=_gather, structure_llm=object()),
+    )
+
+    assert notes["r2"].text == ""
+    assert notes["r1"].text == "notes"
+    assert notes["r3"].text == "notes"
 
 
 def test_a_failed_gather_leaves_a_hole_rather_than_killing_the_run():

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_writing_visibility.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_writing_visibility.py
@@ -139,10 +139,10 @@ def test_asking_for_an_article_that_was_never_written_says_so(run):
         intake_v4.finished_article(run)
 
 
-# --- research, which is ten sequential searches and used to say nothing ------
+# --- research, which is a fan of searches and used to say nothing -----------
 
 
-def test_gathering_reports_which_question_it_is_on():
+def test_gathering_counts_the_searches_that_have_come_back():
     from app.features.prompt2blog.contracts_v4 import (
         ArticleBrief,
         BriefReader,
@@ -189,18 +189,31 @@ def test_gathering_reports_which_question_it_is_on():
 
     gather_research(brief, order, deps, seen.append)
 
-    assert [item["phase"] for item in seen] == ["gathering", "gathering", "structuring"]
+    # One event when the fan goes out, one per search coming back, one for
+    # structuring. `done` counts completions, so it never reports progress the
+    # run has not actually made.
+    assert [item["phase"] for item in seen] == [
+        "gathering",
+        "gathering",
+        "gathering",
+        "structuring",
+    ]
     assert seen[0] == {
         "phase": "gathering",
         "done": 0,
         "total": 2,
-        "current_question": "What do stalls charge?",
+        "last_question_back": "",
     }
-    assert seen[1]["done"] == 1
-    assert seen[1]["current_question"] == "What is it like after dark?"
+    assert [item["done"] for item in seen] == [0, 1, 2, 2]
+    # Which question comes back first is the network's business, so this
+    # asserts the set rather than the order.
+    assert {item["last_question_back"] for item in seen[1:3]} == {
+        "What do stalls charge?",
+        "What is it like after dark?",
+    }
     # Structuring is one call and the longest single wait; it gets its own
     # phase rather than looking like a stall after the last search.
-    assert seen[2]["done"] == seen[2]["total"] == 2
+    assert seen[3]["done"] == seen[3]["total"] == 2
 
 
 def test_a_progress_write_that_fails_does_not_stop_the_research():

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkingScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkingScreen.tsx
@@ -4,10 +4,14 @@ import type { IntakeResearchProgress, IntakeWriting } from '../intake.types'
 /**
  * What is happening, while it happens.
  *
- * Research is ten sequential web searches and writing is a whole article, and
- * both used to leave the page completely silent for as long as they took. A
- * run that looked hung at seven minutes was working; a write that looked dead
- * had already finished. Both facts were on the run the whole time.
+ * Research is a fan of concurrent web searches and writing is a whole article,
+ * and both used to leave the page completely silent for as long as they took.
+ * A run that looked hung at seven minutes was working; a write that looked
+ * dead had already finished. Both facts were on the run the whole time.
+ *
+ * The searches now go out together, so the count is what has come *back*. It
+ * deliberately does not claim to name what is being searched right now:
+ * several are, and picking one to show would be a comforting fiction.
  *
  * The elapsed clock is here because "is this working" is answered by movement,
  * not by a number. The expected duration is here because five minutes of
@@ -40,13 +44,17 @@ export function WorkingScreen({ research, writing }: WorkingScreenProps) {
   const heading = writing
     ? writing.stage_label
     : gathering
-      ? `Searching the web: ${research!.done + 1} of ${research!.total}`
+      ? research!.done === 0
+        ? `Searching the web: ${research!.total} questions at once`
+        : `Searching the web: ${research!.done} of ${research!.total} back`
       : 'Turning the research into records'
 
   const detail = writing
     ? 'The whole article, then a check of every claim against the research. This usually takes five to ten minutes.'
     : gathering
-      ? research!.current_question
+      ? research!.done === 0
+        ? 'They all go out together, so the wait is the slowest single search.'
+        : `Last back: ${research!.last_question_back}`
       : 'One long call. This is the slowest single step in the run.'
 
   const done = research && !writing ? research.done : 0

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -419,27 +419,40 @@ function writing(overrides: Partial<IntakeWriting> = {}): IntakeWriting {
 }
 
 describe('the working screen', () => {
-  it('names the question it is searching, and how far along it is', () => {
+  it('counts the searches that have come back, and names the last one', () => {
     render(
       <WorkingScreen
         research={{
           phase: 'gathering',
           done: 3,
           total: 10,
-          current_question: 'What do the tasting menus charge?',
+          last_question_back: 'What do the tasting menus charge?',
         }}
       />,
     )
 
-    expect(screen.getByText(/searching the web: 4 of 10/i)).toBeInTheDocument()
+    // Three back, not "searching number four": they are all in flight, so a
+    // number that claims to be the current one would be a fiction.
+    expect(screen.getByText(/searching the web: 3 of 10 back/i)).toBeInTheDocument()
     expect(screen.getByText(/what do the tasting menus charge/i)).toBeInTheDocument()
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '3')
+  })
+
+  it('says the searches went out together before any has come back', () => {
+    render(
+      <WorkingScreen
+        research={{ phase: 'gathering', done: 0, total: 7, last_question_back: '' }}
+      />,
+    )
+
+    expect(screen.getByText(/7 questions at once/i)).toBeInTheDocument()
+    expect(screen.getByText(/the slowest single search/i)).toBeInTheDocument()
   })
 
   it('gives structuring its own phase rather than looking like a stall', () => {
     render(
       <WorkingScreen
-        research={{ phase: 'structuring', done: 10, total: 10, current_question: '' }}
+        research={{ phase: 'structuring', done: 10, total: 10, last_question_back: '' }}
       />,
     )
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -126,7 +126,11 @@ export interface IntakeResearchProgress {
   phase: 'gathering' | 'structuring'
   done: number
   total: number
-  current_question: string
+  /**
+   * The last question to come back, not the one being searched: the searches
+   * run concurrently, so there is no single current one.
+   */
+  last_question_back: string
 }
 
 /**

--- a/apps/ai-blog-writer/docs/plans/p2b-v4-issue-phases.md
+++ b/apps/ai-blog-writer/docs/plans/p2b-v4-issue-phases.md
@@ -1,0 +1,212 @@
+# Prompt2Blog v4: the eleven open issues, in phases
+
+Written 2026-09-01, the morning after the handoff. This plan orders issues
+**#440 to #450** into phases and says why each phase sits where it does.
+
+## How this relates to the polish plan
+
+`p2b-v4-polish-plan.md` was written 2026-08-31 and is **mostly delivered**.
+Its phase 1 (sentence rhythm, and `measure_sentence_spread` reporting the
+spread), its phase 2 (the write button disabling, the page following the run,
+per question research progress, a finished article screen) and its phase 5
+(country pinning, omit as a third move at the gate) are all in `main`.
+
+Three of its items survived as issues, and they are carried here rather than
+there:
+
+| Polish plan | Now |
+|---|---|
+| Phase 2e, spend display | #440 — blocked on the accounting being true |
+| Phase 3, delete the title stage | #444 — blocked on the resume suite |
+| Phase 4, the copy out polish prompt | Built as `polish_v4.py`; #443 is about what it says |
+
+Read the polish plan for the reasoning behind the parts already shipped. Read
+this one for what is left.
+
+## The two clusters, and the seven singletons
+
+Eleven issues, and they are **not** eleven separate projects.
+
+- **#441 and #442 are one flaw seen twice.** The app tracks exactly one run,
+  in the browser, and discards the pointer on any failure. One phase.
+- **#440 and #448 are the same business blocker.** You cannot hand this to a
+  stranger without knowing what an article costs. #448 is not a bug at all; it
+  is a written statement of what nobody knows, and it closes by other people
+  using the thing, not by a commit.
+- Everything else is genuinely independent.
+
+## The phases
+
+### Phase 1 — Run the searches at the same time (#450, part one)
+
+Research is 20½ minutes of a ~40 minute run. The whole writing graph is 7.
+`gather_research` loops the work order's requirements one at a time, and
+nothing in question four depends on question three. Concurrency turns roughly
+six minutes into roughly one.
+
+**Same searches, same prompts, same results. No quality change of any kind.**
+This is the only item on the whole list with no downside to weigh, which is
+why it goes first and alone.
+
+Two things the issue flags and this phase must handle:
+
+- The progress callback reports `done: index - 1`, which assumes searches
+  finish in the order they started. It has to **count completions** instead.
+- Grounded search rate limits are unknown. Fan out **bounded**, not all seven
+  at once, and make the bound a named constant so it can be lowered without a
+  code hunt.
+
+Not in this phase: the 14½ minute structuring call, also described in #450.
+That one has a real quality risk (cross question deduplication and conflict
+detection get harder when each call sees only its own slice) and one run is
+not a pattern. **Measure it across several runs before touching it.**
+
+### Phase 2 — Make the receipt true (#440)
+
+Two gaps put a run's receipt wrong by most of its actual cost. Grounded
+search — the grill's seed lookup and every research search — goes out through
+`invoke_google_grounded_text` directly rather than the tracked client, so ten
+searches appear as nothing. And `begin_intake` calls the model before `_record`
+opens the stage, so the grill's own call is filed as `unattributed`.
+
+This is second because three other things sit on it:
+
+- `enforce_run_budget` reads the ledger to decide whether a run may continue.
+  The ceiling is currently guarding a number that omits the most expensive step.
+- The spend display is deliberately unbuilt because it would lie.
+- **Phase 7 must not happen before this.** Adding unbounded searches to the
+  grill while the ceiling ignores searches is the wrong order.
+
+It is also the only phase that speaks to the stated goal. Ghost-writing for
+travelling creators needs a price, and per article cost has never been measured.
+
+### Phase 3 — Stop losing runs (#441 and #442, together)
+
+`useIntake` wipes the remembered run on **any** failure — a timeout, a
+restarting dev server, a momentary fault — and treats that as proof the run is
+gone. On 2026-08-31 the operator left the page exactly as the screen invites
+("You can leave this page. The work carries on."), came back to nothing, and
+the run had completed normally.
+
+Forget a run only on a definitive 404.
+
+Then give the page a way to find a run at all, because today there is none: a
+short list of what is running now and what ran recently, from the `runs` table,
+which already carries `status` and `stage`. A run is now something the operator
+started rather than something that got written (ADR 0031), so runs that never
+reached an article are normal and have to be listed too.
+
+The list is what makes the pointer stop being load bearing, which is why these
+two are one phase and not two.
+
+### Phase 4 — Stop the polish prompt undoing the rhythm fix (#443)
+
+`polish_v4.py` tells a flagship model to vary sentence length and, in the same
+breath, bans em dashes and hyphenated compounds. A model given both has one
+tool left for restructuring: the full stop. Which is the flatness the rhythm
+change just fixed.
+
+The evidence is suggestive rather than proven — a version of the Medellín
+article came back with sentences over 25 words falling from 6 to zero, every
+cut landing on a subordinate clause — and the operator had also been editing by
+hand. But it is the same trap the article rule itself had before `2bd89fb1`.
+
+Prompt only. Say what the anti-AI rules now say: length comes from
+subordination, splitting is the last resort, and a banned dash is not a reason
+to reach for a full stop.
+
+**Judge it with `measure_sentence_spread`, before and after, not by eye.**
+
+### Phase 5 — Let the operator re-ask one question (#446)
+
+At the research gate a question can be answered, marked unpublished, or
+dropped. It cannot be **rewritten**. Run `76b36468` needed exactly that: a
+question about a project in Medellín's Buenos Aires neighbourhood was answered
+about Argentina, and came back marked `supported`, so nothing downstream would
+have caught it.
+
+Dropping it throws away a good question. Answering it by hand means doing the
+research yourself.
+
+This sits after phase 1 on purpose: phase 1 turns the gather loop into
+something that runs a question, which is most of what re-running exactly one
+question needs.
+
+The work order's fingerprint has to be handled — changing a question changes
+the plan the evidence answers.
+
+### Phase 6 — The title stage, and the safety net under it (#444)
+
+The decision is recorded and unchanged: the seed becomes the title, the
+operator edits it, and the AI title stage is **deleted rather than repaired**.
+Partly mitigated already in `7638bcb7`.
+
+It was attempted twice on 2026-08-31 and backed out both times, and the
+blocker is not the graph. `TitleFailsLLM` raises on `invoke_text`, and the
+title stage is the only stage in the graph that calls `invoke_text` at all — so
+it is the only way eight resume tests can simulate a run dying near the end.
+
+Those tests protect money. Resume exists so a run that dies late is not paid
+for twice.
+
+**The work is choosing a new last fallible stage** — the audit is the obvious
+candidate — **and re-deriving what a second leg should re-buy from it.** That
+is a deliberate change to the safety net, not a mechanical rename. It goes late
+because it wants attention, not because it is unimportant.
+
+### Phase 7 — Let the grill look things up again (#447)
+
+The grill researches the seed before its first question and never again. By
+turn four the conversation may have narrowed to one neighbourhood while the
+grill still works from the general city briefing.
+
+That matters because looking things up is what keeps the interview short
+(ADR 0030, rule G2): anything it can find out, it never asks. A grill that
+cannot look up where the conversation went is pushed back into asking, which is
+the form-with-extra-steps failure the interview replaced.
+
+The plumbing exists — the grill already has a `research` dependency separate
+from its `llm`. What is missing is a way to decide mid interview that a lookup
+is needed, and a **budget rule** for doing it.
+
+**Blocked on phase 2**, explicitly.
+
+## Not phases
+
+**#445, the vanishing Keychain token.** Already mitigated: a copy outside the
+repo repairs it on the next run, and it costs nothing today. The cause is
+unknown and the one observation that would separate time based expiry from
+event triggered removal is **when** it goes — relative to a sleep, a restart,
+or the last use. That is a note to make when it next happens, not a task to
+schedule.
+
+**#448, the sample of two.** Not a bug. It closes when somebody who is not the
+owner uses the intake, and when phase 2 produces a cost figure. Keep it open as
+the honest scoreboard.
+
+**#449, one grill three modes.** Design only, nothing built, and the honest
+prerequisite is reading `itineraries_pipeline/` properly — `retrieval.py`,
+`candidate_scoring.py`, `lodging_selection.py`, `day_shells.py`, `ordering.py`,
+behind ADRs 0013 to 0021. Nobody has. That reading is the first real task in
+this thread and it is not a phase in this plan.
+
+## The order, and why
+
+1. **Phase 1** — free, felt on the next run, no risk. Also the groundwork for phase 5.
+2. **Phase 2** — the goal depends on it, the spending ceiling is currently wrong, and it gates phase 7.
+3. **Phase 3** — stops the loss that actually happened to the operator.
+4. **Phase 4** — cheap, but wants a real article to judge it, so it wants phase 1's faster run.
+5. **Phase 5** — builds on phase 1.
+6. **Phase 6** — careful work on the safety net; do it awake.
+7. **Phase 7** — must not precede phase 2.
+
+**One real article between phase 4 and phase 6**, so the polish prompt change is
+judged on its own rather than tangled with a title change.
+
+## The standing rule this plan inherits
+
+From the handoff, and it held again on 2026-09-01 when two more instances were
+found and fixed: **a schema exists so the model knows what to send, not so the
+parser can reject what arrived.** When a stage fails, read the recorded payload
+before theorising. `apps/backend/scripts/replay_dossier.py` replays a recorded
+failure offline in a second, for nothing.


### PR DESCRIPTION
Phase 1 of the new plan (`docs/plans/p2b-v4-issue-phases.md`, added here). Closes the first half of #450.

## The measurement

Run `76b36468`: research was **20½ minutes of a ~40 minute run**. The entire writing graph — outline, compose, repair, groundedness, audit, title, finalize — is **7 minutes combined**. Writing was never the bottleneck.

Inside research, `gather_research` looped the work order's requirements one at a time. Nothing in question four depends on question three; the loop was sequential because that was the simplest thing to write.

**Concurrently, ~6 of those minutes become roughly the slowest single search.** Same prompts, same model, same results — only the waiting changes.

## Bounded, not unbounded

`P2B_V4_GATHER_CONCURRENCY = 4`. Grounded-search rate limits are unknown and the number of questions is set by the work order rather than by us, so the fan-out is capped. Four is a deliberate first guess — enough to collapse most of the wait, small enough that a rate limit shows up as slow rather than a wall of failures. One place to lower it, with a comment saying so.

## Progress had to change with it

It reported `done: index - 1` *before* each search, which assumes searches finish in the order they start. It now:

- fires once when the fan goes out, then **once per search coming back**
- counts **completions**, so it never claims progress the run has not made
- names the last question to come **back**, rather than claiming to name the one being searched now — several are, and picking one would be a fiction

`current_question` is renamed to `last_question_back` so the field does not keep a name that stopped being true. **No compatibility shim** — ADR 0031 made the clean break deliberate.

Screen copy follows: `Searching the web: 3 of 10 back`, and before anything returns, `Searching the web: 7 questions at once`.

## Correctness details

- **Notes are rebuilt in work-order order**, not completion order, so the structure prompt built from them doesn't change shape with the weather.
- **`on_progress` is consumed on the calling thread**, so the stage-row write is never made from a worker and needs no lock.
- **One search failing still leaves a hole rather than killing the run** — now proven with the other searches succeeding beside it.

## The concurrency test has teeth, and that was checked

The first version of it didn't. Two gathers wait on a shared barrier; run sequentially the barrier times out — but `_gather_one` catches that and returns an empty hole, so the keys are present either way and `assert set(notes) == {"r1","r2"}` **passed while sequential**.

It now asserts the notes' *text*. Verified by forcing `P2B_V4_GATHER_CONCURRENCY` to 1 and watching it fail.

The bound test asserts `peak <= 4` **and** `peak > 1`, so it can't pass by quietly staying sequential either.

## Deliberately not in this PR

The **14½ minute structuring call**, also described in #450. Splitting it per question has a real quality risk — cross-question deduplication and conflict detection get harder when each call sees only its own slice, and conflicts across questions are exactly what the evidence contract exists to surface. One run is not a pattern. **Measure across several runs first.**

## Verification

- `pytest apps/backend/tests` — **1110 passed** (was 1106; +4 new)
- `vitest` — **734 passed** (was 733; +1 new)
- `tsc --noEmit` — clean
- `eslint` — 0 errors (1 pre-existing warning, unrelated file)
- `check-boundaries` — passed

Not yet proven on a real run. The next article is what turns the predicted ~5 minutes into a measured one.