### PR TITLE
Listicle pipeline: interview, searches, place profiles and the gate

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/api/router.py
+++ b/apps/ai-blog-writer/apps/backend/app/api/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 from app.features.images import router as images_router
 from app.features.retired import router as retired_router
 from app.features.article_types import router as article_types_router
+from app.features.listicle_pipeline import router as listicle_pipeline_router
 from app.features.prompt2blog import router as prompt2blog_router
 from app.features.editor_assist import router as editor_assist_router
 from app.features.itineraries_pipeline import router as itineraries_pipeline_router
@@ -25,6 +26,7 @@ async def health_check():
 router.include_router(images_router)
 router.include_router(article_types_router)
 router.include_router(prompt2blog_router)
+router.include_router(listicle_pipeline_router)
 router.include_router(editor_assist_router)
 router.include_router(itineraries_pipeline_router)
 router.include_router(staged_drafts_router)

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/__init__.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/__init__.py
@@ -1,0 +1,3 @@
+from .api import router
+
+__all__ = ["router"]

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
@@ -1,0 +1,213 @@
+"""HTTP for the listicle interview.
+
+Handlers are `def`, not `async def`, for the same reason prompt2blog's are:
+every one of them blocks on a model call or a web search, and running that on
+the event loop freezes the whole server for the length of it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.core.staff_auth import require_staff
+
+from ..prompt2blog.contracts_v4 import GrillState
+from ..prompt2blog.dependencies import DefaultPrompt2BlogLLM
+from ..prompt2blog.grill_v4 import GrillDependencies, GrillUnusableResponse
+from . import service
+from .shapes import SHAPES
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/listicle-pipeline", tags=["listicle-pipeline"])
+
+
+class StartRequest(BaseModel):
+    seed: str = Field(min_length=1, max_length=400)
+
+
+class AnswerRequest(BaseModel):
+    run_id: str = Field(min_length=1)
+    answer: str = Field(min_length=1, max_length=4000)
+
+
+def _search_call(prompt: str) -> tuple[str, list[str], int | None]:
+    """The web, asked exactly what the search runner wrote.
+
+    Deliberately NOT the grill's `research`: that one wraps whatever it is
+    given in "brief a travel editor on this in a few dense paragraphs", which
+    is right for a lookup and ruinous for a search -- it would ask for prose
+    about the angle instead of the list of places the angle exists to find.
+
+    Longer timeout and a bigger output than a lookup, because this reply is a
+    dozen named places with evidence for each. The default 60 seconds cut one
+    of seven searches off the first real run.
+    """
+    from utils import invoke_google_grounded_text
+
+    from .search import SEARCH_MAX_TOKENS, SEARCH_MODEL, SEARCH_TIMEOUT_SECONDS
+
+    result = invoke_google_grounded_text(
+        prompt,
+        model_name=SEARCH_MODEL,
+        max_tokens=SEARCH_MAX_TOKENS,
+        timeout_seconds=SEARCH_TIMEOUT_SECONDS,
+    )
+    if result is None:
+        # A helper that returns None swallowed its own failure. Raised here so
+        # the runner's retry can see it; a silent empty string would be
+        # recorded as "nothing published for this angle", which is a different
+        # and much more misleading finding.
+        raise RuntimeError("The grounded search returned nothing.")
+    return result.text, list(result.source_urls), result.total_tokens
+
+
+def _base_dependencies() -> GrillDependencies:
+    """The live model and the one path in this app that reaches the web."""
+    from ..prompt2blog.api.intake import _grounded_call
+    from ..prompt2blog.grill_v4 import GRILL_RESEARCH_MAX_TOKENS, GRILL_RESEARCH_MODEL
+
+    def research(prompt: str) -> tuple[str, list[str], int | None]:
+        return _grounded_call(
+            "Brief a travel editor on this in a few dense paragraphs. How many "
+            "places of this kind the city plausibly has, which neighbourhoods "
+            "matter, and what it is known for.\n\n" + prompt,
+            model_name=GRILL_RESEARCH_MODEL,
+            max_tokens=GRILL_RESEARCH_MAX_TOKENS,
+            usage_recorder=None,
+        )
+
+    return GrillDependencies(
+        llm=DefaultPrompt2BlogLLM(),
+        research=research,
+        model_name=service.LISTICLE_GRILL_MODEL,
+    )
+
+
+def _view(state: GrillState) -> dict[str, Any]:
+    """What the screen needs, and nothing it does not.
+
+    The research digest is deliberately not sent: it is thousands of words the
+    operator never reads, and the screen renders a conversation.
+    """
+    return {
+        "run_id": state.run_id,
+        "seed": state.seed,
+        "status": state.status,
+        "consensus": state.consensus,
+        "markers_covered": list(state.markers_covered),
+        "markers_missing": [
+            key for key in state.marker_keys if key not in state.markers_covered
+        ],
+        "lookups": list(state.lookups),
+        "turns": [
+            {
+                "question_id": t.question.question_id,
+                "ask": t.question.ask,
+                "pushback": t.question.pushback,
+                "answer": t.answer,
+                "accepted_as_drafted": t.accepted_as_drafted,
+            }
+            for t in state.turns
+        ],
+        "pending": None
+        if state.pending is None
+        else {
+            "question_id": state.pending.question_id,
+            "ask": state.pending.ask,
+            "recommendation": state.pending.recommendation,
+            "pushback": state.pending.pushback,
+            # Non-empty only for a question answered by choosing. The screen
+            # switches to a tick list when this arrives and back to a text box
+            # when it does not, so this single field is what decides the input
+            # control.
+            "options": [
+                {"text": o.text, "recommended": o.recommended, "group": o.group}
+                for o in state.pending.options
+            ],
+        },
+    }
+
+
+def _handle(action, *args):
+    try:
+        return _view(action(*args))
+    except LookupError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except GrillUnusableResponse as error:
+        logger.warning("Listicle grill returned nothing usable: %s", error.raw[:400])
+        raise HTTPException(
+            status_code=502,
+            detail="The interview could not decide what to ask next. Try again.",
+        ) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.post("/grill/start")
+def start_listicle_grill(req: StartRequest, _staff=Depends(require_staff)):
+    return _handle(service.start, req.seed, _base_dependencies())
+
+
+@router.post("/grill/answer")
+def answer_listicle_grill(req: AnswerRequest, _staff=Depends(require_staff)):
+    return _handle(service.answer, req.run_id, req.answer, _base_dependencies())
+
+
+@router.post("/grill/reopen")
+def reopen_listicle_grill(run_id: str, _staff=Depends(require_staff)):
+    return _handle(service.reopen, run_id, _base_dependencies())
+
+
+@router.get("/grill/{run_id}")
+def get_listicle_grill(run_id: str, _staff=Depends(require_staff)):
+    state = service.get(run_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="No such interview")
+    return _view(state)
+
+
+@router.post("/search/{run_id}")
+def run_listicle_search(run_id: str, _staff=Depends(require_staff)):
+    """Run the agreed search order.
+
+    Minutes of work and real tokens, so it is a POST the operator asks for and
+    never something a screen does on its own when it loads.
+    """
+    return _handle(service.search, run_id, _search_call)
+
+
+@router.get("/search/{run_id}")
+def get_listicle_search(run_id: str, _staff=Depends(require_staff)):
+    """What a previous run of the search order found, if it has been run."""
+    found = service.results(run_id)
+    if found is None:
+        raise HTTPException(
+            status_code=404, detail="This search order has not been run yet."
+        )
+    return found
+
+
+@router.get("/shapes")
+def list_shapes(_staff=Depends(require_staff)):
+    """The shape catalogue, for a screen that wants to offer more angles.
+
+    Shapes rather than finished angles: the wording of an angle belongs to the
+    topic and is written per interview, so there is no list of searches to
+    hand out -- only the patterns they are written from.
+    """
+    return {
+        "shapes": [
+            {
+                "key": s.key,
+                "label": s.label,
+                "instruction": s.instruction,
+                "collides_with": s.collides_with,
+            }
+            for s in SHAPES
+        ]
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
@@ -1,0 +1,27 @@
+"""What a listicle interview has to settle before it may agree.
+
+The article grill settles a vision: what the piece is for, who reads it, what
+would make it a failure. This settles a specification: what kind of place,
+where, how many, what earns a spot, what is barred, and which angles the list
+gets built from.
+
+Same six-marker shape, same stop condition, deliberately different contents.
+The two are not interchangeable and neither is a mode of the other -- an
+article is judged on whether it reads well, which was never provable; a list
+is judged on whether every item is real, current and earns its place, which
+is checkable.
+"""
+
+from __future__ import annotations
+
+# (marker, the field it fills on the spec, how it is said to a person)
+LISTICLE_MARKERS: tuple[tuple[str, str, str], ...] = (
+    ("kind", "listicle_type", "what kind of place the list is about"),
+    ("place", "location", "where, and how wide an area"),
+    ("count", "target_item_count", "how many items"),
+    ("bar", "selection_standard", "what earns a place on the list"),
+    ("cut", "exclusions", "what is out no matter how good it is"),
+    ("angles", "tropes", "the angles the list gets built from"),
+)
+
+LISTICLE_MARKER_KEYS: tuple[str, ...] = tuple(m for m, _, _ in LISTICLE_MARKERS)

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/gate.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/gate.py
@@ -1,0 +1,169 @@
+"""Is there enough here to write about?
+
+The step that decides a candidate stays on the list. It runs before Location
+Manager sees anything, which is the reason profiles live upstream of LM at all:
+a place that fails here never becomes a canonical record.
+
+It is not a quality bar for the place. A famous restaurant with nothing written
+about it and an unknown one with a newspaper feature both get judged on the
+same thing -- whether a writer opening this profile has something to say.
+
+Three verdicts, not two
+-----------------------
+`missing` and `thin` are different findings and Prompt2Blog spent months
+proving it. A place with two solid history claims is publishable at short
+length; a place with nothing is not; and collapsing them into "no" throws away
+most of a long list. So the gate returns which of the three it is, and what it
+would take to change its mind.
+
+Source quality is weighed, not counted
+--------------------------------------
+The first real profiles came back citing Infobae and Trome -- national
+newspapers -- alongside Facebook, a place's own website, and something called
+"WanderBoat AI Trip Planner". They are not the same evidence. A claim sourced
+to the subject itself is not independent at all, and a claim sourced to
+AI-generated copy is a machine repeating a machine.
+
+Nothing is discarded for its source. It is weighted, and the weighting is
+visible in the verdict, because a place carried entirely by its own website is
+a fact the operator should see rather than a row that quietly vanished.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+from .profiles import PlaceProfile
+
+Verdict = Literal["enough", "thin", "nothing"]
+
+# Publishers that are not independent evidence about the place.
+#
+# Self-published first: a bar's own site saying the bar is historic is the bar
+# saying it. Then user-generated aggregators, which are real signal about what
+# customers think and weak signal about anything factual. Then AI-written
+# directories, which are a machine repeating a machine and are the one source
+# type worth naming out loud, because they look like publications.
+_SELF_PUBLISHED = ("website", "official site", "instagram", "facebook")
+_AI_WRITTEN = ("ai ", " ai", "wanderboat", "trip planner", "gpt")
+_AGGREGATOR = (
+    "tripadvisor", "wanderlog", "yelp", "restaurant guru", "google review",
+    "foursquare", "thefork",
+)
+
+# What a claim of each source class is worth. A newspaper is the unit.
+WEIGHT_INDEPENDENT = 1.0
+WEIGHT_AGGREGATOR = 0.4
+WEIGHT_SELF_PUBLISHED = 0.2
+WEIGHT_AI_WRITTEN = 0.0
+
+# What a blurb needs. Derived from the three profiles built by hand rather than
+# chosen: Bar Rovira scored 8.4 and had a paragraph in it; Antigua Taberna
+# Queirolo scored 1.4 across three claims all repeating its founding year and
+# did not.
+ENOUGH_WEIGHT = 4.0
+THIN_WEIGHT = 1.5
+# Kinds that carry a blurb on their own. A place with four reviews and nothing
+# else is a place with no story, however many reviews there are.
+SUBSTANTIVE_KINDS = ("award", "history", "person", "signature", "setting", "recognition")
+
+
+def source_weight(source_name: str) -> float:
+    """What one claim is worth, by who published it."""
+    name = source_name.lower().strip()
+    if not name:
+        # Unattributed. Not nothing -- something was read to write it -- but it
+        # cannot be checked, so it counts as little as a self-published claim.
+        return WEIGHT_SELF_PUBLISHED
+    if any(marker in name for marker in _AI_WRITTEN):
+        return WEIGHT_AI_WRITTEN
+    if any(marker in name for marker in _SELF_PUBLISHED):
+        return WEIGHT_SELF_PUBLISHED
+    if any(marker in name for marker in _AGGREGATOR):
+        return WEIGHT_AGGREGATOR
+    return WEIGHT_INDEPENDENT
+
+
+def _shape(text: str) -> str:
+    """A claim reduced to what it is about, for spotting repetition.
+
+    Queirolo's three claims were "began around 1880", "began in 1880 when Don
+    Santiago Queirolo founded it", and "arrived from Genoa around 1877". Three
+    rows, one fact. Counting them as three is how a place with one sentence to
+    its name passes a gate that counts.
+    """
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return " ".join(sorted(set(words))[:12])
+
+
+@dataclass
+class GateResult:
+    verdict: Verdict
+    weight: float
+    reason: str
+    # What would change the verdict. Said in words because a person reads this
+    # when deciding whether to keep a place the gate wanted to drop.
+    missing: list[str] = field(default_factory=list)
+    counted: int = 0
+    discounted: int = 0
+
+
+def assess(profile: PlaceProfile) -> GateResult:
+    """Decide whether this place can carry a blurb."""
+    fresh = profile.fresh_claims()
+    if not fresh:
+        return GateResult(
+            "nothing",
+            0.0,
+            "nothing published about this place was found",
+            missing=["anything at all"],
+        )
+
+    weight = 0.0
+    counted = 0
+    discounted = 0
+    seen_shapes: set[str] = set()
+    substantive = 0
+
+    for claim in fresh:
+        shape = _shape(claim.text)
+        if shape in seen_shapes:
+            # The same fact worded again. Real -- it is corroboration -- but it
+            # is not a second thing to say.
+            discounted += 1
+            continue
+        seen_shapes.add(shape)
+
+        value = source_weight(claim.source_name)
+        if value == 0.0:
+            discounted += 1
+            continue
+        weight += value
+        counted += 1
+        if claim.kind in SUBSTANTIVE_KINDS:
+            substantive += 1
+
+    missing: list[str] = []
+    if not substantive:
+        missing.append("something beyond reviews -- a history, an award, a person")
+    if weight < ENOUGH_WEIGHT:
+        missing.append("more from independent publications")
+
+    if weight >= ENOUGH_WEIGHT and substantive:
+        verdict: Verdict = "enough"
+        reason = f"{counted} distinct claims, weighted {weight:.1f}"
+    elif weight >= THIN_WEIGHT:
+        verdict = "thin"
+        reason = (
+            f"{counted} distinct claims, weighted {weight:.1f} -- enough for a "
+            "short entry, not for a full one"
+        )
+    else:
+        verdict = "nothing"
+        reason = f"only {counted} distinct claims, weighted {weight:.1f}"
+
+    if discounted:
+        reason += f"; {discounted} discounted as repeats or unusable sources"
+    return GateResult(verdict, weight, reason, missing, counted, discounted)

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/identity.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/identity.py
@@ -1,0 +1,103 @@
+"""Turning a name a search returned into the identity of a real building.
+
+A name is not an identity. Inside one run the searches returned "Bar Inglés"
+and "Bar Inglés del Country Club" as two bars, and "Gran Hotel Bolívar" and
+"Gran Hotel Bolívar (Bar Catedral)" as two hotels. Stretch that across months,
+across listicles, and across Spanish and English sources, and name matching
+stops being a heuristic with rough edges and becomes a store full of split and
+merged places.
+
+A Google Place ID is stable across all of that, and Location Manager is already
+keyed on it -- `place-details.client.ts` resolves places by text search and
+stores `placeId` on its records. Using the same anchor is what lets a profile
+and an LM record point at one building without either owning the other.
+
+No key, no resolution
+---------------------
+`GOOGLE_MAPS_API_KEY` lives in Location Manager's environment, not this app's.
+Until it is set here, resolution is skipped and profiles keep their provisional
+name-and-city key: they still gather claims, still accumulate sightings, and
+gain their anchor the first time a resolution pass runs.
+
+Degrading is deliberate. Refusing to open a profile without an API key would
+stop the whole pipeline over a setting, and a profile that is merely
+unanchored is useful now and repairable later.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_TEXT_SEARCH = "https://maps.googleapis.com/maps/api/place/textsearch/json"
+RESOLVE_TIMEOUT_SECONDS = 15
+
+
+@dataclass(frozen=True)
+class ResolvedPlace:
+    place_id: str
+    name: str
+    address: str
+    # What Google says this place is. `lodging`, `restaurant`, `bar`,
+    # `point_of_interest`. Kept because it is the cheapest existence-and-kind
+    # check there is: a row that resolves to a `transit_station` or does not
+    # resolve at all is the junk the search runner could not filter by name.
+    types: tuple[str, ...] = ()
+    permanently_closed: bool = False
+
+
+def api_key() -> str:
+    return os.getenv("GOOGLE_MAPS_API_KEY", "").strip()
+
+
+def resolve(name: str, city: str) -> ResolvedPlace | None:
+    """Find the one real place this name refers to, or nothing.
+
+    Returns None when there is no key, when nothing matches, or when the call
+    fails. All three mean the same thing to the caller -- carry on unanchored
+    -- and are distinguished only in the log, because a missing key is a
+    setting and a failed call is a network.
+    """
+    key = api_key()
+    if not key:
+        logger.info(
+            "No GOOGLE_MAPS_API_KEY set; leaving %r unresolved. It is in "
+            "Location Manager's environment.",
+            name,
+        )
+        return None
+
+    import requests  # imported here so the module loads without the dependency
+
+    query = f"{name} {city}".strip()
+    try:
+        response = requests.get(
+            _TEXT_SEARCH,
+            params={"query": query, "key": key},
+            timeout=RESOLVE_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        body = response.json()
+    except Exception as exc:  # pragma: no cover -- network dependent
+        logger.warning("Place lookup failed for %r: %s", query, exc)
+        return None
+
+    results = body.get("results") or []
+    if not results:
+        # Not an error. A name nothing matches is a finding about the row: it
+        # is probably not one named business, which is exactly what the list
+        # needs to know before anyone writes about it.
+        logger.info("No place matched %r", query)
+        return None
+
+    top = results[0]
+    return ResolvedPlace(
+        place_id=str(top.get("place_id") or ""),
+        name=str(top.get("name") or name),
+        address=str(top.get("formatted_address") or ""),
+        types=tuple(str(t) for t in (top.get("types") or [])),
+        permanently_closed=str(top.get("business_status") or "") == "CLOSED_PERMANENTLY",
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/identity.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/identity.py
@@ -36,6 +36,16 @@ _TEXT_SEARCH = "https://maps.googleapis.com/maps/api/place/textsearch/json"
 RESOLVE_TIMEOUT_SECONDS = 15
 
 
+# Google's `types` for a place, and what they tell us. A real bar or
+# restaurant carries `bar`, `restaurant`, `food` or `cafe`. A row that resolves
+# with none of them is not a business a reader can walk into and order in --
+# "Terminal Pesquero" resolved as `establishment, point_of_interest`, which is
+# a fish market, and it reached the pisco sour list as if it were a bar.
+VENUE_TYPES = frozenset(
+    {"bar", "restaurant", "food", "cafe", "night_club", "lodging", "bakery"}
+)
+
+
 @dataclass(frozen=True)
 class ResolvedPlace:
     place_id: str
@@ -47,6 +57,17 @@ class ResolvedPlace:
     # resolve at all is the junk the search runner could not filter by name.
     types: tuple[str, ...] = ()
     permanently_closed: bool = False
+
+    @property
+    def is_venue(self) -> bool:
+        """Is this somewhere a reader could actually go and be served?
+
+        Cheaper and firmer than anything a search prompt can be told. The
+        search runner already refuses rows that name a market or a street, and
+        it still let a fish terminal through, because refusing by name only
+        catches the wordings you thought of.
+        """
+        return bool(VENUE_TYPES & set(self.types))
 
 
 def api_key() -> str:

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/places.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/places.py
@@ -1,0 +1,198 @@
+"""What Google itself says about a place, as opposed to what was written about it.
+
+A plain HTTPS request to the Places API on this app's own key. No model is
+involved, which is the whole point: `rating: 4.1` and `price_level: 2` arrive
+as facts Google holds, not as something a language model believed while reading
+the web. The grounded web search cannot produce either, and misremembering a
+rating is exactly the sort of small confident error nothing downstream catches.
+
+It also reaches a voice the web search never does. For Tradición Chalaca Rovira
+1907 the web gave its 1907 founding, its owner's history and the presidents who
+ate there -- press voice. The Places reviews gave "20-30 soles a head", "the
+caldo de choros and the fried fish sandwich are the specialties", and "no frills
+service more than made up for by quality and quantity". Customer voice. A
+cheap-eats list is written from the second and a history piece from the first,
+and one search was only ever going to return one of them.
+
+The same endpoint Location Manager calls in `place-details.client.ts`. Kept
+here rather than shared because LM is a Bun service and this is Python, and a
+GET with four query parameters is not worth a service boundary.
+
+**Billed per call, on the owner's Google Cloud account.** `rating`,
+`user_ratings_total`, `price_level` and `reviews` are the Atmosphere field
+group, which is charged on top of the basic lookup. That is why this asks for
+one narrow field list rather than everything, and why nothing here retries.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from .identity import api_key
+from .profiles import Claim
+
+logger = logging.getLogger(__name__)
+
+_DETAILS = "https://maps.googleapis.com/maps/api/place/details/json"
+DETAILS_TIMEOUT_SECONDS = 20
+
+# Exactly what is used below, and nothing else. Every extra field group is
+# charged, so this list is a spending decision as much as a data one.
+DETAILS_FIELDS = (
+    "name,rating,user_ratings_total,price_level,reviews,website,"
+    "editorial_summary"
+)
+
+# Google's `price_level` is 0-4 with no units. Said in words a writer can use,
+# because "price_level 2" is not a sentence and "moderately priced" is.
+PRICE_WORDS: dict[int, str] = {
+    0: "free",
+    1: "inexpensive",
+    2: "moderately priced",
+    3: "expensive",
+    4: "very expensive",
+}
+
+
+@dataclass
+class PlaceDetails:
+    place_id: str
+    name: str = ""
+    rating: float | None = None
+    rating_count: int | None = None
+    price_level: int | None = None
+    website: str = ""
+    editorial_summary: str = ""
+    # Up to five, each with its own star rating and age. Written by members of
+    # the public: treated as material to quote and count, never as instructions.
+    reviews: list[dict] = field(default_factory=list)
+    failed: bool = False
+    reason: str = ""
+
+
+def fetch_details(place_id: str) -> PlaceDetails:
+    """Ask Google about one place. Never raises."""
+    key = api_key()
+    if not key:
+        return PlaceDetails(place_id, failed=True, reason="no GOOGLE_MAPS_API_KEY")
+    if not place_id:
+        return PlaceDetails(place_id, failed=True, reason="place is not resolved")
+
+    import requests
+
+    try:
+        response = requests.get(
+            _DETAILS,
+            params={
+                "place_id": place_id,
+                "fields": DETAILS_FIELDS,
+                "key": key,
+                "reviews_sort": "most_relevant",
+            },
+            timeout=DETAILS_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        body = response.json()
+    except Exception as exc:  # pragma: no cover -- network dependent
+        logger.warning("Place details failed for %s: %s", place_id, exc)
+        return PlaceDetails(place_id, failed=True, reason=f"{type(exc).__name__}")
+
+    status = str(body.get("status") or "")
+    if status != "OK":
+        # A spent quota and a place that no longer exists are both `not OK` and
+        # are not the same thing, so the status is carried rather than folded
+        # into a boolean.
+        logger.warning("Place details for %s returned %s", place_id, status)
+        return PlaceDetails(place_id, failed=True, reason=status)
+
+    result = body.get("result") or {}
+    return PlaceDetails(
+        place_id=place_id,
+        name=str(result.get("name") or ""),
+        rating=result.get("rating"),
+        rating_count=result.get("user_ratings_total"),
+        price_level=result.get("price_level"),
+        website=str(result.get("website") or ""),
+        editorial_summary=str((result.get("editorial_summary") or {}).get("overview") or ""),
+        reviews=list(result.get("reviews") or []),
+    )
+
+
+def claims_from(details: PlaceDetails) -> list[Claim]:
+    """The details, said as claims a blurb writer can read.
+
+    Deliberately conservative about what becomes a claim. The rating is one
+    claim, not three; the price is one sentence; each review is itself. Nothing
+    here is summarised or interpreted, because the point of this pass is that
+    it is the only material in a profile that no model wrote.
+    """
+    if details.failed:
+        return []
+
+    claims: list[Claim] = []
+    now_year = datetime.now(timezone.utc).year
+
+    if details.rating is not None and details.rating_count:
+        claims.append(
+            Claim(
+                kind="recognition",
+                text=(
+                    f"Rated {details.rating} out of 5 by {details.rating_count:,} "
+                    "people on Google."
+                ),
+                source_name="Google",
+            )
+        )
+
+    if details.price_level is not None:
+        word = PRICE_WORDS.get(int(details.price_level))
+        if word:
+            claims.append(
+                Claim(
+                    kind="price",
+                    text=f"Google places it in the {word} band for the area.",
+                    source_name="Google",
+                )
+            )
+
+    if details.editorial_summary:
+        claims.append(
+            Claim(
+                kind="recognition",
+                text=details.editorial_summary,
+                source_name="Google",
+            )
+        )
+
+    for review in details.reviews:
+        text = str(review.get("text") or "").strip()
+        if not text:
+            continue
+        stars = review.get("rating")
+        age = str(review.get("relative_time_description") or "").strip()
+        # The star rating and the age travel with the sentence. A five-star
+        # review from eight years ago and a three-star from last month say very
+        # different things, and a blurb written from the first without knowing
+        # its age is a blurb about a restaurant that may have changed hands.
+        prefix = f"A {stars}-star Google review" + (f" from {age}" if age else "")
+        claims.append(
+            Claim(
+                kind="review",
+                text=f"{prefix}: {text}"[:600],
+                source_name="Google review",
+                about_year=_review_year(review, now_year),
+            )
+        )
+    return claims
+
+
+def _review_year(review: dict, default: int) -> int | None:
+    stamp = review.get("time")
+    if not isinstance(stamp, (int, float)):
+        return None
+    try:
+        return datetime.fromtimestamp(float(stamp), tz=timezone.utc).year
+    except Exception:  # pragma: no cover -- defensive
+        return None

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_research.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_research.py
@@ -48,7 +48,9 @@ _KINDS: tuple[tuple[str, str], ...] = (
 _VALID_KINDS = {key for key, _ in _KINDS}
 
 
-def build_research_prompt(name: str, city: str, angles: list[str]) -> str:
+def build_research_prompt(
+    name: str, city: str, angles: list[str], address: str = ""
+) -> str:
     """What one place is looked up with.
 
     The angles are included because they are why this place is on this list,
@@ -58,9 +60,14 @@ def build_research_prompt(name: str, city: str, angles: list[str]) -> str:
     """
     kinds = "\n".join(f"  {key} -- {description}" for key, description in _KINDS)
     reasons = "\n".join(f"  - {angle}" for angle in angles) or "  - (none recorded)"
+    # The resolved street address, when identity has found one. Museo del Pisco
+    # has branches in Arequipa and Cusco, and a lookup on the bare name spread
+    # itself across all three and came back with almost nothing about any of
+    # them. An address pins the search to one building.
+    at = f"\n  {address}" if address else ""
     return f"""Find what has been published about this place:
 
-  {name}, {city}
+  {name}, {city}{at}
 
 It came up in a search for a list because of these:
 {reasons}
@@ -82,8 +89,13 @@ fact.
 Use only these kinds:
 {kinds}
 
+Name the publication for every line -- "El Comercio", "Publimetro", "Summum",
+"TripAdvisor". The name, not a URL. A finding nobody can attribute is weaker
+than one that names a newspaper, and the name is what still means something in
+two years.
+
 Write ONLY the list. One finding per line, in exactly this format:
-KIND | what was said, in one sentence | year or blank | source url
+KIND | what was said, in one sentence | year or blank | publication | url
 
 No preamble, no numbering, no closing line."""
 
@@ -105,14 +117,19 @@ def parse_claims(text: str) -> list[Claim]:
         if not body or body.lower() in {"what was said", "claim"}:
             continue
         year_text = parts[2] if len(parts) > 2 else ""
-        source = parts[3] if len(parts) > 3 else ""
+        # The publication and the URL may arrive in either order, or with only
+        # one of them present. Whichever looks like a link is the link.
+        tail = [part for part in parts[3:] if part]
+        source_url = next((part for part in tail if part.startswith("http")), "")
+        source_name = next((part for part in tail if not part.startswith("http")), "")
         years = re.findall(r"\b(1[6-9]\d{2}|20\d{2})\b", year_text)
         resolved: ClaimKind = kind if kind in _VALID_KINDS else "other"  # type: ignore[assignment]
         claims.append(
             Claim(
                 kind=resolved,
                 text=body[:600],
-                source_url=source if source.startswith("http") else "",
+                source_name=source_name[:120],
+                source_url=source_url,
                 about_year=int(years[0]) if years else None,
             )
         )
@@ -179,9 +196,10 @@ def research_place(
     city: str,
     angles: list[str],
     research: Callable[[str], tuple[str, list[str], int | None]],
+    address: str = "",
 ) -> ResearchResult:
     """Look one place up, more than once if the first answer was thin."""
-    prompt = build_research_prompt(name, city, angles)
+    prompt = build_research_prompt(name, city, angles, address)
     claims: list[Claim] = []
     urls: list[str] = []
     seen: set[str] = set()

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_research.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_research.py
@@ -1,0 +1,237 @@
+"""Finding out what has been said about one place.
+
+This is the step that decides whether a place can carry a blurb, and it is the
+same step that gathers the material to write one. Doing it twice -- once to
+judge and once to write -- would pay for the same search twice, and the second
+pass would be judged against material the first pass never saw.
+
+So it gathers, and what it gathers is what the gate counts and what the blurb
+is written from.
+
+What it does not gather
+-----------------------
+Address, hours, cuisine, price level, photographs. Those belong to Location
+Manager, which already collects them, and a place's opening hours have never
+made a blurb better. This asks only for what has been *said*: awards, reviews,
+history, the people, the one thing it is known for.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+from .profiles import Claim, ClaimKind
+
+logger = logging.getLogger(__name__)
+
+RESEARCH_MAX_TOKENS = 3_072
+RESEARCH_TIMEOUT_SECONDS = 120
+RESEARCH_MODEL = "gemini-2.5-flash"
+
+# Offered to the model as a closed vocabulary. An open one produces a different
+# taxonomy for every place, and a taxonomy nobody applies consistently cannot
+# be counted -- which is the only thing the gate does with it.
+_KINDS: tuple[tuple[str, str], ...] = (
+    ("award", "a named prize, guide listing or ranking, with its year"),
+    ("recognition", "a standing reputation with no single award behind it"),
+    ("review", "a critic or publication writing about it"),
+    ("history", "when it opened, who founded it, what changed"),
+    ("person", "a named chef, bartender or owner"),
+    ("signature", "the one dish or drink it is known for"),
+    ("setting", "the room, the building, the view"),
+    ("practice", "how it works: lunch only, no reservations, cash only"),
+)
+
+_VALID_KINDS = {key for key, _ in _KINDS}
+
+
+def build_research_prompt(name: str, city: str, angles: list[str]) -> str:
+    """What one place is looked up with.
+
+    The angles are included because they are why this place is on this list,
+    and they tell the search where to dig -- a bar returned by "open for
+    decades" wants its history found, where one returned by "just opened"
+    plainly has none and should not be marked short for lacking it.
+    """
+    kinds = "\n".join(f"  {key} -- {description}" for key, description in _KINDS)
+    reasons = "\n".join(f"  - {angle}" for angle in angles) or "  - (none recorded)"
+    return f"""Find what has been published about this place:
+
+  {name}, {city}
+
+It came up in a search for a list because of these:
+{reasons}
+
+Search in the local language of {city} as well as in English. Local press and
+local food and drink writing is where most of this lives, and an English-only
+search finds only what was written for visitors.
+
+Report only what has been SAID about it -- awards, reviews, history, the people,
+what it is known for. Do NOT report its address, opening hours, phone number,
+price level or menu; those are held elsewhere and are not what this is for.
+
+Every line must be something you actually found published, attributed to where
+you found it. If little has been written about this place, say so by returning
+few lines. Do not pad, do not guess, and do not describe what a place like this
+is usually like -- an invented sentence here is one that reaches a reader as a
+fact.
+
+Use only these kinds:
+{kinds}
+
+Write ONLY the list. One finding per line, in exactly this format:
+KIND | what was said, in one sentence | year or blank | source url
+
+No preamble, no numbering, no closing line."""
+
+
+def parse_claims(text: str) -> list[Claim]:
+    """The findings in a reply, dropping anything that is not one.
+
+    A line whose kind is not in the vocabulary is kept as `other` rather than
+    thrown away: the model invented a label, but the sentence it labelled is
+    still something somebody published.
+    """
+    claims: list[Claim] = []
+    for line in text.splitlines():
+        if line.count("|") < 2:
+            continue
+        parts = [part.strip() for part in line.split("|")]
+        kind = re.sub(r"^[\-\*•\d\.\)\s]+", "", parts[0]).strip().strip("*_ ").lower()
+        body = parts[1]
+        if not body or body.lower() in {"what was said", "claim"}:
+            continue
+        year_text = parts[2] if len(parts) > 2 else ""
+        source = parts[3] if len(parts) > 3 else ""
+        years = re.findall(r"\b(1[6-9]\d{2}|20\d{2})\b", year_text)
+        resolved: ClaimKind = kind if kind in _VALID_KINDS else "other"  # type: ignore[assignment]
+        claims.append(
+            Claim(
+                kind=resolved,
+                text=body[:600],
+                source_url=source if source.startswith("http") else "",
+                about_year=int(years[0]) if years else None,
+            )
+        )
+    return claims
+
+
+# URLs that come back in grounding metadata and are not sources. XML and SVG
+# namespaces appear because the model's output or the pages it read contained
+# markup; attributing a claim about a bar to w3.org is worse than attributing
+# it to nothing, because it looks like a citation.
+_NOT_A_SOURCE = ("w3.org", "schema.org", "example.com", "localhost")
+
+
+def usable_sources(urls: list[str]) -> list[str]:
+    return [
+        url
+        for url in urls
+        if url.startswith("http") and not any(bad in url for bad in _NOT_A_SOURCE)
+    ]
+
+
+@dataclass
+class ResearchResult:
+    """What a lookup found, and what kind of nothing it found if it found none.
+
+    Three different things reach a caller as an empty list, and only one of
+    them means the place has nothing written about it:
+
+      the lookup never ran     -> a fact about the network
+      it ran and said nothing  -> a fact about the model
+      it answered with no rows -> a fact about the place
+
+    Conflating them cost a real profile: Antigua Taberna Queirolo -- founded
+    1880, UNESCO Blue Shield, Premios Summum 2023 -- was recorded as having
+    nothing written about it, because the call had failed and a failure was
+    returned as an empty result. The same conflation was already fixed once in
+    the search step and was reintroduced here.
+    """
+
+    claims: list[Claim]
+    sources: list[str]
+    failed: bool = False
+    reason: str = ""
+
+
+# How many times one place is looked up. Not a retry for failure -- this is a
+# retry for a successful call that answered thinly.
+#
+# The same prompt for Antigua Taberna Queirolo returned nineteen claims, then
+# one, then none, with nothing changed between the calls. A grounded search
+# reaches whatever the web handed back that second, and a single attempt makes
+# the difference between a rich profile and a place the gate drops for having
+# nothing written about it. Attempts are merged rather than replaced, because
+# each one finds slightly different material and the store deduplicates
+# anyway.
+RESEARCH_ATTEMPTS = 3
+# Below this, another attempt is worth its cost. Above it, the place is
+# adequately covered and a further call mostly repeats itself.
+RESEARCH_ENOUGH = 6
+
+
+def research_place(
+    name: str,
+    city: str,
+    angles: list[str],
+    research: Callable[[str], tuple[str, list[str], int | None]],
+) -> ResearchResult:
+    """Look one place up, more than once if the first answer was thin."""
+    prompt = build_research_prompt(name, city, angles)
+    claims: list[Claim] = []
+    urls: list[str] = []
+    seen: set[str] = set()
+    failure = ""
+
+    for attempt in range(RESEARCH_ATTEMPTS):
+        try:
+            text, found_urls, _tokens = research(prompt)
+            failure = ""
+        except Exception as exc:  # pragma: no cover -- network dependent
+            failure = f"{type(exc).__name__}"
+            logger.warning(
+                "Profile research call failed for %r (attempt %s): %s",
+                name, attempt + 1, exc,
+            )
+            continue
+
+        urls.extend(url for url in found_urls if url not in urls)
+        for claim in parse_claims(text):
+            key = " ".join(re.findall(r"[a-z0-9]+", claim.text.lower()))
+            if key in seen:
+                continue
+            seen.add(key)
+            claims.append(claim)
+
+        logger.info(
+            "Profile research for %r: attempt %s brought the total to %s claims",
+            name, attempt + 1, len(claims),
+        )
+        if len(claims) >= RESEARCH_ENOUGH:
+            break
+
+    if failure and not claims:
+        return ResearchResult([], [], failed=True, reason=failure)
+
+    sources = usable_sources(urls)
+    # A claim with no source of its own is still evidence, and the lookup's own
+    # source list is the honest attribution: something was read to write that
+    # sentence, we just do not know which of them.
+    fallback = sources[0] if sources else ""
+    for claim in claims:
+        if not claim.source_url and fallback:
+            claim.source_url = fallback
+
+    if claims:
+        return ResearchResult(claims, sources)
+    return ResearchResult(
+        [],
+        sources,
+        reason=(
+            f"{RESEARCH_ATTEMPTS} lookups found nothing published about this place"
+        ),
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_store.py
@@ -1,0 +1,345 @@
+"""Where place profiles are kept.
+
+Three tables in the app's own SQLite file, every name prefixed `listicle_` like
+the interview's and the search's, so this feature's storage is legible as one
+group and cannot collide with another's.
+
+Rows rather than a JSON blob, which is the opposite of what `store.py` does for
+the interview and deliberately so. A grill state is one object read whole and
+written whole; profiles are queried across places -- everything sighted by this
+angle, everything with no award claim, everything not yet resolved to a Place
+ID -- and none of that is answerable against a blob.
+
+Writing is idempotent. Researching a place twice must not double its claims,
+and the same listicle run re-run must not double its sightings, because both
+will happen: a run gets resumed, a profile gets refreshed, and a place turns up
+in three listicles a year apart.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+import unicodedata
+import uuid
+from datetime import datetime, timezone
+
+from app.core.database import get_db_connection
+
+from .profiles import Claim, PlaceProfile, Sighting
+
+_PROFILES = """
+CREATE TABLE IF NOT EXISTS listicle_place_profiles (
+    profile_id     TEXT PRIMARY KEY,
+    -- Google Place ID. Unique when set; many rows may have none yet, and
+    -- SQLite treats each NULL as distinct in a UNIQUE index, which is exactly
+    -- the behaviour wanted: one resolved place cannot exist twice, and any
+    -- number of unresolved ones can.
+    place_id       TEXT,
+    lm_location_id INTEGER,
+    -- The identity used before a Place ID exists: normalised name plus city.
+    -- Weak on purpose -- it is a placeholder, not the anchor -- but unique, so
+    -- two searches returning the same name in the same city meet the same row.
+    provisional_key TEXT NOT NULL,
+    name           TEXT NOT NULL,
+    city           TEXT NOT NULL DEFAULT '',
+    district       TEXT NOT NULL DEFAULT '',
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL
+)
+"""
+
+_CLAIMS = """
+CREATE TABLE IF NOT EXISTS listicle_profile_claims (
+    claim_id   TEXT PRIMARY KEY,
+    profile_id TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    text       TEXT NOT NULL,
+    source_url TEXT NOT NULL DEFAULT '',
+    found_at   TEXT NOT NULL,
+    about_year INTEGER,
+    -- A hash of the claim's normalised text, so researching a place twice
+    -- recognises what it already has. Claims arrive worded slightly
+    -- differently each time; the hash is over the words, not the punctuation.
+    text_key   TEXT NOT NULL,
+    UNIQUE (profile_id, text_key)
+)
+"""
+
+_SIGHTINGS = """
+CREATE TABLE IF NOT EXISTS listicle_profile_sightings (
+    profile_id TEXT NOT NULL,
+    run_id     TEXT NOT NULL,
+    angle      TEXT NOT NULL,
+    seen_at    TEXT NOT NULL,
+    -- One row per (place, run, angle). A resumed or repeated run records the
+    -- same sighting, and a sighting counted twice inflates the one signal this
+    -- pipeline gets for free.
+    PRIMARY KEY (profile_id, run_id, angle)
+)
+"""
+
+_INDEXES = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS listicle_profiles_place_id "
+    "ON listicle_place_profiles (place_id) WHERE place_id IS NOT NULL",
+    "CREATE UNIQUE INDEX IF NOT EXISTS listicle_profiles_provisional "
+    "ON listicle_place_profiles (provisional_key)",
+    "CREATE INDEX IF NOT EXISTS listicle_sightings_angle "
+    "ON listicle_profile_sightings (angle)",
+)
+
+# Words that do not distinguish one business from another. Shared in spirit
+# with the search runner's list, kept separate because that one is tuned for
+# collapsing rows inside a single run and this one for recognising a place a
+# year later.
+_NOISE = {
+    "restaurant", "restaurante", "cevicheria", "cebicheria", "bar", "cafe",
+    "the", "el", "la", "los", "las", "de", "del", "and", "y",
+}
+
+
+def _tokens(value: str) -> list[str]:
+    without_aside = re.sub(r"\([^)]*\)", " ", value)
+    folded = unicodedata.normalize("NFKD", without_aside.lower())
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return [w for w in re.findall(r"[a-z0-9]+", folded) if w not in _NOISE]
+
+
+def provisional_key(name: str, city: str) -> str:
+    """The identity a profile has before it is resolved to a Place ID.
+
+    Explicitly a placeholder. Name matching is what splits "Bar Inglés" from
+    "Bar Inglés del Country Club", and no amount of normalising fixes that --
+    which is why the Place ID is the anchor and this is only what holds a
+    profile together until resolution runs.
+    """
+    words = _tokens(name) or [re.sub(r"[^a-z0-9]+", "", name.lower())]
+    place = "".join(_tokens(city))
+    return f"{''.join(words)}@{place}"
+
+
+def claim_text_key(text: str) -> str:
+    """A claim's identity: its words, ignoring how they were punctuated."""
+    words = re.findall(r"[a-z0-9]+", unicodedata.normalize("NFKD", text.lower()))
+    return hashlib.sha1(" ".join(words).encode("utf-8")).hexdigest()
+
+
+def _iso(moment: datetime) -> str:
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat()
+
+
+def _parse(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def ensure_tables() -> None:
+    with get_db_connection() as conn:
+        conn.execute(_PROFILES)
+        conn.execute(_CLAIMS)
+        conn.execute(_SIGHTINGS)
+        for statement in _INDEXES:
+            conn.execute(statement)
+
+
+def find(*, place_id: str = "", name: str = "", city: str = "") -> PlaceProfile | None:
+    """The profile for this place, by Place ID if we have one, else by name.
+
+    Place ID first and always: it is the only identity that survives a rename,
+    a spelling variant, or a Spanish source and an English one describing the
+    same bar.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = None
+        if place_id:
+            row = conn.execute(
+                "SELECT * FROM listicle_place_profiles WHERE place_id = ?", (place_id,)
+            ).fetchone()
+        if row is None and name:
+            row = conn.execute(
+                "SELECT * FROM listicle_place_profiles WHERE provisional_key = ?",
+                (provisional_key(name, city),),
+            ).fetchone()
+        if row is None:
+            return None
+        return _hydrate(conn, row)
+
+
+def _hydrate(conn: sqlite3.Connection, row: sqlite3.Row) -> PlaceProfile:
+    profile_id = row["profile_id"]
+    claims = [
+        Claim(
+            kind=c["kind"],
+            text=c["text"],
+            source_url=c["source_url"],
+            found_at=_parse(c["found_at"]),
+            about_year=c["about_year"],
+        )
+        for c in conn.execute(
+            "SELECT * FROM listicle_profile_claims WHERE profile_id = ? "
+            "ORDER BY found_at",
+            (profile_id,),
+        )
+    ]
+    sightings = [
+        Sighting(angle=s["angle"], run_id=s["run_id"], seen_at=_parse(s["seen_at"]))
+        for s in conn.execute(
+            "SELECT * FROM listicle_profile_sightings WHERE profile_id = ? "
+            "ORDER BY seen_at",
+            (profile_id,),
+        )
+    ]
+    return PlaceProfile(
+        profile_id=profile_id,
+        place_id=row["place_id"] or "",
+        lm_location_id=row["lm_location_id"],
+        name=row["name"],
+        city=row["city"],
+        district=row["district"],
+        claims=claims,
+        sightings=sightings,
+        created_at=_parse(row["created_at"]),
+        updated_at=_parse(row["updated_at"]),
+    )
+
+
+def open_profile(
+    *, name: str, city: str = "", district: str = "", place_id: str = ""
+) -> PlaceProfile:
+    """Find this place's profile, or start one.
+
+    Called the moment a search returns a name, before anything is known about
+    whether the place is worth writing about -- because deciding that is what
+    the profile is for.
+    """
+    existing = find(place_id=place_id, name=name, city=city)
+    if existing is not None:
+        # A profile opened before resolution gains its anchor the first time
+        # resolution succeeds, without losing the claims gathered meanwhile.
+        if place_id and not existing.place_id:
+            set_place_id(existing.profile_id, place_id)
+            existing = existing.model_copy(update={"place_id": place_id})
+        if district and not existing.district:
+            _touch(existing.profile_id, district=district)
+            existing = existing.model_copy(update={"district": district})
+        return existing
+
+    now = datetime.now(timezone.utc)
+    profile = PlaceProfile(
+        profile_id=uuid.uuid4().hex[:12],
+        place_id=place_id,
+        name=name,
+        city=city,
+        district=district,
+        created_at=now,
+        updated_at=now,
+    )
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_place_profiles (profile_id, place_id, "
+            "provisional_key, name, city, district, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                profile.profile_id,
+                place_id or None,
+                provisional_key(name, city),
+                name,
+                city,
+                district,
+                _iso(now),
+                _iso(now),
+            ),
+        )
+    return profile
+
+
+def _touch(profile_id: str, **fields: object) -> None:
+    """Update named columns, and always `updated_at`.
+
+    Called with no fields to mean "nothing changed on the row itself, but the
+    profile did" -- adding a claim ages the profile even though every column
+    stays as it was. That case has to build a valid statement rather than an
+    empty SET clause.
+    """
+    assignments = [f"{key} = ?" for key in fields]
+    assignments.append("updated_at = ?")
+    values = [*fields.values(), _iso(datetime.now(timezone.utc)), profile_id]
+    with get_db_connection() as conn:
+        conn.execute(
+            f"UPDATE listicle_place_profiles SET {', '.join(assignments)} "
+            "WHERE profile_id = ?",
+            values,
+        )
+
+
+def set_place_id(profile_id: str, place_id: str) -> None:
+    """Anchor a profile once resolution has found its Place ID."""
+    ensure_tables()
+    _touch(profile_id, place_id=place_id)
+
+
+def set_lm_location_id(profile_id: str, lm_location_id: int) -> None:
+    """Record that this place now has a Location Manager record.
+
+    Written back after the LM job, so a later listicle finding the same place
+    knows there is nothing to send.
+    """
+    ensure_tables()
+    _touch(profile_id, lm_location_id=lm_location_id)
+
+
+def add_claims(profile_id: str, claims: list[Claim]) -> int:
+    """Add what is new and leave what is already there. Returns how many landed."""
+    if not claims:
+        return 0
+    ensure_tables()
+    added = 0
+    with get_db_connection() as conn:
+        for claim in claims:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO listicle_profile_claims (claim_id, "
+                "profile_id, kind, text, source_url, found_at, about_year, "
+                "text_key) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    uuid.uuid4().hex[:12],
+                    profile_id,
+                    claim.kind,
+                    claim.text,
+                    claim.source_url,
+                    _iso(claim.found_at),
+                    claim.about_year,
+                    claim_text_key(claim.text),
+                ),
+            )
+            added += cursor.rowcount or 0
+    _touch(profile_id)
+    return added
+
+
+def add_sighting(profile_id: str, sighting: Sighting) -> bool:
+    """Record that a run's angle returned this place. False if already known."""
+    ensure_tables()
+    with get_db_connection() as conn:
+        cursor = conn.execute(
+            "INSERT OR IGNORE INTO listicle_profile_sightings (profile_id, "
+            "run_id, angle, seen_at) VALUES (?, ?, ?, ?)",
+            (profile_id, sighting.run_id, sighting.angle, _iso(sighting.seen_at)),
+        )
+    return bool(cursor.rowcount)
+
+
+def unresolved(limit: int = 100) -> list[PlaceProfile]:
+    """Profiles with no Place ID yet -- what a resolution pass works through."""
+    ensure_tables()
+    with get_db_connection() as conn:
+        rows = conn.execute(
+            "SELECT * FROM listicle_place_profiles WHERE place_id IS NULL "
+            "ORDER BY created_at LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [_hydrate(conn, row) for row in rows]

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_store.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 
 from app.core.database import get_db_connection
 
-from .profiles import Claim, PlaceProfile, Sighting
+from .profiles import Claim, PastBlurb, PlaceProfile, Sighting
 
 _PROFILES = """
 CREATE TABLE IF NOT EXISTS listicle_place_profiles (
@@ -81,6 +81,21 @@ CREATE TABLE IF NOT EXISTS listicle_profile_sightings (
     -- same sighting, and a sighting counted twice inflates the one signal this
     -- pipeline gets for free.
     PRIMARY KEY (profile_id, run_id, angle)
+)
+"""
+
+_BLURBS = """
+CREATE TABLE IF NOT EXISTS listicle_profile_blurbs (
+    blurb_id   TEXT PRIMARY KEY,
+    profile_id TEXT NOT NULL,
+    run_id     TEXT NOT NULL DEFAULT '',
+    angle      TEXT NOT NULL DEFAULT '',
+    text       TEXT NOT NULL,
+    written_at TEXT NOT NULL,
+    -- Hash of the words. Writing the same sentence twice is the thing this
+    -- table exists to prevent, so storing it twice would be absurd.
+    text_key   TEXT NOT NULL,
+    UNIQUE (profile_id, text_key)
 )
 """
 
@@ -145,6 +160,7 @@ def ensure_tables() -> None:
         conn.execute(_PROFILES)
         conn.execute(_CLAIMS)
         conn.execute(_SIGHTINGS)
+        conn.execute(_BLURBS)
         for statement in _INDEXES:
             conn.execute(statement)
 
@@ -198,6 +214,19 @@ def _hydrate(conn: sqlite3.Connection, row: sqlite3.Row) -> PlaceProfile:
             (profile_id,),
         )
     ]
+    past_blurbs = [
+        PastBlurb(
+            text=b["text"],
+            run_id=b["run_id"],
+            angle=b["angle"],
+            written_at=_parse(b["written_at"]),
+        )
+        for b in conn.execute(
+            "SELECT * FROM listicle_profile_blurbs WHERE profile_id = ? "
+            "ORDER BY written_at",
+            (profile_id,),
+        )
+    ]
     return PlaceProfile(
         profile_id=profile_id,
         place_id=row["place_id"] or "",
@@ -207,6 +236,7 @@ def _hydrate(conn: sqlite3.Connection, row: sqlite3.Row) -> PlaceProfile:
         district=row["district"],
         claims=claims,
         sightings=sightings,
+        past_blurbs=past_blurbs,
         created_at=_parse(row["created_at"]),
         updated_at=_parse(row["updated_at"]),
     )
@@ -349,3 +379,30 @@ def unresolved(limit: int = 100) -> list[PlaceProfile]:
             (limit,),
         ).fetchall()
         return [_hydrate(conn, row) for row in rows]
