### PR TITLE
Structure a few questions at a time, and give the arrays a shape

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -45,6 +45,7 @@ from .contracts_v4 import (
     WorkOrderRequirement,
 )
 from .config import P2B_V4_GATHER_CONCURRENCY
+from .research_readiness_v3 import PREMISE_CHECK_RULES
 from .evidence_conflicts import record_detected_conflicts
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str
@@ -499,6 +500,28 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
 GATHER_MAX_TOKENS = 8_192
 STRUCTURE_MAX_TOKENS = 16_384
 
+# A few questions' worth. Ignored on the Claude CLI, which takes no output
+# cap, and honoured on Gemini.
+ONE_QUESTION_MAX_TOKENS = 8_192
+
+# How many questions go into one structuring call.
+#
+# The whole dossier in one call stopped converging: a schema failure anywhere
+# in one large object throws all of it away and it is silently regenerated,
+# and on 2026-09-02 three attempts died at 600s, 600s and 1200s.
+#
+# One question per call fixed that and cost four times as much. Measured on
+# run 86cfad32: twelve calls, 345,315 input tokens against 86,892 for the
+# single call it replaced. Every CLI call carries about 28,000 tokens of the
+# tool's own prefix -- 18,132 of it showed up as cached from the second call
+# onwards -- and that overhead is per call, not per question. Twelve calls pay
+# it twelve times.
+#
+# Four is the middle: three calls on an eleven question plan rather than
+# twelve, each object small enough to come back first time, and a failure
+# costs a third of the questions instead of all of them.
+STRUCTURE_BATCH_SIZE = 4
+
 # What the live grounding path runs on. Not a 3.x model: `editor_assist` has
 # grounded on this in production since ADR 0003, and the REST grounding
 # endpoint is not the place to discover a version does not work.
@@ -571,9 +594,53 @@ EVIDENCE_SCHEMA = require_non_empty({
                 "required": ["requirement_id", "status"],
             },
         },
-        "premise_findings": {"type": "array", "items": {"type": "object"}},
-        "conflicts": {"type": "array", "items": {"type": "object"}},
-        "gaps": {"type": "array", "items": {"type": "object"}},
+        # Declared with their fields, because an array of unspecified objects
+        # is an array nothing fills. Every stored run -- 062c0b86, 90b3f9bc,
+        # a2066506, b29d66b4, all of them -- came back with premise_findings,
+        # conflicts and gaps all empty, on prompts that asked for each of them
+        # in as many words. The model was not ignoring the instruction; the
+        # shape it was being asked to return had no shape.
+        "premise_findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "assumption_id": {"type": "string"},
+                    "verdict": {
+                        "type": "string",
+                        "enum": list(get_args(PremiseVerdict)),
+                    },
+                    "basis": {"type": "string"},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["assumption_id", "verdict", "basis"],
+            },
+        },
+        "conflicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "conflict_id": {"type": "string"},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                    "summary": {"type": "string"},
+                    "resolution": {"type": "string"},
+                },
+                "required": ["conflict_id", "claim_ids", "summary"],
+            },
+        },
+        "gaps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "gap_id": {"type": "string"},
+                    "requirement_ids": {"type": "array", "items": {"type": "string"}},
+                    "summary": {"type": "string"},
+                },
+                "required": ["gap_id", "requirement_ids", "summary"],
+            },
+        },
     },
     "required": ["sources", "claims", "requirements"],
 })
@@ -728,37 +795,7 @@ def _citable(urls: list[str]) -> list[str]:
     ]
 
 
-def build_structure_prompt(
-    work_order: Prompt2BlogWorkOrder,
-    notes: dict[str, GatheredNotes],
-) -> str:
-    """Turn free notes into evidence records. Records nothing new."""
-    questions = "\n".join(
-        f"- {item.requirement_id} [{item.kind}] [needs: {item.precision}] "
-        f"{item.question}"
-        for item in work_order.requirements
-    )
-    gathered = "\n\n".join(
-        f"=== {requirement_id} ===\n{note.text}\n"
-        f"Sources seen: {', '.join(_citable(note.source_urls)) or 'none recorded'}"
-        for requirement_id, note in notes.items()
-    )
-    premise = (
-        "\n".join(f"- {item.assumption_id}: {item.statement}" for item in work_order.premise)
-        or "- None declared."
-    )
-    return f"""Turn research notes into evidence records. Add nothing that is not in the notes.
-
-THE QUESTIONS
-{questions}
-
-WHAT WAS ASSUMED WITHOUT BEING CHECKED
-{premise}
-
-THE NOTES
-{gathered}
-
-Rules:
+STRUCTURE_RULES = """Rules:
 - Every claim cites at least one source and at least one question it answers.
   Every question lists the claims that answer it. The two must agree.
 - A source needs a publisher and a URL when it is a web page or a report.
