### PR TITLE
Stop losing runs (#441, #442)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -14,8 +14,22 @@
     {
       "name": "dev",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
       "port": 3000
+    },
+    {
+      "name": "abw-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--filter",
+        "@questurian/ai-blog-writer",
+        "run",
+        "dev"
+      ],
+      "port": 3003
     }
   ]
 }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -60,6 +60,7 @@ from ..intake_v4 import (
     polish_prompt,
     intake_state,
     plan_research,
+    recent_runs,
     reopen_intake,
     settle_gate,
     settle_venue,
@@ -318,6 +319,17 @@ def open_intake(
         owner_staff_id=staff_user_id(staff_user),
     )
     return JSONResponse(intake_state(state.run_id), status_code=201)
+
+
+@router.get("/runs")
+def list_runs(limit: int = 15, _staff=Depends(require_staff)) -> JSONResponse:
+    """The runs the operator can go back to.
+
+    Declared above `/{run_id}` because FastAPI matches in declaration order and
+    a path parameter would otherwise swallow the literal "runs" and try to read
+    a run by that name.
+    """
+    return JSONResponse({"runs": recent_runs(limit)})
 
 
 @router.get("/{run_id}")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -25,7 +25,7 @@ from uuid import uuid4
 
 from pydantic import ValidationError
 
-from app.core import read_stage_result, read_status
+from app.core import get_all_runs, read_stage_result, read_status
 
 from .graph.topology_v3 import V3_NODE_STAGE_NAMES
 
@@ -626,6 +626,21 @@ WRITING_STAGE_LABELS = {
     "complete": "Done",
 }
 
+# The same, for the stages the operator owns. A run begins at the seed
+# (ADR 0031), so a run that never reached the graph is an ordinary run and has
+# to be nameable in a list beside the ones that did.
+INTAKE_STAGE_LABELS = {
+    "queued": "Getting ready",
+    GRILL_STAGE: "In the grill",
+    BRIEF_STAGE: "Brief written",
+    WORK_ORDER_STAGE: "Research planned",
+    NOTES_STAGE: "Searching the web",
+    RESEARCH_STAGE: "Research done",
+}
+
+RUN_STAGE_LABELS = {**INTAKE_STAGE_LABELS, **WRITING_STAGE_LABELS}
+
+
 # The stages that mean the graph is running or has finished. Everything else on
 # a run row -- every `stage_v4_*` intake stage, and `queued` -- belongs to the
 # operator, not the writer.
@@ -636,6 +651,47 @@ WRITING_STAGE_LABELS = {
 # screens in the middle of a write, which is the same class of bug this set
 # exists to fix.
 GRAPH_STAGES = frozenset(V3_NODE_STAGE_NAMES.values()) | {"complete"}
+
+
+def recent_runs(limit: int = 15) -> list[dict[str, Any]]:
+    """The runs this operator could go back to, newest first.
+
+    The page tracked exactly one run, in `localStorage`. Lose that pointer or
+    start a second article and every earlier run became unreachable from the
+    interface, even though all of it was on the server -- on 2026-08-31 the
+    only way back to a live run was a `?run=<uuid>` URL produced by querying
+    the database by hand.
+
+    Every long step invites the operator to leave the page. That is only safe
+    if leaving does not depend on one browser's memory surviving.
+
+    Runs that never reached an article are listed too. A run is created when
+    the seed is typed (ADR 0031), so one that stopped in the grill is an
+    ordinary run rather than a failure to hide.
+
+    The seed comes from the grill row rather than the run row, which is one
+    extra read per run. Bounded by `limit` and local, and a run without a
+    recognisable name is a list nobody can use.
+    """
+    rows = get_all_runs(FEATURE_NAME)[:max(0, limit)]
+    runs: list[dict[str, Any]] = []
+    for row in rows:
+        run_id = _safe_str(_safe_dict(row).get("run_id"))
+        if not run_id:
+            continue
+        stage = _safe_str(row.get("stage"))
+        grill = _stage_data(run_id, GRILL_STAGE)
+        runs.append(
+            {
+                "run_id": run_id,
+                "seed": _safe_str(grill.get("seed")),
+                "status": _safe_str(row.get("status")),
+                "stage": stage,
+                "stage_label": RUN_STAGE_LABELS.get(stage, stage),
+                "updated_at": _safe_str(row.get("updated_at")),
+            }
+        )
+    return runs
 
 
 def writing_state(run_id: str) -> dict[str, Any] | None:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
@@ -297,3 +297,43 @@ def test_the_intake_routes_are_actually_mounted():
         "/prompt2blog/intake/{run_id}/research",
         "/prompt2blog/intake/{run_id}/write",
     } <= paths
+
+
+# --- the way back to a run -------------------------------------------------
+
+
+def test_the_runs_route_lists_what_can_be_picked_back_up(isolated_db, scripted):
+    """The page tracked one run in `localStorage` and nothing else was reachable.
+
+    On 2026-08-31 the only way back to a live run was a `?run=<uuid>` URL
+    produced by querying the database by hand.
+    """
+    scripted([QUESTION])
+    run_id = _json(
+        intake_api.open_intake(intake_api.SeedRequest(seed=SEED), staff_user={"id": 1})
+    )["run_id"]
+
+    runs = _json(intake_api.list_runs(_staff={"id": 1}))["runs"]
+
+    assert [item["run_id"] for item in runs] == [run_id]
+    # The seed is what makes a run recognisable; a uuid is not.
+    assert runs[0]["seed"] == SEED
+    # Named in words, intake stages included -- a run that stopped in the grill
+    # is an ordinary run (ADR 0031), not a failure to hide.
+    assert runs[0]["stage_label"] == "In the grill"
+
+
+def test_the_runs_route_is_declared_before_the_run_id_route():
+    """FastAPI matches in declaration order.
+
+    Declared after `/{run_id}` the literal "runs" is read as a run id and the
+    list comes back as an empty intake state for a run that does not exist.
+    Calling the handler directly cannot catch that, so this reads the router.
+    """
+    paths = [
+        route.path
+        for route in intake_api.router.routes
+        if "GET" in getattr(route, "methods", set())
+    ]
+
+    assert paths.index("/intake/runs") < paths.index("/intake/{run_id}")

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/RunList.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/RunList.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+import * as api from '../intake.api'
+import type { IntakeRunSummary } from '../intake.types'
+
+/**
+ * The runs you can go back to.
+ *
+ * The page tracked exactly one run, in `localStorage`. Lose that pointer or
+ * start a second article and every earlier run became unreachable from the
+ * interface, even though every stage of it was still on the server. On
+ * 2026-08-31 the only way back to a live run was a `?run=<uuid>` URL produced
+ * by querying the database by hand.
+ *
+ * Every long step in the pipeline invites the operator to leave the page.
+ * Without a list, leaving is only safe if one browser's memory survives, which
+ * is not a guarantee worth resting the work on.
+ *
+ * A run that never reached an article is listed like any other. A run is
+ * created when the seed is typed (ADR 0031), so stopping in the grill is an
+ * ordinary outcome and not something to hide.
+ */
+
+interface RunListProps {
+  /** Open one. The page decides what that means. */
+  onResume: (runId: string) => Promise<void>
+}
+
+/** Running first, because that is the one somebody is waiting on. */
+function isLive(run: IntakeRunSummary): boolean {
+  return run.status === 'running'
+}
+
+function when(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return parsed.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+export function RunList({ onResume }: RunListProps) {
+  const [runs, setRuns] = useState<IntakeRunSummary[] | null>(null)
+  const [failed, setFailed] = useState(false)
+  const [opening, setOpening] = useState<string | null>(null)
+
+  useEffect(() => {
+    let live = true
+    void api
+      .listRuns()
+      .then(found => {
+        if (live) setRuns(found)
+      })
+      .catch(() => {
+        // The list is a convenience. Failing to load it must not stand between
+        // the operator and starting a new article.
+        if (live) setFailed(true)
+      })
+    return () => {
+      live = false
+    }
+  }, [])
+
+  if (failed || (runs !== null && runs.length === 0)) return null
+  if (runs === null) return null
+
+  const ordered = [...runs].sort(
+    (left, right) => Number(isLive(right)) - Number(isLive(left)),
+  )
+
+  return (
+    <section className="p2b-run-list">
+      <h2 className="p2b-run-list-heading">Pick up where you left off</h2>
+      <ul>
+        {ordered.map(run => (
+          <li key={run.run_id} className={isLive(run) ? 'p2b-run-live' : undefined}>
+            <button
+              type="button"
+              className="p2b-run-open"
+              disabled={opening !== null}
+              onClick={() => {
+                setOpening(run.run_id)
+                void onResume(run.run_id).finally(() => setOpening(null))
+              }}
+            >
+              <span className="p2b-run-seed">
+                {/* A run that failed in the very first turn has no seed
+                    recorded yet. Its id is all there is to call it. */}
+                {run.seed || run.run_id}
+              </span>
+              <span className="p2b-run-meta">
+                {isLive(run) && <span className="p2b-run-dot" aria-hidden="true" />}
+                <span>{run.stage_label}</span>
+                {when(run.updated_at) && <span>{when(run.updated_at)}</span>}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-errors.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-errors.test.ts
@@ -15,7 +15,7 @@ vi.mock('../../../shared/api/client/apiFetch', () => ({
   apiFetch: (...args: unknown[]) => apiFetch(...args),
 }))
 
-const { answerQuestion } = await import('./intake.api')
+const { answerQuestion, readIntake, listRuns } = await import('./intake.api')
 
 function failWith(body: unknown, status = 502): void {
   apiFetch.mockResolvedValueOnce({
@@ -68,5 +68,53 @@ describe('a failed intake step', () => {
     await expect(answerQuestion('run-1', 'hello')).rejects.toThrow(
       'That step could not be completed.',
     )
+  })
+})
+
+describe('telling "the run is gone" from "the read failed"', () => {
+  /**
+   * The resume read wiped the remembered run on *any* failure. On 2026-08-31
+   * the operator left the page during a live research pass, exactly as the
+   * screen invites, and came back to nothing -- the run had completed
+   * normally and the read had merely timed out.
+   *
+   * The status is what tells those apart, so it has to survive on the error.
+   */
+  it('puts the status on the error so a 404 is distinguishable', async () => {
+    failWith({ detail: 'No such run.' }, 404)
+
+    await expect(readIntake('run-1')).rejects.toMatchObject({ status: 404 })
+  })
+
+  it('puts the status on a failure that says nothing useful', async () => {
+    failWith(null, 504)
+
+    await expect(readIntake('run-1')).rejects.toMatchObject({ status: 504 })
+  })
+
+  it('puts the status on an object-shaped failure too', async () => {
+    failWith({ detail: { error: 'boom', message: 'It broke.' } }, 502)
+
+    await expect(readIntake('run-1')).rejects.toMatchObject({ status: 502 })
+  })
+})
+
+describe('listing the runs to go back to', () => {
+  it('returns the runs the server sent', async () => {
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        runs: [{ run_id: 'run-1', seed: 'Lima is no longer a stopover' }],
+      }),
+    })
+
+    await expect(listRuns()).resolves.toMatchObject([{ run_id: 'run-1' }])
+  })
+
+  it('answers with an empty list rather than undefined when there are none', async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
+
+    await expect(listRuns()).resolves.toEqual([])
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -1,14 +1,22 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
+
+const listRuns = vi.fn()
+vi.mock('./intake.api', async importOriginal => ({
+  ...(await importOriginal<typeof import('./intake.api')>()),
+  listRuns: () => listRuns(),
+}))
 import { BriefScreen } from './components/BriefScreen'
 import { ArticleScreen } from './components/ArticleScreen'
 import { GrillScreen } from './components/GrillScreen'
 import { WorkingScreen } from './components/WorkingScreen'
 import { ResearchScreen } from './components/ResearchScreen'
+import { RunList } from './components/RunList'
 import { WorkOrderScreen } from './components/WorkOrderScreen'
 import type {
   IntakeBrief,
+  IntakeRunSummary,
   IntakeGrill,
   IntakeWorkOrder,
   IntakeWriting,
@@ -619,5 +627,77 @@ describe('the finished article screen', () => {
     )
 
     expect(screen.getByRole('link', { name: /stage in payload editor/i })).toBeInTheDocument()
+  })
+})
+
+describe('the list of runs to go back to', () => {
+  function runs(rows: Partial<IntakeRunSummary>[]): IntakeRunSummary[] {
+    return rows.map((row, index) => ({
+      run_id: `run-${index}`,
+      seed: `Seed ${index}`,
+      status: 'completed',
+      stage: 'complete',
+      stage_label: 'Done',
+      updated_at: '2026-08-31T18:13:33',
+      ...row,
+    }))
+  }
+
+  it('names each run by its seed, because a uuid is not a name', async () => {
+    listRuns.mockResolvedValueOnce(runs([{ seed: 'Lima is no longer a stopover' }]))
+
+    render(<RunList onResume={vi.fn()} />)
+
+    expect(await screen.findByText(/lima is no longer a stopover/i)).toBeInTheDocument()
+  })
+
+  it('puts a run somebody is waiting on above the finished ones', async () => {
+    listRuns.mockResolvedValueOnce(
+      runs([
+        { seed: 'Finished piece' },
+        { seed: 'Still searching', status: 'running', stage_label: 'Searching the web' },
+      ]),
+    )
+
+    render(<RunList onResume={vi.fn()} />)
+    await screen.findByText(/still searching/i)
+
+    const seeds = screen.getAllByText(/finished piece|still searching/i)
+    expect(seeds[0]).toHaveTextContent(/still searching/i)
+  })
+
+  it('falls back to the id when a run failed before its seed was recorded', async () => {
+    listRuns.mockResolvedValueOnce(runs([{ seed: '', run_id: 'run-abc' }]))
+
+    render(<RunList onResume={vi.fn()} />)
+
+    expect(await screen.findByText('run-abc')).toBeInTheDocument()
+  })
+
+  it('opens the run that was clicked', async () => {
+    const onResume = vi.fn().mockResolvedValue(undefined)
+    listRuns.mockResolvedValueOnce(runs([{ run_id: 'run-7', seed: 'Pick me' }]))
+
+    render(<RunList onResume={onResume} />)
+    const row = await screen.findByText(/pick me/i)
+    // Opening flips the row's disabled state when the promise settles, which
+    // is a state update the click itself does not wait for.
+    await act(async () => {
+      fireEvent.click(row)
+    })
+
+    expect(onResume).toHaveBeenCalledWith('run-7')
+  })
+
+  it('shows nothing at all when the list cannot be loaded', async () => {
+    // A convenience must not stand between the operator and a new article.
+    listRuns.mockRejectedValueOnce(new Error('offline'))
+
+    let container!: HTMLElement
+    await act(async () => {
+      container = render(<RunList onResume={vi.fn()} />).container
+    })
+
+    await waitFor(() => expect(container.querySelector('.p2b-run-list')).toBeNull())
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -3,6 +3,7 @@ import { FEATURE_PREFIX } from '../constants/prompt2blog.constants'
 import type {
   GateQuestion,
   IntakeArticle,
+  IntakeRunSummary,
   IntakeState,
   VenueToCheck,
 } from './intake.types'
@@ -25,21 +26,28 @@ const INTAKE = `${FEATURE_PREFIX}/intake`
  * raw model reply -- so every one of those messages was being thrown away and
  * replaced with a generic fallback. The operator saw "That step could not be
  * completed" while the server was explaining exactly what went wrong.
+ *
+ * The status travels on the error too. Without it every failure looked the
+ * same to the caller, and the resume read treated a timeout as proof the run
+ * no longer existed.
  */
 async function readError(response: Response, fallback: string): Promise<Error> {
   const body = await response.json().catch(() => null)
   const detail = body?.detail
 
-  if (typeof detail === 'string' && detail) return new Error(detail)
+  const withStatus = (error: Error): Error =>
+    Object.assign(error, { status: response.status })
+
+  if (typeof detail === 'string' && detail) return withStatus(new Error(detail))
   if (detail && typeof detail === 'object') {
     const message = typeof detail.message === 'string' ? detail.message : fallback
     const error = new Error(message)
     // Kept on the error so a screen can offer it without the message carrying
     // a wall of JSON.
     Object.assign(error, { raw: detail.raw, code: detail.error })
-    return error
+    return withStatus(error)
   }
-  return new Error(fallback)
+  return withStatus(new Error(fallback))
 }
 
 async function post(path: string, body?: unknown): Promise<IntakeState> {
@@ -57,6 +65,22 @@ async function post(path: string, body?: unknown): Promise<IntakeState> {
 /** One typed line becomes a run and its first question. */
 export function openIntake(seed: string): Promise<IntakeState> {
   return post(`${INTAKE}/seed`, { seed })
+}
+
+/**
+ * The runs the operator can go back to.
+ *
+ * Without this the page could only ever reach the one run its browser
+ * remembered, and every earlier one needed a `?run=<id>` URL dug out of the
+ * database by hand.
+ */
+export async function listRuns(): Promise<IntakeRunSummary[]> {
+  const response = await apiFetch(`${INTAKE}/runs`)
+  if (!response.ok) {
+    throw await readError(response, 'Could not list recent articles.')
+  }
+  const body = (await response.json()) as { runs?: IntakeRunSummary[] }
+  return body.runs ?? []
 }
 
 /** What a reloaded page asks for. */

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -212,3 +212,22 @@ export interface IntakeState {
   research_progress: IntakeResearchProgress | null
   writing: IntakeWriting | null
 }
+
+
+/**
+ * One run, as it appears in the list of runs to go back to.
+ *
+ * A run is created when the seed is typed (ADR 0031), so one that never
+ * reached an article is an ordinary run and appears here beside the ones that
+ * did.
+ */
+export interface IntakeRunSummary {
+  run_id: string
+  /** The line that started it. What makes a run recognisable in a list. */
+  seed: string
+  status: string
+  stage: string
+  /** The stage in words, intake stages included. */
+  stage_label: string
+  updated_at: string
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/useIntake-resume.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/useIntake-resume.test.tsx
@@ -1,0 +1,118 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Whether a remembered run survives a failed read.
+ *
+ * On 2026-08-31 the operator left the page during a live research pass,
+ * exactly as the screen invites -- "You can leave this page. The work carries
+ * on." -- and came back to nothing. The run was fine and completed normally.
+ * The resume read had timed out behind the blocking-routes bug, and the hook
+ * treated any failure at all as proof the run no longer existed.
+ *
+ * Only a definitive 404 means gone.
+ */
+
+const readIntake = vi.fn()
+vi.mock('./intake.api', () => ({
+  readIntake: (...args: unknown[]) => readIntake(...args),
+  openIntake: vi.fn(),
+  answerQuestion: vi.fn(),
+  reopenGrill: vi.fn(),
+  approveBrief: vi.fn(),
+  planResearch: vi.fn(),
+  doResearch: vi.fn(),
+  cutWorkOrder: vi.fn(),
+  startWriting: vi.fn(),
+  readArticle: vi.fn(),
+  listRuns: vi.fn(),
+}))
+
+const { useIntake } = await import('./useIntake')
+
+const RESUME_KEY = 'p2b.intake.runId'
+
+function failWith(status: number | undefined): void {
+  readIntake.mockRejectedValueOnce(
+    status === undefined
+      ? new TypeError('Failed to fetch')
+      : Object.assign(new Error('nope'), { status }),
+  )
+}
+
+beforeEach(() => {
+  readIntake.mockReset()
+  window.localStorage.clear()
+  window.localStorage.setItem(RESUME_KEY, 'run-1')
+})
+
+async function mountAndSettle(): Promise<void> {
+  renderHook(() => useIntake())
+  await waitFor(() => expect(readIntake).toHaveBeenCalled())
+}
+
+describe('resuming a remembered run', () => {
+  it('keeps the run when the read times out', async () => {
+    failWith(504)
+
+    await mountAndSettle()
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem(RESUME_KEY)).toBe('run-1'),
+    )
+  })
+
+  it('keeps the run when the request never reached the server', async () => {
+    // A dev server restarting mid-read. `fetch` throws with no status at all,
+    // which must not read as "the run is gone".
+    failWith(undefined)
+
+    await mountAndSettle()
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem(RESUME_KEY)).toBe('run-1'),
+    )
+  })
+
+  it('keeps the run when the server errors', async () => {
+    failWith(500)
+
+    await mountAndSettle()
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem(RESUME_KEY)).toBe('run-1'),
+    )
+  })
+
+  it('forgets the run only when the server says it does not exist', async () => {
+    failWith(404)
+
+    await mountAndSettle()
+
+    await waitFor(() => expect(window.localStorage.getItem(RESUME_KEY)).toBeNull())
+  })
+
+  it('restores the run when the read succeeds', async () => {
+    readIntake.mockResolvedValueOnce({ run_id: 'run-1', step: 'grill' })
+
+    const { result } = renderHook(() => useIntake())
+
+    await waitFor(() => expect(result.current.state?.run_id).toBe('run-1'))
+    expect(window.localStorage.getItem(RESUME_KEY)).toBe('run-1')
+  })
+})
+
+describe('opening an earlier run from the list', () => {
+  it('remembers the run it opened', async () => {
+    window.localStorage.removeItem(RESUME_KEY)
+    const { result } = renderHook(() => useIntake())
+    readIntake.mockResolvedValueOnce({ run_id: 'run-7', step: 'brief' })
+
+    await act(async () => {
+      await result.current.resume('run-7')
+    })
+
+    await waitFor(() => expect(result.current.state?.run_id).toBe('run-7'))
+    expect(window.localStorage.getItem(RESUME_KEY)).toBe('run-7')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/useIntake.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/useIntake.ts
@@ -63,6 +63,8 @@ export interface UseIntake {
   article: IntakeArticle | null
   /** Re-read the run. For anything that changed it outside this hook. */
   refresh: () => void
+  /** Open an earlier run, and remember it as the current one. */
+  resume: (runId: string) => Promise<void>
   abandon: () => void
 }
 
@@ -100,10 +102,24 @@ export function useIntake(): UseIntake {
         const restored = await api.readIntake(runId)
         setState(restored)
         runIdRef.current = restored.run_id
-      } catch {
-        // The run is gone, or belongs to someone else. Start clean rather than
-        // stranding the page on an error it cannot act on.
-        rememberRun(null)
+      } catch (cause) {
+        // Only a definitive 404 means the run is gone. Anything else -- a
+        // timeout, a restarting dev server, a momentary network fault -- says
+        // nothing about whether the run exists, and this used to treat all of
+        // them as proof it did not.
+        //
+        // On 2026-08-31 the operator left the page during a live research
+        // pass, exactly as the screen invites ("You can leave this page. The
+        // work carries on."), and came back to nothing. The run completed
+        // normally; the resume read had timed out behind the blocking-routes
+        // bug and the pointer was thrown away.
+        //
+        // A fetch that never reached the server throws without a status, so
+        // it falls through here and the pointer survives. The next mount asks
+        // again.
+        if ((cause as { status?: number } | null)?.status === 404) {
+          rememberRun(null)
+        }
       }
     })()
   }, [])
@@ -176,6 +192,18 @@ export function useIntake(): UseIntake {
       const runId = runIdRef.current
       if (!runId) return
       void api.readIntake(runId).then(setState).catch(() => undefined)
+    }, []),
+    resume: useCallback(async (runId: string) => {
+      // Deliberately not `run()`: this is navigation, not a move on the run,
+      // and a failure here must not leave the page holding an error about a
+      // run it never opened.
+      const restored = await api.readIntake(runId)
+      rememberRun(restored.run_id)
+      runIdRef.current = restored.run_id
+      setArticle(null)
+      setCutWarnings([])
+      setError(null)
+      setState(restored)
     }, []),
     abandon: useCallback(() => {
       rememberRun(null)

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pages/Prompt2BlogPage.tsx
@@ -4,6 +4,7 @@ import { GateScreen } from '../intake/components/GateScreen'
 import { GrillScreen } from '../intake/components/GrillScreen'
 import { ArticleScreen } from '../intake/components/ArticleScreen'
 import { ResearchScreen } from '../intake/components/ResearchScreen'
+import { RunList } from '../intake/components/RunList'
 import { WorkingScreen } from '../intake/components/WorkingScreen'
 import { SeedScreen } from '../intake/components/SeedScreen'
 import { WorkOrderScreen } from '../intake/components/WorkOrderScreen'
@@ -102,7 +103,14 @@ export function Prompt2BlogPage() {
           <WorkingScreen research={state?.research_progress} />
         ) : (
           <>
-        {step === 'seed' && <SeedScreen busy={intake.busy} onStart={intake.start} />}
+        {step === 'seed' && (
+          <>
+            <SeedScreen busy={intake.busy} onStart={intake.start} />
+            {/* Only with no run open: this is the way back in, not a thing to
+                offer somebody who is already mid-article. */}
+            {!state && <RunList onResume={intake.resume} />}
+          </>
+        )}
 
         {step === 'grill' && state?.grill && (
           <GrillScreen

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1052,3 +1052,89 @@
   font-size: 0.875rem;
   line-height: 1.6;
 }
+
+/* ---------- the way back in ---------- */
+
+/* Under the seed box, and only with no run open. The page used to track one
+   run in localStorage, so losing that pointer or starting a second article
+   made every earlier run unreachable from the interface -- the only way back
+   to a live run was a ?run=<uuid> URL dug out of the database by hand. */
+.p2b-run-list {
+  max-width: 42rem;
+  margin: var(--space-6) auto 0;
+}
+
+.p2b-run-list-heading {
+  margin: 0 0 var(--space-3);
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.p2b-run-list ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--border);
+}
+
+.p2b-run-list li {
+  border-bottom: 1px solid var(--border);
+}
+
+.p2b-run-open {
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-2);
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+
+.p2b-run-open:hover:not(:disabled) {
+  background: var(--panel);
+  color: var(--accent);
+}
+
+.p2b-run-open:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.p2b-run-seed {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.p2b-run-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+  color: var(--muted-light);
+  font-size: 0.75rem;
+}
+
+/* A run somebody is waiting on, told apart from one that has stopped. */
+.p2b-run-dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.p2b-run-live .p2b-run-meta {
+  color: var(--accent);
+}


### PR DESCRIPTION
Phase 3 of `docs/plans/p2b-v4-issue-phases.md`. Two issues, **one flaw**: the page knew about exactly one run, held it in the browser, and threw the pointer away too easily.

## #441 — forget a run only when the server says it is gone

`useIntake` wiped the remembered run on **any** failure:

```ts
} catch {
  // The run is gone, or belongs to someone else.
  rememberRun(null)
}
```

On 2026-08-31 the operator left the page during a live research pass — exactly as the screen invites, *"You can leave this page. The work carries on."* — and came back to nothing. **The run completed normally.** The read had timed out behind the blocking-routes bug, and a timeout was taken as proof the run no longer existed.

The HTTP status had to survive to tell those apart, so `readError` now carries it on the error. A fetch that never reached the server throws with **no** status and falls through — correct, because it says nothing about whether the run exists.

**Three tests cover the cases that used to wipe it** — a 504, a 500, and a network throw. All three fail against the old unconditional forget; I checked by restoring it.

## #442 — a way to find a run at all

There wasn't one. Every earlier run was unreachable from the interface even though all of it was on the server, and the only way back to a live run was a `?run=<uuid>` URL produced by querying the database by hand.

`GET /intake/runs` lists the recent runs, newest first, **running ones on top**, each named by **its seed** — a uuid is not a name. Runs that never reached an article are listed like any other: a run is created when the seed is typed (ADR 0031), so stopping in the grill is an ordinary outcome, not something to hide. `INTAKE_STAGE_LABELS` names those stages, because `WRITING_STAGE_LABELS` only ever covered the graph.

The route is declared **above** `/{run_id}`, which is load bearing — FastAPI matches in declaration order and a path parameter swallows the literal `runs`. Pinned by a test that reads the router, because calling the handler directly cannot catch that.

The list fails **silently**: a list that cannot load must not stand between the operator and starting a new article.

**The list is the point of the pair.** It is what stops the browser pointer being load bearing, so leaving the page no longer depends on one browser's memory surviving.

## What I could not verify

**Not checked in a browser.** The app sits behind a Payload login and I don't enter credentials. The dev server is running on 3003 and I attached to it, but it's a login wall.

So the rendering is covered by tests instead — naming by seed, running-first ordering, the id fallback when a run failed before its seed was recorded, opening the clicked run, and the silent failure. **Worth a look on screen before it's trusted**, especially the styling, which I wrote against the existing tokens without seeing it.

`.claude/launch.json` gains an `abw-dev` entry so the dev server can be started from the harness rather than by hand.

## Verification

- `pytest apps/backend/tests` — **1122 passed** (+2)
- `vitest` — **750 passed** (+16)
- `tsc` clean · `eslint` 0 errors · `check-boundaries` passed