+
+
+def add_blurb(profile_id: str, blurb: PastBlurb) -> bool:
+    """Record what was written about this place, so it is not written again.
+
+    False when this exact text is already on the profile. Returning that rather
+    than silently succeeding matters: a writer handed the same sentence back
+    twice has not written a second blurb.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        cursor = conn.execute(
+            "INSERT OR IGNORE INTO listicle_profile_blurbs (blurb_id, "
+            "profile_id, run_id, angle, text, written_at, text_key) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                uuid.uuid4().hex[:12],
+                profile_id,
+                blurb.run_id,
+                blurb.angle,
+                blurb.text,
+                _iso(blurb.written_at),
+                claim_text_key(blurb.text),
+            ),
+        )
+    _touch(profile_id)
+    return bool(cursor.rowcount)

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profile_store.py
@@ -56,6 +56,10 @@ CREATE TABLE IF NOT EXISTS listicle_profile_claims (
     profile_id TEXT NOT NULL,
     kind       TEXT NOT NULL,
     text       TEXT NOT NULL,
+    -- Who published it. Kept beside the URL rather than instead of it: the
+    -- URL is a grounding redirect that names nobody and will not outlive the
+    -- claim, and the name is what still means something in two years.
+    source_name TEXT NOT NULL DEFAULT '',
     source_url TEXT NOT NULL DEFAULT '',
     found_at   TEXT NOT NULL,
     about_year INTEGER,
@@ -175,6 +179,7 @@ def _hydrate(conn: sqlite3.Connection, row: sqlite3.Row) -> PlaceProfile:
         Claim(
             kind=c["kind"],
             text=c["text"],
+            source_name=c["source_name"],
             source_url=c["source_url"],
             found_at=_parse(c["found_at"]),
             about_year=c["about_year"],
@@ -303,13 +308,14 @@ def add_claims(profile_id: str, claims: list[Claim]) -> int:
         for claim in claims:
             cursor = conn.execute(
                 "INSERT OR IGNORE INTO listicle_profile_claims (claim_id, "
-                "profile_id, kind, text, source_url, found_at, about_year, "
-                "text_key) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "profile_id, kind, text, source_name, source_url, found_at, "
+                "about_year, text_key) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     uuid.uuid4().hex[:12],
                     profile_id,
                     claim.kind,
                     claim.text,
+                    claim.source_name,
                     claim.source_url,
                     _iso(claim.found_at),
                     claim.about_year,

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profiles.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profiles.py
@@ -1,0 +1,203 @@
+"""What is known about one place, gathered once and reused.
+
+A listicle needs two different things about a place and they are not the same
+thing. Location Manager owns what a place **is** -- address, hours, cuisine,
+photographs, taxonomy -- and syncs that to Payload. A blurb needs what has been
+**said** about it: reviews, awards, who cooks there, what happened in 1978.
+None of that belongs in a canonical store that publishes.
+
+So a profile lives here, upstream of Location Manager, and it has to: the gate
+that decides a place is not worth writing about runs before any record is
+created, and a place that fails it must never reach LM at all. A profile
+therefore exists for places LM will never hold.
+
+The profile points at LM and LM does not point back. Nothing in Location
+Manager changes to make this work.
+
+Claims, not fields
+------------------
+A field schema decides in advance what matters, and every place is different. A
+1920s bar has history; a rooftop that opened last year has a bartender's name
+and nothing else. Fixed fields leave a profile mostly empty, and an empty field
+reads as "we failed to find this" when the truth is "this does not apply here"
+-- the same confusion that cost Prompt2Blog months (ADR 0031 lineage: the
+`unpublished` and `nonexistent` verdicts exist for exactly this reason).
+
+Pure prose is worse: it cannot be counted, traced to a source, or aged.
+
+So the unit is one claim -- a sentence, its kind, where it came from, and when
+we found it. A profile is a bag of dated, sourced claims. The gate counts them,
+the blurb writer chooses among them, and a later listicle appends to them
+rather than starting again.
+
+Staleness belongs to the claim, not the profile
+-----------------------------------------------
+An award from 2019 never rots; it is history. A review ages into history and
+stays usable. "Opened last year" is false twelve months later. Hours and prices
+rot fastest, and those live in Location Manager, which is another reason the
+two stores stay apart. One date on a profile cannot express that. A date on
+each claim can.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# What a claim is about. Kept short on purpose: this is what the gate counts,
+# and a taxonomy nobody can apply consistently counts nothing.
+#
+# `recognition` and `award` are separate because they age differently -- an
+# award is a dated event that never stops being true, where "regularly called
+# the best in the city" is a standing reputation that can quietly stop being
+# said.
+ClaimKind = Literal[
+    "award",         # a named prize or guide listing, usually with a year
+    "recognition",   # standing reputation, no single award behind it
+    "review",        # a critic or publication writing about it
+    "history",       # when it opened, who founded it, what changed
+    "person",        # a named chef, bartender or owner
+    "signature",     # the one dish or drink it is known for
+    "setting",       # the room, the view, the building
+    "practice",      # how it works -- lunch only, no reservations, cash only
+    "other",
+]
+
+# How long a claim of each kind stays worth trusting without being looked at
+# again. `None` means it does not rot: an award in 2019 was still won in 2019.
+#
+# These are advisory. Nothing deletes a stale claim -- it is shown as old, and
+# a person or the gate decides. Silently dropping material is how a profile
+# becomes quietly wrong.
+CLAIM_SHELF_LIFE_DAYS: dict[str, int | None] = {
+    "award": None,
+    "history": None,
+    "person": 730,        # chefs and owners move
+    "signature": 730,
+    "setting": 1095,
+    "recognition": 545,   # a standing reputation stops being said quietly
+    "review": 1095,       # ages into history rather than expiring
+    "practice": 365,      # opening patterns change with a season
+    "other": 365,
+}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Claim(BaseModel):
+    """One thing that has been said about a place, and where it came from."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ClaimKind = "other"
+    # One sentence. Long enough to be usable in a blurb without going back to
+    # the source, short enough that a gate can count what it has.
+    text: str = Field(min_length=1, max_length=600)
+    # Where it was published. Empty is allowed and is itself a finding: a claim
+    # nobody can point at is weaker than one that cites a newspaper.
+    source_url: str = ""
+    # When we found it. Not when it happened.
+    found_at: datetime = Field(default_factory=_now)
+    # The year the claim is *about*, when it has one: an award's year, an
+    # opening year. Separate from `found_at` because "won in 2019, found in
+    # 2026" and "won in 2026, found in 2026" are different facts.
+    about_year: int | None = None
+
+    def is_stale(self, *, as_of: datetime | None = None) -> bool:
+        shelf = CLAIM_SHELF_LIFE_DAYS.get(self.kind, 365)
+        if shelf is None:
+            return False
+        moment = as_of or _now()
+        found = self.found_at
+        if found.tzinfo is None:
+            found = found.replace(tzinfo=timezone.utc)
+        return (moment - found).days > shelf
+
+
+class Sighting(BaseModel):
+    """One time a listicle search returned this place, and why.
+
+    Recorded as an event rather than as a property of the place, because the
+    angle belongs to the run that used it. A bar is not permanently "a rooftop
+    bar"; it was returned by a rooftop search on a particular day.
+
+    Accumulated across listicles, these are worth more than any single one: a
+    place returned under nine angles across four different lists is objectively
+    a major place, and that was learned for free.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    angle: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    seen_at: datetime = Field(default_factory=_now)
+
+
+class PlaceProfile(BaseModel):
+    """One place, everything said about it, and every list that found it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Our own id. Stable for the life of the profile even if the place is later
+    # resolved to a Google Place ID or renamed.
+    profile_id: str = Field(min_length=1)
+    # The anchor. Google Place IDs survive renames, spelling variants and the
+    # difference between a Spanish and an English source -- all three of which
+    # already split entries within a single run. Location Manager is keyed on
+    # the same thing, so a profile and an LM record point at one building
+    # without either owning the other.
+    #
+    # Empty until resolution runs, which is allowed: a profile is created the
+    # moment a search returns a name, and resolution may not have happened yet
+    # or may have no API key to run with.
+    place_id: str = ""
+    # Location Manager's numeric id, once this place has a record there. Empty
+    # for every place that has not reached LM -- which is most of them, because
+    # LM is the last step and only receives what survives the gate.
+    lm_location_id: int | None = None
+
+    name: str = Field(min_length=1)
+    city: str = ""
+    district: str = ""
+
+    claims: list[Claim] = Field(default_factory=list)
+    sightings: list[Sighting] = Field(default_factory=list)
+
+    created_at: datetime = Field(default_factory=_now)
+    updated_at: datetime = Field(default_factory=_now)
+
+    @property
+    def angles_seen(self) -> list[str]:
+        """Every distinct angle that has ever returned this place."""
+        seen: list[str] = []
+        for sighting in self.sightings:
+            if sighting.angle not in seen:
+                seen.append(sighting.angle)
+        return seen
+
+    @property
+    def runs_seen(self) -> list[str]:
+        seen: list[str] = []
+        for sighting in self.sightings:
+            if sighting.run_id not in seen:
+                seen.append(sighting.run_id)
+        return seen
+
+    def claims_by_kind(self) -> dict[str, int]:
+        """How much of each kind of material there is.
+
+        What the gate reads. "Four reviews and no history" and "no reviews and
+        four history claims" are both four claims and are not the same place to
+        write about.
+        """
+        counts: dict[str, int] = {}
+        for claim in self.claims:
+            counts[claim.kind] = counts.get(claim.kind, 0) + 1
+        return counts
+
+    def fresh_claims(self, *, as_of: datetime | None = None) -> list[Claim]:
+        return [claim for claim in self.claims if not claim.is_stale(as_of=as_of)]

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profiles.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profiles.py
@@ -56,12 +56,17 @@ from pydantic import BaseModel, ConfigDict, Field
 ClaimKind = Literal[
     "award",         # a named prize or guide listing, usually with a year
     "recognition",   # standing reputation, no single award behind it
-    "review",        # a critic or publication writing about it
+    "review",        # a critic, a publication, or a customer writing about it
     "history",       # when it opened, who founded it, what changed
     "person",        # a named chef, bartender or owner
     "signature",     # the one dish or drink it is known for
     "setting",       # the room, the view, the building
     "practice",      # how it works -- lunch only, no reservations, cash only
+    # What it costs. Its own kind rather than a `practice`, because a whole
+    # class of list is about nothing else -- cheap eats, the splurge, good and
+    # cheap -- and those lists need to find this claim without reading every
+    # other thing said about the place.
+    "price",
     "other",
 ]
 
@@ -80,6 +85,7 @@ CLAIM_SHELF_LIFE_DAYS: dict[str, int | None] = {
     "recognition": 545,   # a standing reputation stops being said quietly
     "review": 1095,       # ages into history rather than expiring
     "practice": 365,      # opening patterns change with a season
+    "price": 365,         # rots fast, and a wrong price is worse than none
     "other": 365,
 }
 
@@ -143,6 +149,30 @@ class Sighting(BaseModel):
     seen_at: datetime = Field(default_factory=_now)
 
 
+class PastBlurb(BaseModel):
+    """Something already written about this place, and where it ran.
+
+    Kept so the next blurb is DIFFERENT, not so it can be reused. Two
+    Questurian articles carrying the same paragraph compete with each other in
+    search, and a place that earns a spot on four lists would otherwise be
+    described in the same words four times.
+
+    So this is read by the writer as a list of sentences already spent. It is
+    not a library to draw from.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(min_length=1)
+    # The run that produced it, and the angle it was written for. The angle
+    # matters most: the same bar on a cheap-eats list and on a history list
+    # should read as two different places to go, and knowing which angle was
+    # already used is what makes that possible.
+    run_id: str = ""
+    angle: str = ""
+    written_at: datetime = Field(default_factory=_now)
+
+
 class PlaceProfile(BaseModel):
     """One place, everything said about it, and every list that found it."""
 
