### PR TITLE
Put a price on the cut step

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -101,20 +101,44 @@ P2B_REPAIR_ESTIMATED_TOKENS = 90_000
 # doubling down. Set above the Lima run's pre-repair spend (~158k) on purpose:
 # the first repair on a normal run must still be affordable.
 #
-# CAVEAT, 2026-09-01: both this number and P2B_REPAIR_ESTIMATED_TOKENS were
-# derived from the Lima run's receipt, and that receipt omitted every grounded
-# search and the whole of intake. Now that those are counted, the same run
-# measures higher against an unchanged threshold. Run b78a9fe8's pre-repair
-# spend was 113,413 by the old count and 140,620 once its searches are
-# included, before the grill, brief, work order and structuring calls are
-# added -- against a refusal line of 320,000 - 90,000 = 230,000.
+# RE-DERIVED, 2026-09-02, from the two runs that have complete accounting.
+# Everything before PR #455 recorded zero for the intake leg, so the earlier
+# number was set against receipts that omitted intake and every grounded
+# search. Measured properly:
 #
-# So a run that would have been granted its one repair may now be refused it.
-# Deliberately NOT retuned here: the right number comes from a real run
-# measured with the accounting fixed, not from a guess layered on a guess.
-# Re-derive both after the next article. The hard ceiling below has ample
-# headroom either way and is not affected.
-P2B_RUN_TOKEN_BUDGET = 320_000
+#   a2066506:  9 questions, 133,882 research tokens, 260,586 pre-repair
+#   b29d66b4: 14 questions, 206,507 research tokens, 370,114 pre-repair
+#
+# Both were refused their one repair against the old 320,000, on drafts
+# scoring 5 and 6 with actionable revisions waiting. The repair path had
+# never once been affordable since the accounting was fixed, which is
+# arithmetic rather than two unlucky runs: research costs about 14,800 a
+# question, writing about 134,000, and a repair 90,000, so 320,000 left room
+# for roughly three questions.
+#
+# 425,000 grants the repair up to about eleven questions, which covers the
+# normal size. The ladder, projected from those rates rather than from any one
+# run's receipt:
+#
+#   380,000 -> repair affordable to ~8 questions
+#   400,000 -> ~9 to 10
+#   425,000 -> ~11          <- set here
+#   470,000 -> 14, the size that broke b29d66b4
+#
+# A fourteen question plan still will not fit, and `budget_projection` says so
+# at the cut step while the plan can still be changed, rather than at the
+# settle node when the money is already spent.
+#
+# Do not set this from a single run's actual pre-repair spend. a2066506
+# finished at 260,586, which suggests 350,000 is enough for nine questions --
+# but its writing leg was 89,707, the cheapest of six, against a median of
+# 134,000. The projection uses the median, which is the honest basis for a
+# plan nobody has run yet.
+#
+# P2B_REPAIR_ESTIMATED_TOKENS above is still untested: no run has repaired
+# since the accounting was fixed, so 90,000 remains a measurement of a repair
+# nobody has watched. Re-derive it the first time one actually runs.
+P2B_RUN_TOKEN_BUDGET = 425_000
 
 # The hard ceiling. Distinct from P2B_RUN_TOKEN_BUDGET above, which only asks
 # whether one more *rescue* is affordable: this asks whether the run may

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -311,7 +311,9 @@ def plan_research(run_id: str, services: IntakeServices) -> Prompt2BlogWorkOrder
         run_id,
         WORK_ORDER_STAGE,
         {
-            **work_order_stage_record(work_order),
+            **work_order_stage_record(
+                work_order, tokens_spent=_run_tokens_spent(run_id)
+            ),
             STATE_KEY: json.loads(work_order.model_dump_json()),
         },
     )
@@ -341,7 +343,11 @@ def apply_cut(
         run_id,
         WORK_ORDER_STAGE,
         {
-            **work_order_stage_record(outcome.work_order, outcome.warnings),
+            **work_order_stage_record(
+                outcome.work_order,
+                outcome.warnings,
+                tokens_spent=_run_tokens_spent(run_id),
+            ),
             STATE_KEY: json.loads(outcome.work_order.model_dump_json()),
         },
     )
@@ -514,7 +520,9 @@ def settle_gate(
             run_id,
             WORK_ORDER_STAGE,
             {
-                **work_order_stage_record(work_order, [cost]),
+                **work_order_stage_record(
+                    work_order, [cost], tokens_spent=_run_tokens_spent(run_id)
+                ),
                 STATE_KEY: json.loads(work_order.model_dump_json()),
             },
         )
