### PR TITLE
Raise the Claude CLI timeout to 1200s (does not fix #494)

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
@@ -91,7 +91,21 @@ WRITER_PROVIDER_ENV = "WRITER_PROVIDER"
 # which is the default -- leaves the Gemini path untouched.
 PROVIDER_CLAUDE_CLI = "claude-cli"
 
-CALL_TIMEOUT_SECONDS = 600.0
+# Ten minutes was the edge of what the work takes, not a limit on a hang. The
+# research structure call generates the whole evidence package in one go --
+# 86,892 in and 32,060 out on run b29d66b4 -- and run 86cfad32 hit this limit
+# twice in a row on a smaller plan, eleven questions against fourteen, while a
+# trivial `claude --print` on the same machine answered in five seconds.
+#
+# So the timeout was killing work that was proceeding. It runs in a background
+# task, and the quota breaker and run budget both still bound the spend, so
+# waiting longer on a genuine hang costs less than cutting off a call that
+# would have finished.
+#
+# This does not make the structure call fast. Generating 32k tokens in one
+# request is the real shape of #494 and wants a leaner record or a split per
+# requirement, which is a redesign rather than a constant.
+CALL_TIMEOUT_SECONDS = 1200.0
 
 # Stable, and outside the repo so no CLAUDE.md, settings file, or skill is
 # discovered. Stable also because a moving working directory would defeat the

--- a/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/claude_connection/cli_writer.py
@@ -102,9 +102,13 @@ PROVIDER_CLAUDE_CLI = "claude-cli"
 # waiting longer on a genuine hang costs less than cutting off a call that
 # would have finished.
 #
-# This does not make the structure call fast. Generating 32k tokens in one
-# request is the real shape of #494 and wants a leaner record or a split per
-# requirement, which is a redesign rather than a constant.
+# This does NOT fix #494. The same call then failed at 1200s too, three times
+# in a row, while a structured call with a tiny schema returned in 3.1s on the
+# same machine. So the call at this size does not complete at all today,
+# whatever the limit is set to. Raising it is still right on its own terms --
+# a call measured at ten minutes should not have a ten minute limit -- but the
+# real shape is one request generating 32k tokens, and that wants a leaner
+# record or a split per requirement. A redesign, not a constant.
 CALL_TIMEOUT_SECONDS = 1200.0
 
 # Stable, and outside the repo so no CLAUDE.md, settings file, or skill is


### PR DESCRIPTION
Run `86cfad32` failed its research pass with `Claude did not answer within 600s`, on `structure_research` — the one call that turns gathered notes into the evidence package, and the call nothing downstream can run without.

## What this changes

`CALL_TIMEOUT_SECONDS` 600 → 1200.

Justified on its own terms: the structure call on run `b29d66b4` measured **86,892 tokens in and 32,060 out**, which is roughly a ten-minute generation. A ten-minute limit on ten minutes of work means whether a run survives is decided by latency on the night.

## Read the title: this does not fix #494

I raised it on two data points and it failed again at 1200s. Three consecutive failures.

| call | result |
|---|---|
| `claude --print "Reply with exactly: ok"` | 5s |
| structured call, tiny schema | **3.1s** |
| `structure_research`, 93KB notes, ~32k out | never returns at 600s **or** 1200s |

Structured output is not broken and the CLI is not down. This one call, at this size, does not complete today — though it did yesterday, on a *larger* plan. #494 stays open with the fuller evidence, and the real shape named there is one request generating 32k tokens, which wants a leaner evidence record or structuring per requirement rather than a bigger number.

## What this could break

- **A genuinely hung call now blocks for twenty minutes instead of ten.** It runs in a background task; the quota breaker and run budget still bound the spend.
- **It could read as a fix.** Hence the title, the issue comment, and the comment in the code.

Nothing was lost when this fired: `stage_v4_research_notes` is written before structuring, so each retry re-bought one call rather than eleven searches. That part of the design worked three times out of three.

Refs #494