### PR TITLE
A bad heading is not a reason to delete the plan

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -181,14 +181,87 @@ def validate_v3_outline(
     return all(checks.values()), diagnostics
 
 
+def drop_context_only_sections(
+    outline: dict[str, Any], headings: list[str]
+) -> dict[str, Any]:
+    """Remove the sections a context-only place was organising, keep the rest.
+
+    Rejecting the whole plan for one bad heading was throwing away six good
+    sections to stop one, and it did not even stop it: run b29d66b4 lost its
+    entire outline over a single heading about a ranking that does not exist,
+    wrote its article with no plan, and discussed the ranking anyway. Dropping
+    the section is what the check actually wanted -- that section never reaches
+    compose -- and it costs nothing and asks no model.
+
+    The dropped word budget is spread across what remains, or the repaired plan
+    would fail `within_word_budget` for the crime of being repaired.
+    """
+    unwanted = {heading.casefold() for heading in headings}
+    kept = [
+        section
+        for section in outline.get("sections") or []
+        if section["heading"].casefold() not in unwanted
+    ]
+    if not kept:
+        return {**outline, "sections": []}
+
+    dropped_words = sum(
+        _safe_int(section.get("target_words"), default=0)
+        for section in outline.get("sections") or []
+        if section["heading"].casefold() in unwanted
+    )
+    share, remainder = divmod(dropped_words, len(kept))
+    repaired = []
+    for index, section in enumerate(kept):
+        extra = share + (1 if index < remainder else 0)
+        repaired.append(
+            {
+                **section,
+                "target_words": _safe_int(section.get("target_words"), default=0)
+                + extra,
+            }
+        )
+    return {**outline, "sections": repaired}
+
+
+def outline_focus_only(outline: dict[str, Any]) -> dict[str, Any]:
+    """What survives when the sections cannot be used.
+
+    `direct_answer_focus` and `takeaway_focus` are separately valid and are the
+    most valuable lines the outline produces -- b29d66b4's named the one stall
+    to send the reader to, with its survival caveat, and it was deleted along
+    with the sections over an unrelated heading. A bad heading is not a reason
+    to throw away the answer.
+    """
+    return {
+        "working_title": _safe_str(outline.get("working_title")),
+        "direct_answer_focus": _safe_str(outline.get("direct_answer_focus")),
+        "sections": [],
+        "takeaway_focus": _safe_str(outline.get("takeaway_focus")),
+        "brief_alignment": "Brief alignment not stated.",
+        "unsupported_requirements": [],
+    }
+
+
 def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
     """Render a validated plan as the section brief compose writes against."""
     sections = outline.get("sections") or []
     if not sections:
-        return (
-            "No outline was produced. Structure the article from the approved "
-            "brief and the evidence records only."
+        # A plan whose sections were unusable can still carry the answer and
+        # the takeaway. Handing compose nothing at all is how b29d66b4 came
+        # back at 502 words against an 800 floor.
+        focus = _safe_str(outline.get("direct_answer_focus"))
+        takeaway = _safe_str(outline.get("takeaway_focus"))
+        salvaged = []
+        if focus:
+            salvaged.append(f"Direct answer near the top should cover: {focus}")
+        if takeaway:
+            salvaged.append(f"The takeaways should land: {takeaway}")
+        opening = (
+            "No usable section plan was produced. Structure the article from "
+            "the approved brief and the evidence records only."
         )
+        return "\n\n".join([opening, *salvaged])
 
     lines: list[str] = []
     direct_answer = _safe_str(outline.get("direct_answer_focus"))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -7,7 +7,9 @@ from app.shared.provider_faults import is_fatal_provider_fault
 
 from ...config import P2B_V3_OUTLINE_MODEL
 from ...content.outline_v3 import (
+    drop_context_only_sections,
     format_v3_outline_for_prompt,
+    outline_focus_only,
     sanitize_v3_outline,
     validate_v3_outline,
 )
@@ -55,6 +57,8 @@ def run_v3_outline_stage(
     outline = dict(EMPTY_OUTLINE)
     diagnostics: dict[str, Any] = {}
     accepted = False
+    repaired = False
+    dropped_headings: list[str] = []
     raw_response = ""
     outline_model = state.get("outline_model", P2B_V3_OUTLINE_MODEL)
 
@@ -85,9 +89,50 @@ def run_v3_outline_stage(
         if accepted:
             outline = candidate
         else:
-            logger.warning(
-                "Prompt2Blog v3 outline rejected for run %s: %s", run_id, diagnostics
-            )
+            # One failed check used to delete the whole plan. Repair what can
+            # be repaired first: a context-only heading is fixed by dropping
+            # that section, which is what the check wanted, and leaves the
+            # sections that passed intact.
+            headings = diagnostics.get("context_only_headings") or []
+            if headings:
+                repaired_candidate = drop_context_only_sections(candidate, headings)
+                repaired_accepted, repaired_diagnostics = validate_v3_outline(
+                    repaired_candidate,
+                    work_order=state["work_order"],
+                    claim_ids={claim["claim_id"] for claim in evidence["claims"]},
+                    requirement_ids={
+                        requirement["requirement_id"]
+                        for requirement in evidence["requirements"]
+                    },
+                    target_word_count=target_word_count,
+                )
+                if repaired_accepted:
+                    logger.warning(
+                        "Prompt2Blog v3 outline repaired for run %s by dropping "
+                        "context-only sections %s",
+                        run_id,
+                        headings,
+                    )
+                    accepted = True
+                    repaired = True
+                    dropped_headings = list(headings)
+                    outline = repaired_candidate
+                    diagnostics = {
+                        **repaired_diagnostics,
+                        "repaired": True,
+                        "dropped_headings": dropped_headings,
+                        "original_checks": diagnostics,
+                    }
+            if not accepted:
+                # Still unusable as a plan. The answer and the takeaway are
+                # separately valid and are the most useful lines the stage
+                # produces, so they travel even when the sections cannot.
+                outline = outline_focus_only(candidate)
+                logger.warning(
+                    "Prompt2Blog v3 outline rejected for run %s: %s",
+                    run_id,
+                    diagnostics,
+                )
         _append_stage_trace(
             state["trace"],
             state["include_debug"],
@@ -117,6 +162,10 @@ def run_v3_outline_stage(
         {
             "outline": outline,
             "accepted": accepted,
+            # A plan that needed repair is a signal about the outline model
+            # worth reading later, not something to bury in a log line.
+            "repaired": repaired,
+            "dropped_headings": dropped_headings,
             "checks": diagnostics,
             "raw_response": raw_response,
         },

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
@@ -290,6 +290,9 @@ def test_a_brief_aligned_plan_is_accepted_and_rendered_for_compose():
 
 
 def test_the_outline_stage_keeps_a_drifted_plan_out_of_compose():
+    """Dropping the drifted section here would leave two, below the minimum,
+    so the plan is still unusable and compose is told so. What compose is no
+    longer denied is the answer the plan reached."""
     drifted = _outline_payload()
     drifted["sections"][2]["heading"] = "How Medellín compares"
     llm = FakeLLM(json_response=drifted)
@@ -318,8 +321,10 @@ def test_the_outline_stage_keeps_a_drifted_plan_out_of_compose():
     )
 
     compose_prompt = compose_llm.prompts[0]
-    assert "No outline was produced." in compose_prompt
+    assert "No usable section plan was produced." in compose_prompt
     assert "How Medellín compares" not in compose_prompt
+    # The sections were unusable; the answer the plan reached was not.
+    assert "Whether Lima still offers long-stay value." in compose_prompt
 
 
 def test_the_outline_prompt_gets_planning_context_not_the_whole_stack():
@@ -393,3 +398,95 @@ def test_compose_does_not_fall_back_to_pasting_the_evidence():
     rewrite = updates["rewrite"]
     assert rewrite["improved_content"] == ""
     assert rewrite["improved_title"] == _fixture()["brief"]["seed"]
+
+
+# --- a bad heading is not a reason to delete the plan -----------------------
+#
+# Run b29d66b4 produced a seven section plan, failed one check of seven over a
+# single heading, lost the whole outline, and compose wrote 502 words against
+# an 800 floor with no plan at all. The heading it lost the plan over was
+# about a municipal ranking that does not exist, and the article discussed the
+# ranking anyway -- so the discard did not even buy what the check wanted.
+
+
+def _five_section_payload() -> dict[str, Any]:
+    payload = _outline_payload()
+    payload["sections"] = payload["sections"] + [
+        {
+            "heading": "Where the money actually goes",
+            "purpose": "Break the monthly figure into what a resident pays.",
+            "claim_ids": ["c1"],
+            "requirement_ids": ["r1"],
+            "target_words": 150,
+        },
+        {
+            "heading": "What a long stay commits you to",
+            "purpose": "Say what the decision costs beyond money.",
+            "claim_ids": ["c2"],
+            "requirement_ids": ["r2"],
+            "target_words": 150,
+        },
+    ]
+    return payload
+
+
+def test_one_drifted_heading_drops_its_section_and_keeps_the_rest():
+    drifted = _five_section_payload()
+    drifted["sections"][2]["heading"] = "How Medellín compares"
+    llm = FakeLLM(json_response=drifted)
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_outline_stage(_state(), dependencies)
+
+    assert updates["outline_accepted"] is True
+    headings = [section["heading"] for section in updates["outline"]["sections"]]
+    assert "How Medellín compares" not in headings
+    assert len(headings) == 4
+    assert recorder.recorded[0][1]["repaired"] is True
+    assert recorder.recorded[0][1]["dropped_headings"] == ["How Medellín compares"]
+
+
+def test_the_dropped_section_budget_is_spread_over_what_remains():
+    """A repaired plan must not fail `within_word_budget` for the crime of
+    being repaired."""
+    drifted = _five_section_payload()
+    planned_before = sum(item["target_words"] for item in drifted["sections"])
+    drifted["sections"][2]["heading"] = "How Medellín compares"
+    dependencies, _recorder = _dependencies(FakeLLM(json_response=drifted))
+
+    updates = run_v3_outline_stage(_state(), dependencies)
+
+    planned_after = sum(
+        section["target_words"] for section in updates["outline"]["sections"]
+    )
+    assert planned_after == planned_before
+
+
+def test_a_plan_that_cannot_be_repaired_still_hands_over_its_answer():
+    """`direct_answer_focus` is separately valid and is the most useful line
+    the stage produces. b29d66b4's named the one stall to send the reader to,
+    with its survival caveat, and it was deleted along with the sections."""
+    drifted = _outline_payload(working_title="How Medellín compares")
+    drifted["sections"][2]["heading"] = "How Medellín compares"
+    dependencies, _recorder = _dependencies(FakeLLM(json_response=drifted))
+
+    updates = run_v3_outline_stage(_state(), dependencies)
+
+    assert updates["outline_accepted"] is False
+    assert updates["outline"]["sections"] == []
+    assert (
+        updates["outline"]["direct_answer_focus"]
+        == "Whether Lima still offers long-stay value."
+    )
+    assert "Whether Lima still offers long-stay value." in updates["outline_text"]
+
+
+def test_a_plan_that_passes_is_not_touched():
+    dependencies, recorder = _dependencies(FakeLLM(json_response=_outline_payload()))
+
+    updates = run_v3_outline_stage(_state(), dependencies)
+
+    assert updates["outline_accepted"] is True
+    assert recorder.recorded[0][1]["repaired"] is False
+    assert recorder.recorded[0][1]["dropped_headings"] == []
+    assert len(updates["outline"]["sections"]) == 3


### PR DESCRIPTION
Run `b29d66b4` came back at **502 words against an 800 floor** — the shortest of the eighteen stored runs. The audit blamed the length and the inventory-shaped middle section. Both were downstream of this.

## What actually happened

The outline stage produced a seven-section plan, failed **one** check of seven, and the entire plan was discarded. Compose wrote the article with no plan and delivered three sections.

```
accepted: false
enough_sections ✓   headings_unique ✓   within_word_budget ✓
claims_resolve ✓    requirements_resolve ✓   covers_primary_subject ✓
no_context_only_sections ✗  → ["Who Actually Ranks Lima's Cevicherias, and It Isn't City Hall"]
```

| outline | runs | words |
|---|---|---|
| accepted | 15 of the last 16 | 739 - 1650 |
| rejected | `b29d66b4` | **502** |

The two shortest articles ever recorded, 502 and 388, both came from discarded plans.

Discarding everything did not even buy what the check wanted: the article discussed the context-only subject anyway, just with no plan around it.

## What changed

**Repair what can be repaired.** A context-only heading is fixed by dropping that section — exactly what the check was asking for — and the sections that passed survive. The dropped word budget is spread across what remains, or a repaired plan would fail `within_word_budget` for the crime of being repaired. Everything is re-validated after the drop, so a plan that loses too much still fails and still degrades.

**When the sections cannot be saved, the answer still travels.** `direct_answer_focus` and `takeaway_focus` are separately valid and are the most useful lines the stage produces. This run's said:

> "Walk to **Bam Bam y sus Conchas Negras** behind Mercado No. 1 — the one Surquillo stall confirmed open and trading as of August 2026... Be there by 11:30; do not count on food after 1pm."

That is the decisive answer the operator's `fails_if` demanded, and it was deleted along with the sections over an unrelated heading.

**A repaired plan is recorded**, not buried in a log line: `repaired` and `dropped_headings` go on the stage record, so an outline model that keeps needing repair is visible.

## Replayed against the real failure

Feeding `b29d66b4`'s actual rejected outline through the fix: seven sections become six, the 735-word plan stays 735, and it validates. The section that comes back is *"The Stall to Walk To, and the One You Can't Count On"* — the decision the finished article never made.

## What this could break

- **Dropping sections could leave too few.** It does, and it should: the existing 3-section test now leaves 2, fails `enough_sections`, and correctly degrades — with the answer preserved, which is the only behaviour change there.
- **Repair could weaken the guard.** It cannot: a dropped section never reaches compose, which is what rejection was for. `enough_sections` and `covers_primary_subject` are re-run after the drop.
- **No retry is included.** The issue proposes one for checks dropping cannot fix (`covers_primary_subject` and friends). Deliberately left out here: an outline retry carries the full stage context, and on the Claude path three calls were 200,788 tokens on this run, so it interacts with the budget question in #485 and deserves its own decision.

## Verification

`pytest apps/backend/tests` — 1248 tests, 0 failures (4 new, 1 updated), plus the replay above.

Closes #488