### PR TITLE
Ask what the article needs, not what sounds rigorous

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -138,6 +138,19 @@ CreativityLevel = Literal["low", "medium", "high"]
 # What a requirement costs when research cannot answer it. Load-bearing means
 # the piece cannot be written without it; texture means the piece is duller.
 RequirementKind = Literal["load_bearing", "texture"]
+# How exact the ARTICLE needs this answer to be. Never how freely the model may
+# estimate -- see the research prompt, where that line is held.
+#
+# Run a2066506 asked for "the exact travel time in minutes" on a bus route
+# nobody times. Research bounded it instead -- 55 minutes for the full 16-mile
+# line, five intermediate stops on this segment -- and blocked, because the
+# question demanded a number that does not exist. A reader does not need it: a
+# fare they hand over in coins is `exact`, how long a bus takes is
+# `approximate`.
+#
+# Defaults to `exact`, so a plan that says nothing behaves exactly as it did
+# before. Loosening is a thing the planner has to choose.
+RequirementPrecision = Literal["exact", "approximate"]
 # Where the operator's material came from. `firsthand` bypasses fact-checking
 # by design -- nobody can verify someone's lunch -- which is exactly why its
 # statement is stored as the operator typed it and never as a model's
@@ -220,6 +233,9 @@ class WorkOrderRequirement(V4ContractModel):
     requirement_id: str = Field(min_length=1)
     question: str = Field(min_length=1)
     kind: RequirementKind
