### PR TITLE
Ask for the sentence, not the checkbox

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_conflicts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_conflicts.py
@@ -87,6 +87,41 @@ DISAGREEMENT_RATIO = 1.5
 AGREEMENT_TOLERANCE = 0.05
 
 
+# Words that can only mean two sources saying different things about the same
+# thing. Chosen by sweeping the stored dossiers rather than by guessing, and
+# the exclusions matter more than the inclusions:
+#
+# - "differ" fired three times across the corpus and two were wrong -- "only
+#   Don Danilo's stall (#486), a different vendor" and "prices found are for
+#   different dishes" are both distinctions, not disagreements. It would have
+#   manufactured two conflicts out of nothing.
+# - " vs " fired only inside a sentence that already said "conflicting", so it
+#   adds nothing here and would fire on any comparison piece.
+#
+# The corpus is thin: seven v4 dossiers, ten requirements carrying a gap at
+# all. This list is narrow on purpose because of that, not in spite of it.
+_DISAGREEMENT_WORDS = (
+    "conflicting",
+    "disagree",
+    "discrepan",
+    "contradict",
+    "inconsistent",
+    "outlier",
+)
+
+_HAS_DIGIT = re.compile(r"[0-9]")
+
+
+@dataclass(frozen=True)
+class DeclaredDisagreement:
+    """A requirement whose own gap text says the sources disagree."""
+
+    requirement_id: str
+    claim_ids: tuple[str, ...]
+    word: str
+    gap: str
+
+
 @dataclass(frozen=True)
 class NumericDisagreement:
     """Two claims on one requirement whose numbers do not agree."""
