### PR TITLE
Strike a dead obligation, and stop the punch list breaking house rules

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/brief_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/brief_v4.py
@@ -111,7 +111,10 @@ rather than leaving it blank.
 - `outcome` is what the reader should do or decide afterwards.
 - `fails_if` is what would make this a failure, taken from what they said, not
   invented. This is the line the finished article gets judged against.
-- `must_name` is only what the piece genuinely has to mention.
+- `must_name` is only what the piece genuinely has to mention, and it is a
+  list: one name per entry, never several in one string separated by commas.
+  A single entry reading "Surquillo market, Miraflores, the municipal ranking"
+  is three obligations the system can then only measure as one.
 - `material` is what they personally have. For each entry, `quoted_answer` must
   be an EXACT copy of one of their answers above -- do not summarise, tidy or
   merge. `kind` is firsthand, interview, or research.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -427,6 +427,52 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
     return verdict
 
 
+def _strike_must_name(
+    run_id: str, services: IntakeServices, names: list[str]
+) -> ArticleBrief:
+    """Drop an obligation research has just proved cannot be met.
+
+    Run b29d66b4 asked for the shortlist to be cross-checked against "Lima's
+    municipal ranking of cevicherias". Research settled it: the ranking does
+    not exist. `must_name` still carried it, the article named it anyway, and
+    `must_include_covered` scored true -- the check rewarding the piece for
+    naming a thing the run had established is not real.
+
+    The operator says which entries to strike. No matcher tries to guess which
+    `must_name` line a dead question corresponds to: that matcher would be
+    wrong in both directions and would need its own repair later.
+
+    `brief_fingerprint` is deliberately left alone. It binds the work order and
+    the evidence to the brief they were derived from, and re-deriving it here
+    would break both bindings over an operator edit. `omit_requirement` makes
+    the same choice when it trims a work order, for the same reason.
+    """
+    brief = load_brief(run_id)
+    unwanted = {name.strip().casefold() for name in names if name.strip()}
+    kept = [item for item in brief.must_name if item.casefold() not in unwanted]
+    if len(kept) == len(brief.must_name):
+        raise GateAnswerRefused(
+            "None of those are on the brief's must-name list."
+        )
+    struck = brief.model_copy(update={"must_name": kept})
+    logger.info(
+        "Operator struck must_name %s at the research gate",
+        sorted(unwanted),
+        extra={"run_id": run_id},
+    )
+    _record(
+        services,
+        run_id,
+        BRIEF_STAGE,
+        {
+            **brief_stage_record(struck),
+            "struck_must_name": sorted(unwanted),
+            STATE_KEY: json.loads(struck.model_dump_json()),
+        },
+    )
+    return struck
+
+
 def settle_gate(
     run_id: str,
     services: IntakeServices,
@@ -436,6 +482,7 @@ def settle_gate(
     source_url: str | None = None,
     unpublished_note: str | None = None,
     nonexistent_note: str | None = None,
+    strike_must_name: list[str] | None = None,
     omit: bool = False,
 ) -> CoverageVerdict:
     """Settle one blocking question without re-buying the research.
@@ -452,6 +499,9 @@ def settle_gate(
     work_order = load_work_order(run_id)
     evidence = load_evidence(run_id)
     notes = _stage_data(run_id, RESEARCH_STAGE).get("notes") or {}
+
+    if strike_must_name:
+        _strike_must_name(run_id, services, strike_must_name)
 
     if omit:
         evidence, work_order, cost = omit_requirement(
@@ -666,6 +716,7 @@ def blocking_questions(run_id: str) -> list[dict[str, Any]]:
     """
     work_order = load_work_order(run_id)
     evidence = load_evidence(run_id)
+    brief = load_brief(run_id)
     verdict = assess_coverage(work_order, evidence)
     if verdict.can_write:
         return []
@@ -703,6 +754,17 @@ def blocking_questions(run_id: str) -> list[dict[str, Any]]:
                     for claim_id in (record.claim_ids if record else [])
                     if claim_id in claims
                 ],
+                # A question that came back `nonexistent` may have a matching
+                # obligation on the brief. b29d66b4 proved a municipal ranking
+                # does not exist and then named it in the article anyway,
+                # because `must_name` still said to. The operator is the one
+                # who can say which line that is, so they are shown the list
+                # rather than a guess at it.
+                "must_name": (
+                    list(brief.must_name)
+                    if (record and record.status == "nonexistent")
+                    else []
+                ),
             }
         )
     return blocking

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/notes_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/notes_v4.py
@@ -264,6 +264,21 @@ with nothing checking it.
 
 Any figure you write must already appear in the article or in the dossier. A
 note carrying a number from neither will be thrown away.