+    # What the article needs, which is not always what the question's wording
+    # demands. Research is judged against this rather than against the phrasing.
+    precision: RequirementPrecision = "exact"
     # Empty when the question stands on its own. Every id here must name a
     # premise the same commission declares.
     assumption_ids: list[str] = Field(default_factory=list)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -554,6 +554,33 @@ def notes_from_record(
     return notes
 
 
+def _precision_brief(precision: str) -> str:
+    """What the article needs, and what that does not license.
+
+    A loosened target says how exact the ARTICLE must be. It never says how
+    freely the model may estimate. "Under 55 minutes for the full line, five
+    intermediate stops, so allow about half an hour" is built from published
+    numbers and shows its working. "About 25 minutes" is arithmetic printed as
+    fact, and a reader cannot tell it from the S/3.20 fare beside it.
+    """
+    if precision == "approximate":
+        return (
+            "A range or an order of magnitude is what the article needs. If "
+            "nobody publishes the precise figure, say so, then give the "
+            "bounded answer and show the published numbers you bounded it "
+            "with -- that is a complete answer, not a partial one.\n"
+            "This is not permission to estimate. Never derive a number and "
+            "state it as a found fact. A figure with its working shown is an "
+            "answer; a figure you calculated and presented bare is a "
+            "fabrication a reader cannot tell from a real one."
+        )
+    return (
+        "The article needs the actual figure, because a reader acts on it. If "
+        "nobody publishes it, say so plainly and say where you looked, rather "
+        "than approximating it."
+    )
+
+
 def build_gather_prompt(
     brief: ArticleBrief,
     requirement: WorkOrderRequirement,
@@ -574,6 +601,9 @@ looking like a found fact and nothing downstream can tell.
 
 THE QUESTION
 {requirement.question}
+
+HOW EXACT THE ARTICLE NEEDS THIS
+{_precision_brief(requirement.precision)}
 
 Answer it as fully as you can, with sources. Then keep going:
 
@@ -611,7 +641,8 @@ def build_structure_prompt(
 ) -> str:
     """Turn free notes into evidence records. Records nothing new."""
     questions = "\n".join(
-        f"- {item.requirement_id} [{item.kind}] {item.question}"
+        f"- {item.requirement_id} [{item.kind}] [needs: {item.precision}] "
+        f"{item.question}"
         for item in work_order.requirements
     )
     gathered = "\n\n".join(
@@ -647,6 +678,13 @@ Rules:
 - `confidence` on a claim is one of: high, medium, low. An answer that is
   genuinely a range is still `supported` at `medium` or `low`; it does not
   become `partial` for being approximate.
+- Judge each question against what it says it `needs`, not against its wording.
+  A question marked `approximate` is `supported` by a bounded answer that shows
+  the published numbers behind it -- "the full 16-mile line runs about 55
+  minutes at peak and this segment passes five stops" answers "roughly how
+  long" completely, and marking it `partial` because no one publishes the exact
+  minute blocks a run over a number the article never needed. A question marked
+  `exact` is not settled by a range.
 - Set `venue` only on a claim that sends a reader to a place whose survival is
   genuinely in doubt: an independent tour operator, a small guesthouse, one
   restaurant, a bar, a family business, a tour run by a few people. Put the

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -26,6 +26,7 @@ from typing import Any, get_args
 
 from .contracts_v4 import (
     ReferenceRole,
+    RequirementPrecision,
     ArticleBrief,
     Prompt2BlogWorkOrder,
     WorkOrderAssumption,
@@ -95,6 +96,10 @@ WORK_ORDER_SCHEMA = require_non_empty({
                     "requirement_id": {"type": "string"},
                     "question": {"type": "string"},
                     "kind": {"type": "string"},
+                    "precision": {
+                        "type": "string",
+                        "enum": list(get_args(RequirementPrecision)),
+                    },
                     "assumption_ids": {"type": "array", "items": {"type": "string"}},
                 },
                 "required": ["requirement_id", "question", "kind"],
@@ -154,6 +159,21 @@ Rules:
 - Each question must be separately checkable by someone with a search engine.
   "Is Lima good value?" is not a question; "What does a one-bedroom in
   Miraflores rent for, and as of when?" is.
+- One question, one fact. If a question has two separate answers, it gets two
+  ids. "What is the travel time in minutes and the current fare in PEN?" is two
+  questions, and asking it as one holds the answered half hostage to the
+  unanswered half -- the fare is published and the journey time is not, and
+  that question can only come back half right. A question that asks a value and
+  the date it was true is still one question; a question that asks for two
+  different values is not.
+- Set `precision` to what the ARTICLE needs, not to what sounds rigorous.
+  `exact` when a reader acts on the number: a fare they hand over in coins, an
+  opening time they turn up for, an address. `approximate` when a reader only
+  needs the size of the thing: how long a bus takes, how many places are in a
+  district, how far something is. Asking for "the exact travel time in minutes"
+  on a route nobody times produces a question that cannot be answered however
+  good the research is, and blocks a run over a number no reader wanted.
+  `exact` is the default, so mark the ones that do not need it.
 - Every question names its place unambiguously. Whoever answers it sees the
   question and little else, so a neighbourhood or district that shares its name
   with somewhere else carries the city and country: "the Buenos Aires
@@ -170,6 +190,18 @@ Rules:
   with the questions that rest on it listing its id. An assumption nobody wrote
   down cannot be refuted later, and that is how a run dies five unanswerable
   questions in.
+- A question that takes something for granted is assuming it. "What are the
+  names and rates of three 4-star hotels within five blocks of the Plaza
+  Mayor?" assumes 4-star hotels are there; "how many listings does Booking.com
+  show for Miraflores?" assumes Booking.com publishes that. When the assumption
+  turns out to be false the question cannot be satisfied however good the
+  research is, and a good answer gets recorded as a failure.
+  So write the question so it survives being wrong, and declare what it assumed:
+  "the best-rated hotels within five blocks of the Plaza Mayor, with their
+  ratings and rates", assuming "hotels rated 4-star or better exist within five
+  blocks of the Plaza Mayor". A false premise then comes back as a refuted
+  premise, which is a finding, instead of as a failed question, which is a dead
+  end.
 - `references` must list every place the plan touches, and must include the
   subject itself. Roles are exactly `primary_subject`, `context_only` and
   `comparator`. Exactly one entry is the `primary_subject` -- that is the thing
@@ -315,6 +347,11 @@ def _requirements_from(
         assumption_ids = _safe_str_list(
             _first(record, "assumption_ids", "premise_ids", "premises")
         )
+        # A precision we cannot read is `exact`, which is how every question
+        # behaved before this field existed. Loosening has to be deliberate.
+        precision = _safe_str(_first(record, "precision", "exactness"))
+        if precision not in set(get_args(RequirementPrecision)):
+            precision = "exact"
         requirements.append(
             WorkOrderRequirement(
                 requirement_id=_safe_str(
@@ -323,6 +360,7 @@ def _requirements_from(
                 or f"r{len(requirements) + 1}",
                 question=question,
                 kind=kind,
+                precision=precision,
                 # A reference to an assumption nobody declared is dropped
                 # rather than fatal: the question is still worth asking, and
                 # the contract refuses a dangling id.
@@ -511,6 +549,73 @@ def cut_work_order(
     )
 
 
+# Words that name a thing with its own answer. Two of them on opposite sides of
+# an "and" is the shape of a question that will come back half right.
+#
+# Deliberately does not include a date or an "as of when", because "What does a
+# one-bedroom in Miraflores rent for, and as of when?" is one question -- a
+# value and the date it was true always travel together, and that phrasing is
+# the model answer in the prompt above.
+_MEASURED_THINGS = (
+    "fare",
+    "price",
+    "cost",
+    "rate",
+    "rent",
+    "time",
+    "minutes",
+    "hours",
+    "duration",
+    "distance",
+    "kilometres",
+    "kilometers",
+    "miles",
+    "temperature",
+    "population",
+    "altitude",
+    "elevation",
+    "capacity",
+    "count",
+    "number of",
+    "how many",
+    "how long",
+    "how far",
+    "how much",
+)
+
+
+def bundled_question_note(question: str) -> str:
+    """Say when a question looks like two, without refusing it.
+
+    Run a2066506 asked for "the exact travel time in minutes AND the current
+    fare in PEN". The fare is published; the journey time is not. One question,
+    two facts, one status -- so the answered half was held hostage by the
+    unanswered half, and the operator had to settle a question that was already
+    half correct.
+
+    Advisory, and it stays advisory. Whether two clauses have two answers is a
+    judgement, and a check that refused a plan on a heuristic would reject good
+    questions in a stage the operator is already reading line by line. They can
+    strike this one and add two, which is the move the screen already offers.
+    """
+    lowered = question.casefold()
+    halves = lowered.split(" and ")
+    if len(halves) < 2:
+        return ""
+    measured = [
+        half
+        for half in halves
+        if any(thing in half for thing in _MEASURED_THINGS)
+    ]
+    if len(measured) < 2:
+        return ""
+    return (
+        "This asks for two things at once. One of them may be published and the "
+        "other not, and a single question can only come back one way -- strike "
+        "it and add the two halves separately."
+    )
+
+
 def work_order_stage_record(
     work_order: Prompt2BlogWorkOrder,
     warnings: list[str] | None = None,
@@ -525,6 +630,11 @@ def work_order_stage_record(
                 "requirement_id": item.requirement_id,
                 "question": item.question,
                 "kind": item.kind,
+                "precision": item.precision,
+                # Empty for a question that reads as one. Shown beside the
+                # question rather than counted, because the operator is the one
+                # who can tell.
+                "bundled_note": bundled_question_note(item.question),
             }
             for item in work_order.requirements
         ],

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
@@ -138,12 +138,15 @@ def test_runtime_request_keeps_the_commission_and_evidence_whole():
     runtime = prepare_v3_runtime_request(_request(evidence_package=_ready_evidence()))
 
     # A commission written before the direction step declared its premise still
-    # runs. The empty premise and empty assumption_ids are the defaults filling
-    # in, not the runtime losing anything the fixture carried.
+    # runs. The empty premise, the empty assumption_ids and the `exact`
+    # precision are the defaults filling in, not the runtime losing anything
+    # the fixture carried. `exact` is the default on purpose: a plan that never
+    # said how precise it needed to be behaves as it always did.
     expected_work_order = deepcopy(fixture["work_order"])
     expected_work_order["premise"] = []
     for requirement in expected_work_order["requirements"]:
         requirement["assumption_ids"] = []
+        requirement["precision"] = "exact"
     assert runtime.work_order == expected_work_order
     assert runtime.brief == fixture["brief"]
     source = runtime.evidence["sources"][0]

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -21,6 +21,7 @@ from app.features.prompt2blog.grill_v4 import GrillDependencies
 from app.features.prompt2blog.work_order_v4 import (
     build_work_order,
     build_work_order_prompt,
+    bundled_question_note,
     cut_work_order,
     work_order_stage_record,
 )
@@ -523,3 +524,147 @@ def test_the_headline_instruction_names_the_kinds_of_claim_to_check():
 
     for kind in ("an age", "a superlative", '"oldest"', "a comparison"):
         assert kind in flat
+
+
+# --- what the article needs, rather than what the wording demands -----------
+#
+# Every blocked question on run a2066506 (2026-09-01) had research that
+# answered what a reader needs and failed what the question literally asked
+# for. Three for three, from one stage.
+
+
+def test_a_question_carries_what_the_article_needs():
+    payload = _payload()
+    payload["requirements"][0]["precision"] = "approximate"
+
+    work_order = build_work_order(_brief(), _deps(payload))
+
+    needs = {item.requirement_id: item.precision for item in work_order.requirements}
+    assert needs == {"r1": "approximate", "r2": "exact", "r3": "exact"}
+
+
+def test_a_plan_that_says_nothing_about_precision_behaves_as_it_always_did():
+    """`exact` is the default on purpose. Loosening is a choice the planner
+    makes, never something that happens by omission."""
+    work_order = build_work_order(_brief(), _deps(_payload()))
+
+    assert all(item.precision == "exact" for item in work_order.requirements)
+
+
+def test_an_unreadable_precision_falls_back_to_exact_rather_than_failing():
+    payload = _payload()
+    payload["requirements"][0]["precision"] = "ballpark-ish"
+
+    work_order = build_work_order(_brief(), _deps(payload))
+
+    assert work_order.requirements[0].precision == "exact"
+
+
+def test_the_prompt_says_precision_is_about_the_reader_not_about_rigour():
+    flat = " ".join(build_work_order_prompt(_brief()).split())
+
+    assert "Set `precision` to what the ARTICLE needs" in flat
+    assert "a fare they hand over in coins" in flat
+
+
+def test_research_is_told_what_each_question_needs():
+    """Otherwise the target is recorded and never read, and a bounded answer
+    still comes back `partial`."""
+    from app.features.prompt2blog.research_v4 import (
+        build_gather_prompt,
+        build_structure_prompt,
+    )
+
+    payload = _payload()
+    payload["requirements"][0]["precision"] = "approximate"
+    work_order = build_work_order(_brief(), _deps(payload))
+    loose = work_order.requirements[0]
+
+    gather = " ".join(build_gather_prompt(_brief(), loose).split())
+    assert "A range or an order of magnitude is what the article needs" in gather
+    # The line that must not move.
+    assert "This is not permission to estimate" in gather
+    assert "state it as a found fact" in gather
+
+    strict = " ".join(
+        build_gather_prompt(_brief(), work_order.requirements[1]).split()
+    )
+    assert "the actual figure" in strict
+    assert "not permission to estimate" not in strict
+
+    structure = " ".join(build_structure_prompt(work_order, {}).split())
+    assert "[needs: approximate]" in structure
+    assert "Judge each question against what it says it `needs`" in structure
+
+
+# --- one question, one fact ------------------------------------------------
+
+
+def test_a_question_asking_for_two_measured_things_is_flagged():
+    """Run a2066506's q6 asked for the exact travel time AND the fare. The fare
+    is published; the journey time is not. One question, two facts, one status,
+    and the answered half held hostage by the other."""
+    note = bundled_question_note(
+        "What is the exact travel time in minutes and the current fare in PEN "
+        "to ride the Metropolitano from Estacion Central to Estacion Bulevar?"
+    )
+
+    assert "two things at once" in note
+
+
+def test_a_value_and_the_date_it_was_true_is_still_one_question():
+    """This phrasing is the model answer in the prompt itself. A check that
+    flagged it would be teaching the planner to avoid good questions."""
+    assert (
+        bundled_question_note(
+            "What does a one-bedroom in Miraflores rent for, and as of when?"
+        )
+        == ""
+    )
+
+
+def test_a_list_of_places_with_their_rates_is_one_question():
+    assert (
+        bundled_question_note(
+            "What are the names and approximate nightly rates in USD of three "
+            "highly-rated hotels within five blocks of the Plaza Mayor?"
+        )
+        == ""
+    )
+
+
+def test_the_flag_reaches_the_screen_beside_the_question_it_is_about():
+    payload = _payload()
+    payload["requirements"][1]["question"] = (
+        "What are the opening hours and the ticket price for Huaca Pucllana?"
+    )
+    work_order = build_work_order(_brief(), _deps(payload))
+
+    record = work_order_stage_record(work_order)
+    notes = {item["requirement_id"]: item["bundled_note"] for item in record["requirements"]}
+
+    assert notes["r2"]
+    assert notes["r1"] == ""
+    assert record["requirements"][0]["precision"] == "exact"
+
+
+def test_the_prompt_says_one_question_one_fact_with_the_case_that_broke():
+    flat = " ".join(build_work_order_prompt(_brief()).split())
+
+    assert "One question, one fact." in flat
+    assert "holds the answered half hostage" in flat
+
+
+# --- a premise declared instead of buried ----------------------------------
+
+
+def test_the_prompt_names_a_presupposition_as_an_assumption():
+    """"Three 4-star hotels within five blocks" assumes such hotels exist. The
+    contract has modelled premises as separately refutable since v4; the
+    planner was burying them in the question text, where nothing can check
+    them, so a false premise failed a whole question instead."""
+    flat = " ".join(build_work_order_prompt(_brief()).split())
+
+    assert "A question that takes something for granted is assuming it." in flat
+    assert "write the question so it survives being wrong" in flat
+    assert "refuted premise, which is a finding" in flat

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
@@ -66,6 +66,15 @@ export function WorkOrderScreen({
               >
                 {item.kind === 'load_bearing' ? 'the piece rests on this' : 'colour'}
               </span>
+              {item.precision === 'approximate' && (
+                /* Said out loud so a loosened target is a visible choice. A
+                   question that only needs the size of a thing will not block
+                   the run for want of a figure nobody publishes. */
+                <span className="p2b-kind">roughly is enough</span>
+              )}
+              {item.bundled_note && !isStruck && (
+                <p className="p2b-question-note">{item.bundled_note}</p>
+              )}
             </li>
           )
         })}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -266,8 +266,20 @@ const WORK_ORDER: IntakeWorkOrder = {
   brief_fingerprint: 'bf-1',
   primary_subject: 'Lima',
   requirements: [
-    { requirement_id: 'r1', question: 'What do stalls charge?', kind: 'load_bearing' },
-    { requirement_id: 'r2', question: 'What is it like at night?', kind: 'texture' },
+    {
+      requirement_id: 'r1',
+      question: 'What do stalls charge?',
+      kind: 'load_bearing',
+      precision: 'exact',
+      bundled_note: '',
+    },
+    {
+      requirement_id: 'r2',
+      question: 'What is it like at night?',
+      kind: 'texture',
+      precision: 'approximate',
+      bundled_note: '',
+    },
   ],
   load_bearing_count: 1,
   texture_count: 1,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -70,6 +70,17 @@ export interface IntakeRequirement {
   requirement_id: string
   question: string
   kind: 'load_bearing' | 'texture'
+  /**
+   * How exact the article needs this. `exact` for a figure a reader acts on,
+   * `approximate` for one they only need the size of.
+   */
+  precision: 'exact' | 'approximate'
+  /**
+   * Set when the question reads as two questions bundled into one. Advisory —
+   * whether two clauses have two answers is a judgement, and the operator is
+   * the one who can tell.
+   */
+  bundled_note: string
 }
 
 export interface IntakeWorkOrder {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -426,6 +426,20 @@
 
 /* Said once, after the fact. Not a warning to acknowledge — the cut already
    happened. */
+/*
+ * A question that looks like two, said beside the question rather than in the
+ * warnings block at the foot. It is about this line, and it is advisory: the
+ * operator strikes it and adds two if they agree.
+ */
+.p2b-question-note {
+  margin: var(--space-2) 0 0;
+  color: var(--ink-light);
+  font-size: 0.875rem;
+  line-height: 1.55;
+  border-left: 2px solid var(--accent);
+  padding-left: var(--space-3);
+}
+
 .p2b-cut-warnings {
   margin: var(--space-4) 0 0;
   padding: var(--space-4) var(--space-5);


### PR DESCRIPTION
Closes #465. Phase 2.

All three blocked questions on run `a2066506` had research that answered what a **reader** needs and failed what the question **literally asked for**. The research wasn't underperforming — the questions were asking for the wrong thing.

## 1. A precision target per question

"The exact travel time in minutes" on a bus route nobody times. Research bounded it — 55 minutes for the full 16-mile line, five intermediate stops on this segment — and blocked, because it couldn't produce a figure that does not exist. A reader hands over coins for the S/3.20 fare and needs *that* exact. Nobody needs the bus time to the minute.

Questions now carry `exact` or `approximate`, research is told the target in **both** prompts, and judges the answer against what was required rather than against the phrasing.

`exact` is the default — a plan that says nothing behaves as it always did. Loosening is a choice, never an omission.

**The line that must not move, with a test on it:** the target says how exact the *article* must be, never how freely the *model* may estimate. A bounded answer showing its published numbers is an answer. A figure derived and stated bare is a fabrication a reader cannot tell from the fare beside it.

## 2. One question, one fact

q6 asked for the travel time **and** the fare. The fare is published, the journey time is not, so the answered half was held hostage by the unanswered half. The rule already existed and wasn't followed, so the prompt now carries the case that broke it, and a check flags questions that read as two.

**Advisory on purpose.** Whether two clauses have two answers is a judgement; a check that refused a plan on a heuristic would reject good questions in a stage the operator already reads line by line. It shows beside the question, where they can strike it and add two.

## 3. A premise declared instead of buried

"Three 4-star hotels within five blocks of the Plaza Mayor" assumes such hotels exist. They don't — so a complete answer couldn't satisfy the question, and a good finding was recorded as a failure.

The machinery was already there: `assumption_ids` on the requirement and `premise_findings` with a `refuted` verdict have existed since v4. The planner just wasn't using them. It now has the worked case and the instruction to write questions that survive their premise being false.

## Verification against real runs

Ran the bundling check over **every question in all five stored runs — 4 of 43 flagged (9%)**:

| run | flagged |
|---|---|
| `a2066506` | the Metropolitano time-and-fare, and the Miraflores-vs-Lima listing counts — both named in the issue |
| `062c0b86` | ticket price + whether a guided tour is included; walking time + taxi time |
| `76b36468`, `90b3f9bc`, `b78a9fe8` | none |

No false positives found, and it stays quiet on the prompt's own model answer ("what does a one-bedroom rent for, and as of when?") — a check that flagged that would teach the planner to avoid good questions. 43 questions from one author on one kind of subject is a small sample; that is what it is.

All five stored work orders still load, precision reading `exact` throughout.

- Backend 1178 passed (41 in the work-order suite, 12 new) · Prompt2Blog frontend 141 passed · `tsc --noEmit` clean

**Not proven:** whether the planner actually sets `approximate` where it should, and whether declared premises show up. Both need a real run.