### PR TITLE
Catch choppy prose, and make the headline a claim the research answers

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -335,8 +335,13 @@ class ArticleBrief(V4ContractModel):
     which is the measure the system has never had: every score v3 owned said
     the Lima article passed.
 
-    `seed` is provenance, not instruction. In v3 the typed title was locked on
-    entry and handed to five stages as a promise nobody examined.
+    `seed` was provenance rather than instruction: in v3 the typed title was
+    locked on entry and handed to five stages as a promise nobody examined.
+
+    ADR 0034 changed half of that. The seed is now the published headline, so
+    it is no longer inert -- whatever it asserts is a claim the article has to
+    stand behind. It still does not steer the writing; it does bind the
+    research, which is why the work order is shown it.
     """
 
     schema_version: Literal[4] = 4

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/polish_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/polish_v4.py
@@ -50,6 +50,26 @@ from .support import _safe_dict, _safe_str
 # Below this, the prose is varied enough that saying so would be noise.
 SPREAD_WORTH_MENTIONING = 0.45
 
+# One sentence past 25 words for every this-many sentences, as a floor.
+#
+# Crowding alone missed the failure it most needed to catch. Run 062c0b86
+# (2026-09-01) came back with 64 sentences, 2 of them past 25 words and 16
+# under 8, and a crowding share of 0.36 -- comfortably under the threshold, so
+# nothing was said. The prose was choppy: three sentences in the whole article
+# used a subordinating clause.
+#
+# That is the metric and the fault coming apart. Adding very short sentences
+# widens the distribution and *improves* the crowding number while making the
+# writing worse, so an article can chop its way to a passing score.
+#
+# Derived rather than tuned. `anti_ai_tells` already requires every section to
+# carry at least one sentence over 25 words; a section runs 7 to 10 sentences,
+# so one in fifteen is a floor well below what the house rules already demand,
+# and it is not a number picked to fit three articles. It separates them
+# correctly all the same: Lima 1-in-75 and Huaca 1-in-32 both fire, Medellin
+# 1-in-9 stays quiet, and Medellin is the one that read well.
+LONG_SENTENCE_AT_LEAST_EVERY = 15
+
 
 def _measured_problems(checks: dict[str, Any]) -> list[str]:
     """What the run measured about its own prose, as instructions.
@@ -63,17 +83,43 @@ def _measured_problems(checks: dict[str, Any]) -> list[str]:
     count = checks.get("sentence_count")
     if isinstance(share, (int, float)) and isinstance(count, int) and count:
         long_ones = checks.get("sentences_over_25_words") or 0