+
+WHAT AN ABSENCE IS FOR
+
+Some claims in the dossier record what the research could not establish: that
+nobody publishes a figure, that a list does not exist, that a price is not
+posted anywhere. Those are internal. They never become a reader-facing
+sentence, and an article that leaves them out has done the right thing rather
+than missed something.
+
+Never ask for one to be stated. "State clearly that repeated searches returned
+no official published ranking" is not an edit anyone may make: the house rules
+refuse a sentence that announces what the research could not find, so an
+operator who followed it would write a sentence the pipeline rejects. If an
+absence matters, the item is to cut or rewrite whatever the article built on
+top of it, in terms of what the article does know.
 """
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_v4.py
@@ -456,3 +456,97 @@ def test_recutting_the_plan_discards_the_research_that_answered_the_old_one(isol
     # Research answered the questions that were there before the cut, so
     # leaving it would attach answers to a plan that no longer asks them.
     assert read_stage_result(run_id, RESEARCH_STAGE) is None
+
+
+# --- an obligation research proved cannot be met ---------------------------
+#
+# Run b29d66b4 asked for the shortlist to be cross-checked against "Lima's
+# municipal ranking of cevicherias". Research settled it: it does not exist.
+# `must_name` still carried it, the article named it anyway, and
+# `must_include_covered` scored true.
+
+
+def _brief_with(*names: str) -> dict[str, Any]:
+    return {**BRIEF_PAYLOAD, "must_name": list(names)}
+
+
+def _run_with_brief(isolated, *names: str) -> tuple[str, IntakeServices]:
+    services = _services(
+        [{"done": False, "question": _question()}, AGREED, _brief_with(*names)]
+    )
+    run_id = _to_agreement(services)
+    approve_brief(run_id, services)
+    return run_id, services
+
+
+def test_a_struck_must_name_leaves_the_brief(isolated_db):
+    from app.features.prompt2blog.intake_v4 import _strike_must_name
+
+    run_id, services = _run_with_brief(
+        isolated_db, "Surquillo market", "the municipal ranking of cevicherias"
+    )
+
+    struck = _strike_must_name(
+        run_id, services, ["the municipal ranking of cevicherias"]
+    )
+
+    assert struck.must_name == ["Surquillo market"]
+    assert load_brief(run_id).must_name == ["Surquillo market"]
+
+
+def test_striking_keeps_the_fingerprint_that_binds_the_work_order(isolated_db):
+    """The fingerprint binds the work order and the evidence to the brief they
+    were derived from. Re-deriving it on an operator edit would break both
+    bindings; `omit_requirement` makes the same choice when it trims a work
+    order."""
+    from app.features.prompt2blog.intake_v4 import _strike_must_name
+
+    run_id, services = _run_with_brief(
+        isolated_db, "Surquillo market", "the municipal ranking of cevicherias"
+    )
+    before = load_brief(run_id).brief_fingerprint
+
+    struck = _strike_must_name(
+        run_id, services, ["the municipal ranking of cevicherias"]
+    )
+
+    assert struck.brief_fingerprint == before
+
+
+def test_striking_a_name_that_is_not_there_is_refused(isolated_db):
+    from app.features.prompt2blog.gate_v4 import GateAnswerRefused
+    from app.features.prompt2blog.intake_v4 import _strike_must_name
+
+    run_id, services = _run_with_brief(isolated_db, "Surquillo market")
+
+    with pytest.raises(GateAnswerRefused, match="must-name"):
+        _strike_must_name(run_id, services, ["something else entirely"])
+
+
+def test_the_strike_is_recorded_on_the_run(isolated_db):
+    from app.features.prompt2blog.intake_v4 import _strike_must_name
+
+    run_id, services = _run_with_brief(
+        isolated_db, "Surquillo market", "the municipal ranking of cevicherias"
+    )
+
+    _strike_must_name(run_id, services, ["the municipal ranking of cevicherias"])
+
+    assert _stage_data(run_id, BRIEF_STAGE)["struck_must_name"] == [
+        "the municipal ranking of cevicherias"
+    ]
+
+
+def test_the_brief_writer_is_told_one_name_per_entry(isolated_db):
+    """b29d66b4's brief recorded three names in one string, so coverage was
+    measured against a blob and one missing name could not be told from
+    three."""
+    from app.features.prompt2blog.brief_v4 import build_brief_prompt
+    from app.features.prompt2blog.intake_v4 import _load_grill
+
+    services = _services([{"done": False, "question": _question()}, AGREED])
+    run_id = _to_agreement(services)
+
+    prompt = build_brief_prompt(_load_grill(run_id))
+
+    assert "one name per entry" in prompt

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_punch_list.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_punch_list.py
@@ -431,3 +431,42 @@ def test_the_list_is_read_under_its_other_names_too():
 def test_a_payload_with_nothing_usable_in_it_is_simply_empty():
     assert _run({"summary": "the article is fine"})["items"] == []
 
+
+
+# --- an absence is not a sentence ------------------------------------------
+#
+# Run b29d66b4's punch list said: "State clearly that repeated searches
+# returned no official published municipal ranking of cevicherias." That is
+# the exact sentence `_research_meta` in the anti-AI validator refuses, and
+# the evidence disposition policy forbids twice over. An operator who followed
+# the note would have written a sentence the pipeline rejects.
+
+
+def test_the_punch_list_may_not_ask_for_a_research_absence_to_be_stated():
+    prompt = build_punch_list_prompt(
+        brief=_brief(),
+        title="t",
+        article_markdown=ARTICLE,
+        evidence=_evidence(),
+        unused=[],
+    )
+    flat = " ".join(prompt.split())
+
+    assert "WHAT AN ABSENCE IS FOR" in prompt
+    assert "Never ask for one to be stated" in flat
+    # The offending note quoted back, so nobody re-adds the behaviour.
+    assert "repeated searches returned no official published ranking" in flat
+
+
+def test_an_article_that_leaves_an_absence_out_has_done_the_right_thing():
+    prompt = " ".join(
+        build_punch_list_prompt(
+            brief=_brief(),
+            title="t",
+            article_markdown=ARTICLE,
+            evidence=_evidence(),
+            unused=[],
+        ).split()
+    )
+
+    assert "has done the right thing rather than missed something" in prompt


### PR DESCRIPTION
Two small faults from run `b29d66b4`, both in what the system asks of a person after research has settled something.

## A must-name research proved cannot be met

The operator asked for the shortlist to be cross-checked against "Lima's municipal ranking of cevicherías". Research settled it — Q2 came back `nonexistent`. `must_name` still carried the obligation, so the writer named the ranking anyway:

> "Visitors looking for **Lima's municipal ranking of cevicherias** will find that the government runs periodic events..."

and `must_include_covered` scored **true**. The check rewarded the article for naming a thing the run had already established is not real.

**The gate now offers the strike.** A question that comes back `nonexistent` carries the brief's `must_name` list to the screen, and the operator says which entry dies. No matcher tries to guess which line a dead question corresponds to — that matcher would be wrong in both directions and would need its own repair later.

`brief_fingerprint` is deliberately **not** re-derived. It binds the work order and the evidence to the brief they were derived from, and recomputing it on an operator edit would break both bindings mid-run. `omit_requirement` already makes the same choice when it trims a work order, so this follows the established precedent rather than inventing one. A test pins it.

**The brief writer is also told `must_name` is one name per entry.** This run recorded `["Surquillo market, Miraflores, Lima's municipal ranking of cevicherias"]` — three obligations in one string, so coverage could only be measured as a blob and one missing name could not be told from three. No automatic splitting: names contain commas, and a splitter breaks "Villa María del Triunfo, Lima" the first time it meets one.

## The punch list told the operator to break a house rule

Its fourth item on this run:

> "**State clearly that repeated searches returned no official published municipal ranking of cevicherias.**"

That is the exact sentence `_research_meta` in the anti-AI validator refuses, and the evidence disposition policy forbids twice over (*"Unpublished fact: omit it silently. Never narrate research absence."*). An operator who followed the note would write a sentence the pipeline rejects — and the punch list is the one output a person is most likely to act on by hand, because it is written for them rather than for a model.

It now knows that a claim recording an absence is internal, that an article leaving it out has done the right thing rather than missed something, and that the edit is to fix whatever the article built on top of it.

The offending sentence is quoted in the prompt so the behaviour is not re-added later.

### What this could break

- **Over-filtering.** "The municipality does not publish a ranking" is an absence; "it runs a contest instead" is a fact about the world and belongs in the article. The rule instructs the punch list rather than filtering its output, so a wrong call stays visible in the note instead of disappearing.
- **`researched_and_unused` is untouched** — absence claims still appear there, so the operator can see the research produced them.

## Verification

`pytest apps/backend/tests` — 1252 tests, 0 failures (7 new).

Closes #484
Closes #487