@@ -172,6 +202,7 @@ class PlaceProfile(BaseModel):
 
     claims: list[Claim] = Field(default_factory=list)
     sightings: list[Sighting] = Field(default_factory=list)
+    past_blurbs: list[PastBlurb] = Field(default_factory=list)
 
     created_at: datetime = Field(default_factory=_now)
     updated_at: datetime = Field(default_factory=_now)
@@ -207,3 +238,13 @@ class PlaceProfile(BaseModel):
 
     def fresh_claims(self, *, as_of: datetime | None = None) -> list[Claim]:
         return [claim for claim in self.claims if not claim.is_stale(as_of=as_of)]
+
+    def claims_for(self, kinds: tuple[str, ...]) -> list[Claim]:
+        """The material a particular kind of list is written from.
+
+        A cheap-eats piece wants the price and what people say they paid; a
+        history piece wants the founding and the family. One bag of claims,
+        filtered -- rather than a separate profile, or a separate research
+        pass, per angle.
+        """
+        return [claim for claim in self.claims if claim.kind in kinds]

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profiles.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/profiles.py
@@ -97,6 +97,12 @@ class Claim(BaseModel):
     # One sentence. Long enough to be usable in a blurb without going back to
     # the source, short enough that a gate can count what it has.
     text: str = Field(min_length=1, max_length=600)
