### PR TITLE
Four ways a complete dossier was thrown away, found by running one

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/notes_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/notes_v4.py
@@ -267,8 +267,29 @@ note carrying a number from neither will be thrown away.
 """
 
 
+def _items_in(payload: Any) -> list[Any]:
+    """The list of edits, under whichever shape the read came back in.
+
+    Run 849ae5aa returned a bare array of four good items -- including the one
+    that caught the article's own rainfall contradiction -- against a schema
+    asking for `{"items": [...]}`. All four were thrown away, and the operator
+    got an empty list on an article with real problems in it.
+
+    Same lesson the evidence parser has learned three times: a schema exists so
+    the model knows what to send, not so the parser can reject what arrived.
+    """
+    if isinstance(payload, list):
+        return payload
+    record = _safe_dict(payload)
+    for name in ("items", "edits", "notes", "punch_list", "fixes"):
+        value = record.get(name)
+        if isinstance(value, list):
+            return value
+    return []
+
+
 def _valid_items(
-    payload: dict[str, Any],
+    payload: Any,
     *,
     article_markdown: str,
     evidence: EvidencePackage,
@@ -285,7 +306,7 @@ def _valid_items(
 
     items: list[dict[str, Any]] = []
     dropped: list[str] = []
-    for raw in payload.get("items") or []:
+    for raw in _items_in(payload):
         record = _safe_dict(raw)
         note = _safe_str(record.get("note"))
         kind = _safe_str(record.get("kind"))
@@ -370,7 +391,7 @@ def build_punch_list(
         temperature=0.0,
     )
     items, dropped = _valid_items(
-        _safe_dict(parsed),
+        parsed,
         article_markdown=article_markdown,
         evidence=evidence,
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -26,6 +26,7 @@ import json
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+import re
 from datetime import date
 from typing import Any, Callable, get_args
 
@@ -160,6 +161,66 @@ def _rows(payload: dict[str, Any], *names: str) -> list[dict[str, Any]]:
     return [_safe_dict(item) for item in value] if isinstance(value, list) else []
 
 
+def _source_id_for(row: dict[str, Any]) -> str:
+    """A stable id for a source the model described but never named.
+
+    Derived from what it did give -- publisher, then title -- so the same
+    publisher cited by six claims becomes one source rather than six.
+    """
+    label = _safe_str(_first(row, "publisher", "site", "title", "name"))
+    if not label:
+        return ""
+    slug = re.sub(r"[^a-z0-9]+", "_", label.casefold()).strip("_")
+    return f"s_{slug}"[:60] if slug else ""
+
+
+def _sources_inside_claims(
+    payload: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, list[str]]]:
+    """Sources the model nested inside each claim instead of listing at the top.
+
+    Run 849ae5aa (2026-09-01) returned thirteen claims, each carrying its
+    sources as objects -- publisher, source_type, material_type -- and no
+    top-level `sources` array at all. Every claim therefore cited nothing the
+    parser could resolve, all thirteen were dropped as unusable, and twelve
+    answered questions arrived at the gate reading "its supporting claims could
+    not be used". The dossier was complete. It was shaped differently.
+
+    So the sources are lifted out and given ids, and each claim is handed the
+    ids of its own. Same principle as every other repair here: a schema exists
+    so the model knows what to send, not so the parser can reject what arrived.
+    """
+    harvested: dict[str, dict[str, Any]] = {}
+    by_claim: dict[str, list[str]] = {}
+    for row in _rows(payload, "claims"):
+        claim_id = _safe_str(_first(row, "claim_id", "id"))
+        if not claim_id:
+            continue
+        for entry in _first(row, "sources", "source_ids") or []:
+            if not isinstance(entry, dict):
+                continue
+            record = _safe_dict(entry)
+            source_id = _safe_str(_first(record, "source_id", "id")) or _source_id_for(
+                record
+            )
+            if not source_id:
+                continue
+            harvested.setdefault(
+                source_id,
+                {
+                    **record,
+                    "source_id": source_id,
+                    "title": _safe_str(_first(record, "title", "name"))
+                    or _safe_str(_first(record, "publisher", "site"))
+                    or source_id,
+                },
+            )
+            ids = by_claim.setdefault(claim_id, [])
+            if source_id not in ids:
+                ids.append(source_id)
+    return list(harvested.values()), by_claim
+
+
 def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
     """Take the dossier the model sent, whatever it named things.
 
