### PR TITLE
The audit finally reads the line that defines failure

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -184,7 +184,8 @@ Return strict JSON only:
   "word_count_estimate": 0,
   "constraint_checks": {{
     "audience_match": false,
-    "tone_match": false
+    "tone_match": false,
+    "fails_if_avoided": false
   }},
   "required_revisions": ["string"],
   "quality_summary": "string"
@@ -221,9 +222,22 @@ Rules:
   built from.
 - Mark too_close_to_source=true when phrasing or structure tracks an evidence
   record too closely.
-- Judge only audience_match and tone_match. Word count, paragraph length, CTA,
-  and keyword presence are measured deterministically outside this prompt, so
-  do not report them.
+- Judge only audience_match, tone_match and fails_if_avoided. Word count,
+  paragraph length, CTA, and keyword presence are measured deterministically
+  outside this prompt, so do not report them.
+- The line under "This piece fails if" is the operator's own definition of
+  failure for this piece, written in their words before anything was
+  researched. It is the one criterion nobody else can supply. Read the draft
+  against that sentence and set fails_if_avoided accordingly. Where the draft
+  walks into it, name the sentence that does in required_revisions, quoting
+  it, and let it weigh on brief_adherence_score and overall_score the way any
+  other failure of the brief does. Run 849ae5aa was told the piece fails if it
+  "describes the projects in the present tense when nobody has confirmed they
+  are still running", opened with "Hundreds of fog nets built in Lima are
+  standing and functioning in 2026", and passed.
+- The line is freehand and it is not a gate. A sentence you cannot apply is a
+  sentence you leave alone: set fails_if_avoided true and say nothing rather
+  than inventing a reading of it.
 - Score honestly. A draft that merely avoids mistakes is a 7, not a 9. Being
   grounded, complete, and constraint-compliant is the floor this scale starts
   from, not what earns the top of it.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -555,6 +555,13 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
     checks = {
         "audience_match": _safe_bool(checks_raw.get("audience_match"), default=True),
         "tone_match": _safe_bool(checks_raw.get("tone_match"), default=True),
+        # The brief's own definition of failure, judged for the first time.
+        # Deliberately not in HARD_CONSTRAINT_CHECK_KEYS: the line is freehand
+        # and a badly worded one must not be able to block a run. It weighs
+        # through the scores and the revisions the auditor writes beside it.
+        "fails_if_avoided": _safe_bool(
+            checks_raw.get("fails_if_avoided"), default=True
+        ),
     }
 
     # A missing or unparseable score used to default to 6, which sits below the

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
@@ -99,6 +99,7 @@ def test_audit_keeps_only_semantic_constraint_checks():
     assert quality["constraint_checks"] == {
         "audience_match": False,
         "tone_match": True,
+        "fails_if_avoided": True,
     }
 
 
@@ -226,3 +227,55 @@ def test_length_measurements_never_land_among_the_pass_fail_verdicts():
 
     # A count sitting in a dict of booleans reads as a check that failed.
     assert all(isinstance(value, bool) for value in verdicts.values())
