### PR TITLE
Two figures on one question, and nothing saying they disagree

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_conflicts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_conflicts.py
@@ -1,0 +1,229 @@
+"""Numbers that disagree on one question, when nothing said they did.
+
+Run 849ae5aa asked one question about Lima's rainfall. Research answered it
+with "between 5 and 25 millimeters" at high confidence and "197 millimeters"
+at low, attached to the same requirement, and recorded no conflict at all.
+The writer used both, in consecutive clauses, under a headline saying fog is
+the only rain the city gets.
+
+The mechanism was there and the prompt asked for it. The stored notes even
+carry a section headed "Discrepancies and Credibility" naming 197 as the
+outlier -- so the gather step surfaced the disagreement and the structure step
+dropped it.
+
+This is the cheap half of the fix, and the half that cannot invent anything:
+two claims answering one requirement, each carrying a number in the same unit,
+where the numbers disagree and no conflict names them. It is a comparison
+against the dossier's own consistency, not a judgement about the world. It
+misses every conflict expressed in prose with no figures in it, which is why
+the prompt still asks for the rest.
+
+A detected conflict is recorded unresolved, which routes it to the gate the
+operator already answers before writing. Nothing here picks a figure.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .contracts_v4 import EvidenceConflict, EvidencePackage
+
+# A number and the word immediately after it. The word is what makes two
+# figures comparable: 197 and 25 mean nothing beside each other until both are
+# millimetres.
+_NUMBER_WITH_UNIT = re.compile(
+    r"(?P<value>\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?)"
+    r"\s*(?P<unit>%|[A-Za-z][A-Za-z.]{0,19})"
+)
+
+# Words that follow a number without being a unit. Without these, "5 and 25
+# millimetres" reports a quantity of 5 "and", and a range stops comparing
+# against anything.
+_NOT_A_UNIT = frozenset(
+    {
+        "a", "an", "and", "are", "as", "at", "but", "by", "for", "from", "if",
+        "in", "into", "is", "of", "on", "or", "out", "over", "per", "than",
+        "that", "the", "then", "to", "under", "up", "was", "were", "when",
+        "which", "while", "with",
+    }
+)
+
+# Same quantity, different spelling. Only units where the two spellings are
+# certainly the same thing; anything unlisted compares against its own exact
+# spelling and nothing else, which is the safe direction to be wrong in.
+_UNIT_ALIASES = {
+    "millimetre": "mm",
+    "millimeter": "mm",
+    "centimetre": "cm",
+    "centimeter": "cm",
+    "metre": "m",
+    "meter": "m",
+    "kilometre": "km",
+    "kilometer": "km",
+    "mile": "mi",
+    "kilogram": "kg",
+    "litre": "l",
+    "liter": "l",
+    "percent": "%",
+    "pct": "%",
+    "hectare": "ha",
+    "year": "yr",
+    "hour": "hr",
+    "minute": "min",
+    "usd": "$",
+    "dollar": "$",
+    "sol": "pen",
+    "soles": "pen",
+}
+
+# How far apart two figures have to be before this says anything. Deliberately
+# blunt: a rounding difference, a revised estimate and a figure quoted to a
+# different precision are all normal, and a check that fires on those would be
+# turned off within a week. 197 against 25 is what this is for.
+DISAGREEMENT_RATIO = 1.5
+
+# Two figures this close are the same figure, quoted differently.
+AGREEMENT_TOLERANCE = 0.05
+
+
+@dataclass(frozen=True)
+class NumericDisagreement:
+    """Two claims on one requirement whose numbers do not agree."""
+
+    requirement_id: str
+    claim_ids: tuple[str, str]
+    unit: str
+    values: tuple[float, float]
+
+
+def _normalise_unit(raw: str) -> str | None:
+    unit = raw.strip(".").lower()
+    if not unit or unit in _NOT_A_UNIT:
+        return None
+    if unit != "%" and unit.endswith("s") and len(unit) > 2:
+        unit = unit[:-1]
+    return _UNIT_ALIASES.get(unit, unit)
+
+
+def quantities(text: str) -> dict[str, set[float]]:
+    """Every number in the text, keyed by the unit it was written with."""
+    found: dict[str, set[float]] = {}
+    for match in _NUMBER_WITH_UNIT.finditer(text):
+        unit = _normalise_unit(match.group("unit"))
+        if unit is None:
+            continue
+        try:
+            value = float(match.group("value").replace(",", ""))
+        except ValueError:  # pragma: no cover -- the pattern cannot produce this
+            continue
+        if value == 0:
+            continue
+        found.setdefault(unit, set()).add(value)
+    return found
+
+
+def _disagree(left: set[float], right: set[float]) -> tuple[float, float] | None:
+    for one in left:
+        for other in right:
+            if abs(one - other) <= AGREEMENT_TOLERANCE * max(one, other):
+                return None
+    low = min(min(left), min(right))
+    high = max(max(left), max(right))
+    if high / low < DISAGREEMENT_RATIO:
+        return None
+    return (low, high)
+
+
+def detect_numeric_disagreements(
+    package: EvidencePackage,
+) -> list[NumericDisagreement]:
+    """Numbers on one question that disagree with no conflict naming them."""
+    already_paired = {
+        frozenset(pair)
+        for conflict in package.conflicts
+        for pair in _pairs(conflict.claim_ids)
+    }
+    found: list[NumericDisagreement] = []
+    for requirement in package.requirements:
+        claims = [
+            claim
+            for claim in package.claims
+            if requirement.requirement_id in claim.requirement_ids
+        ]
+        measured = [(claim, quantities(claim.text)) for claim in claims]
+        for index, (claim, left) in enumerate(measured):
+            for other, right in measured[index + 1 :]:
+                if frozenset({claim.claim_id, other.claim_id}) in already_paired:
+                    continue
+                for unit in sorted(set(left) & set(right)):
+                    values = _disagree(left[unit], right[unit])
+                    if values is None:
+                        continue
+                    found.append(
+                        NumericDisagreement(
+                            requirement_id=requirement.requirement_id,
+                            claim_ids=(claim.claim_id, other.claim_id),
+                            unit=unit,
+                            values=values,
+                        )
+                    )
+                    break
+    return found
+
+
+def _pairs(claim_ids: list[str]) -> list[tuple[str, str]]:
+    return [
+        (claim_ids[index], other)
+        for index in range(len(claim_ids))
+        for other in claim_ids[index + 1 :]
+    ]
+
+
+def _figure(value: float, unit: str) -> str:
+    rendered = f"{value:g}"
+    return f"{rendered}{unit}" if unit in {"%", "$"} else f"{rendered} {unit}"
+
+
+def record_numeric_conflicts(package: EvidencePackage) -> EvidencePackage:
+    """Add a conflict for every numeric disagreement research left unrecorded.
+
+    Unresolved, because nothing here knows which figure is right. That routes
+    it to the gate the operator already answers before writing, which is the
+    one place a person is asked to settle the dossier.
+    """
+    disagreements = detect_numeric_disagreements(package)
+    if not disagreements:
+        return package
+
+    taken = {conflict.conflict_id for conflict in package.conflicts}
+    additions: list[EvidenceConflict] = []
+    for index, item in enumerate(disagreements, start=1):
+        conflict_id = f"measured_{item.requirement_id}_{index}"
+        while conflict_id in taken:
+            conflict_id = f"{conflict_id}_x"
+        taken.add(conflict_id)
+        low, high = item.values
+        additions.append(
+            EvidenceConflict(
+                conflict_id=conflict_id,
+                claim_ids=list(item.claim_ids),
+                summary=(
+                    f"{item.claim_ids[0]} and {item.claim_ids[1]} both answer "
+                    f"{item.requirement_id} and their figures disagree: "
+                    f"{_figure(low, item.unit)} against "
+                    f"{_figure(high, item.unit)}. Research recorded no conflict "
+                    f"between them."
+                ),
+            )
+        )
+
+    return EvidencePackage.model_validate(
+        {
+            **package.model_dump(),
+            "conflicts": [
+                *(conflict.model_dump() for conflict in package.conflicts),
+                *(conflict.model_dump() for conflict in additions),
+            ],
+        }
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -45,6 +45,7 @@ from .contracts_v4 import (
     WorkOrderRequirement,
 )
 from .config import P2B_V4_GATHER_CONCURRENCY
+from .evidence_conflicts import record_numeric_conflicts
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
@@ -821,7 +822,18 @@ Rules:
 - Record a `premise_findings` verdict for every assumption above: `confirmed`,
   `refuted`, or `unverified`, with the basis.
 - Where the notes say sources disagree, record a conflict rather than picking
-  silently.
+  silently. The notes rarely use the word "conflict". A section headed
+  "Discrepancies", a figure called an outlier, a sentence saying one source is
+  inconsistent with the others, or two numbers you are about to write into two
+  claims that do not agree -- each of those is a conflict, and each has to be
+  recorded as one. Two claims answering the same question with figures that
+  disagree, and no conflict naming them, is the failure this is here to stop.
+- Where the notes weigh the disagreement and say which figure to prefer, put
+  that in the conflict's `resolution`, in their reasoning. A conflict recorded
+  without it leaves the writer choosing between two numbers with nothing to
+  choose on. Leave `resolution` empty when the notes do not settle it: an
+  unresolved conflict is a question for a person, and inventing a resolution
+  takes it away from them.
 - Keep the interesting detail. A note that puts a reader somewhere belongs in a
   claim as much as a price does; do not drop it for not being a number.
 """
