### PR TITLE
End a run by saying what to fix, without saying what the fact is

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -58,6 +58,7 @@ from ..intake_v4 import (
     do_research,
     finished_article,
     polish_prompt,
+    punch_list,
     intake_state,
     plan_research,
     reask_question,
@@ -538,6 +539,17 @@ def read_article(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     the graph works, and this is the whole article.
     """
     return JSONResponse(_handle(finished_article, run_id))
+
+
+@router.get("/{run_id}/punch-list")
+def read_punch_list(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
+    """The short list of edits a person should make by hand.
+
+    One model call the first time it is asked for, then read from the run.
+    Nothing downstream of `finalize` changes the article, so the answer cannot
+    go stale, and paying for it twice would be paying for the same paragraph.
+    """
+    return JSONResponse(_handle(punch_list, run_id, _services(run_id)))
 
 
 @router.get("/{run_id}/polish-prompt")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -48,6 +48,7 @@ from .grill_v4 import (
     start_grill,
 )
 from .coverage_v4 import CoverageVerdict, assess_coverage
+from .notes_v4 import PUNCH_LIST_STAGE, build_punch_list
 from .gate_v4 import (
     GateAnswerRefused,
     answer_requirement,
@@ -907,6 +908,36 @@ def polish_prompt(run_id: str) -> dict[str, Any]:
             audit_problems=audit_problems,
         ),
     }
+
+
+def punch_list(run_id: str, services: IntakeServices) -> dict[str, Any]:
+    """What a person should fix by hand, computed once and kept.
+
+    Read from the run after the first time, because it is a model call over a
+    finished article and the answer cannot change: nothing downstream of
+    `finalize` edits the piece. Re-deriving it on every page load would charge
+    the run again for the same paragraph.
+
+    Not a stage in the graph. The article is written, stamped and stored before
+    this is asked for, so a failure here loses the notes and not the piece --
+    which is the whole reason it is allowed to run at all (ADR 0030 keeps the
+    one gate before writing, and nothing blocks after it).
+    """
+    stored = _stage_data(run_id, PUNCH_LIST_STAGE)
+    if stored.get("items") is not None:
+        return {"run_id": run_id, **{k: v for k, v in stored.items() if k != STATE_KEY}}
+
+    article = finished_article(run_id)
+    result = build_punch_list(
+        brief=load_brief(run_id),
+        title=article["title"],
+        article_markdown=article["markdown"],
+        evidence=load_evidence(run_id),
+        llm=services.dependencies.llm,
+        model_name=services.dependencies.model_name,
+    )
+    _record(services, run_id, PUNCH_LIST_STAGE, result)
+    return {"run_id": run_id, **result}
 
 
 def _research_view(run_id: str, research: dict[str, Any]) -> dict[str, Any]:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/notes_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/notes_v4.py
@@ -1,0 +1,384 @@
+"""What a person should fix by hand, once the article exists.
+
+A run ends with an article, a readiness stamp and some measurements, and
+nothing that says what to actually do about it. The gap was found by accident
+on 2026-09-01: after run 062c0b86 the owner asked what I thought of the output,
+and the resulting read -- what works, what is missing, what is buried -- was
+more useful than any mechanical check the run already produces. It named things
+no measurement in the system can see.
+
+So: a short ranked list of specific, placeable edits, for a person to spend
+twenty minutes on. Not for another model to rewrite the piece, and not to make
+the pipeline more perfect. `polish_v4` already assembles the paste-into-a-
+chatbot path; this is the other branch, where the operator edits it themselves.
+
+**The hard part is that it must never supply the missing fact.**
+
+Run 062c0b86 was titled "Lima Has a Pyramid Older Than the Inca Empire" and the
+article never gives a date. The tempting note is "add a sentence saying it
+dates to around 400 AD" -- a number invented at the last possible moment, after
+every evidence check in the pipeline has already run, entering the article
+through the one door with no guard on it.
+
+Three things stop that here:
+
+1. Every item is one of two kinds, and says which. **You have this already**
+   cites claims from the dossier, and the quoted text is looked up from the
+   dossier rather than taken from the model, so it cannot be misquoted. **Nobody
+   established this** says what is missing and nothing more.
+2. An item claiming the run has something, that cites nothing the dossier
+   contains, is demoted to "nobody established this". The safe direction is
+   never asserting the run holds a fact it does not.
+3. No note may contain a number the run does not already have. Every figure in
+   the punch list must appear in the article or in the dossier. "Around 400 AD"
+   appears in neither, so the note carrying it is dropped.
+
+It is not a gate, not a score, and not a rewrite. It runs after the article is
+finished and stored, so a failure here loses the notes and not the piece.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .contracts_v4 import ArticleBrief, EvidencePackage
+from .support import _safe_dict, _safe_str
+
+logger = logging.getLogger(__name__)
+
+PUNCH_LIST_STAGE = "stage_v4_punch_list"
+PUNCH_LIST_MAX_TOKENS = 4000
+
+# Six items a person will act on beats thirty they will scroll past.
+MAX_ITEMS = 6
+
+ITEM_KINDS = ("add_sentence", "add_paragraph", "move", "rephrase", "cut")
+
+# What the operator is told about where each item's fact would come from.
+HAVE_IT = "have_it"
+NOT_ESTABLISHED = "not_established"
+
+_NUMBER = re.compile(r"\d[\d,.]*")
+_HEADING = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+# A word that is capitalised without starting a sentence: a name, a place, a
+# brand. Long enough to be distinctive rather than "The" or "And".
+_PROPER = re.compile(r"(?<![.!?]\s)(?<!^)\b([A-Z][\w'’-]{3,})\b", re.MULTILINE)
+
+
+def _numbers(text: str) -> set[str]:
+    """Every figure in a piece of text, comparable across its own formatting.
+
+    "16,000" and "16000" are the same number written twice, and a note that
+    reformatted one would otherwise read as introducing a new one.
+    """
+    found = set()
+    for raw in _NUMBER.findall(text or ""):
+        cleaned = raw.rstrip(".,")
+        if not cleaned:
+            continue
+        found.add(cleaned)
+        found.add(cleaned.replace(",", ""))
+    return found
+
+
+def _proper_nouns(text: str) -> set[str]:
+    return {match.casefold() for match in _PROPER.findall(text or "")}
+
+
+def article_headings(markdown: str) -> list[str]:
+    """The headings an item is allowed to point at.
+
+    "In the introduction" is not a place. A note the operator cannot put their
+    finger on is a note they will not act on.
+    """
+    return [heading.strip() for heading in _HEADING.findall(markdown or "") if heading.strip()]
+
+
+def unused_claims(
+    evidence: EvidencePackage,
+    article_markdown: str,
+) -> list[dict[str, str]]:
+    """Claims the run researched, graded and then did not use.
+
+    Fully deterministic, which is the point: these are the items that can be
+    raised without any risk of inventing something, because the fact was
+    researched, checked and graded before the writing started.
+
+    A claim counts as used when any figure or name in it appears in the
+    article. Deliberately generous -- one match is enough -- because telling an
+    operator they left something out when they did not is worse than staying
+    quiet about one they did.
+    """
+    article_numbers = _numbers(article_markdown)
+    article_names = _proper_nouns(article_markdown)
+    missed: list[dict[str, str]] = []
+    for claim in evidence.claims:
+        figures = _numbers(claim.text)
+        names = _proper_nouns(claim.text)
+        if not figures and not names:
+            # Nothing distinctive enough to look for. Saying "this claim is
+            # unused" on a guess is exactly the kind of noise that gets a list
+            # ignored.
+            continue
+        if figures & article_numbers or names & article_names:
+            continue
+        missed.append({"claim_id": claim.claim_id, "text": claim.text})
+    return missed
+
+
+def numbers_the_run_does_not_have(
+    text: str,
+    *,
+    article_markdown: str,
+    evidence: EvidencePackage,
+) -> list[str]:
+    """Figures in a note that appear nowhere in the run's own material.
+
+    The guard on the one door with no other guard on it. A note may repeat a
+    number the article has, or one the dossier established and the article
+    dropped. A number from neither was invented while writing the note, which
+    is the failure this whole module is shaped around avoiding.
+    """
+    known = _numbers(article_markdown)
+    for claim in evidence.claims:
+        known |= _numbers(claim.text)
+    for requirement in evidence.requirements:
+        known |= _numbers(requirement.gap)
+    return sorted(figure for figure in _numbers(text) if figure not in known)
+
+
+PUNCH_LIST_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "enum": list(ITEM_KINDS)},
+                    "heading": {"type": "string"},
+                    "where": {"type": "string"},
+                    "note": {"type": "string"},
+                    "needs": {"type": "string", "enum": [HAVE_IT, NOT_ESTABLISHED]},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["kind", "heading", "note", "needs"],
+            },
+        }
+    },
+    "required": ["items"],
+}
+
+
+def build_punch_list_prompt(
+    *,
+    brief: ArticleBrief,
+    title: str,
+    article_markdown: str,
+    evidence: EvidencePackage,
+    unused: list[dict[str, str]],
+) -> str:
+    """Ask for the read a person would give it, with the run's own material."""
+    headings = "\n".join(f"- {heading}" for heading in article_headings(article_markdown))
+    dossier = (
+        "\n".join(f"- [{claim.claim_id}] {claim.text}" for claim in evidence.claims)
+        or "- Nothing. Every item you raise is the second kind."
+    )
+    never_used = (
+        "\n".join(f"- [{item['claim_id']}] {item['text']}" for item in unused)
+        or "- None. Everything researched reached the piece in some form."
+    )
+    return f"""Read this finished article the way an editor would, and list what one
+person should fix by hand in twenty minutes.
+
+Not a rewrite. Not a score. Somebody else is going to open this article and
+make these edits themselves, so every item has to be small, specific, and
+somewhere they can put their finger on.
+
+WHAT THIS ARTICLE IS FOR
+Reader: {brief.reader.primary_reader}
+Their question: {brief.reader_question}
+What it should make them do: {brief.outcome}
+What it is built on: {brief.spine}
+
+IT FAILS IF: {brief.fails_if}
+
+That line defines failure for this specific piece and nothing in this system
+has ever read it. Read it now. If the article is drifting toward it, that is
+your first item.
+
+THE HEADLINE IT WILL BE PUBLISHED UNDER
+{title}
+
+Whatever that line asserts is a promise to a reader who clicked it. If it names
+an age, a number, a superlative, a first or an oldest, and the article does not
+answer it, that is an item -- and check the dossier below before you decide
+which kind it is.
+
+THE HEADINGS YOU MAY POINT AT
+{headings or "- The article has no headings."}
+
+WHAT THE RESEARCH ESTABLISHED
+{dossier}
+
+RESEARCHED AND NEVER USED
+These were checked and graded before the writing started, and did not make the
+article. They are the safest items on the list: the article can use them today.
+{never_used}
+
+THE ARTICLE
+{article_markdown}
+
+WHAT TO RETURN
+
+At most {MAX_ITEMS} items, best first. Six a person will act on beats thirty
+they will scroll past. Most of the value is rearranging and re-pointing what
+the article already earned, so most items should need no new information at
+all.
+
+Each item has:
+- `kind`: one of add_sentence, add_paragraph, move, rephrase, cut.
+- `heading`: exactly one of the headings listed above, copied as written. Use
+  the heading the edit happens in, not the one it moves to.
+- `where`: a few words quoted from the article so the person can find the spot.
+- `note`: one line, in the reader's terms. What is wrong and what to do. Not
+  "improve flow" -- say what a reader experiences and what fixes it.
+- `needs`: `{HAVE_IT}` or `{NOT_ESTABLISHED}`.
+- `claim_ids`: on a `{HAVE_IT}` item, the dossier claims that answer it.
+
+THE RULE THAT MATTERS MOST
+
+`{HAVE_IT}` means the dossier above already contains the fact and the article
+did not use it. Name the claim ids. Do not retype the fact; it will be quoted
+from the dossier.
+
+`{NOT_ESTABLISHED}` means nothing in the dossier answers it. Say what is
+missing and that it needs looking up. **Never state the value.** If the
+headline promises an age and no research established one, the item is "the
+headline promises an age, the research never established one, you need a date
+before this headline is honest" -- and nothing more. Writing a plausible date
+here would put an invented fact into a published article through the only step
+with nothing checking it.
+
+Any figure you write must already appear in the article or in the dossier. A
+note carrying a number from neither will be thrown away.
+"""
+
+
+def _valid_items(
+    payload: dict[str, Any],
+    *,
+    article_markdown: str,
+    evidence: EvidencePackage,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """The items that survive their own rules, and what was dropped.
+
+    Degrade rather than fail: a run whose notes came back half usable gives the
+    operator the usable half. Nothing here can stop or endanger the article,
+    which is already written and stored by the time this is asked for.
+    """
+    headings = article_headings(article_markdown)
+    by_heading = {heading.casefold(): heading for heading in headings}
+    claims = {claim.claim_id: claim.text for claim in evidence.claims}
+
+    items: list[dict[str, Any]] = []
+    dropped: list[str] = []
+    for raw in payload.get("items") or []:
+        record = _safe_dict(raw)
+        note = _safe_str(record.get("note"))
+        kind = _safe_str(record.get("kind"))
+        if not note or kind not in ITEM_KINDS:
+            dropped.append("an item with no note or no kind")
+            continue
+
+        invented = numbers_the_run_does_not_have(
+            note, article_markdown=article_markdown, evidence=evidence
+        )
+        if invented:
+            # The guard doing its job. Logged loudly because a model reaching
+            # for a number at this stage is the failure mode this module was
+            # built around, and it should be visible when it happens.
+            logger.warning(
+                "Dropped a punch list item carrying figures the run does not "
+                "have: %s",
+                ", ".join(invented),
+            )
+            dropped.append(
+                f"an item that introduced a figure the run does not have "
+                f"({', '.join(invented)})"
+            )
+            continue
+
+        cited = [
+            claim_id
+            for claim_id in (record.get("claim_ids") or [])
+            if _safe_str(claim_id) in claims
+        ]
+        needs = _safe_str(record.get("needs"))
+        # A claim of "you have this already" that cites nothing the dossier
+        # contains is demoted rather than trusted. Telling someone the research
+        # covered something it did not is how a fact gets written from memory.
+        if needs != HAVE_IT or not cited:
+            needs = NOT_ESTABLISHED
+            cited = []
+
+        heading = by_heading.get(_safe_str(record.get("heading")).casefold(), "")
+        items.append(
+            {
+                "kind": kind,
+                # Empty when the model named a heading the article does not
+                # have. The item still reads; it just points at the piece as a
+                # whole.
+                "heading": heading,
+                "where": _safe_str(record.get("where")),
+                "note": note,
+                "needs": needs,
+                # Quoted from the dossier, never from the model, so an item
+                # cannot misstate the fact it is pointing at.
+                "have": [{"claim_id": claim_id, "text": claims[claim_id]} for claim_id in cited],
+            }
+        )
+        if len(items) == MAX_ITEMS:
+            break
+    return items, dropped
+
+
+def build_punch_list(
+    *,
+    brief: ArticleBrief,
+    title: str,
+    article_markdown: str,
+    evidence: EvidencePackage,
+    llm: Any,
+    model_name: str | None,
+) -> dict[str, Any]:
+    """One model call over a finished article, plus the checks that are free."""
+    unused = unused_claims(evidence, article_markdown)
+    parsed, _raw = llm.invoke_json(
+        prompt=build_punch_list_prompt(
+            brief=brief,
+            title=title,
+            article_markdown=article_markdown,
+            evidence=evidence,
+            unused=unused,
+        ),
+        model_name=model_name,
+        schema=PUNCH_LIST_SCHEMA,
+        max_tokens=PUNCH_LIST_MAX_TOKENS,
+        temperature=0.0,
+    )
+    items, dropped = _valid_items(
+        _safe_dict(parsed),
+        article_markdown=article_markdown,
+        evidence=evidence,
+    )
+    return {
+        "items": items,
+        # Kept beside the list because it is the deterministic half and it
+        # stands on its own: these were researched, graded, and never used,
+        # whatever the model did or did not say about them.
+        "researched_and_unused": unused,
+        "dropped": dropped,
+    }

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_punch_list.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_punch_list.py
@@ -1,0 +1,409 @@
+"""The list of edits a person makes by hand, and the fact it must never supply.
+
+Run 062c0b86 (2026-09-01) was titled "Lima Has a Pyramid Older Than the Inca
+Empire" and the article never gives a date. Nine research questions, not one of
+which asked how old the pyramid is.
+
+The tempting note is "add a sentence saying it dates to around 400 AD". That
+number would be invented at the last possible moment, after every evidence
+check in the pipeline has run, and would enter a published article through the
+one door with nothing else guarding it. Most of what follows is about that.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.contracts_v4 import (
+    ArticleBrief,
+    BriefReader,
+    EvidencePackage,
+)
+from app.features.prompt2blog.notes_v4 import (
+    HAVE_IT,
+    MAX_ITEMS,
+    NOT_ESTABLISHED,
+    article_headings,
+    build_punch_list,
+    build_punch_list_prompt,
+    numbers_the_run_does_not_have,
+    unused_claims,
+)
+
+ARTICLE = """# Lima Has a Pyramid Older Than the Inca Empire
+
+Allow about ninety minutes for the visit.
+
+## What the digs found
+
+The site sits in Miraflores and the adobe is stacked in bookshelf rows.
+
+## The night tour
+
+It opens Wednesday to Monday, and the terrace restaurant seats 40.
+"""
+
+
+def _brief(**overrides) -> ArticleBrief:
+    payload: dict[str, Any] = dict(
+        brief_fingerprint="bf-1",
+        seed="Lima Has a Pyramid Older Than the Inca Empire",
+        location="Lima, Peru",
+        form_id="destination-guide",
+        reader=BriefReader(primary_reader="layover traveller"),
+        reader_question="Is the Huaca worth an evening?",
+        outcome="book the night tour",
+        spine="a working dig you can eat beside",
+        fails_if="reads like a tourist board",
+    )
+    payload.update(overrides)
+    return ArticleBrief(**payload)
+
+
+def _evidence(**overrides) -> EvidencePackage:
+    payload = {
+        "work_order_fingerprint": "wo-1",
+        "sources": [
+            {
+                "source_id": "s1",
+                "title": "Site report",
+                "publisher": "Municipalidad de Miraflores",
+                "url": "https://miraflores.gob.pe/huaca",
+                "retrieved_at": "2026-09-01",
+                "source_type": "official",
+                "material_type": "web",
+                "notes": ["Dig summary."],
+            }
+        ],
+        "claims": [
+            {
+                "claim_id": "c1",
+                "text": "Excavations recovered 16,000 shark vertebrae from the site.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r1"],
+                "confidence": "high",
+            },
+            {
+                "claim_id": "c2",
+                "text": "The adobe is stacked in bookshelf rows across the Miraflores site.",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r1"],
+                "confidence": "high",
+            },
+        ],
+        "requirements": [
+            {"requirement_id": "r1", "status": "supported", "claim_ids": ["c1", "c2"]}
+        ],
+    }
+    payload.update(overrides)
+    return EvidencePackage.model_validate(payload)
+
+
+class FakeLLM:
+    """Returns whatever the test wants the read to have come back as."""
+
+    def __init__(self, payload: dict[str, Any]):
+        self.payload = payload
+        self.prompts: list[str] = []
+
+    def invoke_json(self, *, prompt: str, **_kwargs: Any) -> tuple[dict[str, Any], str]:
+        self.prompts.append(prompt)
+        return self.payload, ""
+
+
+def _run(payload: dict[str, Any], **overrides) -> dict[str, Any]:
+    llm = FakeLLM(payload)
+    return build_punch_list(
+        brief=overrides.get("brief", _brief()),
+        title="Lima Has a Pyramid Older Than the Inca Empire",
+        article_markdown=overrides.get("article", ARTICLE),
+        evidence=overrides.get("evidence", _evidence()),
+        llm=llm,
+        model_name=None,
+    )
+
+
+def _item(**overrides) -> dict[str, Any]:
+    item = {
+        "kind": "rephrase",
+        "heading": "The night tour",
+        "where": "It opens Wednesday to Monday",
+        "note": "Dinner beside a lit pyramid is buried inside opening hours.",
+        "needs": NOT_ESTABLISHED,
+    }
+    item.update(overrides)
+    return item
+
+
+# --- the fact it must never supply -----------------------------------------
+
+
+def test_an_item_carrying_a_figure_the_run_does_not_have_is_thrown_away():
+    """The Huaca date. Nothing in the run establishes it, so a note offering
+    one is a fact invented after every evidence check has already run."""
+    result = _run(
+        {
+            "items": [
+                _item(
+                    kind="add_sentence",
+                    heading="What the digs found",
+                    note="Add a sentence saying the pyramid dates to around 400 AD.",
+                )
+            ]
+        }
+    )
+
+    assert result["items"] == []
+    assert "400" in result["dropped"][0]
+
+
+def test_a_note_may_repeat_a_figure_the_dossier_established():
+    """The guard is against inventing, not against arithmetic-free reuse. The
+    shark vertebrae are researched, graded and sitting unused."""
+    result = _run(
+        {
+            "items": [
+                _item(
+                    kind="move",
+                    heading="What the digs found",
+                    note="16,000 shark vertebrae is the most repeatable fact here and it is missing.",
+                    needs=HAVE_IT,
+                    claim_ids=["c1"],
+                )
+            ]
+        }
+    )
+
+    assert len(result["items"]) == 1
+    assert result["dropped"] == []
+
+
+def test_a_note_may_repeat_a_figure_the_article_already_prints():
+    result = _run({"items": [_item(note="The 40 seats are worth saying earlier.")]})
+
+    assert len(result["items"]) == 1
+    assert result["dropped"] == []
+
+
+def test_a_figure_the_article_spells_out_in_words_is_still_dropped():
+    """A known limitation, kept on purpose and visible when it fires.
+
+    The article says "ninety minutes"; a note saying "90 minutes" is talking
+    about a number the run does have, and loses its item anyway. Reading word
+    forms would fix it and would also be the first crack in a guard whose
+    whole value is that it is dumb and total. Losing one note of six is cheap;
+    an invented figure in a published article is not, and the drop is reported
+    rather than silent.
+    """
+    result = _run({"items": [_item(note="Lead with the 90 minutes, not the history.")]})
+
+    assert result["items"] == []
+    assert "90" in result["dropped"][0]
+
+
+def test_the_guard_reads_a_number_the_same_however_it_is_punctuated():
+    assert numbers_the_run_does_not_have(
+        "16000 vertebrae", article_markdown=ARTICLE, evidence=_evidence()
+    ) == []
+    assert numbers_the_run_does_not_have(
+        "dates to 400 AD", article_markdown=ARTICLE, evidence=_evidence()
+    ) == ["400"]
+
+
+def test_the_prompt_forbids_stating_the_value_and_says_why():
+    prompt = build_punch_list_prompt(
+        brief=_brief(),
+        title="Lima Has a Pyramid Older Than the Inca Empire",
+        article_markdown=ARTICLE,
+        evidence=_evidence(),
+        unused=[],
+    )
+    flat = " ".join(prompt.split())
+
+    assert "Never state the value." in flat
+    assert "you need a date before this headline is honest" in flat
+    assert "the only step with nothing checking it" in flat
+
+
+# --- the two kinds, and which one an item really is ------------------------
+
+
+def test_saying_the_run_has_it_requires_naming_a_claim_that_exists():
+    """Otherwise "you have this already" is itself a fact stated from memory."""
+    result = _run(
+        {"items": [_item(needs=HAVE_IT, claim_ids=["c99"])]}
+    )
+
+    assert result["items"][0]["needs"] == NOT_ESTABLISHED
+    assert result["items"][0]["have"] == []
+
+
+def test_a_have_it_item_quotes_the_dossier_rather_than_the_model():
+    """The model gives ids; the text comes from the evidence package. An item
+    cannot misstate the fact it is pointing at."""
+    result = _run(
+        {
+            "items": [
+                _item(
+                    needs=HAVE_IT,
+                    claim_ids=["c1"],
+                    note="The strongest fact in the research never made the piece.",
+                )
+            ]
+        }
+    )
+
+    assert result["items"][0]["have"] == [
+        {
+            "claim_id": "c1",
+            "text": "Excavations recovered 16,000 shark vertebrae from the site.",
+        }
+    ]
+
+
+def test_an_item_with_no_claims_is_the_second_kind_by_default():
+    result = _run({"items": [_item()]})
+
+    assert result["items"][0]["needs"] == NOT_ESTABLISHED
+
+
+# --- placeable, short, ranked ----------------------------------------------
+
+
+def test_an_item_points_at_a_heading_the_article_actually_has():
+    result = _run({"items": [_item(heading="the night tour")]})
+
+    assert result["items"][0]["heading"] == "The night tour"
+
+
+def test_an_invented_heading_leaves_the_item_pointing_at_the_whole_piece():
+    """Rather than dropping a note that may still be worth reading. It just
+    stops pretending to be placeable."""
+    result = _run({"items": [_item(heading="Getting there")]})
+
+    assert result["items"][0]["heading"] == ""
+    assert result["items"][0]["note"]
+
+
+def test_the_list_is_capped_because_a_long_one_is_scrolled_past():
+    result = _run({"items": [_item(where=f"spot {index}") for index in range(20)]})
+
+    assert len(result["items"]) == MAX_ITEMS
+
+
+def test_the_order_the_read_gave_is_the_order_kept():
+    result = _run(
+        {
+            "items": [
+                _item(note="First thing."),
+                _item(note="Second thing."),
+            ]
+        }
+    )
+
+    assert [item["note"] for item in result["items"]] == ["First thing.", "Second thing."]
+
+
+def test_an_item_with_no_note_or_no_kind_is_dropped_rather_than_guessed():
+    result = _run({"items": [_item(note=""), _item(kind="reword")]})
+
+    assert result["items"] == []
+    assert len(result["dropped"]) == 2
+
+
+def test_headings_are_read_off_the_article():
+    assert article_headings(ARTICLE) == [
+        "Lima Has a Pyramid Older Than the Inca Empire",
+        "What the digs found",
+        "The night tour",
+    ]
+
+
+# --- the half that needs no model ------------------------------------------
+
+
+def test_a_researched_claim_the_article_never_used_is_found_without_a_model():
+    """The safest items on the list: checked and graded before the writing
+    started, so raising them cannot invent anything."""
+    unused = unused_claims(_evidence(), ARTICLE)
+
+    assert [item["claim_id"] for item in unused] == ["c1"]
+
+
+def test_a_claim_the_article_did_use_is_not_reported_as_missing():
+    # c2's bookshelf rows and Miraflores are both in the article.
+    assert all(item["claim_id"] != "c2" for item in unused_claims(_evidence(), ARTICLE))
+
+
+def test_a_claim_with_nothing_distinctive_in_it_is_left_alone():
+    """One match is enough, and no match at all means nothing to look for.
+    Telling an operator they left something out when they did not is worse
+    than staying quiet about one they did."""
+    evidence = _evidence(
+        claims=[
+            {
+                "claim_id": "c3",
+                "text": "the site is open to visitors on most days",
+                "source_ids": ["s1"],
+                "requirement_ids": ["r1"],
+                "confidence": "low",
+            }
+        ],
+        requirements=[
+            {"requirement_id": "r1", "status": "supported", "claim_ids": ["c3"]}
+        ],
+    )
+
+    assert unused_claims(evidence, ARTICLE) == []
+
+
+def test_the_unused_claims_are_reported_whatever_the_model_said():
+    """They stand on their own. The deterministic half does not depend on the
+    read agreeing with it."""
+    result = _run({"items": []})
+
+    assert [item["claim_id"] for item in result["researched_and_unused"]] == ["c1"]
+
+
+# --- what the read is actually asked ---------------------------------------
+
+
+def test_the_prompt_finally_reads_the_line_that_defines_failure():
+    """`fails_if` has been on the brief since v4 and nothing has ever read
+    it."""
+    prompt = build_punch_list_prompt(
+        brief=_brief(),
+        title="t",
+        article_markdown=ARTICLE,
+        evidence=_evidence(),
+        unused=[],
+    )
+
+    assert "IT FAILS IF: reads like a tourist board" in prompt
+    assert "nothing in this system has ever read it" in " ".join(prompt.split())
+
+
+def test_the_prompt_says_it_is_not_a_rewrite_and_not_a_score():
+    prompt = build_punch_list_prompt(
+        brief=_brief(),
+        title="t",
+        article_markdown=ARTICLE,
+        evidence=_evidence(),
+        unused=[],
+    )
+
+    assert "Not a rewrite. Not a score." in prompt
+
+
+def test_the_read_is_given_the_headline_as_a_promise_to_the_reader():
+    prompt = build_punch_list_prompt(
+        brief=_brief(),
+        title="Lima Has a Pyramid Older Than the Inca Empire",
+        article_markdown=ARTICLE,
+        evidence=_evidence(),
+        unused=[],
+    )
+    flat = " ".join(prompt.split())
+
+    assert "is a promise to a reader who clicked it" in flat
+    assert "an age, a number, a superlative, a first or an oldest" in flat

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ArticleScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ArticleScreen.tsx
@@ -3,6 +3,7 @@ import payloadLogoUrl from '../../../../assets/payload-logo.svg?url'
 import { buildStageArticleUrl } from '../../../blogArticles'
 import type { IntakeArticle, IntakeWriting } from '../intake.types'
 import { PolishPrompt } from './PolishPrompt'
+import { PunchList } from './PunchList'
 
 /**
  * The finished article.
@@ -120,6 +121,8 @@ export function ArticleScreen({ runId, writing, article, onReopen, busy }: Artic
       ) : (
         <p className="p2b-note">Loading the article…</p>
       )}
+
+      <PunchList runId={runId} />
 
       <PolishPrompt runId={runId} />
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/PunchList.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/PunchList.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react'
+import { readPunchList } from '../intake.api'
+import type { PunchList as PunchListPayload, PunchListItem } from '../intake.types'
+
+/**
+ * What to fix by hand, in twenty minutes.
+ *
+ * The run ends with an article, a stamp and some measurements, and nothing
+ * that says what to do about it. This is the other branch from the polish
+ * prompt: that one hands the piece to a chatbot, this one hands it back to the
+ * person, who knows things no model does.
+ *
+ * The distinction that carries the whole screen is where each fact comes from.
+ * An item marked as already researched can be acted on immediately — that fact
+ * was checked and graded before the writing started, and the claim shown under
+ * it is quoted from the dossier rather than written by the read. An item marked
+ * as unresearched says what is missing and never what it is. Run 062c0b86 was
+ * headlined "older than the Inca Empire" and gave no date; the useful note is
+ * that the date was never established, and a note supplying one would put an
+ * invented fact into a published article at the last possible moment.
+ *
+ * Not a gate and not a score. Nothing here blocks anything, and there is no
+ * number: "7/10" tells a person nothing they can act on.
+ */
+
+interface PunchListProps {
+  runId: string
+}
+
+const KIND_LABELS: Record<PunchListItem['kind'], string> = {
+  add_sentence: 'Add a sentence',
+  add_paragraph: 'Add a paragraph',
+  move: 'Move',
+  rephrase: 'Rephrase',
+  cut: 'Cut',
+}
+
+function Item({ item, index }: { item: PunchListItem; index: number }) {
+  const researched = item.needs === 'have_it'
+  return (
+    <li className="p2b-punch-item">
+      <div className="p2b-punch-head">
+        <span className="p2b-punch-rank">{index + 1}</span>
+        <span className="p2b-kind">{KIND_LABELS[item.kind]}</span>
+        <span className="p2b-punch-where">
+          {item.heading || 'The article overall'}
+          {item.where && <span className="p2b-punch-quote">“{item.where}”</span>}
+        </span>
+      </div>
+
+      <p className="p2b-punch-note">{item.note}</p>
+
+      {researched ? (
+        <div className="p2b-punch-have">
+          <span className="p2b-label">You already have this</span>
+          <ul>
+            {item.have.map(claim => (
+              <li key={claim.claim_id}>{claim.text}</li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="p2b-punch-missing">
+          Nobody established this. It needs looking up before it goes in.
+        </p>
+      )}
+    </li>
+  )
+}
+
+export function PunchList({ runId }: PunchListProps) {
+  const [notes, setNotes] = useState<PunchListPayload | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    let live = true
+    void readPunchList(runId)
+      .then(result => live && setNotes(result))
+      .catch(() => live && setFailed(true))
+    return () => {
+      live = false
+    }
+  }, [runId])
+
+  // A failure here loses the notes, not the article, which is the reason this
+  // is allowed to run at all. Said quietly and then left alone.
+  if (failed) {
+    return (
+      <section className="p2b-punch" aria-label="What to fix by hand">
+        <p className="p2b-eyebrow">What to fix by hand</p>
+        <p className="p2b-note">
+          The read did not come back. The article is unaffected.
+        </p>
+      </section>
+    )
+  }
+
+  if (!notes) {
+    return (
+      <section className="p2b-punch" aria-label="What to fix by hand">
+        <p className="p2b-eyebrow">What to fix by hand</p>
+        <p className="p2b-note">Reading it…</p>
+      </section>
+    )
+  }
+
+  const unusedOnly = notes.items.length === 0 && notes.researched_and_unused.length > 0
+  if (notes.items.length === 0 && !unusedOnly) return null
+
+  return (
+    <section className="p2b-punch" aria-label="What to fix by hand">
+      <p className="p2b-eyebrow">What to fix by hand</p>
+      <p className="p2b-note">
+        Twenty minutes of edits, best first. Most need no new information — they
+        move or re-point something the article already earned.
+      </p>
+
+      {notes.items.length > 0 && (
+        <ol className="p2b-punch-list">
+          {notes.items.map((item, index) => (
+            <Item key={`${item.heading}-${index}`} item={item} index={index} />
+          ))}
+        </ol>
+      )}
+
+      {notes.researched_and_unused.length > 0 && (
+        /* The half that needed no model, and stands whatever the read said:
+           these were checked and graded before the writing started. */
+        <div className="p2b-punch-unused">
+          <span className="p2b-label">
+            Researched and never used — safe to add today
+          </span>
+          <ul>
+            {notes.researched_and_unused.map(claim => (
+              <li key={claim.claim_id}>{claim.text}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {notes.dropped.length > 0 && (
+        /* Shown rather than swallowed. A dropped item is usually the read
+           reaching for a figure the run does not have, and knowing it happened
+           is worth more than a silently shorter list. */
+        <ul className="p2b-punch-dropped">
+          {notes.dropped.map(reason => (
+            <li key={reason}>Not shown: {reason}.</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -5,6 +5,7 @@ import type {
   IntakeArticle,
   IntakeRunSummary,
   IntakeState,
+  PunchList,
   VenueToCheck,
 } from './intake.types'
 
@@ -209,6 +210,20 @@ export function reaskQuestion(
   body: { requirement_id: string; question: string },
 ): Promise<IntakeState> {
   return post(`${INTAKE}/${runId}/gate/reask`, body)
+}
+
+/**
+ * The short list of edits a person should make by hand.
+ *
+ * One model call the first time it is asked for, then read from the run, so
+ * this is slow once and instant afterwards.
+ */
+export async function readPunchList(runId: string): Promise<PunchList> {
+  const response = await apiFetch(`${INTAKE}/${runId}/punch-list`)
+  if (!response.ok) {
+    throw await readError(response, 'Could not read the notes on this article.')
+  }
+  return (await response.json()) as PunchList
 }
 
 /** The places this run would send a reader, for a person to look at. */

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -210,6 +210,35 @@ export interface VenueToCheck {
   sole_support_for: string[]
 }
 
+/**
+ * One edit a person should make by hand, and where the fact behind it comes
+ * from.
+ *
+ * `needs` is the whole design. `have_it` means the research already answered
+ * it and the article did not use it, and the claims are quoted from the
+ * dossier rather than written by the read. `not_established` means nothing in
+ * the run answers it — those items say what is missing and never what it is.
+ */
+export interface PunchListItem {
+  kind: 'add_sentence' | 'add_paragraph' | 'move' | 'rephrase' | 'cut'
+  /** A heading from the article. Empty when the item is about the whole piece. */
+  heading: string
+  /** A few words quoted from the article, to find the spot. */
+  where: string
+  note: string
+  needs: 'have_it' | 'not_established'
+  have: { claim_id: string; text: string }[]
+}
+
+export interface PunchList {
+  run_id: string
+  items: PunchListItem[]
+  /** Researched, graded, and never used. Found without a model. */
+  researched_and_unused: { claim_id: string; text: string }[]
+  /** What was thrown away and why — mostly items that reached for a figure. */
+  dropped: string[]
+}
+
 /** The finished article. Its own call: the state is polled, this is not. */
 export interface IntakeArticle {
   run_id: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/punch-list.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/punch-list.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PunchList as PunchListPayload } from './intake.types'
+
+const readPunchList = vi.fn()
+vi.mock('./intake.api', () => ({
+  readPunchList: (...args: unknown[]) => readPunchList(...args),
+}))
+
+const { PunchList } = await import('./components/PunchList')
+
+/**
+ * The screen that tells a person what to fix, and where each fact comes from.
+ *
+ * Run 062c0b86 was headlined "older than the Inca Empire" and never gave a
+ * date. The useful note is that no research established one. A note supplying
+ * a date would be an invented fact entering a published article at the last
+ * possible moment, so the two kinds of item must never read alike.
+ */
+
+function payload(overrides: Partial<PunchListPayload> = {}): PunchListPayload {
+  return {
+    run_id: 'run-1',
+    items: [],
+    researched_and_unused: [],
+    dropped: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  readPunchList.mockReset()
+})
+
+describe('where each fact comes from', () => {
+  it('quotes the research behind an item the run already has', async () => {
+    readPunchList.mockResolvedValue(
+      payload({
+        items: [
+          {
+            kind: 'move',
+            heading: 'What the digs found',
+            where: 'The site sits in Miraflores',
+            note: 'The strongest fact in the piece is in section two.',
+            needs: 'have_it',
+            have: [
+              {
+                claim_id: 'c1',
+                text: 'Excavations recovered 16,000 shark vertebrae from the site.',
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    render(<PunchList runId="run-1" />)
+
+    expect(await screen.findByText(/You already have this/i)).toBeTruthy()
+    expect(screen.getByText(/16,000 shark vertebrae/)).toBeTruthy()
+    expect(screen.queryByText(/Nobody established this/i)).toBeNull()
+  })
+
+  it('says an unresearched item needs looking up, and gives no value', async () => {
+    readPunchList.mockResolvedValue(
+      payload({
+        items: [
+          {
+            kind: 'add_sentence',
+            heading: 'What the digs found',
+            where: 'The site sits in Miraflores',
+            note: 'The headline promises an age and no date appears anywhere.',
+            needs: 'not_established',
+            have: [],
+          },
+        ],
+      }),
+    )
+    render(<PunchList runId="run-1" />)
+
+    expect(await screen.findByText(/Nobody established this/i)).toBeTruthy()
+    expect(screen.queryByText(/You already have this/i)).toBeNull()
+  })
+
+  it('places an item on a heading, and says so plainly when it cannot', async () => {
+    readPunchList.mockResolvedValue(
+      payload({
+        items: [
+          {
+            kind: 'rephrase',
+            heading: '',
+            where: '',
+            note: 'It opens on how long the visit takes.',
+            needs: 'not_established',
+            have: [],
+          },
+        ],
+      }),
+    )
+    render(<PunchList runId="run-1" />)
+
+    expect(await screen.findByText(/The article overall/i)).toBeTruthy()
+  })
+})
+
+describe('the half that needed no model', () => {
+  it('lists what was researched and never used, even with no items at all', async () => {
+    readPunchList.mockResolvedValue(
+      payload({
+        researched_and_unused: [
+          { claim_id: 'c1', text: 'Excavations recovered 16,000 shark vertebrae.' },
+        ],
+      }),
+    )
+    render(<PunchList runId="run-1" />)
+
+    expect(await screen.findByText(/safe to add today/i)).toBeTruthy()
+  })
+
+  it('says when an item was thrown away rather than quietly showing fewer', async () => {
+    readPunchList.mockResolvedValue(
+      payload({
+        dropped: ['an item that introduced a figure the run does not have (400)'],
+        researched_and_unused: [{ claim_id: 'c1', text: 'Something unused.' }],
+      }),
+    )
+    render(<PunchList runId="run-1" />)
+
+    expect(await screen.findByText(/figure the run does not have \(400\)/)).toBeTruthy()
+  })
+})
+
+describe('when it does not come back', () => {
+  it('says the article is unaffected, because that is the point of running here', async () => {
+    readPunchList.mockRejectedValue(new Error('nope'))
+    render(<PunchList runId="run-1" />)
+
+    expect(await screen.findByText(/The article is unaffected/i)).toBeTruthy()
+  })
+
+  it('shows nothing at all when there is nothing to say', async () => {
+    readPunchList.mockResolvedValue(payload())
+    const { container } = render(<PunchList runId="run-1" />)
+
+    await waitFor(() => expect(container.querySelector('.p2b-punch')).toBeNull())
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -791,6 +791,104 @@
  * and typed changes leave nothing able to say what was actually asked for.
  */
 
+/* ---------- what to fix by hand ---------- */
+
+/*
+ * A worklist, not a report. It is read standing up, with the article open, so
+ * the rank and the place come before the reasoning and the items are separated
+ * by rules rather than boxed -- a card each would make six items look like six
+ * decisions.
+ */
+.p2b-punch {
+  margin: var(--space-5) 0 0;
+}
+
+.p2b-punch-list {
+  margin: var(--space-4) 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.p2b-punch-item {
+  padding: var(--space-4) 0;
+  border-top: 1px solid var(--border);
+}
+
+.p2b-punch-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+}
+
+.p2b-punch-rank {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.p2b-punch-where {
+  color: var(--ink-light);
+  font-size: 0.875rem;
+}
+
+.p2b-punch-quote {
+  margin-left: var(--space-2);
+  font-style: italic;
+}
+
+.p2b-punch-note {
+  margin: var(--space-2) 0 0;
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+
+/*
+ * The one distinction the screen exists to make. A fact the run already holds
+ * is quoted and actionable now; a fact nobody established is stated as absent
+ * and never filled in, because filling it in here would be inventing it after
+ * every check in the pipeline has run.
+ */
+.p2b-punch-have,
+.p2b-punch-unused {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-3) var(--space-4);
+  background: var(--accent-softer);
+  border-radius: var(--radius-md);
+}
+
+.p2b-punch-have ul,
+.p2b-punch-unused ul {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-4);
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.p2b-punch-missing {
+  margin: var(--space-3) 0 0;
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  border-left: 2px solid var(--accent);
+  padding-left: var(--space-3);
+}
+
+.p2b-punch-unused {
+  margin-top: var(--space-5);
+}
+
+.p2b-punch-dropped {
+  margin: var(--space-3) 0 0;
+  padding-left: var(--space-4);
+  color: var(--muted);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
 .p2b-polish {
   margin: var(--space-5) 0 0;
   padding: var(--space-4) clamp(var(--space-4), 3vw, var(--space-5));


### PR DESCRIPTION
Closes #463. Phase 3.

A run ended with an article, a stamp and some measurements, and nothing saying what to do about it. This is the short ranked list of placeable edits — for a person with twenty minutes, not for a model to rewrite the piece.

Not a gate (nothing blocks after prose exists). Not a score. Not `polish_v4` again — that hands the article to a chatbot, this hands it back to the person.

## The design problem: it must never supply the missing fact

Run `062c0b86` was headlined *"Lima Has a Pyramid Older Than the Inca Empire"* and never gives a date. The tempting note is "add a sentence saying it dates to around 400 AD" — a number invented after every evidence check in the pipeline has run, entering through the one door with nothing else on it.

**Three guards, in order of how much I trust them:**

1. **No note may carry a figure the run does not already have.** Every number must appear in the article or the dossier. Blunt and total. Verified on the real run: `400` is caught, and a note reusing the 16,000 shark vertebrae passes.
2. **"You have this already" quotes the dossier, not the model.** The read supplies claim ids; the text is looked up. An item cannot misquote the fact it points at.
3. **An item claiming the run has something, citing nothing that exists, is demoted** to "nobody established this". The safe direction is never asserting the run holds a fact it does not.

## The half that needs no model

A claim researched, graded, and never used is found by comparison rather than opinion — the safest items on the list, because the article can use them today.

Run against all three finished articles, it finds **exactly one each**:

| run | what the research paid for and the article dropped |
|---|---|
| `062c0b86` | visitors may climb the pyramid on daytime tours |
| `a2066506` | what the Miraflores high-rises actually look like |
| `76b36468` | Moravia's transformation began around 2004–2005 |

One per article is the right order of magnitude for a list nobody scrolls past.

It also finally reads `fails_if` — on the brief since v4, never once looked at by anything.

## Where it runs

**A route, computed once and kept — not a graph node.** The article is written, stamped and stored before this is asked for, so a failure loses the notes and not the piece, which is the only reason it's allowed to run. Nothing downstream of `finalize` edits the article, so the answer can't go stale and the run isn't charged twice. A graph node would also have meant touching topology, resume, and the stage list I removed a stage from two PRs ago.

## One known limitation, tested rather than hidden

A note saying "90 minutes" about an article that says "ninety minutes" loses its item. Reading word forms would fix it — and would be the first crack in a guard whose entire value is being dumb and total. The drop is reported on screen, never silent.

## Verification

- Backend 1200 passed (22 new) · Prompt2Blog frontend 148 passed (7 new) · `tsc --noEmit` clean
- Deterministic half and the number guard both run against real stored runs

**Not proven:** the model read itself. No real call has been made — the item shape, the ranking and the quality of the notes are proven by fixtures and by the guards, not by a run.