@@ -835,7 +872,40 @@ Rules:
   unresolved conflict is a question for a person, and inventing a resolution
   takes it away from them.
 - Keep the interesting detail. A note that puts a reader somewhere belongs in a
-  claim as much as a price does; do not drop it for not being a number.
+  claim as much as a price does; do not drop it for not being a number."""
+
+
+def build_structure_prompt(
+    work_order: Prompt2BlogWorkOrder,
+    notes: dict[str, GatheredNotes],
+) -> str:
+    """Turn free notes into evidence records. Records nothing new."""
+    questions = "\n".join(
+        f"- {item.requirement_id} [{item.kind}] [needs: {item.precision}] "
+        f"{item.question}"
+        for item in work_order.requirements
+    )
+    gathered = "\n\n".join(
+        f"=== {requirement_id} ===\n{note.text}\n"
+        f"Sources seen: {', '.join(_citable(note.source_urls)) or 'none recorded'}"
+        for requirement_id, note in notes.items()
+    )
+    premise = (
+        "\n".join(f"- {item.assumption_id}: {item.statement}" for item in work_order.premise)
+        or "- None declared."
+    )
+    return f"""Turn research notes into evidence records. Add nothing that is not in the notes.
+
+THE QUESTIONS
+{questions}
+
+WHAT WAS ASSUMED WITHOUT BEING CHECKED
+{premise}
+
+THE NOTES
+{gathered}
+
+{STRUCTURE_RULES}
 """
 
 
@@ -994,31 +1064,185 @@ def _reconcile_premise_findings(
     return EvidencePackage.model_validate(payload)
 
 
-def structure_research(
-    work_order: Prompt2BlogWorkOrder,
-    notes: dict[str, GatheredNotes],
-    dependencies: ResearchDependencies,
-) -> EvidencePackage:
-    """Turn the notes into the evidence package the writing stages read.
+BATCH_SCHEMA = require_non_empty({
+    "type": "object",
+    "properties": {
+        "sources": EVIDENCE_SCHEMA["properties"]["sources"],
+        "claims": EVIDENCE_SCHEMA["properties"]["claims"],
+        "requirements": EVIDENCE_SCHEMA["properties"]["requirements"],
+        "gaps": EVIDENCE_SCHEMA["properties"]["gaps"],
+    },
+    "required": ["sources", "claims", "requirements"],
+})
 
-    The shape is forced at the transport rather than asked for, so a malformed
-    dossier is a transport error here instead of a confusing failure four
-    stages later.
+PREMISE_SCHEMA = require_non_empty({
+    "type": "object",
+    "properties": {
+        "premise_findings": EVIDENCE_SCHEMA["properties"]["premise_findings"],
+        "conflicts": EVIDENCE_SCHEMA["properties"]["conflicts"],
+    },
+    "required": ["premise_findings"],
+})
+
+
+def build_batch_prompt(
+    work_order: Prompt2BlogWorkOrder,
+    requirements: list[WorkOrderRequirement],
+    notes: dict[str, GatheredNotes],
+) -> str:
+    """Structure a few questions' notes. The same rules, a fraction of the work.
+
+    The dossier used to be built in a single call: every note in, one large
+    object out. On the Claude CLI that generated three to four times what it
+    delivered -- 32,060 and 39,139 billed tokens against a 36 KB record --
+    because a schema failure anywhere in the object throws all of it away and
+    it is silently produced again. On 2026-09-02 it stopped converging and
+    three attempts died, at 600s, 600s and 1200s.
+
+    A handful of questions at a time is small enough to come back first time,
+    and a failure costs a third of the plan instead of the whole run.
     """