+
+
+# --- the line that defines failure ----------------------------------------
+#
+# `fails_if` is the operator's own definition of failure, written in their
+# words. Run 849ae5aa named "describes the projects in the present tense when
+# nobody has confirmed they are still running", opened with "Hundreds of fog
+# nets built in Lima are standing and functioning in 2026", and the audit
+# passed it: the line was in the brief the auditor was shown, and nothing had
+# ever asked it to read it.
+
+
+def test_the_auditor_is_asked_whether_the_draft_walks_into_the_failure():
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "constraint_checks": {"fails_if_avoided": False},
+        }
+    )
+
+    assert quality["constraint_checks"]["fails_if_avoided"] is False
+
+
+def test_an_auditor_that_omits_the_verdict_does_not_manufacture_a_failure():
+    quality = _sanitize_quality({"overall_score": 8, "constraint_checks": {}})
+
+    assert quality["constraint_checks"]["fails_if_avoided"] is True
+
+
+def test_walking_into_the_failure_does_not_block_the_run():
+    """Freehand text must never gain the power to block. It weighs through
+    the scores the auditor sets beside it, per ADR 0030."""
+    from app.features.prompt2blog.policies import evaluate_readiness
+
+    verdict = evaluate_readiness(
+        quality={"audit_complete": True, "overall_score": 8},
+        checks={"fails_if_avoided": False},
+        groundedness={"checked": True, "grounded": True},
+    )
+
+    assert verdict.ready
+    assert "fails_if_avoided" not in verdict.blockers
+
+
+def test_walking_into_the_failure_does_not_by_itself_buy_a_repair():
+    assert (
+        _should_run_repair(
+            {"audit_complete": True, "overall_score": 8},
+            {"fails_if_avoided": False},
+        )
+        is False
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -335,3 +335,31 @@ def test_compose_is_given_the_voice_and_the_conventions():
 
     assert "THE VOICE YOU ARE WRITING IN" in compose
     assert "WRITING CONVENTIONS" in compose
+
+
+# --- the failure line reaches the stage that can act on it ------------------
+#
+# The line was already in the brief block every stage is shown. What was
+# missing was anyone being asked to read it: run 849ae5aa walked into its own
+# stated failure in the first sentence and the audit scored it 8.
+
+
+def test_the_audit_is_shown_the_line_that_defines_failure():
+    fixture = _fixture()
+    audit = assemble_v3_instructions(_request()).stage_contexts.audit.text
+
+    assert f"This piece fails if: {fixture['brief']['fails_if']}" in audit
+
+
+def test_the_audit_prompt_asks_whether_the_draft_walks_into_it():
+    from app.features.prompt2blog.prompts.editorial_v3 import (
+        P2B_V3_QUALITY_AUDIT_PROMPT,
+    )
+
+    prompt = _flat(P2B_V3_QUALITY_AUDIT_PROMPT)
+
+    assert "fails_if_avoided" in prompt
+    assert 'The line under "This piece fails if"' in prompt
+    # Freehand text, so an auditor that cannot apply it must leave it alone
+    # rather than invent a reading.
+    assert "it is not a gate" in prompt


### PR DESCRIPTION
Run `849ae5aa` was told the piece fails if it *"describes the projects in the present tense when nobody has confirmed they are still running"*, opened with *"Hundreds of fog nets built in Lima are standing and functioning in 2026"*, and the audit scored it 8 with no blockers.

## Correction to the issue

#476 says outline, compose, audit and repair are all blind to `fails_if`. That is not what the code does. The line has been in `_brief_body` since the v4 migration (`instructions_v3.py:127`), and that block is in all four stage contexts; `_repair_lock_body` carries it separately.

What was missing is that nobody was ever **asked to read it**. The audit prompt names every other thing it judges and never named this one, so the operator's own definition of failure sat in the middle of a long brief with no instruction attached. Smaller fix than filed, same value.

## What changed

- The audit prompt names the line, asks whether the draft walks into it, and answers as `fails_if_avoided`, with the offending sentence quoted into `required_revisions` where repair can act on it.
- An auditor that cannot apply the sentence is told to leave it alone rather than invent a reading of it.
- `_sanitize_quality` carries the verdict, defaulting to `True` when the auditor omits it — an absent answer never manufactures a failure.

## Deliberately not a gate

`fails_if_avoided` is **not** in `HARD_CONSTRAINT_CHECK_KEYS`. The line is freehand text typed during the grill, and a badly worded one must not be able to block a run — nothing blocks after writing (ADR 0030). It weighs through `brief_adherence_score` and `overall_score`, which is the route repair already travels. Two tests pin that: walking into the failure neither blocks readiness nor by itself buys a repair.

## Verification

`pytest apps/backend/tests` — 1282 tests, 0 failures (6 new).

Closes #476