### PR TITLE
Tell the polish prompt how to lengthen a sentence (#443)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/polish_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/polish_v4.py
@@ -19,6 +19,22 @@ ban and the hyphenated compound ban are deliberate, and a chatbot asked to
 improve rhythm will reach for an em dash within a sentence or two. Telling it
 not to is cheaper than reading the result and finding out.
 
+**And it has to say how to lengthen a sentence, not only what it cannot use.**
+Asked to vary the rhythm and forbidden the dash in the same breath, a model has
+one tool left: the full stop. A version of the Medellin article came back from
+an outside model with 65 sentences where the pipeline wrote 54, a spread of 5.0
+where the pipeline had 7.7, and **zero** sentences over 25 words where the
+pipeline had six. Every cut landed on a subordinate clause -- "667 people per
+day, *which* falls far short of" became two sentences -- which is exactly the
+joint the rhythm fix in `2bd89fb1` had just added.
+
+Not proven to have come from this prompt: the operator had also been editing by
+hand. But the failure matches the prompt's shape precisely, and it is the same
+trap `anti_ai_tells.py` had before that commit, where the only escape offered
+from an aside was "split it". So the wording here now mirrors what those rules
+settled on: length comes from subordination, and splitting is the last resort
+rather than the house style.
+
 It is generated, never hand edited. Operator influence belongs in a control
 carrying its own validated field; typed text into a generated prompt leaves
 nothing downstream able to say what was actually asked for.
@@ -51,9 +67,13 @@ def _measured_problems(checks: dict[str, Any]) -> list[str]:
             problems.append(
                 f"The sentences are too uniform. {round(share * 100)}% of the "
                 f"{count} sentences sit within five words of each other, and "
-                f"{long_ones} run past 25 words. Join related facts into longer "
-                "sentences where one explains another, and let short sentences "
-                "land the points. Do not cut anything to do it."
+                f"{long_ones} run past 25 words. Fix this by joining, never by "
+                "splitting: where one fact explains another, carry both in one "
+                "sentence using because, which, while, after or so that, and "
+                "let short sentences land the points. Length comes from "
+                "subordination. Cutting a long sentence in two makes this "
+                "measurement worse, not better, and cutting content is never "
+                "the fix."
             )
 
     if checks.get("target_word_count_met") is False:
@@ -122,6 +142,11 @@ RULES YOU MUST NOT BREAK
 - No em dashes, and no substitutes. A comma bracketed aside is an em dash in
   disguise. This is deliberate: em dashes now read as a sign of AI writing and
   this publication does not use them.
+  This is not a reason to reach for a full stop. The replacement for a dash is
+  a subordinate clause, not two sentences: "the room is warm throughout, which
+  is what makes the terrace worth booking" keeps the thought whole and needs no
+  dash. Long sentences are wanted, and commas joining clauses are correct. What
+  is banned is a comma standing in for a dash around an aside.
 - No hyphenated compounds. "A visa for long stays", never "a long stay visa".
   Proper names keep their hyphens; nothing else does.
 - Invent nothing. No new places, prices, dates, dishes, names or numbers, and

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_polish_prompt.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_polish_prompt.py
@@ -68,8 +68,11 @@ def test_the_measured_spread_becomes_an_instruction_with_its_numbers():
 
     assert "57% of the 75 sentences sit within five words" in prompt
     assert "1 run past 25 words" in prompt
-    assert "Join related facts into longer sentences" in prompt
-    assert "Do not cut anything to do it" in prompt
+    # The instruction that follows the numbers is covered by the joining tests
+    # below; what this one holds is that the measurement reaches the prompt as
+    # a sentence with its own figures in it.
+    assert "The sentences are too uniform." in prompt
+    assert "cutting content is never the fix" in prompt
 
 
 def test_varied_prose_is_not_complained_about():
@@ -138,3 +141,111 @@ def test_a_length_miss_says_which_way_it_missed():
 
     assert "180 words under the agreed length" in prompt
     assert "never by inventing facts" in prompt
+
+
+# --- how to lengthen a sentence, not only what it cannot use ---------------
+
+
+def test_the_uniformity_fix_names_joining_and_rules_out_splitting():
+    """Told "vary the rhythm" and "no dashes" in one breath, a model has one
+    tool left: the full stop.
+
+    A version of the Medellin article came back from an outside model with 65
+    sentences where the pipeline wrote 54, a spread of 5.0 where the pipeline
+    had 7.7, and zero sentences over 25 words where the pipeline had six. Every
+    cut landed on a subordinate clause.
+    """
+    prompt = _prompt()
+
+    assert "joining, never by splitting" in prompt
+    assert "Length comes from subordination." in prompt
+    # The connectives, named. "Join related facts" alone leaves the model to
+    # work out how, and splitting is the easier guess.
+    for word in ("because", "which", "while", "after", "so that"):
+        assert word in prompt
+
+
+def test_it_says_a_split_makes_the_measurement_worse():
+    """The instruction and the measurement have to agree.
+
+    Cutting a long sentence in two raises the sentence count and narrows the
+    spread, so a model doing what it was asked would move the number the wrong
+    way and think it had complied.
+    """
+    prompt = _prompt()
+
+    assert "makes this measurement worse" in prompt
+
+
+def test_the_dash_ban_says_what_to_reach_for_instead():
+    """A ban with no replacement is why the full stop won.
+
+    `anti_ai_tells.py` had the same trap until `2bd89fb1`: the only escape it
+    offered from an aside was "split it", and the model generalised that one
+    option into a house style.
+    """
+    prompt = _prompt()
+
+    assert "not a reason to reach for a full stop" in prompt
+    assert "subordinate clause, not two sentences" in prompt
+    # Long sentences are wanted. Without this the ban reads as a length limit.
+    assert "Long sentences are wanted" in prompt
+
+
+def test_a_clean_article_is_not_told_how_to_lengthen_anything():
+    """The advice rides on the complaint. No complaint, no advice."""
+    prompt = _prompt(
+        constraint_checks={
+            "sentence_count": 60,
+            "sentence_widest_band_share": 0.3,
+            "sentences_over_25_words": 6,
+        }
+    )
+
+    assert "joining, never by splitting" not in prompt
+    # The dash rule is a house rule and stays regardless.
+    assert "not a reason to reach for a full stop" in prompt
+
+
+def test_splitting_really_does_make_the_spread_worse():
+    """The prompt tells the model a split moves the number the wrong way.
+
+    That claim has to be true, or the instruction is asking a model to trust
+    an assertion the measurement would contradict. These are the two versions
+    of the same passage from issue #443, joined and then split at the joint,
+    measured by the function that produces the number the prompt quotes.
+
+    Splitting loses on every measure at once: the spread collapses, the long
+    sentence disappears, and the crowding share -- which is the metronome,
+    measured, and where high is bad -- goes UP. A model that split its way
+    through the article would think it had complied.
+    """
+    from app.features.prompt2blog.quality import measure_sentence_spread
+
+    joined = (
+        "Cusco sits at 3,399 meters. "
+        "Lima averages between 101 and 161, which is the difference between "
+        "arriving and arriving able to do anything, because tourists who fly "
+        "straight to the Andes often meet a pounding headache within 6 to 24 "
+        "hours, followed by nausea, dizziness and fatigue that take up to two "
+        "days of rest and water to clear. "
+        "You lose the start of your trip to a hotel bed."
+    )
+    split = (
+        "Cusco sits at 3,399 meters. "
+        "Lima averages between 101 and 161. "
+        "That is the difference between arriving and arriving able to do "
+        "anything. "
+        "Tourists who fly straight to the Andes often meet a pounding headache "
+        "within 6 to 24 hours. "
+        "Nausea, dizziness and fatigue follow. "
+        "These take up to two days of rest and water to clear. "
+        "You lose the start of your trip to a hotel bed."
+    )
+
+    before = measure_sentence_spread(joined)
+    after = measure_sentence_spread(split)
+
+    assert after["sentence_stdev_words"] < before["sentence_stdev_words"]
+    assert after["sentences_over_25_words"] < before["sentences_over_25_words"]
+    assert after["sentence_widest_band_share"] > before["sentence_widest_band_share"]


### PR DESCRIPTION
Phase 4, the last of the seven. Closes #443.

## The trap

The copy-out prompt asked a flagship model to fix uniform sentence length **and** forbade em dashes and hyphenated compounds in the same breath.

A model told *"vary the rhythm"* and *"no dashes"* has one tool left: **the full stop.**

A version of the Medellín article came back from an outside model:

| | pipeline | after |
|---|---|---|
| sentences | 54 | 65 |
| stdev | **7.7** | 5.0 |
| over 25 words | **6** | **0** |

Every cut landed on a subordinate clause — *"667 people per day, **which** falls far short of"* became two sentences. That is exactly the joint the rhythm fix in `2bd89fb1` had just added.

Not proven to have come from this prompt; the operator had also been editing by hand. But the failure matches the prompt's shape precisely, and it's the same trap `anti_ai_tells.py` had before that commit, where the only escape offered from an aside was *"split it"* — and the model generalised one option into a house style.

## What changed

The wording now mirrors what those rules already settled on:

- **The uniformity note** says to fix it *by joining, never by splitting*, **names the connectives** (`because, which, while, after, so that`) rather than leaving the model to work out how, and says outright that cutting a long sentence in two **makes the measurement worse**.
- **The em dash rule** now says what to reach for instead: the replacement for a dash is a subordinate clause, *not* two sentences, and long sentences joined by commas are wanted. A ban with no replacement is why the full stop won.

## The claim is checked, not asserted

The prompt now tells the model that splitting moves the number the wrong way. That had better be true, or it's asking a model to trust an assertion the measurement would contradict.

So the test measures both versions of the #443 passage with `measure_sentence_spread` — the same function that produces the number the prompt quotes:

| | joined | split |
|---|---|---|
| stdev | 21.5 | **4.1** |
| over 25 words | 1 | **0** |
| widest band (high is bad) | 0.33 | **0.43** |

**Splitting loses on every measure at once.** A model that split its way through the article would have thought it had complied.

## What this does not prove

**This is a prompt change and no test can show it improves prose.** The suite being green says the words reach the prompt, nothing more.

Whether it worked is read off the next real article with `measure_sentence_spread`, before and after the copy-out, rather than judged by eye. If the spread drops after a polish pass, this didn't work.

## Verification

- `pytest apps/backend/tests` — **1145 passed** (+5)
- `vitest` 756 · `tsc` clean · `eslint` 0 errors · `check-boundaries` passed

One existing test asserted the old wording and was updated; its intent (the measurement reaches the prompt with its own figures in it) is unchanged.