### PR TITLE
Let the gate say "that is not there", and which move fits

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -405,6 +405,10 @@ class GateAnswerRequest(BaseModel):
     answer: str | None = None
     source_url: str | None = None
     unpublished_note: str | None = None
+    # What research found instead, when the thing the question asked about is
+    # not there. Different from the note above: that one says the figure exists
+    # and nobody prints it.
+    nonexistent_note: str | None = None
     # Drop the question. Permitted for a load-bearing one, and answered once
     # with what the article can no longer claim (ADR 0030).
     omit: bool = False
@@ -454,14 +458,16 @@ def settle_the_gate(
     chosen = [
         request.answer is not None,
         request.unpublished_note is not None,
+        request.nonexistent_note is not None,
         request.omit,
     ]
     if sum(chosen) != 1:
         raise HTTPException(
             status_code=400,
             detail=(
-                "Say one of three things: what the answer is, that it is not "
-                "published anywhere, or that the question should be dropped."
+                "Say one of four things: what the answer is, that nobody "
+                "publishes it, that the thing is not there, or that the "
+                "question should be dropped."
             ),
         )
     _handle(
@@ -472,6 +478,7 @@ def settle_the_gate(
         answer=request.answer,
         source_url=request.source_url,
         unpublished_note=request.unpublished_note,
+        nonexistent_note=request.nonexistent_note,
         omit=request.omit,
     )
     return JSONResponse(intake_state(run_id))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -80,7 +80,52 @@ EvidenceConfidence = Literal["high", "medium", "low"]
 # either terminal — could only be reported as `partial`, which blocked the run and
 # sent the operator back to ask again for a fact that does not exist. It is a
 # finding, not a failure: the article omits the number without narrating the gap.
-EvidenceRequirementStatus = Literal["supported", "partial", "missing", "unpublished"]
+# `nonexistent` is the other half, and run a2066506 needed it twice in one run.
+# Research asked for three 4-star hotels within five blocks of the Plaza Mayor,
+# found three named properties with rates and distances, and stated plainly that
+# no genuine 4-star exists there -- the nearest being the Sheraton, 1.4 km away.
+# The research did not fail. It answered, and the answer was "that is not
+# there", which no status could record, so the run blocked on a question that
+# was already settled.
+#
+# Distinct from `unpublished`, which means the figure exists and nobody prints
+# it. This means the thing the question presupposes is not there. Both are
+# publishable sentences: "there is no 4-star hotel in the historic centre, the
+# nearest is a fifteen minute walk" is better travel writing than three invented
+# ones.
+EvidenceRequirementStatus = Literal[
+    "supported", "partial", "missing", "unpublished", "nonexistent"
+]
+# Every status that leaves a question unsettled, and therefore has to say what
+# is missing. Named once because coverage, the gate and the contract all ask.
+UNSETTLED_STATUSES = frozenset({"partial", "missing", "unpublished", "nonexistent"})
+# Why research came up short, in its own words rather than the gate's guess.
+#
+# The gate used to show four buttons and no indication which one was right, so
+# the operator read a dozen research bullets and worked out for themselves
+# whether they were looking at a search that went wrong, a number nobody
+# publishes, a thing that is not there, or a question that asked for more
+# precision than the article needed. The diagnosis was already sitting in the
+# notes -- "Booking.com published no separate aggregate figure" -- unread.
+#
+# Declared by research rather than inferred by the gate from that prose. A
+# pattern match over English fails silently on the phrasing nobody wrote it for,
+# and research is the only step that actually knows why it fell short.
+EvidenceShortfallCause = Literal[
+    "unknown",
+    # A source was checked and does not print the figure.
+    "not_published",
+    # The thing the question assumes exists is not there, and research can say
+    # what is there instead.
+    "does_not_exist",
+    # Near-miss numbers found, none exact, because the question asked for more
+    # precision than anyone publishes.
+    "question_too_precise",
+    # The answer is about a different place, period or subject than was asked.
+    "answered_something_else",
+    # Nothing relevant came back at all.
+    "nothing_found",
+]
 # What research found when it went to check what the direction step assumed.
 #
 # `refuted` is the verdict that had nowhere to live. A question about a ranking
@@ -493,6 +538,9 @@ class EvidenceRequirement(V4ContractModel):
     status: EvidenceRequirementStatus
     claim_ids: list[str] = Field(default_factory=list)
     gap: str = ""
+    # Why it fell short, so the gate can suggest a move instead of offering
+    # four buttons and no opinion. Meaningless on a `supported` requirement.
+    cause: EvidenceShortfallCause = "unknown"
 
     @model_validator(mode="after")
     def validate_status_details(self) -> "EvidenceRequirement":
@@ -501,9 +549,10 @@ class EvidenceRequirement(V4ContractModel):
             raise ValueError("supported requirements must reference at least one claim")
         if self.status == "supported" and self.gap:
             raise ValueError("supported requirements cannot describe a gap")
-        if self.status in {"partial", "missing", "unpublished"} and not self.gap:
+        if self.status in UNSETTLED_STATUSES and not self.gap:
             raise ValueError(
-                "partial, missing, and unpublished requirements must describe the gap"
+                "partial, missing, unpublished, and nonexistent requirements "
+                "must describe the gap"
             )
         if self.status == "missing" and self.claim_ids:
             raise ValueError("missing requirements cannot reference claims")
@@ -511,6 +560,18 @@ class EvidenceRequirement(V4ContractModel):
         # measures immigration and baggage and no other step" is a real claim with
         # a real source, and it is what makes the absence reportable rather than
         # merely asserted.
+        #
+        # `nonexistent` goes further and *requires* them. "There is no 4-star
+        # hotel within five blocks" is a finding when three named 3-star
+        # properties and a Sheraton 1.4 km away sit behind it, and an assertion
+        # when nothing does. A search that returned nothing has not established
+        # that a thing is absent -- it has established that it found nothing,
+        # which is `missing`.
+        if self.status == "nonexistent" and not self.claim_ids:
+            raise ValueError(
+                "nonexistent requirements must reference the claims that show "
+                "what is there instead"
+            )
         return self
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/coverage_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/coverage_v4.py
@@ -31,6 +31,16 @@ from .contracts_v4 import EvidencePackage, Prompt2BlogWorkOrder
 # whether it was interesting.
 ENJOYABLE_STATUSES = {"supported", "partial"}
 
+# The statuses that settle a load-bearing question rather than block on it.
+#
+# `unpublished` and `nonexistent` are findings, not failures, and both are
+# publishable sentences: nobody prints Lima's customs times, and there is no
+# 4-star hotel within five blocks of the Plaza Mayor. Neither is a hole in the
+# article -- they are things the article can say. What they are not is texture,
+# which is why they stay out of ENJOYABLE_STATUSES above: a dossier answering
+# every question with an absence still has nothing a reader would enjoy.
+SETTLED_STATUSES = {"supported", "unpublished", "nonexistent"}
+
 
 @dataclass
 class CoverageVerdict:
@@ -77,7 +87,7 @@ def assess_coverage(
         requirement_id
         for requirement_id, kind in kind_by_id.items()
         if kind == "load_bearing"
-        and status_by_id.get(requirement_id) not in {"supported", "unpublished"}
+        and status_by_id.get(requirement_id) not in SETTLED_STATUSES
     )
     refuted = sorted(
         finding.assumption_id

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
@@ -526,6 +526,113 @@ def drop_venue(evidence: EvidencePackage, *, claim_id: str) -> EvidencePackage:
     return EvidencePackage.model_validate(payload)
 
 
+def mark_nonexistent(
+    evidence: EvidencePackage,
+    *,
+    requirement_id: str,
+    note: str,
+) -> EvidencePackage:
+    """Record that the thing the question asked about is not there.
+
+    Not the same as nobody publishing it. Run a2066506 asked for three 4-star
+    hotels within five blocks of the Plaza Mayor and research answered with
+    three named properties, their distances and their ratings, plus the
+    finding that no genuine 4-star exists in that radius -- the nearest being
+    the Sheraton at 1.4 km. Nothing was missing. The question presupposed
+    something that is not so.
+
+    The claims stay, and the contract insists on them: what research found is
+    what makes the absence a finding rather than an assertion. A search that
+    came back empty has not established that a thing is absent, and belongs in
+    `missing`.
+
+    Left as the operator's click rather than a status research can set itself.
+    "It does not exist" is a strong claim, and a model that looked in the wrong
+    place would make it in exactly the same words as a model that looked
+    properly -- which is the confusion this whole verdict exists to end.
+    """
+    cleaned = _safe_str(note)
+    if not cleaned:
+        raise GateAnswerRefused(
+            "Say what research found instead, so the article can state the "
+            "absence rather than assert it."
+        )
+    _guard(evidence, requirement_id)
+
+    payload = evidence.model_dump(mode="json")
+    for item in payload["requirements"]:
+        if item["requirement_id"] == requirement_id:
+            if not item["claim_ids"]:
+                raise GateAnswerRefused(
+                    "Research found nothing here, so it has not established "
+                    "that the thing is absent -- only that it did not find it. "
+                    "Answer it, ask it differently, or drop it."
+                )
+            item["status"] = "nonexistent"
+            item["gap"] = cleaned
+
+    logger.info("Operator marked %s as a thing that does not exist", requirement_id)
+    return EvidencePackage.model_validate(payload)
+
+
+# What research's own diagnosis implies the operator should do about it. The
+# move names one of the buttons the gate already offers, except `nonexistent`,
+# which is the button this issue added.
+#
+# `why` is written to be read by a person deciding, not to explain the system
+# to itself.
+_MOVE_FOR_CAUSE: dict[str, tuple[str, str]] = {
+    "not_published": (
+        "unpublished",
+        "A source was checked and does not print this. That is a sentence the "
+        "article can say outright.",
+    ),
+    "does_not_exist": (
+        "nonexistent",
+        "Research answered, and the answer was that the thing is not there. "
+        "What it found instead is below, and that is what makes the absence "
+        "reportable.",
+    ),
+    "question_too_precise": (
+        "answer",
+        "The question asked for more precision than anyone publishes. What was "
+        "found is below and is probably what the article needed.",
+    ),
+    "answered_something_else": (
+        "reask",
+        "The answer is about something other than what was asked. The question "
+        "is fine -- the search went somewhere else.",
+    ),
+    "nothing_found": (
+        "answer",
+        "Nothing relevant came back, so there is nothing here to confirm. "
+        "Answer it yourself, or drop it.",
+    ),
+}
+
+
+def suggested_move(status: str, cause: str) -> dict[str, str] | None:
+    """Which of the moves fits, and why, in plain words.
+
+    The gate showed the question, what research found, the gap, and then four
+    buttons with no indication which one was right. Two of the three blockers
+    on run a2066506 were questions research had already answered -- the
+    operator's only real job was confirming that "no such thing" counts -- and
+    working that out meant reading a dozen bullets first.
+
+    A suggestion, never a decision: nothing here settles anything, and every
+    other move stays one click away. Returns None when research did not say
+    why, which is the honest outcome for a run recorded before causes existed.
+    """
+    if status == "supported":
+        return None
+    entry = _MOVE_FOR_CAUSE.get(cause)
+    if entry is None:
+        return None
+    move, why = entry
+    return {"move": move, "why": why}
+
+
 def mark_unpublished(
     evidence: EvidencePackage,
     *,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -53,10 +53,12 @@ from .gate_v4 import (
     answer_requirement,
     dismiss_venue,
     drop_venue,
+    mark_nonexistent,
     mark_unpublished,
     note_venue,
     omit_requirement,
     reask_requirement,
+    suggested_move,
     venues_to_check,
 )
 from .contracts_v4 import (
@@ -432,6 +434,7 @@ def settle_gate(
     answer: str | None = None,
     source_url: str | None = None,
     unpublished_note: str | None = None,
+    nonexistent_note: str | None = None,
     omit: bool = False,
 ) -> CoverageVerdict:
     """Settle one blocking question without re-buying the research.
@@ -467,6 +470,10 @@ def settle_gate(
     elif unpublished_note is not None:
         evidence = mark_unpublished(
             evidence, requirement_id=requirement_id, note=unpublished_note
+        )
+    elif nonexistent_note is not None:
+        evidence = mark_nonexistent(
+            evidence, requirement_id=requirement_id, note=nonexistent_note
         )
     else:
         evidence = answer_requirement(
@@ -679,6 +686,14 @@ def blocking_questions(run_id: str) -> list[dict[str, Any]]:
                 "kind": question.kind if question else "load_bearing",
                 "status": record.status if record else "missing",
                 "gap": record.gap if record else "",
+                # Why research fell short, and what that implies. A run
+                # recorded before causes existed says nothing here, and the
+                # screen then shows what it always showed.
+                "cause": record.cause if record else "unknown",
+                "suggestion": suggested_move(
+                    record.status if record else "missing",
+                    record.cause if record else "unknown",
+                ),
                 # What it did find. A question is rarely a blank: run 76b36468
                 # was stopped holding a name, a URL and two founders, missing
                 # only a price nobody publishes.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -37,6 +37,7 @@ from .contracts_v4 import (
     EvidenceMaterialType,
     PremiseVerdict,
     EvidenceRequirementStatus,
+    EvidenceShortfallCause,
     EvidenceSourceType,
     EvidencePackage,
     Prompt2BlogWorkOrder,
@@ -88,7 +89,9 @@ EVIDENCE_CLAIM_FIELDS = frozenset(
         "venue_dismissed",
     }
 )
-EVIDENCE_REQUIREMENT_FIELDS = frozenset({"requirement_id", "status", "claim_ids", "gap"})
+EVIDENCE_REQUIREMENT_FIELDS = frozenset(
+    {"requirement_id", "status", "claim_ids", "gap", "cause"}
+)
 EVIDENCE_FINDING_FIELDS = frozenset({"assumption_id", "verdict", "basis", "claim_ids"})
 EVIDENCE_CONFLICT_FIELDS = frozenset({"conflict_id", "claim_ids", "summary", "resolution"})
 EVIDENCE_GAP_FIELDS = frozenset({"gap_id", "requirement_ids", "summary"})
@@ -241,6 +244,13 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
                 **_only(row, EVIDENCE_REQUIREMENT_FIELDS),
                 "requirement_id": requirement_id,
                 "status": status,
+                # A cause we cannot read is `unknown`, which the gate treats as
+                # "no suggestion" rather than as a wrong one.
+                "cause": _one_of(
+                    _first(row, "cause", "shortfall_cause", "reason"),
+                    EvidenceShortfallCause,
+                    "unknown",
+                ),
                 # The contract insists an unsettled question describes its gap,
                 # and a status we had to guess at has one by definition.
                 "gap": ""
@@ -460,6 +470,10 @@ EVIDENCE_SCHEMA = require_non_empty({
                     },
                     "claim_ids": {"type": "array", "items": {"type": "string"}},
                     "gap": {"type": "string"},
+                    "cause": {
+                        "type": "string",
+                        "enum": list(get_args(EvidenceShortfallCause)),
+                    },
                 },
                 "required": ["requirement_id", "status"],
             },
@@ -660,6 +674,20 @@ Rules:
   Use `unpublished` when the notes establish that nobody publishes the answer,
   and say where was checked in `gap`. That is different from not having looked.
 - Anything with a status other than `supported` must describe the gap.
+- On anything other than `supported`, set `cause` to why you fell short. A
+  person reads this to decide what to do about it, so pick the one that is
+  actually true rather than the one that sounds least like a failure:
+  - `not_published` -- you checked a source and it does not print the figure.
+  - `does_not_exist` -- the thing the question assumes exists is not there, and
+    you can say what is there instead. "No genuine 4-star hotel within five
+    blocks; the nearest is the Sheraton at 1.4 km" is this. Only use it when
+    your claims show what you found instead. If you simply did not find
+    anything, that is `nothing_found`, not this.
+  - `question_too_precise` -- you found near-miss figures but not the exact one
+    the question demanded, because nobody publishes it to that precision.
+  - `answered_something_else` -- what came back is about a different place,
+    period or subject than was asked.
+  - `nothing_found` -- nothing relevant came back at all.
 - Record a `premise_findings` verdict for every assumption above: `confirmed`,
   `refuted`, or `unverified`, with the basis.
 - Where the notes say sources disagree, record a conflict rather than picking

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_gate.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_gate.py
@@ -15,7 +15,9 @@ from app.features.prompt2blog.contracts_v4 import EvidencePackage
 from app.features.prompt2blog.gate_v4 import (
     GateAnswerRefused,
     answer_requirement,
+    mark_nonexistent,
     mark_unpublished,
+    suggested_move,
 )
 
 
@@ -541,3 +543,155 @@ def test_the_pair_stays_bound_to_one_plan():
     assert {r.requirement_id for r in rewritten.requirements} == {
         r.requirement_id for r in settled.requirements
     }
+
+
+# --- the thing the question asked about is not there -----------------------
+#
+# Run a2066506 (2026-09-01) needed this twice in one run. The gate had four
+# verdicts and none of them meant "we looked properly and it is not there", so
+# a question research had fully answered still blocked.
+
+
+def test_nonexistent_settles_it_and_keeps_what_was_found_instead():
+    """Three named 3-star hotels and a Sheraton 1.4 km away are what make
+    "there is no 4-star in the old town" a fact rather than an assertion."""
+    settled = mark_nonexistent(
+        _evidence(),
+        requirement_id="q3",
+        note="No 4-star within five blocks. Nearest is the Sheraton, 1.4 km.",
+    )
+
+    requirement = next(r for r in settled.requirements if r.requirement_id == "q3")
+    assert requirement.status == "nonexistent"
+    assert requirement.claim_ids == ["c10"]
+    assert "Sheraton" in requirement.gap
+
+
+def test_the_gate_accepts_nonexistent_as_answered():
+    from app.features.prompt2blog.contracts_v4 import (
+        Prompt2BlogWorkOrder,
+        WorkOrderReference,
+        WorkOrderRequirement,
+        WorkOrderScope,
+    )
+    from app.features.prompt2blog.coverage_v4 import assess_coverage
+
+    work_order = Prompt2BlogWorkOrder(
+        work_order_fingerprint="wo-1",
+        brief_fingerprint="bf-1",
+        primary_subject="Lima",
+        scope=WorkOrderScope(
+            mode="single_subject",
+            references=[WorkOrderReference(name="Lima", role="primary_subject")],
+        ),
+        requirements=[
+            WorkOrderRequirement(requirement_id="q3", question="Hotels?", kind="load_bearing"),
+            WorkOrderRequirement(requirement_id="q1", question="Visitors?", kind="texture"),
+        ],
+    )
+
+    assert assess_coverage(work_order, _evidence()).can_write is False
+
+    settled = mark_nonexistent(
+        _evidence(), requirement_id="q3", note="There is no such hotel in that radius."
+    )
+    assert assess_coverage(work_order, settled).can_write is True
+
+
+def test_a_search_that_found_nothing_cannot_declare_a_thing_absent():
+    """"We failed to find it" and "it is not there" are opposite outcomes.
+
+    A question with no claims behind it has established the first and not the
+    second, and letting it through here would publish the confusion this
+    verdict exists to end.
+    """
+    evidence = _evidence(
+        requirements=[
+            {
+                "requirement_id": "q3",
+                "status": "missing",
+                "claim_ids": [],
+                "gap": "Nothing relevant came back.",
+            },
+            {"requirement_id": "q1", "status": "supported", "claim_ids": ["c20"]},
+            {"requirement_id": "q5", "status": "supported", "claim_ids": ["c30"]},
+        ],
+        claims=[
+            {
+                "claim_id": "c20",
+                "text": "Comuna 13 drew a documented visitor count.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["q1"],
+                "confidence": "high",
+            },
+            {
+                "claim_id": "c30",
+                "text": "The Morro is planted with guadua.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["q5"],
+                "confidence": "medium",
+            },
+        ],
+    )
+
+    with pytest.raises(GateAnswerRefused, match="has not established"):
+        mark_nonexistent(evidence, requirement_id="q3", note="Not there.")
+
+
+def test_nonexistent_needs_a_sentence_the_article_can_use():
+    with pytest.raises(GateAnswerRefused, match="what research found instead"):
+        mark_nonexistent(_evidence(), requirement_id="q3", note="   ")
+
+
+def test_the_contract_refuses_a_nonexistent_verdict_with_no_evidence_behind_it():
+    """The guard is in the contract as well as the move, so no other path can
+    file an absence nothing supports."""
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError, match="what is there instead"):
+        EvidencePackage.model_validate(
+            {
+                "work_order_fingerprint": "wo-1",
+                "sources": [],
+                "claims": [],
+                "requirements": [
+                    {
+                        "requirement_id": "q3",
+                        "status": "nonexistent",
+                        "claim_ids": [],
+                        "gap": "Not there.",
+                    }
+                ],
+            }
+        )
+
+
+# --- saying which move fits ------------------------------------------------
+
+
+def test_each_cause_names_the_move_that_fits():
+    """The gate showed four buttons and no indication which was right, while
+    the diagnosis sat unread in the research notes."""
+    assert suggested_move("partial", "not_published")["move"] == "unpublished"
+    assert suggested_move("partial", "does_not_exist")["move"] == "nonexistent"
+    assert suggested_move("partial", "question_too_precise")["move"] == "answer"
+    assert suggested_move("partial", "answered_something_else")["move"] == "reask"
+    assert suggested_move("missing", "nothing_found")["move"] == "answer"
+
+
+def test_the_reason_is_written_for_the_person_deciding():
+    suggestion = suggested_move("partial", "does_not_exist")
+
+    assert "not there" in suggestion["why"]
+    # Not an id, a status name, or a field name.
+    assert "requirement" not in suggestion["why"].lower()
+
+
+def test_a_run_recorded_before_causes_existed_gets_no_suggestion():
+    """Rather than a confident wrong one. The screen then shows what it always
+    showed."""
+    assert suggested_move("partial", "unknown") is None
+
+
+def test_an_answered_question_is_never_given_a_move():
+    assert suggested_move("supported", "not_published") is None

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/GateScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/GateScreen.tsx
@@ -26,6 +26,20 @@ import type { GateQuestion } from '../intake.types'
  *
  * It is set apart from the other three because it is the only one that spends
  * money: it buys one search, not the whole pass again.
+ *
+ * The fifth is "nothing like this exists", and run a2066506 needed it twice.
+ * Research was asked for three 4-star hotels within five blocks of the Plaza
+ * Mayor, came back with three named properties and the finding that no genuine
+ * 4-star is in that radius, and the run blocked — because the system could not
+ * tell "we failed to find it" from "it is not there". Those are opposite
+ * outcomes and they looked identical from the inside.
+ *
+ * And the screen now says which move fits. It used to show the question, what
+ * research found, the gap, and then four buttons with no indication which one
+ * was right, leaving the operator to read a dozen bullets and infer it. The
+ * diagnosis was already in the notes — "Booking.com published no separate
+ * aggregate figure" — so research now declares it and the gate reads it out. A
+ * suggestion, never a decision: every other move stays one click away.
  */
 
 interface GateScreenProps {
@@ -44,9 +58,10 @@ function Question({
   question: GateQuestion
   onSettled: () => void
 }) {
-  const [mode, setMode] = useState<'idle' | 'answer' | 'unpublished' | 'omit' | 'reask'>(
-    'idle',
-  )
+  const [mode, setMode] = useState<
+    'idle' | 'answer' | 'unpublished' | 'nonexistent' | 'omit' | 'reask'
+  >('idle')
+  const suggested = question.suggestion?.move ?? null
   const [text, setText] = useState('')
   const [rewritten, setRewritten] = useState(question.question)
   const [url, setUrl] = useState('')
@@ -71,7 +86,9 @@ function Question({
       requirement_id: question.requirement_id,
       ...(mode === 'answer'
         ? { answer: text, source_url: url.trim() || undefined }
-        : { unpublished_note: text }),
+        : mode === 'nonexistent'
+          ? { nonexistent_note: text }
+          : { unpublished_note: text }),
     })
   }
 
@@ -93,32 +110,51 @@ function Question({
       {question.gap && <p className="p2b-gate-gap">{question.gap}</p>}
 
       {mode === 'idle' ? (
-        <div className="p2b-intake-actions">
-          <button type="button" onClick={() => setMode('answer')}>
-            I&rsquo;ll answer this
-          </button>
-          <button
-            type="button"
-            className="p2b-secondary"
-            onClick={() => setMode('unpublished')}
-          >
-            Nobody publishes this
-          </button>
-          <button
-            type="button"
-            className="p2b-secondary"
-            onClick={() => setMode('reask')}
-          >
-            Ask it differently
-          </button>
-          <button
-            type="button"
-            className="p2b-secondary"
-            onClick={() => setMode('omit')}
-          >
-            Drop the question
-          </button>
-        </div>
+        <>
+          {question.suggestion && (
+            <p className="p2b-gate-suggestion">
+              <span className="p2b-label">What this looks like</span>
+              {question.suggestion.why}
+            </p>
+          )}
+          <div className="p2b-intake-actions">
+            <button
+              type="button"
+              className={suggested && suggested !== 'answer' ? 'p2b-secondary' : undefined}
+              onClick={() => setMode('answer')}
+            >
+              I&rsquo;ll answer this
+            </button>
+            <button
+              type="button"
+              className={suggested === 'unpublished' ? undefined : 'p2b-secondary'}
+              onClick={() => setMode('unpublished')}
+            >
+              Nobody publishes this
+            </button>
+            <button
+              type="button"
+              className={suggested === 'nonexistent' ? undefined : 'p2b-secondary'}
+              onClick={() => setMode('nonexistent')}
+            >
+              Nothing like this exists
+            </button>
+            <button
+              type="button"
+              className={suggested === 'reask' ? undefined : 'p2b-secondary'}
+              onClick={() => setMode('reask')}
+            >
+              Ask it differently
+            </button>
+            <button
+              type="button"
+              className="p2b-secondary"
+              onClick={() => setMode('omit')}
+            >
+              Drop the question
+            </button>
+          </div>
+        </>
       ) : mode === 'reask' ? (
         <div className="p2b-gate-form">
           <label className="p2b-field">
@@ -213,7 +249,9 @@ function Question({
             <span className="p2b-label">
               {mode === 'answer'
                 ? 'Your answer, in your own words'
-                : 'What you looked for, and where'}
+                : mode === 'nonexistent'
+                  ? 'What is there instead'
+                  : 'What you looked for, and where'}
             </span>
             <textarea
               value={text}
@@ -223,7 +261,9 @@ function Question({
               placeholder={
                 mode === 'answer'
                   ? 'They quote COP 60,000 per person, over WhatsApp only.'
-                  : 'Moravia Tours takes bookings directly and posts no price on its site.'
+                  : mode === 'nonexistent'
+                    ? 'No 4-star hotel within five blocks of the Plaza Mayor. The nearest is the Sheraton, 1.4 km away.'
+                    : 'Moravia Tours takes bookings directly and posts no price on its site.'
               }
             />
           </label>
@@ -252,6 +292,17 @@ function Question({
             <p className="p2b-note">
               The article can say this outright. It is a real finding, not a
               workaround.
+            </p>
+          )}
+
+          {mode === 'nonexistent' && (
+            /* The claims research found stay, and they are the point: they are
+               what makes the absence a finding rather than an assertion. */
+            <p className="p2b-note">
+              Use this when research answered and the answer was that the thing
+              is not there. What it found instead stays on the record — that is
+              what lets the article state the absence rather than assert it. If
+              research simply found nothing, answer it or ask it differently.
             </p>
           )}
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/gate-reask.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/gate-reask.test.tsx
@@ -33,6 +33,11 @@ const QUESTION: GateQuestion = {
   status: 'supported',
   gap: '',
   found: ['A garden collective in Puerto Madero, Argentina.'],
+  cause: 'answered_something_else',
+  suggestion: {
+    move: 'reask',
+    why: 'The answer is about something other than what was asked.',
+  },
 }
 
 beforeEach(() => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/gate-suggestion.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/gate-suggestion.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GateQuestion } from './intake.types'
+
+/**
+ * The gate saying which move fits, and the move it did not have.
+ *
+ * Run a2066506 (2026-09-01) blocked three times. Two of the three were
+ * questions research had already answered: no Miraflores listing count is
+ * published anywhere, and there is no 4-star hotel within five blocks of the
+ * Plaza Mayor. The gate could record neither, and offered four buttons with no
+ * indication which was right — so the operator read a dozen research bullets
+ * to work out what the notes already said.
+ */
+
+const readGate = vi.fn()
+const reaskQuestion = vi.fn()
+const settleGate = vi.fn()
+vi.mock('./intake.api', () => ({
+  readGate: (...args: unknown[]) => readGate(...args),
+  reaskQuestion: (...args: unknown[]) => reaskQuestion(...args),
+  settleGate: (...args: unknown[]) => settleGate(...args),
+}))
+
+const { GateScreen } = await import('./components/GateScreen')
+
+function question(overrides: Partial<GateQuestion> = {}): GateQuestion {
+  return {
+    requirement_id: 'q4',
+    question: 'Three 4-star hotels within five blocks of the Plaza Mayor?',
+    kind: 'load_bearing',
+    status: 'partial',
+    gap: 'No 4-star property was found in that radius.',
+    found: [
+      'Hotel Maury is 3-star, two blocks from the Plaza Mayor.',
+      'The nearest 4-star is the Sheraton Lima Historic Center, 1.4 km away.',
+    ],
+    cause: 'does_not_exist',
+    suggestion: {
+      move: 'nonexistent',
+      why: 'Research answered, and the answer was that the thing is not there.',
+    },
+    ...overrides,
+  }
+}
+
+function show() {
+  render(<GateScreen runId="run-1" onSettled={vi.fn()} onReopen={vi.fn()} busy={false} />)
+}
+
+beforeEach(() => {
+  readGate.mockReset()
+  reaskQuestion.mockReset()
+  settleGate.mockReset()
+  settleGate.mockResolvedValue({})
+  readGate.mockResolvedValue({ blocking: [question()] })
+})
+
+describe('recording that the thing is not there', () => {
+  it('offers the move at all, which is the whole issue', async () => {
+    show()
+
+    expect(await screen.findByText(/nothing like this exists/i)).toBeTruthy()
+  })
+
+  it('sends what research found instead, not an answer the operator invented', async () => {
+    show()
+    fireEvent.click(await screen.findByText(/nothing like this exists/i))
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Nearest 4-star is the Sheraton, 1.4 km away.' },
+    })
+    fireEvent.click(screen.getByText(/save and continue/i))
+
+    await waitFor(() =>
+      expect(settleGate).toHaveBeenCalledWith('run-1', {
+        requirement_id: 'q4',
+        nonexistent_note: 'Nearest 4-star is the Sheraton, 1.4 km away.',
+      }),
+    )
+  })
+
+  it('is not confused with nobody publishing it', async () => {
+    show()
+    fireEvent.click(await screen.findByText(/nothing like this exists/i))
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Not there.' } })
+    fireEvent.click(screen.getByText(/save and continue/i))
+
+    await waitFor(() => expect(settleGate).toHaveBeenCalled())
+    expect(settleGate.mock.calls[0][1]).not.toHaveProperty('unpublished_note')
+  })
+
+  it('says the found claims are what let the article state the absence', async () => {
+    show()
+    fireEvent.click(await screen.findByText(/nothing like this exists/i))
+
+    expect(screen.getByText(/state the absence rather than assert it/i)).toBeTruthy()
+  })
+})
+
+describe('saying which move fits', () => {
+  it('reads out the diagnosis instead of leaving it in the notes', async () => {
+    show()
+
+    expect(
+      await screen.findByText(/the answer was that the thing is not there/i),
+    ).toBeTruthy()
+  })
+
+  it('marks only the suggested move as the primary one', async () => {
+    show()
+    await screen.findByText(/nothing like this exists/i)
+
+    const suggested = screen.getByText(/nothing like this exists/i)
+    const other = screen.getByText(/nobody publishes this/i)
+    expect(suggested.className).not.toContain('p2b-secondary')
+    expect(other.className).toContain('p2b-secondary')
+  })
+
+  it('leaves every other move one click away, because it is a suggestion', async () => {
+    show()
+    await screen.findByText(/nothing like this exists/i)
+
+    for (const label of [
+      /i.ll answer this/i,
+      /nobody publishes this/i,
+      /ask it differently/i,
+      /drop the question/i,
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+  })
+
+  it('says nothing at all when research did not say why', async () => {
+    // A run recorded before causes existed. Silence beats a confident guess.
+    readGate.mockResolvedValue({
+      blocking: [question({ cause: 'unknown', suggestion: null })],
+    })
+    show()
+    await screen.findByText(/nothing like this exists/i)
+
+    expect(screen.queryByText(/what this looks like/i)).toBeNull()
+    // And with no suggestion, the answer move is primary as it always was.
+    expect(screen.getByText(/i.ll answer this/i).className).not.toContain('p2b-secondary')
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -180,8 +180,8 @@ export async function readGate(runId: string): Promise<{ blocking: GateQuestion[
 /**
  * Settle one blocking question without re-buying the research.
  *
- * Either an answer, or a note saying it is not published anywhere. No model
- * call: this is the operator's decision, recorded.
+ * An answer, a note saying nobody publishes it, a note saying the thing is not
+ * there, or a drop. No model call: this is the operator's decision, recorded.
  */
 export function settleGate(
   runId: string,
@@ -190,6 +190,7 @@ export function settleGate(
     answer?: string
     source_url?: string
     unpublished_note?: string
+    nonexistent_note?: string
     omit?: boolean
   },
 ): Promise<IntakeState> {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -168,6 +168,14 @@ export interface GateQuestion {
   status: string
   gap: string
   found: string[]
+  /** Why research fell short, in its own words. `unknown` on older runs. */
+  cause: string
+  /**
+   * Which move fits, and why, in words meant for the person deciding. Null
+   * when research did not say why — the screen then shows what it always
+   * showed, four moves and no opinion.
+   */
+  suggestion: { move: string; why: string } | null
 }
 
 /**

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -861,6 +861,23 @@
   line-height: 1.6;
 }
 
+/*
+ * What research's own diagnosis implies. Set apart from `p2b-gate-gap`, which
+ * says what is missing: this one says what to do about it, and the suggested
+ * button below it is the only one not styled as secondary.
+ */
+.p2b-gate-suggestion {
+  margin: 0 0 var(--space-4);
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.p2b-gate-suggestion .p2b-label {
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
 .p2b-gate-form {
   margin-top: var(--space-4);
 }


### PR DESCRIPTION
Closes #464. Second half of Phase 1.

Run `a2066506` blocked three times. **Two of the three were questions research had already answered.**

## 1. The verdict that did not exist

Asked for three 4-star hotels within five blocks of the Plaza Mayor, research returned three named properties with rates and distances, plus the finding that no genuine 4-star is in that radius — nearest being the Sheraton at 1.4 km. It answered, and the answer was *"that is not there"*, which none of `supported` / `partial` / `missing` / `unpublished` could record. "We failed to find it" and "it does not exist" are opposite outcomes that looked identical from the inside.

`nonexistent` records it — distinct from `unpublished` (the figure exists, nobody prints it). Both keep their claims, both unblock, and both are publishable sentences.

**Two guards worth reviewing:**
- **The claims are required, not optional.** Three named 3-star properties and a Sheraton 1.4 km away are what make the absence a finding rather than an assertion. A search that came back empty has established only that it found nothing — that is `missing`. Enforced in the contract *and* in the move, so no path can file an absence nothing supports.
- **It stays an operator click**, not a status research can set itself. A model that looked in the wrong place would assert non-existence in exactly the same words as one that looked properly, which is the confusion this verdict exists to end.

## 2. Which move fits

The gate showed four buttons and no opinion, so the operator read a dozen research bullets to work out what the notes already said — "Booking.com published no separate aggregate figure" *is* the diagnosis.

Research now declares a `cause` (`not_published`, `does_not_exist`, `question_too_precise`, `answered_something_else`, `nothing_found`) and the gate reads it out with the move it implies. **Declared rather than inferred from gap prose** — a pattern match over English fails silently on phrasing nobody wrote it for. A suggestion, never a decision: the suggested button is the only one not styled secondary, every other move stays one click away, and no cause means no suggestion.

## What the replay actually showed

All three blockers on that run were settled by hand, so three claims research found are filed as **operator-supplied**. `opc-r4` reads *"There is no genuine 4-star hotel within five blocks of the Plaza Mayor"* — the verdict this PR adds, recorded as the operator's own word. That is the record degradation #464 predicted, confirmed on a real run.

## Verification

- All 5 stored v4 runs load unchanged under the new contract; `cause` defaults to `unknown` → no suggestion
- Backend 1167 passed (37 in the gate suite, 12 new) · Prompt2Blog frontend 141 passed (8 new in `gate-suggestion.test.tsx`) · `tsc --noEmit` clean

**Not proven:** no stored run carries a declared cause, so the suggestion path is proven by tests and not yet by a real run. The first new run exercises it.