@@ -179,9 +240,11 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
     unioned and written back consistently, so the contract is satisfied by
     construction and keeps its guarantee.
     """
+    embedded, embedded_by_claim = _sources_inside_claims(payload)
     sources: list[dict[str, Any]] = []
     seen_sources: set[str] = set()
-    for row in _rows(payload, "sources"):
+    # Declared first, so a top-level entry wins over one lifted out of a claim.
+    for row in [*_rows(payload, "sources"), *embedded]:
         source_id = _safe_str(_first(row, "source_id", "id"))
         if not source_id or source_id in seen_sources:
             continue
@@ -191,9 +254,15 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
                 **_only(row, EVIDENCE_SOURCE_FIELDS),
                 "source_id": source_id,
                 "title": _safe_str(_first(row, "title", "name")) or source_id,
+                # Today when the model gave nothing, which is not a guess:
+                # these pages were read during this run. Run 849ae5aa
+                # (2026-09-01) came back with eleven sources and not one
+                # retrieval date, and the whole dossier was refused over a
+                # field the parser was in a position to know.
                 "retrieved_at": _as_date(
                     _first(row, "retrieved_at", "retrieved", "accessed_at")
-                ),
+                )
+                or date.today().isoformat(),
                 "published_at": _as_date(_first(row, "published_at", "published"))
                 or None,
                 # Both vocabularies carry an "other" member, which is what
@@ -226,7 +295,13 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
                     _safe_str(row.get("url")),
                     _safe_str(_first(row, "publisher", "site")),
                 ),
-                "notes": _id_list(row, "notes"),
+                # The contract wants every source to carry a note, and the
+                # same run returned eleven sources with none. Said plainly
+                # rather than invented: a sentence about what the record does
+                # not contain is honest, and a sentence about the world would
+                # not be.
+                "notes": _id_list(row, "notes")
+                or ["No note recorded for this source."],
             }
         )
 
@@ -244,6 +319,13 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
                 **_only(row, EVIDENCE_REQUIREMENT_FIELDS),
                 "requirement_id": requirement_id,
                 "status": status,
+                # Read under its aliases here, because the union below reads
+                # this dict and not the raw row -- and the field allowlist has
+                # already stripped whatever the model called it. Run 849ae5aa
+                # said `claims`, so every question arrived linked to nothing,
+                # every claim was dropped for answering nothing, and a complete
+                # dossier reached the gate with twelve empty questions.
+                "claim_ids": _id_list(row, "claim_ids", "claims"),
                 # A cause we cannot read is `unknown`, which the gate treats as
                 # "no suggestion" rather than as a wrong one.
                 "cause": _one_of(
@@ -272,9 +354,19 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
                 **_only(row, EVIDENCE_CLAIM_FIELDS),
                 "claim_id": claim_id,
                 "text": text,
+                # Declared ids first, and the ones minted from this claim's
+                # own nested sources when none of the declared ones resolve --
+                # a claim citing "s1" against a dossier that never listed a
+                # top-level source has told us nothing, while the objects
+                # hanging off it name a real publisher.
                 "source_ids": [
                     item
                     for item in _id_list(row, "source_ids", "sources")
+                    if item in seen_sources
+                ]
+                or [
+                    item
+                    for item in embedded_by_claim.get(claim_id, [])
                     if item in seen_sources
                 ],
                 "requirement_ids": [

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_punch_list.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_punch_list.py
@@ -407,3 +407,27 @@ def test_the_read_is_given_the_headline_as_a_promise_to_the_reader():
 
     assert "is a promise to a reader who clicked it" in flat
     assert "an age, a number, a superlative, a first or an oldest" in flat
+
+
+# --- the shape the read actually came back in ------------------------------
+
+
+def test_a_bare_list_of_items_is_still_a_punch_list():
+    """Run 849ae5aa returned four good items as a bare array against a schema
+    asking for {"items": [...]} -- including the one that caught the article
+    contradicting its own headline on rainfall. All four were thrown away and
+    the operator got an empty list on an article with real problems in it."""
+    result = _run([_item(note="First thing."), _item(note="Second thing.")])
+
+    assert [item["note"] for item in result["items"]] == ["First thing.", "Second thing."]
+
+
+def test_the_list_is_read_under_its_other_names_too():
+    for name in ("edits", "notes", "punch_list", "fixes"):
+        result = _run({name: [_item(note=f"Found under {name}.")]})
+        assert result["items"], f"a list named {name} was dropped"
+
+
+def test_a_payload_with_nothing_usable_in_it_is_simply_empty():
+    assert _run({"summary": "the article is fine"})["items"] == []
+

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
@@ -745,3 +745,93 @@ def test_the_verdict_record_says_what_a_page_has_to_show():
         "has_texture",
         "findings",
     }
+
+
+# --- the shapes run 849ae5aa actually sent (2026-09-01) ---------------------
+#
+# One real run, four ways of losing a complete dossier. It came back with
+# thirteen good claims and every one was thrown away.
+
+
+def test_a_question_linking_its_claims_under_claims_still_links_them():
+    """The one that cost the run.
+
+    The model wrote `{"id": "q1", "claims": ["c1"], "status": "supported"}`.
+    The field allowlist strips `claims` before the two-way union reads it, and
+    the union reads the normalised dict rather than the raw row -- so every
+    question arrived linked to nothing, every claim was dropped for answering
+    nothing, and twelve answered questions reached the gate saying "its
+    supporting claims could not be used".
+    """
+    payload = _evidence_payload()
+    for row in payload["requirements"]:
+        row["claims"] = row.pop("claim_ids")
+    for claim in payload["claims"]:
+        claim.pop("requirement_ids", None)
+
+    evidence = structure_research(_work_order(), {}, _deps(payload))
+
+    assert len(evidence.claims) == len(payload["claims"])
+    by_id = {item.requirement_id: item for item in evidence.requirements}
+    assert by_id["r1"].claim_ids
+    assert by_id["r1"].status == "supported"
+
+
+def test_sources_nested_inside_a_claim_are_lifted_out_and_kept():
+    """The same run described its sources inside each claim -- publisher,
+    source_type, material_type -- and sent no top-level `sources` at all."""
+    payload = _evidence_payload()
+    payload.pop("sources")
+    for claim in payload["claims"]:
+        claim["sources"] = [
+            {
+                "publisher": "Movimiento Peruano Sin Agua",
+                "source_type": "official",
+                "material_type": "web",
+            }
+        ]
+
+    evidence = structure_research(_work_order(), {}, _deps(payload))
+
+    assert evidence.sources, "a described source is still a source"
+    assert len(evidence.claims) == len(payload["claims"])
+    assert all(claim.source_ids for claim in evidence.claims)
+
+
+def test_one_publisher_cited_by_every_claim_becomes_one_source():
+    payload = _evidence_payload()
+    payload.pop("sources")
+    for claim in payload["claims"]:
+        claim["sources"] = [{"publisher": "SENAMHI", "source_type": "official"}]
+
+    evidence = structure_research(_work_order(), {}, _deps(payload))
+
+    assert len(evidence.sources) == 1
+
+
+def test_a_source_with_no_retrieval_date_is_dated_by_the_run_that_read_it():
+    """Eleven sources, not one date, and the whole dossier refused over a field
+    the parser was in a position to know: these pages were read today."""
+    from datetime import date
+
+    payload = _evidence_payload()
+    for source in payload["sources"]:
+        source["retrieved_at"] = ""
+
+    evidence = structure_research(_work_order(), {}, _deps(payload))
+
+    assert all(item.retrieved_at == date.today() for item in evidence.sources)
+
+
+def test_a_source_with_no_note_says_so_rather_than_being_refused():
+    """The contract wants a note on every source. Saying the record has none is
+    honest; writing a sentence about the world would not be."""
+    payload = _evidence_payload()
+    for source in payload["sources"]:
+        source["notes"] = []
+
+    evidence = structure_research(_work_order(), {}, _deps(payload))
+
+    assert all(item.notes for item in evidence.sources)
+    assert "No note recorded" in evidence.sources[0].notes[0]
+


### PR DESCRIPTION
Found by doing the thing every PR today said was missing: **a real run**. Run `849ae5aa`, an article about Lima's fog nets.

Research returned **13 good claims and 11 sources**. The run reached the gate with **12 questions all reading "its supporting claims could not be used"**. Nothing was missing — the model had shaped its answer differently, four separate ways, and each one lost everything.

## 1. A question linking its claims under `claims` — the costly one

The two-way union reads the *normalised* requirement dict, and the field allowlist has already stripped whatever alias the model used. So `{"id": "q1", "claims": ["c1"], "status": "supported"}` arrived linked to nothing → every claim dropped for answering no question → all 12 questions demoted to `partial`.

This one is not new tonight. It has been silently halving the two-way union for any run where the model said `claims`.

## 2. Sources nested inside each claim

Same run described sources as objects hanging off each claim — publisher, source_type, material_type — and sent **no top-level `sources` array at all**. Now lifted out, given ids derived from the publisher (so one publisher cited twelve times is one source), and handed back to the claims that named them. A claim whose declared ids resolve to nothing falls back to them.

## 3 & 4. Sources with no retrieval date, and no notes

Eleven sources, not one date — refused over a field the parser was in a position to know: these pages were read during this run, so the date is today. Not a guess. And a source with no note now says the record has none, which is honest; a sentence about the world would not have been.

## Plus one in tonight's own code

The punch list read came back as a **bare array** against a schema asking for `{"items": [...]}`, so all four items were dropped and a finished article with real problems got an empty list. One of those four had caught the article contradicting its own headline on rainfall. Now read under a bare array and four aliases.

Every one of these is the lesson `_normalised_evidence` was already written around, in its own words: *a schema exists so the model knows what to send, not so the parser can reject what arrived.*

## Verification

- The same stored notes now structure into **12 claims answering all 12 questions**; gate passes with no blockers; the article writes
- Backend **1208 passed** (8 new, each pinning a shape this run actually sent) · frontend 148 · `tsc` clean