### PR TITLE
Count what a run actually spent (#440)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -39,7 +39,7 @@ from app.core.staff_auth import require_staff, staff_user_id
 
 from ..config import P2B_V4_RESEARCH_STRUCTURE_MODEL
 from ..brief_v4 import BriefIncomplete, BriefUnusable
-from ..dependencies import PipelineDependencies
+from ..dependencies import PipelineDependencies, dependencies_for_run
 from ..grill_v4 import (
     GRILL_RESEARCH_MAX_TOKENS,
     GRILL_RESEARCH_MODEL,
@@ -92,41 +92,93 @@ class CutRequest(BaseModel):
     added_questions: list[str] = Field(default_factory=list)
 
 
-def _ground(prompt: str) -> tuple[str, list[str], int | None]:
-    """Look something up on the one path in this app that reaches the web.
+def _grounded_call(
+    prompt: str,
+    *,
+    model_name: str,
+    max_tokens: int,
+    usage_recorder: Any | None,
+) -> tuple[str, list[str], int | None]:
+    """A grounded search, counted.
 
-    Search stays off Claude on purpose: its WebSearch denial is a deliberate
-    security boundary, and research is the most token-hungry step there is --
-    spending Claude's budget reading web pages risks running out during the
-    writing, which is the part that actually needs it.
+    Grounded search is raw REST: it never passes through the LangChain
+    adapters the token ledger watches, so every search a run made was
+    invisible to it. Measured on two real runs, that was 27,207 tokens over
+    eight searches (b78a9fe8) and 31,992 over seven (76b36468), and the
+    receipt for both reported zero. The per-run ceiling reads that same total,
+    so it was guarding a number with the most token-hungry step missing.
+
+    A response that carried no usage block is recorded as a call with no
+    measurement rather than a call that cost nothing: `record` files a `None`
+    usage as unmetered, and both real runs had exactly one search like that.
     """
     from utils import invoke_google_grounded_text
 
     result = invoke_google_grounded_text(
-        f"Brief a travel editor on this in a few dense paragraphs. "
-        f"Facts, reputation, neighbourhoods, what it is known for.\n\n{prompt}",
-        model_name=GRILL_RESEARCH_MODEL,
-        max_tokens=GRILL_RESEARCH_MAX_TOKENS,
+        prompt, model_name=model_name, max_tokens=max_tokens
     )
     if result is None:
+        # The call failed rather than returned nothing. There is no successful
+        # call to record.
         return "", [], None
+    if usage_recorder is not None:
+        counts = {
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "total_tokens": result.total_tokens,
+        }
+        measured = {key: value for key, value in counts.items() if value is not None}
+        try:
+            usage_recorder(
+                str(result.model_name or model_name),
+                measured or None,
+            )
+        except Exception as exc:  # pragma: no cover -- telemetry only
+            logger.warning("Grounded search usage record failed: %s", exc)
     return result.text, list(result.source_urls), result.total_tokens
 
 
-def _gather(prompt: str, model_name: str) -> tuple[str, list[str], int | None]:
-    """One grounded pass, for research rather than for the grill."""
-    from utils import invoke_google_grounded_text
+def _services(run_id: str | None = None) -> IntakeServices:
+    """The intake's dependencies, continuing `run_id`'s ledger where there is one.
 
-    result = invoke_google_grounded_text(
-        prompt, model_name=model_name, max_tokens=GATHER_MAX_TOKENS
+    Built per request. Without the restore each request's tracker held only
+    its own calls, and writing the ledger under one stage name then replaced
+    the run's accounting with that request's slice -- see
+    `dependencies_for_run`.
+    """
+    pipeline = (
+        dependencies_for_run(run_id) if run_id else PipelineDependencies()
     )
-    if result is None:
-        return "", [], None
-    return result.text, list(result.source_urls), result.total_tokens
+    record_usage = getattr(
+        getattr(pipeline.llm, "usage_tracker", None), "record", None
+    )
 
+    def _ground(prompt: str) -> tuple[str, list[str], int | None]:
+        """Look something up on the one path in this app that reaches the web.
 
-def _services() -> IntakeServices:
-    pipeline = PipelineDependencies()
+        Search stays off Claude on purpose: its WebSearch denial is a
+        deliberate security boundary, and research is the most token-hungry
+        step there is -- spending Claude's budget reading web pages risks
+        running out during the writing, which is the part that actually needs
+        it.
+        """
+        return _grounded_call(
+            f"Brief a travel editor on this in a few dense paragraphs. "
+            f"Facts, reputation, neighbourhoods, what it is known for.\n\n{prompt}",
+            model_name=GRILL_RESEARCH_MODEL,
+            max_tokens=GRILL_RESEARCH_MAX_TOKENS,
+            usage_recorder=record_usage,
+        )
+
+    def _gather(prompt: str, model_name: str) -> tuple[str, list[str], int | None]:
+        """One grounded pass, for research rather than for the grill."""
+        return _grounded_call(
+            prompt,
+            model_name=model_name,
+            max_tokens=GATHER_MAX_TOKENS,
+            usage_recorder=record_usage,
+        )
+
     return IntakeServices(
         dependencies=GrillDependencies(llm=pipeline.llm, research=_ground),
         recorder=pipeline.recorder,
@@ -278,27 +330,27 @@ def read_intake(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
 def answer_question(
     run_id: str, request: AnswerRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
-    _handle(answer_intake, run_id, request.answer, _services())
+    _handle(answer_intake, run_id, request.answer, _services(run_id))
     return JSONResponse(intake_state(run_id))
 
 
 @router.post("/{run_id}/reopen")
 def reopen(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     """Go back into the grill. The single exit from every dead end."""
-    _handle(reopen_intake, run_id, _services())
+    _handle(reopen_intake, run_id, _services(run_id))
     return JSONResponse(intake_state(run_id))
 
 
 @router.post("/{run_id}/brief")
 def build_the_brief(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     """Turn an agreed grill into the brief the run answers to."""
-    _handle(approve_brief, run_id, _services())
+    _handle(approve_brief, run_id, _services(run_id))
     return JSONResponse(intake_state(run_id))
 
 
 @router.post("/{run_id}/work-order")
 def plan_the_research(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
-    _handle(plan_research, run_id, _services())
+    _handle(plan_research, run_id, _services(run_id))
     return JSONResponse(intake_state(run_id))
 
 
@@ -314,7 +366,7 @@ def cut_the_work_order(
     outcome = _handle(
         apply_cut,
         run_id,
-        _services(),
+        _services(run_id),
         struck_ids=request.struck_ids,
         added_questions=request.added_questions,
     )
@@ -329,7 +381,7 @@ def do_the_research(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     not an error. The page reads `research.coverage` to see whether it may go
     on, and what is missing if not.
     """
-    _handle(do_research, run_id, _services())
+    _handle(do_research, run_id, _services(run_id))
     return JSONResponse(intake_state(run_id))
 
 
@@ -377,7 +429,7 @@ def settle_the_gate(
     _handle(
         settle_gate,
         run_id,
-        _services(),
+        _services(run_id),
         requirement_id=request.requirement_id,
         answer=request.answer,
         source_url=request.source_url,
@@ -417,7 +469,7 @@ def mark_venue(
     _handle(
         settle_venue,
         run_id,
-        _services(),
+        _services(run_id),
         claim_id=request.claim_id,
         drop=request.drop,
         note=request.note,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -101,6 +101,20 @@ P2B_REPAIR_ESTIMATED_TOKENS = 90_000
 # an unusually expensive run stops paying for rescue attempts instead of
 # doubling down. Set above the Lima run's pre-repair spend (~158k) on purpose:
 # the first repair on a normal run must still be affordable.
+#
+# CAVEAT, 2026-09-01: both this number and P2B_REPAIR_ESTIMATED_TOKENS were
+# derived from the Lima run's receipt, and that receipt omitted every grounded
+# search and the whole of intake. Now that those are counted, the same run
+# measures higher against an unchanged threshold. Run b78a9fe8's pre-repair
+# spend was 113,413 by the old count and 140,620 once its searches are
+# included, before the grill, brief, work order and structuring calls are
+# added -- against a refusal line of 320,000 - 90,000 = 230,000.
+#
+# So a run that would have been granted its one repair may now be refused it.
+# Deliberately NOT retuned here: the right number comes from a real run
+# measured with the accounting fixed, not from a guess layered on a guess.
+# Re-derive both after the next article. The hard ceiling below has ample
+# headroom either way and is not affected.
 P2B_RUN_TOKEN_BUDGET = 320_000
 
 # The hard ceiling. Distinct from P2B_RUN_TOKEN_BUDGET above, which only asks

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
@@ -4,14 +4,15 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, Protocol
 
-from app.core import get_article_type_by_id
+from app.core import get_article_type_by_id, read_stage_result
 from app.shared.text import normalize_dashes
 from app.shared.writer_models import resolve_writer_model
 
 from . import llm
 from .options import _read_article_type_markdown
 from .pricing import Prompt2BlogTokenUsageTracker
-from .run_recorder import RunRecorder
+from .run_recorder import USAGE_LEDGER_STAGE, RunRecorder
+from .support import _safe_dict
 
 
 class Prompt2BlogLLM(Protocol):
@@ -104,3 +105,26 @@ class PipelineDependencies:
             "recorder",
             replace(self.recorder, usage_tracker=tracker),
         )
+
+
+def dependencies_for_run(run_id: str) -> PipelineDependencies:
+    """Dependencies whose token tracker continues this run's existing ledger.
+
+    Every leg of a run -- each intake request, then the writing graph -- used
+    to build a fresh tracker, and `_write_usage_ledger` writes whatever that
+    tracker holds under one stage name. So each leg did not extend the ledger,
+    it **replaced** it, and the run's receipt ended up being whatever the last
+    leg happened to spend.
+
+    Measured on run b78a9fe8: the final ledger held eight calls, all of them
+    writing-graph stages, and reported 166,027 tokens. The grill, the brief,
+    the work order and the research structuring call had all been written to
+    that row earlier in the run and were gone by the end.
+
+    Restoring first makes the ledger's own promise -- "every rewrite is a
+    superset of the one before it" -- true for ordinary runs rather than only
+    for resumed ones.
+    """
+    stored = _safe_dict(_safe_dict(read_stage_result(run_id, USAGE_LEDGER_STAGE)).get("data"))
+    tracker = Prompt2BlogTokenUsageTracker.from_ledger(stored)
+    return PipelineDependencies(llm=DefaultPrompt2BlogLLM(usage_tracker=tracker))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -126,11 +126,25 @@ def _run_tokens_spent(run_id: str) -> int | None:
     return total if isinstance(total, int) else None
 
 
+def _open(services: IntakeServices, run_id: str, stage: str) -> None:
+    """Open the stage before the model call it is going to pay for.
+
+    Usage is attributed to whichever stage was open when the call was made.
+    Every intake stage used to call the model first and open the stage after,
+    so the call landed under `unattributed` and the stage row reported zero.
+    Run cac73671 recorded exactly that: one call, 2,196 tokens, stage
+    `unattributed`, beside a `stage_v4_grill` row claiming nothing was spent.
+    """
+    services.recorder.start_stage(run_id, stage)
+
+
 def _record(services: IntakeServices, run_id: str, stage: str, payload: dict[str, Any]) -> None:
     # start_stage opens a fresh usage attempt, which is what keeps a repeated
     # stage -- and the grill repeats by design -- from overwriting its own
-    # receipt in the ledger.
-    services.recorder.start_stage(run_id, stage)
+    # receipt in the ledger. `_once` because `_open` has usually opened it
+    # already; opening again here would file the row under an attempt the
+    # call was not recorded against.
+    services.recorder.start_stage_once(run_id, stage)
     services.recorder.record_stage(run_id, stage, payload)
 
 
@@ -178,6 +192,7 @@ def begin_intake(
 
     run_id = str(uuid4())
     services.recorder.queue(run_id, owner_staff_id)
+    _open(services, run_id, GRILL_STAGE)
     logger.info("Prompt2Blog intake opened", extra={"run_id": run_id, "feature": FEATURE_NAME})
     try:
         return _write_grill(
@@ -200,6 +215,7 @@ def answer_intake(run_id: str, answer: str, services: IntakeServices) -> GrillSt
     """Record what the operator typed and take the next turn."""
     enforce_run_budget(_run_tokens_spent(run_id), stage=GRILL_STAGE)
     state = _load_grill(run_id)
+    _open(services, run_id, GRILL_STAGE)
     return _write_grill(services, answer_grill(state, answer, services.dependencies))
 
 
@@ -213,6 +229,7 @@ def reopen_intake(run_id: str, services: IntakeServices) -> GrillState:
     """
     enforce_run_budget(_run_tokens_spent(run_id), stage=GRILL_STAGE)
     state = _load_grill(run_id)
+    _open(services, run_id, GRILL_STAGE)
     reopened = reopen_grill(state, services.dependencies)
 
     for stage in (BRIEF_STAGE, WORK_ORDER_STAGE, RESEARCH_STAGE, NOTES_STAGE):
@@ -226,6 +243,7 @@ def approve_brief(run_id: str, services: IntakeServices) -> ArticleBrief:
     """Turn an agreed grill into the brief the run answers to."""
     enforce_run_budget(_run_tokens_spent(run_id), stage=BRIEF_STAGE)
     try:
+        _open(services, run_id, BRIEF_STAGE)
         brief = build_brief(_load_grill(run_id), services.dependencies)
     except BriefUnusable as error:
         _record(
@@ -268,6 +286,7 @@ def plan_research(run_id: str, services: IntakeServices) -> Prompt2BlogWorkOrder
     """Translate the approved brief into checkable questions."""
     enforce_run_budget(_run_tokens_spent(run_id), stage=WORK_ORDER_STAGE)
     try:
+        _open(services, run_id, WORK_ORDER_STAGE)
         work_order = build_work_order(load_brief(run_id), services.dependencies)
     except WorkOrderUnusable as error:
         _record(
@@ -355,6 +374,7 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
 
     notes = notes_from_record(_stage_data(run_id, NOTES_STAGE), work_order)
     if notes is None:
+        _open(services, run_id, NOTES_STAGE)
         notes = gather_research(
             brief, work_order, services.research, record_progress
         )
@@ -370,6 +390,7 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
     record_progress({"phase": "structuring", "done": len(notes), "total": len(notes),
                      "last_question_back": ""})
     try:
+        _open(services, run_id, RESEARCH_STAGE)
         evidence = structure_research(work_order, notes, services.research)
     except ResearchUnusable as error:
         # The most expensive step in intake. A failure here that leaves nothing

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/orchestrator_v3.py
@@ -27,7 +27,11 @@ from .config import (
     PROMPT2BLOG_CREATIVITY_TEMPERATURES,
     PROMPT2BLOG_DEFAULT_COMPOSE_TEMPERATURE,
 )
-from .dependencies import DefaultPrompt2BlogLLM, PipelineDependencies
+from .dependencies import (
+    DefaultPrompt2BlogLLM,
+    PipelineDependencies,
+    dependencies_for_run,
+)
 from .graph.runner import GraphNode, run_prompt2blog_stage_graph
 from .graph.state import Prompt2BlogV3GraphState
 from .run_budget import enforce_run_budget
@@ -251,7 +255,11 @@ def run_pipeline_v3(
     request: PipelineV4RuntimeRequest,
     dependencies: PipelineDependencies | None = None,
 ) -> Prompt2BlogV3GraphState:
-    dependencies = dependencies or PipelineDependencies()
+    # Continues intake's ledger rather than starting a new one. A fresh
+    # tracker here overwrote the grill, brief, work order and research spend
+    # with the graph's own, which is why every finished run reported only its
+    # writing half.
+    dependencies = dependencies or dependencies_for_run(run_id)
     return _execute_v3_graph(
         run_id=run_id,
         request=request,
@@ -270,8 +278,7 @@ def _resume_dependencies(run_id: str) -> PipelineDependencies:
     spent. The ledger the earlier legs wrote is the run's accounting, so the
     resumed leg starts from it.
     """
-    tracker = Prompt2BlogTokenUsageTracker.from_ledger(stored_ledger(run_id))
-    return PipelineDependencies(llm=DefaultPrompt2BlogLLM(usage_tracker=tracker))
+    return dependencies_for_run(run_id)
 
 
 def _record_resume_attempt(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -248,6 +249,9 @@ class Prompt2BlogTokenUsageTracker:
     stage_attempts: dict[str, int] = field(default_factory=dict)
     current_stage: str | None = None
     current_attempt: int = 0
+    _lock: Any = field(
+        default_factory=threading.Lock, compare=False, repr=False
+    )
 
     @classmethod
     def from_ledger(cls, ledger: Any) -> "Prompt2BlogTokenUsageTracker":
@@ -370,6 +374,19 @@ class Prompt2BlogTokenUsageTracker:
         }
 
     def record(self, model_name: str, raw_usage: Any) -> None:
+        """Append one successful call. Safe to call from several threads.
+
+        Research runs its grounded searches concurrently, and each of them
+        records here from a worker thread. Every mutation below is a
+        read-modify-write -- the two counters, the `by_model` totals, and an
+        append to `calls` whose `seq` comes from the list's own length -- so
+        two interleaving calls would lose a call or hand two of them the same
+        sequence number.
+        """
+        with self._lock:
+            self._record_call(model_name, raw_usage)
+
+    def _record_call(self, model_name: str, raw_usage: Any) -> None:
         self.successful_calls += 1
         usage = normalize_token_usage(raw_usage)
         stage = self.current_stage or UNATTRIBUTED_STAGE

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/run_recorder.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/run_recorder.py
@@ -145,6 +145,22 @@ class RunRecorder:
             feature=FEATURE_NAME,
         )
 
+    def start_stage_once(self, run_id: str, stage: str) -> None:
+        """Open `stage` unless this recorder already has it open for the run.
+
+        The intake opens a stage *before* its model call, so the call is filed
+        under that stage rather than under `unattributed`, and then records the
+        row when the call comes back. Recording must not open a second attempt:
+        the row would then report an attempt the call was not filed under, and
+        say the stage cost nothing.
+
+        `start_stage` keeps its unconditional meaning, because the writing
+        graph relies on a repeated stage opening a fresh numbered attempt.
+        """
+        if self.active_stages.get(run_id) == stage:
+            return
+        self.start_stage(run_id, stage)
+
     def record_stage(self, run_id: str, stage: str, data: dict[str, Any]) -> None:
         stage_usage = self._stage_usage(run_id, stage)
         if stage_usage is not None:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
@@ -111,7 +111,9 @@ def scripted(monkeypatch):
         monkeypatch.setattr(
             intake_api,
             "_services",
-            lambda: IntakeServices(
+            # `run_id` is optional: the route passes it so the real services
+            # can continue that run's ledger. This double has no ledger.
+            lambda run_id=None: IntakeServices(
                 dependencies=GrillDependencies(
                     llm=llm, research=lambda _s: ("Lima has a food reputation.", [], 900)
                 ),

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_usage_accounting.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_usage_accounting.py
@@ -1,0 +1,269 @@
+"""What a run actually cost, and the four ways it used not to say so.
+
+Measured on real runs before any of this was written:
+
+- run `cac73671` recorded one call, 2,196 tokens, under stage `unattributed`,
+  beside a `stage_v4_grill` row claiming it had spent nothing;
+- run `b78a9fe8` finished with a ledger holding eight calls, every one of them
+  a writing-graph stage. The grill, brief, work order and research structuring
+  calls had all been written to that row earlier in the run and were gone;
+- the same run's eight grounded searches cost 27,207 tokens (one of them
+  reporting nothing at all), and the ledger counted none of them. Run
+  `76b36468` was 31,992 over seven searches, likewise counted as zero.
+
+The per-run ceiling reads that same total, so it was guarding a number missing
+most of the run. These tests are what stop each of those coming back.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from app.features.prompt2blog.api import intake as intake_api
+from app.features.prompt2blog.pricing import (
+    UNATTRIBUTED_STAGE,
+    Prompt2BlogTokenUsageTracker,
+)
+from app.features.prompt2blog.run_recorder import RunRecorder
+
+
+class _Result:
+    """A grounded search response, as `invoke_google_grounded_text` returns it."""
+
+    def __init__(
+        self,
+        *,
+        input_tokens: int | None = 100,
+        output_tokens: int | None = 50,
+        total_tokens: int | None = 150,
+        model_name: str = "gemini-3.7-flash",
+    ) -> None:
+        self.text = "What the search found."
+        self.source_urls = ["https://example.pe/a"]
+        self.model_name = model_name
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.total_tokens = total_tokens
+
+
+def _grounded(monkeypatch, result: Any) -> Prompt2BlogTokenUsageTracker:
+    """Run one grounded call against `result` and hand back the tracker."""
+    import utils
+
+    monkeypatch.setattr(
+        utils, "invoke_google_grounded_text", lambda *_a, **_k: result
+    )
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.begin_stage("stage_v4_research_notes")
+    intake_api._grounded_call(
+        "What do the stalls charge?",
+        model_name="gemini-3.7-flash",
+        max_tokens=4_000,
+        usage_recorder=tracker.record,
+    )
+    return tracker
+
+
+# --- the searches are counted ---------------------------------------------
+
+
+def test_a_grounded_search_reaches_the_ledger(monkeypatch):
+    """Grounded search is raw REST and never passed the adapters the ledger
+    watches, so ten searches a run appeared on the receipt as nothing."""
+    tracker = _grounded(monkeypatch, _Result())
+
+    assert tracker.totals()["total_tokens"] == 150
+    rows = {row["stage"]: row for row in tracker.ledger()["by_stage"]}
+    assert rows["stage_v4_research_notes"]["calls"] == 1
+
+
+def test_a_search_that_reported_nothing_is_unknown_rather_than_free(monkeypatch):
+    """One search in each of the two real runs came back with no usage block.
+
+    Recording it as zero would say the search was free. It was not; we were
+    not told what it cost, and the ledger has to keep those apart.
+    """
+    tracker = _grounded(
+        monkeypatch,
+        _Result(input_tokens=None, output_tokens=None, total_tokens=None),
+    )
+
+    ledger = tracker.ledger()
+    assert ledger["successful_calls"] == 1
+    assert ledger["unmetered_calls"] == 1
+    assert ledger["totals"]["total_tokens"] == 0
+
+
+def test_a_failed_search_is_not_recorded_as_a_call(monkeypatch):
+    """`None` means the call failed, not that it succeeded and cost nothing."""
+    tracker = _grounded(monkeypatch, None)
+
+    assert tracker.ledger()["successful_calls"] == 0
+
+
+# --- the call is filed under the stage that paid for it --------------------
+
+
+def test_a_call_made_before_its_stage_opens_is_unattributed():
+    """The failure this exists to stop, stated as the behaviour it depends on."""
+    tracker = Prompt2BlogTokenUsageTracker()
+
+    tracker.record("gemini-3.1-pro-preview", {"input_tokens": 1_121, "output_tokens": 1_075})
+    tracker.begin_stage("stage_v4_grill")
+
+    rows = {row["stage"]: row for row in tracker.ledger()["by_stage"]}
+    assert rows[UNATTRIBUTED_STAGE]["total_tokens"] == 2_196
+    assert rows["stage_v4_grill"]["total_tokens"] == 0
+
+
+def test_opening_the_stage_first_puts_the_spend_on_its_row():
+    tracker = Prompt2BlogTokenUsageTracker()
+
+    tracker.begin_stage("stage_v4_grill")
+    tracker.record("gemini-3.1-pro-preview", {"input_tokens": 1_121, "output_tokens": 1_075})
+
+    rows = {row["stage"]: row for row in tracker.ledger()["by_stage"]}
+    assert rows["stage_v4_grill"]["total_tokens"] == 2_196
+    assert UNATTRIBUTED_STAGE not in rows
+
+
+def test_recording_does_not_open_a_second_attempt_over_the_call():
+    """`_record` runs after the stage is already open.
+
+    Opening again would number a fresh attempt, and the stage row would then
+    report that attempt -- which the call was not filed under -- as zero.
+    """
+    written: list[tuple[str, dict[str, Any]]] = []
+    tracker = Prompt2BlogTokenUsageTracker()
+    recorder = RunRecorder(
+        status_writer=lambda *_a, **_k: None,
+        stage_writer=lambda _run, stage, payload: written.append((stage, payload)),
+        artifact_writer=lambda *_a, **_k: None,
+        clock=lambda: "2026-09-01T00:00:00Z",
+        usage_tracker=tracker,
+    )
+
+    recorder.start_stage("run-1", "stage_v4_grill")
+    tracker.record("gemini-3.1-pro-preview", {"input_tokens": 1_121, "output_tokens": 1_075})
+    recorder.start_stage_once("run-1", "stage_v4_grill")
+    recorder.record_stage("run-1", "stage_v4_grill", {"status": "ok"})
+
+    row = next(payload for stage, payload in written if stage == "stage_v4_grill")
+    assert row["data"]["stage_usage"]["total_tokens"] == 2_196
+    assert row["data"]["stage_attempt"] == 1
+
+
+def test_start_stage_still_opens_a_fresh_attempt_when_a_stage_repeats():
+    """The writing graph depends on this; `_once` must not have changed it."""
+    tracker = Prompt2BlogTokenUsageTracker()
+    recorder = RunRecorder(
+        status_writer=lambda *_a, **_k: None,
+        stage_writer=lambda *_a, **_k: None,
+        artifact_writer=lambda *_a, **_k: None,
+        clock=lambda: "2026-09-01T00:00:00Z",
+        usage_tracker=tracker,
+    )
+
+    recorder.start_stage("run-1", "stage_v3_quality_audit")
+    recorder.start_stage("run-1", "stage_v3_quality_audit")
+
+    assert recorder.active_attempts["run-1"] == 2
+
+
+# --- the ledger continues instead of being replaced ------------------------
+
+
+def test_a_new_leg_continues_the_stored_ledger(monkeypatch):
+    """Every leg wrote its own tracker's ledger under one stage name.
+
+    So each leg replaced the run's accounting rather than extending it, and a
+    finished run reported only whatever the last leg spent.
+    """
+    from app.features.prompt2blog import dependencies as deps_module
+
+    first = Prompt2BlogTokenUsageTracker()
+    first.begin_stage("stage_v4_grill")
+    first.record("gemini-3.1-pro-preview", {"input_tokens": 1_121, "output_tokens": 1_075})
+    stored = {"data": first.ledger()}
+
+    monkeypatch.setattr(deps_module, "read_stage_result", lambda *_a, **_k: stored)
+
+    pipeline = deps_module.dependencies_for_run("run-1")
+    tracker = pipeline.llm.usage_tracker
+    tracker.begin_stage("stage_v3_outline")
+    tracker.record("claude-sonnet-5", {"input_tokens": 20_000, "output_tokens": 3_000})
+
+    rows = {row["stage"]: row for row in tracker.ledger()["by_stage"]}
+    assert rows["stage_v4_grill"]["total_tokens"] == 2_196
+    assert rows["stage_v3_outline"]["total_tokens"] == 23_000
+    assert tracker.totals()["total_tokens"] == 25_196
+
+
+def test_a_run_with_no_stored_ledger_starts_empty(monkeypatch):
+    """A first leg has nothing to continue, and must not invent anything."""
+    from app.features.prompt2blog import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module, "read_stage_result", lambda *_a, **_k: None)
+
+    tracker = deps_module.dependencies_for_run("run-1").llm.usage_tracker
+
+    assert tracker.ledger()["successful_calls"] == 0
+
+
+# --- concurrent searches do not lose calls ---------------------------------
+
+
+def test_recording_is_mutually_exclusive():
+    """Research runs its searches concurrently, so this is written in parallel.
+
+    Every mutation in `record` is a read-modify-write, including the `seq`
+    taken from the length of `calls`. Two interleaving calls would drop one or
+    give two of them the same sequence number.
+
+    This asserts the lock's actual guarantee rather than trying to observe the
+    race, because on a GIL build the race almost never shows: an unlocked
+    version of this passed 400 concurrent records with every sequence number
+    intact. What can be proven is that two threads are never inside the
+    critical section at once, and that fails immediately without the lock.
+    """
+    tracker = Prompt2BlogTokenUsageTracker()
+    tracker.begin_stage("stage_v4_research_notes")
+
+    inside = 0
+    peak = 0
+    seen = threading.Lock()
+    real = tracker._record_call
+
+    def _watched(model_name, raw_usage):
+        nonlocal inside, peak
+        with seen:
+            inside += 1
+            peak = max(peak, inside)
+        # Wide enough that an unserialised caller is certain to overlap.
+        time.sleep(0.001)
+        real(model_name, raw_usage)
+        with seen:
+            inside -= 1
+
+    tracker._record_call = _watched
+    start = threading.Barrier(8)
+
+    def _record() -> None:
+        start.wait()
+        for _ in range(10):
+            tracker.record("gemini-3.7-flash", {"input_tokens": 10, "output_tokens": 5})
+
+    threads = [threading.Thread(target=_record) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert peak == 1
+
+    ledger = tracker.ledger()
+    assert ledger["successful_calls"] == 80
+    assert len({call["seq"] for call in ledger["calls"]}) == 80
+    assert ledger["totals"]["total_tokens"] == 80 * 15


### PR DESCRIPTION
Phase 2 of `docs/plans/p2b-v4-issue-phases.md`. Closes the buildable part of #440.

## #440 describes two gaps. Reading the real database found a third, and it is the one that erased everything.

### 1. The ledger was replaced, not extended

Every leg of a run — each intake HTTP request, then the writing graph — built a **fresh** tracker, and `_write_usage_ledger` writes whatever that tracker holds under one stage name. So each leg **overwrote** the run's accounting with its own slice.

Run `b78a9fe8` finished reporting **166,027 tokens over eight calls, every one of them a writing-graph stage**:

```
stage_v3_groundedness  69,743      stage_v3_quality_audit  13,837
stage_v3_outline       25,899      stage_v3_repair         10,377
stage_v3_compose       28,720      stage_v3_title          17,395
```

The grill, brief, work order and research structuring calls had all been written to that row earlier in the run and were gone by the end.

The comment on `USAGE_LEDGER_STAGE` promised *"every rewrite is a superset of the one before it."* That was true only on the **resume** path — the only path that restored the stored ledger first. Being the only thing that did it is what hid the bug.

`dependencies_for_run` now does that restore, and both the intake routes and the graph's first leg use it. `_resume_dependencies` becomes a call to it.

### 2. Grounded search was unmetered

It's raw REST and never passes the adapters the ledger watches. `GroundedGenerationResult` has carried `input_tokens`/`output_tokens`/`total_tokens` since it was written, with a docstring saying exactly why — *"a per-run ceiling that cannot see the most expensive stage is not a ceiling"* — and **nothing ever read them.**

Measured from the notes rows, which did keep the counts:

| run | searches | tokens | on the receipt |
|---|---|---|---|
| `b78a9fe8` | 8 | **27,207** | 0 |
| `76b36468` | 7 | **31,992** | 0 |

A response with no usage block is recorded as a call with **no measurement**, not a free one. Both runs had exactly one such search.

### 3. Calls landed under `unattributed`

Every intake stage called the model first and opened its stage after; usage is attributed to whichever stage was open. Run `cac73671`:

```
unattributed      2,196 tokens   1 call
stage_v4_grill        0 tokens   0 calls
```

**Zero, not unknown** — the worse of the two lies. `_open` now opens the stage before the call at all six intake sites, and `_record` uses `start_stage_once` so recording doesn't number a second attempt over a call filed under the first. `start_stage` keeps its unconditional meaning; the writing graph relies on a repeated stage opening a fresh attempt, and there's a test pinning that.

### 4. The tracker is now written from several threads

Parallel research ([#454](https://github.com/Questurian/questurian/pull/454), merged) means `record` is called from worker threads. Every mutation in it is a read-modify-write, including the `seq` taken from the length of `calls`.

A lock — and a test that asserts **mutual exclusion** rather than trying to observe the race. An unlocked version passed 400 concurrent records with every sequence number intact on this GIL build, so a test watching for lost calls would have proven nothing. Watching the critical section fails immediately without the lock: peak concurrency **8** instead of **1**.

## What I deliberately did not change

**The thresholds.** `P2B_RUN_TOKEN_BUDGET` and `P2B_REPAIR_ESTIMATED_TOKENS` were both derived from a receipt that omitted the searches and the whole of intake. Now that those count, the same run measures higher against an unchanged line:

- `b78a9fe8` pre-repair spend: **113,413** by the old count → **140,620** with its searches alone, before any intake model call is added
- repair is refused above **230,000** (`320,000 − 90,000`)

**So a run that would have been granted its one repair may now be refused it.** That is a real behaviour change and it is why I have not retuned the number: the right figure comes from a real run measured with the accounting fixed, not a guess layered on a guess. The caveat is recorded beside the constant. The hard ceiling (650,000) has ample headroom and is unaffected.

**The spend display.** Blocked on this being true; it should not be built until a real run confirms the receipt adds up.

## Verification

- `pytest apps/backend/tests` — **1120 passed** (was 1110; +10 new in `test_prompt2blog_usage_accounting.py`)
- `vitest` — 734 passed · `tsc` clean · `eslint` 0 errors · `check-boundaries` passed

The numbers above are read off the real `data/pipeline.db`, not estimated. What is **not** proven is the total for a whole run with all four fixes in — that needs the next real article.