### PR TITLE
Stop asking whether KFC is still open

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -479,8 +479,11 @@ def settle_the_gate(
 
 class VenueMarkRequest(BaseModel):
     claim_id: str = Field(min_length=1)
-    # Drop it, or say what you saw. Marking it fine is simply not calling this.
+    # Three moves, and marking it fine is still simply not calling this.
+    # `drop` takes the claim out of the dossier; `dismiss` takes the question
+    # off the list and leaves the dossier alone; a note says what was seen.
     drop: bool = False
+    dismiss: bool = False
     note: str | None = None
 
 
@@ -499,10 +502,14 @@ def mark_venue(
     run_id: str, request: VenueMarkRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
     """Record what the operator saw when they looked."""
-    if request.drop == (request.note is not None):
+    chosen = [request.drop, request.dismiss, request.note is not None]
+    if sum(1 for move in chosen if move) != 1:
         raise HTTPException(
             status_code=400,
-            detail="Either drop it, or say what you saw. Not both, and not neither.",
+            detail=(
+                "Pick one: drop it, dismiss it as not worth checking, "
+                "or say what you saw."
+            ),
         )
     _handle(
         settle_venue,
@@ -510,6 +517,7 @@ def mark_venue(
         _services(run_id),
         claim_id=request.claim_id,
         drop=request.drop,
+        dismiss=request.dismiss,
         note=request.note,
     )
     return JSONResponse(intake_state(run_id))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -445,18 +445,41 @@ class EvidenceClaim(V4ContractModel):
     requirement_ids: list[str] = Field(min_length=1)
     as_of: date | None = None
     confidence: EvidenceConfidence
-    # The place this claim would send a reader: a tour, a restaurant, a bar, a
-    # museum. Set only when the claim names somewhere bookable or visitable,
-    # so the operator can be shown a short list rather than every fact.
+    # A place this claim sends a reader to, whose survival is genuinely in
+    # doubt: an independent operator, a small guesthouse, one restaurant, a
+    # tour run by a few people.
     #
     # Research can confirm a site resolves and a price is published. It cannot
     # see that the last post was 2024 and the checkout is janky. Moravia Tours
     # came back correct in every word and was a business winding down, which is
     # not a fact on a page but the absence of recent activity. That judgment
     # needs a person, and this field is how they are given the short list.
+    #
+    # Two things this is not, both from run a2066506, which put McDonald's,
+    # Starbucks and KFC in front of the operator:
+    #
+    # A place nobody doubts is not worth a person's eye. A chain, a plaza, a
+    # metro station, a museum that has been open for forty years -- confirming
+    # any of them is a decision the operator can never learn anything from, and
+    # it dilutes the two or three that matter.
+    #
+    # Naming a place is not recommending it. "Parque Kennedy is surrounded by
+    # McDonald's, Starbucks and KFC" names three venues and sends a reader to
+    # none of them; it is a sentence about the character of an area, and on
+    # that run it was one of the better lines available. Only a claim that
+    # actually points a reader somewhere carries the risk this field exists to
+    # catch.
     venue: str = ""
     # What the operator said about it after looking. Reaches the writer.
     venue_note: str = ""
+    # The operator said this one never needed checking. The claim is untouched
+    # and still supports whatever it supported -- it only leaves the list.
+    #
+    # Dropping is the move that costs something, because it takes the claim out
+    # of the dossier and can put a question back behind the gate. Making that
+    # the only way to clear an irrelevant entry meant the obvious move and the
+    # safe move were different, which is the wrong way round.
+    venue_dismissed: bool = False
 
     @model_validator(mode="after")
     def validate_unique_links(self) -> "EvidenceClaim":

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
@@ -392,15 +392,21 @@ def _cost_of_omitting(work_order: "Prompt2BlogWorkOrder", requirement_id: str) -
 def venues_to_check(evidence: EvidencePackage) -> list[dict[str, Any]]:
     """The places the article would send a reader, for a person to look at.
 
-    Only claims that name somewhere bookable or visitable. In run 76b36468 that
-    was five of nineteen claims, two of them the same operator: a two minute
-    job, because most claims are facts rather than places.
+    Only claims naming somewhere whose survival is in doubt. In run 76b36468
+    that was five of nineteen claims, two of them the same operator: a two
+    minute job, because most claims are facts rather than places.
+
+    `sole_support_for` names the questions that would be left with nothing if
+    this place were dropped. Dropping is the one move here that costs
+    something, and run a2066506 is why it has to be said in advance: an
+    operator clearing three irrelevant chains out of the list could push their
+    own run back behind the gate without being told.
     """
     seen: set[str] = set()
     venues: list[dict[str, Any]] = []
     for claim in evidence.claims:
         name = _safe_str(claim.venue)
-        if not name or name.casefold() in seen:
+        if not name or claim.venue_dismissed or name.casefold() in seen:
             continue
         seen.add(name.casefold())
         urls = [
@@ -415,9 +421,42 @@ def venues_to_check(evidence: EvidencePackage) -> list[dict[str, Any]]:
                 "text": claim.text,
                 "urls": urls,
                 "note": _safe_str(claim.venue_note),
+                "sole_support_for": _questions_resting_on(evidence, claim.claim_id),
             }
         )
     return venues
+
+
+def _questions_resting_on(evidence: EvidencePackage, claim_id: str) -> list[str]:
+    """Questions this claim is the last thing holding up."""
+    return sorted(
+        requirement.requirement_id
+        for requirement in evidence.requirements
+        if requirement.claim_ids == [claim_id]
+    )
+
+
+def dismiss_venue(evidence: EvidencePackage, *, claim_id: str) -> EvidencePackage:
+    """Take a place off the list without touching the dossier.
+
+    The answer to a place that should never have been asked about. The claim
+    keeps its questions, its sources and its place in what the writer is given
+    -- all that changes is that nobody is asked about it again.
+
+    Separate from `drop_venue` because the two mean opposite things. Dropping
+    says the research is wrong and the article must not rest on it. This says
+    the research is fine and the question was never worth a person's time.
+    """
+    payload = evidence.model_dump(mode="json")
+    found = False
+    for claim in payload["claims"]:
+        if claim["claim_id"] == claim_id:
+            claim["venue_dismissed"] = True
+            found = True
+    if not found:
+        raise GateAnswerRefused(f"No claim called {claim_id}.")
+    logger.info("Operator dismissed the venue on claim %s as not worth checking", claim_id)
+    return EvidencePackage.model_validate(payload)
 
 
 def note_venue(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -51,6 +51,7 @@ from .coverage_v4 import CoverageVerdict, assess_coverage
 from .gate_v4 import (
     GateAnswerRefused,
     answer_requirement,
+    dismiss_venue,
     drop_venue,
     mark_unpublished,
     note_venue,
@@ -607,23 +608,29 @@ def settle_venue(
     *,
     claim_id: str,
     drop: bool = False,
+    dismiss: bool = False,
     note: str | None = None,
 ) -> CoverageVerdict:
     """Record what the operator saw when they looked at a place.
 
     No model call. Dropping one can put the run back behind the gate, when the
     dropped place was a question's only support -- which is correct: an article
-    must not rest on a claim its operator looked at and rejected.
+    must not rest on a claim its operator looked at and rejected. The screen
+    says so before the click, rather than after it.
+
+    Dismissing costs nothing by design: it is the move for a place that should
+    never have been on the list, and it leaves the dossier exactly as it was.
     """
     work_order = load_work_order(run_id)
     evidence = load_evidence(run_id)
     notes = _stage_data(run_id, RESEARCH_STAGE).get("notes") or {}
 
-    evidence = (
-        drop_venue(evidence, claim_id=claim_id)
-        if drop
-        else note_venue(evidence, claim_id=claim_id, note=note or "")
-    )
+    if drop:
+        evidence = drop_venue(evidence, claim_id=claim_id)
+    elif dismiss:
+        evidence = dismiss_venue(evidence, claim_id=claim_id)
+    else:
+        evidence = note_venue(evidence, claim_id=claim_id, note=note or "")
 
     verdict = assess_coverage(work_order, evidence)
     _record(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -83,6 +83,9 @@ EVIDENCE_CLAIM_FIELDS = frozenset(
         "confidence",
         "venue",
         "venue_note",
+        # Operator-set, like `venue_note`. It survives a re-parse of stored
+        # evidence, so a place already cleared off the list stays cleared.
+        "venue_dismissed",
     }
 )
 EVIDENCE_REQUIREMENT_FIELDS = frozenset({"requirement_id", "status", "claim_ids", "gap"})
@@ -630,12 +633,26 @@ Rules:
 - `confidence` on a claim is one of: high, medium, low. An answer that is
   genuinely a range is still `supported` at `medium` or `low`; it does not
   become `partial` for being approximate.
-- Set `venue` on a claim that names somewhere a reader could actually go: a
-  tour operator, a restaurant, a bar, a museum, a shop, anything bookable or
-  visitable. Put the name of the place there and nothing else. Leave it empty
-  for a claim that is only a fact -- an elevation, a visitor count, a date. A
-  person checks these before the article recommends them, and a list with every
-  fact in it is a list nobody reads.
+- Set `venue` only on a claim that sends a reader to a place whose survival is
+  genuinely in doubt: an independent tour operator, a small guesthouse, one
+  restaurant, a bar, a family business, a tour run by a few people. Put the
+  name of the place there and nothing else. A person looks these up before the
+  article recommends them, and they are looking for one thing -- whether it is
+  still going.
+  Leave it empty in all three of these cases:
+  - The claim is only a fact: an elevation, a visitor count, a date.
+  - Nobody doubts the place is still there: a chain, a plaza, a park, a metro
+    station, a cathedral, a museum that has been open for decades. Asking about
+    one of these is a question the person can never learn anything from, and it
+    buries the two or three worth their time.
+  - The claim names the place as evidence rather than as a destination.
+    "Parque Kennedy is surrounded by McDonald's, Starbucks and KFC" names three
+    venues and sends a reader to none of them -- it describes what an area has
+    become, and that is a good sentence to write. Tag the place the article
+    points at, never the place it merely mentions.
+  Most claims should have no venue. On a run with nineteen claims, three or
+  four is a normal count, and a list with every fact in it is a list nobody
+  reads.
 - A `conflict` records two or more claims that disagree, and must list their
   claim ids. If you cannot name at least two claims in conflict, it is not a
   conflict -- leave it out.

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_venue_check.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_venue_check.py
@@ -17,6 +17,7 @@ import pytest
 from app.features.prompt2blog.contracts_v4 import EvidencePackage
 from app.features.prompt2blog.gate_v4 import (
     GateAnswerRefused,
+    dismiss_venue,
     drop_venue,
     note_venue,
     venues_to_check,
@@ -251,5 +252,106 @@ def test_the_schema_asks_for_the_venue_and_the_prompt_explains_it():
     )
     flat = " ".join(build_structure_prompt(work_order, {}).split())
 
-    assert "somewhere a reader could actually go" in flat
+    assert "sends a reader to a place whose survival is genuinely in doubt" in flat
     assert "a list with every fact in it is a list nobody reads" in flat
+    # The two faults from run a2066506, named in the instruction itself.
+    assert "Nobody doubts the place is still there" in flat
+    assert "names the place as evidence rather than as a destination" in flat
+
+
+# --- what does not belong on the list at all --------------------------------
+
+
+def test_a_place_the_operator_dismissed_leaves_the_list():
+    """Run a2066506 put McDonald's, Starbucks and KFC in front of the operator.
+
+    Nobody needs to confirm McDonald's is still trading, and clearing one has
+    to be free -- the whole point is that it should never have been asked.
+    """
+    evidence = dismiss_venue(_evidence(), claim_id="c11")
+
+    assert [v["venue"] for v in venues_to_check(evidence)] == ["Real City Tours"]
+
+
+def test_dismissing_leaves_the_dossier_exactly_as_it_was():
+    """The research was right. Only the question was not worth asking."""
+    evidence = dismiss_venue(_evidence(), claim_id="c11")
+
+    claim = next(c for c in evidence.claims if c.claim_id == "c11")
+    assert claim.text == "Moravia Tours was co-founded by community leaders."
+    assert claim.requirement_ids == ["q3"]
+    requirement = next(r for r in evidence.requirements if r.requirement_id == "q3")
+    assert requirement.status == "supported"
+    assert requirement.claim_ids == ["c10", "c11"]
+
+
+def test_a_dismissal_survives_a_re_parse_of_stored_evidence():
+    """Otherwise the same three chains come back on the next page load."""
+    from app.features.prompt2blog.research_v4 import _normalised_evidence
+
+    dismissed = dismiss_venue(_evidence(), claim_id="c11")
+    stored = dismissed.model_dump(mode="json")
+    reparsed = EvidencePackage.model_validate(
+        {
+            **_normalised_evidence(stored),
+            "work_order_fingerprint": stored["work_order_fingerprint"],
+        }
+    )
+
+    claim = next(c for c in reparsed.claims if c.claim_id == "c11")
+    assert claim.venue_dismissed is True
+
+
+def test_dismissing_an_unknown_claim_says_so():
+    with pytest.raises(GateAnswerRefused, match="No claim called"):
+        dismiss_venue(_evidence(), claim_id="c999")
+
+
+# --- saying what a drop will cost, before the click -------------------------
+
+
+def test_the_list_says_which_questions_rest_on_this_place_alone():
+    """The trap in run a2066506: clearing an irrelevant entry could push the
+    run back behind the gate with no warning."""
+    evidence = _evidence(
+        claims=[
+            {
+                "claim_id": "c11",
+                "text": "Moravia Tours runs weekly tours.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["q3"],
+                "confidence": "high",
+                "venue": "Moravia Tours",
+            },
+            {
+                "claim_id": "c10",
+                "text": "Real City Tours costs COP 100,000.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["q1"],
+                "confidence": "high",
+                "venue": "Real City Tours",
+            },
+            {
+                "claim_id": "c4",
+                "text": "The Graffitour draws 7,000 daily.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["q1"],
+                "confidence": "high",
+            },
+        ],
+        requirements=[
+            {"requirement_id": "q3", "status": "supported", "claim_ids": ["c11"]},
+            {"requirement_id": "q1", "status": "supported", "claim_ids": ["c10", "c4"]},
+        ],
+    )
+
+    by_name = {v["venue"]: v for v in venues_to_check(evidence)}
+    assert by_name["Moravia Tours"]["sole_support_for"] == ["q3"]
+    # q1 keeps c4 whatever happens to this one, so dropping it costs nothing.
+    assert by_name["Real City Tours"]["sole_support_for"] == []
+
+
+def test_nothing_rests_on_a_place_a_second_claim_also_supports():
+    by_name = {v["venue"]: v for v in venues_to_check(_evidence())}
+
+    assert by_name["Moravia Tours"]["sole_support_for"] == []

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/VenueCheck.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/VenueCheck.tsx
@@ -15,6 +15,13 @@ import type { VenueToCheck } from '../intake.types'
  * is exactly what went wrong, and naming it accurately is what keeps this a two
  * minute job instead of a review of places nobody has been.
  *
+ * Three moves, because two were not enough. Run a2066506 listed McDonald's,
+ * Starbucks and KFC — places whose status nobody doubts — and the only way to
+ * clear one was to drop it, which takes the claim out of the dossier and can
+ * put the run back behind the gate. So the obvious move was the costly one.
+ * "Not worth checking" is the free one, and a drop that would cost something
+ * now says so before the click.
+ *
  * Not a gate. Exactly one gate blocks in this pipeline (ADR 0030) and this is
  * not it: everything here is skippable in one click.
  */
@@ -28,22 +35,29 @@ function Venue({
   runId,
   venue,
   onChanged,
+  onSettled,
 }: {
   runId: string
   venue: VenueToCheck
   onChanged: () => void
+  onSettled: () => void
 }) {
   const [noting, setNoting] = useState(false)
   const [note, setNote] = useState(venue.note)
   const [busy, setBusy] = useState(false)
-  const [done, setDone] = useState<'dropped' | 'noted' | null>(null)
+  const [done, setDone] = useState<'dropped' | 'dismissed' | 'noted' | null>(null)
+  const costsAQuestion = venue.sole_support_for.length > 0
 
-  async function send(body: { drop?: boolean; note?: string }) {
+  async function send(
+    outcome: 'dropped' | 'dismissed' | 'noted',
+    body: { drop?: boolean; dismiss?: boolean; note?: string },
+  ) {
     setBusy(true)
     try {
       await markVenue(runId, { claim_id: venue.claim_id, ...body })
-      setDone(body.drop ? 'dropped' : 'noted')
+      setDone(outcome)
       onChanged()
+      onSettled()
     } finally {
       setBusy(false)
     }
@@ -64,7 +78,11 @@ function Venue({
 
       {done ? (
         <p className="p2b-venue-done">
-          {done === 'dropped' ? 'Dropped. It will not reach the writer.' : `Noted: ${note}`}
+          {done === 'dropped'
+            ? 'Dropped. It will not reach the writer.'
+            : done === 'dismissed'
+              ? 'Left alone. It stays in the dossier; you just will not be asked again.'
+              : `Noted: ${note}`}
         </p>
       ) : noting ? (
         <>
@@ -81,7 +99,7 @@ function Venue({
           <div className="p2b-intake-actions">
             <button
               type="button"
-              onClick={() => void send({ note })}
+              onClick={() => void send('noted', { note })}
               disabled={busy || !note.trim()}
             >
               Save the note
@@ -97,24 +115,44 @@ function Venue({
           </div>
         </>
       ) : (
-        <div className="p2b-intake-actions">
-          <button
-            type="button"
-            className="p2b-secondary"
-            onClick={() => void send({ drop: true })}
-            disabled={busy}
-          >
-            Drop it
-          </button>
-          <button
-            type="button"
-            className="p2b-secondary"
-            onClick={() => setNoting(true)}
-            disabled={busy}
-          >
-            Add a note
-          </button>
-        </div>
+        <>
+          {costsAQuestion ? (
+            <p className="p2b-venue-cost">
+              Dropping this puts{' '}
+              {venue.sole_support_for.length === 1
+                ? 'a question'
+                : `${venue.sole_support_for.length} questions`}{' '}
+              back behind the gate — it is the only thing supporting{' '}
+              {venue.sole_support_for.join(', ')}. A note costs nothing.
+            </p>
+          ) : null}
+          <div className="p2b-intake-actions">
+            <button
+              type="button"
+              className="p2b-secondary"
+              onClick={() => void send('dropped', { drop: true })}
+              disabled={busy}
+            >
+              Drop it
+            </button>
+            <button
+              type="button"
+              className="p2b-secondary"
+              onClick={() => setNoting(true)}
+              disabled={busy}
+            >
+              Add a note
+            </button>
+            <button
+              type="button"
+              className="p2b-secondary"
+              onClick={() => void send('dismissed', { dismiss: true })}
+              disabled={busy}
+            >
+              Not worth checking
+            </button>
+          </div>
+        </>
       )}
     </li>
   )
@@ -129,6 +167,33 @@ export function VenueCheck({ runId, onChanged }: VenueCheckProps) {
       .then(result => setVenues(result.venues))
       .catch(() => setVenues([]))
   }, [runId])
+
+  /**
+   * Re-read what each remaining drop would cost, because one drop changes the
+   * others. Two claims holding up a question both cost nothing to drop until
+   * the first one goes — and then the second is the only support left. Read
+   * once at mount, that second row would still be promising it was free.
+   *
+   * Rows are updated in place rather than replaced: a dropped claim is gone
+   * from the server's list, and the operator should still see that it was
+   * dropped.
+   */
+  function refreshCosts() {
+    void readVenues(runId)
+      .then(result => {
+        const fresh = new Map(result.venues.map(v => [v.claim_id, v.sole_support_for]))
+        setVenues(
+          current =>
+            current?.map(venue => ({
+              ...venue,
+              sole_support_for: fresh.get(venue.claim_id) ?? venue.sole_support_for,
+            })) ?? null,
+        )
+      })
+      .catch(() => {
+        /* The costs stay as last read. Nothing here blocks the run. */
+      })
+  }
 
   if (skipped || venues === null || venues.length === 0) return null
 
@@ -145,7 +210,13 @@ export function VenueCheck({ runId, onChanged }: VenueCheckProps) {
 
       <ul className="p2b-venue-list">
         {venues.map(venue => (
-          <Venue key={venue.claim_id} runId={runId} venue={venue} onChanged={onChanged} />
+          <Venue
+            key={venue.claim_id}
+            runId={runId}
+            venue={venue}
+            onChanged={onChanged}
+            onSettled={refreshCosts}
+          />
         ))}
       </ul>
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -219,10 +219,13 @@ export async function readVenues(runId: string): Promise<{ venues: VenueToCheck[
   return (await response.json()) as { venues: VenueToCheck[] }
 }
 
-/** Record what the operator saw. Drop it, or say what you found. */
+/**
+ * Record what the operator saw. Exactly one move per call: drop it, dismiss it
+ * as never worth checking, or say what you found.
+ */
 export function markVenue(
   runId: string,
-  body: { claim_id: string; drop?: boolean; note?: string },
+  body: { claim_id: string; drop?: boolean; dismiss?: boolean; note?: string },
 ): Promise<IntakeState> {
   return post(`${INTAKE}/${runId}/venues`, body)
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -183,6 +183,12 @@ export interface VenueToCheck {
   text: string
   urls: string[]
   note: string
+  /**
+   * Questions this place is the last thing holding up. Dropping it puts them
+   * back behind the gate, which the screen has to say before the click rather
+   * than after it.
+   */
+  sole_support_for: string[]
 }
 
 /** The finished article. Its own call: the state is polled, this is not. */

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/venue-check.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/venue-check.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readVenues = vi.fn()
+const markVenue = vi.fn()
+
+vi.mock('./intake.api', async importOriginal => ({
+  ...(await importOriginal<typeof import('./intake.api')>()),
+  readVenues: (runId: string) => readVenues(runId),
+  markVenue: (runId: string, body: unknown) => markVenue(runId, body),
+}))
+
+import { VenueCheck } from './components/VenueCheck'
+import type { VenueToCheck } from './intake.types'
+
+/**
+ * The screen that asked run a2066506's operator to confirm KFC was still open.
+ *
+ * Two faults, and they need different answers. A place nobody doubts should
+ * never have been on the list — and until the research prompt stops tagging
+ * them, clearing one has to be free. A place that genuinely holds up a question
+ * is the opposite: dropping it costs something, and the cost has to be visible
+ * before the click rather than discovered after it.
+ */
+
+function venue(overrides: Partial<VenueToCheck> = {}): VenueToCheck {
+  return {
+    claim_id: 'c1',
+    venue: 'Hotel Maury',
+    text: 'Hotel Maury sits two blocks from the Plaza Mayor.',
+    urls: [],
+    note: '',
+    sole_support_for: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  readVenues.mockReset()
+  markVenue.mockReset()
+  markVenue.mockResolvedValue({})
+})
+
+describe('clearing a place that never needed checking', () => {
+  it('offers a move that is not the destructive one', async () => {
+    readVenues.mockResolvedValue({ venues: [venue({ venue: 'KFC' })] })
+    render(<VenueCheck runId="r1" onChanged={() => {}} />)
+    await screen.findByText('KFC')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Not worth checking' }))
+
+    await waitFor(() =>
+      expect(markVenue).toHaveBeenCalledWith('r1', { claim_id: 'c1', dismiss: true }),
+    )
+    // Not a drop. The claim stays in the dossier holding up whatever it held up.
+    expect(markVenue).not.toHaveBeenCalledWith('r1', expect.objectContaining({ drop: true }))
+  })
+
+  it('says the dossier was left alone, so the two moves are not confused', async () => {
+    readVenues.mockResolvedValue({ venues: [venue({ venue: 'Starbucks' })] })
+    render(<VenueCheck runId="r1" onChanged={() => {}} />)
+    await screen.findByText('Starbucks')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Not worth checking' }))
+
+    expect(await screen.findByText(/stays in the dossier/)).toBeTruthy()
+  })
+})
+
+describe('what a drop would cost, before the click', () => {
+  it('stays quiet when the question survives without this place', async () => {
+    readVenues.mockResolvedValue({ venues: [venue()] })
+    render(<VenueCheck runId="r1" onChanged={() => {}} />)
+    await screen.findByText('Hotel Maury')
+
+    expect(screen.queryByText(/back behind the gate/)).toBeNull()
+  })
+
+  it('names the question a drop would put back behind the gate', async () => {
+    readVenues.mockResolvedValue({
+      venues: [venue({ sole_support_for: ['q3'] })],
+    })
+    render(<VenueCheck runId="r1" onChanged={() => {}} />)
+
+    const warning = await screen.findByText(/back behind the gate/)
+    expect(warning.textContent).toContain('q3')
+    expect(warning.textContent).toContain('A note costs nothing.')
+  })
+
+  it('re-reads the cost after a move, because one drop changes the others', async () => {
+    // Two claims hold up q3, so neither costs anything to drop. Once the first
+    // goes, the second is the only support left — and a list read once at mount
+    // would still be promising it was free.
+    readVenues
+      .mockResolvedValueOnce({
+        venues: [
+          venue({ claim_id: 'c1', venue: 'Bar Cordano' }),
+          venue({ claim_id: 'c2', venue: 'Bar Maury' }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        venues: [venue({ claim_id: 'c2', venue: 'Bar Maury', sole_support_for: ['q3'] })],
+      })
+
+    render(<VenueCheck runId="r1" onChanged={() => {}} />)
+    await screen.findByText('Bar Cordano')
+    expect(screen.queryByText(/back behind the gate/)).toBeNull()
+
+    const dropButtons = screen.getAllByRole('button', { name: 'Drop it' })
+    await userEvent.click(dropButtons[0])
+
+    const warning = await screen.findByText(/back behind the gate/)
+    expect(warning.textContent).toContain('q3')
+    // The row that was acted on keeps its confirmation rather than vanishing.
+    expect(screen.getByText(/will not reach the writer/)).toBeTruthy()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -950,6 +950,20 @@
   font-size: 0.875rem;
 }
 
+/*
+ * What a drop would cost, said before the click. The one destructive move on
+ * this screen sits next to two free ones, so the difference has to be visible
+ * rather than discovered.
+ */
+.p2b-venue-cost {
+  margin: var(--space-3) 0 0;
+  color: var(--ink-light);
+  font-size: 0.875rem;
+  line-height: 1.55;
+  border-left: 2px solid var(--accent);
+  padding-left: var(--space-3);
+}
+
 .p2b-venue .p2b-intake-actions {
   margin-top: var(--space-3);
 }


### PR DESCRIPTION
Closes #466. First half of Phase 1.

## The two faults

Run `a2066506` listed **14 venues out of 37 claims** — including Starbucks, KFC, Plaza Mayor, Estación Central and Jirón de la Unión. Replayed through the current code to confirm before changing anything.

**1. It asked about places whose status is never in doubt.** The check exists for the Moravia Tours case: a business correct in every word and quietly winding down, which research cannot see and a person can in two minutes. A chain is the exact case where it is worth nothing, and each one dilutes the handful that matter.

**2. It treated naming a place as recommending it.** "Parque Kennedy is surrounded by McDonald's, Starbucks and KFC" sends a reader to none of them — research found those chains *because they are evidence for the article's argument*. The check saw three venue names and asked for three verifications.

Both are the research instruction, so `venue` is now defined as *a place the article points a reader at, whose survival is genuinely in doubt*, with the chain case and the evidence case named explicitly.

**No name list.** A list of global chains is unbounded and rots; "is this place's survival in doubt" is a judgement a model can make and a list cannot. The tests pin that the instruction says it — the real proof is a run.

## The trap underneath it

Dropping a venue removes the claim and can put a question back behind the gate, so clearing three irrelevant chains could push a run backwards silently. The workaround was to leave a note, which made the safe move and the obvious move different.

- **"Not worth checking"** — new, free. Sets `venue_dismissed` on the claim; questions, sources and writer input all unchanged. This is also the only thing that helps runs whose evidence was tagged by the old prompt.
- **A drop that costs something says so first** — `venues_to_check` reports `sole_support_for`, and the row names the question before the click.
- **The cost is re-read after every action.** Two claims holding up one question both cost nothing to drop until the first goes. Read once at mount, the second row would still promise it was free. Caught while replaying the real run, not in review.

## Verification

- Replayed stored run `a2066506` through `venues_to_check` — this is where the 14/37 figure and the stale-cost bug came from
- `test_prompt2blog_venue_check.py` extended: dismissal leaves the dossier intact, survives a re-parse of stored evidence, and `sole_support_for` is right
- New `venue-check.test.tsx` — the component had **no** frontend test before this
- Backend 1158 passed · Prompt2Blog frontend 133 passed · `tsc --noEmit` clean

**Not proven:** the instruction change cannot retag evidence that already exists, so its effect is unknown until the next real run. That is what the dismiss move covers in the meantime.