@@ -172,6 +207,61 @@ def detect_numeric_disagreements(
     return found
 
 
+def detect_declared_disagreements(
+    package: EvidencePackage,
+) -> list[DeclaredDisagreement]:
+    """Requirements whose gap says the sources disagree, with no conflict filed.
+
+    Run b29d66b4 wrote this gap and recorded no conflict:
+
+        "only conflicting general closing-hour listings (10am-5pm daily vs
+        9am-5:30/6:30pm)"
+
+    The numeric comparison cannot catch that one: 9 against 10 is a ratio of
+    1.11, far under a magnitude threshold that exists to stay quiet, and a
+    clock time is not a quantity anyway. What can catch it is the structure
+    step's own sentence. This reads what the model wrote rather than judging
+    the world, so it invents nothing.
+    """
+    already_paired = {
+        frozenset(pair)
+        for conflict in package.conflicts
+        for pair in _pairs(conflict.claim_ids)
+    }
+    claims_by_id = {claim.claim_id: claim for claim in package.claims}
+    found: list[DeclaredDisagreement] = []
+    for requirement in package.requirements:
+        gap = (requirement.gap or "").lower()
+        if not gap:
+            continue
+        word = next((item for item in _DISAGREEMENT_WORDS if item in gap), None)
+        if word is None:
+            continue
+        ids = [item for item in requirement.claim_ids if item in claims_by_id]
+        if any(
+            frozenset(pair) in already_paired for pair in _pairs(ids)
+        ):
+            continue
+        # The claims that carry figures are the ones that can disagree. On
+        # b29d66b4's Q7 that is the two sets of opening hours and not the
+        # third claim, which says no time is published at all.
+        measured = [
+            item for item in ids if _HAS_DIGIT.search(claims_by_id[item].text)
+        ]
+        named = measured if len(measured) >= 2 else ids
+        if len(named) < 2:
+            continue
+        found.append(
+            DeclaredDisagreement(
+                requirement_id=requirement.requirement_id,
+                claim_ids=tuple(named),
+                word=word,
+                gap=requirement.gap or "",
+            )
+        )
+    return found
+
+
 def _pairs(claim_ids: list[str]) -> list[tuple[str, str]]:
     return [
         (claim_ids[index], other)
@@ -185,20 +275,43 @@ def _figure(value: float, unit: str) -> str:
     return f"{rendered}{unit}" if unit in {"%", "$"} else f"{rendered} {unit}"
 
 
-def record_numeric_conflicts(package: EvidencePackage) -> EvidencePackage:
-    """Add a conflict for every numeric disagreement research left unrecorded.
+def record_detected_conflicts(package: EvidencePackage) -> EvidencePackage:
+    """Add a conflict for every disagreement research left unrecorded.
 
-    Unresolved, because nothing here knows which figure is right. That routes
-    it to the gate the operator already answers before writing, which is the
-    one place a person is asked to settle the dossier.
+    Two ways of finding one, and they are complements rather than overlaps.
+    The numeric comparison catches figures that disagree in magnitude and says
+    nothing about clock times, where a real disagreement is a rounding error
+    away in ratio terms. The declared check catches the structure step's own
+    sentence saying the sources conflict, which is the half no comparison can
+    reach.
+
+    Both record unresolved, because nothing here knows which is right. That
+    routes them to the gate the operator already answers before writing, which
+    is the one place a person is asked to settle the dossier.
     """
-    disagreements = detect_numeric_disagreements(package)
-    if not disagreements:
+    numeric = detect_numeric_disagreements(package)
+    declared = detect_declared_disagreements(package)
+    if not numeric and not declared:
         return package
 
     taken = {conflict.conflict_id for conflict in package.conflicts}
     additions: list[EvidenceConflict] = []
-    for index, item in enumerate(disagreements, start=1):
+    for index, item in enumerate(declared, start=1):
+        conflict_id = f"declared_{item.requirement_id}_{index}"
+        while conflict_id in taken:
+            conflict_id = f"{conflict_id}_x"
+        taken.add(conflict_id)
+        additions.append(
+            EvidenceConflict(
+                conflict_id=conflict_id,
+                claim_ids=list(item.claim_ids),
+                summary=(
+                    f"Research reported a disagreement on {item.requirement_id} "
+                    f"in its own words and filed no conflict: \"{item.gap}\""
+                ),
+            )
+        )
+    for index, item in enumerate(numeric, start=1):
         conflict_id = f"measured_{item.requirement_id}_{index}"
         while conflict_id in taken:
             conflict_id = f"{conflict_id}_x"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -184,9 +184,10 @@ Return strict JSON only:
   "word_count_estimate": 0,
   "constraint_checks": {{
     "audience_match": false,
-    "tone_match": false,
-    "fails_if_avoided": false
+    "tone_match": false
   }},
+  "fails_if_quote": "string",
+  "fails_if_why": "string",
   "required_revisions": ["string"],
   "quality_summary": "string"
 }}
@@ -222,22 +223,32 @@ Rules:
   built from.
 - Mark too_close_to_source=true when phrasing or structure tracks an evidence
   record too closely.
-- Judge only audience_match, tone_match and fails_if_avoided. Word count,
-  paragraph length, CTA, and keyword presence are measured deterministically
-  outside this prompt, so do not report them.
+- Judge only audience_match and tone_match. Word count, paragraph length, CTA,
+  and keyword presence are measured deterministically outside this prompt, so
+  do not report them.
 - The line under "This piece fails if" is the operator's own definition of
   failure for this piece, written in their words before anything was
-  researched. It is the one criterion nobody else can supply. Read the draft
-  against that sentence and set fails_if_avoided accordingly. Where the draft
-  walks into it, name the sentence that does in required_revisions, quoting
-  it, and let it weigh on brief_adherence_score and overall_score the way any
-  other failure of the brief does. Run 849ae5aa was told the piece fails if it
-  "describes the projects in the present tense when nobody has confirmed they
-  are still running", opened with "Hundreds of fog nets built in Lima are
-  standing and functioning in 2026", and passed.
+  researched. It is the one criterion nobody else can supply.
+  Do not answer whether the draft avoids it. Answer with evidence:
+  fails_if_quote is the sentence copied out of the draft, word for word, that
+  walks into that line, and fails_if_why is one line saying how it does. If
+  the draft does not walk into it, fails_if_quote is an empty string and
+  fails_if_why says why the line does not apply. Copy the sentence exactly;
+  the quote is checked against the draft, and a sentence that is not in it
+  tells us the answer cannot be relied on.
+  A quoted sentence also belongs in required_revisions, and it weighs on
+  brief_adherence_score and overall_score the way any other failure of the
+  brief does.
+  Two runs walked into their own line and reported otherwise. 849ae5aa was
+  told the piece fails if it "describes the projects in the present tense when
+  nobody has confirmed they are still running", opened with "Hundreds of fog
+  nets built in Lima are standing and functioning in 2026", and passed.
+  b29d66b4 was told it fails if it walks the stalls one after another and
+  never says which to go to, wrote a section this audit itself called an
+  inventory, and still answered that the failure was avoided.
 - The line is freehand and it is not a gate. A sentence you cannot apply is a
-  sentence you leave alone: set fails_if_avoided true and say nothing rather
-  than inventing a reading of it.
+  sentence you leave alone: return an empty quote and say so rather than
+  inventing a reading of it.
 - Score honestly. A draft that merely avoids mistakes is a 7, not a 9. Being
   grounded, complete, and constraint-compliant is the floor this scale starts
   from, not what earns the top of it.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -714,13 +714,6 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
     checks = {
         "audience_match": _safe_bool(checks_raw.get("audience_match"), default=True),
         "tone_match": _safe_bool(checks_raw.get("tone_match"), default=True),
-        # The brief's own definition of failure, judged for the first time.
-        # Deliberately not in HARD_CONSTRAINT_CHECK_KEYS: the line is freehand
-        # and a badly worded one must not be able to block a run. It weighs
-        # through the scores and the revisions the auditor writes beside it.
-        "fails_if_avoided": _safe_bool(
-            checks_raw.get("fails_if_avoided"), default=True
-        ),
     }
 
     # A missing or unparseable score used to default to 6, which sits below the
@@ -750,6 +743,12 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
             0, _safe_int(parsed.get("word_count_estimate"), default=0)
         ),
         "constraint_checks": checks,
+        # Evidence, not a verdict. `evaluate_fails_if` turns it into one by
+        # checking the quote is really in the draft; a boolean asked for
+        # directly was answered "avoided" on a draft the same response called
+        # an inventory (run b29d66b4).
+        "fails_if_quote": _safe_str(parsed.get("fails_if_quote")),
+        "fails_if_why": _safe_str(parsed.get("fails_if_why")),
         "required_revisions": required_revisions,
         "quality_summary": _safe_str(parsed.get("quality_summary"))
         or "Quality summary not provided.",
@@ -825,6 +824,69 @@ def looks_truncated(content: str, *, max_output_tokens: int) -> bool:
     stripped = content.rstrip()
     ends_cleanly = stripped.endswith((".", "!", "?", '"', "'", ")", "`"))
     return near_cap and not ends_cleanly
+
+
+# How much of a quoted sentence has to be found in the draft before the quote
+# counts as real. Not an exact match: a model that drops a comma or repairs a
+# dash has still located the sentence, and losing a true finding to punctuation
+# would be the worst way to fail.
+QUOTE_MATCH_THRESHOLD = 0.6
+# An auditor quoting the problem often quotes more than one sentence of it.
+QUOTE_MATCH_MAX_SENTENCES = 3
+
+
+def evaluate_fails_if(quality: dict[str, Any], content: str) -> dict[str, Any]:
+    """Turn the auditor's quote into a verdict, or into a visible shrug.
+
+    Three outcomes, and the third is the point:
+
+    - No quote: the auditor says the draft does not walk into its failure
+      line, and there is nothing to check.
+    - A quote found in the draft: the failure is real and named, and the
+      sentence is on the record for repair to work from.
+    - A quote that is not in the draft: the answer cannot be relied on. It
+      does not become a failure -- inventing one from an unverifiable quote is
+      the same sin in the other direction -- but it is recorded as unjudged
+      rather than banked as a pass.
+    """
+    quote = _safe_str(quality.get("fails_if_quote"))
+    if not quote:
+        return {
+            "quote": "",
+            "why": _safe_str(quality.get("fails_if_why")),
+            "verdict": "avoided",
+            "matched": "",
+            "match_score": 0.0,
+        }
+
+    wanted = _content_words(quote)
+    best, score = "", 0.0
+    if wanted:
+        # Windows of up to three consecutive sentences, because an auditor
+        # quoting the problem often quotes two sentences of it. Scored against
+        # a single sentence, a two sentence quote can never match anything and
+        # a true finding is thrown away for spanning a full stop.
+        for section in _sections(content):
+            for start in range(len(section)):
+                for width in range(1, QUOTE_MATCH_MAX_SENTENCES + 1):
+                    window = section[start : start + width]
+                    if len(window) < width:
+                        break
+                    words = _content_words(" ".join(window))
+                    if not words:
+                        continue
+                    overlap = len(wanted & words) / len(wanted)
+                    if overlap > score:
+                        best, score = " ".join(window), overlap
+
+    found = score >= QUOTE_MATCH_THRESHOLD
+    return {
+        "quote": quote,
+        "why": _safe_str(quality.get("fails_if_why")),
+        "verdict": "walks_into_it" if found else "unjudged",
+        "matched": best if found else "",
+        "match_score": round(score, 3),
+    }
 
 
 def _should_run_repair(quality: dict[str, Any], checks: dict[str, Any]) -> bool:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -45,7 +45,7 @@ from .contracts_v4 import (
     WorkOrderRequirement,
 )
 from .config import P2B_V4_GATHER_CONCURRENCY
-from .evidence_conflicts import record_numeric_conflicts
+from .evidence_conflicts import record_detected_conflicts
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
 
@@ -971,7 +971,7 @@ def structure_research(
         # The prompt asks for conflicts and the Lima run did not record the
         # one its own notes had named. The comparison below is the half of
         # that a model cannot forget to do.
-        return record_numeric_conflicts(EvidencePackage.model_validate(payload))
+        return record_detected_conflicts(EvidencePackage.model_validate(payload))
     except ValidationError as error:
         raise ResearchUnusable(
             "; ".join(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -14,6 +14,7 @@ from ...prompts.editorial_v3 import (
 )
 from ...quality import (
     CONSTRAINT_MEASUREMENT_KEYS,
+    evaluate_fails_if,
     _build_constraint_checks,
     _sanitize_quality,
     _sanitize_rewrite,
@@ -91,6 +92,25 @@ def _audit_v3_rewrite(
         model_name=state["audit_model"],
     )
     quality = _sanitize_quality(parsed)
+    # The auditor answered with a quote; this is where that becomes a verdict.
+    fails_if = evaluate_fails_if(quality, rewrite["improved_content"])
+    quality["fails_if_check"] = fails_if
+    quality["fails_if_avoided"] = fails_if["verdict"] != "walks_into_it"
+    if fails_if["verdict"] == "walks_into_it":
+        # Repair reads required_revisions, so the sentence has to be in there
+        # whether or not the auditor remembered to put it there.
+        revision = (
+            f"The draft walks into the line the brief says it fails on. "
+            f"Rewrite this sentence: \"{fails_if['matched']}\". "
+            f"{fails_if['why']}".strip()
+        )
+        if not any(
+            fails_if["matched"][:40] in item for item in quality["required_revisions"]
+        ):
+            quality["required_revisions"] = [
+                revision,
+                *quality["required_revisions"],
+            ]
     quality_checks = {
         **quality.get("constraint_checks", {}),
         **{

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_numeric_conflicts.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_numeric_conflicts.py
@@ -21,7 +21,7 @@ from app.features.prompt2blog.contracts_v4 import EvidencePackage
 from app.features.prompt2blog.evidence_conflicts import (
     detect_numeric_disagreements,
     quantities,
-    record_numeric_conflicts,
+    record_detected_conflicts,
 )
 
 
@@ -104,7 +104,7 @@ def test_the_rainfall_claims_are_seen_to_disagree():
 
 
 def test_the_disagreement_is_recorded_as_an_unresolved_conflict():
-    package = record_numeric_conflicts(_package(RAINFALL))
+    package = record_detected_conflicts(_package(RAINFALL))
 
     assert len(package.conflicts) == 1
     conflict = package.conflicts[0]
@@ -188,13 +188,13 @@ def test_a_conflict_research_already_recorded_is_not_duplicated():
     )
 
     assert detect_numeric_disagreements(package) == []
-    assert len(record_numeric_conflicts(package).conflicts) == 1
+    assert len(record_detected_conflicts(package).conflicts) == 1
 
 
 def test_a_clean_dossier_is_returned_untouched():
     package = _package([_claim("c1", "The nets are maintained by volunteers.")])
 
-    assert record_numeric_conflicts(package) is package
+    assert record_detected_conflicts(package) is package
 
 
 # --- the prompt still asks for the half a comparison cannot do -------------

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_signals.py
@@ -99,7 +99,6 @@ def test_audit_keeps_only_semantic_constraint_checks():
     assert quality["constraint_checks"] == {
         "audience_match": False,
         "tone_match": True,
-        "fails_if_avoided": True,
     }
 
 
@@ -239,21 +238,110 @@ def test_length_measurements_never_land_among_the_pass_fail_verdicts():
 # ever asked it to read it.
 
 
-def test_the_auditor_is_asked_whether_the_draft_walks_into_the_failure():
+def test_the_auditor_answers_with_a_sentence_not_a_checkbox():
+    """A boolean can be answered without reading. On b29d66b4 it was: the
+    audit reported the failure avoided in the same response where it called
+    the section an inventory and told repair to rewrite it."""
+    from app.features.prompt2blog.quality import evaluate_fails_if
+
+    content = (
+        "## Where to eat\n\nNorma Cevicheria receives the most acclaim and "
+        "serves a fish ceviche with fried pork rinds.\n\n## The cost\n\n"
+        "Punto Azul charges 51 soles for a classic fish ceviche."
+    )
     quality = _sanitize_quality(
         {
             "overall_score": 8,
-            "constraint_checks": {"fails_if_avoided": False},
+            "fails_if_quote": (
+                "Norma Cevicheria receives the most acclaim and serves a fish "
+                "ceviche with fried pork rinds."
+            ),
+            "fails_if_why": "It lists a stall without saying to go there.",
         }
     )
 
-    assert quality["constraint_checks"]["fails_if_avoided"] is False
+    result = evaluate_fails_if(quality, content)
+
+    assert result["verdict"] == "walks_into_it"
+    assert "Norma Cevicheria" in result["matched"]
 
 
-def test_an_auditor_that_omits_the_verdict_does_not_manufacture_a_failure():
-    quality = _sanitize_quality({"overall_score": 8, "constraint_checks": {}})
+def test_a_quote_that_is_not_in_the_draft_is_recorded_as_unjudged():
+    """An invented quote must not become a failure -- that is the same sin in
+    the other direction -- but it must not be banked as a pass either."""
+    from app.features.prompt2blog.quality import evaluate_fails_if
 
-    assert quality["constraint_checks"]["fails_if_avoided"] is True
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "fails_if_quote": "The tram runs every eleven minutes from the plaza.",
+            "fails_if_why": "Present tense about a service nobody confirmed.",
+        }
+    )
+
+    result = evaluate_fails_if(quality, "## Cost\n\nA plate runs 25 soles.")
+
+    assert result["verdict"] == "unjudged"
+    assert result["matched"] == ""
+
+
+def test_a_quote_that_lost_its_punctuation_still_counts():
+    """A model that repairs a dash has still located the sentence. Losing a
+    true finding to punctuation would be the worst way to fail."""
+    from app.features.prompt2blog.quality import evaluate_fails_if
+
+    content = (
+        "## Stalls\n\nDon Danilo operates from stall 486, and you will sit "
+        "on plastic stools if you eat at El Rey Luhcin."
+    )
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "fails_if_quote": (
+                "Don Danilo operates from stall 486 and you will sit on plastic "
+                "stools if you eat at El Rey Luhcin"
+            ),
+        }
+    )
+
+    assert evaluate_fails_if(quality, content)["verdict"] == "walks_into_it"
+
+
+def test_a_quote_spanning_two_sentences_still_matches():
+    """An auditor quoting the problem often quotes two sentences of it.
+    Scored against single sentences, such a quote can never match anything and
+    a true finding is thrown away for spanning a full stop."""
+    from app.features.prompt2blog.quality import evaluate_fails_if
+
+    content = (
+        "## Stalls\n\nYou will sit on plastic stools if you eat at El Rey "
+        "Luhcin. Don Danilo operates from stall 486. Al Toke Pez sits nearby."
+    )
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "fails_if_quote": (
+                "You will sit on plastic stools if you eat at El Rey Luhcin. "
+                "Don Danilo operates from stall 486."
+            ),
+        }
+    )
+
+    assert evaluate_fails_if(quality, content)["verdict"] == "walks_into_it"
+
+
+def test_an_auditor_that_answers_with_no_quote_does_not_manufacture_a_failure():
+    from app.features.prompt2blog.quality import evaluate_fails_if
+
+    quality = _sanitize_quality({"overall_score": 8})
+
+    assert evaluate_fails_if(quality, "## Cost\n\nA plate runs 25 soles.") == {
+        "quote": "",
+        "why": "",
+        "verdict": "avoided",
+        "matched": "",
+        "match_score": 0.0,
+    }
 
 
 def test_walking_into_the_failure_does_not_block_the_run():

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -358,8 +358,11 @@ def test_the_audit_prompt_asks_whether_the_draft_walks_into_it():
 
     prompt = _flat(P2B_V3_QUALITY_AUDIT_PROMPT)
 
-    assert "fails_if_avoided" in prompt
+    assert "fails_if_quote" in prompt
     assert 'The line under "This piece fails if"' in prompt
+    # Evidence, not a verdict: a boolean here was answered without reading.
+    assert "Do not answer whether the draft avoids it" in prompt
+    assert "the quote is checked against the draft" in prompt
     # Freehand text, so an auditor that cannot apply it must leave it alone
     # rather than invent a reading.
     assert "it is not a gate" in prompt


### PR DESCRIPTION
Two stages have now described a fault in prose and reported the opposite in a field beside it.

- The audit on `b29d66b4` answered `fails_if_avoided: true` while writing *"the middle section reads like an inventory"* and telling repair to rewrite it.
- The structure step wrote *"only **conflicting** general closing-hour listings (10am-5pm daily vs 9am-5:30/6:30pm)"* and filed `conflicts: []` — **after** PR #480 added prompt text saying that a described discrepancy is a conflict.

A field a model can fill in without doing the work will be filled in without doing the work. Two prompt rewrites have failed against that, so this stops asking for the verdict.

## The audit returns a sentence

`fails_if_quote` is the sentence copied out of the draft that walks into the operator's line, or nothing. The boolean is **derived** from whether a quote came back, and the quote is checked against the draft before it counts.

Three outcomes, and the third is the point:

| auditor returns | verdict |
|---|---|
| no quote | `avoided` |
| a quote found in the draft | `walks_into_it`, and the sentence is pushed onto `required_revisions` so repair has it |
| a quote **not** in the draft | `unjudged` — recorded, not banked as a pass |

An unverifiable quote does not become a failure: inventing one is the same sin in the other direction. It is recorded as unjudged so the unreliability is visible instead of green.

Matching runs over windows of up to **three consecutive sentences**. Scored against single sentences, a two-sentence quote can never match anything, and losing a true finding to a full stop would be the worst way to fail. Against the real `b29d66b4` article:

| quote | score | verdict |
|---|---|---|
| a real two-sentence quote | 1.00 | walks_into_it |
| a real one-sentence quote | 1.00 | walks_into_it |
| an invented sentence | 0.20 | unjudged |
| a paraphrase rather than a quote | 0.25 | unjudged |

The 0.6 line sits in that gap.

## Research reads its own gap text

Words that can only mean two sources disagreeing trigger an unresolved conflict naming the claims on that requirement that **actually carry figures**. On Q7 that is the two sets of opening hours and not the third claim, which says no time is published at all. It routes to the gate the operator already answers, costs no model call, and picks no figure.

This catches what the numeric detector structurally cannot: 9am against 10am is a real disagreement and a ratio of 1.11, far under a magnitude threshold that exists to stay quiet.

## The word list was swept, and the exclusions are the point

| word | fires across the stored dossiers | kept |
|---|---|---|
| `conflicting` | 1 — the true case | yes |
| `differ` | 3 — **two wrong**: "a *different* vendor", "prices for *different* dishes" | **no** |
| ` vs ` | 1, inside a sentence that already said "conflicting" | no |
| `disagree`, `discrepan`, `contradict`, `inconsistent`, `outlier` | 0 | yes, narrow enough to be safe |

`differ` would have manufactured two conflicts out of nothing. The corpus is thin — seven v4 dossiers, ten requirements carrying a gap at all — which is why the list is narrow rather than generous, and that is stated in the code.

## Replayed against the real run

Feeding `b29d66b4`'s dossier as research left it: `declared_Q7_1`, claims `['C12a', 'C12b']`, unresolved. Nothing else fires on the other thirteen requirements.

## What this could break

- **A quote-shaped question biases toward answering it.** The cost of a false positive is a dipped score on an article the operator is reading anyway; nothing blocks after writing, repair is capped at one attempt, and a budget refusal sits in front of that.
- **Auto-recorded conflicts add gate questions.** One on this run. If a future sweep shows more, the trigger narrows.
- **`fails_if_avoided` is no longer read from the model**, so an auditor that keeps returning unusable quotes shows up as `unjudged` rather than as a pass. That is the intended failure mode.

## Verification

`pytest apps/backend/tests` — 1251 tests, 0 failures (6 new, 3 rewritten), plus both replays above.

Closes #482