+    # Who published it -- "El Comercio", "Publimetro", "Summum". The durable
+    # half of the attribution: grounded search returns its sources as opaque
+    # `vertexaisearch.cloud.google.com/grounding-api-redirect/...` links that
+    # name no publisher and do not last, so a claim held for two years would
+    # otherwise become a sentence nobody can place.
+    source_name: str = ""
     # Where it was published. Empty is allowed and is itself a finding: a claim
     # nobody can point at is weaker than one that cites a newspaper.
     source_url: str = ""

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/prompts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/prompts.py
@@ -1,0 +1,240 @@
+"""What the listicle grill is told before it decides its next move.
+
+The loop, the retry, the lookup budget, the pushback and the stop condition
+all come from `prompt2blog.grill_v4` unchanged. This file is the only thing
+that makes the interview about a list, which is why it is the only thing that
+had to be written.
+"""
+
+from __future__ import annotations
+
+from ..prompt2blog.contracts_v4 import GrillState
+from ..prompt2blog.grill_v4 import _lookups_left, _marker_status, _transcript
+from .contracts import LISTICLE_MARKERS
+from .shapes import collision_groups, shape_menu
+
+
+def build_listicle_turn_prompt(state: GrillState) -> str:
+    left = _lookups_left(state)
+    can_look_up = (
+        f"""You may look something up before deciding. Set `lookup` to what you
+want to know, in plain words, and leave everything else empty -- you will be
+asked again with the answer in hand. Use it when you need to know whether a
+place is big enough to fill the list they asked for, or what a neighbourhood
+they named actually covers. Do NOT use it to check something you were already
+told. You may do this {left} more time(s) this interview."""
+        if left
+        else """Your lookup budget is spent. Work from the briefing above."""
+    )
+
+    return f"""You are interviewing someone who wants to commission a listicle -- a
+ranked or grouped list of places in one city. They are a traveller or a writer,
+not an editor. Do not use editorial jargon.
+
+You are not planning an article. You are filling out a SEARCH ORDER: a set of
+web searches that will be run separately and whose results become the list. A
+question that does not change what gets searched for is a question you must not
+ask.
+
+THE WORKING TITLE THEY TYPED:
+{state.seed}
+
+Read it as a headline written for search. "Best" in a title is an SEO word: it
+promises nothing about method and you must NEVER treat it as a stated
+criterion. The title usually carries the kind of place, the location and the
+count, and nothing else.
+
+WHAT YOU ALREADY LOOKED UP (never ask about anything in here):
+{state.research_digest or "Nothing; you could not look anything up."}
+
+LOOKING SOMETHING UP:
+{can_look_up}
+
+THE INTERVIEW SO FAR:
+{_transcript(state)}
+
+WHAT THE SEARCH ORDER STILL NEEDS:
+{_marker_status(state, LISTICLE_MARKERS)}
+
+Decide the single most useful next move. It must be about a marker still
+listed as missing above, and the markers have an order:
+
+    kind, place, count   first -- or claimed without asking, see below
+    bar, cut             next
+    angles               LAST, and never before `count` is covered
+
+`angles` is last because it is built FROM the others: the number of angles
+comes from the count, and their wording comes from the kind and the place. A
+live run asked about angles on turn four with the count still unsettled,
+learned the count two turns later, and had to ask the whole angle question
+again -- the most expensive question in the interview, asked twice. If every marker is covered, you are done -- say so and
+write the consensus. A live run asked the same `count` question twice in a row
+because it chose a marker it had already settled, and an interview that repeats
+itself is not one.
+
+If a marker is plainly answered by the title and you have nothing to warn them
+about, do NOT spend a turn confirming it: put it straight into
+`markers_covered` and move to a marker you actually need. Three turns of "I'm
+reading Lima as the location, is that right?" is the form-with-extra-steps this
+interview replaced.
+
+Output shape (mechanical -- get it right and then forget about it): every reply
+carries `ask`, `recommendation`, `consensus`, `markers_covered` and
+`asks_about`. When you are asking, fill `ask`, `recommendation` and
+`asks_about`, and leave `consensus` empty. When you are done, fill `consensus`
+and leave the others empty. `markers_covered` is always the full list of
+markers you can now fill. `options` is used for one question only and is
+described below.
+
+Now the part that matters.
+
+- Ask about ONE thing. If you are joining two questions with "and", you are
+  asking two: keep the one you need first and save the other for next turn.
+
+- `recommendation` is your best answer to your own question, and it goes
+  straight into their answer box for them to accept or correct. State the
+  answer, not a sentence about who holds it. No "you", no "I", no question
+  mark. Write "Dining." Never "I'm guessing you mean restaurants."
+
+- `kind`, `place` and `count` are usually already in the title. Do not
+  interview someone about what they just typed: read them off it, put them in
+  the recommendation, and ask them to correct you. One turn each at most, and
+  skip any that is not genuinely in doubt.
+
+  `kind` is the searchable noun, as narrow as the title makes it. "Cevicherias",
+  not "dining". "Pizzerias", not "restaurants". Everything downstream searches
+  with this word.
+
+  For `place`, say which level you read it as -- a country, a city, or one
+  neighbourhood. "Miraflores" is a neighbourhood and "Lima" is a city, and the
+  difference decides how wide the search goes.
+
+- `count` is not just read off the title, it is CHECKED. Before you settle it,
+  work out from your briefing whether this city plausibly has that many of this
+  kind of place with enough of a web presence to be written about. If it does
+  not, say so plainly and recommend a smaller number. Say it as a warning, not
+  a refusal: they know the city and you do not, and they may take the number
+  anyway. A number that reality cannot fill is the most expensive mistake this
+  interview can make, because every later search inherits it.
+
+- `bar` is what earns a place, beyond the angle that found it -- awards, local
+  critics, customer reviews, what locals say, or their own judgement. Ask it
+  plainly and do not accept "the best", which is the question restated.
+
+- `cut` is what is barred no matter how good it is -- chains, delivery-only,
+  hotel restaurants, anywhere they simply refuse to send a reader. People find
+  this easier to answer than the bar, so it is a good question to ask second.
+
+- `angles` is the search order itself, and it is the question this whole
+  interview exists to reach.
+
+  One angle is one search and one reason a place is on the list. A list cannot
+  be built from one search: ask for forty award winners in most cities and you
+  will find nine. So the list is filled from several angles at once, each
+  searched separately.
+
+  Roughly SEVEN items per angle. Work out the number of angles from the count
+  they settled on: about 40 items wants 6 angles, about 24 wants 4, about 15
+  wants 3, 8 or fewer wants 2.
+
+  That is how many to RECOMMEND. It is not a quota to hold them to. If they
+  send back more angles than you suggested, or fewer, that is their answer and
+  the marker is settled -- take it and move on. A live run recommended six,
+  was given seven, and asked the whole question again to get back to six; an
+  interview that re-asks a question it has already been answered is broken,
+  and more angles than planned is not a problem in the first place.
+
+  You do not invent angles freely and you do not pick finished ones off a
+  list. You choose SHAPES from the catalogue below and write each one's version
+  for THIS topic.
+
+THE SHAPE CATALOGUE:
+{shape_menu()}
+
+  Rules for writing an angle from a shape, in order of how badly each one bites:
+
+  ADD NOTHING THE SHAPE DID NOT ASK FOR. The shape sets how tight the search
+  is. Every extra condition you volunteer empties it. Asked for "opened in the
+  last year" a previous run wrote "opened in the last 1-3 years AND has
+  significant buzz" and found one place instead of eight. No "AND". No quality
+  clause. No number of years where the shape says "decades".
+
+  NEVER CHOOSE TWO SHAPES FROM THE SAME GROUP. Shapes in a group return the
+  same places for the same reason. These are the groups:
+{collision_groups()}
+  A previous run picked three prestige-shaped angles and all three returned the
+  same three restaurants; a third of the list was wasted. At most one per
+  group. Everything outside a group may be combined freely.
+
+  MAKE IT SPECIFIC TO THE TOPIC. This is the whole reason you write the angle
+  instead of reading it. "Tiny plain places where the food is the whole point"
+  is the same sentence for ceviche, pizza and wings. "Lunch-only cevicherias
+  that close when the fish runs out" could only be about ceviche. Use what you
+  looked up: the local words, the local formats, the local neighbourhoods.
+
+  WRITE IT AS A SEARCH, NOT A LABEL. It is sent to a web search almost
+  verbatim. "Hidden gem" is a label. "Unmarked huariques serving ceviche that
+  locals know by word of mouth" is a search. It must include the kind of place
+  and be a plain description of what to look for.
+
+  When and only when you ask about `angles`, fill `options` with a MENU, not
+  just your picks. Each entry is `{{text, recommended, group}}`:
+
+    text         the finished search line, standing alone -- no numbering, no
+                 shape name, no commentary
+    recommended  true for the ones you are proposing, false for the rest
+    group        the shape's collision group, or "" if it has none
+
+  The menu has three parts, and all three go in the same list:
+
+    1. YOUR PICKS, `recommended` true. As many as the count needs.
+
+    2. EVERY OTHER SHAPE IN THE CATALOGUE, `recommended` false, each written
+       for this topic exactly as carefully as your picks. This is the part
+       that makes the question answerable: an operator shown only the six you
+       chose has nothing to swap in, and a shape written badly because it was
+       not going to be chosen is a trap for whoever ticks it.
+
+       Skip a shape only when it genuinely does not exist for this topic, and
+       skip it silently.
+
+    3. ANGLES THE CATALOGUE HAS NO SHAPE FOR, `recommended` false, `group` "".
+       Up to four. These are the reasons a place makes THIS list that no
+       general pattern could have anticipated -- what you know about this
+       topic in this city that a catalogue written for restaurants, bars,
+       hotels and sights could never contain. Ceviche in Lima has places by
+       the fishing landings serving what came off the boat that morning;
+       nothing in the catalogue is that. Find that kind of thing.
+
+       They obey every other rule: one idea, no "AND", searchable, worded as
+       a search. Do not restate a shape you have already written under a new
+       name -- if it answers a shape, it IS that shape.
+
+  Put only the recommended lines in `recommendation`, one per line, so an
+  operator answering in plain text gets your picks and nothing else.
+
+- Push back when an answer contradicts the title or an earlier answer.
+
+- Set `asks_about` to the marker your question is meant to settle, spelled
+  exactly as one of: kind, place, count, bar, cut, angles. A question that
+  does not name its marker cannot count as progress, and the interview will
+  ask it again. Never ask about the same marker twice: once they have
+  responded, it is settled and you move on.
+
+- `markers_covered` lists every marker you could now fill. Accepting your
+  draft IS answering -- they read it and put their name to it. It is weaker
+  than an answer they wrote themselves, and worth noticing, but it does NOT
+  mean the marker is unanswered.
+
+- Set `done` TRUE and write `consensus` only when every marker is covered.
+  Both, together: a reply with a consensus but `done` false is neither a
+  question nor an agreement, and the interview cannot act on it. When you are
+  done, `ask`, `recommendation` and `options` must be empty and `done` must be
+  true.
+
+  `consensus` is the search order read back plainly -- the kind of place, the
+  location, the number of items, what earns a place, what is barred, how many
+  each search should aim to return, and then every angle on its own line
+  exactly as it will be searched. They should
+  be able to read it and know exactly what is about to be looked for.
+"""

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/search.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/search.py
@@ -1,0 +1,369 @@
+"""Running the search order, and pooling what comes back.
+
+This is the step the whole interview exists to reach. The grill settles what to
+search for; this runs those searches and produces the candidate places. Nothing
+here judges whether a place is good -- it establishes that a place is real,
+named, and found by at least one of the angles that were agreed.
+
+Three things it does that a single search cannot:
+
+**It splits the ask.** One search for forty places returns a dozen and repeats
+itself. Six searches for eight each returned 49 rows on the first real run
+(2026-09-04, Lima cevicherias). The split is not an optimisation; it is the
+only reason the list fills.
+
+**It overshoots.** Rows collapse: that same run lost 15 of its 49 to
+duplicates, which is a third. Asking for exactly the target guarantees missing
+it, so each angle is asked for enough that the pooled total clears the target
+with the overlap already priced in.
+
+**It keeps the overlap.** A place found by four angles is not four rows to be
+thinned to one -- it is the strongest thing on the list, and `found_by` is
+where ranking comes from later. Deduplication merges the rows and keeps the
+count.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# What one angle is asked for, before overshoot. Seven is what a list is
+# planned at; asking for exactly seven and losing a third to overlap is how a
+# forty-item list arrives at twenty-eight.
+OVERSHOOT = 1.8
+# Nothing is gained by asking one search for more than this: the answers get
+# thinner and the response starts truncating mid-row rather than listing more
+# places.
+MAX_PER_ANGLE = 15
+MIN_PER_ANGLE = 6
+# A search that asks for a dozen named places with evidence for each takes
+# longer than the helper's default. One of seven searches on the first real run
+# was lost to a 60-second read timeout and reported as zero results.
+SEARCH_TIMEOUT_SECONDS = 180
+SEARCH_MAX_TOKENS = 4_096
+SEARCH_ATTEMPTS = 3
+SEARCH_MODEL = "gemini-2.5-flash"
+
+# Rows that name a container of places rather than one place. The searches
+# return these in good faith -- "Surquillo Market (stalls)" is a fair answer to
+# "stalls inside Lima's markets" -- but a listicle entry has to be somewhere a
+# reader can walk into as one business.
+#
+# Deliberately narrow, and matched on collective words only. The obvious
+# version of this filter rejected any name containing "market" or "mercado",
+# which threw away El Mercado -- a real restaurant in Miraflores, and the
+# highest-overlap place in the first real run. Keeping a junk row costs the
+# operator one glance; dropping the strongest entry on the list is silent and
+# unrecoverable.
+_NOT_A_BUSINESS = re.compile(
+    r"^(the\s+)?(various|several|many|multiple|assorted|different)\b"
+    r"|\b(stalls|stands|vendors|kiosks|carts|puestos|food court|foodcourt)\b",
+    re.IGNORECASE,
+)
+
+# Words that do not distinguish one place from another, dropped before
+# comparing names. "Cevichería Nancy" and "Nancy" are one place; "La Mar" and
+# "La Mar Cebichería" are one place. Without this the pool double-counts its
+# strongest entries, which is the one error that corrupts ranking rather than
+# just padding the list.
+_NOISE_WORDS = {
+    "restaurant", "restaurante", "cevicheria", "cebicheria", "ceviche",
+    "cebiche", "marisqueria", "bar", "cafe", "el", "la", "los", "las", "de",
+    "del", "don", "dona", "the", "and", "y",
+}
+
+
+def per_angle_ask(target_items: int, angle_count: int) -> int:
+    """How many places to ask one search for."""
+    if angle_count <= 0:
+        return 0
+    raw = round((target_items * OVERSHOOT) / angle_count)
+    return max(MIN_PER_ANGLE, min(MAX_PER_ANGLE, raw))
+
+
+def name_tokens(name: str) -> list[str]:
+    """The words in a name that distinguish it from another place.
+
+    A parenthetical is dropped before anything else. Searches qualify a name
+    with what the row is about -- "Gran Hotel Bolívar (Bar Catedral)", "Hotel B
+    (Rooftop bar)" -- and that qualifier is the row's reason, not part of the
+    business's name.
+    """
+    without_aside = re.sub(r"\([^)]*\)", " ", name)
+    folded = unicodedata.normalize("NFKD", without_aside.lower())
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return [w for w in re.findall(r"[a-z0-9]+", folded) if w not in _NOISE_WORDS]
+
+
+def normalise_name(name: str) -> str:
+    """A name reduced to what makes it a different place from another."""
+    words = name_tokens(name)
+    # A name that is nothing but noise words keeps them; "El Mercado" is a real
+    # restaurant and dropping both words would erase it.
+    if words:
+        return "".join(words)
+    folded = unicodedata.normalize("NFKD", name.lower())
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", "", folded)
+
+
+# How many distinguishing words a shorter name needs before it may be treated
+# as the same place as a longer one that contains it.
+#
+# Two is the whole safety margin. One would merge "Museo del Pisco" into
+# "Pisco Bar" on the single word they share, which is two different bars.
+_CONTAINMENT_MIN_TOKENS = 2
+
+
+def merge_contained(candidates: list["Candidate"]) -> list["Candidate"]:
+    """Fold a place named twice at different lengths into one entry.
+
+    Exact-key pooling catches "La Mar" and "La Mar Cebichería" because the
+    noise words fall away. It does not catch a name qualified by where it is:
+    "Bar Inglés at the Country Club Hotel" and "Bar Inglés del Country Club"
+    are one bar and share no normalised key.
+
+    Searching in the local language made this worse rather than better, which
+    is the point -- more sources means more spellings of the same place, and an
+    undetected duplicate does not merely pad the list, it splits an entry's
+    overlap in half and drops it down the ranking.
+
+    The name kept is the one carrying the most distinguishing words, and on a
+    tie the shorter string -- because a tie means the difference was a
+    parenthetical, and "Hotel B" is the bar's name where "Hotel B (Rooftop
+    bar)" is a search's note about why it turned up. `found_by` absorbs the
+    other spelling's, so a place found under two names is correctly counted as
+    found twice.
+    """
+    ordered = sorted(
+        candidates, key=lambda c: (-len(name_tokens(c.name)), len(c.name))
+    )
+    kept: list[Candidate] = []
+    for candidate in ordered:
+        tokens = set(name_tokens(candidate.name))
+        host = None
+        if len(tokens) >= _CONTAINMENT_MIN_TOKENS:
+            host = next(
+                (k for k in kept if tokens <= set(name_tokens(k.name))), None
+            )
+        if host is None:
+            kept.append(candidate)
+            continue
+        for angle in candidate.found_by:
+            if angle not in host.found_by:
+                host.found_by.append(angle)
+        if candidate.district and not host.district:
+            host.district = candidate.district
+    return kept
+
+
+@dataclass
+class Candidate:
+    """One place, and every angle that found it."""
+
+    name: str
+    district: str
+    evidence: str
+    found_by: list[str] = field(default_factory=list)
+
+    @property
+    def overlap(self) -> int:
+        return len(self.found_by)
+
+
+@dataclass
+class AngleResult:
+    """What one search returned, including when it returned nothing.
+
+    A failed search and an empty one are different facts and the screen has to
+    tell them apart: an angle nobody has written about is a finding about the
+    topic, and a timeout is a finding about the network.
+    """
+
+    angle: str
+    rows: int
+    sources: int
+    failed: bool = False
+    reason: str = ""
+
+
+def build_search_prompt(
+    angle: str,
+    *,
+    kind: str,
+    place: str,
+    exclusions: str,
+    standard: str,
+    wanted: int,
+) -> str:
+    """What one angle is sent to the web as.
+
+    The exclusions and the standard are in here because the first real run
+    proved they are worthless anywhere else: the operator barred "general
+    restaurants where ceviche is one line on the menu" and the Nikkei search
+    returned four of exactly that, because nothing carried the bar from the
+    interview to the search.
+    """
+    return f"""List real, currently open {kind} in {place} that match this description:
+{angle}
+
+Find {wanted}. Keep going until you have {wanted} or have genuinely run out --
+listing four when eight exist is the failure mode here, and a place you are
+reasonably confident about belongs on the list. Breadth first: this is a
+shortlist someone will check, not a final answer.
+
+Search in the local language of {place} as well as in English, and say so to
+yourself before you start: run the query the way a resident would type it.
+Local press, local food and drink blogs, and local review sites are where most
+of this is written down, and an English-only search reaches the places written
+up for visitors and stops there. Evidence in the local language counts exactly
+the same. Write the results in English, but keep every business name exactly as
+it is written locally.
+
+Every entry must be ONE named business a reader could walk into. Not a market,
+a street or a district -- if the answer is "the stalls in X market", name the
+individual stalls or leave it out.
+
+{f"Leave out: {exclusions}" if exclusions else ""}
+
+{f"Prefer places that meet this standard, but do not drop a well-known place for want of a citation: {standard}" if standard else ""}
+
+Write ONLY the list. One place per line, in exactly this format:
+NAME | DISTRICT | evidence in under ten words
+
+No preamble, no numbering, no closing line."""
+
+
+def parse_rows(text: str) -> list[tuple[str, str, str]]:
+    """The named places in a search's reply.
+
+    Tolerant of a preamble and of numbering, because models add both however
+    firmly they are told not to, and a reply thrown away for its shape is a
+    whole angle missing from the list.
+    """
+    rows: list[tuple[str, str, str]] = []
+    for line in text.splitlines():
+        if "|" not in line:
+            continue
+        parts = [part.strip() for part in line.split("|")]
+        name = re.sub(r"^[\-\*•\d\.\)\s]+", "", parts[0]).strip().strip("*_ ")
+        if not name or name.lower() in {"name", "place", "business", "restaurant"}:
+            continue
+        if _NOT_A_BUSINESS.search(name):
+            logger.info("Dropped a row that is not one named business: %r", name)
+            continue
+        rows.append(
+            (name, parts[1] if len(parts) > 1 else "", parts[2] if len(parts) > 2 else "")
+        )
+    return rows
+
+
+def _search_once(prompt: str, research) -> tuple[str, list[str]]:
+    digest, urls, _tokens = research(prompt)
+    return digest, urls
+
+
+def run_search_order(
+    angles: list[str],
+    *,
+    kind: str,
+    place: str,
+    target_items: int,
+    exclusions: str = "",
+    standard: str = "",
+    research=None,
+) -> tuple[list[Candidate], list[AngleResult]]:
+    """Run every angle and pool what comes back.
+
+    `research(prompt) -> (text, urls, tokens)` is the one path in this app that
+    reaches the web, passed in so this is testable without a network.
+
+    Returns the pooled candidates, strongest overlap first, and one result row
+    per angle so a search that found nothing is visible as itself rather than
+    as an absence.
+    """
+    if research is None:  # pragma: no cover -- wiring error, not a runtime one
+        raise ValueError("run_search_order needs a research callable")
+
+    wanted = per_angle_ask(target_items, len(angles))
+    pool: dict[str, Candidate] = {}
+    results: list[AngleResult] = []
+
+    for angle in angles:
+        prompt = build_search_prompt(
+            angle,
+            kind=kind,
+            place=place,
+            exclusions=exclusions,
+            standard=standard,
+            wanted=wanted,
+        )
+        text, urls, failure = "", [], ""
+        for attempt in range(SEARCH_ATTEMPTS):
+            try:
+                text, urls = _search_once(prompt, research)
+                failure = ""
+                break
+            except Exception as exc:  # pragma: no cover -- network dependent
+                failure = f"{type(exc).__name__}"
+                logger.warning(
+                    "Angle search failed (attempt %s) for %r: %s", attempt + 1, angle, exc
+                )
+
+        rows = parse_rows(text)
+        # Three different things look identical as a zero on the screen, and
+        # only one of them is worth re-running:
+        #
+        #   the search never ran          -> a fact about the network
+        #   it ran and said nothing       -> a fact about the model or the quota
+        #   it answered but named nobody  -> a fact about the angle
+        #
+        # The first real run labelled all three "nothing published for this
+        # angle", which sent the operator looking for a better angle when the
+        # actual problem was a 60-second timeout.
+        if failure:
+            reason = failure
+        elif rows:
+            reason = ""
+        elif not text.strip():
+            reason = "the search came back empty"
+        else:
+            reason = "the search answered but named no places"
+        results.append(
+            AngleResult(
+                angle=angle,
+                rows=len(rows),
+                sources=len(urls),
+                failed=bool(failure),
+                reason=reason,
+            )
+        )
+
+        for name, district, evidence in rows:
+            key = normalise_name(name)
+            if not key:
+                continue
+            existing = pool.get(key)
+            if existing is None:
+                pool[key] = Candidate(
+                    name=name, district=district, evidence=evidence, found_by=[angle]
+                )
+                continue
+            if angle not in existing.found_by:
+                existing.found_by.append(angle)
+            # Keep the longer name and fill a district the first row lacked:
+            # "La Mar" and "La Mar Cebichería" are one place, and the fuller
+            # name is the one worth printing.
+            if len(name) > len(existing.name):
+                existing.name = name
+            if district and not existing.district:
+                existing.district = district
+
+    merged = merge_contained(list(pool.values()))
+    candidates = sorted(merged, key=lambda c: (-c.overlap, c.name.lower()))
+    return candidates, results

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -1,0 +1,147 @@
+"""Starting and advancing a listicle interview.
+
+Everything mechanical about the interview -- the loop, the single retry, the
+mid-interview lookup budget, the pushback, the "accepted draft is not new
+information" rule, the stop condition -- comes from
+`prompt2blog.grill_v4` untouched. This module supplies the two things that
+make it a listicle: the checklist it has to settle, and the prompt it asks
+with.
+
+That split is the point. Every bug worth fixing in the article grill lived in
+the loop, and a forked copy of it would have to be fixed twice and would be
+fixed once.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from ..prompt2blog.contracts_v4 import GrillState
+from ..prompt2blog.grill_v4 import (
+    GrillDependencies,
+    answer_grill,
+    reopen_grill,
+    start_grill,
+)
+from . import spec, store
+from .contracts import LISTICLE_MARKER_KEYS
+from .prompts import build_listicle_turn_prompt
+from .search import run_search_order
+
+# gemini-2.5-flash: the model the live grounding path already runs on, and
+# cheap enough that the interview is not the expensive part of a run.
+LISTICLE_GRILL_MODEL = "gemini-2.5-flash"
+
+
+def _dependencies(base: GrillDependencies) -> GrillDependencies:
+    """The article grill's dependencies, pointed at the listicle prompt."""
+    return GrillDependencies(
+        llm=base.llm,
+        research=base.research,
+        model_name=base.model_name,
+        build_prompt=build_listicle_turn_prompt,
+    )
+
+
+def start(seed: str, base: GrillDependencies) -> GrillState:
+    run_id = uuid.uuid4().hex[:8]
+    state = start_grill(
+        run_id=run_id,
+        seed=seed,
+        dependencies=_dependencies(base),
+        marker_keys=LISTICLE_MARKER_KEYS,
+    )
+    store.save(state)
+    return state
+
+
+def answer(run_id: str, text: str, base: GrillDependencies) -> GrillState:
+    state = store.load(run_id)
+    if state is None:
+        raise LookupError(f"No listicle interview with id {run_id}")
+    state = answer_grill(state, text, _dependencies(base))
+    store.save(state)
+    return state
+
+
+def reopen(run_id: str, base: GrillDependencies) -> GrillState:
+    """Not quite -- keep talking. Sends an agreed interview back to asking."""
+    state = store.load(run_id)
+    if state is None:
+        raise LookupError(f"No listicle interview with id {run_id}")
+    state = reopen_grill(state, _dependencies(base))
+    store.save(state)
+    return state
+
+
+def get(run_id: str) -> GrillState | None:
+    return store.load(run_id)
+
+
+def search(run_id: str, research) -> dict:
+    """Run the agreed search order and pool what comes back.
+
+    Refuses to run before the interview has agreed. A half-settled order is
+    missing the angles, and searching without them is six searches for whatever
+    the seed happened to say -- which is the single-search failure the split
+    exists to avoid, at six times the cost.
+    """
+    state = store.load(run_id)
+    if state is None:
+        raise LookupError(f"No listicle interview with id {run_id}")
+    if state.status != "agreed":
+        raise ValueError(
+            "This interview has not agreed a search order yet, so there is "
+            "nothing to search for."
+        )
+
+    angles = spec.angles_from(state)
+    if not angles:
+        raise ValueError("The agreed interview carries no angles to search.")
+
+    target = spec.count_from(state)
+    candidates, results = run_search_order(
+        angles,
+        kind=spec.kind_from(state),
+        place=spec.place_from(state),
+        target_items=target,
+        exclusions=spec.exclusions_from(state),
+        standard=spec.standard_from(state),
+        research=research,
+    )
+    payload = {
+        "run_id": run_id,
+        "target": target,
+        # Said plainly rather than left to be worked out from the list length.
+        # Whether the order filled the list is the only question this step was
+        # built to answer.
+        "found": len(candidates),
+        "shortfall": max(0, target - len(candidates)),
+        "rows_returned": sum(result.rows for result in results),
+        "angles": [
+            {
+                "angle": r.angle,
+                "rows": r.rows,
+                "sources": r.sources,
+                "failed": r.failed,
+                "reason": r.reason,
+            }
+            for r in results
+        ],
+        "candidates": [
+            {
+                "name": c.name,
+                "district": c.district,
+                "evidence": c.evidence,
+                "found_by": list(c.found_by),
+                "overlap": c.overlap,
+            }
+            for c in candidates
+        ],
+    }
+    store.save_results(run_id, payload)
+    return payload
+
+
+def results(run_id: str) -> dict | None:
+    return store.load_results(run_id)

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -177,15 +177,28 @@ def build_profile(
     from . import identity, profile_research, profile_store
 
     place_id = ""
+    address = ""
+    lookup_name = name
     if resolve_identity:
         resolved = identity.resolve(name, city)
         if resolved is not None:
             place_id = resolved.place_id
+            address = resolved.address
+            # The name Google holds, not the one a search happened to write.
+            # "Bar Rovira del Callao" is really "Tradición Chalaca Rovira
+            # 1907", and looking a place up under a name it does not use is
+            # how a lookup comes back thin.
+            lookup_name = resolved.name or name
             if resolved.permanently_closed:
                 # Recorded rather than acted on. Whether a closed place stays
                 # on a list is the gate's decision and the operator's, not
                 # this step's.
                 logger.warning("%r resolves to a permanently closed place", name)
+            if not resolved.is_venue:
+                logger.warning(
+                    "%r resolves to %s, which is not somewhere a reader can be "
+                    "served", name, ", ".join(resolved.types) or "nothing",
+                )
 
     profile = profile_store.open_profile(
         name=name, city=city, district=district, place_id=place_id
@@ -199,7 +212,7 @@ def build_profile(
 
     if research is not None:
         result = profile_research.research_place(
-            name, city, list(angles or []), research
+            lookup_name, city, list(angles or []), research, address=address
         )
         if result.failed:
             # Raised rather than logged. A profile recorded as having nothing

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -14,9 +14,11 @@ fixed once.
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from ..prompt2blog.contracts_v4 import GrillState
+from .profiles import PlaceProfile
 from ..prompt2blog.grill_v4 import (
     GrillDependencies,
     answer_grill,
@@ -31,6 +33,8 @@ from .search import run_search_order
 # gemini-2.5-flash: the model the live grounding path already runs on, and
 # cheap enough that the interview is not the expensive part of a run.
 LISTICLE_GRILL_MODEL = "gemini-2.5-flash"
+
+logger = logging.getLogger(__name__)
 
 
 def _dependencies(base: GrillDependencies) -> GrillDependencies:
@@ -145,3 +149,76 @@ def search(run_id: str, research) -> dict:
 
 def results(run_id: str) -> dict | None:
     return store.load_results(run_id)
+
+
+def build_profile(
+    *,
+    name: str,
+    city: str,
+    district: str = "",
+    angles: list[str] | None = None,
+    run_id: str = "",
+    research=None,
+    resolve_identity: bool = True,
+) -> "PlaceProfile":
+    """Open this place's profile, anchor it, and gather what has been said.
+
+    Deliberately not called by the search step. A profile is worth building for
+    a candidate that survives, and which candidates survive is what the gate --
+    not yet built -- decides. Wiring this into the pipeline before that gate
+    exists would research every row returned, including the ones the gate is
+    there to throw away.
+
+    Running it twice on the same place is safe and is the normal case: the
+    profile is found rather than created, claims already held are not added
+    again, and a sighting from a run already recorded is ignored.
+    """
+    from .profiles import Sighting
+    from . import identity, profile_research, profile_store
+
+    place_id = ""
+    if resolve_identity:
+        resolved = identity.resolve(name, city)
+        if resolved is not None:
+            place_id = resolved.place_id
+            if resolved.permanently_closed:
+                # Recorded rather than acted on. Whether a closed place stays
+                # on a list is the gate's decision and the operator's, not
+                # this step's.
+                logger.warning("%r resolves to a permanently closed place", name)
+
+    profile = profile_store.open_profile(
+        name=name, city=city, district=district, place_id=place_id
+    )
+
+    for angle in angles or []:
+        if run_id:
+            profile_store.add_sighting(
+                profile.profile_id, Sighting(angle=angle, run_id=run_id)
+            )
+
+    if research is not None:
+        result = profile_research.research_place(
+            name, city, list(angles or []), research
+        )
+        if result.failed:
+            # Raised rather than logged. A profile recorded as having nothing
+            # written about it, when the truth is the call never ran, is a
+            # place the gate will drop for the network's mistake.
+            raise RuntimeError(
+                f"Research for {name!r} failed ({result.reason}); the profile "
+                "was left as it was rather than recorded as empty."
+            )
+        added = profile_store.add_claims(profile.profile_id, result.claims)
+        logger.info(
+            "Profile %s: %s claims found, %s new%s",
+            profile.profile_id,
+            len(result.claims),
+            added,
+            f" -- {result.reason}" if result.reason else "",
+        )
+
+    refreshed = profile_store.find(
+        place_id=profile.place_id, name=name, city=city
+    )
+    return refreshed or profile

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -174,7 +174,7 @@ def build_profile(
     again, and a sighting from a run already recorded is ignored.
     """
     from .profiles import Sighting
-    from . import identity, profile_research, profile_store
+    from . import identity, places, profile_research, profile_store
 
     place_id = ""
     address = ""
@@ -209,6 +209,21 @@ def build_profile(
             profile_store.add_sighting(
                 profile.profile_id, Sighting(angle=angle, run_id=run_id)
             )
+
+    # What Google holds, before anything a model read. Cheap, factual, and the
+    # only material in a profile no model wrote -- and the only source of the
+    # customer voice a cheap-eats or value angle is written from.
+    if place_id:
+        details = places.fetch_details(place_id)
+        if details.failed:
+            logger.warning(
+                "Place details unavailable for %r: %s", name, details.reason
+            )
+        else:
+            added = profile_store.add_claims(
+                profile.profile_id, places.claims_from(details)
+            )
+            logger.info("Profile %s: %s claims from Places", profile.profile_id, added)
 
     if research is not None:
         result = profile_research.research_place(

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/shapes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/shapes.py
@@ -1,0 +1,253 @@
+"""The shapes an angle can take, and how many a list needs.
+
+An *angle* is one reason a place is on the list, and one search. A *shape* is
+the pattern behind it, with the topic left blank.
+
+The difference is the whole design. A fixed list of finished angles said "tiny,
+plain, unglamorous places where the food is the whole point" for ceviche, for
+pizza and for wings -- the same sentence three times, generic because it was
+written to survive any topic. A shape says *the humble one* and makes the model
+write ceviche's version of it: places that shut when the fish runs out.
+
+So the model writes the words and the shapes hold the discipline. That split is
+not a preference; it is what two failed runs on 2026-09-03 cost. Asked to
+choose AND word its own angles for Lima restaurants, gemini-2.5-flash:
+
+- **Over-tightened its own wording.** Given "open for decades" it wrote
+  "operating for 50+ years" and found 3 places instead of 9. It wrote "opened
+  in the last 1-3 years AND has significant buzz" and found 1 instead of 8.
+  Every condition it volunteered emptied a search.
+- **Picked the same angle three times.** "Iconic", "Where Chefs Eat" and
+  "Experiential Dining" all returned Central, Maido and Astrid y Gastón. 49
+  rows collapsed into 30 places.
+
+Hand-picked angles on the same model, same city, same day: 53 rows, 42 distinct
+places, from five searches instead of eight.
+
+A shape fixes both. It sets the tightness, so there is no blank to bolt an
+extra condition onto; and it belongs to a `collides_with` group, so the three
+angles that are all "the prestigious one" can no longer be chosen together.
+
+The groups are the second failure written down. `prestige` exists because
+world-renowned, luxury, award-winning and tasting-menu return the same handful
+of restaurants in every city on earth. One of them is the strongest thing on a
+list. Three of them is a third of the list wasted.
+"""
+
+from __future__ import annotations
+
+
+class Shape:
+    """One pattern an angle can take.
+
+    `instruction` is addressed to the model and says what to write. `example`
+    shows the same shape instantiated for two unlike topics, because one
+    example reads as a template to copy and two read as a pattern to apply.
+    """
+
+    __slots__ = ("key", "label", "instruction", "example", "collides_with")
+
+    def __init__(
+        self,
+        key: str,
+        label: str,
+        instruction: str,
+        example: str,
+        collides_with: str = "",
+    ) -> None:
+        self.key = key
+        self.label = label
+        self.instruction = instruction
+        self.example = example
+        # Shapes sharing a group return the same places for the same reason.
+        # At most one of a group may be chosen.
+        self.collides_with = collides_with
+
+    def __repr__(self) -> str:  # pragma: no cover -- diagnostics only
+        return f"Shape({self.key!r})"
+
+
+SHAPES: tuple[Shape, ...] = (
+    # --- prestige: these four find the same short list in every city ---------
+    Shape(
+        "world-renowned",
+        "World renowned",
+        "The ones known outside the country. International lists, foreign press.",
+        "ceviche: cevicherias that appear on world's-best restaurant lists | "
+        "pizza: pizzerias written up in the international food press",
+        collides_with="prestige",
+    ),
+    Shape(
+        "luxury",
+        "The splurge",
+        "The expensive end. What people book for an anniversary.",
+        "ceviche: expensive cevicherias people save up for | "
+        "hotels: the most expensive hotels in the city",
+        collides_with="prestige",
+    ),
+    Shape(
+        "award",
+        "Award listed",
+        "Formally recognised by a guide, award or national body.",
+        "ceviche: cevicherias that have won a national restaurant award | "
+        "pizza: AVPN-certified pizzerias",
+        collides_with="prestige",
+    ),
+    Shape(
+        "the-experience",
+        "The set experience",
+        "Booked in advance, fixed format, you sit down for the whole thing.",
+        "ceviche: cevicherias serving a tasting menu | "
+        "bars: bars with a reservation-only cocktail programme",
+        collides_with="prestige",
+    ),
+    # --- heritage: the old one and the first one are usually one place -------
+    Shape(
+        "institution",
+        "Local institution",
+        "Open for decades. Predates whatever is fashionable now. Say 'decades',"
+        " never a specific number of years -- a number empties the search.",
+        "ceviche: cevicherias that have been open for decades | "
+        "hotels: hotels that have been operating for decades",
+        collides_with="heritage",
+    ),
+    Shape(
+        "origin",
+        "Where it started",
+        "The place credited with starting this locally, or with one dish"
+        " everyone else now copies.",
+        "ceviche: the cevicheria credited with starting Lima's ceviche boom | "
+        "pizza: the pizzeria credited with inventing the local style",
+        collides_with="heritage",
+    ),
+    # --- humble: cheap, hidden and informal are close but not the same -------
+    Shape(
+        "hidden",
+        "Hard to find",
+        "No sign, no listing, someone's front room, known by word of mouth.",
+        "ceviche: unmarked huariques serving ceviche that locals know by word"
+        " of mouth | bars: unmarked bars behind another business",
+        collides_with="humble",
+    ),
+    Shape(
+        "cheap",
+        "Cheap and good",
+        "Very cheap, and rated highly anyway. Price is the point.",
+        "ceviche: very cheap cevicherias that people rate highly | "
+        "hotels: very cheap places to stay that people rate highly",
+        collides_with="humble",
+    ),
+    Shape(
+        "informal",
+        "Stall, counter or market",
+        "Not a restaurant. A stall, a counter, a stand, a spot in a market.",
+        "ceviche: ceviche stalls inside the city's markets | "
+        "pizza: pizza served by the slice from a counter",
+        collides_with="humble",
+    ),
+    # --- standalone: none of these answer each other -------------------------
+    Shape(
+        "new-wave",
+        "Just opened",
+        "Opened in the last year. Nothing else -- no buzz clause, no quality"
+        " clause. Adding one is what found a single place instead of eight.",
+        "ceviche: cevicherias that opened in the last year | "
+        "hotels: hotels that opened in the last year",
+    ),
+    Shape(
+        "purist",
+        "The orthodox version",
+        "Does it the traditional way and refuses to vary it.",
+        "ceviche: cevicherias serving classic ceviche with no fusion | "
+        "pizza: pizzerias doing only wood-fired Neapolitan",
+    ),
+    Shape(
+        "crossed",
+        "Crossed with something else",
+        "The same thing put through another cuisine, culture or technique.",
+        "ceviche: nikkei cevicherias doing Japanese-Peruvian preparations | "
+        "pizza: pizzerias doing a non-Italian style",
+    ),
+    Shape(
+        "one-thing",
+        "Known for one thing",
+        "Famous for a single item and little else.",
+        "ceviche: places known above all for their leche de tigre | "
+        "wings: places famous for one sauce",
+    ),
+    Shape(
+        "insider",
+        "Where the trade goes",
+        "Where people who work in this field eat, drink or stay themselves.",
+        "ceviche: where Lima chefs say they eat ceviche on their days off | "
+        "bars: where bartenders drink after their shift",
+    ),
+    Shape(
+        "family",
+        "Family run",
+        "Run by one family, often across generations.",
+        "ceviche: cevicherias run by the same family for more than one"
+        " generation | hotels: guesthouses run by the family who own them",
+    ),
+    Shape(
+        "setting",
+        "For the room or the view",
+        "Chosen for where you sit rather than what you get.",
+        "ceviche: cevicherias people go to for the view of the sea | "
+        "bars: rooftop bars people go to for what they can see",
+    ),
+    Shape(
+        "hours",
+        "Defined by when",
+        "Only exists at one time of day. Lunch only, late night, breakfast.",
+        "ceviche: lunch-only cevicherias that close when the fish runs out | "
+        "bars: places busiest after most bars have closed",
+    ),
+    Shape(
+        "district",
+        "One neighbourhood's own",
+        "The place people in one specific district go to, that visitors miss.",
+        "ceviche: cevicherias that one Lima neighbourhood keeps to itself | "
+        "hotels: places chosen for the street they are on",
+    ),
+)
+
+SHAPES_BY_KEY: dict[str, Shape] = {shape.key: shape for shape in SHAPES}
+
+
+def shape_menu() -> str:
+    """The catalogue as the model is shown it."""
+    lines: list[str] = []
+    for shape in SHAPES:
+        group = f"  [group: {shape.collides_with}]" if shape.collides_with else ""
+        lines.append(f"{shape.key} -- {shape.label}{group}")
+        lines.append(f"    write: {shape.instruction}")
+        lines.append(f"    e.g.  {shape.example}")
+    return "\n".join(lines)
+
+
+def collision_groups() -> str:
+    """The groups, named, so the rule can be stated rather than implied."""
+    groups: dict[str, list[str]] = {}
+    for shape in SHAPES:
+        if shape.collides_with:
+            groups.setdefault(shape.collides_with, []).append(shape.key)
+    return "\n".join(
+        f"- {name}: {', '.join(keys)}" for name, keys in sorted(groups.items())
+    )
+
+
+def suggested_angle_count(target_items: int) -> int:
+    """How many angles a list of this length gets built from.
+
+    Roughly seven items per angle. A short list wants few angles asked hard; a
+    long one cannot be filled from a handful and needs the spread. Capped at
+    the number of shapes that can actually be chosen together -- an angle with
+    no places behind it is a search that returns nothing and a slot that
+    becomes padding.
+    """
+    if target_items <= 8:
+        return 2
+    if target_items <= 15:
+        return 3
+    return max(4, min(10, round(target_items / 7)))

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/spec.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/spec.py
@@ -1,0 +1,69 @@
+"""Reading the search order back off a finished interview.
+
+The grill's `consensus` is prose, written to be read by a person. It is the
+wrong thing to execute: a number parsed out of a sentence is a number that can
+be parsed wrong, and silently.
+
+The answers themselves are structured enough. Every question declares the
+marker it settles, so the answer to `count` is the count and the answer to
+`angles` is the angle list, one per line -- which is exactly how the picker
+sends them and why the picker sends lines instead of a paragraph.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..prompt2blog.contracts_v4 import GrillState
+
+
+def _answer_for(state: GrillState, marker: str) -> str:
+    """The last thing said about one marker.
+
+    Last rather than first: a marker asked about twice was asked again because
+    something was wrong with the first answer.
+    """
+    for turn in reversed(state.turns):
+        if turn.question.asks_about == marker:
+            return turn.answer.strip()
+    return ""
+
+
+def angles_from(state: GrillState) -> list[str]:
+    """The agreed angles, one per line, in the order they were chosen."""
+    raw = _answer_for(state, "angles")
+    lines = [re.sub(r"^[\-\*•\d\.\)\s]+", "", line).strip() for line in raw.splitlines()]
+    return [line for line in lines if line]
+
+
+def count_from(state: GrillState, default: int = 20) -> int:
+    """How many items the list is aiming at.
+
+    Read from the count answer, and from the seed when the interview settled
+    the count without anyone restating the number -- "Yes, that's right" is a
+    perfectly good answer to "is 40 the number?" and carries no number at all.
+    """
+    for text in (_answer_for(state, "count"), state.seed):
+        numbers = [int(n) for n in re.findall(r"\b(\d{1,3})\b", text)]
+        # Ignore years and other incidental numbers; a list length is small.
+        plausible = [n for n in numbers if 3 <= n <= 200]
+        if plausible:
+            return max(plausible)
+    return default
+
+
+def kind_from(state: GrillState) -> str:
+    """The searchable noun. Falls back to the seed, which usually carries it."""
+    return _answer_for(state, "kind") or state.seed
+
+
+def place_from(state: GrillState) -> str:
+    return _answer_for(state, "place") or state.location or state.seed
+
+
+def standard_from(state: GrillState) -> str:
+    return _answer_for(state, "bar")
+
+
+def exclusions_from(state: GrillState) -> str:
+    return _answer_for(state, "cut")

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
@@ -1,0 +1,90 @@
+"""Where a listicle interview is kept between turns.
+
+Persisted per turn rather than held in the browser, for the same reason the
+article grill is (ADR 0031): an abandoned interview is resumable, and a closed
+tab is not a lost run. The whole state goes in as JSON because it is a
+pydantic contract that will grow, and a column per field would have to be
+migrated every time a marker changes.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.core.database import get_db_connection
+
+from ..prompt2blog.contracts_v4 import GrillState
+
+_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_grills (
+    run_id     TEXT PRIMARY KEY,
+    state      TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+_RESULTS_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_search_results (
+    run_id     TEXT PRIMARY KEY,
+    payload    TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+def ensure_tables() -> None:
+    with get_db_connection() as conn:
+        conn.execute(_TABLE)
+        conn.execute(_RESULTS_TABLE)
+
+
+def save(state: GrillState) -> None:
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_grills (run_id, state) VALUES (?, ?) "
+            "ON CONFLICT(run_id) DO UPDATE SET state=excluded.state, "
+            "updated_at=datetime('now')",
+            (state.run_id, state.model_dump_json()),
+        )
+
+
+def load(run_id: str) -> GrillState | None:
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT state FROM listicle_grills WHERE run_id = ?", (run_id,)
+        ).fetchone()
+    if row is None:
+        return None
+    return GrillState.model_validate(json.loads(row[0]))
+
+
+def save_results(run_id: str, payload: dict) -> None:
+    """What the searches found, kept whole.
+
+    Stored so the search is run once and looked at many times. Seven grounded
+    searches take minutes and cost real tokens; a screen that re-ran them on
+    every reload would be unusable and expensive, and re-running is a decision
+    the operator makes, not a side effect of looking.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_search_results (run_id, payload) VALUES (?, ?) "
+            "ON CONFLICT(run_id) DO UPDATE SET payload=excluded.payload, "
+            "updated_at=datetime('now')",
+            (run_id, json.dumps(payload, ensure_ascii=False)),
+        )
+
+
+def load_results(run_id: str) -> dict | None:
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT payload FROM listicle_search_results WHERE run_id = ?", (run_id,)
+        ).fetchone()
+    return None if row is None else json.loads(row[0])

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -244,6 +244,25 @@ class WorkOrderRequirement(V4ContractModel):
 GrillStatus = Literal["asking", "agreed"]
 
 
+class GrillOption(V4ContractModel):
+    """One choice on a question answered by picking rather than by writing.
+
+    `recommended` is what arrives ticked. The rest are offered unticked, which
+    is the difference between a recommendation and a menu: a screen showing
+    only what was chosen cannot be argued with, because there is nothing
+    visible to swap in.
+
+    `group` names a set whose members answer each other -- ticking two of them
+    runs two searches that return the same places. The screen says so; it does
+    not enforce it, because the operator knows the city and the rule is a
+    default, not a law.
+    """
+
+    text: str = Field(min_length=1)
+    recommended: bool = False
+    group: str = ""
+
+
 class GrillQuestion(V4ContractModel):
     """One question, and the operator's answer to it, written in advance.
 
@@ -273,6 +292,16 @@ class GrillQuestion(V4ContractModel):
     # run a9959013 (2026-08-30 19:29Z) asked the same failure question four
     # times and never moved.
     asks_about: str = ""
+    # A question whose answer is a choice rather than a sentence. The screen
+    # renders these as a list to tick and edit; the answer that comes back is
+    # still the text of what was kept, so the transcript, the contract and the
+    # loop are unchanged and only the input control differs.
+    #
+    # Empty for almost every question. Filled for the listicle grill's angle
+    # question, where each entry becomes a literal web search and prose would
+    # have to be re-parsed into lines -- which is exactly where wording gets
+    # mangled, and wording is the thing that empties a search.
+    options: list[GrillOption] = Field(default_factory=list)
 
 
 class GrillTurn(V4ContractModel):
@@ -349,6 +378,14 @@ class GrillState(V4ContractModel):
     # grill that stalls shows what it is still missing, rather than looking
     # like it is asking at random.
     markers_covered: list[str] = Field(default_factory=list)
+    # What this interview is trying to settle, so the same loop can run an
+    # interview that is not about an article. An article grill leaves this
+    # alone and gets `MARKER_KEYS`; the listicle grill passes its own.
+    # Carried on the state rather than read from the module so the stop
+    # condition travels with the run it belongs to -- a resumed grill must be
+    # judged against the checklist it started with, not whichever one the
+    # process happens to import.
+    marker_keys: tuple[str, ...] = MARKER_KEYS
 
     @model_validator(mode="after")
     def validate_grill_state(self) -> "GrillState":
@@ -362,7 +399,9 @@ class GrillState(V4ContractModel):
                 raise ValueError("an agreed grill cannot still be asking something")
             if not self.consensus:
                 raise ValueError("an agreed grill must have played back what it agreed")
-            missing = [key for key in MARKER_KEYS if key not in self.markers_covered]
+            missing = [
+                key for key in self.marker_keys if key not in self.markers_covered
+            ]
             if missing:
                 # The code refuses to agree without these, so the contract says
                 # so too. A schema that permits what the code refuses is a

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -38,12 +38,13 @@ from .config import (
 from .contracts_v4 import (
     BRIEF_MARKERS,
     MARKER_KEYS,
+    GrillOption,
     GrillQuestion,
     GrillState,
     GrillTurn,
 )
 from .schema_guards import require_non_empty
-from .support import _safe_dict, _safe_str
+from .support import _safe_dict, _safe_str, _safe_str_list
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,18 @@ NEXT_TURN_SCHEMA = require_non_empty({
         "location": {"type": "string"},
         "markers_covered": {"type": "array", "items": {"type": "string"}},
         "asks_about": {"type": "string"},
+        "options": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "recommended": {"type": "boolean"},
+                    "group": {"type": "string"},
+                },
+                "required": ["text", "recommended"],
+            },
+        },
         "lookup": {"type": "string"},
     },
     "required": [
@@ -122,6 +135,16 @@ class GrillDependencies:
     # this one reaches the web and the other does not.
     research: Callable[[str], tuple[str, list[str], int | None]]
     model_name: str = P2B_V4_GRILL_MODEL
+    # What the grill is told before it decides its next move. The five rules in
+    # this module are about how an interview behaves and hold whatever is being
+    # commissioned; the wording of the questions is not, and belongs to the
+    # thing doing the commissioning. A listicle grill passes its own and gets
+    # the loop, the retry, the lookup budget, the pushback and the stop
+    # condition unchanged -- which is the whole point of putting it here rather
+    # than forking the file.
+    # None means the article interview, whose prompt is defined further down
+    # this module and so cannot be named as a default here.
+    build_prompt: Callable[[GrillState], str] | None = None
 
 
 def research_seed(dependencies: GrillDependencies, seed: str) -> tuple[str, list[str], int | None]:
@@ -207,25 +230,42 @@ def _transcript(state: GrillState) -> str:
         lines = [f"Q{index}. You asked: {turn.question.ask}"]
         if turn.question.pushback:
             lines.append(f"You pushed back: {turn.question.pushback}")
-        lines.append(f"You drafted this answer for them: {turn.question.recommendation}")
-        if turn.accepted_as_drafted:
-            lines.append(
-                "They sent your draft back untouched. Those are YOUR words, not "
-                "theirs: it means they did not object, and it tells you nothing "
-                "you did not already believe."
-            )
+        if turn.question.options:
+            # A question answered by picking is not a draft they let stand.
+            # Ticking six boxes out of twenty is a decision, and the
+            # accepted-draft warning below says the opposite -- it tells the
+            # grill it learned nothing, and a grill that believes it learned
+            # nothing asks again. A live listicle run asked its angle question
+            # twice in a row on exactly this, which is the single most
+            # expensive question in that interview.
+            offered = len(turn.question.options)
+            lines.append(f"You offered them {offered} options to choose from.")
+            lines.append(f"They chose these, and this is SETTLED:\n{turn.answer}")
         else:
-            lines.append(f"They wrote, in their own words: {turn.answer}")
+            lines.append(
+                f"You drafted this answer for them: {turn.question.recommendation}"
+            )
+            if turn.accepted_as_drafted:
+                lines.append(
+                    "They sent your draft back untouched. Those are YOUR words, not "
+                    "theirs: it means they did not object, and it tells you nothing "
+                    "you did not already believe."
+                )
+            else:
+                lines.append(f"They wrote, in their own words: {turn.answer}")
         blocks.append("\n".join(lines))
     return "\n\n".join(blocks)
 
 
-def _marker_status(state: GrillState) -> str:
+def _marker_status(
+    state: GrillState,
+    markers: tuple[tuple[str, str, str], ...] = BRIEF_MARKERS,
+) -> str:
     """What the brief still needs, named in plain English."""
     covered = set(state.markers_covered)
     return "\n".join(
         f"- {marker}: {description} — {'COVERED' if marker in covered else 'still missing'}"
-        for marker, _, description in BRIEF_MARKERS
+        for marker, _, description in markers
     )
 
 
@@ -339,7 +379,11 @@ Now the part that matters:
 """
 
 
-def _question_from(payload: dict[str, Any], fallback_id: str) -> GrillQuestion | None:
+def _question_from(
+    payload: dict[str, Any],
+    fallback_id: str,
+    marker_keys: tuple[str, ...] = MARKER_KEYS,
+) -> GrillQuestion | None:
     """Read the question, however the model chose to arrange it.
 
     Flat is what the schema asks for and what models actually produce. Nested
@@ -360,8 +404,16 @@ def _question_from(payload: dict[str, Any], fallback_id: str) -> GrillQuestion |
         or _safe_str(nested.get("ask"))
         or _safe_str(flat_ask)
     )
-    recommendation = _safe_str(payload.get("recommendation")) or _safe_str(
-        nested.get("recommendation")
+    # A recommendation that is a list of lines rather than a string is what a
+    # model sends when the answer IS a list -- the angle question, where the
+    # recommendation is the picked lines. `_safe_str` returns "" for a list, a
+    # question with no recommendation is refused, and a live run spent a whole
+    # retry on that. The lines are the answer; joining them loses nothing.
+    recommendation = (
+        _safe_str(payload.get("recommendation"))
+        or _safe_str(nested.get("recommendation"))
+        or "\n".join(_safe_str_list(payload.get("recommendation")))
+        or "\n".join(_safe_str_list(nested.get("recommendation")))
     )
     if not ask or not recommendation:
         # A question with no recommendation is a blank box, which is the thing
@@ -378,11 +430,55 @@ def _question_from(payload: dict[str, Any], fallback_id: str) -> GrillQuestion |
         ask=ask,
         recommendation=recommendation,
         pushback=_safe_str(payload.get("pushback")) or _safe_str(nested.get("pushback")),
-        asks_about=asks_about if asks_about in MARKER_KEYS else "",
+        asks_about=asks_about if asks_about in marker_keys else "",
+        options=_options_from(payload.get("options") or nested.get("options")),
     )
 
 
-def _markers_from(payload: dict[str, Any], state: GrillState) -> list[str]:
+def _options_from(raw: Any) -> list[GrillOption]:
+    """The choices, however the model chose to arrange them.
+
+    Objects are what the schema asks for. A bare list of strings is what a
+    model that skimmed the schema sends, and it carries the only part that
+    cannot be reconstructed -- the wording. Refusing it would throw away the
+    whole answer over its shape, which is the mistake this module has already
+    made twice.
+
+    A plain string is read as recommended, because a model that sent no flag
+    sent only the ones it meant.
+    """
+    if isinstance(raw, str):
+        return [
+            GrillOption(text=text, recommended=True) for text in _safe_str_list(raw)
+        ]
+    if not isinstance(raw, list):
+        return []
+    options: list[GrillOption] = []
+    seen: set[str] = set()
+    for item in raw:
+        if isinstance(item, str):
+            text, recommended, group = _safe_str(item), True, ""
+        elif isinstance(item, dict):
+            text = _safe_str(item.get("text")) or _safe_str(item.get("angle"))
+            recommended = item.get("recommended") is True
+            group = _safe_str(item.get("group"))
+        else:
+            continue
+        # Duplicates are the failure this question exists to avoid: the same
+        # search offered twice is the same search run twice.
+        key = text.lower()
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        options.append(GrillOption(text=text, recommended=recommended, group=group))
+    return options
+
+
+def _markers_from(
+    payload: dict[str, Any],
+    state: GrillState,
+    marker_keys: tuple[str, ...] | None = None,
+) -> list[str]:
     """Which brief markers are settled: what the grill claims, plus what the
     conversation shows.
 
@@ -405,7 +501,8 @@ def _markers_from(payload: dict[str, Any], state: GrillState) -> list[str]:
     claimed = {_safe_str(item) for item in raw} if isinstance(raw, list) else set()
     answered = {turn.question.asks_about for turn in state.turns}
     settled = claimed | answered
-    return [key for key in MARKER_KEYS if key in settled]
+    keys = marker_keys if marker_keys is not None else state.marker_keys
+    return [key for key in keys if key in settled]
 
 
 class GrillUnusableResponse(RuntimeError):
@@ -470,7 +567,7 @@ def _advance_once(
     # turn where the grill finally asks its question.
     while True:
         parsed, raw = dependencies.llm.invoke_json(
-            prompt=build_next_turn_prompt(state),
+            prompt=(dependencies.build_prompt or build_next_turn_prompt)(state),
             model_name=dependencies.model_name,
             schema=NEXT_TURN_SCHEMA,
             max_tokens=2_048,
@@ -497,7 +594,7 @@ def _advance_once(
 
     if payload.get("done") is True:
         consensus = _safe_str(payload.get("consensus"))
-        missing = [key for key in MARKER_KEYS if key not in covered]
+        missing = [key for key in state.marker_keys if key not in covered]
         if consensus and not missing:
             return state.model_copy(
                 update={
@@ -517,7 +614,11 @@ def _advance_once(
             ", ".join(missing) or "none",
         )
 
-    question = _question_from(payload, fallback_id=f"q{len(state.turns) + 1}")
+    question = _question_from(
+        payload,
+        fallback_id=f"q{len(state.turns) + 1}",
+        marker_keys=state.marker_keys,
+    )
     if question is None:
         raise GrillUnusableResponse(raw or _json_or_repr(payload), state)
     return state.model_copy(
@@ -534,12 +635,19 @@ def start_grill(
     run_id: str,
     seed: str,
     dependencies: GrillDependencies,
+    marker_keys: tuple[str, ...] = MARKER_KEYS,
 ) -> GrillState:
-    """Open a grill on one typed line."""
+    """Open a grill on one typed line.
+
+    `marker_keys` is what this interview has to settle before it may agree.
+    It defaults to the article brief's, and is carried on the state from here
+    so every later turn is judged against the checklist the run opened with.
+    """
     digest, source_urls, _tokens = research_seed(dependencies, seed)
     opening = GrillState(
         run_id=run_id,
         seed=seed,
+        marker_keys=marker_keys,
         research_digest=digest,
         research_source_urls=source_urls,
         # `pending` is filled by advance_grill; the contract forbids an asking

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -505,6 +505,45 @@ def _markers_from(
     return [key for key in keys if key in settled]
 
 
+def _consensus_text(raw: Any) -> str:
+    """The agreement, whether it arrived as prose or as the object it describes.
+
+    The schema asks for a string and the prompt says to play the whole thing
+    back in plain sentences. Models still send the structured version -- run
+    a5858d6e (2026-09-04) returned `{"kind": "Pisco Sour bars", "place": "Lima,
+    Peru", "count": 30, ...}`, which was a complete, correct agreement with
+    every marker covered.
+
+    `_safe_str` reads a dict as the empty string, so that agreement was
+    discarded as "done with nothing agreed" and the interview asked two more
+    questions to arrive back where it already was. Two model calls and forty
+    seconds, thrown away over the shape of a field whose content was right.
+
+    Rendered rather than refused, for the same reason `_question_from` accepts
+    three arrangements of a question: the words are what matter and they were
+    all there.
+    """
+    text = _safe_str(raw)
+    if text:
+        return text
+    if isinstance(raw, dict):
+        lines = []
+        for key, value in raw.items():
+            label = str(key).replace("_", " ").strip()
+            if isinstance(value, (list, tuple)):
+                rendered = "\n".join(f"  - {item}" for item in value if item)
+                if rendered:
+                    lines.append(f"{label}:\n{rendered}")
+                continue
+            if value in (None, "", [], {}):
+                continue
+            lines.append(f"{label}: {value}")
+        return "\n".join(lines)
+    if isinstance(raw, (list, tuple)):
+        return "\n".join(f"- {item}" for item in raw if item)
+    return ""
+
+
 class GrillUnusableResponse(RuntimeError):
     """The grill answered with something it cannot act on.
 
@@ -593,7 +632,7 @@ def _advance_once(
     covered = _markers_from(payload, state)
 
     if payload.get("done") is True:
-        consensus = _safe_str(payload.get("consensus"))
+        consensus = _consensus_text(payload.get("consensus"))
         missing = [key for key in state.marker_keys if key not in covered]
         if consensus and not missing:
             return state.model_copy(

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_gate.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_gate.py
@@ -1,0 +1,181 @@
+"""The gate: is there enough published about this place to write about it?"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline import gate, places
+from app.features.listicle_pipeline.places import PlaceDetails
+from app.features.listicle_pipeline.profiles import Claim, PlaceProfile
+
+
+def profile(*claims: Claim) -> PlaceProfile:
+    return PlaceProfile(profile_id="p", name="Somewhere", claims=list(claims))
+
+
+def independent(kind: str, text: str, source: str = "Infobae") -> Claim:
+    return Claim(kind=kind, text=text, source_name=source)
+
+
+# --- weighing who said it -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source, weight",
+    [
+        ("Infobae", gate.WEIGHT_INDEPENDENT),
+        ("Trome.com", gate.WEIGHT_INDEPENDENT),
+        ("Google review", gate.WEIGHT_AGGREGATOR),
+        ("TripAdvisor", gate.WEIGHT_AGGREGATOR),
+        # The subject talking about itself is not evidence about the subject.
+        ("Antigua Taberna Queirolo website", gate.WEIGHT_SELF_PUBLISHED),
+        ("Facebook", gate.WEIGHT_SELF_PUBLISHED),
+        ("", gate.WEIGHT_SELF_PUBLISHED),
+        # A machine repeating a machine. All of these came back on real runs.
+        ("WanderBoat AI Trip Planner", gate.WEIGHT_AI_WRITTEN),
+    ],
+)
+def test_who_published_it_changes_what_it_is_worth(source, weight):
+    assert gate.source_weight(source) == weight
+
+
+def test_a_place_carried_entirely_by_ai_written_directories_has_nothing():
+    result = gate.assess(
+        profile(
+            *[
+                independent("history", f"Fact number {n}.", "WanderBoat AI Trip Planner")
+                for n in range(8)
+            ]
+        )
+    )
+    assert result.verdict == "nothing"
+    assert result.counted == 0
+    assert result.discounted == 8
+
+
+# --- the same fact said three times ---------------------------------------
+
+
+def test_one_fact_worded_three_ways_is_one_fact():
+    """Queirolo's first three claims were "began around 1880", "began in 1880
+    when Don Santiago Queirolo founded it" and "the family arrived around
+    1877". Three rows, one thing to say."""
+    result = gate.assess(
+        profile(
+            independent("history", "The tavern began around 1880."),
+            independent("history", "The tavern began around 1880."),
+            independent("history", "Around 1880 the tavern began."),
+        )
+    )
+    assert result.counted == 1
+    assert result.discounted == 2
+
+
+# --- three verdicts, not two ----------------------------------------------
+
+
+def test_nothing_found_is_its_own_verdict():
+    result = gate.assess(profile())
+    assert result.verdict == "nothing"
+    assert result.missing == ["anything at all"]
+
+
+def test_a_place_with_one_newspaper_paragraph_is_thin_not_dropped():
+    """Publishable at short length. Collapsing this into "no" throws away most
+    of a long list."""
+    result = gate.assess(
+        profile(
+            independent("history", "Founded in 1907 by a Catalan immigrant."),
+            independent("person", "The owner started as a waiter in 1964."),
+        )
+    )
+    assert result.verdict == "thin"
+    assert "short entry" in result.reason
+
+
+def test_a_place_with_several_independent_sources_is_enough():
+    result = gate.assess(
+        profile(
+            independent("history", "Founded in 1907 by a Catalan immigrant."),
+            independent("person", "The owner started as a waiter in 1964.", "Trome.com"),
+            independent("signature", "Known for pan con pejerrey.", "El Comercio"),
+            independent("award", "Won best classic restaurant.", "Summum"),
+            independent("setting", "The original vitrine is still in use.", "La República"),
+        )
+    )
+    assert result.verdict == "enough"
+
+
+def test_reviews_alone_are_not_a_story():
+    """A place with four reviews and nothing else has no story, however many
+    reviews there are."""
+    result = gate.assess(
+        profile(
+            *[
+                Claim(kind="review", text=f"Diner {n} liked it.", source_name="Infobae")
+                for n in range(9)
+            ]
+        )
+    )
+    assert result.verdict != "enough"
+    assert any("beyond reviews" in m for m in result.missing)
+
+
+def test_the_verdict_says_what_would_change_it():
+    result = gate.assess(profile(independent("review", "Someone liked it.")))
+    assert result.missing
+
+
+# --- the Places pass ------------------------------------------------------
+
+
+def test_google_facts_become_claims_without_a_model_touching_them():
+    claims = places.claims_from(
+        PlaceDetails("id", "Rovira", rating=4.1, rating_count=601, price_level=2)
+    )
+    kinds = {claim.kind for claim in claims}
+    assert "recognition" in kinds and "price" in kinds
+    assert any("4.1" in claim.text and "601" in claim.text for claim in claims)
+    # Said in words a writer can use. "price_level 2" is not a sentence.
+    assert any("moderately priced" in claim.text for claim in claims)
+
+
+def test_a_review_carries_its_stars_and_its_age():
+    """A five-star review from eight years ago and a three-star from last month
+    say very different things, and a blurb written from the first without
+    knowing its age is a blurb about a restaurant that may have changed hands."""
+    claims = places.claims_from(
+        PlaceDetails(
+            "id",
+            "Rovira",
+            reviews=[
+                {
+                    "text": "20-30 soles a head.",
+                    "rating": 5,
+                    "relative_time_description": "8 years ago",
+                    "time": 1500000000,
+                }
+            ],
+        )
+    )
+    assert "5-star" in claims[0].text
+    assert "8 years ago" in claims[0].text
+    assert claims[0].about_year == 2017
+
+
+def test_a_failed_places_call_adds_nothing_rather_than_guessing():
+    assert places.claims_from(PlaceDetails("id", failed=True, reason="OVER_QUERY_LIMIT")) == []
+
+
+def test_the_price_band_is_findable_on_its_own():
+    """A cheap-eats list has to find this without reading everything else said
+    about the place."""
+    stored = PlaceProfile(
+        profile_id="p",
+        name="x",
+        claims=[
+            Claim(kind="price", text="Inexpensive band.", source_name="Google"),
+            Claim(kind="history", text="Founded 1907.", source_name="Infobae"),
+        ],
+    )
+    assert [c.kind for c in stored.claims_for(("price",))] == ["price"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_profiles.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_profiles.py
@@ -322,3 +322,39 @@ def test_google_says_whether_a_row_is_somewhere_you_can_be_served():
     market = ResolvedPlace("id", "Terminal Pesquero", "", ("establishment", "point_of_interest"))
     assert bar.is_venue is True
     assert market.is_venue is False
+
+
+def test_a_blurb_is_recorded_so_the_next_one_differs():
+    """Two Questurian articles carrying the same paragraph compete with each
+    other in search. Past blurbs are a list of sentences already spent, not a
+    library to draw from."""
+    from app.features.listicle_pipeline.profiles import PastBlurb
+
+    profile = profile_store.open_profile(name="Bar Rovira", city="Lima, Peru")
+    first = PastBlurb(text="The oldest bar in Callao.", run_id="r1", angle="decades")
+
+    assert profile_store.add_blurb(profile.profile_id, first) is True
+    # The same sentence again is not a second blurb.
+    assert profile_store.add_blurb(profile.profile_id, first) is False
+
+    stored = profile_store.find(name="Bar Rovira", city="Lima, Peru")
+    assert len(stored.past_blurbs) == 1
+    assert stored.past_blurbs[0].angle == "decades"
+
+
+def test_blurbs_from_different_lists_stack_up():
+    """The same bar on a cheap-eats list and a history list should read as two
+    different places to go."""
+    from app.features.listicle_pipeline.profiles import PastBlurb
+
+    profile = profile_store.open_profile(name="Museo del Pisco", city="Lima, Peru")
+    for text, angle in (
+        ("Where Lima drinks its pisco sour straight.", "traditional recipe"),
+        ("A rooftop over the Presidential Palace.", "the view"),
+    ):
+        profile_store.add_blurb(
+            profile.profile_id, PastBlurb(text=text, run_id="r", angle=angle)
+        )
+
+    stored = profile_store.find(name="Museo del Pisco", city="Lima, Peru")
+    assert {b.angle for b in stored.past_blurbs} == {"traditional recipe", "the view"}

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_profiles.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_profiles.py
@@ -1,0 +1,267 @@
+"""Place profiles: what is kept about a place, and what stays true on a rerun."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.features.listicle_pipeline import profile_store
+from app.features.listicle_pipeline.profile_research import (
+    build_research_prompt,
+    parse_claims,
+    research_place,
+)
+from app.features.listicle_pipeline.profiles import Claim, PlaceProfile, Sighting
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Never let these touch the real pipeline database.
+
+    Routes driven through this app run real handlers against `data/pipeline.db`
+    unless the path is redirected, and that has cost real data before.
+    """
+    import app.config as config
+    import app.core.database as database
+
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "test.db", raising=False)
+    monkeypatch.setattr(database, "DATA_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "test.db", raising=False)
+    yield
+
+
+# --- identity -------------------------------------------------------------
+
+
+def test_the_same_place_typed_two_ways_opens_one_profile():
+    first = profile_store.open_profile(name="Museo del Pisco", city="Lima, Peru")
+    second = profile_store.open_profile(name="museo  del  pisco", city="Lima, Peru")
+    assert first.profile_id == second.profile_id
+
+
+def test_the_same_name_in_another_city_is_another_place():
+    lima = profile_store.open_profile(name="Museo del Pisco", city="Lima, Peru")
+    cusco = profile_store.open_profile(name="Museo del Pisco", city="Cusco, Peru")
+    assert lima.profile_id != cusco.profile_id
+
+
+def test_a_profile_gains_its_anchor_without_losing_what_it_gathered():
+    """Profiles are opened before resolution runs -- there may be no API key at
+    all -- so the anchor has to arrive later without starting again."""
+    opened = profile_store.open_profile(name="Bar Cordano", city="Lima, Peru")
+    profile_store.add_claims(
+        opened.profile_id, [Claim(kind="history", text="Opened in 1905.")]
+    )
+
+    profile_store.open_profile(
+        name="Bar Cordano", city="Lima, Peru", place_id="ChIJcordano"
+    )
+
+    anchored = profile_store.find(place_id="ChIJcordano")
+    assert anchored is not None
+    assert anchored.profile_id == opened.profile_id
+    assert len(anchored.claims) == 1
+
+
+def test_an_anchored_profile_is_found_by_its_place_id_whatever_it_is_called():
+    """The whole reason for the Place ID: a later run spelling the name
+    differently must reach the same profile."""
+    opened = profile_store.open_profile(
+        name="Bar Inglés", city="Lima, Peru", place_id="ChIJingles"
+    )
+    found = profile_store.find(place_id="ChIJingles", name="Bar Inglés del Country Club")
+    assert found is not None and found.profile_id == opened.profile_id
+
+
+# --- accumulating ---------------------------------------------------------
+
+
+def test_researching_the_same_place_twice_does_not_double_its_claims():
+    profile = profile_store.open_profile(name="Canta Rana", city="Lima, Peru")
+    claim = Claim(kind="award", text="Won the Summum award in 2019.")
+
+    assert profile_store.add_claims(profile.profile_id, [claim]) == 1
+    # Reworded punctuation, same words. This is what a second research pass
+    # actually returns.
+    assert (
+        profile_store.add_claims(
+            profile.profile_id, [Claim(kind="award", text="won the summum award in 2019")]
+        )
+        == 0
+    )
+    assert len(profile_store.find(name="Canta Rana", city="Lima, Peru").claims) == 1
+
+
+def test_a_rerun_of_the_same_listicle_does_not_inflate_the_overlap_signal():
+    profile = profile_store.open_profile(name="Chez Wong", city="Lima, Peru")
+    sighting = Sighting(angle="open for decades", run_id="run-a")
+
+    assert profile_store.add_sighting(profile.profile_id, sighting) is True
+    assert profile_store.add_sighting(profile.profile_id, sighting) is False
+
+
+def test_a_second_listicle_adds_to_the_same_profile():
+    """The payoff for keeping profiles at all: a place found by four angles
+    across two lists is known to be a major place, for free."""
+    profile = profile_store.open_profile(name="Museo del Pisco", city="Lima, Peru")
+    for run_id, angle in (
+        ("pisco-run", "bars open for decades"),
+        ("pisco-run", "rooftop bars"),
+        ("cocktail-run", "where bartenders drink"),
+    ):
+        profile_store.add_sighting(
+            profile.profile_id, Sighting(angle=angle, run_id=run_id)
+        )
+
+    stored = profile_store.find(name="Museo del Pisco", city="Lima, Peru")
+    assert len(stored.angles_seen) == 3
+    assert sorted(stored.runs_seen) == ["cocktail-run", "pisco-run"]
+
+
+def test_a_place_with_no_place_id_is_listed_for_resolution():
+    profile_store.open_profile(name="El Bar de Niko", city="Lima, Peru")
+    profile_store.open_profile(
+        name="Anchored Bar", city="Lima, Peru", place_id="ChIJanchored"
+    )
+    assert [p.name for p in profile_store.unresolved()] == ["El Bar de Niko"]
+
+
+def test_the_lm_link_is_written_back():
+    """So a later listicle finding this place knows there is nothing to send."""
+    profile = profile_store.open_profile(name="La Mar", city="Lima, Peru")
+    profile_store.set_lm_location_id(profile.profile_id, 4417)
+    assert profile_store.find(name="La Mar", city="Lima, Peru").lm_location_id == 4417
+
+
+# --- what the gate will read ---------------------------------------------
+
+
+def test_claims_are_counted_by_kind_not_just_totalled():
+    """Four reviews and no history is not the same place to write about as no
+    reviews and four history claims, and both are four claims."""
+    profile = PlaceProfile(
+        profile_id="p",
+        name="x",
+        claims=[
+            Claim(kind="review", text="a"),
+            Claim(kind="review", text="b"),
+            Claim(kind="history", text="c"),
+        ],
+    )
+    assert profile.claims_by_kind() == {"review": 2, "history": 1}
+
+
+def test_an_award_never_goes_stale_and_a_practice_does():
+    """An award in 2019 was still won in 2019. "Lunch only" from three years
+    ago may simply be untrue now."""
+    long_ago = datetime.now(timezone.utc) - timedelta(days=900)
+    assert Claim(kind="award", text="won", found_at=long_ago).is_stale() is False
+    assert Claim(kind="practice", text="lunch only", found_at=long_ago).is_stale() is True
+
+
+# --- research -------------------------------------------------------------
+
+
+def test_the_angles_go_into_the_lookup():
+    """They are why the place is on this list, and they tell the search where
+    to dig."""
+    prompt = build_research_prompt("Chez Wong", "Lima, Peru", ["open for decades"])
+    assert "Chez Wong" in prompt
+    assert "open for decades" in prompt
+    # And the local-language instruction that was worth 27% more results in the
+    # search step applies here for the same reason.
+    assert "local language" in prompt
+
+
+def test_the_lookup_refuses_the_fields_location_manager_owns():
+    prompt = build_research_prompt("Chez Wong", "Lima, Peru", [])
+    assert "opening hours" in prompt
+    assert "Do NOT report its address" in prompt
+
+
+def test_an_invented_kind_keeps_the_sentence():
+    """The model invented a label; the thing it labelled was still published."""
+    claims = parse_claims("vibe | Regulars have gone for thirty years | 2020 | http://a")
+    assert len(claims) == 1
+    assert claims[0].kind == "other"
+    assert claims[0].about_year == 2020
+
+
+def test_a_claim_with_no_source_of_its_own_inherits_the_searchs():
+    """Something was read to write that sentence; we just do not know which."""
+    def research(prompt: str):
+        return "history | Opened in 1905 | 1905 | ", ["https://elcomercio.pe/x"], 10
+
+    result = research_place("Bar Cordano", "Lima, Peru", [], research)
+    assert result.claims[0].source_url == "https://elcomercio.pe/x"
+    assert result.sources == ["https://elcomercio.pe/x"]
+
+
+def test_a_failed_lookup_leaves_the_profile_alone():
+    def research(prompt: str):
+        raise TimeoutError("read timed out")
+
+    result = research_place("Somewhere", "Lima, Peru", [], research)
+    assert result.claims == [] and result.sources == []
+    # And it says so, rather than looking like a place nobody has written about.
+    assert result.failed is True
+    assert "TimeoutError" in result.reason
+
+
+def test_a_namespace_url_is_not_a_citation():
+    """Grounding metadata returns XML and SVG namespaces alongside real
+    sources. Attributing a claim about a bar to w3.org is worse than
+    attributing it to nothing: it looks like a citation."""
+    def research(prompt: str):
+        return "history | Opened in 1880 | 1880 | ", [
+            "http://www.w3.org/2000/svg",
+            "https://elcomercio.pe/real",
+        ], 10
+
+    result = research_place("Antigua Taberna Queirolo", "Lima, Peru", [], research)
+    assert result.sources == ["https://elcomercio.pe/real"]
+    assert result.claims[0].source_url == "https://elcomercio.pe/real"
+
+
+def test_a_thin_first_answer_is_looked_up_again():
+    """The same prompt for Antigua Taberna Queirolo returned nineteen claims,
+    then one, then none, with nothing changed between the calls."""
+    replies = iter([
+        "history | Opened in 1880 | 1880 | http://a.test",
+        "award | UNESCO Blue Shield | 2026 | http://b.test",
+        "person | Founded by Santiago Queirolo | 1880 | http://c.test",
+    ])
+    calls = {"n": 0}
+
+    def research(prompt: str):
+        calls["n"] += 1
+        return next(replies), ["http://a.test"], 5
+
+    result = research_place("Antigua Taberna Queirolo", "Lima, Peru", [], research)
+    # Every attempt is kept, because each finds different material.
+    assert calls["n"] == 3
+    assert len(result.claims) == 3
+
+
+def test_a_place_with_plenty_is_not_looked_up_again():
+    rich = "\n".join(f"review | finding number {n} | | http://a.test" for n in range(8))
+    calls = {"n": 0}
+
+    def research(prompt: str):
+        calls["n"] += 1
+        return rich, ["http://a.test"], 5
+
+    result = research_place("Museo del Pisco", "Lima, Peru", [], research)
+    assert calls["n"] == 1
+    assert len(result.claims) == 8
+
+
+def test_a_place_nobody_has_written_about_says_so_after_trying():
+    def research(prompt: str):
+        return "Nothing found.", ["http://a.test"], 1
+
+    result = research_place("Somewhere Obscure", "Lima, Peru", [], research)
+    assert result.failed is False
+    assert "found nothing published" in result.reason

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_profiles.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_profiles.py
@@ -265,3 +265,60 @@ def test_a_place_nobody_has_written_about_says_so_after_trying():
     result = research_place("Somewhere Obscure", "Lima, Peru", [], research)
     assert result.failed is False
     assert "found nothing published" in result.reason
+
+
+def test_the_publisher_name_is_kept_beside_the_link():
+    """Grounded search returns opaque redirect links that name nobody and do
+    not outlive the claim. The publication name is the half that still means
+    something in two years."""
+    claims = parse_claims(
+        "award | Won best classic restaurant | 2023 | Premios Summum | https://s.pe/x"
+    )
+    assert claims[0].source_name == "Premios Summum"
+    assert claims[0].source_url == "https://s.pe/x"
+
+
+def test_the_publication_and_the_link_may_arrive_in_either_order():
+    both_ways = parse_claims(
+        "history | Founded 1907 | 1907 | https://elcomercio.pe/a | El Comercio\n"
+        "history | Founded 1907 too | 1907 | El Comercio | https://elcomercio.pe/a"
+    )
+    assert {c.source_name for c in both_ways} == {"El Comercio"}
+    assert {c.source_url for c in both_ways} == {"https://elcomercio.pe/a"}
+
+
+def test_a_claim_may_name_a_publication_with_no_link_at_all():
+    claims = parse_claims("history | Opened in 1880 | 1880 | El Comercio |")
+    assert claims[0].source_name == "El Comercio"
+    assert claims[0].source_url == ""
+
+
+def test_the_publisher_name_survives_a_round_trip_through_the_store():
+    profile = profile_store.open_profile(name="Bar Cordano", city="Lima, Peru")
+    profile_store.add_claims(
+        profile.profile_id,
+        [Claim(kind="history", text="Opened 1905.", source_name="El Comercio")],
+    )
+    stored = profile_store.find(name="Bar Cordano", city="Lima, Peru")
+    assert stored.claims[0].source_name == "El Comercio"
+
+
+def test_the_address_pins_a_lookup_to_one_building():
+    """Museo del Pisco has branches in Arequipa and Cusco. A lookup on the bare
+    name spread across all three and came back with almost nothing."""
+    prompt = build_research_prompt(
+        "MUSEO DEL PISCO - LIMA", "Lima, Peru", [], "Jr. Junín 201, Lima 15001"
+    )
+    assert "Jr. Junín 201" in prompt
+
+
+def test_google_says_whether_a_row_is_somewhere_you_can_be_served():
+    """The search runner refuses rows that name a market or a street by
+    wording, and still let a fish terminal onto a pisco sour list. Refusing by
+    name only catches the wordings you thought of."""
+    from app.features.listicle_pipeline.identity import ResolvedPlace
+
+    bar = ResolvedPlace("id", "Museo del Pisco", "", ("bar", "establishment", "food"))
+    market = ResolvedPlace("id", "Terminal Pesquero", "", ("establishment", "point_of_interest"))
+    assert bar.is_venue is True
+    assert market.is_venue is False

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_search.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_search.py
@@ -1,0 +1,283 @@
+"""The search order: what it asks for, and what it does with the answers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline.search import (
+    Candidate,
+    merge_contained,
+    name_tokens,
+    normalise_name,
+    parse_rows,
+    per_angle_ask,
+    run_search_order,
+)
+
+
+def test_asks_for_more_than_the_target_because_rows_collapse():
+    """The first real run lost 15 of 49 rows to duplicates.
+
+    Asking each angle for exactly its share guarantees falling short, so the
+    ask carries the overlap already priced in.
+    """
+    assert per_angle_ask(40, 6) * 6 > 40
+
+
+def test_the_ask_is_bounded_at_both_ends():
+    # A tiny list still has to ask for enough to survive any overlap at all.
+    assert per_angle_ask(4, 2) >= 6
+    # And no single search is worth asking for more than it will answer well.
+    assert per_angle_ask(500, 1) <= 15
+
+
+def test_a_preamble_and_numbering_do_not_lose_the_list():
+    """Models add both however firmly they are told not to, and a reply thrown
+    away for its shape is a whole angle missing from the list."""
+    rows = parse_rows(
+        "Here are the places I found:\n"
+        "1. Pescados Capitales | Miraflores | opened 2001\n"
+        "- Chez Wong | La Victoria | reservation only\n"
+        "I hope this helps.\n"
+    )
+    assert [row[0] for row in rows] == ["Pescados Capitales", "Chez Wong"]
+
+
+def test_a_market_is_not_a_listicle_entry():
+    """`Surquillo Market (stalls)` is a fair answer to "stalls inside Lima's
+    markets" and is not a place a reader can walk into as one business."""
+    rows = parse_rows(
+        "Surquillo Market (stalls) | Surquillo | many stalls\n"
+        "Al Toke Pez | Surquillo | counter with six stools\n"
+    )
+    assert [row[0] for row in rows] == ["Al Toke Pez"]
+
+
+def test_the_same_place_under_two_names_is_one_place():
+    """Double-counting the strongest entries corrupts the ranking rather than
+    merely padding the list."""
+    assert normalise_name("La Mar") == normalise_name("La Mar Cebichería")
+    assert normalise_name("Cevichería Nancy") == normalise_name("Nancy")
+
+
+def test_a_name_that_is_only_noise_words_survives():
+    """`El Mercado` is a real restaurant; stripping both words would erase it."""
+    assert normalise_name("El Mercado")
+
+
+def test_overlap_is_kept_rather_than_thinned():
+    """A place several angles agree on is the strongest thing on the list, and
+    that count is the only ranking signal the pipeline has earned."""
+    replies = {
+        "awards": "El Mercado | Miraflores | on best-of lists",
+        "nikkei": "El Mercado | Miraflores | Japanese-Peruvian",
+        "decades": "Canta Rana | Barranco | open since the 1980s",
+    }
+    calls: list[str] = []
+
+    def research(prompt: str):
+        for angle, reply in replies.items():
+            if angle in prompt:
+                calls.append(angle)
+                return reply, ["https://example.test"], 10
+        raise AssertionError("unexpected prompt")
+
+    candidates, results = run_search_order(
+        list(replies),
+        kind="cevicherias",
+        place="Lima, Peru",
+        target_items=10,
+        research=research,
+    )
+
+    assert len(calls) == 3
+    assert [c.name for c in candidates] == ["El Mercado", "Canta Rana"]
+    assert candidates[0].overlap == 2
+    assert sorted(candidates[0].found_by) == ["awards", "nikkei"]
+    assert all(result.rows == 1 for result in results)
+
+
+def test_the_bar_and_the_cut_reach_the_search():
+    """The operator barred general restaurants and the Nikkei search returned
+    four of them, because nothing carried the bar out of the interview."""
+    seen: list[str] = []
+
+    def research(prompt: str):
+        seen.append(prompt)
+        return "", [], 0
+
+    run_search_order(
+        ["nikkei cevicherias"],
+        kind="cevicherias",
+        place="Lima, Peru",
+        target_items=10,
+        exclusions="no hotel restaurants",
+        standard="someone other than the place has written about it",
+        research=research,
+    )
+
+    assert "no hotel restaurants" in seen[0]
+    assert "someone other than the place has written about it" in seen[0]
+
+
+def test_a_search_that_broke_is_not_a_search_that_found_nothing():
+    """One is a fact about the network and the other is a fact about the topic,
+    and only one of them is worth re-running."""
+    attempts = {"n": 0}
+
+    def research(prompt: str):
+        attempts["n"] += 1
+        raise TimeoutError("read timed out")
+
+    candidates, results = run_search_order(
+        ["fishing ports"],
+        kind="cevicherias",
+        place="Lima, Peru",
+        target_items=10,
+        research=research,
+    )
+
+    assert candidates == []
+    assert results[0].failed is True
+    assert "TimeoutError" in results[0].reason
+    # Retried rather than abandoned: the first real run lost a whole angle to a
+    # single timeout.
+    assert attempts["n"] > 1
+
+
+def test_a_transient_failure_does_not_lose_the_angle():
+    calls = {"n": 0}
+
+    def research(prompt: str):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError("read timed out")
+        return "Al Toke Pez | Surquillo | counter", [], 5
+
+    candidates, results = run_search_order(
+        ["hidden"], kind="cevicherias", place="Lima, Peru", target_items=10,
+        research=research,
+    )
+
+    assert [c.name for c in candidates] == ["Al Toke Pez"]
+    assert results[0].failed is False
+
+
+def test_the_fuller_name_and_a_missing_district_are_filled_in():
+    # Matched on a word the prompt itself cannot contain: an earlier version of
+    # this stub keyed on "one" and started matching every prompt the day the
+    # search prompt gained the word "someone".
+    def research(prompt: str):
+        if "ANGLE-A" in prompt:
+            return "La Mar |  | first sighting", [], 1
+        return "La Mar Cebichería | Miraflores | second sighting", [], 1
+
+    candidates, _ = run_search_order(
+        ["ANGLE-A", "ANGLE-B"], kind="cevicherias", place="Lima, Peru",
+        target_items=10, research=research,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].name == "La Mar Cebichería"
+    assert candidates[0].district == "Miraflores"
+
+
+def test_candidate_overlap_counts_angles():
+    assert Candidate(name="x", district="", evidence="", found_by=["a", "b"]).overlap == 2
+
+
+@pytest.mark.parametrize(
+    "reply, expected",
+    [
+        ("", "the search came back empty"),
+        ("I could not find any places matching that.", "the search answered but named no places"),
+    ],
+)
+def test_an_empty_angle_says_which_kind_of_empty_it_was(reply, expected):
+    """Three different things look identical as a zero, and only one of them is
+    worth re-running."""
+
+    def research(prompt: str):
+        return reply, [], 1
+
+    _, results = run_search_order(
+        ["decades"], kind="cevicherias", place="Lima, Peru", target_items=10,
+        research=research,
+    )
+    assert results[0].failed is False
+    assert results[0].reason == expected
+
+
+@pytest.mark.parametrize(
+    "first, second",
+    [
+        # Both seen on the same run once the searches read Spanish sources.
+        ("Bar Inglés at the Country Club Hotel", "Bar Inglés del Country Club"),
+        ("Gran Hotel Bolívar", "Gran Hotel Bolívar (Bar Catedral)"),
+        ("Hotel B", "Hotel B (Rooftop bar)"),
+    ],
+)
+def test_one_place_named_two_ways_is_one_entry(first, second):
+    """An undetected duplicate does not merely pad the list -- it splits the
+    entry's overlap in half and drops it down the ranking."""
+    merged = merge_contained(
+        [
+            Candidate(name=first, district="", evidence="", found_by=["a"]),
+            Candidate(name=second, district="Barranco", evidence="", found_by=["b"]),
+        ]
+    )
+    assert len(merged) == 1
+    assert sorted(merged[0].found_by) == ["a", "b"]
+    # A district either row carried survives the merge.
+    assert merged[0].district == "Barranco"
+
+
+def test_the_name_kept_is_the_business_not_the_searchs_note():
+    """A tie on distinguishing words means the difference was a parenthetical,
+    and the parenthetical is why the row turned up rather than what it is
+    called."""
+    merged = merge_contained(
+        [
+            Candidate(name="Hotel B (Rooftop bar)", district="", evidence="", found_by=["a"]),
+            Candidate(name="Hotel B", district="", evidence="", found_by=["b"]),
+        ]
+    )
+    assert merged[0].name == "Hotel B"
+
+
+def test_a_single_distinguishing_word_is_not_enough_to_merge():
+    """"Bar Inglés" reduces to one word once "bar" falls away, and one word is
+    not evidence that two rows are the same place. The two spellings the real
+    run actually produced both carry more than that and do merge."""
+    merged = merge_contained(
+        [
+            Candidate(name="Bar Inglés", district="", evidence="", found_by=["a"]),
+            Candidate(
+                name="Bar Inglés del Country Club", district="", evidence="", found_by=["b"]
+            ),
+        ]
+    )
+    assert len(merged) == 2
+
+
+@pytest.mark.parametrize(
+    "first, second",
+    [
+        # One shared word is not evidence. These are two different bars.
+        ("Museo del Pisco", "Pisco Bar"),
+        ("Cala Restaurante", "Carnaval Bar"),
+        ("Bodega Piselli", "Bar Piselli 1915"),
+    ],
+)
+def test_two_places_that_merely_share_a_word_stay_apart(first, second):
+    merged = merge_contained(
+        [
+            Candidate(name=first, district="", evidence="", found_by=["a"]),
+            Candidate(name=second, district="", evidence="", found_by=["b"]),
+        ]
+    )
+    assert len(merged) == 2
+
+
+def test_a_parenthetical_is_the_rows_reason_not_part_of_the_name():
+    assert name_tokens("Hotel B (Rooftop bar)") == name_tokens("Hotel B")

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_grill.py
@@ -949,3 +949,36 @@ def test_a_grill_that_is_done_does_not_look_anything_up_first():
     assert state.status == "agreed"
     assert state.lookups == []
     assert len(research.queries) == 1
+
+
+def test_a_structured_consensus_is_read_rather_than_discarded():
+    """Run a5858d6e agreed with every marker covered and sent the consensus as
+    the object it describes rather than as prose. Reading a dict as the empty
+    string threw that agreement away and cost two more model calls to arrive
+    back at it."""
+    from app.features.prompt2blog.grill_v4 import _consensus_text
+
+    rendered = _consensus_text(
+        {
+            "kind": "Pisco Sour bars",
+            "place": "Lima, Peru",
+            "count": 30,
+            "angles": ["bars open for decades", "rooftop bars"],
+            "cut": "",
+        }
+    )
+
+    assert "Pisco Sour bars" in rendered
+    assert "Lima, Peru" in rendered
+    assert "30" in rendered
+    assert "bars open for decades" in rendered
+    assert "rooftop bars" in rendered
+    # An empty field is left out rather than played back as a blank line.
+    assert "cut" not in rendered
+
+
+def test_prose_consensus_is_untouched():
+    from app.features.prompt2blog.grill_v4 import _consensus_text
+
+    assert _consensus_text("  The list is about ceviche.  ") == "The list is about ceviche."
+    assert _consensus_text(None) == ""

--- a/apps/ai-blog-writer/apps/frontend/src/App.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import {
   ListicleItineraryBuilderPage,
 } from './features/listicleItineraries'
 import { ItinerariesPipelinePage } from './features/itinerariesPipeline'
+import { ListiclePipelinePage } from './features/listiclePipeline'
 import {
   PayloadArticlesPage,
   PayloadArticleStagePage,
@@ -87,6 +88,9 @@ export default function App() {
 
               {/* Itineraries Pipeline */}
               <Route path="itineraries-pipeline" element={<ItinerariesPipelinePage />} />
+
+              {/* Listicle Pipeline */}
+              <Route path="listicle-pipeline" element={<ListiclePipelinePage />} />
 
               {/* Location Images */}
               <Route path="location-documents" element={<LocationDocumentsPage />} />

--- a/apps/ai-blog-writer/apps/frontend/src/css/landing.css
+++ b/apps/ai-blog-writer/apps/frontend/src/css/landing.css
@@ -294,6 +294,14 @@
   --card-accent-softer: rgba(75, 85, 99, 0.06);
 }
 
+/* Teal, matching the section's own accent, so the card and the page it opens
+   read as the same thing. Deliberately not the Prompt2Blog blue. */
+.landing-card--listicle-pipeline {
+  --card-accent: #0f766e;
+  --card-accent-soft: rgba(15, 118, 110, 0.14);
+  --card-accent-softer: rgba(15, 118, 110, 0.06);
+}
+
 .landing-card--single-listicles {
   --card-accent: #b7791f;
   --card-accent-soft: rgba(183, 121, 31, 0.14);

--- a/apps/ai-blog-writer/apps/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -111,6 +111,26 @@ const LANDING_CARDS: LandingCardConfig[] = [
     ),
   },
   {
+    id: 'listicle-pipeline',
+    title: 'Listicle Pipeline',
+    description:
+      'Interview-led listicles: say what the list is, and research finds the places, checks the evidence and files what is missing.',
+    to: '/listicle-pipeline',
+    section: 'article-generation',
+    priority: 5,
+    accentClass: 'landing-card--listicle-pipeline',
+    actionLabel: 'Get Started',
+    icon: (
+      <path
+        d="M4 6h16M4 12h16M4 18h10M18 15v6M15 18h6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    ),
+  },
+  {
     id: 'single-type-listicles',
     title: 'Single Type Listicles',
     description: 'Build and stage Single Type Listicles directly with full Payload field and block control.',

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/api.ts
@@ -1,0 +1,83 @@
+import { apiFetch } from '../../shared/api/client/apiFetch'
+import type { ListicleGrillState, ListicleSearchResults } from './types'
+
+/**
+ * One call per move the operator can make.
+ *
+ * Every one returns the whole interview rather than a fragment, because the
+ * page is a view of where the run stands and not a thing that accumulates its
+ * own copy of the truth.
+ */
+
+const BASE = '/api/listicle-pipeline'
+
+/**
+ * Read whatever the server actually said.
+ *
+ * A failed turn is the interesting case here: the operator has to be able to
+ * tell "the model could not decide what to ask" from "nothing happened", and
+ * a generic fallback throws that away.
+ */
+async function readError(response: Response, fallback: string): Promise<Error> {
+  try {
+    const body = (await response.json()) as { detail?: unknown }
+    if (typeof body.detail === 'string' && body.detail) return new Error(body.detail)
+  } catch {
+    // Not JSON. The fallback is the honest answer.
+  }
+  return new Error(fallback)
+}
+
+async function call(
+  path: string,
+  init?: RequestInit,
+): Promise<ListicleGrillState> {
+  const response = await apiFetch(path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+  })
+  if (!response.ok) {
+    throw await readError(response, 'That turn could not be completed.')
+  }
+  return (await response.json()) as ListicleGrillState
+}
+
+export function startGrill(seed: string): Promise<ListicleGrillState> {
+  return call(`${BASE}/grill/start`, {
+    method: 'POST',
+    body: JSON.stringify({ seed }),
+  })
+}
+
+export function answerGrill(runId: string, answer: string): Promise<ListicleGrillState> {
+  return call(`${BASE}/grill/answer`, {
+    method: 'POST',
+    body: JSON.stringify({ run_id: runId, answer }),
+  })
+}
+
+export function loadGrill(runId: string): Promise<ListicleGrillState> {
+  return call(`${BASE}/grill/${runId}`)
+}
+
+
+/**
+ * Run the agreed search order, or read what a previous run found.
+ *
+ * Running is minutes of grounded searching and real tokens, so it is only ever
+ * something the operator asks for -- `loadSearch` is what a screen calls when
+ * it opens.
+ */
+export async function runSearch(runId: string): Promise<ListicleSearchResults> {
+  const response = await apiFetch(`${BASE}/search/${runId}`, { method: 'POST' })
+  if (!response.ok) throw await readError(response, 'The search could not be run.')
+  return (await response.json()) as ListicleSearchResults
+}
+
+export async function loadSearch(runId: string): Promise<ListicleSearchResults | null> {
+  const response = await apiFetch(`${BASE}/search/${runId}`)
+  // A 404 here means "not run yet", which is a state and not a failure.
+  if (response.status === 404) return null
+  if (!response.ok) throw await readError(response, 'Those results could not be read.')
+  return (await response.json()) as ListicleSearchResults
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/AnglePicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/AnglePicker.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ListicleGrillOption } from '../types'
+
+/**
+ * The angle question, answered by choosing rather than by writing.
+ *
+ * Every other question in this interview is a sentence, and a text box is the
+ * right control for a sentence. This one is not: each line becomes a literal
+ * web search, run separately, and the list of them IS the search order. Asked
+ * as prose it comes back as prose and has to be split apart again -- and
+ * splitting is exactly where the wording gets mangled, which is the thing that
+ * empties a search.
+ *
+ * It is a menu, not a summary of what was chosen. The recommended angles
+ * arrive ticked and the rest arrive unticked, because a screen showing only
+ * the six it picked cannot be argued with -- there is nothing visible to swap
+ * in, and "no" is not an answer the interview can act on.
+ *
+ * Editing is allowed on every line, ticked or not. The rule these are written
+ * under is that an angle must not carry conditions its shape did not ask for,
+ * and a model that has just broken that rule will not notice it did. Someone
+ * reading "opened in the last year AND has significant buzz" is the only check
+ * there is.
+ */
+
+export interface AnglePickerProps {
+  options: ListicleGrillOption[]
+  busy: boolean
+  onSend: (answer: string) => void
+}
+
+interface Choice extends ListicleGrillOption {
+  keep: boolean
+}
+
+export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
+  const [choices, setChoices] = useState<Choice[]>([])
+
+  // A new question replaces the list outright. Carrying edits across questions
+  // would silently answer the new one with the old one's lines.
+  useEffect(() => {
+    setChoices(options.map(option => ({ ...option, keep: option.recommended })))
+  }, [options])
+
+  const kept = choices.filter(choice => choice.keep && choice.text.trim())
+  const answer = kept.map(choice => choice.text.trim()).join('\n')
+
+  // Two ticked angles from one group run two searches that come back with the
+  // same places. Said, not enforced: the operator knows the city, and this is
+  // a default rather than a law.
+  const clashes = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const choice of kept) {
+      if (choice.group) counts.set(choice.group, (counts.get(choice.group) ?? 0) + 1)
+    }
+    return [...counts].filter(([, count]) => count > 1).map(([group]) => group)
+  }, [kept])
+
+  function update(index: number, patch: Partial<Choice>) {
+    setChoices(current =>
+      current.map((choice, at) => (at === index ? { ...choice, ...patch } : choice)),
+    )
+  }
+
+  function row(choice: Choice, index: number) {
+    return (
+      // Index-keyed on purpose: rows are edited in place and never reordered,
+      // and the text itself changes as it is typed.
+      <li
+        key={index}
+        className={choice.keep ? 'lp-picker-row' : 'lp-picker-row lp-picker-row-off'}
+      >
+        <input
+          type="checkbox"
+          checked={choice.keep}
+          disabled={busy}
+          aria-label={`Search for ${choice.text}`}
+          onChange={event => update(index, { keep: event.target.checked })}
+        />
+        <textarea
+          value={choice.text}
+          rows={2}
+          disabled={busy}
+          onChange={event => update(index, { text: event.target.value })}
+        />
+        {choice.group && <span className="lp-picker-group">{choice.group}</span>}
+      </li>
+    )
+  }
+
+  const picks = choices.map((choice, index) => [choice, index] as const)
+  const recommended = picks.filter(([choice]) => choice.recommended)
+  const alternates = picks.filter(([choice]) => !choice.recommended)
+
+  return (
+    <div className="lp-picker">
+      <p className="lp-picker-hint">
+        These are the searches. Untick what you don&apos;t want, edit the wording, or
+        take one from below.
+      </p>
+
+      <ul className="lp-picker-list">{recommended.map(([choice, index]) => row(choice, index))}</ul>
+
+      {alternates.length > 0 && (
+        <>
+          <p className="lp-picker-heading">
+            Other angles for this list &mdash; tick any to add
+          </p>
+          <ul className="lp-picker-list">
+            {alternates.map(([choice, index]) => row(choice, index))}
+          </ul>
+        </>
+      )}
+
+      {clashes.length > 0 && (
+        <p className="lp-picker-warning" role="status">
+          Two ticked angles are both <strong>{clashes.join(' and ')}</strong>. They tend
+          to return the same places, so one of them is probably a wasted search.
+        </p>
+      )}
+
+      <div className="lp-picker-actions">
+        <button
+          type="button"
+          className="lp-secondary"
+          disabled={busy}
+          onClick={() =>
+            setChoices(current => [
+              ...current,
+              { text: '', recommended: true, group: '', keep: true },
+            ])
+          }
+        >
+          Add an angle
+        </button>
+        <span className="lp-picker-count">
+          {/* The honest progress signal: roughly seven items come from each
+              search, so this number is what decides whether the list can reach
+              its target at all. */}
+          {kept.length} {kept.length === 1 ? 'search' : 'searches'}
+        </span>
+        <button type="button" disabled={busy || !answer} onClick={() => onSend(answer)}>
+          Use these
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/GrillScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/GrillScreen.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'react'
+import { AnglePicker } from './AnglePicker'
+import type { ListicleGrillState } from '../types'
+
+/**
+ * The interview, as a conversation.
+ *
+ * Lifted in shape from the article grill, which got two things right that are
+ * worth keeping whatever is being commissioned: it reads as a thread rather
+ * than a card, so you can tell whether it is actually learning anything; and
+ * the composer arrives pre-filled with a suggested answer, so the operator
+ * corrects rather than composes into an empty box.
+ *
+ * Accepting a suggestion is marked as accepting, not as answering. Those are
+ * worth different amounts and nothing shows the difference otherwise.
+ *
+ * What is NOT shared is the questions. A listicle grill settles a
+ * specification — what kind of place, where, how many, what earns a spot —
+ * where the article grill settles a vision. They will diverge, and this
+ * component is a copy so that they can.
+ */
+
+const MARKER_LABELS: Record<string, string> = {
+  kind: 'what kind of place',
+  place: 'where',
+  count: 'how many',
+  bar: 'what earns a spot',
+  cut: "what's out",
+  angles: 'the angles',
+}
+
+interface GrillScreenProps {
+  state: ListicleGrillState
+  busy: boolean
+  onAnswer: (text: string) => void
+  onReset: () => void
+}
+
+export function GrillScreen({ state, busy, onAnswer, onReset }: GrillScreenProps) {
+  const pending = state.pending
+  const [draft, setDraft] = useState('')
+  const endOfThread = useRef<HTMLDivElement>(null)
+
+  // Each new question arrives with its suggestion already in the box.
+  useEffect(() => {
+    setDraft(pending?.recommendation ?? '')
+  }, [pending?.question_id, pending?.recommendation])
+
+  // Follow the conversation the way a chat does. The movement is what tells
+  // you something new arrived above the composer.
+  useEffect(() => {
+    // Optional-called: jsdom does not implement scrollIntoView, and a test
+    // environment missing it is not a reason for the component to throw.
+    endOfThread.current?.scrollIntoView?.({ behavior: 'smooth', block: 'end' })
+  }, [state.turns.length, pending?.question_id, state.status])
+
+  const isSuggestion = draft.trim() === (pending?.recommendation ?? '').trim()
+  const finished = state.status === 'agreed'
+  // One question in this interview is answered by choosing, and it is the one
+  // the whole interview exists to reach. The server says so by sending options
+  // rather than the screen guessing from the marker.
+  const choosing = (pending?.options?.length ?? 0) > 0
+
+  function send() {
+    if (!draft.trim() || busy) return
+    onAnswer(draft)
+  }
+
+  return (
+    <section className="lp-chat" aria-label="The interview">
+      {state.markers_missing.length > 0 && !finished && (
+        // What the specification still needs. An honest progress line -- a
+        // question count never was one, because the interview stops when the
+        // spec is full, not after N turns.
+        <p className="lp-chat-progress">
+          <span className="lp-muted">Still to settle:</span>{' '}
+          {state.markers_missing.map(m => MARKER_LABELS[m] ?? m).join(', ')}
+        </p>
+      )}
+
+      <div className="lp-thread" role="log" aria-live="polite">
+        <p className="lp-message lp-message-mine lp-message-seed">{state.seed}</p>
+
+        {state.turns.map(turn => (
+          <div key={turn.question_id} className="lp-exchange">
+            {turn.pushback && <p className="lp-pushback">{turn.pushback}</p>}
+            <p className="lp-message lp-message-theirs">{turn.ask}</p>
+            <p className="lp-message lp-message-mine">
+              {turn.answer}
+              {turn.accepted_as_drafted && (
+                // Said plainly, because it changes what the answer is worth:
+                // you did not object, which is not the same as telling it
+                // something.
+                <span className="lp-accepted">You accepted the suggestion</span>
+              )}
+            </p>
+          </div>
+        ))}
+
+        {finished ? (
+          <p className="lp-message lp-message-theirs lp-message-consensus">{state.consensus}</p>
+        ) : (
+          pending && (
+            <div className="lp-exchange">
+              {/* Shown above the question it exists to resolve, so the
+                  contradiction reads as the reason for asking. */}
+              {pending.pushback && <p className="lp-pushback">{pending.pushback}</p>}
+              <p className="lp-message lp-message-theirs">{pending.ask}</p>
+            </div>
+          )
+        )}
+
+        <div ref={endOfThread} />
+      </div>
+
+      {finished ? (
+        <div className="lp-actions lp-chat-actions">
+          <button type="button" className="lp-secondary" onClick={onReset} disabled={busy}>
+            Start over
+          </button>
+        </div>
+      ) : (
+        pending &&
+        (choosing ? (
+          <AnglePicker options={pending.options} busy={busy} onSend={onAnswer} />
+        ) : (
+          <div className="lp-composer">
+            <label className="lp-visually-hidden" htmlFor="lp-answer">
+              Your answer
+            </label>
+            <textarea
+              id="lp-answer"
+              value={draft}
+              rows={3}
+              onChange={event => setDraft(event.target.value)}
+              onKeyDown={event => {
+                // Enter sends, shift+enter breaks the line. The convention
+                // every chat already taught them.
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault()
+                  send()
+                }
+              }}
+              disabled={busy}
+            />
+            <div className="lp-composer-actions">
+              {isSuggestion && (
+                <p className="lp-composer-hint">
+                  This is the suggested answer. Edit it, or clear it and say it your way.
+                </p>
+              )}
+              <div className="lp-composer-buttons">
+                {isSuggestion && (
+                  <button
+                    type="button"
+                    className="lp-secondary"
+                    onClick={() => setDraft('')}
+                    disabled={busy}
+                  >
+                    Clear
+                  </button>
+                )}
+                <button type="button" onClick={send} disabled={busy || !draft.trim()}>
+                  {isSuggestion ? 'Sounds right' : 'Send'}
+                </button>
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
@@ -1,0 +1,89 @@
+import type { ListicleSearchResults } from '../types'
+
+/**
+ * What the searches found.
+ *
+ * The list is ordered by how many angles found each place, not alphabetically
+ * and not by any score. A place three separate searches returned is the
+ * strongest thing here, and that ordering is the only ranking the pipeline has
+ * earned so far -- it comes out of the searches rather than out of a model
+ * being asked which restaurant is best.
+ *
+ * The per-angle table is above the list on purpose. When the count falls short
+ * the question is always "which search failed", and an angle that returned
+ * nothing is the answer.
+ */
+
+interface SearchResultsProps {
+  results: ListicleSearchResults
+  busy: boolean
+  onRerun: () => void
+}
+
+export function SearchResults({ results, busy, onRerun }: SearchResultsProps) {
+  const short = results.shortfall > 0
+
+  return (
+    <section className="lp-results" aria-label="What the searches found">
+      <header className="lp-results-head">
+        <p className="lp-results-score">
+          <strong>{results.found}</strong> places found
+          <span className="lp-muted"> of {results.target} wanted</span>
+        </p>
+        <p className="lp-muted lp-results-sub">
+          {results.rows_returned} results across {results.angles.length} searches,{' '}
+          {results.rows_returned - results.found} of them the same place found twice
+        </p>
+        {short && (
+          <p className="lp-results-short" role="status">
+            {results.shortfall} short. Add an angle, or take the shorter list.
+          </p>
+        )}
+      </header>
+
+      <table className="lp-angle-table">
+        <tbody>
+          {results.angles.map(angle => (
+            <tr key={angle.angle} className={angle.failed ? 'lp-angle-failed' : undefined}>
+              <td className="lp-angle-count">{angle.rows}</td>
+              <td>{angle.angle}</td>
+              <td className="lp-muted lp-angle-note">
+                {/* A search that broke and a search that found nothing are
+                    different findings, and only one of them is worth
+                    re-running. */}
+                {angle.failed ? `failed — ${angle.reason}` : angle.reason}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <ol className="lp-candidates">
+        {results.candidates.map(candidate => (
+          <li key={candidate.name} className="lp-candidate">
+            <div className="lp-candidate-line">
+              <span className="lp-candidate-name">{candidate.name}</span>
+              {candidate.district && (
+                <span className="lp-muted lp-candidate-district">{candidate.district}</span>
+              )}
+              {candidate.overlap > 1 && (
+                <span className="lp-candidate-overlap" title={candidate.found_by.join('\n')}>
+                  found by {candidate.overlap}
+                </span>
+              )}
+            </div>
+            {candidate.evidence && (
+              <p className="lp-candidate-evidence">{candidate.evidence}</p>
+            )}
+          </li>
+        ))}
+      </ol>
+
+      <div className="lp-actions">
+        <button type="button" className="lp-secondary" onClick={onRerun} disabled={busy}>
+          {busy ? 'Searching…' : 'Run the searches again'}
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SeedScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SeedScreen.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+
+/**
+ * One box, and what goes in it is a working title.
+ *
+ * This is the one place the listicle intake deliberately differs from the
+ * article one at the very first screen. An article starts from a thought
+ * ("Lima's fog is the only rain the city gets"); a listicle starts from a
+ * finished, SEO-shaped headline ("The Best Cevicherias in Lima"), because
+ * that headline already carries the type, the place and the count.
+ *
+ * The title is written for search, not as a statement of method. "Best"
+ * promises nothing about how the list was built — that gets asked about
+ * separately, and nothing here should read criteria out of the headline.
+ */
+
+interface SeedScreenProps {
+  busy: boolean
+  onStart: (seed: string) => void
+}
+
+export function SeedScreen({ busy, onStart }: SeedScreenProps) {
+  const [seed, setSeed] = useState('')
+
+  return (
+    <section className="lp-intake" aria-label="Start a listicle">
+      <p className="lp-eyebrow">What is the list?</p>
+      <label className="lp-field">
+        <span className="lp-label">Paste a working title</span>
+        <textarea
+          value={seed}
+          rows={2}
+          disabled={busy}
+          placeholder="The Best Cevicherias in Lima"
+          onChange={event => setSeed(event.target.value)}
+        />
+      </label>
+      <p className="lp-note">
+        Write it the way it would run as a headline. The type, the place and the count
+        get read off it, and you confirm them next.
+      </p>
+      <div className="lp-actions">
+        <button type="button" disabled={busy || !seed.trim()} onClick={() => onStart(seed)}>
+          Start
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/index.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/index.ts
@@ -1,0 +1,7 @@
+export { ListiclePipelinePage } from './pages/ListiclePipelinePage'
+export { useListicleGrill } from './useListicleGrill'
+export type {
+  ListicleGrillPending,
+  ListicleGrillState,
+  ListicleGrillTurn,
+} from './types'

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/pages/ListiclePipelinePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/pages/ListiclePipelinePage.tsx
@@ -1,0 +1,112 @@
+import { Link } from 'react-router-dom'
+import { GrillScreen } from '../components/GrillScreen'
+import { SearchResults } from '../components/SearchResults'
+import { SeedScreen } from '../components/SeedScreen'
+import { useListicleGrill } from '../useListicleGrill'
+import '../styles.css'
+
+/**
+ * The listicle pipeline's front door.
+ *
+ * A section of its own rather than a mode of Prompt2Blog. The two commission
+ * different things: an article is judged on whether it reads well, which is
+ * arguable and was never provable; a listicle is judged on whether every item
+ * is real, current and earns its place against a stated standard, which is
+ * checkable. Different definitions of success do not share a spine.
+ *
+ * Its own screen treatment is deliberate too — the operator should be able to
+ * tell at a glance which one they are in.
+ *
+ * Right now this is the shell and nothing else: no run, no server, no model,
+ * no research. The grill walks a hardcoded placeholder script so the shape can
+ * be looked at and argued with before anything is built underneath it.
+ */
+
+export function ListiclePipelinePage() {
+  const grill = useListicleGrill()
+  const { state, results, busy, searching, error } = grill
+
+  return (
+    <div className="lp-page">
+      <header className="lp-hero">
+        <div>
+          <p className="lp-eyebrow">Questurian Studio</p>
+          <h1>
+            Build a <span className="lp-underline-text">list</span>
+            <span className="lp-dot">.</span>
+          </h1>
+        </div>
+        <div className="lp-badge-row">
+          <Link to="/" className="lp-nav-link">
+            &larr; Home
+          </Link>
+          <Link to="/single-type-listicles" className="lp-nav-link">
+            Manual builder
+          </Link>
+        </div>
+      </header>
+
+      <main className="lp-container">
+        {/* The interview runs, and stops when the specification is full.
+            Nothing after it is built: there is no research, no gate, no list.
+            Said on the screen so nobody opening this mistakes an agreed
+            interview for a finished listicle. */}
+        <p className="lp-scaffold-banner" role="status">
+          <strong>Interview and search.</strong> The interview settles the search
+          order and the searches return candidate places. Checking each one has
+          enough published material to write about is not built yet.
+        </p>
+
+        {state && (
+          <div className="lp-step-bar">
+            <span className="lp-step">
+              {state.status === 'agreed' ? 'Settled' : 'A few questions'}
+            </span>
+            {/* On screen so an interview can be returned to: it lives on the
+                run, not in this tab. */}
+            <span className="lp-run-id">run {state.run_id}</span>
+          </div>
+        )}
+
+        {error && (
+          <p className="lp-error" role="alert">
+            {error}
+          </p>
+        )}
+
+        {state === null ? (
+          <SeedScreen busy={busy} onStart={grill.start} />
+        ) : (
+          <>
+            <GrillScreen
+              state={state}
+              busy={busy}
+              onAnswer={grill.answer}
+              onReset={grill.reset}
+            />
+
+            {/* Offered only once the order is settled, and only as a button:
+                seven grounded searches take minutes and cost real tokens, so
+                nothing starts them except someone asking. */}
+            {state.status === 'agreed' && results === null && (
+              <div className="lp-actions lp-search-cta">
+                <button type="button" onClick={grill.search} disabled={searching}>
+                  {searching ? 'Searching the web…' : 'Run the searches'}
+                </button>
+                {searching && (
+                  <p className="lp-muted">
+                    One search per angle. This takes a few minutes.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {results && (
+              <SearchResults results={results} busy={searching} onRerun={grill.search} />
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles.css
@@ -1,0 +1,2 @@
+@import './styles/layout.css';
+@import './styles/grill.css';

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
@@ -1,0 +1,548 @@
+/*
+ * Listicle pipeline — the seed box and the interview.
+ *
+ * The chat shape is carried over from the article grill on purpose: a thread
+ * read top to bottom, newest at the end, composer underneath. What a
+ * conversation looks like is not the part worth reinventing.
+ */
+
+/* ---------- the seed box ---------- */
+
+.lp-intake {
+  max-width: 42rem;
+  margin: 0 auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6) clamp(var(--space-4), 4vw, var(--space-7));
+  box-shadow: 0 2px 16px var(--shadow-soft);
+}
+
+.lp-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 var(--space-3);
+}
+
+.lp-field {
+  display: block;
+  margin: 0 0 var(--space-3);
+}
+
+.lp-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--ink);
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.lp-field textarea,
+.lp-composer textarea {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--cream);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.lp-field textarea:focus,
+.lp-composer textarea:focus {
+  outline: 2px solid var(--lp-accent);
+  outline-offset: 1px;
+  border-color: var(--lp-accent);
+}
+
+.lp-note {
+  margin: var(--space-4) 0 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+/* ---------- the interview, as a chat ---------- */
+
+.lp-chat {
+  max-width: 42rem;
+  margin: 0 auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5) clamp(var(--space-4), 4vw, var(--space-6));
+  box-shadow: 0 2px 16px var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.lp-thread {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-height: min(58vh, 34rem);
+  overflow-y: auto;
+  padding-right: var(--space-2);
+  scroll-behavior: smooth;
+}
+
+.lp-exchange {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.lp-message {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  line-height: 1.5;
+  max-width: 88%;
+  text-wrap: pretty;
+}
+
+/* The grill's side: plain, on the page's own ground. It does most of the
+   talking, so it should not shout. */
+.lp-message-theirs {
+  align-self: flex-start;
+  background: var(--cream-dark);
+  color: var(--ink);
+  border-bottom-left-radius: var(--space-1);
+}
+
+/* Yours: kept word for word, and set on the section's accent rather than a
+   second beige, so the thread does not read as one voice talking to itself. */
+.lp-message-mine {
+  align-self: flex-end;
+  background: var(--lp-accent-soft);
+  color: var(--ink);
+  border-bottom-right-radius: var(--space-1);
+}
+
+.lp-message-seed {
+  font-style: italic;
+  color: var(--ink-light);
+}
+
+.lp-message-consensus {
+  max-width: 100%;
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  border-left: 3px solid var(--lp-accent);
+}
+
+.lp-accepted {
+  display: block;
+  margin-top: var(--space-2);
+  color: var(--muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* ---------- the composer ---------- */
+
+.lp-composer {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-4);
+}
+
+.lp-composer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.lp-composer-hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  flex: 1 1 14rem;
+}
+
+.lp-composer-buttons {
+  display: flex;
+  gap: var(--space-3);
+  margin-left: auto;
+}
+
+.lp-actions {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+  margin-top: var(--space-5);
+}
+
+.lp-chat-actions {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-4);
+  margin-top: 0;
+}
+
+.lp-composer-buttons button,
+.lp-actions button {
+  padding: var(--space-3) var(--space-5);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--lp-accent);
+  color: white;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-base);
+}
+
+.lp-composer-buttons button:hover:not(:disabled),
+.lp-actions button:hover:not(:disabled) {
+  background: var(--lp-accent-hover);
+}
+
+.lp-composer-buttons button:disabled,
+.lp-actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.lp-composer-buttons .lp-secondary,
+.lp-actions .lp-secondary {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border-strong);
+}
+
+.lp-composer-buttons .lp-secondary:hover:not(:disabled),
+.lp-actions .lp-secondary:hover:not(:disabled) {
+  background: var(--cream-dark);
+  color: var(--ink);
+}
+
+.lp-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .lp-message {
+    max-width: 96%;
+  }
+}
+
+/* ---------- progress, pushback, failure ---------- */
+
+/* What the specification still needs. A question count never was progress:
+   the interview stops when the spec is full, not after N turns. */
+.lp-chat-progress {
+  margin: 0;
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
+  color: var(--ink-light);
+  font-size: 0.8125rem;
+}
+
+.lp-muted {
+  color: var(--muted);
+}
+
+/* Shown above the question it exists to resolve, so the contradiction reads as
+   the reason for asking rather than as a complaint. */
+.lp-pushback {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--lp-accent-softer);
+  border-left: 3px solid var(--lp-accent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+}
+
+/* A failed turn leaves the interview exactly where it was. That has to look
+   different from a turn that simply had nothing to ask. */
+.lp-error {
+  max-width: 42rem;
+  margin: 0 auto var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(180, 35, 24, 0.07);
+  border-left: 3px solid #b42318;
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--ink);
+  font-size: 0.9375rem;
+}
+
+/* ---------- the angle picker ----------
+ *
+ * The one question answered by choosing. It sits where the composer sits, in
+ * the same box, because it is still the operator's turn -- it is a different
+ * control, not a different part of the screen.
+ */
+
+.lp-picker {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.lp-picker-hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.lp-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.lp-picker-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--cream);
+}
+
+.lp-picker-row input[type='checkbox'] {
+  margin-top: 0.55rem;
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--lp-accent);
+  flex: none;
+}
+
+.lp-picker-row textarea {
+  flex: 1;
+  border: none;
+  background: none;
+  padding: var(--space-2) 0;
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.9375rem;
+  line-height: 1.45;
+  resize: vertical;
+}
+
+.lp-picker-row textarea:focus {
+  outline: none;
+}
+
+.lp-picker-row:focus-within {
+  border-color: var(--lp-accent);
+  box-shadow: 0 0 0 1px var(--lp-accent);
+}
+
+/* An unticked angle stays readable -- it is a search you may put back, not a
+   thing you deleted. */
+.lp-picker-row-off {
+  opacity: 0.5;
+}
+
+.lp-picker-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.lp-picker-count {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.lp-picker-heading {
+  margin: var(--space-2) 0 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* The collision group, sitting quietly at the end of the row. It only matters
+   when two of them are ticked, and then the warning below says so. */
+.lp-picker-group {
+  align-self: center;
+  flex: none;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.1rem 0.4rem;
+}
+
+.lp-picker-warning {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--lp-accent);
+  background: var(--lp-accent-soft);
+  color: var(--ink);
+  font-size: 0.875rem;
+}
+
+/* ---------- what the searches found ---------- */
+
+.lp-results {
+  max-width: 46rem;
+  margin: var(--space-5) auto 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5) clamp(var(--space-4), 4vw, var(--space-6));
+  box-shadow: 0 2px 16px var(--shadow-soft);
+}
+
+.lp-search-cta {
+  justify-content: center;
+  margin-top: var(--space-4);
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.lp-results-head {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.lp-results-score {
+  margin: 0;
+  font-size: 1.375rem;
+  color: var(--ink);
+}
+
+.lp-results-score strong {
+  font-size: 1.75rem;
+}
+
+.lp-results-sub {
+  margin: var(--space-1) 0 0;
+  font-size: 0.8125rem;
+}
+
+.lp-results-short {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--lp-accent);
+  background: var(--lp-accent-soft);
+  font-size: 0.875rem;
+}
+
+/* Per angle, so a short list can be traced to the search that came up empty
+   rather than read as a general failure. */
+.lp-angle-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-5);
+  font-size: 0.8125rem;
+}
+
+.lp-angle-table td {
+  padding: var(--space-2) var(--space-2);
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.lp-angle-count {
+  width: 2.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.lp-angle-note {
+  width: 30%;
+}
+
+.lp-angle-failed .lp-angle-count {
+  color: var(--lp-accent);
+}
+
+.lp-candidates {
+  list-style: none;
+  counter-reset: candidate;
+  margin: 0;
+  padding: 0;
+}
+
+.lp-candidate {
+  counter-increment: candidate;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: var(--space-2) 0 var(--space-2) var(--space-6);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.lp-candidate::before {
+  content: counter(candidate);
+  position: absolute;
+  left: 0;
+  top: var(--space-2);
+  width: var(--space-5);
+  text-align: right;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.lp-candidate-line {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.lp-candidate-name {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.lp-candidate-district {
+  font-size: 0.8125rem;
+}
+
+/* The ranking signal, and the only one the pipeline has actually earned. */
+.lp-candidate-overlap {
+  margin-left: auto;
+  font-size: 0.6875rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--lp-accent);
+  border: 1px solid var(--lp-accent);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.05rem 0.4rem;
+}
+
+.lp-candidate-evidence {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/layout.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/layout.css
@@ -1,0 +1,128 @@
+/*
+ * Listicle pipeline — page shell.
+ *
+ * Built on the app's existing tokens (css/base.css) rather than new ones, the
+ * same way Prompt2Blog was: this is one section of an app that already has a
+ * look, and it should not arrive with its own.
+ *
+ * The one deliberate difference is the accent. Prompt2Blog owns the blue.
+ * This owns a teal, so the operator can tell which section they are in
+ * without reading the heading — the point made in issue #449 about a mode
+ * wanting its own screen treatment.
+ */
+
+.lp-page {
+  width: min(100%, 1440px);
+  margin: 0 auto;
+  padding: var(--space-7) clamp(var(--space-4), 4vw, var(--space-8)) var(--space-10);
+  animation: lpFadeIn 0.35s ease-out;
+
+  --lp-accent: #0f766e;
+  --lp-accent-hover: #115e59;
+  --lp-accent-soft: rgba(15, 118, 110, 0.12);
+  --lp-accent-softer: rgba(15, 118, 110, 0.06);
+}
+
+@keyframes lpFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.lp-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+  max-width: 1240px;
+  margin: 0 auto var(--space-8);
+  padding: 0 0 var(--space-6);
+  border-bottom: 1px solid var(--border-strong);
+  text-align: center;
+}
+
+.lp-hero h1 {
+  max-width: 800px;
+  margin: 0 auto;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: clamp(2.35rem, 4.5vw, 4.35rem);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 0.98;
+}
+
+.lp-underline-text {
+  text-decoration: underline;
+  text-decoration-color: var(--lp-accent);
+  text-decoration-thickness: 3px;
+  text-underline-offset: 8px;
+}
+
+.lp-dot {
+  color: var(--lp-accent);
+  font-weight: 700;
+}
+
+.lp-badge-row {
+  display: flex;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.lp-nav-link {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  transition: color var(--transition-base), background var(--transition-base);
+}
+
+.lp-nav-link:hover {
+  color: var(--ink);
+  background: var(--cream-dark);
+}
+
+.lp-container {
+  max-width: 1240px;
+  margin: 0 auto;
+}
+
+/* Said on the screen because a reader should not have to open the source to
+   learn that nothing behind this runs yet. Delete it when it stops being
+   true. */
+.lp-scaffold-banner {
+  max-width: 42rem;
+  margin: 0 auto var(--space-5);
+  padding: var(--space-3) var(--space-4);
+  background: var(--lp-accent-softer);
+  border-left: 3px solid var(--lp-accent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--ink-light);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.lp-step-bar {
+  max-width: 42rem;
+  margin: 0 auto var(--space-4);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+/* The interview lives on the run, not in this tab, so the id is on screen. */
+.lp-run-id {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.lp-step {
+  font-size: 0.75rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
@@ -1,0 +1,91 @@
+/**
+ * The listicle interview, as the screen sees it.
+ *
+ * Mirrors what the server sends, which is deliberately less than it holds:
+ * the research digest is thousands of words nobody reads, so it never crosses
+ * the wire.
+ */
+
+export interface ListicleGrillTurn {
+  question_id: string
+  ask: string
+  pushback: string
+  answer: string
+  /** Accepting a suggestion is worth less than volunteering an answer, and the
+   *  screen has to show the difference or the grill agrees with itself. */
+  accepted_as_drafted: boolean
+}
+
+export interface ListicleGrillPending {
+  question_id: string
+  ask: string
+  /** Pre-written answer. Arrives in the composer, ready to be corrected. */
+  recommendation: string
+  /** Set when this question exists because an answer contradicted something. */
+  pushback: string
+  /** Non-empty only for a question answered by choosing rather than writing.
+   *  Today that is the angle question, where every entry becomes one literal
+   *  web search and prose would have to be split back into lines. */
+  options: ListicleGrillOption[]
+}
+
+export interface ListicleGrillOption {
+  /** The finished search line. Sent to the web almost verbatim. */
+  text: string
+  /** Arrives ticked. The rest are the menu you can swap in. */
+  recommended: boolean
+  /** Options sharing a group return the same places for the same reason.
+   *  Empty when the option answers to nothing else. */
+  group: string
+}
+
+export interface ListicleGrillState {
+  run_id: string
+  seed: string
+  status: 'asking' | 'agreed'
+  consensus: string
+  markers_covered: string[]
+  markers_missing: string[]
+  /** What it looked up mid-interview, in order. */
+  lookups: string[]
+  turns: ListicleGrillTurn[]
+  pending: ListicleGrillPending | null
+}
+
+
+/**
+ * What the search order found.
+ *
+ * `found` against `target` is the only question this step exists to answer, so
+ * it arrives as a number rather than as something the screen counts for
+ * itself.
+ */
+export interface ListicleCandidate {
+  name: string
+  district: string
+  evidence: string
+  /** Every angle that returned this place. More than one is the ranking
+   *  signal: a place three searches agree on is the strongest on the list. */
+  found_by: string[]
+  overlap: number
+}
+
+export interface ListicleAngleResult {
+  angle: string
+  rows: number
+  sources: number
+  /** A search that never ran. Different from one that ran and found nothing,
+   *  and the screen must not present them as the same thing. */
+  failed: boolean
+  reason: string
+}
+
+export interface ListicleSearchResults {
+  run_id: string
+  target: number
+  found: number
+  shortfall: number
+  rows_returned: number
+  angles: ListicleAngleResult[]
+  candidates: ListicleCandidate[]
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/useListicleGrill.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/useListicleGrill.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react'
+import { answerGrill, loadSearch, runSearch, startGrill } from './api'
+import type { ListicleGrillState, ListicleSearchResults } from './types'
+
+/**
+ * The listicle interview, driven by the server.
+ *
+ * There is no local copy of the conversation: every move posts and replaces
+ * the whole state with what came back. The interview lives on the run, so a
+ * closed tab is not a lost interview -- the same reason the article grill
+ * persists per turn rather than holding the thread in a browser.
+ *
+ * Each turn is a live model call and takes a few seconds, so `busy` is what
+ * the screen disables itself on.
+ */
+
+interface UseListicleGrill {
+  state: ListicleGrillState | null
+  results: ListicleSearchResults | null
+  busy: boolean
+  /** Set only while the searches are running. They take minutes where a grill
+   *  turn takes seconds, and a screen that says "working" for both tells the
+   *  operator nothing about how long to wait. */
+  searching: boolean
+  error: string | null
+  start: (seed: string) => void
+  answer: (text: string) => void
+  search: () => void
+  reset: () => void
+}
+
+export function useListicleGrill(): UseListicleGrill {
+  const [state, setState] = useState<ListicleGrillState | null>(null)
+  const [results, setResults] = useState<ListicleSearchResults | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [searching, setSearching] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const run = useCallback(async (work: () => Promise<ListicleGrillState>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      setState(await work())
+    } catch (caught) {
+      // Said on the screen rather than swallowed: a failed turn leaves the
+      // interview exactly where it was, and the operator has to be able to
+      // tell that from a turn that simply had nothing to ask.
+      setError(caught instanceof Error ? caught.message : 'That turn failed.')
+    } finally {
+      setBusy(false)
+    }
+  }, [])
+
+  const start = useCallback(
+    (seed: string) => {
+      if (!seed.trim()) return
+      void run(() => startGrill(seed.trim()))
+    },
+    [run],
+  )
+
+  const answer = useCallback(
+    (text: string) => {
+      const runId = state?.run_id
+      if (!runId || !text.trim()) return
+      void run(() => answerGrill(runId, text.trim()))
+    },
+    [run, state?.run_id],
+  )
+
+  // Running the order is minutes of grounded searching, so it is never done
+  // on a screen opening -- it looks for what a previous run stored first, and
+  // only searches when there is nothing there or the operator asks again.
+  const search = useCallback(() => {
+    const runId = state?.run_id
+    if (!runId || searching) return
+    setSearching(true)
+    setError(null)
+    void (async () => {
+      try {
+        setResults(await runSearch(runId))
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'The search failed.')
+      } finally {
+        setSearching(false)
+      }
+    })()
+  }, [searching, state?.run_id])
+
+  // An agreed interview may already have results behind it, from this session
+  // or another one. Read them before offering to spend on new ones.
+  useEffect(() => {
+    const runId = state?.run_id
+    if (!runId || state?.status !== 'agreed' || results) return
+    void loadSearch(runId)
+      .then(found => {
+        if (found) setResults(found)
+      })
+      .catch(() => {
+        // Nothing stored is the normal case, and it is not an error worth
+        // putting on the screen: the button to run them is right there.
+      })
+  }, [results, state?.run_id, state?.status])
+
+  const reset = useCallback(() => {
+    setState(null)
+    setResults(null)
+    setError(null)
+  }, [])
+
+  return { state, results, busy, searching, error, start, answer, search, reset }
+}

--- a/apps/ai-blog-writer/packages/utils/src/utils/google_grounding.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/google_grounding.py
@@ -219,6 +219,7 @@ def _generate_with_google_search(
     model_name: str,
     max_tokens: int,
     temperature: float,
+    timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
 ) -> dict[str, Any] | None:
     session, project, location = _get_authorized_grounding_session()
     if session is None or not project or not location:
@@ -247,7 +248,7 @@ def _generate_with_google_search(
         response = session.post(
             url,
             json=payload,
-            timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except Exception:  # pragma: no cover - network/runtime dependent
         logger.warning(
@@ -289,6 +290,11 @@ def invoke_google_grounded_text(
     max_tokens: int = 1024,
     temperature: float = 0.05,
     dynamic_threshold: float = DEFAULT_DYNAMIC_THRESHOLD,
+    # Raised by callers whose searches are long. A listicle angle asks for a
+    # dozen named places with evidence for each, and the default 60s cut one
+    # of seven searches off entirely -- a whole angle missing from the list,
+    # reported as an empty result rather than as a timeout.
+    timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
 ) -> GroundedGenerationResult | None:
     del dynamic_threshold
 
@@ -300,6 +306,7 @@ def invoke_google_grounded_text(
             model_name=resolved_model_name,
             max_tokens=max_tokens,
             temperature=temperature,
+            timeout_seconds=timeout_seconds,
         )
 
     response = _generate_with_model(model_name)


### PR DESCRIPTION
Builds the first half of the listicle pipeline: an interview that settles a
search order, the searches that fill it, a profile per place holding what has
been published about it, and the gate that decides whether a place can carry a
blurb.

Nothing here writes a blurb, and nothing reaches Location Manager.

## What it does

**The interview** is the article grill's loop (`prompt2blog.grill_v4`) with two
things swapped: the checklist it settles and the prompt it asks with. It fills
out a search order — kind, place, count, what earns a spot, what is barred, and
the angles — rather than a vision. A question that does not change what gets
searched for is a question it must not ask.

**Angles are written per topic from fixed shapes.** "Tiny plain places where the
food is the whole point" is the same sentence for ceviche, pizza and wings. But
two runs on 2026-09-03 that let the model choose and word its own angles cost
half the list: it over-tightened its own wording ("operating for 50+ years" for
"open for decades", 3 places instead of 9) and picked three angles that were one
angle. So the model writes the words and a catalogue of 17 shapes holds the
discipline — the shape sets the tightness, and shapes in a collision group
cannot be chosen together.

**The searches run in the local language.** Measured on one agreed order for
Lima pisco sour bars: English only found 30 places, adding the local language
found 38, and the angle that had returned one row returned seven. The
English-only list was Miraflores and Barranco; the local-language list reaches
Cercado de Lima.

**Profiles** hold what has been *said* about a place — awards, reviews, history,
the people — as dated, sourced claims rather than fields. Location Manager owns
what a place *is*, and none of this belongs in a store that publishes. Identity
is the Google Place ID, which LM is already keyed on, so both point at one
building without either owning the other.

**A Places pass** asks Google directly. No model is involved, which is the
point: `rating` and `price_level` arrive as facts rather than as something a
model believed. It also reaches the customer voice the web search never does.

**The gate** returns three verdicts, not two. A place with two newspaper claims
is publishable at short length, and collapsing that into "no" throws away most
of a long list. Source quality is weighed rather than counted — a claim sourced
to the subject's own website is not evidence about the subject, and one real
profile cited an AI trip planner.

## Measured

| | result |
|---|---|
| Ceviche, 40 asked | 31 distinct places |
| Pisco sour bars, 30 asked | 30 English-only, 38 with local language |
| Bar Rovira del Callao (obscure, 1 angle) | 46 claims incl. 1907 founding, entirely from Spanish sources |

## Not done, on purpose

- **Nothing is wired into the pipeline past the search.** Which candidates
  deserve a profile is the gate's decision, and hooking profile-building into
  the search would research every row the gate exists to throw away.
- **The gate's thresholds are derived from three places.** Every real profile
  built so far returns `enough`, so the `thin` and `nothing` boundaries are
  exercised only by tests and will need re-deriving against a full list.
- **Nothing weighs an angle that reliably returns nothing.** New-opening angles
  came back with 1–7 rows on both topics.
- **The screens are unclicked.** Backend proven end to end through the real
  service layer; the UI typechecks and its tests pass, but nobody has driven it
  in a browser.

## Verification

- 1337 backend tests pass
- 778 frontend tests pass
- `tsc --noEmit` clean