@@ -956,7 +968,10 @@ def structure_research(
     payload["schema_version"] = 4
     payload["work_order_fingerprint"] = work_order.work_order_fingerprint
     try:
-        return EvidencePackage.model_validate(payload)
+        # The prompt asks for conflicts and the Lima run did not record the
+        # one its own notes had named. The comparison below is the half of
+        # that a model cannot forget to do.
+        return record_numeric_conflicts(EvidencePackage.model_validate(payload))
     except ValidationError as error:
         raise ResearchUnusable(
             "; ".join(

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_numeric_conflicts.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_numeric_conflicts.py
@@ -1,0 +1,239 @@
+"""Two figures on one question, and nothing saying they disagree.
+
+Run 849ae5aa asked one question about Lima's rainfall and research answered it
+twice: "between 5 and 25 millimeters" at high confidence, "197 millimeters" at
+low. Both were attached to `q_rainfall`, `evidence.conflicts` was empty, and
+the writer used both in consecutive clauses under a headline saying fog is the
+only rain the city gets.
+
+The stored notes for that question carry a section headed "Discrepancies and
+Credibility" naming 197 as the outlier. So the gather step found it and the
+structure step dropped it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.prompt2blog.contracts_v4 import EvidencePackage
+from app.features.prompt2blog.evidence_conflicts import (
+    detect_numeric_disagreements,
+    quantities,
+    record_numeric_conflicts,
+)
+
+
+def _package(claims: list[dict[str, Any]], **overrides: Any) -> EvidencePackage:
+    requirement_ids = sorted(
+        {
+            requirement_id
+            for claim in claims
+            for requirement_id in claim["requirement_ids"]
+        }
+    )
+    payload: dict[str, Any] = {
+        "schema_version": 4,
+        "work_order_fingerprint": "fp",
+        "sources": [
+            {
+                "source_id": "s1",
+                "title": "Climate summary",
+                "publisher": "Weather and Climate",
+                "url": "https://example.com/lima",
+                "retrieved_at": "2026-09-01",
+                "source_type": "reporting",
+                "material_type": "web",
+                "notes": ["Annual rainfall figures."],
+            }
+        ],
+        "claims": claims,
+        "requirements": [
+            {
+                "requirement_id": requirement_id,
+                "status": "supported",
+                "claim_ids": [
+                    claim["claim_id"]
+                    for claim in claims
+                    if requirement_id in claim["requirement_ids"]
+                ],
+            }
+            for requirement_id in requirement_ids
+        ],
+    }
+    payload.update(overrides)
+    return EvidencePackage.model_validate(payload)
+
+
+def _claim(claim_id: str, text: str, requirement: str = "q_rainfall") -> dict[str, Any]:
+    return {
+        "claim_id": claim_id,
+        "text": text,
+        "source_ids": ["s1"],
+        "requirement_ids": [requirement],
+        "confidence": "high",
+    }
+
+
+RAINFALL = [
+    _claim(
+        "c1",
+        "The average annual rainfall in Lima typically ranges between 5 and 25 "
+        "millimeters.",
+    ),
+    _claim(
+        "c2",
+        "Weather and Climate reports Lima's average annual rainfall as 197 "
+        "millimeters based on 1990-2020 data.",
+    ),
+]
+
+
+# --- the run that produced this -------------------------------------------
+
+
+def test_the_rainfall_claims_are_seen_to_disagree():
+    found = detect_numeric_disagreements(_package(RAINFALL))
+
+    assert len(found) == 1
+    assert found[0].requirement_id == "q_rainfall"
+    assert set(found[0].claim_ids) == {"c1", "c2"}
+    assert found[0].unit == "mm"
+    assert found[0].values == (25.0, 197.0)
+
+
+def test_the_disagreement_is_recorded_as_an_unresolved_conflict():
+    package = record_numeric_conflicts(_package(RAINFALL))
+
+    assert len(package.conflicts) == 1
+    conflict = package.conflicts[0]
+    assert sorted(conflict.claim_ids) == ["c1", "c2"]
+    assert "25 mm" in conflict.summary and "197 mm" in conflict.summary
+    # Unresolved on purpose: nothing here knows which figure is right, and an
+    # unresolved conflict is a readiness finding the operator settles at the
+    # gate before writing.
+    assert conflict.resolution is None
+
+
+def test_the_year_range_in_the_same_sentence_is_not_a_quantity():
+    # "1990-2020 data" is provenance. Reading it as a figure would put every
+    # dated claim in conflict with every other one.
+    assert 1990.0 not in {
+        value for values in quantities(RAINFALL[1]["text"]).values() for value in values
+    }
+
+
+# --- what it must not fire on ---------------------------------------------
+
+
+def test_two_claims_on_different_questions_are_not_compared():
+    claims = [
+        _claim("c1", "The district collects 200 litres a day.", "q_yield"),
+        _claim("c2", "The museum charges 20 soles.", "q_price"),
+    ]
+
+    assert detect_numeric_disagreements(_package(claims)) == []
+
+
+def test_the_same_figure_written_differently_is_not_a_disagreement():
+    claims = [
+        _claim("c1", "Over 600 collectors were built in the district."),
+        _claim("c2", "The count of collectors reached 600 by 2015."),
+    ]
+
+    assert detect_numeric_disagreements(_package(claims)) == []
+
+
+def test_a_small_difference_is_not_a_disagreement():
+    """Rounding, a revised estimate and a figure quoted to another precision
+    are all normal. A check that fires on those gets turned off."""
+    claims = [
+        _claim("c1", "Rainfall is about 7 millimetres a year."),
+        _claim("c2", "Rainfall is roughly 5 millimetres a year."),
+    ]
+
+    assert detect_numeric_disagreements(_package(claims)) == []
+
+
+def test_figures_in_different_units_are_not_compared():
+    claims = [
+        _claim("c1", "The nets stand 900 metres above sea level."),
+        _claim("c2", "The nets yield 200 litres a day."),
+    ]
+
+    assert detect_numeric_disagreements(_package(claims)) == []
+
+
+def test_metric_spellings_are_the_same_unit():
+    claims = [
+        _claim("c1", "Rainfall reaches 25 millimetres."),
+        _claim("c2", "Rainfall reaches 197 millimeters."),
+    ]
+
+    assert len(detect_numeric_disagreements(_package(claims))) == 1
+
+
+def test_a_conflict_research_already_recorded_is_not_duplicated():
+    package = _package(
+        RAINFALL,
+        conflicts=[
+            {
+                "conflict_id": "x1",
+                "claim_ids": ["c1", "c2"],
+                "summary": "The two rainfall figures disagree.",
+                "resolution": "Prefer the 5 to 25 millimetre range.",
+            }
+        ],
+    )
+
+    assert detect_numeric_disagreements(package) == []
+    assert len(record_numeric_conflicts(package).conflicts) == 1
+
+
+def test_a_clean_dossier_is_returned_untouched():
+    package = _package([_claim("c1", "The nets are maintained by volunteers.")])
+
+    assert record_numeric_conflicts(package) is package
+
+
+# --- the prompt still asks for the half a comparison cannot do -------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "A section headed",
+        "called an outlier",
+        "put that in the conflict\'s `resolution`",
+        "inventing a resolution",
+    ],
+)
+def test_the_structure_prompt_names_what_a_conflict_looks_like_in_notes(phrase: str):
+    from app.features.prompt2blog.contracts_v4 import (
+        Prompt2BlogWorkOrder,
+        WorkOrderReference,
+        WorkOrderRequirement,
+        WorkOrderScope,
+    )
+    from app.features.prompt2blog.research_v4 import build_structure_prompt
+
+    work_order = Prompt2BlogWorkOrder(
+        work_order_fingerprint="wo",
+        brief_fingerprint="bf",
+        primary_subject="Lima",
+        scope=WorkOrderScope(
+            mode="single_subject",
+            references=[WorkOrderReference(name="Lima", role="primary_subject")],
+        ),
+        requirements=[
+            WorkOrderRequirement(
+                requirement_id="q_rainfall",
+                question="How much rain?",
+                kind="load_bearing",
+            )
+        ],
+    )
+    flat = " ".join(build_structure_prompt(work_order, {}).split())
+
+    assert phrase in flat


### PR DESCRIPTION
Run `849ae5aa` answered one rainfall question twice — "between 5 and 25 millimeters" (high confidence) and "197 millimeters" (low) — both on `q_rainfall`, with `evidence.conflicts` empty. The writer used both in consecutive clauses, under a headline saying fog is the only rain the city gets.

## The open question the issue asked, answered

The notes are on the run and were free to read. The gather step **did** surface it: a section headed *"Discrepancies and Credibility"* that names 197 as *"one notable outlier"*, points out the same source also describes Lima as almost rainless, lists six figures in the 5-25mm range, and recommends the lower range outright. The structure step read that and emitted two flat claims with no conflict. Full quotes in the [issue comment](https://github.com/Questurian/questurian/issues/475#issuecomment-5504215389).

So the fix is in two halves, and neither is new machinery.

## The comparison

`evidence_conflicts.py`: two claims answering one requirement, each carrying a number in the same unit, figures more than 1.5x apart, and no conflict naming them.

It cannot invent anything — it is a question about the dossier's own consistency, not about the world. It misses every conflict expressed in prose with no figures in it, which is why the prompt still asks for the rest.

The threshold is blunt deliberately. A rounding difference, a revised estimate and a figure quoted to another precision are all normal, and a check that fires on those gets turned off within a week. Units are compared by the word written next to the number, with metric spellings aliased; a year range in the same sentence ("1990-2020 data") is provenance, not a quantity, and is not read as one.

**Replayed against the real stored dossier it finds exactly one thing across thirteen claims: the rainfall pair, 25mm against 197mm.** No false positives on the other twelve.

## The consequence

Recorded as an **unresolved** conflict. That is already a `unresolved_conflict` readiness finding, which is already the gate the operator answers before writing (ADR 0030 — one gate, before writing). Nothing here picks a figure: it puts the choice in front of the person whose choice it is.

## The prompt half

The structure prompt now says what a conflict looks like when the notes never use the word — a Discrepancies heading, a figure called an outlier, a source called inconsistent with the others — and asks for the notes' own reasoning in `resolution`, since a conflict recorded without it still leaves the writer choosing between two numbers with nothing to choose on. It also says not to invent a resolution the notes did not reach: an unresolved conflict is a question for a person.

## Verification

`pytest apps/backend/tests` — 1222 tests, 0 failures (14 new), plus the replay above against run `849ae5aa`.

Refs #475