### PR TITLE
The repair pass shipped the frame it was shown

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/shared/text/__init__.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/text/__init__.py
@@ -4,6 +4,7 @@ from .normalize import (
     enforce_anti_ai_tells_markdown,
     normalize_dashes,
     normalize_dashes_markdown,
+    strip_prompt_delimiters,
     validate_anti_ai_tells_markdown,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "enforce_anti_ai_tells_markdown",
     "normalize_dashes",
     "normalize_dashes_markdown",
+    "strip_prompt_delimiters",
     "validate_anti_ai_tells_markdown",
 ]

--- a/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/text/normalize.py
@@ -299,6 +299,29 @@ def _iter_markdown_prose_lines(text: str) -> list[tuple[int, str]]:
     return prose_lines
 
 
+# A prompt wrapper the model handed back with the article still inside it.
+# `build_anti_ai_repair_prompt` shows the draft between `<<<CONTENT>>>` and
+# `<<<END_CONTENT>>>`; run 849ae5aa shipped both lines to staging, wrapping
+# the whole body, because nothing stripped them and nothing looked for them.
+# The pattern is deliberately generic: every prompt in this codebase that
+# frames its input uses the same `<<<NAME>>>` on its own line.
+_PROMPT_DELIMITER_LINE = re.compile(
+    r"^[ \t]*<<<[^<>\n]{1,64}>>>[ \t]*\n?", re.MULTILINE
+)
+
+
+def strip_prompt_delimiters(text: str) -> tuple[str, list[str]]:
+    """Remove whole-line prompt wrappers, and say what was removed.
+
+    Returns the cleaned text and the markers found, so a caller can decide
+    what an echoed wrapper means rather than only quietly deleting it.
+    """
+    found = [match.group(0).strip() for match in _PROMPT_DELIMITER_LINE.finditer(text)]
+    if not found:
+        return text, []
+    return _PROMPT_DELIMITER_LINE.sub("", text).strip(), found
+
+
 def _has_non_numeric_en_dash(line: str) -> bool:
     for match in re.finditer("–", line):
         before = line[: match.start()].rstrip()