@@ -603,7 +611,9 @@ def reask_question(
         run_id,
         WORK_ORDER_STAGE,
         {
-            **work_order_stage_record(work_order, [note]),
+            **work_order_stage_record(
+                work_order, [note], tokens_spent=_run_tokens_spent(run_id)
+            ),
             STATE_KEY: json.loads(work_order.model_dump_json()),
         },
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, get_args
 
 from .contracts_v4 import (
@@ -36,6 +36,7 @@ from .contracts_v4 import (
 )
 from pydantic import ValidationError
 
+from .config import P2B_REPAIR_ESTIMATED_TOKENS, P2B_RUN_TOKEN_BUDGET
 from .grill_v4 import GrillDependencies
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str, _safe_str_list
@@ -616,12 +617,127 @@ def bundled_question_note(question: str) -> str:
     )
 
 
+# What one research question costs, measured rather than guessed. Only two
+# stored runs have complete intake accounting -- everything before PR #455
+# recorded zero for the intake leg -- and those two agree to within one per
+# cent across five questions of difference:
+#
+#   a2066506:  9 questions -> 133,882 tokens -> 14,876 each
+#   b29d66b4: 14 questions -> 206,507 tokens -> 14,750 each
+#
+# Two points is a thin line to draw, and it is drawn here rather than in the
+# operator's head.
+RESEARCH_TOKENS_PER_QUESTION = 14_800
+
+# Below this a work order is not an article, whatever the budget says.
+MIN_WORKABLE_QUESTIONS = 5
+
+# What the writing graph costs once research is done, median of the six stored
+# runs that reached it: 89,707 / 125,299 / 143,166 / 161,897 / 166,027 /
+# 173,801. Writing was counted correctly even on the runs whose intake was not.
+WRITING_TOKENS_TYPICAL = 134_000
+
+
+@dataclass(frozen=True)
+class BudgetProjection:
+    """What this many questions is likely to cost, and what it leaves.
+
+    Run b29d66b4 planned fourteen questions, reached the settle node at
+    370,114 tokens against a 320,000 ceiling, and had its one repair attempt
+    refused on a 5/10 draft with four actionable revisions sitting there. The
+    refusal was correct. What was missing is that nothing said so while the
+    plan could still be changed -- and the cut step, where the operator strikes
+    and adds questions, is where that belongs.
+    """
+
+    question_count: int
+    spent: int
+    projected_research: int
+    projected_writing: int
+    projected_total: int
+    repair_reserve: int
+    budget: int
+    repair_affordable: bool
+    questions_that_fit: int
+    note: str
+
+
+def budget_projection(
+    question_count: int, tokens_spent: int | None
+) -> BudgetProjection | None:
+    """Say what this plan will cost before it is paid for.
+
+    Returns nothing when the run has no token accounting, the same way
+    `decide_repair` skips its budget check rather than treating an absent
+    count as zero.
+    """
+    if tokens_spent is None or question_count <= 0:
+        return None
+
+    research = question_count * RESEARCH_TOKENS_PER_QUESTION
+    total = tokens_spent + research + WRITING_TOKENS_TYPICAL
+    affordable = total + P2B_REPAIR_ESTIMATED_TOKENS <= P2B_RUN_TOKEN_BUDGET
+    room = (
+        P2B_RUN_TOKEN_BUDGET
+        - P2B_REPAIR_ESTIMATED_TOKENS
+        - WRITING_TOKENS_TYPICAL
+        - tokens_spent
+    )
+    fits = max(0, room // RESEARCH_TOKENS_PER_QUESTION)
+
+    if affordable:
+        note = (
+            f"{question_count} questions projects to about {total:,} tokens "
+            f"against a {P2B_RUN_TOKEN_BUDGET:,} ceiling, leaving room for "
+            f"the one repair attempt."
+        )
+    elif fits >= MIN_WORKABLE_QUESTIONS:
+        note = (
+            f"{question_count} questions projects to about {total:,} tokens. "
+            f"With the {P2B_REPAIR_ESTIMATED_TOKENS:,} a repair costs, that "
+            f"passes the {P2B_RUN_TOKEN_BUDGET:,} ceiling, so this article "
+            f"will not be able to repair itself. About {fits} questions would "
+            f"leave room."
+        )
+    else:
+        # Both fully accounted runs were refused their repair, at 260,586 and
+        # 370,114. No plan worth writing fits, which makes this a question
+        # about the ceiling rather than about the plan.
+        note = (
+            f"{question_count} questions projects to about {total:,} tokens, "
+            f"past the {P2B_RUN_TOKEN_BUDGET:,} ceiling once the "
+            f"{P2B_REPAIR_ESTIMATED_TOKENS:,} a repair costs is counted. Only "
+            f"about {fits} questions would fit, which is not an article. This "
+            f"is the ceiling being too low for the pipeline as it now bills, "
+            f"not the plan being too large."
+        )
+    return BudgetProjection(
+        question_count=question_count,
+        spent=tokens_spent,
+        projected_research=research,
+        projected_writing=WRITING_TOKENS_TYPICAL,
+        projected_total=total,
+        repair_reserve=P2B_REPAIR_ESTIMATED_TOKENS,
+        budget=P2B_RUN_TOKEN_BUDGET,
+        repair_affordable=affordable,
+        questions_that_fit=fits,
+        note=note,
+    )
+
+
 def work_order_stage_record(
     work_order: Prompt2BlogWorkOrder,
     warnings: list[str] | None = None,
+    tokens_spent: int | None = None,
 ) -> dict[str, Any]:
     """What the run keeps about the plan the operator approved."""
+    projection = budget_projection(len(work_order.requirements), tokens_spent)
     return {
+        # What this plan is about to cost, next to the decision that changes
+        # it. The cut step had no price on it, so the difference between a run
+        # that can fix its own article and one that cannot was being decided
+        # invisibly.
+        "budget_projection": asdict(projection) if projection else None,
         "work_order_fingerprint": work_order.work_order_fingerprint,
         "brief_fingerprint": work_order.brief_fingerprint,
         "primary_subject": work_order.primary_subject,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -668,3 +668,75 @@ def test_the_prompt_names_a_presupposition_as_an_assumption():
     assert "A question that takes something for granted is assuming it." in flat
     assert "write the question so it survives being wrong" in flat
     assert "refuted premise, which is a finding" in flat
+
+
+# --- what a plan is about to cost ------------------------------------------
+#
+# Run b29d66b4 planned fourteen questions, reached the settle node at 370,114
+# tokens against a 320,000 ceiling, and had its one repair attempt refused on
+# a 5/10 draft with four actionable revisions sitting there. The refusal was
+# correct. Nothing said so while the plan could still be changed.
+
+
+def test_the_projection_lands_on_the_run_that_produced_it():
+    """Measured against b29d66b4: 38,308 spent at the cut, fourteen
+    questions, and a real total of 383,407."""
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(14, 38_308)
+
+    assert projection.projected_total == 379_508
+    assert abs(projection.projected_total - 383_407) / 383_407 < 0.02
+
+
+def test_a_plan_that_cannot_repair_itself_says_so():
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(14, 38_308)
+
+    assert projection.repair_affordable is False
+    assert "will not be able to repair itself" in projection.note or (
+        "past the" in projection.note
+    )
+
+
+def test_a_small_plan_on_a_fresh_run_can_afford_its_repair():
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(3, 5_000)
+
+    assert projection.repair_affordable is True
+    assert "leaving room for the one repair attempt" in projection.note
+
+
+def test_the_note_blames_the_ceiling_when_no_workable_plan_fits():
+    """Both fully accounted runs were refused their repair, at 260,586 and
+    370,114. Telling the operator to cut to three questions is not an
+    article, so the note has to say what is actually wrong."""
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(9, 36_997)
+
+    assert projection.questions_that_fit < 5
+    assert "ceiling being too low" in projection.note
+
+
+def test_a_run_with_no_accounting_gets_no_projection():
+    """`decide_repair` skips its budget check rather than reading an absent
+    count as zero, and this does the same."""
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    assert budget_projection(9, None) is None
+
+
+def test_the_projection_travels_on_the_stage_record():
+    from app.features.prompt2blog.work_order_v4 import work_order_stage_record
+
+    work_order = build_work_order(_brief(), _deps(_payload()))
+    record = work_order_stage_record(work_order, tokens_spent=38_308)
+
+    assert record["budget_projection"]["question_count"] == len(
+        work_order.requirements
+    )
+    assert record["budget_projection"]["budget"] == 320_000
+    assert work_order_stage_record(work_order)["budget_projection"] is None

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -710,15 +710,28 @@ def test_a_small_plan_on_a_fresh_run_can_afford_its_repair():
 
 
 def test_the_note_blames_the_ceiling_when_no_workable_plan_fits():
-    """Both fully accounted runs were refused their repair, at 260,586 and
-    370,114. Telling the operator to cut to three questions is not an
-    article, so the note has to say what is actually wrong."""
+    """Telling the operator to cut to three questions is not an article, so
+    when nothing workable fits the note says what is actually wrong.
+
+    Driven by a run that has already spent most of the ceiling rather than by
+    the ceiling's current value, so raising the budget does not silently
+    delete the branch this covers."""
+    from app.features.prompt2blog.config import P2B_RUN_TOKEN_BUDGET
     from app.features.prompt2blog.work_order_v4 import budget_projection
 
-    projection = budget_projection(9, 36_997)
+    projection = budget_projection(9, P2B_RUN_TOKEN_BUDGET - 150_000)
 
+    assert projection.repair_affordable is False
     assert projection.questions_that_fit < 5
     assert "ceiling being too low" in projection.note
+
+
+def test_a_normal_plan_can_afford_its_repair_at_the_current_ceiling():
+    """The size the pipeline actually plans. b29d66b4 asked fourteen and
+    a2066506 nine; eleven is the middle of what a run costs."""
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    assert budget_projection(11, 38_000).repair_affordable is True
 
 
 def test_a_run_with_no_accounting_gets_no_projection():
@@ -735,8 +748,10 @@ def test_the_projection_travels_on_the_stage_record():
     work_order = build_work_order(_brief(), _deps(_payload()))
     record = work_order_stage_record(work_order, tokens_spent=38_308)
 
+    from app.features.prompt2blog.config import P2B_RUN_TOKEN_BUDGET
+
     assert record["budget_projection"]["question_count"] == len(
         work_order.requirements
     )
-    assert record["budget_projection"]["budget"] == 320_000
+    assert record["budget_projection"]["budget"] == P2B_RUN_TOKEN_BUDGET
     assert work_order_stage_record(work_order)["budget_projection"] is None


### PR DESCRIPTION
Run `b29d66b4` planned 14 questions, reached the settle node at **370,114 tokens against a 320,000 ceiling**, and had its one repair attempt refused on a 5/10 draft with four actionable revisions sitting there.

The refusal is the control working. What was missing is that nothing said so while the plan could still be changed. The operator already has the control — the cut step, where they strike questions and add one — and it had no price on it.

## The numbers are measured, not guessed

Only **two** stored runs have complete intake accounting; everything before PR #455 recorded zero for the intake leg. Those two agree to within one per cent across five questions of difference:

| run | questions | research tokens | per question |
|---|---|---|---|
| `a2066506` | 9 | 133,882 | **14,876** |
| `b29d66b4` | 14 | 206,507 | **14,750** |

Writing is the median of the six runs that reached it (89,707 / 125,299 / 143,166 / 161,897 / 166,027 / 173,801) = **134,000**. Writing was counted correctly even on runs whose intake was not.

Checked against the run that prompted this: the projection gives **379,508** where `b29d66b4` actually cost **383,407**. Within 1%.

Two points is a thin line to draw, and it is drawn in the code with its provenance rather than in the operator's head.

## What the projection then said, which the issue did not anticipate

At 14,800 a question, with 134,000 for writing and 90,000 reserved for a repair, the 320,000 ceiling leaves room for **about three questions**.

| plan | projected | repair affordable? |
|---|---|---|
| 14 questions | 379,508 | no |
| 9 questions | 304,197 | no |
| 6 questions | 260,800 | no |
| 3 questions, fresh run | 179,400 | yes |

Both fully accounted runs were refused their repair — 260,586 and 370,114. **The repair path has never once been affordable since the accounting was fixed.**

So the note does not advise cutting to three questions, because three questions is not an article. It says what is actually wrong: the ceiling is too low for the pipeline as it now bills.

## The decision this surfaces is yours, and is not made here

`config.py` already carries this, written on 2026-09-01:

> "CAVEAT: both this number and `P2B_REPAIR_ESTIMATED_TOKENS` were derived from the Lima run's receipt, and that receipt omitted every grounded search and the whole of intake... Deliberately NOT retuned here: the right number comes from a real run measured with the accounting fixed. Re-derive both after the next article."

There have now been two such runs. Re-deriving is a decision about money, so the numbers are here rather than applied:

- To grant a repair on a **9-question** run: `P2B_RUN_TOKEN_BUDGET` ≈ **362,000**
- To grant one on a **14-question** run: ≈ **460,000**
- `P2B_REPAIR_ESTIMATED_TOKENS = 90,000` is still untested — no run has repaired since the accounting was fixed. Groundedness alone cost 44,457 on `b29d66b4`, so 90,000 is plausible and unproven.

Nothing in this PR changes either constant. The hard runaway ceiling is untouched.

## What this could break

- **A wrong projection is worse than none.** It is derived from two runs, states itself as a projection, and carries its provenance. If the model stack changes, the number moves — the Claude structure step alone was 200,788 tokens on `b29d66b4`.
- **It must not become a gate.** It is a number beside a decision the operator is already making. Nothing refuses a large plan.
- **A run with no accounting gets no projection** rather than one built on a zero, the same way `decide_repair` skips its budget check instead of reading an absent count as zero.

## Verification

`pytest apps/backend/tests` — 1258 tests, 0 failures (6 new).

Closes #485