### PR TITLE
Stop the handoff to the writer erasing what intake spent

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -567,7 +567,15 @@ def start_writing(
     # what the graph is about to run rather than queueing a new one. That is
     # the whole point of starting a run at the seed: one article, one record,
     # one receipt covering intake and writing together.
-    recorder = PipelineDependencies().recorder
+    # Continuing the run's ledger, not a fresh one. `record_stage` writes the
+    # whole ledger at the end of every call, so a recorder built on an empty
+    # tracker does not merely fail to add -- it ERASES what intake spent.
+    #
+    # Measured on run 062c0b86 (2026-09-01): the intake stages had recorded
+    # 105,098 tokens, this line wrote the `pipeline_input_v3` row at 19:29:14,
+    # and the run's finished receipt reported 161,897 -- the writing graph
+    # alone. The ceiling reads that same total.
+    recorder = dependencies_for_run(run_id).recorder
     artifact = v3_run_input_artifact(runtime)
     artifact["claude_account_label"] = credential.label if credential else None
     recorder.record_stage(run_id, RUN_INPUT_STAGE, artifact)

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_routes.py
@@ -440,3 +440,71 @@ def test_re_asking_the_same_wording_is_refused(isolated_db, scripted):
         )
 
     assert raised.value.status_code == 400
+
+
+def test_handing_the_run_to_the_writer_does_not_erase_what_intake_spent(
+    isolated_db, scripted, monkeypatch
+):
+    """`record_stage` writes the whole ledger, so a recorder built on an empty
+    tracker erases rather than merely failing to add.
+
+    Missed when the ledger restore was first wired in, and it cost a real run.
+    On 062c0b86 (2026-09-01) the intake stages had recorded 105,098 tokens;
+    writing the `pipeline_input_v3` row wiped them, and the finished receipt
+    reported 161,897 -- the writing graph alone. The per-run ceiling reads that
+    same total, so it was guarding a number missing 39% of the run.
+    """
+    from fastapi import BackgroundTasks
+    from app.core import read_stage_result, write_stage_result
+
+    scripted([QUESTION, AGREED, BRIEF, WORK_ORDER])
+    monkeypatch.setattr(intake_api, "_prompt2blog_credential_for_run", lambda: None)
+    monkeypatch.setattr(intake_api, "_run_pipeline_v4_background", lambda *_a: None)
+
+    run_id = _json(
+        intake_api.open_intake(intake_api.SeedRequest(seed=SEED), staff_user={"id": 1})
+    )["run_id"]
+    intake_api.answer_question(
+        run_id, intake_api.AnswerRequest(answer="guide"), _staff={"id": 1}
+    )
+    intake_api.build_the_brief(run_id, _staff={"id": 1})
+    intake_api.plan_the_research(run_id, _staff={"id": 1})
+    intake_api.do_the_research(run_id, _staff={"id": 1})
+
+    # What intake spent, as the real run would have recorded it by this point.
+    write_stage_result(
+        run_id,
+        "usage_ledger",
+        {
+            "created_at": "2026-09-01T19:28:00Z",
+            "data": {
+                "ledger_version": 1,
+                "calls": [
+                    {
+                        "seq": 1,
+                        "stage": "stage_v4_research",
+                        "attempt": 1,
+                        "model": "gemini-3.1-pro-preview",
+                        "input_tokens": 60_000,
+                        "output_tokens": 1_145,
+                        "reasoning_tokens": 0,
+                        "cached_input_tokens": 0,
+                        "total_tokens": 61_145,
+                        "calls": 1,
+                        "metered": True,
+                        "cost_usd": 0.42,
+                        "cost_basis": "rate_table",
+                    }
+                ],
+                "totals": {"total_tokens": 61_145},
+                "successful_calls": 1,
+                "unmetered_calls": 0,
+            },
+        },
+    )
+
+    intake_api.start_writing(run_id, BackgroundTasks(), _staff={"id": 1})
+
+    ledger = (read_stage_result(run_id, "usage_ledger") or {}).get("data") or {}
+    assert ledger.get("totals", {}).get("total_tokens") == 61_145
+    assert ledger.get("successful_calls") == 1


### PR DESCRIPTION
A miss from #455, caught by the first real article run since that work.

## What happened

`start_writing` built `PipelineDependencies()` for the one stage row it writes. `record_stage` persists the **whole ledger** at the end of every call — so a recorder holding an empty tracker doesn't merely fail to add to the run's accounting, **it erases it.**

## Run 062c0b86, 2026-09-01

The per-stage receipts were **right**, and all of it was new:

| stage | tokens |
|---|---|
| grill | 4,344 |
| brief | 3,737 |
| work order | 4,624 |
| research notes | 31,248 (9 searches, 0 unreported) |
| research structuring | 61,145 |

Every one of those read **zero** before #455.

Then `pipeline_input_v3` was written at 19:29:14 and the ledger went back to empty. The graph restored from that empty row and wrote its own seven calls, so the finished receipt said **161,897** when the run had actually spent **266,995**.

The per-run ceiling reads that same total, so it was still guarding a number missing **39% of the run**.

## About the test

The first version I wrote built the recorder through `dependencies_for_run` directly — and **passed against the broken code**, because it was testing the helper that was already right rather than the call site that was wrong. I only noticed by reverting the fix and watching it stay green.

The one here drives the real route: it seeds the ledger the way intake would have left it, calls `start_writing`, and reads the row back. Against the old line it fails with `assert 0 == 61145`.

## Verification

`pytest apps/backend/tests` — **1146 passed**.