### PR TITLE
Let the operator ask a research question again (#446)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -60,6 +60,7 @@ from ..intake_v4 import (
     polish_prompt,
     intake_state,
     plan_research,
+    reask_question,
     recent_runs,
     reopen_intake,
     settle_gate,
@@ -407,6 +408,31 @@ class GateAnswerRequest(BaseModel):
     # Drop the question. Permitted for a load-bearing one, and answered once
     # with what the article can no longer claim (ADR 0030).
     omit: bool = False
+
+
+class ReaskRequest(BaseModel):
+    requirement_id: str = Field(min_length=1)
+    question: str = Field(min_length=1)
+
+
+@router.post("/{run_id}/gate/reask")
+def reask_the_question(
+    run_id: str, request: ReaskRequest, _staff=Depends(require_staff)
+) -> JSONResponse:
+    """Rewrite one question and buy one search.
+
+    The only move at the gate that spends money, which is why it is its own
+    route rather than a fourth branch of the settle one: the other three are
+    the operator recording a decision, and this one re-runs research.
+    """
+    _handle(
+        reask_question,
+        run_id,
+        _services(run_id),
+        requirement_id=request.requirement_id,
+        question=request.question,
+    )
+    return JSONResponse(intake_state(run_id))
 
 
 @router.get("/{run_id}/gate")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
@@ -235,6 +235,133 @@ def omit_requirement(
     return EvidencePackage.model_validate(payload), trimmed, cost
 
 
+def reask_requirement(
+    evidence: EvidencePackage,
+    work_order: "Prompt2BlogWorkOrder",
+    *,
+    requirement_id: str,
+    question: str,
+) -> tuple[EvidencePackage, "Prompt2BlogWorkOrder", str]:
+    """Rewrite one question and clear what the old wording bought.
+
+    The third move, and the one run 76b36468 needed. Its q6 asked for a
+    community-led project "in Buenos Aires" and research answered about a
+    garden collective in Puerto Madero, **Argentina** -- the article is about
+    Medellín, whose Buenos Aires is the neighbourhood the Ayacucho tram runs
+    through. It came back marked `supported`, so nothing downstream would have
+    caught it.
+
+    Dropping that throws away a legitimate question. Answering it by hand means
+    doing the research yourself. Neither is right when the question was fine
+    and only the answer was about the wrong continent.
+
+    **`_guard` deliberately does not apply.** It refuses to let a hand-written
+    answer overwrite research, which is correct for the other two moves. Here
+    the operator is not answering; they are saying the research is wrong and
+    asking again. A `supported` requirement is exactly the case this exists
+    for.
+
+    The requirement keeps its id, so every claim, gap and conflict that links
+    to it stays linked and the work order and the dossier still declare the
+    same set. The fingerprint is left alone for the same reason `omit` leaves
+    it alone: it is the token binding this dossier to this plan, and both
+    sides move together in one operation. What changed is recorded in the
+    returned note rather than hidden in a hash.
+
+    Returns the pair with the requirement emptied and back to `unverified`.
+    The caller re-runs the one search and re-structures.
+    """
+    cleaned = _safe_str(question)
+    if not cleaned:
+        raise GateAnswerRefused("A rewritten question cannot be empty.")
+
+    existing = next(
+        (
+            item
+            for item in work_order.requirements
+            if item.requirement_id == requirement_id
+        ),
+        None,
+    )
+    if existing is None:
+        raise GateAnswerRefused(f"No research question called {requirement_id}.")
+    if _safe_str(existing.question) == cleaned:
+        raise GateAnswerRefused(
+            "That is the same question. Change it, or answer it yourself."
+        )
+    # Proves the requirement is one the dossier knows about before anything is
+    # discarded on its behalf.
+    _requirement(evidence, requirement_id)
+
+    was = _safe_str(existing.question)
+    rewritten = [
+        item.model_copy(update={"question": cleaned})
+        if item.requirement_id == requirement_id
+        else item
+        for item in work_order.requirements
+    ]
+
+    payload = evidence.model_dump(mode="json")
+    # Everything the old wording bought goes. A claim that also served another
+    # question keeps its other links and stays, because that fact is still
+    # doing work elsewhere -- the same reconciliation `omit` already does.
+    kept_claims = []
+    dropped: set[str] = set()
+    for claim in payload["claims"]:
+        links = [rid for rid in claim["requirement_ids"] if rid != requirement_id]
+        if not links:
+            dropped.add(claim["claim_id"])
+            continue
+        claim["requirement_ids"] = links
+        kept_claims.append(claim)
+    payload["claims"] = kept_claims
+    surviving = {claim["claim_id"] for claim in kept_claims}
+
+    for item in payload["requirements"]:
+        if item["requirement_id"] == requirement_id:
+            # `missing` rather than a status of its own: nothing answers this
+            # question right now, which is exactly what the word means and
+            # exactly what the coverage gate has to block on until the new
+            # search comes back.
+            item["status"] = "missing"
+            item["claim_ids"] = []
+            item["gap"] = "Re-asked; awaiting research."
+        else:
+            item["claim_ids"] = [c for c in item["claim_ids"] if c in surviving]
+
+    payload["gaps"] = [
+        gap for gap in payload.get("gaps", []) if requirement_id not in gap["requirement_ids"]
+    ]
+    payload["conflicts"] = [
+        conflict
+        for conflict in payload.get("conflicts", [])
+        if len([c for c in conflict["claim_ids"] if c in surviving]) >= 2
+    ]
+    for conflict in payload["conflicts"]:
+        conflict["claim_ids"] = [c for c in conflict["claim_ids"] if c in surviving]
+    payload["premise_findings"] = [
+        finding
+        for finding in payload.get("premise_findings", [])
+        if all(c in surviving for c in finding["claim_ids"])
+    ]
+    payload["sources"] = [
+        source
+        for source in payload["sources"]
+        if any(source["source_id"] in claim["source_ids"] for claim in kept_claims)
+    ]
+
+    note = (
+        f'Re-asked {requirement_id}: "{was}" is now "{cleaned}". '
+        f"{len(dropped)} claim(s) that answered only the old wording were dropped."
+    )
+    logger.info("Operator re-asked %s at the research gate", requirement_id)
+    return (
+        EvidencePackage.model_validate(payload),
+        work_order.model_copy(update={"requirements": rewritten}),
+        note,
+    )
+
+
 def _cost_of_omitting(work_order: "Prompt2BlogWorkOrder", requirement_id: str) -> str:
     """What the article can no longer claim, said once and plainly.
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -55,6 +55,7 @@ from .gate_v4 import (
     mark_unpublished,
     note_venue,
     omit_requirement,
+    reask_requirement,
     venues_to_check,
 )
 from .contracts_v4 import (
@@ -68,6 +69,7 @@ from .research_v4 import (
     RESEARCH_STAGE,
     ResearchDependencies,
     ResearchUnusable,
+    gather_one_requirement,
     gather_research,
     notes_from_record,
     notes_stage_record,
@@ -490,6 +492,104 @@ def settle_gate(
                     requirement_id,
                 }
             ),
+            STATE_KEY: json.loads(evidence.model_dump_json()),
+        },
+    )
+    return verdict
+
+
+def reask_question(
+    run_id: str,
+    services: IntakeServices,
+    *,
+    requirement_id: str,
+    question: str,
+) -> CoverageVerdict:
+    """Rewrite one research question and buy one search, not a whole pass.
+
+    Run 76b36468 asked for a community-led project "in Buenos Aires" and got a
+    garden collective in Argentina; the article is about Medellín, whose Buenos
+    Aires is a neighbourhood. The answer came back `supported`, so nothing
+    downstream would have caught it, and the only moves available were to drop
+    a perfectly good question or research it by hand.
+
+    One search, then one structuring call. The other questions keep the notes
+    they already paid for -- which is the whole reason the notes are stored per
+    requirement rather than as one blob.
+
+    The structuring call is not free and is the longest single wait in a run.
+    It is re-run rather than patched because deduplication and conflict
+    detection are cross-question by construction: splicing one requirement's
+    records into a finished dossier would leave the new answer unchecked
+    against everything already in it.
+    """
+    if services.research is None:
+        raise RuntimeError("Research dependencies are not configured.")
+
+    enforce_run_budget(_run_tokens_spent(run_id), stage=NOTES_STAGE)
+
+    brief = load_brief(run_id)
+    work_order = load_work_order(run_id)
+    evidence = load_evidence(run_id)
+
+    evidence, work_order, note = reask_requirement(
+        evidence, work_order, requirement_id=requirement_id, question=question
+    )
+
+    # The work order first: if the search or the structuring fails, the run is
+    # left holding the rewritten question rather than the wording the operator
+    # already rejected.
+    _record(
+        services,
+        run_id,
+        WORK_ORDER_STAGE,
+        {
+            **work_order_stage_record(work_order, [note]),
+            STATE_KEY: json.loads(work_order.model_dump_json()),
+        },
+    )
+
+    requirement = next(
+        item for item in work_order.requirements if item.requirement_id == requirement_id
+    )
+    notes = notes_from_record(_stage_data(run_id, NOTES_STAGE), work_order) or {}
+    _open(services, run_id, NOTES_STAGE)
+    notes = {
+        **notes,
+        requirement_id: gather_one_requirement(brief, requirement, services.research),
+    }
+    _record(services, run_id, NOTES_STAGE, notes_stage_record(work_order, notes))
+
+    _open(services, run_id, RESEARCH_STAGE)
+    try:
+        evidence = structure_research(work_order, notes, services.research)
+    except ResearchUnusable as error:
+        _record(
+            services,
+            run_id,
+            RESEARCH_STAGE,
+            {
+                "status": "failed",
+                "reason": error.reason,
+                "unusable_response": error.raw[:40000],
+            },
+        )
+        raise
+
+    verdict = assess_coverage(work_order, evidence)
+    _record(
+        services,
+        run_id,
+        RESEARCH_STAGE,
+        {
+            **research_stage_record(evidence, notes),
+            "coverage": verdict.as_record(),
+            # Every rewrite, in order. A question the article rests on that was
+            # asked three ways before it answered is worth seeing later.
+            "reasked": [
+                *(_stage_data(run_id, RESEARCH_STAGE).get("reasked") or []),
+                note,
+            ],
             STATE_KEY: json.loads(evidence.model_dump_json()),
         },
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -655,6 +655,31 @@ Rules:
 PROGRESS_STAGE = "stage_v4_research_progress"
 
 
+def gather_one_requirement(
+    brief: ArticleBrief,
+    requirement: WorkOrderRequirement,
+    dependencies: ResearchDependencies,
+) -> GatheredNotes:
+    """One question, one grounded pass. Never raises.
+
+    A hole is survivable and a dead run is not, so a failed search comes back
+    empty rather than taking the other searches down with it.
+
+    Module level rather than a closure inside `gather_research`, because the
+    gate re-asks exactly one rewritten question (#446) and re-running the whole
+    pass to do it would re-buy every search that was already right.
+    """
+    prompt = build_gather_prompt(brief, requirement)
+    try:
+        text, urls, tokens = dependencies.gather(prompt, GATHER_MODEL)
+    except Exception as exc:  # pragma: no cover -- network dependent
+        logger.warning("Gather failed for %s: %s", requirement.requirement_id, exc)
+        text, urls, tokens = "", [], None
+    return GatheredNotes(
+        text=_safe_str(text), source_urls=list(urls or []), tokens=tokens
+    )
+
+
 def gather_research(
     brief: ArticleBrief,
     work_order: Prompt2BlogWorkOrder,
@@ -698,20 +723,6 @@ def gather_research(
         except Exception as exc:  # pragma: no cover -- telemetry only
             logger.warning("Research progress write failed: %s", exc)
 
-    def _gather_one(requirement: WorkOrderRequirement) -> GatheredNotes:
-        """Never raises: a hole is survivable, a dead run is not."""
-        prompt = build_gather_prompt(brief, requirement)
-        try:
-            text, urls, tokens = dependencies.gather(prompt, GATHER_MODEL)
-        except Exception as exc:  # pragma: no cover -- network dependent
-            logger.warning(
-                "Gather failed for %s: %s", requirement.requirement_id, exc
-            )
-            text, urls, tokens = "", [], None
-        return GatheredNotes(
-            text=_safe_str(text), source_urls=list(urls or []), tokens=tokens
-        )
-
     gathered: dict[str, GatheredNotes] = {}
     if requirements:
         # Only once there is something to wait for. A work order with no
@@ -721,7 +732,9 @@ def gather_research(
         workers = max(1, min(P2B_V4_GATHER_CONCURRENCY, total))
         with ThreadPoolExecutor(max_workers=workers) as pool:
             pending = {
-                pool.submit(_gather_one, requirement): requirement
+                pool.submit(
+                    gather_one_requirement, brief, requirement, dependencies
+                ): requirement
                 for requirement in requirements
             }
             # Consumed on this thread, so `on_progress` -- which writes a stage

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from fastapi import HTTPException
 
 from app.features.prompt2blog.contracts_v4 import MARKER_KEYS
 from app.features.prompt2blog.api import intake as intake_api
@@ -295,6 +296,7 @@ def test_the_intake_routes_are_actually_mounted():
         "/prompt2blog/intake/{run_id}/work-order",
         "/prompt2blog/intake/{run_id}/work-order/cut",
         "/prompt2blog/intake/{run_id}/research",
+        "/prompt2blog/intake/{run_id}/gate/reask",
         "/prompt2blog/intake/{run_id}/write",
     } <= paths
 
@@ -337,3 +339,104 @@ def test_the_runs_route_is_declared_before_the_run_id_route():
     ]
 
     assert paths.index("/intake/runs") < paths.index("/intake/{run_id}")
+
+
+# --- re-asking one question ------------------------------------------------
+
+
+class CountingGather:
+    """A gather that remembers what it was asked."""
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def __call__(self, prompt: str, _model: str):
+        self.prompts.append(prompt)
+        return "Notes.", ["https://example.pe/a"], 800
+
+
+def test_re_asking_buys_one_search_not_a_whole_pass(isolated_db, monkeypatch):
+    """The reason this exists rather than "go back to the grill".
+
+    Run 76b36468 asked about a project "in Buenos Aires" and research answered
+    about Argentina; the article is about Medellín. Dropping the question threw
+    away a good one, and re-running research re-bought every search that was
+    already right.
+    """
+    gather = CountingGather()
+    llm = ScriptedLLM([QUESTION, AGREED, BRIEF, WORK_ORDER])
+    monkeypatch.setattr(
+        intake_api,
+        "_services",
+        lambda run_id=None: IntakeServices(
+            dependencies=GrillDependencies(
+                llm=llm, research=lambda _s: ("Lima has a food reputation.", [], 900)
+            ),
+            recorder=RunRecorder(),
+            research=ResearchDependencies(
+                gather=gather,
+                structure_llm=ScriptedLLM([EVIDENCE, EVIDENCE]),
+            ),
+        ),
+    )
+
+    run_id = _json(
+        intake_api.open_intake(intake_api.SeedRequest(seed=SEED), staff_user={"id": 1})
+    )["run_id"]
+    intake_api.answer_question(
+        run_id, intake_api.AnswerRequest(answer="guide"), _staff={"id": 1}
+    )
+    intake_api.build_the_brief(run_id, _staff={"id": 1})
+    intake_api.plan_the_research(run_id, _staff={"id": 1})
+    intake_api.do_the_research(run_id, _staff={"id": 1})
+    first_pass = len(gather.prompts)
+    assert first_pass >= 1
+
+    body = _json(
+        intake_api.reask_the_question(
+            run_id,
+            intake_api.ReaskRequest(
+                requirement_id="r1",
+                question="What do market stalls charge in Lima, Peru?",
+            ),
+            _staff={"id": 1},
+        )
+    )
+
+    # One search. Not the whole pass again.
+    assert len(gather.prompts) == first_pass + 1
+    assert "in Lima, Peru" in gather.prompts[-1]
+    # And the work order now carries the wording that was actually asked.
+    asked = {
+        item["requirement_id"]: item["question"]
+        for item in body["work_order"]["requirements"]
+    }
+    assert asked["r1"] == "What do market stalls charge in Lima, Peru?"
+
+
+def test_re_asking_the_same_wording_is_refused(isolated_db, scripted):
+    scripted([QUESTION, AGREED, BRIEF, WORK_ORDER])
+    run_id = _json(
+        intake_api.open_intake(intake_api.SeedRequest(seed=SEED), staff_user={"id": 1})
+    )["run_id"]
+    intake_api.answer_question(
+        run_id, intake_api.AnswerRequest(answer="guide"), _staff={"id": 1}
+    )
+    intake_api.build_the_brief(run_id, _staff={"id": 1})
+    intake_api.plan_the_research(run_id, _staff={"id": 1})
+    intake_api.do_the_research(run_id, _staff={"id": 1})
+
+    asked = _json(intake_api.read_intake(run_id, _staff={"id": 1}))["work_order"][
+        "requirements"
+    ][0]
+
+    with pytest.raises(HTTPException) as raised:
+        intake_api.reask_the_question(
+            run_id,
+            intake_api.ReaskRequest(
+                requirement_id=asked["requirement_id"], question=asked["question"]
+            ),
+            _staff={"id": 1},
+        )
+
+    assert raised.value.status_code == 400

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_gate.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_gate.py
@@ -416,3 +416,128 @@ def test_omitting_unblocks_the_run():
         evidence, work_order, requirement_id="q3"
     )
     assert assess_coverage(trimmed, settled).can_write is True
+
+
+# --- the operator re-asks it ----------------------------------------------
+
+
+def _reask(**kwargs):
+    from app.features.prompt2blog.gate_v4 import reask_requirement
+
+    evidence, work_order = _pair()
+    return reask_requirement(evidence, work_order, **kwargs)
+
+
+def test_re_asking_rewrites_the_question_and_keeps_its_id():
+    """The id is what every claim, gap and conflict links to.
+
+    Changing it would leave the work order and the dossier declaring different
+    sets, which the request contract refuses outright.
+    """
+    _settled, rewritten, _note = _reask(
+        requirement_id="q3", question="What does a Moravia Tours walk cost per person?"
+    )
+
+    asked = {item.requirement_id: item.question for item in rewritten.requirements}
+    assert asked["q3"] == "What does a Moravia Tours walk cost per person?"
+    assert asked["q1"] == "Visitors?"
+    assert [item.requirement_id for item in rewritten.requirements] == ["q3", "q1", "q5"]
+
+
+def test_re_asking_puts_the_question_back_to_unanswered():
+    """`missing` is the honest word: nothing answers it right now."""
+    settled, _rewritten, _note = _reask(requirement_id="q3", question="Cost per person?")
+
+    requirement = next(r for r in settled.requirements if r.requirement_id == "q3")
+    assert requirement.status == "missing"
+    assert requirement.claim_ids == []
+
+
+def test_what_the_old_wording_bought_is_discarded():
+    """The Argentina answer must not survive the question that produced it."""
+    settled, _rewritten, note = _reask(
+        requirement_id="q3", question="Cost per person?"
+    )
+
+    assert "c10" not in {claim.claim_id for claim in settled.claims}
+    assert "1 claim(s)" in note
+    assert "Prices?" in note and "Cost per person?" in note
+
+
+def test_a_claim_still_serving_another_question_survives_a_re_ask():
+    from app.features.prompt2blog.gate_v4 import reask_requirement
+
+    evidence = _evidence(
+        claims=[
+            {
+                "claim_id": "c10",
+                "text": "Moravia Tours was co-founded by community leaders.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["q3", "q1"],
+                "confidence": "high",
+            }
+        ],
+        requirements=[
+            {"requirement_id": "q3", "status": "partial", "claim_ids": ["c10"], "gap": "No price."},
+            {"requirement_id": "q1", "status": "supported", "claim_ids": ["c10"]},
+        ],
+    )
+    work_order = _work_order(
+        {"requirement_id": "q3", "question": "Prices?", "kind": "load_bearing"},
+        {"requirement_id": "q1", "question": "Visitors?", "kind": "texture"},
+    )
+
+    settled, _rewritten, _note = reask_requirement(
+        evidence, work_order, requirement_id="q3", question="Cost per person?"
+    )
+
+    survivor = next(claim for claim in settled.claims if claim.claim_id == "c10")
+    assert survivor.requirement_ids == ["q1"]
+
+
+def test_a_question_the_research_answered_can_be_re_asked():
+    """The point of the whole move, and the one place `_guard` must not apply.
+
+    Run 76b36468's q6 asked about a project "in Buenos Aires" and research
+    answered about Argentina; the article is about Medellín, whose Buenos
+    Aires is a neighbourhood. It came back marked `supported`, so refusing to
+    touch a supported requirement would refuse exactly the case this exists
+    for.
+    """
+    settled, _rewritten, _note = _reask(
+        requirement_id="q1", question="How many visitors in 2024, in Medellin?"
+    )
+
+    requirement = next(r for r in settled.requirements if r.requirement_id == "q1")
+    assert requirement.status == "missing"
+
+
+def test_the_same_question_is_refused():
+    with pytest.raises(GateAnswerRefused, match="same question"):
+        _reask(requirement_id="q3", question="Prices?")
+
+
+def test_an_empty_rewrite_is_refused():
+    with pytest.raises(GateAnswerRefused, match="cannot be empty"):
+        _reask(requirement_id="q3", question="   ")
+
+
+def test_re_asking_an_unknown_question_is_refused():
+    with pytest.raises(GateAnswerRefused, match="No research question"):
+        _reask(requirement_id="q99", question="Anything at all?")
+
+
+def test_the_pair_stays_bound_to_one_plan():
+    """The fingerprint is the token binding this dossier to this work order.
+
+    Both sides move together in one operation, so it is deliberately left
+    alone -- exactly as `omit` leaves it alone. What changed is in the note.
+    """
+    evidence, work_order = _pair()
+    settled, rewritten, _note = _reask(requirement_id="q3", question="Cost per person?")
+
+    assert rewritten.work_order_fingerprint == work_order.work_order_fingerprint
+    assert settled.work_order_fingerprint == evidence.work_order_fingerprint
+    assert {r.requirement_id for r in rewritten.requirements} == {
+        r.requirement_id for r in settled.requirements
+    }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/GateScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/GateScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { readGate, settleGate } from '../intake.api'
+import { readGate, reaskQuestion, settleGate } from '../intake.api'
 import type { GateQuestion } from '../intake.types'
 
 /**
@@ -12,11 +12,20 @@ import type { GateQuestion } from '../intake.types'
  * publish its price, with six of seven questions answered and ten web searches
  * spent.
  *
- * So each blocking question offers both honest answers. Either you found it,
+ * So each blocking question offers the honest answers. Either you found it,
  * or nobody publishes it. The second is not a workaround: "Moravia Tours takes
  * bookings directly and posts no price" is a sentence that belongs in the
  * article, and the coverage rules have accepted that verdict since the Lima
  * airport run stalled on times no agency publishes.
+ *
+ * The fourth move is asking again. Run 76b36468 asked about a project "in
+ * Buenos Aires" and research answered about Argentina — the article is about
+ * Medellín, whose Buenos Aires is a neighbourhood. The question was fine; the
+ * answer was about the wrong continent. Dropping it threw away a good
+ * question, and answering it by hand meant doing the research yourself.
+ *
+ * It is set apart from the other three because it is the only one that spends
+ * money: it buys one search, not the whole pass again.
  */
 
 interface GateScreenProps {
@@ -35,8 +44,11 @@ function Question({
   question: GateQuestion
   onSettled: () => void
 }) {
-  const [mode, setMode] = useState<'idle' | 'answer' | 'unpublished' | 'omit'>('idle')
+  const [mode, setMode] = useState<'idle' | 'answer' | 'unpublished' | 'omit' | 'reask'>(
+    'idle',
+  )
   const [text, setText] = useState('')
+  const [rewritten, setRewritten] = useState(question.question)
   const [url, setUrl] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -95,10 +107,76 @@ function Question({
           <button
             type="button"
             className="p2b-secondary"
+            onClick={() => setMode('reask')}
+          >
+            Ask it differently
+          </button>
+          <button
+            type="button"
+            className="p2b-secondary"
             onClick={() => setMode('omit')}
           >
             Drop the question
           </button>
+        </div>
+      ) : mode === 'reask' ? (
+        <div className="p2b-gate-form">
+          <label className="p2b-field">
+            <span className="p2b-label">The question, rewritten</span>
+            <textarea
+              value={rewritten}
+              rows={3}
+              onChange={event => setRewritten(event.target.value)}
+              disabled={saving}
+            />
+          </label>
+          {/* The one move here that costs anything, said before they press it
+              rather than after. */}
+          <p className="p2b-note">
+            This buys one new search and re-reads the research. Every other
+            question keeps the answer it already has.
+          </p>
+          {error && <p className="p2b-gate-error">{error}</p>}
+          <div className="p2b-intake-actions">
+            <button
+              type="button"
+              onClick={() => {
+                setSaving(true)
+                setError(null)
+                reaskQuestion(runId, {
+                  requirement_id: question.requirement_id,
+                  question: rewritten,
+                })
+                  .then(onSettled)
+                  .catch((cause: unknown) => {
+                    setError(
+                      cause instanceof Error
+                        ? cause.message
+                        : 'That could not be asked again.',
+                    )
+                    setSaving(false)
+                  })
+              }}
+              disabled={
+                saving ||
+                !rewritten.trim() ||
+                rewritten.trim() === question.question.trim()
+              }
+            >
+              {saving ? 'Searching' : 'Ask it again'}
+            </button>
+            <button
+              type="button"
+              className="p2b-secondary"
+              onClick={() => {
+                setRewritten(question.question)
+                setMode('idle')
+              }}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       ) : mode === 'omit' ? (
         <div className="p2b-gate-form">

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/gate-reask.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/gate-reask.test.tsx
@@ -1,0 +1,117 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GateQuestion } from './intake.types'
+
+/**
+ * Asking a research question again, at the gate.
+ *
+ * Run 76b36468 asked for a community-led project "in Buenos Aires" and
+ * research answered about a garden collective in Argentina — the article is
+ * about Medellín, whose Buenos Aires is the neighbourhood the Ayacucho tram
+ * runs through. The question was fine; the answer was about the wrong
+ * continent, and it came back marked supported so nothing downstream caught it.
+ *
+ * Before this the operator could only drop a good question or research it
+ * themselves.
+ */
+
+const readGate = vi.fn()
+const reaskQuestion = vi.fn()
+const settleGate = vi.fn()
+vi.mock('./intake.api', () => ({
+  readGate: (...args: unknown[]) => readGate(...args),
+  reaskQuestion: (...args: unknown[]) => reaskQuestion(...args),
+  settleGate: (...args: unknown[]) => settleGate(...args),
+}))
+
+const { GateScreen } = await import('./components/GateScreen')
+
+const QUESTION: GateQuestion = {
+  requirement_id: 'q6',
+  question: 'What community-led project offers guided visits in Buenos Aires?',
+  kind: 'load_bearing',
+  status: 'supported',
+  gap: '',
+  found: ['A garden collective in Puerto Madero, Argentina.'],
+}
+
+beforeEach(() => {
+  readGate.mockReset()
+  reaskQuestion.mockReset()
+  settleGate.mockReset()
+  readGate.mockResolvedValue({ blocking: [QUESTION] })
+  reaskQuestion.mockResolvedValue({})
+})
+
+async function openReask(): Promise<void> {
+  render(<GateScreen runId="run-1" onSettled={vi.fn()} onReopen={vi.fn()} busy={false} />)
+  fireEvent.click(await screen.findByText(/ask it differently/i))
+}
+
+describe('asking a research question again', () => {
+  it('offers it beside the other moves', async () => {
+    render(
+      <GateScreen runId="run-1" onSettled={vi.fn()} onReopen={vi.fn()} busy={false} />,
+    )
+
+    expect(await screen.findByText(/ask it differently/i)).toBeInTheDocument()
+    expect(screen.getByText(/drop the question/i)).toBeInTheDocument()
+  })
+
+  it('starts from the wording that is already there, so it is edited not retyped', async () => {
+    await openReask()
+
+    expect(await screen.findByDisplayValue(QUESTION.question)).toBeInTheDocument()
+  })
+
+  it('says what it costs before the operator presses it', async () => {
+    // The only move at this gate that spends anything.
+    await openReask()
+
+    expect(await screen.findByText(/buys one new search/i)).toBeInTheDocument()
+    expect(screen.getByText(/keeps the answer it already has/i)).toBeInTheDocument()
+  })
+
+  it('refuses to send the same question back unchanged', async () => {
+    await openReask()
+
+    expect(await screen.findByText(/ask it again/i)).toBeDisabled()
+  })
+
+  it('sends the rewritten question', async () => {
+    const onSettled = vi.fn()
+    render(
+      <GateScreen runId="run-1" onSettled={onSettled} onReopen={vi.fn()} busy={false} />,
+    )
+    fireEvent.click(await screen.findByText(/ask it differently/i))
+
+    const field = await screen.findByDisplayValue(QUESTION.question)
+    fireEvent.change(field, {
+      target: { value: 'What community-led project offers guided visits in Medellin?' },
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByText(/ask it again/i))
+    })
+
+    expect(reaskQuestion).toHaveBeenCalledWith('run-1', {
+      requirement_id: 'q6',
+      question: 'What community-led project offers guided visits in Medellin?',
+    })
+    await waitFor(() => expect(onSettled).toHaveBeenCalled())
+  })
+
+  it('keeps the operator on the question when the search fails', async () => {
+    reaskQuestion.mockRejectedValueOnce(new Error('The search did not come back.'))
+    await openReask()
+
+    const field = await screen.findByDisplayValue(QUESTION.question)
+    fireEvent.change(field, { target: { value: 'Something else entirely?' } })
+    await act(async () => {
+      fireEvent.click(screen.getByText(/ask it again/i))
+    })
+
+    expect(await screen.findByText(/did not come back/i)).toBeInTheDocument()
+    // Still editable, rather than stuck saying "Searching".
+    expect(screen.getByText(/ask it again/i)).not.toBeDisabled()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -196,6 +196,20 @@ export function settleGate(
   return post(`${INTAKE}/${runId}/gate`, body)
 }
 
+/**
+ * Rewrite one research question and buy one search.
+ *
+ * The only move at the gate that spends money. The other three record a
+ * decision the operator already made; this one asks the web again, because the
+ * question was fine and the answer was about the wrong place.
+ */
+export function reaskQuestion(
+  runId: string,
+  body: { requirement_id: string; question: string },
+): Promise<IntakeState> {
+  return post(`${INTAKE}/${runId}/gate/reask`, body)
+}
+
 /** The places this run would send a reader, for a person to look at. */
 export async function readVenues(runId: string): Promise<{ venues: VenueToCheck[] }> {
   const response = await apiFetch(`${INTAKE}/${runId}/venues`)


### PR DESCRIPTION
Phase 5 of `docs/plans/p2b-v4-issue-phases.md`. Closes #446.

## The case none of the three moves fitted

The gate offered: **answer it**, **say nobody publishes it**, **drop it**.

Run `76b36468`'s q6 asked for a community-led project *"in Buenos Aires"*. Research answered about a garden collective in Puerto Madero, **Argentina**. The article is about **Medellín**, whose Buenos Aires is the neighbourhood the Ayacucho tram runs through.

The question was fine. The answer was about the wrong continent — and it came back marked **`supported`**, so nothing downstream would have caught it.

Dropping it throws away a legitimate question. Answering it by hand means doing the research yourself. Neither is right, so the fourth move is **asking again**.

## One search, not a pass

The other questions keep the notes they already paid for — which is the whole reason notes are stored per requirement rather than as one blob. Phase 1 ([#454](https://github.com/Questurian/questurian/pull/454)) already made the gather loop per-question; this extracts `gather_one_requirement` from the closure it left behind.

Pinned end to end: the test counts gather calls through the real routes and asserts **exactly one more** after a re-ask.

**The structuring call is re-run rather than patched.** Deduplication and conflict detection are cross-question by construction, so splicing one requirement's records into a finished dossier would leave the new answer unchecked against everything already in it. That cost is stated on screen *before* the operator presses the button — it's the only move at this gate that spends anything.

## Two decisions worth checking

**`_guard` deliberately does not apply.** It refuses to let a hand-written answer overwrite research, which is right for the other three moves. Here the operator isn't answering — they're saying the research is wrong and asking again. A `supported` requirement is **exactly** the case this exists for, and applying the guard would refuse the only case that has actually happened.

**The fingerprint is left alone**, as `omit` already leaves it alone. It's the token binding this dossier to this plan, and both sides move together in one operation. The requirement keeps its id, so every claim, gap and conflict that links to it stays linked and the two sides go on declaring the same set — which the request contract checks.

What changed is written into the run as a note (old wording → new wording, and how many claims were dropped) rather than hidden in a hash. Every rewrite appends under `reasked`, so a question asked three ways before it answered is visible later.

## Details

- The re-asked requirement goes back to **`missing`** with its claims cleared, so the coverage gate blocks on it until the new search returns. (`missing` is the existing vocabulary — there is no separate "re-asked" status, and inventing one would mean teaching every reader of that field a new word for the same thing.)
- A claim that **also** served another question keeps its other links and stays.
- **The work order is written before the search runs.** If the search or the structuring then fails, the run is left holding the rewritten question rather than the wording the operator already rejected.

## Verification

- `pytest apps/backend/tests` — **1132 passed** (+11)
- `vitest` — **756 passed** (+6; `GateScreen` had no tests at all before this)
- `tsc` clean · `eslint` 0 errors · `check-boundaries` passed

**Not seen in a browser** — same as phase 3, the app is behind a Payload login. The new gate mode is covered by tests: the button sits beside the other three, it opens pre-filled with the existing wording so it's edited rather than retyped, it states the cost, it refuses to send the same question back unchanged, it sends the rewrite, and a failed search leaves the operator on the question rather than stuck on "Searching".