### PR TITLE
Let the grill look something up part way through the interview (#447)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -132,6 +132,27 @@ P2B_RUN_TOKEN_BUDGET = 320_000
 # in one place, so a ceiling set wrong is obvious rather than mysterious.
 P2B_RUN_TOKEN_CEILING = 650_000
 
+# How many times the grill may look something up *during* the interview, on
+# top of the one lookup it always makes on the seed.
+#
+# G2 (ADR 0030) is what keeps the grill short: anything it can look up, it
+# never asks. It looked the seed up once and then went blind, so by the fourth
+# turn the conversation could be about one neighbourhood while the grill was
+# still working from a general city briefing -- and a grill that cannot look up
+# where the conversation went is forced back into asking, which is the
+# form-with-extra-steps failure the interview replaced (ADR 0033).
+#
+# Bounded because the grill stops at agreement rather than at a question count,
+# so it has no upper bound on turns by construction and would have none on
+# searches either. Three is enough to follow a conversation that narrows twice
+# and still cheap beside a run: a grounded search measured 3-5k tokens on runs
+# b78a9fe8 and 76b36468.
+#
+# This number is only enforceable because the receipt now counts grounded
+# search at all (#440). Before that, adding searches here would have been
+# spending against a ceiling that could not see them.
+P2B_V4_GRILL_MAX_LOOKUPS = 3
+
 # How many grounded searches research may have in flight at once.
 #
 # One question per search, and nothing in question four depends on question

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -270,6 +270,11 @@ class GrillState(V4ContractModel):
     # grill short -- not a question limit (G2).
     research_digest: str = ""
     research_source_urls: list[str] = Field(default_factory=list)
+    # What it looked up *during* the interview, in order, on top of the seed.
+    # The queries rather than a count, because "it asked the web about the
+    # Ayacucho tram on turn four" is the thing worth reading back later; the
+    # count is just `len`.
+    lookups: list[str] = Field(default_factory=list)
     location: str = ""
     turns: list[GrillTurn] = Field(default_factory=list)
     status: GrillStatus = "asking"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -30,7 +30,11 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
-from .config import P2B_V4_GRILL_MODEL, P2B_V4_GRILL_TEMPERATURE
+from .config import (
+    P2B_V4_GRILL_MAX_LOOKUPS,
+    P2B_V4_GRILL_MODEL,
+    P2B_V4_GRILL_TEMPERATURE,
+)
 from .contracts_v4 import (
     BRIEF_MARKERS,
     MARKER_KEYS,
@@ -90,6 +94,7 @@ NEXT_TURN_SCHEMA = require_non_empty({
         "location": {"type": "string"},
         "markers_covered": {"type": "array", "items": {"type": "string"}},
         "asks_about": {"type": "string"},
+        "lookup": {"type": "string"},
     },
     "required": [
         "done",
@@ -131,6 +136,54 @@ def research_seed(dependencies: GrillDependencies, seed: str) -> tuple[str, list
     except Exception as exc:  # pragma: no cover -- network dependent
         logger.warning("Grill pre-research failed, continuing ungrounded: %s", exc)
         return "", [], None
+
+
+def _lookups_left(state: GrillState) -> int:
+    return max(0, P2B_V4_GRILL_MAX_LOOKUPS - len(state.lookups))
+
+
+def look_up_mid_interview(
+    state: GrillState,
+    dependencies: GrillDependencies,
+    query: str,
+) -> GrillState:
+    """Look something up in the middle of the interview, and remember it.
+
+    The seed lookup happens once, before the first question. After that the
+    grill went blind: by the fourth turn the conversation could have narrowed
+    to one neighbourhood while the grill was still working from the general
+    city briefing it pulled at the start.
+
+    That matters because G2 is what keeps the grill short. A grill that cannot
+    look up what the conversation has moved to is forced back into asking,
+    which is the form-with-extra-steps failure the interview replaced.
+
+    The budget is consumed whether or not the search comes back. A failed
+    lookup that cost nothing to retry is a loop: the model would ask for the
+    same thing again every turn, and the run has no question limit to stop it.
+    What failed is written into the digest so the next call knows not to wait
+    for it.
+    """
+    try:
+        digest, urls, _tokens = dependencies.research(query)
+    except Exception as exc:  # pragma: no cover -- network dependent
+        logger.warning("Grill lookup failed for %r: %s", query, exc)
+        digest, urls = "", []
+
+    body = digest.strip() or "Nothing came back for this."
+    return state.model_copy(
+        update={
+            "research_digest": (
+                f"{state.research_digest}\n\n"
+                f"--- Looked up mid-interview: {query} ---\n{body}"
+            ).strip(),
+            "research_source_urls": [
+                *state.research_source_urls,
+                *[url for url in urls if url not in state.research_source_urls],
+            ],
+            "lookups": [*state.lookups, query],
+        }
+    )
 
 
 def _transcript(state: GrillState) -> str:
@@ -179,6 +232,19 @@ def _marker_status(state: GrillState) -> str:
 def build_next_turn_prompt(state: GrillState) -> str:
     """What the grill is told before it decides its next move."""
     asked = len(state.turns)
+    left = _lookups_left(state)
+    can_look_up = (
+        f"""You may look something up before deciding. Set `lookup` to what you
+want to know, in plain words, and leave everything else empty -- you will be
+asked again with the answer in hand. Use it when the conversation has moved
+somewhere your briefing does not cover: they named a neighbourhood, a festival,
+a business you know nothing about. Do NOT use it to check something you were
+already told, and do NOT use it instead of asking them what only they can say.
+You may do this {left} more time(s) this interview."""
+        if left
+        else """Your lookup budget is spent for this interview. Work from the
+briefing above and ask them; do not set `lookup`."""
+    )
     return f"""You are interviewing a writer about an article they want to commission.
 They are a traveller or researcher, not an editor. Do not use editorial jargon.
 
@@ -187,6 +253,9 @@ THEIR OPENING LINE:
 
 WHAT YOU ALREADY LOOKED UP (never ask about anything in here):
 {state.research_digest or "Nothing; you could not look anything up."}
+
+LOOKING SOMETHING UP:
+{can_look_up}
 
 THE INTERVIEW SO FAR:
 {_transcript(state)}
@@ -347,11 +416,16 @@ class GrillUnusableResponse(RuntimeError):
     needs explaining was the one moment with no evidence.
     """
 
-    def __init__(self, raw: str) -> None:
+    def __init__(self, raw: str, state: "GrillState | None" = None) -> None:
         super().__init__(
             "The grill returned neither a usable question nor a consensus."
         )
         self.raw = raw
+        # The state as it stood when this failed, carrying any lookups the
+        # attempt already paid for. Without it the retry starts from the
+        # original state, the lookup budget resets, and one turn can spend it
+        # twice -- measured at six searches against a budget of three.
+        self.state = state
 
 
 def advance_grill(
@@ -369,31 +443,55 @@ def advance_grill(
     before it has started.
     """
     attempts: list[str] = []
+    # Carried across attempts, so a lookup the first attempt paid for is not
+    # bought again by the second.
+    working = state
     for attempt in range(2):
         try:
-            return _advance_once(state, dependencies)
+            return _advance_once(working, dependencies)
         except GrillUnusableResponse as error:
             attempts.append(error.raw)
+            if error.state is not None:
+                working = error.state
             logger.warning(
                 "Grill returned an unusable response (attempt %s): %s",
                 attempt + 1,
                 error.raw[:500],
             )
-    raise GrillUnusableResponse("\n---\n".join(attempts))
+    raise GrillUnusableResponse("\n---\n".join(attempts), working)
 
 
 def _advance_once(
     state: GrillState,
     dependencies: GrillDependencies,
 ) -> GrillState:
-    parsed, raw = dependencies.llm.invoke_json(
-        prompt=build_next_turn_prompt(state),
-        model_name=dependencies.model_name,
-        schema=NEXT_TURN_SCHEMA,
-        max_tokens=2_048,
-        temperature=P2B_V4_GRILL_TEMPERATURE,
-    )
-    payload = _safe_dict(parsed)
+    # `state` is rebound as lookups land, so the enlarged digest and the record
+    # of what was looked up survive on whatever this returns -- including the
+    # turn where the grill finally asks its question.
+    while True:
+        parsed, raw = dependencies.llm.invoke_json(
+            prompt=build_next_turn_prompt(state),
+            model_name=dependencies.model_name,
+            schema=NEXT_TURN_SCHEMA,
+            max_tokens=2_048,
+            temperature=P2B_V4_GRILL_TEMPERATURE,
+        )
+        payload = _safe_dict(parsed)
+        lookup = _safe_str(payload.get("lookup"))
+        # A lookup is a move, not an answer, so nothing else on the payload is
+        # read: the model is saying "I need to know this before I decide".
+        # Bounded by the budget, and the budget is spent even on a failure, so
+        # this cannot become a turn that never ends.
+        if lookup and payload.get("done") is not True and _lookups_left(state):
+            logger.info("Grill looked up %r mid-interview", lookup)
+            state = look_up_mid_interview(state, dependencies, lookup)
+            continue
+        if lookup and not _lookups_left(state):
+            logger.info(
+                "Grill wanted to look up %r with no budget left; asking instead",
+                lookup,
+            )
+        break
     location = _safe_str(payload.get("location")) or state.location
     covered = _markers_from(payload, state)
 
@@ -421,7 +519,7 @@ def _advance_once(
 
     question = _question_from(payload, fallback_id=f"q{len(state.turns) + 1}")
     if question is None:
-        raise GrillUnusableResponse(raw or _json_or_repr(payload))
+        raise GrillUnusableResponse(raw or _json_or_repr(payload), state)
     return state.model_copy(
         update={
             "status": "asking",

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
@@ -23,6 +23,8 @@ from app.features.prompt2blog.grill_v4 import (
     start_grill,
 )
 
+from app.features.prompt2blog.config import P2B_V4_GRILL_MAX_LOOKUPS
+
 SEED = "Lima is no longer simply the stopover before Machu Picchu"
 
 
@@ -776,3 +778,174 @@ def test_the_schema_has_nothing_left_to_nest():
         spec.get("type") in {"string", "boolean", "array"}
         for spec in NEXT_TURN_SCHEMA["properties"].values()
     )
+
+
+# --- looking something up mid-interview (G2, after turn one) ---------------
+
+
+class CountingResearch:
+    """A research callable that remembers what it was asked."""
+
+    def __init__(self, digest: str = "The Ayacucho tram runs through it.") -> None:
+        self.queries: list[str] = []
+        self.digest = digest
+
+    def __call__(self, query: str):
+        self.queries.append(query)
+        return self.digest, ["https://example.co/tram"], 400
+
+
+def _lookup(query: str) -> dict[str, Any]:
+    """The move: say what you need to know and nothing else."""
+    return {"done": False, "lookup": query, "ask": "", "recommendation": ""}
+
+
+def _grill_with(responses, research=None):
+    research = research or CountingResearch()
+    deps = GrillDependencies(llm=FakeLLM(responses), research=research)
+    return deps, research
+
+
+def test_the_grill_can_look_something_up_part_way_through():
+    """It used to research the seed once and then go blind.
+
+    By the fourth turn the conversation may have narrowed to one neighbourhood
+    while the grill is still working from the general city briefing. G2 is what
+    keeps the grill short, so a grill that cannot look up where the
+    conversation went is pushed back into asking -- the form-with-extra-steps
+    failure the interview replaced.
+    """
+    deps, research = _grill_with(
+        [_lookup("Buenos Aires neighbourhood Medellin"), {"done": False, **_question()}]
+    )
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert research.queries[1:] == ["Buenos Aires neighbourhood Medellin"]
+    assert state.lookups == ["Buenos Aires neighbourhood Medellin"]
+    # It asks its question with the answer in hand, not on the next turn.
+    assert state.pending is not None
+    assert state.status == "asking"
+
+
+def test_what_it_looked_up_reaches_the_next_call_and_the_state():
+    deps, _research = _grill_with(
+        [_lookup("Ayacucho tram"), {"done": False, **_question()}]
+    )
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert "Looked up mid-interview: Ayacucho tram" in state.research_digest
+    assert "The Ayacucho tram runs through it." in state.research_digest
+    # The second call is the one that has to see it; the first is what asked.
+    assert "The Ayacucho tram runs through it." in deps.llm.prompts[1]
+    assert "https://example.co/tram" in state.research_source_urls
+
+
+def _spends_the_budget() -> list[dict[str, Any]]:
+    """Every lookup the budget allows, then one more asked for beside a
+    question -- which is what a model does once the prompt tells it the
+    budget is gone."""
+    return [
+        *[_lookup(f"thing {index}") for index in range(P2B_V4_GRILL_MAX_LOOKUPS)],
+        {"done": False, "lookup": "one more please", **_question()},
+    ]
+
+
+def test_the_lookups_are_bounded():
+    """The grill stops at agreement, not at a count, so it has no upper bound
+    on turns by construction -- and would have none on searches either."""
+    deps, research = _grill_with(_spends_the_budget())
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert len(state.lookups) == P2B_V4_GRILL_MAX_LOOKUPS
+    assert "one more please" not in state.lookups
+    # The seed lookup, plus the budget. Not one more.
+    assert len(research.queries) == P2B_V4_GRILL_MAX_LOOKUPS + 1
+    # The refused lookup does not cost the turn: the question beside it is used.
+    assert state.pending is not None
+
+
+def test_the_prompt_says_how_many_lookups_are_left():
+    """Otherwise the model asks for one it cannot have, every turn, forever."""
+    deps, _research = _grill_with(_spends_the_budget())
+
+    start_grill("run-1", SEED, deps)
+
+    assert f"{P2B_V4_GRILL_MAX_LOOKUPS} more time(s)" in deps.llm.prompts[0]
+    assert "budget is spent" in deps.llm.prompts[-1]
+
+
+def test_a_retry_does_not_buy_the_lookups_again():
+    """Found by the bounded test above, and it was a real overspend.
+
+    `advance_grill` retries once on an unusable reply. It used to re-enter with
+    the state it was given, so every lookup the first attempt had already paid
+    for was bought again: six searches against a budget of three. The state now
+    travels on the failure.
+    """
+    deps, research = _grill_with(
+        [
+            # First attempt: spends the budget, then returns something that is
+            # neither a question nor a consensus.
+            *[_lookup(f"thing {index}") for index in range(P2B_V4_GRILL_MAX_LOOKUPS)],
+            {"done": False, "ask": "", "recommendation": ""},
+            # Second attempt: asks again, and must be refused. The question
+            # rides beside it, which is what the prompt now tells it to do.
+            {"done": False, "lookup": "sneaking one in", **_question()},
+        ]
+    )
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert len(state.lookups) == P2B_V4_GRILL_MAX_LOOKUPS
+    assert "sneaking one in" not in state.lookups
+    assert len(research.queries) == P2B_V4_GRILL_MAX_LOOKUPS + 1
+
+
+def test_a_failed_lookup_still_costs_its_budget():
+    """A free retry is a loop. The run has no question limit to stop it."""
+
+    class Broken(CountingResearch):
+        def __call__(self, query: str):
+            self.queries.append(query)
+            raise RuntimeError("no network")
+
+    research = Broken()
+    deps = GrillDependencies(
+        llm=FakeLLM([_lookup("something"), {"done": False, **_question()}]),
+        research=research,
+    )
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert state.lookups == ["something"]
+    assert "Nothing came back for this." in state.research_digest
+    assert state.pending is not None
+
+
+def test_a_lookup_is_not_read_as_a_question():
+    """The model is saying "I need to know this first", not answering."""
+    deps, _research = _grill_with(
+        [
+            {**_lookup("something"), "ask": "junk", "recommendation": "junk"},
+            {"done": False, **_question()},
+        ]
+    )
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert state.pending is not None
+    assert state.pending.ask != "junk"
+
+
+def test_a_grill_that_is_done_does_not_look_anything_up_first():
+    """Agreement is the end of the interview, not a reason to spend."""
+    deps, research = _grill_with([{**_done(), "lookup": "one more thing"}])
+
+    state = start_grill("run-1", SEED, deps)
+
+    assert state.status == "agreed"
+    assert state.lookups == []
+    assert len(research.queries) == 1

--- a/apps/ai-blog-writer/docs/adr/0033-the-grill-is-a-conversation.md
+++ b/apps/ai-blog-writer/docs/adr/0033-the-grill-is-a-conversation.md
@@ -136,5 +136,12 @@ per-turn form-filling is what goes.
   it may be working from a briefing the conversation has moved past. That is a
   real limitation, it is accepted for now, and it is the next thing to build
   once the conversation itself is right.
+
+  **Built on 2026-09-01 (#447).** The grill can now set `lookup` on any turn to
+  ask the web something before it decides, bounded by
+  `P2B_V4_GRILL_MAX_LOOKUPS` and recorded on the state as the queries it made.
+  It waited on the token accounting (#440): adding unbounded searches to a
+  stage while the run's ceiling could not see grounded search at all would have
+  been spending against a number that did not exist.
 - Nothing here is evidence that articles improve. This makes the interview an
   interview; whether the brief it produces is any good is read by a person.


### PR DESCRIPTION
Phase 7 of `docs/plans/p2b-v4-issue-phases.md`. Closes #447 and closes the limitation ADR 0033 recorded against itself.

## The problem

The grill researched the seed **once**, before its first question, and then went blind. By the fourth turn the conversation may have narrowed to one neighbourhood while the grill is still working from the general city briefing it pulled at the start.

That matters because **G2 is what keeps the grill short**: anything it can look up, it never asks. A grill that cannot look up where the conversation went is pushed back into asking — the form-with-extra-steps failure the interview replaced.

## How it works

The model sets `lookup` on any turn to say what it needs to know. **Nothing else on that payload is read** — it's saying *"I need this before I decide"*, not answering — and it is asked again with the answer in the digest.

The enlarged digest and the record of what was asked travel on whatever the turn returns, including the turn that finally produces a question. `GrillState.lookups` keeps the **queries**, not a count: *"it asked the web about the Ayacucho tram on turn four"* is the thing worth reading back later.

## Bounded, and why each guard exists

`P2B_V4_GRILL_MAX_LOOKUPS = 3`. The grill stops at agreement rather than at a question count, so it has no upper bound on turns **by construction** — and would have had none on searches either.

- **The prompt states the remaining budget**, and says plainly when it's gone. Without that the model asks for one it cannot have on every turn, forever.
- **A failed lookup still costs its budget.** A free retry is a loop with nothing to stop it. What failed is written into the digest so the next call doesn't wait for it.
- **A refused lookup doesn't cost the turn** — a question sitting beside it is still used.

This waited on #440 on purpose. Adding searches to a stage while the run's ceiling could not see grounded search at all would have been spending against a number that did not exist. Now the searches land in the ledger, attributed to `stage_v4_grill`, because phase 2 both metered grounded search and opened the stage before the call.

## A real overspend, found by the bounding test

`advance_grill` retries once on an unusable reply, and re-entered with **the state it was given** — so every lookup the first attempt had already paid for was bought again. Measured: **six searches against a budget of three.**

The state now travels on `GrillUnusableResponse`, so the second attempt continues the budget rather than resetting it. Pinned by `test_a_retry_does_not_buy_the_lookups_again`, which I checked fails without the fix.

I'd have shipped the overspend if the bounding test had only asserted the happy path.

## Verification

- `pytest apps/backend/tests` — **1140 passed** (+8)
- `vitest` 756 · `tsc` clean · `eslint` 0 errors · `check-boundaries` passed

No UI change: this is entirely inside the interview. Whether the grill uses the move *well* — looking up the right things, at the right moments — is a judgement about a real interview and cannot be read from a test.