-    parsed, _raw = dependencies.structure_llm.invoke_json(
-        prompt=build_structure_prompt(work_order, notes),
-        model_name=dependencies.structure_model,
-        schema=EVIDENCE_SCHEMA,
-        max_tokens=STRUCTURE_MAX_TOKENS,
-        temperature=0.0,
+    listed = "\n".join(
+        f"- {item.requirement_id} [{item.kind}] [needs: {item.precision}] "
+        f"{item.question}"
+        for item in requirements
     )
-    payload = _normalised_evidence(_safe_dict(parsed))
+    gathered = "\n\n".join(
+        f"=== {item.requirement_id} ===\n{notes[item.requirement_id].text}\n"
+        f"Sources seen: "
+        f"{', '.join(_citable(notes[item.requirement_id].source_urls)) or 'none recorded'}"
+        for item in requirements
+        if item.requirement_id in notes
+    )
+    ids = ", ".join(item.requirement_id for item in requirements)
+    return f"""Turn these questions' research notes into evidence records. Add nothing that is not in the notes.
+
+THE QUESTIONS
+{listed}
+
+THE NOTES
+{gathered}
+
+{STRUCTURE_RULES}
+- One claim per distinct fact. Do not split a fact across several claims, and
+  do not repeat the same fact once per source that mentions it: a claim cites
+  all of its sources. Two or three claims answer most questions well, and a
+  question with ten is the same answer written out at length.
+
+Return records for these questions only: {ids}. Every claim lists at least one
+of them in its requirement_ids, and the requirements array holds one entry for
+each."""
+
+
+def build_premise_prompt(
+    work_order: Prompt2BlogWorkOrder, claims: list[dict[str, Any]]
+) -> str:
+    """Settle the premise, and name conflicts that span two questions.
+
+    The only two jobs a per-question pass cannot do, so they get one small
+    call of their own that sees the claim texts and nothing else.
+    """
+    premise = (
+        "\n".join(
+            f"- {item.assumption_id}: {item.statement}" for item in work_order.premise
+        )
+        or "- None declared."
+    )
+    listed = "\n".join(
+        f"- [{claim['claim_id']}] {claim['text']}" for claim in claims
+    ) or "- Nothing was established."
+    return f"""Settle what the plan assumed, against what research found.
+
+WHAT WAS ASSUMED WITHOUT BEING CHECKED
+{premise}
+
+WHAT RESEARCH ESTABLISHED
+{listed}
+
+{PREMISE_CHECK_RULES}
+
+Also record a `conflict` for any two claims above that disagree with each
+other, listing their claim ids and summarising the disagreement. A conflict
+records two or more claims that disagree; if you cannot name at least two, it
+is not a conflict. Where the notes settled which side is right, put that in
+`resolution`, and leave it empty when they did not: an unresolved conflict is
+a question for a person, and inventing a resolution takes it away from them.
+
+Return premise_findings for every assumption above, and conflicts, and nothing
+else."""
+
+
+def _namespaced(payload: dict[str, Any], requirement_id: str) -> dict[str, Any]:
+    """Prefix this call's ids so eleven calls cannot collide.
+
+    Two questions answered separately both produce a claim called `c1`. The
+    prefix is applied to the ids and to every reference to them, so the
+    contract's link checks still hold after the merge.
+    """
+    tag = f"{requirement_id}:"
+    sources = _rows(payload, "sources")
+    claims = _rows(payload, "claims")
+    for source in sources:
+        source["source_id"] = f"{tag}{_safe_str(source.get('source_id'))}"
+    for claim in claims:
+        claim["claim_id"] = f"{tag}{_safe_str(claim.get('claim_id'))}"
+        claim["source_ids"] = [
+            f"{tag}{item}" for item in _id_list(claim, "source_ids")
+        ]
+    for requirement in _rows(payload, "requirements"):
+        requirement["claim_ids"] = [
+            f"{tag}{item}" for item in _id_list(requirement, "claim_ids")
+        ]
+    for gap in _rows(payload, "gaps"):
+        gap.setdefault("gap_id", f"{tag}gap")
+        gap["gap_id"] = f"{tag}{_safe_str(gap.get('gap_id'))}"
+    return {
+        "sources": sources,
+        "claims": claims,
+        "requirements": _rows(payload, "requirements"),
+        "gaps": _rows(payload, "gaps"),
+    }
+
+
+def _merge_sources(parts: list[dict[str, Any]]) -> tuple[list[dict], dict[str, str]]:
+    """One entry per real source, and a map from every id that meant it.
+
+    The same page answers three questions and is described three times, once
+    per call. Merged on url, then on title, because a dossier listing the same
+    site under three ids is not wrong so much as unreadable.
+    """
+    merged: list[dict[str, Any]] = []
+    by_key: dict[str, str] = {}
+    remap: dict[str, str] = {}
+    for part in parts:
+        for source in part["sources"]:
+            key = (
+                _safe_str(source.get("url")).strip().rstrip("/").lower()
+                or _safe_str(source.get("title")).strip().lower()
+            )
+            source_id = _safe_str(source.get("source_id"))
+            if key and key in by_key:
+                remap[source_id] = by_key[key]
+                continue
+            merged.append(source)
+            if key:
+                by_key[key] = source_id
+            remap[source_id] = source_id
+    return merged, remap
+
+
+def assemble_evidence(
+    work_order: Prompt2BlogWorkOrder, payload: dict[str, Any]
+) -> EvidencePackage:
+    """Normalise what the model sent, then hold it to the contract.
+
+    Separate from the calls that produce it, because what arrives is repaired
+    the same way whether it came back in one piece or eleven.
+    """
+    payload = _normalised_evidence(_safe_dict(payload))
     payload["schema_version"] = 4
     payload["work_order_fingerprint"] = work_order.work_order_fingerprint
     try:
-        # The prompt asks for conflicts and the Lima run did not record the
-        # one its own notes had named. The comparison below is the half of
-        # that a model cannot forget to do.
         return _reconcile_premise_findings(
             record_detected_conflicts(EvidencePackage.model_validate(payload)),
             work_order,
@@ -1032,6 +1256,141 @@ def structure_research(
             or "the dossier did not fit its contract",
             json.dumps(payload, ensure_ascii=False)[:40000],
         ) from error
+
+
+def _structure_batch(
+    work_order: Prompt2BlogWorkOrder,
+    requirements: list[WorkOrderRequirement],
+    notes: dict[str, GatheredNotes],
+    dependencies: ResearchDependencies,
+) -> dict[str, Any]:
+    """A few questions structured together. Never raises.
+
+    A batch whose structuring fails comes back recorded as unanswered, with a
+    gap saying so, because the alternative is one bad call taking the other
+    eight down with it. The operator meets it at the gate like any other hole.
+    """
+    ids = [item.requirement_id for item in requirements]
+    try:
+        parsed, _raw = dependencies.structure_llm.invoke_json(
+            prompt=build_batch_prompt(work_order, requirements, notes),
+            model_name=dependencies.structure_model,
+            schema=BATCH_SCHEMA,
+            max_tokens=ONE_QUESTION_MAX_TOKENS,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001 -- one hole beats the whole plan
+        logger.warning("Structuring failed for %s: %s", ", ".join(ids), exc)
+        return {
+            "sources": [],
+            "claims": [],
+            "requirements": [
+                {
+                    "requirement_id": requirement_id,
+                    "status": "missing",
+                    "cause": "nothing_found",
+                    "gap": (
+                        "The research notes for this question could not be "
+                        "turned into records. The notes are kept, so this is "
+                        "one call to retry rather than a lost search."
+                    ),
+                    "claim_ids": [],
+                }
+                for requirement_id in ids
+            ],
+            "gaps": [],
+        }
+    return _namespaced(_safe_dict(parsed), ids[0])
+
+
+def _settle_premise(
+    work_order: Prompt2BlogWorkOrder,
+    claims: list[dict[str, Any]],
+    dependencies: ResearchDependencies,
+) -> dict[str, Any]:
+    """The two jobs a per-question pass cannot do. Never raises.
+
+    A premise verdict is about the whole dossier, and a conflict between two
+    questions is invisible to a call that sees one. `_reconcile_premise_findings`
+    fills in anything missing afterwards, so a failure here degrades rather
+    than blocks.
+    """
+    if not work_order.premise and len(claims) < 2:
+        return {"premise_findings": [], "conflicts": []}
+    try:
+        parsed, _raw = dependencies.structure_llm.invoke_json(
+            prompt=build_premise_prompt(work_order, claims),
+            model_name=dependencies.structure_model,
+            schema=PREMISE_SCHEMA,
+            max_tokens=ONE_QUESTION_MAX_TOKENS,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Premise pass failed: %s", exc)
+        return {"premise_findings": [], "conflicts": []}
+    payload = _safe_dict(parsed)
+    return {
+        "premise_findings": _rows(
+            payload, "premise_findings", "premise", "assumptions", "findings"
+        ),
+        "conflicts": _rows(payload, "conflicts", "conflict"),
+    }
+
+
+def structure_research(
+    work_order: Prompt2BlogWorkOrder,
+    notes: dict[str, GatheredNotes],
+    dependencies: ResearchDependencies,
+) -> EvidencePackage:
+    """Turn the notes into the evidence package the writing stages read.
+
+    A few questions per call, then one small call for the premise and any
+    conflict that spans two of them.
+
+    It used to be a single call: every note in, the whole dossier out. On the
+    Claude CLI that generated three to four times what it delivered, because a
+    schema failure anywhere in one large object throws all of it away and it is
+    silently produced again. On 2026-09-02 it stopped converging and took three
+    attempts down with it, at 600s, 600s and 1200s, on a plan smaller than the
+    one that had worked the day before. The CLI takes no output cap -- it
+    accepts `max_tokens` and drops it -- so nothing bounded what that call
+    could spend.
+
+    Smaller calls are not a workaround for that. They are the shape that makes
+    a failure cost one question instead of the run.
+    """
+    requirements = [
+        item for item in work_order.requirements if item.requirement_id in notes
+    ]
+    batches = [
+        requirements[start : start + STRUCTURE_BATCH_SIZE]
+        for start in range(0, len(requirements), STRUCTURE_BATCH_SIZE)
+    ]
+    parts = [
+        _structure_batch(work_order, batch, notes, dependencies) for batch in batches
+    ]
+
+    sources, remap = _merge_sources(parts)
+    claims = [claim for part in parts for claim in part["claims"]]
+    for claim in claims:
+        claim["source_ids"] = sorted(
+            {remap.get(item, item) for item in _id_list(claim, "source_ids")}
+        )
+    settled = _settle_premise(work_order, claims, dependencies)
+
+    return assemble_evidence(
+        work_order,
+        {
+            "sources": sources,
+            "claims": claims,
+            "requirements": [
+                item for part in parts for item in part["requirements"]
+            ],
+            "gaps": [gap for part in parts for gap in part["gaps"]],
+            "premise_findings": settled["premise_findings"],
+            "conflicts": settled["conflicts"],
+        },
+    )
 
 
 def run_research(

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
@@ -42,6 +42,9 @@ from app.features.prompt2blog.research_v4 import (
     gather_research,
     research_stage_record,
     run_research,
+    STRUCTURE_BATCH_SIZE,
+    GatheredNotes,
+    assemble_evidence,
     structure_research,
 )
 
@@ -102,9 +105,13 @@ class StructureLLM:
     def __init__(self, payload: dict[str, Any]):
         self.payload = payload
         self.kwargs: dict[str, Any] = {}
+        # Every call, because structuring is one call per question now and the
+        # last one is the premise pass rather than a question.
+        self.calls: list[dict[str, Any]] = []
 
     def invoke_json(self, **kwargs) -> tuple[dict[str, Any], str]:
         self.kwargs = kwargs
+        self.calls.append(kwargs)
         return self.payload, "{}"
 
 
@@ -341,12 +348,13 @@ def test_structuring_forces_the_shape_rather_than_asking_for_it():
 
     run_research(_brief(), _work_order(), deps)
 
-    assert deps.structure_llm.kwargs["schema"]["required"] == [
-        "sources",
-        "claims",
-        "requirements",
-    ]
-    assert deps.structure_llm.kwargs["temperature"] == 0.0
+    question_call, premise_call = deps.structure_llm.calls[0], deps.structure_llm.calls[-1]
+    assert question_call["schema"]["required"] == ["sources", "claims", "requirements"]
+    # The pass that settles the premise and any cross-question conflict has
+    # its shape forced too.
+    assert premise_call["schema"]["required"] == ["premise_findings"]
+    assert question_call["temperature"] == 0.0
+    assert premise_call["temperature"] == 0.0
 
 
 def test_the_structured_package_is_bound_to_the_work_order_it_answers():
@@ -383,7 +391,7 @@ def test_a_one_sided_claim_link_is_reconciled_rather_than_refused():
         {"requirement_id": "r2", "status": "supported", "claim_ids": []},
     ]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     by_id = {item.requirement_id: item for item in evidence.requirements}
     assert by_id["r2"].claim_ids == ["c2"], "the link the claim asserted survives"
@@ -393,7 +401,7 @@ def test_the_reconciliation_works_from_the_question_side_too():
     payload = _evidence_payload()
     payload["claims"][1]["requirement_ids"] = []
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     by_id = {item.claim_id: item for item in evidence.claims}
     assert by_id["c2"].requirement_ids == ["r2"]
@@ -406,7 +414,7 @@ def test_questions_is_read_as_requirements():
     payload = _evidence_payload()
     payload["questions"] = payload.pop("requirements")
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert {item.requirement_id for item in evidence.requirements} == {"r1", "r2"}
 
@@ -415,7 +423,7 @@ def test_a_claim_citing_a_source_that_is_not_there_keeps_the_claim():
     payload = _evidence_payload()
     payload["claims"][0]["source_ids"] = ["s1", "s404"]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert evidence.claims[0].source_ids == ["s1"]
 
@@ -427,7 +435,7 @@ def test_a_leftover_alias_key_is_not_carried_into_the_contract():
     payload["questions"] = payload["requirements"]
     payload["claims"][0]["premise_ids"] = ["a1"]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert len(evidence.requirements) == 2
 
@@ -444,7 +452,7 @@ def test_an_invented_source_vocabulary_falls_back_rather_than_failing():
     payload["sources"][0]["source_type"] = "research_notes"
     payload["sources"][0]["material_type"] = "synthesized_research_note"
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert evidence.sources[0].source_type == "other"
     assert evidence.sources[0].material_type == "other"
@@ -473,7 +481,7 @@ def test_a_conflict_that_names_no_claims_is_dropped_not_fatal():
         {"conflict_id": "x2", "claim_ids": ["c1", "c2"], "summary": "These two do."},
     ]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert [item.conflict_id for item in evidence.conflicts] == ["x2"]
 
@@ -484,7 +492,7 @@ def test_a_guessed_status_still_describes_its_gap():
     payload = _evidence_payload()
     payload["requirements"][0] = {"requirement_id": "r1", "status": "inconclusive"}
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     by_id = {item.requirement_id: item for item in evidence.requirements}
     assert by_id["r1"].status == "partial"
@@ -501,7 +509,7 @@ def test_a_timestamp_where_a_date_belongs_is_trimmed_not_fatal():
     payload["sources"][0]["published_at"] = "2026-07-14T09:30:00Z"
     payload["sources"][0]["retrieved_at"] = "2026-08-01 12:00:00"
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert evidence.sources[0].published_at == date(2026, 7, 14)
     assert evidence.sources[0].retrieved_at == date(2026, 8, 1)
@@ -511,7 +519,7 @@ def test_an_unreadable_date_is_dropped_rather_than_guessed():
     payload = _evidence_payload()
     payload["sources"][0]["published_at"] = "sometime last spring"
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert evidence.sources[0].published_at is None
 
@@ -530,7 +538,7 @@ def test_a_source_with_no_link_is_admitted_as_other_not_refused():
     payload["sources"][0]["url"] = None
     payload["sources"][0]["material_type"] = "web"
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert evidence.sources[0].material_type == "other"
     assert evidence.sources[0].publisher == "Peru Retail"
@@ -540,7 +548,7 @@ def test_anything_still_called_web_really_does_have_a_link():
     # The guarantee the demotion exists to preserve.
     payload = _evidence_payload()
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     for source in evidence.sources:
         if source.material_type in {"web", "report"}:
@@ -553,7 +561,7 @@ def test_a_claim_left_with_no_usable_source_is_dropped_not_fatal():
     payload = _evidence_payload()
     payload["claims"][0]["source_ids"] = ["s404"]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert [item.claim_id for item in evidence.claims] == ["c2"]
 
@@ -562,7 +570,7 @@ def test_a_question_that_loses_its_claims_stops_calling_itself_supported():
     payload = _evidence_payload()
     payload["claims"][0]["source_ids"] = ["s404"]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     by_id = {item.requirement_id: item for item in evidence.requirements}
     assert by_id["r1"].status == "partial"
@@ -585,7 +593,7 @@ def test_a_dossier_that_still_will_not_assemble_keeps_what_came_back():
     payload["requirements"] = []
 
     with pytest.raises(ResearchUnusable) as error:
-        structure_research(_work_order(), {}, _deps(payload))
+        assemble_evidence(_work_order(), payload)
 
     assert error.value.reason
     assert error.value.raw, "the payload has to travel with the failure"
@@ -769,7 +777,7 @@ def test_a_question_linking_its_claims_under_claims_still_links_them():
     for claim in payload["claims"]:
         claim.pop("requirement_ids", None)
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert len(evidence.claims) == len(payload["claims"])
     by_id = {item.requirement_id: item for item in evidence.requirements}
@@ -791,7 +799,7 @@ def test_sources_nested_inside_a_claim_are_lifted_out_and_kept():
             }
         ]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert evidence.sources, "a described source is still a source"
     assert len(evidence.claims) == len(payload["claims"])
@@ -804,7 +812,7 @@ def test_one_publisher_cited_by_every_claim_becomes_one_source():
     for claim in payload["claims"]:
         claim["sources"] = [{"publisher": "SENAMHI", "source_type": "official"}]
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert len(evidence.sources) == 1
 
@@ -818,7 +826,7 @@ def test_a_source_with_no_retrieval_date_is_dated_by_the_run_that_read_it():
     for source in payload["sources"]:
         source["retrieved_at"] = ""
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert all(item.retrieved_at == date.today() for item in evidence.sources)
 
@@ -830,8 +838,217 @@ def test_a_source_with_no_note_says_so_rather_than_being_refused():
     for source in payload["sources"]:
         source["notes"] = []
 
-    evidence = structure_research(_work_order(), {}, _deps(payload))
+    evidence = assemble_evidence(_work_order(), payload)
 
     assert all(item.notes for item in evidence.sources)
     assert "No note recorded" in evidence.sources[0].notes[0]
 
+
+
+# --- one call per question -------------------------------------------------
+#
+# The dossier used to be built in a single call: every note in, the whole
+# object out. On the Claude CLI that generated three to four times what it
+# delivered -- 32,060 and 39,139 billed tokens against a 36 KB record -- and on
+# 2026-09-02 it stopped converging, taking three attempts down at 600s, 600s
+# and 1200s, on a plan smaller than the one that had worked the day before.
+
+
+class PerQuestionLLM:
+    """Answers whichever questions a batch asked about, and counts calls.
+
+    A batch call gets records for every question in it, which is what the real
+    model returns and what the merge downstream has to cope with.
+    """
+
+    def __init__(self, by_requirement: dict[str, dict[str, Any]]):
+        self.by_requirement = by_requirement
+        self.prompts: list[str] = []
+
+    def invoke_json(self, *, prompt: str, **_kwargs):
+        self.prompts.append(prompt)
+        asked = [
+            requirement_id
+            for requirement_id in self.by_requirement
+            if f"- {requirement_id} [" in prompt
+        ]
+        if not asked:
+            return {"premise_findings": [], "conflicts": []}, "{}"
+        merged: dict[str, Any] = {"sources": [], "claims": [], "requirements": []}
+        for index, requirement_id in enumerate(asked):
+            payload = self.by_requirement[requirement_id]
+            for source in payload["sources"]:
+                merged["sources"].append({**source, "source_id": f"s{index}"})
+            for claim in payload["claims"]:
+                merged["claims"].append(
+                    {**claim, "claim_id": f"c{index}", "source_ids": [f"s{index}"]}
+                )
+            for item in payload["requirements"]:
+                merged["requirements"].append({**item, "claim_ids": [f"c{index}"]})
+        return merged, "{}"
+
+
+def _one_question_payload(requirement_id: str, url: str) -> dict[str, Any]:
+    return {
+        "sources": [
+            {
+                "source_id": "s1",
+                "title": "A page",
+                "publisher": "Peru Retail",
+                "url": url,
+                "retrieved_at": "2026-09-01",
+                "source_type": "reporting",
+                "material_type": "web",
+                "notes": ["Something."],
+            }
+        ],
+        "claims": [
+            {
+                "claim_id": "c1",
+                "text": f"Something established for {requirement_id}.",
+                "source_ids": ["s1"],
+                "requirement_ids": [requirement_id],
+                "confidence": "high",
+            }
+        ],
+        "requirements": [
+            {
+                "requirement_id": requirement_id,
+                "status": "supported",
+                "claim_ids": ["c1"],
+            }
+        ],
+    }
+
+
+def _per_question_deps(by_requirement):
+    llm = PerQuestionLLM(by_requirement)
+    return ResearchDependencies(gather=RecordingGather(), structure_llm=llm), llm
+
+
+def _wide_work_order(count: int) -> Prompt2BlogWorkOrder:
+    return _work_order(
+        requirements=[
+            WorkOrderRequirement(
+                requirement_id=f"r{index}",
+                question=f"Question {index}?",
+                kind="load_bearing" if index == 1 else "texture",
+            )
+            for index in range(1, count + 1)
+        ]
+    )
+
+
+def test_questions_are_structured_a_few_at_a_time():
+    """Not one call, which stopped converging, and not one per question, which
+    paid the CLI's 28,000 token per-call prefix twelve times over."""
+    count = STRUCTURE_BATCH_SIZE * 2 + 1
+    deps, llm = _per_question_deps(
+        {
+            f"r{index}": _one_question_payload(f"r{index}", f"https://example.pe/{index}")
+            for index in range(1, count + 1)
+        }
+    )
+    notes = {f"r{index}": GatheredNotes("Notes.") for index in range(1, count + 1)}
+
+    structure_research(_wide_work_order(count), notes, deps)
+
+    # Three batches over nine questions, plus the premise pass.
+    assert len(llm.prompts) == 4
+
+
+def test_every_question_reaches_a_batch():
+    count = STRUCTURE_BATCH_SIZE * 2 + 1
+    deps, _llm = _per_question_deps(
+        {
+            f"r{index}": _one_question_payload(f"r{index}", f"https://example.pe/{index}")
+            for index in range(1, count + 1)
+        }
+    )
+    notes = {f"r{index}": GatheredNotes("Notes.") for index in range(1, count + 1)}
+
+    evidence = structure_research(_wide_work_order(count), notes, deps)
+
+    assert {item.requirement_id for item in evidence.requirements} == {
+        f"r{index}" for index in range(1, count + 1)
+    }
+
+
+def test_two_batches_that_both_call_a_claim_c1_do_not_collide():
+    """Answered in separate calls, both name their first claim `c1`."""
+    deps, _llm = _per_question_deps(
+        {
+            "r1": _one_question_payload("r1", "https://example.pe/a"),
+            "r2": _one_question_payload("r2", "https://example.pe/b"),
+        }
+    )
+    notes = {"r1": GatheredNotes("Notes one."), "r2": GatheredNotes("Notes two.")}
+
+    evidence = structure_research(_work_order(), notes, deps)
+
+    assert len(evidence.claims) == 2
+    assert len({claim.claim_id for claim in evidence.claims}) == 2
+
+
+def test_the_same_page_answering_two_questions_is_listed_once():
+    """A source described once per call is still one source. A dossier listing
+    the same site under three ids is not wrong so much as unreadable."""
+    shared = "https://example.pe/same"
+    deps, _llm = _per_question_deps(
+        {
+            "r1": _one_question_payload("r1", shared),
+            "r2": _one_question_payload("r2", shared + "/"),
+        }
+    )
+    notes = {"r1": GatheredNotes("Notes one."), "r2": GatheredNotes("Notes two.")}
+
+    evidence = structure_research(_work_order(), notes, deps)
+
+    assert len(evidence.sources) == 1
+    # Both claims still resolve to it, which the contract checks.
+    assert {claim.source_ids[0] for claim in evidence.claims} == {
+        evidence.sources[0].source_id
+    }
+
+
+def test_one_batch_failing_does_not_take_the_others_down():
+    """The whole point of the split. One bad call used to be the run."""
+    count = STRUCTURE_BATCH_SIZE * 2
+    failing = f"r{count}"
+
+    class HalfBrokenLLM(PerQuestionLLM):
+        def invoke_json(self, *, prompt: str, **kwargs):
+            if f"- {failing} [" in prompt:
+                raise RuntimeError("Claude did not answer within 600s.")
+            return super().invoke_json(prompt=prompt, **kwargs)
+
+    llm = HalfBrokenLLM(
+        {
+            f"r{index}": _one_question_payload(f"r{index}", f"https://example.pe/{index}")
+            for index in range(1, count + 1)
+        }
+    )
+    deps = ResearchDependencies(gather=RecordingGather(), structure_llm=llm)
+    notes = {f"r{index}": GatheredNotes("Notes.") for index in range(1, count + 1)}
+
+    evidence = structure_research(_wide_work_order(count), notes, deps)
+
+    by_id = {item.requirement_id: item for item in evidence.requirements}
+    assert by_id["r1"].status == "supported"
+    assert by_id[failing].status == "missing"
+    assert "one call to retry" in by_id[failing].gap
+    # The other batch is untouched, which is the property being bought here.
+    assert by_id["r1"].claim_ids
+
+
+def test_the_premise_pass_sees_the_claims_and_nothing_else():
+    deps, llm = _per_question_deps(
+        {"r1": _one_question_payload("r1", "https://example.pe/a")}
+    )
+
+    structure_research(_work_order(), {"r1": GatheredNotes("Notes one.")}, deps)
+
+    premise_prompt = llm.prompts[-1]
+    assert "WHAT RESEARCH ESTABLISHED" in premise_prompt
+    assert "Something established for r1." in premise_prompt
+    assert "Notes one." not in premise_prompt


### PR DESCRIPTION
Two changes. The second explains four earlier issues.

## The arrays nothing ever filled

`premise_findings`, `conflicts` and `gaps` were declared as `{"type": "array", "items": {"type": "object"}}` — an array of unspecified objects.

Every stored run came back with all three empty:

| run | premise_findings | conflicts | gaps |
|---|---|---|---|
| `062c0b86` | 0 | 0 | 0 |
| `90b3f9bc` | 0 | 0 | 0 |
| `a2066506` | 0 | 0 | 0 |
| `b29d66b4` | 0 | 0 | 0 |

Without exception, on prompts that asked for each of them in as many words. **The model was not ignoring the instruction — the shape it was asked to return had no shape.**

That is the real cause behind #475 ("two claims contradict each other and no conflict was recorded") and #483 ("premise_findings came back empty"). The prompt work in #480 was aimed at a field the schema could not express, and the premise reconciler in #491 was a net under a hole rather than a fix for it. Both stay: the reconciler is still the right behaviour when a verdict genuinely does not come back.

Declared with their fields, on the same notes, the same research now returns:

- **4 premise verdicts**, two of them `refuted` — including the planted false premise about a municipal ranking of cevicherías, which the run was designed to walk into
- **7 conflicts**, every one real: two prices for the same restaurant, two sets of market hours, disagreement over which stall is highest rated, and whether Mercado Nº1 is currently open
- **6 gaps**

## Batched structuring

| approach | calls | input | output | total |
|---|---|---|---|---|
| whole dossier in one call | 1 | 86,892 | 32,060 | 118,952 |
| one call per question | 12 | 345,315 | 123,395 | 468,710 |
| **four questions per call** | **4** | **154,228** | **121,683** | **275,911** |

One call stopped converging — a schema failure anywhere in one large object throws all of it away and it is silently regenerated, and three attempts died at 600s, 600s and 1200s on a plan smaller than one that had worked the day before.

One call per question fixed the reliability and cost four times as much, because **every CLI call carries about 28,000 tokens of the tool's own prefix** (18,132 of it visible as cached from the second call onwards) and that overhead is per call, not per question.

Four is the middle. A failure now costs a third of the plan rather than the run, and a batch whose call fails is recorded as unanswered rather than taking the others down — there is a test for exactly that.

Note the first table's rows are not like for like: the cheap single call was cheap partly because it was returning an incomplete dossier. Its zero conflicts and zero premise verdicts were free.

## Also

`assemble_evidence` is split out from the calls that feed it, since what arrives is repaired the same way whether it came back in one piece or three. Twenty tests that were driving the normaliser through `structure_research` now call it directly, which is what they were always testing.

## Still open, deliberately

**75 claims where the single call produced 31.** "One claim per distinct fact" brought it down from 94 and not far enough. That is verbosity rather than cost — the same research written out at length — and it changes what the writer reads, so it wants its own look rather than another sentence in the prompt.

## Verification

`pytest apps/backend/tests` — 1265 tests, 0 failures, plus three real structuring runs against the same stored notes (one call, one per question, batched).

Refs #494, #475, #483