@@ -318,6 +341,12 @@ def validate_anti_ai_tells_markdown(text: str) -> AntiAiValidationResult:
     """
     errors: list[str] = []
     for line_number, line in _iter_markdown_prose_lines(text):
+        if _PROMPT_DELIMITER_LINE.match(line):
+            errors.append(
+                f"Line {line_number}: prompt delimiter left in the output: "
+                f"{line.strip()}"
+            )
+            continue
         if "—" in line:
             errors.append(f"Line {line_number}: em dash is not allowed.")
         if _DOUBLE_HYPHEN_PROSE.search(line):
@@ -408,7 +437,31 @@ def enforce_anti_ai_tells_markdown(
         )
         return candidate
 
+    # A repair that echoes the frame it was shown did not follow the
+    # instruction it was given. Stripping alone would hide that, and only the
+    # obvious half of it is visible: the delimiters are what can be seen of a
+    # response that may have ignored the rest of the prompt too. So the
+    # wrapper never ships, and the repair stops counting as a success -- it is
+    # kept only if the stripped text validates clean on its own.
+    repaired, leaked = strip_prompt_delimiters(repaired)
     repaired_result = validate_anti_ai_tells_markdown(repaired)
+    if leaked:
+        logger.warning(
+            "%s anti-AI repair echoed its prompt wrapper (%s); "
+            "the repair is not trusted",
+            context,
+            ", ".join(sorted(set(leaked))),
+        )
+        if not repaired_result.valid:
+            logger.warning(
+                "%s anti-AI repair still invalid after stripping the wrapper: "
+                "%s; keeping original",
+                context,
+                repaired_result.errors,
+            )
+            return candidate
+        return repaired
+
     if not repaired_result.valid:
         logger.warning(
             "%s anti-AI repair still invalid: %s", context, repaired_result.errors

--- a/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_shared_text_normalize.py
@@ -3,6 +3,7 @@ from app.shared.text import (
     enforce_anti_ai_tells_markdown,
     normalize_dashes,
     normalize_dashes_markdown,
+    strip_prompt_delimiters,
     validate_anti_ai_tells_markdown,
 )
 
@@ -320,3 +321,79 @@ class TestResearchMetaIsNotReaderFacing:
         )
         assert "reports on the research by deleting it" in prompt
         assert "Never soften it" in prompt
+
+
+# --- prompt delimiters that came back with the article ---------------------
+#
+# Run 849ae5aa shipped a `ready_for_staging` article whose body was wrapped in
+# the literal `<<<CONTENT>>>` and `<<<END_CONTENT>>>` lines the repair prompt
+# had shown it. Nothing stripped them and nothing looked for them.
+
+
+WRAPPED = "<<<CONTENT>>>\nThe room has six tables.\n<<<END_CONTENT>>>"
+
+
+def test_a_prompt_delimiter_in_the_output_fails_validation():
+    result = validate_anti_ai_tells_markdown(WRAPPED)
+
+    assert not result.valid
+    assert any("prompt delimiter left in the output" in error for error in result.errors)
+    assert any("<<<CONTENT>>>" in error for error in result.errors)
+
+
+def test_stripping_returns_what_it_removed():
+    cleaned, found = strip_prompt_delimiters(WRAPPED)
+
+    assert cleaned == "The room has six tables."
+    assert found == ["<<<CONTENT>>>", "<<<END_CONTENT>>>"]
+
+
+def test_stripping_leaves_ordinary_prose_alone():
+    text = "The room has six tables.\n\nBook before noon."
+
+    assert strip_prompt_delimiters(text) == (text, [])
+
+
+def test_an_angle_bracketed_phrase_inside_a_sentence_is_not_a_delimiter():
+    # The rule is a whole line that is only a marker. A sentence that happens
+    # to contain one is prose with a typo in it, not a wrapper.
+    text = "The sign reads <<<CONTENT>>> and nobody knows why."
+
+    assert strip_prompt_delimiters(text) == (text, [])
+
+
+def test_a_repair_that_echoes_the_wrapper_never_ships_it():
+    result = enforce_anti_ai_tells_markdown(
+        "The room is small — barely six tables.",
+        repair=lambda _prompt: WRAPPED,
+        context="test",
+    )
+
+    assert result == "The room has six tables."
+
+
+def test_a_repair_that_echoes_the_wrapper_and_stays_dirty_is_discarded():
+    # Stripping alone would hand back a repair that ignored its instructions
+    # and call it a success. The original is at least uncorrupted.
+    original = "The room is small — barely six tables."
+
+    result = enforce_anti_ai_tells_markdown(
+        original,
+        repair=lambda _prompt: "<<<CONTENT>>>\nStill dirty — no rewrite.\n<<<END_CONTENT>>>",
+        context="test",
+    )
+
+    assert result == original
+
+
+def test_the_echoed_wrapper_is_logged_even_when_the_repair_is_kept(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        enforce_anti_ai_tells_markdown(
+            "The room is small — barely six tables.",
+            repair=lambda _prompt: WRAPPED,
+            context="test",
+        )
+
+    assert "echoed its prompt wrapper" in caplog.text


### PR DESCRIPTION
Run `849ae5aa` produced a `ready_for_staging` article whose body was wrapped in the literal `<<<CONTENT>>>` and `<<<END_CONTENT>>>` lines that `build_anti_ai_repair_prompt` had shown the repair model. Nothing stripped them and nothing looked for them, so a wrapped article was "valid".

## What changed

- A whole-line `<<<NAME>>>` marker is a validation error. The pattern is generic on purpose: every framed prompt in this codebase uses the same shape, so a leak from `<<<BLOCK>>>` or `<<<ARTICLE_CONTEXT>>>` is caught too, not only this one.
- `strip_prompt_delimiters` removes them and says what it removed.
- An echoed wrapper stops counting as a successful repair. Stripping alone would have hidden the real fault: a response that hands back the frame it was shown did not follow the instruction it was given, and the delimiters are only the visible half of that. The repair is kept only if the stripped text validates clean on its own; otherwise the original is kept.

The blurb pipeline parses its own `<<<BLURB:id>>>` markers before calling `enforce_anti_ai_tells_markdown` on each body, so it is unaffected.

## Verification

`pytest apps/backend/tests` — 1282 tests, 0 failures (7 new).

Closes #474