-        if share >= SPREAD_WORTH_MENTIONING or not long_ones:
+        short_ones = checks.get("sentences_under_8_words") or 0
+        crowded = share >= SPREAD_WORTH_MENTIONING
+        starved = long_ones * LONG_SENTENCE_AT_LEAST_EVERY < count
+        if crowded or starved:
+            # Named for the faults that actually fired, and both when both
+            # did. Telling a choppy article its sentences "sit within five
+            # words of each other" describes something that is not wrong with
+            # it, and an instruction opening on a wrong diagnosis is easy to
+            # dismiss. Picking one when both are true has the same problem in
+            # the other direction, so neither is dropped.
+            if crowded and starved:
+                fault = (
+                    f"The sentences are too uniform and too short. "
+                    f"{round(share * 100)}% of the {count} sentences sit "
+                    f"within five words of each other, only {long_ones} run "
+                    f"past 25 words, and {short_ones} are under 8."
+                )
+            elif starved:
+                fault = (
+                    f"The sentences are too short and too alike. Only "
+                    f"{long_ones} of {count} run past 25 words and "
+                    f"{short_ones} are under 8, so the article moves in short "
+                    "steps with nothing carrying two ideas at once."
+                )
+            else:
+                fault = (
+                    f"The sentences are too uniform. {round(share * 100)}% of "
+                    f"the {count} sentences sit within five words of each "
+                    f"other, and {long_ones} run past 25 words."
+                )
             problems.append(
-                f"The sentences are too uniform. {round(share * 100)}% of the "
-                f"{count} sentences sit within five words of each other, and "
-                f"{long_ones} run past 25 words. Fix this by joining, never by "
-                "splitting: where one fact explains another, carry both in one "
-                "sentence using because, which, while, after or so that, and "
-                "let short sentences land the points. Length comes from "
-                "subordination. Cutting a long sentence in two makes this "
-                "measurement worse, not better, and cutting content is never "
-                "the fix."
+                f"{fault} Fix this by joining, never by splitting: where one "
+                "fact explains another, carry both in one sentence using "
+                "because, which, while, after or so that, and let short "
+                "sentences land the points. Length comes from subordination. "
+                "Cutting a long sentence in two makes this measurement worse, "
+                "not better, and cutting content is never the fix."
             )
 
     if checks.get("target_word_count_met") is False:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -126,6 +126,15 @@ def build_work_order_prompt(brief: ArticleBrief) -> str:
     return f"""Plan the research for a commissioned article. You cannot browse; you are
 writing the questions someone else will answer.
 
+THE HEADLINE THIS ARTICLE WILL BE PUBLISHED UNDER
+{brief.seed}
+
+Anything that line asserts as fact is a claim the article has to stand behind,
+and it is load bearing whether or not the brief mentions it again. If it names
+an age, a number, a superlative, a "first", an "oldest", or a comparison, one
+of your questions establishes it. A reader who clicked that headline is owed
+the answer to it.
+
 THE BRIEF
 Location: {brief.location}
 Form: {brief.form_id}

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_polish_prompt.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_polish_prompt.py
@@ -71,7 +71,9 @@ def test_the_measured_spread_becomes_an_instruction_with_its_numbers():
     # The instruction that follows the numbers is covered by the joining tests
     # below; what this one holds is that the measurement reaches the prompt as
     # a sentence with its own figures in it.
-    assert "The sentences are too uniform." in prompt
+    # The fixture is the Lima run: crowded AND starved of long sentences, so
+    # both faults are named rather than one being picked.
+    assert "too uniform and too short" in prompt
     assert "cutting content is never the fix" in prompt
 
 
@@ -249,3 +251,71 @@ def test_splitting_really_does_make_the_spread_worse():
     assert after["sentence_stdev_words"] < before["sentence_stdev_words"]
     assert after["sentences_over_25_words"] < before["sentences_over_25_words"]
     assert after["sentence_widest_band_share"] > before["sentence_widest_band_share"]
+
+
+# --- catching choppy prose, not only crowded prose -------------------------
+
+
+def _checks(*, count: int, share: float, long_ones: int, short_ones: int = 9):
+    return {
+        "sentence_count": count,
+        "sentence_widest_band_share": share,
+        "sentences_over_25_words": long_ones,
+        "sentences_under_8_words": short_ones,
+    }
+
+
+def test_choppy_prose_is_caught_even_when_the_crowding_looks_fine():
+    """Run 062c0b86 (2026-09-01): 64 sentences, 2 past 25 words, 16 under 8,
+    crowding 0.36 -- under the threshold, so nothing was said at all.
+
+    Three sentences in the whole article used a subordinating clause. Adding
+    very short sentences widens the distribution and improves the crowding
+    number while making the writing worse, so an article can chop its way to a
+    passing score.
+    """
+    prompt = _prompt(
+        constraint_checks=_checks(count=64, share=0.36, long_ones=2, short_ones=16)
+    )
+
+    assert "too short and too alike" in prompt
+    assert "Only 2 of 64 run past 25 words and 16 are under 8" in prompt
+    assert "joining, never by splitting" in prompt
+
+
+def test_an_article_that_is_both_crowded_and_choppy_is_told_both():
+    """Run 90b3f9bc (2026-08-30): 75 sentences, 59% inside a five word band,
+    and one solitary sentence past 25 words. Both faults are real."""
+    prompt = _prompt(
+        constraint_checks=_checks(count=75, share=0.59, long_ones=1, short_ones=10)
+    )
+
+    assert "too uniform and too short" in prompt
+    assert "59% of the 75 sentences" in prompt
+    assert "only 1 run past 25 words" in prompt
+
+
+def test_prose_that_actually_varies_is_left_alone():
+    """Run 76b36468 (2026-08-31): 54 sentences, 6 past 25 words, crowding 0.35.
+
+    The one of the three that read well. A trigger that fires on this is a
+    trigger that fires on everything.
+    """
+    prompt = _prompt(
+        constraint_checks=_checks(count=54, share=0.35, long_ones=6, short_ones=9)
+    )
+
+    assert "too uniform" not in prompt
+    assert "too short and too alike" not in prompt
+    assert "Nothing measurable is wrong with it" in prompt
+
+
+def test_the_diagnosis_names_the_fault_that_fired():
+    """An instruction that opens by describing something not wrong with the
+    article is easy to dismiss."""
+    choppy = _prompt(
+        constraint_checks=_checks(count=64, share=0.36, long_ones=2, short_ones=16)
+    )
+
+    # Not told its sentences sit within five words of each other. They do not.
+    assert "sit within five words" not in choppy

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -489,3 +489,37 @@ def test_the_stage_record_keeps_why_the_plan_is_the_size_it_is():
     assert record["texture_count"] == 0
     # A thin article later is often explained by a cut made here.
     assert record["cut_warnings"] == outcome.warnings
+
+
+# --- the headline is a claim the article has to stand behind ---------------
+
+
+def test_the_research_plan_is_shown_the_headline_it_has_to_support():
+    """Nothing told the work order what the article would be published under.
+
+    ADR 0034 made the seed the headline, so whatever it asserts now goes out
+    as a claim. Run 062c0b86 (2026-09-01) was titled "Lima Has a Pyramid Older
+    Than the Inca Empire" and asked nine research questions, not one of which
+    established how old the pyramid is. The article never gave a date. The
+    reader who clicked that headline finished the piece without the answer to
+    the exact question that made them click.
+
+    Same shape as the failure ADR 0034 removed from the title stage: the seed
+    existed on the run the whole time and the stage that needed it was never
+    shown it.
+    """
+    prompt = build_work_order_prompt(_brief())
+    flat = " ".join(prompt.split())
+
+    assert "Lima is no longer simply the stopover before Machu Picchu" in flat
+    assert "PUBLISHED UNDER" in prompt
+    assert "load bearing whether or not the brief mentions it again" in flat
+
+
+def test_the_headline_instruction_names_the_kinds_of_claim_to_check():
+    """"Verify the headline" is not actionable. The failure was concrete -- an
+    age -- so the categories are named."""
+    flat = " ".join(build_work_order_prompt(_brief()).split())
+
+    for kind in ("an age", "a superlative", '"oldest"', "a comparison"):
+        assert kind in flat


### PR DESCRIPTION
Two things the first real article since the phase work exposed. Run `062c0b86`, 2026-09-01.

## 1. The flatness trigger measured the wrong thing

It fired on crowding ≥ 0.45. That run came back at **0.36** — with 64 sentences, **2** past 25 words, **16** under 8, and three subordinating clauses in the entire article. Nothing was said.

**Adding very short sentences widens the distribution and *improves* the crowding number while making the writing worse.** An article can chop its way to a passing score.

So a second trigger: fewer than one sentence past 25 words for every fifteen sentences.

**Derived, not tuned.** `anti_ai_tells` already requires every section to carry one sentence over 25 words, and a section runs 7–10 sentences — so one in fifteen is a floor well below what the house rules already demand. It happens to separate the three real articles correctly:

| run | long sentences | fires? | read well? |
|---|---|---|---|
| Lima 08-30 | 1 in 75 | yes | no |
| **Huaca 09-01** | **1 in 32** | **yes** | **no** |
| Medellín 08-31 | 1 in 9 | no | yes |

Both faults are named when both fire. Telling a choppy article its sentences "sit within five words of each other" describes something that is *not* wrong with it; picking one when both are true has the same problem in the other direction.

## 2. The work order was never shown the headline

ADR 0034 made the seed the published title, so whatever it asserts now goes out as a claim.

That run was titled **"Lima Has a Pyramid Older Than the Inca Empire."** It asked **nine** research questions. Not one established how old the pyramid is. The article never gives a date, a century, or a comparison — a reader who clicked that headline finished the piece without the answer to the exact question that made them click.

This is the same shape as the failure ADR 0034 *removed* from the title stage: the seed was sitting on the run the whole time and the stage that needed it was never shown it. I moved the problem rather than closing it.

The work order prompt now carries the headline and says anything it asserts is load bearing whether or not the brief repeats it — naming the kinds of claim that need establishing (an age, a number, a superlative, a "first", an "oldest", a comparison), because *"verify the headline"* is not actionable.

The `seed` docstring saying it is "provenance, not instruction" is corrected: still not an instruction to the writing, but it does now bind the research.

## Verification

`pytest apps/backend/tests` — **1152 passed** (+7). The new trigger tests use the real measurements from all three articles rather than invented numbers.

Neither of these can be confirmed without another run. The trigger is deterministic and I can show it fires correctly on recorded data; whether the *instruction* then improves the prose, and whether the work order actually asks about the headline's claim, are both read off the next article.