### PR TITLE
fix(p2b): research keeps the work it paid for, and structuring costs a third

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -37,6 +37,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from app.core.staff_auth import require_staff, staff_user_id
 
+from ..intake_lock import exclusive_run
 from ..brief_v4 import BriefIncomplete, BriefUnusable
 from ..dependencies import PipelineDependencies, dependencies_for_run
 from ..grill_v4 import (
@@ -100,6 +101,7 @@ def _grounded_call(
     model_name: str | None = None,
     max_tokens: int,
     usage_recorder: Any | None,
+    correlation_id: str | None = None,
 ) -> tuple[str, list[str], int | None]:
     """A grounded search, counted.
 
@@ -116,11 +118,15 @@ def _grounded_call(
     """
     from app.shared.model_calls import grounded_text
 
+    if correlation_id is None:
+        correlation_id = getattr(getattr(usage_recorder, "__self__", None), "run_id", None)
+
     # Reported here for the first time. These two searches are the most
     # token-hungry step in a run and neither has ever reached the dashboard,
     # because reporting was wired per call site and these sites were missed.
     result = grounded_text(
-        job_id, prompt, model=model_name, max_tokens=max_tokens, endpoint="grounded"
+        job_id, prompt, model=model_name, max_tokens=max_tokens, endpoint="grounded",
+        correlation_id=correlation_id
     )
     if result is None:
         # The call failed rather than returned nothing. There is no successful
@@ -133,6 +139,9 @@ def _grounded_call(
             "total_tokens": result.total_tokens,
         }
         measured = {key: value for key, value in counts.items() if value is not None}
+        if measured:
+            measured["output_token_details"] = {"reasoning": getattr(result, "reasoning_tokens", 0) or 0}
+            measured["cached_input_tokens"] = getattr(result, "cached_input_tokens", 0) or 0
         try:
             usage_recorder(
                 str(result.model_name or model_name),
@@ -173,6 +182,7 @@ def _services(run_id: str | None = None) -> IntakeServices:
             job_id="p2b.grill_research",
             max_tokens=GRILL_RESEARCH_MAX_TOKENS,
             usage_recorder=record_usage,
+            correlation_id=run_id,
         )
 
     def _gather(prompt: str, model_name: str | None = None) -> tuple[str, list[str], int | None]:
@@ -182,6 +192,7 @@ def _services(run_id: str | None = None) -> IntakeServices:
             job_id="p2b.research_gather",
             max_tokens=GATHER_MAX_TOKENS,
             usage_recorder=record_usage,
+            correlation_id=run_id,
         )
 
     return IntakeServices(
@@ -345,6 +356,7 @@ def read_intake(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
 
 
 @router.post("/{run_id}/answer")
+@exclusive_run
 def answer_question(
     run_id: str, request: AnswerRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
@@ -353,6 +365,7 @@ def answer_question(
 
 
 @router.post("/{run_id}/reopen")
+@exclusive_run
 def reopen(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     """Go back into the grill. The single exit from every dead end."""
     _handle(reopen_intake, run_id, _services(run_id))
@@ -360,6 +373,7 @@ def reopen(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
 
 
 @router.post("/{run_id}/brief")
+@exclusive_run
 def build_the_brief(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     """Turn an agreed grill into the brief the run answers to."""
     _handle(approve_brief, run_id, _services(run_id))
@@ -367,12 +381,14 @@ def build_the_brief(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
 
 
 @router.post("/{run_id}/work-order")
+@exclusive_run
 def plan_the_research(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     _handle(plan_research, run_id, _services(run_id))
     return JSONResponse(intake_state(run_id))
 
 
 @router.post("/{run_id}/work-order/cut")
+@exclusive_run
 def cut_the_work_order(
     run_id: str, request: CutRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
@@ -392,6 +408,7 @@ def cut_the_work_order(
 
 
 @router.post("/{run_id}/research")
+@exclusive_run
 def do_the_research(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
     """Both research passes, then the one gate that blocks.
 
@@ -425,6 +442,7 @@ class ReaskRequest(BaseModel):
 
 
 @router.post("/{run_id}/gate/reask")
+@exclusive_run
 def reask_the_question(
     run_id: str, request: ReaskRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
@@ -451,6 +469,7 @@ def read_gate(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
 
 
 @router.post("/{run_id}/gate")
+@exclusive_run
 def settle_the_gate(
     run_id: str, request: GateAnswerRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
@@ -510,6 +529,7 @@ def read_venues(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
 
 
 @router.post("/{run_id}/venues")
+@exclusive_run
 def mark_venue(
     run_id: str, request: VenueMarkRequest, _staff=Depends(require_staff)
 ) -> JSONResponse:
@@ -576,6 +596,7 @@ def read_writing_request(
 
 
 @router.post("/{run_id}/write", status_code=202)
+@exclusive_run
 def start_writing(
     run_id: str,
     background_tasks: BackgroundTasks,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -236,6 +236,8 @@ class WorkOrderRequirement(V4ContractModel):
     # What the article needs, which is not always what the question's wording
     # demands. Research is judged against this rather than against the phrasing.
     precision: RequirementPrecision = "exact"
+    # Related facts can share retrieval while keeping separate coverage verdicts.
+    search_group: str = ""
     # Empty when the question stands on its own. Every id here must name a
     # premise the same commission declares.
     assumption_ids: list[str] = Field(default_factory=list)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
@@ -50,6 +50,7 @@ class Prompt2BlogLLM(Protocol):
 
 @dataclass(frozen=True)
 class DefaultPrompt2BlogLLM:
+    run_id: str | None = None
     usage_tracker: Prompt2BlogTokenUsageTracker = field(
         default_factory=Prompt2BlogTokenUsageTracker,
         compare=False,
@@ -60,12 +61,14 @@ class DefaultPrompt2BlogLLM:
         return llm._invoke_text_llm(
             **kwargs,
             usage_recorder=self.usage_tracker.record,
+            correlation_id=self.run_id or self.usage_tracker.run_id,
         )
 
     def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
         return llm._invoke_json_llm(
             **kwargs,
             usage_recorder=self.usage_tracker.record,
+            correlation_id=self.run_id or self.usage_tracker.run_id,
         )
 
     def enforce_anti_ai(self, text: str, **kwargs: Any) -> str:
@@ -73,6 +76,7 @@ class DefaultPrompt2BlogLLM:
             text,
             **kwargs,
             usage_recorder=self.usage_tracker.record,
+            correlation_id=self.run_id or self.usage_tracker.run_id,
         )
 
     def usage_summary(self, **kwargs: Any) -> dict[str, Any]:
@@ -127,4 +131,4 @@ def dependencies_for_run(run_id: str) -> PipelineDependencies:
     """
     stored = _safe_dict(_safe_dict(read_stage_result(run_id, USAGE_LEDGER_STAGE)).get("data"))
     tracker = Prompt2BlogTokenUsageTracker.from_ledger(stored)
-    return PipelineDependencies(llm=DefaultPrompt2BlogLLM(usage_tracker=tracker))
+    return PipelineDependencies(llm=DefaultPrompt2BlogLLM(usage_tracker=tracker, run_id=run_id))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_lock.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_lock.py
@@ -1,0 +1,38 @@
+"""Prevent overlapping intake mutations from buying work or overwriting receipts."""
+from contextlib import contextmanager
+from functools import wraps
+import fcntl
+import hashlib
+
+from fastapi import HTTPException
+
+
+def exclusive_run(action):
+    @wraps(action)
+    def guarded(run_id: str, *args, **kwargs):
+        with intake_lock(run_id):
+            return action(run_id, *args, **kwargs)
+    return guarded
+
+
+@contextmanager
+def intake_lock(run_id: str):
+    # File locks cover both threadpool requests and multiple local workers.
+    # The OS releases them on process exit; no stale 'running' flag to clear.
+    from app.config import DATA_DIR
+
+    directory = DATA_DIR / "intake-locks"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / (hashlib.sha256(run_id.encode()).hexdigest() + ".lock")
+    with path.open("a") as handle:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise HTTPException(status_code=409, detail={
+                "error": "intake_busy",
+                "message": "This run is already working. Wait for it to finish before changing or retrying it.",
+            }) from error
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -75,6 +75,7 @@ from .research_v4 import (
     ResearchUnusable,
     gather_one_requirement,
     gather_research,
+    BATCHES_STAGE,
     notes_from_record,
     notes_stage_record,
     research_stage_record,
@@ -328,7 +329,7 @@ def apply_cut(
     added_questions: list[str] | None = None,
 ) -> CutOutcome:
     """Apply the operator's cut. No model call; this is their decision, not one."""
-    for stage in (RESEARCH_STAGE, NOTES_STAGE):
+    for stage in (RESEARCH_STAGE,):
         # Research answered the questions that were there before the cut.
         if read_stage_result(run_id, stage) is not None:
             services.recorder.discard_stage(run_id, stage)
@@ -374,36 +375,34 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
     brief = load_brief(run_id)
     work_order = load_work_order(run_id)
 
-    # Ten sequential web searches, then one structuring call. Every structuring
-    # failure used to buy the searches again -- run 90b3f9bc paid for them
-    # twice in one evening. The notes are kept the moment they exist and are
-    # reused only when they answer this exact plan.
     def record_progress(progress: dict[str, Any]) -> None:
-        # Written straight, not through `_record`: that opens a fresh usage
-        # attempt each time, and ten empty attempts would bury the stage's real
-        # receipt in the ledger.
         services.recorder.record_stage(run_id, PROGRESS_STAGE, progress)
 
-    notes = notes_from_record(_stage_data(run_id, NOTES_STAGE), work_order)
-    if notes is None:
+    def check_budget() -> None:
+        enforce_run_budget(_run_tokens_spent(run_id), stage=RESEARCH_STAGE)
+
+    def save_notes(notes: dict[str, Any]) -> None:
+        services.recorder.record_stage(run_id, NOTES_STAGE, notes_stage_record(work_order, notes))
+
+    notes = notes_from_record(_stage_data(run_id, NOTES_STAGE), work_order) or {}
+    if len(notes) < len(work_order.requirements) or any(not note.text.strip() for note in notes.values()):
         _open(services, run_id, NOTES_STAGE)
         notes = gather_research(
-            brief, work_order, services.research, record_progress
+            brief, work_order, services.research, record_progress,
+            kept_notes=notes, checkpoint=save_notes, before_call=check_budget,
         )
-        _record(
-            services, run_id, NOTES_STAGE, notes_stage_record(work_order, notes)
-        )
-    else:
-        logger.info(
-            "Reusing kept research notes",
-            extra={"run_id": run_id, "feature": FEATURE_NAME},
-        )
+        save_notes(notes)
 
     record_progress({"phase": "structuring", "done": len(notes), "total": len(notes),
                      "last_question_back": ""})
     try:
         _open(services, run_id, RESEARCH_STAGE)
-        evidence = structure_research(work_order, notes, services.research)
+        evidence = structure_research(
+            work_order, notes, services.research,
+            kept_batches=_stage_data(run_id, BATCHES_STAGE).get("batches", {}),
+            checkpoint=lambda batches: services.recorder.record_stage(run_id, BATCHES_STAGE, {"batches": batches}),
+            before_call=lambda: enforce_run_budget(_run_tokens_spent(run_id), stage=RESEARCH_STAGE),
+        )
     except ResearchUnusable as error:
         # The most expensive step in intake. A failure here that leaves nothing
         # behind means the next attempt is another guess.
@@ -631,7 +630,12 @@ def reask_question(
 
     _open(services, run_id, RESEARCH_STAGE)
     try:
-        evidence = structure_research(work_order, notes, services.research)
+        evidence = structure_research(
+            work_order, notes, services.research,
+            kept_batches=_stage_data(run_id, BATCHES_STAGE).get("batches", {}),
+            checkpoint=lambda batches: services.recorder.record_stage(run_id, BATCHES_STAGE, {"batches": batches}),
+            before_call=lambda: enforce_run_budget(_run_tokens_spent(run_id), stage=RESEARCH_STAGE),
+        )
     except ResearchUnusable as error:
         _record(
             services,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
@@ -53,6 +53,7 @@ def _invoke_text_llm(
     model_name: str | None,
     usage_recorder: UsageRecorder | None = None,
     job_id: str | None = None,
+    correlation_id: str | None = None,
 ) -> str:
     resolved_model = _resolved_model(job_id, model_name)
     # get_vertex_llm routes claude-* models to the Anthropic API.
@@ -69,6 +70,7 @@ def _invoke_text_llm(
         provider=provider_for_llm(llm, reported_model),
         feature=job_id or USAGE_FEATURE,
         model=reported_model,
+        correlation_id=correlation_id,
         endpoint="invoke_text",
     ) as observed:
         result = llm.invoke(prompt)
@@ -110,6 +112,7 @@ def _enforce_anti_ai_markdown_with_model(
     context: str,
     usage_recorder: UsageRecorder | None = None,
     job_id: str | None = None,
+    correlation_id: str | None = None,
 ) -> str:
     return enforce_anti_ai_tells_markdown(
         text,
@@ -120,6 +123,7 @@ def _enforce_anti_ai_markdown_with_model(
             model_name=model_name,
             usage_recorder=usage_recorder,
             job_id=job_id,
+            correlation_id=correlation_id,
         ),
         context=context,
     )
@@ -141,6 +145,7 @@ def _invoke_schema_json_llm(
     schema: dict[str, Any],
     usage_recorder: UsageRecorder | None = None,
     job_id: str | None = None,
+    correlation_id: str | None = None,
 ) -> tuple[dict[str, Any], str] | None:
     """One validated call, or None if this provider cannot make one.
 
@@ -170,13 +175,19 @@ def _invoke_schema_json_llm(
         provider=provider_for_llm(llm, reported_model),
         feature=job_id or USAGE_FEATURE,
         model=reported_model,
+        correlation_id=correlation_id,
         endpoint="invoke_json",
     ) as observed:
-        parsed = invoke_json(prompt, input_schema=schema)
-        usage = _usage_with_measured_cost(llm)
-        observed.record_usage(usage)
-    if usage_recorder is not None:
-        usage_recorder(reported_model, usage)
+        options = {"input_schema": schema}
+        if job_id == "p2b.research_structure" and reported_model == "gemini-2.5-flash":
+            options["thinking_budget"] = 0
+        try:
+            parsed = invoke_json(prompt, **options)
+        finally:
+            usage = _usage_with_measured_cost(llm)
+            observed.record_usage(usage)
+            if usage_recorder is not None and usage is not None:
+                usage_recorder(reported_model, usage)
     if not isinstance(parsed, dict):
         raise RuntimeError("Schema-validated LLM response was not an object")
     # The trace wants the raw response the stage saw. There was no prose reply
@@ -194,6 +205,7 @@ def _invoke_json_llm(
     schema: dict[str, Any] | None = None,
     usage_recorder: UsageRecorder | None = None,
     job_id: str | None = None,
+    correlation_id: str | None = None,
 ) -> tuple[dict[str, Any], str]:
     if schema is not None:
         validated = _invoke_schema_json_llm(
@@ -204,9 +216,13 @@ def _invoke_json_llm(
             schema=schema,
             usage_recorder=usage_recorder,
             job_id=job_id,
+            correlation_id=correlation_id,
         )
         if validated is not None:
             return validated
+
+    if schema is not None:
+        prompt += "\nREQUIRED JSON SCHEMA:\n" + json.dumps(schema)
 
     strict_prompt = (
         f"{prompt}\n\n"
@@ -234,6 +250,7 @@ def _invoke_json_llm(
             model_name=model_name,
             usage_recorder=usage_recorder,
             job_id=job_id,
+            correlation_id=correlation_id,
         )
         last_response = raw_response
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -105,6 +105,7 @@ def _empty_usage() -> dict[str, int]:
 
 @dataclass
 class Prompt2BlogTokenUsageTracker:
+    run_id: str | None = None
     successful_calls: int = 0
     measured_calls: int = 0
     by_model: dict[str, dict[str, Any]] = field(default_factory=dict)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -23,8 +23,10 @@ writing, which is the part that actually needs it.
 from __future__ import annotations
 
 import json
+import hashlib
+import copy
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from dataclasses import dataclass, field
 import re
 from datetime import date
@@ -663,6 +665,21 @@ class GatheredNotes:
 
 
 NOTES_STAGE = "stage_v4_research_notes"
+BATCHES_STAGE = "stage_v4_research_batches"
+
+
+def _fingerprint(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, default=str).encode()).hexdigest()
+
+
+def requirement_fingerprint(work_order: Prompt2BlogWorkOrder, requirement: WorkOrderRequirement) -> str:
+    return _fingerprint({
+        "brief": work_order.brief_fingerprint,
+        "subject": work_order.primary_subject,
+        "scope": work_order.scope.model_dump(mode="json"),
+        "premise": [item.model_dump(mode="json") for item in work_order.premise],
+        "requirement": requirement.model_dump(mode="json", exclude={"search_group"}),
+    })
 
 
 def notes_stage_record(
@@ -671,13 +688,13 @@ def notes_stage_record(
 ) -> dict[str, Any]:
     """The raw gather, kept so a failure downstream is not re-bought.
 
-    Gathering is ten sequential web searches and structuring is one call, so
-    every structuring failure used to cost the searches again. The notes are
-    bound to the work order they answer, because a re-cut plan asks different
-    questions and old notes are not answers to them.
+    Persist after each completed search. Per-question fingerprints include
+    brief, scope, and premise so cuts retain unrelated work while a changed
+    question or changed editorial context cannot reuse stale answers.
     """
     return {
         "work_order_fingerprint": work_order.work_order_fingerprint,
+        "requirement_fingerprints": {item.requirement_id: requirement_fingerprint(work_order, item) for item in work_order.requirements if item.requirement_id in notes},
         "notes": {
             requirement_id: {
                 "text": item.text,
@@ -694,13 +711,20 @@ def notes_from_record(
     work_order: Prompt2BlogWorkOrder,
 ) -> dict[str, GatheredNotes] | None:
     """The kept notes, when they answer this exact plan. Otherwise nothing."""
-    if record.get("work_order_fingerprint") != work_order.work_order_fingerprint:
+    fingerprints = record.get("requirement_fingerprints", {})
+    if not fingerprints and record.get("work_order_fingerprint") != work_order.work_order_fingerprint:
         return None
     stored = record.get("notes")
     if not isinstance(stored, dict) or not stored:
         return None
     notes: dict[str, GatheredNotes] = {}
-    for requirement_id, raw in stored.items():
+    for requirement in work_order.requirements:
+        requirement_id = requirement.requirement_id
+        if requirement_id not in stored:
+            continue
+        if fingerprints and fingerprints.get(requirement_id) != requirement_fingerprint(work_order, requirement):
+            continue
+        raw = stored[requirement_id]
         item = _safe_dict(raw)
         notes[_safe_str(requirement_id)] = GatheredNotes(
             text=_safe_str(item.get("text")),
@@ -867,6 +891,9 @@ STRUCTURE_RULES = """Rules:
   choose on. Leave `resolution` empty when the notes do not settle it: an
   unresolved conflict is a question for a person, and inventing a resolution
   takes it away from them.
+- Keep records concise: source metadata once per URL, short source IDs, and
+  one claim per distinct fact. Do not copy the research narrative into records.
+  A source's notes should contain only a caveat needed to interpret it.
 - Keep the interesting detail. A note that puts a reader somewhere belongs in a
   claim as much as a price does; do not drop it for not being a number."""
 
@@ -935,21 +962,49 @@ def gather_one_requirement(
     )
 
 
+def gather_requirement_group(
+    brief: ArticleBrief, requirements: list[WorkOrderRequirement], dependencies: ResearchDependencies,
+) -> dict[str, GatheredNotes]:
+    if len(requirements) == 1:
+        item = requirements[0]
+        return {item.requirement_id: gather_one_requirement(brief, item, dependencies)}
+    prompt = (
+        "Research these related questions together using shared sources. "
+        "Keep each question's precision and scope. Return concise cited facts under "
+        "each question ID; explicitly say when a question could not be answered. "
+        "Do not repeat the same background or source description.\n\n"
+        + "\n\n".join(f"QUESTION {item.requirement_id}\n{build_gather_prompt(brief, item)}" for item in requirements)
+    )
+    try:
+        text, urls, tokens = dependencies.gather(prompt, None)
+    except Exception as exc:
+        logger.warning("Grouped research failed: %s", exc)
+        text, urls, tokens = "", [], None
+    # All questions retain the original cited response; attribution happens in
+    # structuring. Only one note carries call tokens so totals do not multiply.
+    return {item.requirement_id: GatheredNotes(_safe_str(text), list(urls or []), tokens if index == 0 else None)
+            for index, item in enumerate(requirements)}
+
+
 def gather_research(
     brief: ArticleBrief,
     work_order: Prompt2BlogWorkOrder,
     dependencies: ResearchDependencies,
     on_progress: Callable[[dict[str, Any]], None] | None = None,
+    *,
+    kept_notes: dict[str, GatheredNotes] | None = None,
+    checkpoint: Callable[[dict[str, GatheredNotes]], None] | None = None,
+    before_call: Callable[[], None] | None = None,
 ) -> dict[str, GatheredNotes]:
-    """One grounded pass per question, texture included, all at once.
+    """Bounded concurrent searches, sharing retrieval for related questions.
 
     Texture is researched to the identical standard: a scene we cannot source
     is still cut, so it has to be sourced like anything else.
 
-    The searches run concurrently because they are independent -- nothing in
-    question four depends on question three -- and sequentially they were about
-    six minutes of run 76b36468's twenty-and-a-half minute research pass. Same
-    prompts, same model, same results; only the waiting changes.
+    The work order may group related questions; each request holds at most
+    four, while coverage still judges every question separately. Complete
+    results are checkpointed before another request is dispatched. An error
+    stops new submissions but lets in-flight work finish and be saved.
 
     Bounded at `P2B_V4_GATHER_CONCURRENCY`, because grounded-search rate limits
     are unknown and the number of questions is set by the work order rather
@@ -978,26 +1033,46 @@ def gather_research(
         except Exception as exc:  # pragma: no cover -- telemetry only
             logger.warning("Research progress write failed: %s", exc)
 
-    gathered: dict[str, GatheredNotes] = {}
-    if requirements:
-        # Only once there is something to wait for. A work order with no
-        # questions cannot reach here through the contract, and an empty
-        # "0 of 0" on the screen would be worse than silence if it did.
-        _emit("gathering", 0, "")
-        workers = max(1, min(P2B_V4_GATHER_CONCURRENCY, total))
+    gathered = {key: note for key, note in (kept_notes or {}).items() if note.text.strip()}
+    missing = [item for item in requirements if item.requirement_id not in gathered]
+    grouped: dict[str, list[WorkOrderRequirement]] = {}
+    for item in missing:
+        grouped.setdefault(item.search_group or f"single:{item.requirement_id}", []).append(item)
+    groups = [items[start:start + STRUCTURE_BATCH_SIZE] for items in grouped.values()
+              for start in range(0, len(items), STRUCTURE_BATCH_SIZE)]
+    if missing:
+        _emit("gathering", len(gathered), "")
+        workers = max(1, min(P2B_V4_GATHER_CONCURRENCY, len(groups)))
+        remaining = iter(groups)
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            pending = {
-                pool.submit(
-                    gather_one_requirement, brief, requirement, dependencies
-                ): requirement
-                for requirement in requirements
-            }
-            # Consumed on this thread, so `on_progress` -- which writes a stage
-            # row -- is never called from a worker and needs no lock.
-            for done, future in enumerate(as_completed(pending), start=1):
-                requirement = pending[future]
-                gathered[requirement.requirement_id] = future.result()
-                _emit("gathering", done, requirement.question)
+            pending = {}
+            stopped: Exception | None = None
+            while True:
+                while stopped is None and len(pending) < workers:
+                    requirement = next(remaining, None)
+                    if requirement is None:
+                        break
+                    try:
+                        if before_call:
+                            before_call()
+                    except Exception as error:
+                        stopped = error
+                        break
+                    pending[pool.submit(gather_requirement_group, brief, requirement, dependencies)] = requirement
+                if not pending:
+                    break
+                completed, _ = wait(pending, return_when=FIRST_COMPLETED)
+                for future in completed:
+                    requirement = pending.pop(future)
+                    try:
+                        gathered.update(future.result())
+                        if checkpoint:
+                            checkpoint(dict(gathered))
+                    except Exception as error:
+                        stopped = error
+                    _emit("gathering", len(gathered), requirement[-1].question)
+            if stopped is not None:
+                raise stopped
 
     # Rebuilt in work-order order rather than completion order, so the notes,
     # the structure prompt built from them and anything diffing two runs do not
@@ -1008,8 +1083,7 @@ def gather_research(
         if requirement.requirement_id in gathered
     }
 
-    # Structuring is one call and the longest single wait in the run, so it gets
-    # its own phase rather than looking like a stall after the last search.
+    # Structuring has its own progress phase after the last search.
     _emit("structuring", total, "")
     return notes
 
@@ -1083,6 +1157,43 @@ PREMISE_SCHEMA = require_non_empty({
 })
 
 
+def _batch_source_table(
+    requirements: list[WorkOrderRequirement], notes: dict[str, GatheredNotes],
+) -> dict[str, str]:
+    """Keep opaque grounding redirect URLs out of generated JSON (#499).
+
+    The model copies short handles; the application restores exact URLs.
+    Includes URLs embedded in prose as well as the grounding metadata.
+    """
+    urls: set[str] = set()
+    for item in requirements:
+        if item.requirement_id not in notes:
+            continue
+        note = notes[item.requirement_id]
+        urls.update(_citable(note.source_urls))
+        urls.update(match.rstrip(".,;:") for match in re.findall(r'https?://[^\s<>"\]\)\}]+', note.text))
+    return {f"URL{index}": url for index, url in enumerate(sorted(urls), start=1)}
+
+
+def _compact_batch_notes(
+    requirements: list[WorkOrderRequirement], notes: dict[str, GatheredNotes],
+) -> dict[str, GatheredNotes]:
+    table = _batch_source_table(requirements, notes)
+    replacements = sorted(table.items(), key=lambda pair: len(pair[1]), reverse=True)
+    compact = {}
+    for item in requirements:
+        if item.requirement_id not in notes:
+            continue
+        note = notes[item.requirement_id]
+        text = note.text
+        for handle, url in replacements:
+            text = text.replace(url, handle)
+        compact[item.requirement_id] = GatheredNotes(
+            text, [handle for handle, url in table.items() if url in note.source_urls], note.tokens,
+        )
+    return compact
+
+
 def build_batch_prompt(
     work_order: Prompt2BlogWorkOrder,
     requirements: list[WorkOrderRequirement],
@@ -1100,17 +1211,25 @@ def build_batch_prompt(
     A handful of questions at a time is small enough to come back first time,
     and a failure costs a third of the plan instead of the whole run.
     """
+    notes = _compact_batch_notes(requirements, notes)
     listed = "\n".join(
         f"- {item.requirement_id} [{item.kind}] [needs: {item.precision}] "
         f"{item.question}"
         for item in requirements
     )
+    shared_notes: dict[str, tuple[list[str], GatheredNotes]] = {}
+    for item in requirements:
+        if item.requirement_id not in notes:
+            continue
+        note = notes[item.requirement_id]
+        key = _fingerprint({"text": note.text, "urls": note.source_urls})
+        if key not in shared_notes:
+            shared_notes[key] = ([], note)
+        shared_notes[key][0].append(item.requirement_id)
     gathered = "\n\n".join(
-        f"=== {item.requirement_id} ===\n{notes[item.requirement_id].text}\n"
-        f"Sources seen: "
-        f"{', '.join(_citable(notes[item.requirement_id].source_urls)) or 'none recorded'}"
-        for item in requirements
-        if item.requirement_id in notes
+        f"=== {', '.join(question_ids)} ===\n{note.text}\n"
+        f"Sources seen: {', '.join(_citable(note.source_urls)) or 'none recorded'}"
+        for question_ids, note in shared_notes.values()
     )
     ids = ", ".join(item.requirement_id for item in requirements)
     return f"""Turn these questions' research notes into evidence records. Add nothing that is not in the notes.
@@ -1120,6 +1239,10 @@ THE QUESTIONS
 
 THE NOTES
 {gathered}
+
+URL1, URL2, etc. are exact source references. Copy the relevant handle into
+source.url. The application restores the original URL. Never expand a handle
+or invent a URL. Use short source_id values; the URL handle is not a claim.
 
 {STRUCTURE_RULES}
 - One claim per distinct fact. Do not split a fact across several claims, and
@@ -1278,9 +1401,35 @@ def _structure_batch(
             max_tokens=ONE_QUESTION_MAX_TOKENS,
             temperature=0.0,
         )
+        parsed = copy.deepcopy(_safe_dict(parsed))
+        source_table = _batch_source_table(requirements, notes)
+        unresolved: list[str] = []
+        for source in _rows(parsed, "sources"):
+            given = source.get("url")
+            resolved = source_table.get(given, given)
+            # A handle it never saw, or a bare host it typed from memory. Both
+            # mean this source was not retrieved, and "not a valid URL" from the
+            # model further down does not say which value caused it.
+            if isinstance(resolved, str) and resolved and not resolved.startswith(
+                ("http://", "https://")
+            ):
+                unresolved.append(resolved)
+            source["url"] = resolved
+        if unresolved:
+            raise ResearchUnusable(
+                "Structuring returned source URLs that are not links: "
+                + ", ".join(sorted(set(unresolved))[:5]),
+                _raw,
+            )
+        part = _namespaced(parsed, ids[0])
+        package = assemble_evidence(work_order, part)
+        if {item.requirement_id for item in package.requirements} != set(ids):
+            raise ResearchUnusable("Structuring did not return exactly the requested questions", _raw)
+        return package.model_dump(mode="json")
     except Exception as exc:  # noqa: BLE001 -- one hole beats the whole plan
         logger.warning("Structuring failed for %s: %s", ", ".join(ids), exc)
         return {
+            "_retryable": True,
             "sources": [],
             "claims": [],
             "requirements": [
@@ -1299,7 +1448,6 @@ def _structure_batch(
             ],
             "gaps": [],
         }
-    return _namespaced(_safe_dict(parsed), ids[0])
 
 
 def _settle_premise(
@@ -1327,7 +1475,7 @@ def _settle_premise(
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("Premise pass failed: %s", exc)
-        return {"premise_findings": [], "conflicts": []}
+        return {"premise_findings": [], "conflicts": [], "_retryable": True}
     payload = _safe_dict(parsed)
     return {
         "premise_findings": _rows(
@@ -1341,6 +1489,10 @@ def structure_research(
     work_order: Prompt2BlogWorkOrder,
     notes: dict[str, GatheredNotes],
     dependencies: ResearchDependencies,
+    *,
+    kept_batches: dict[str, Any] | None = None,
+    checkpoint: Callable[[dict[str, Any]], None] | None = None,
+    before_call: Callable[[], None] | None = None,
 ) -> EvidencePackage:
     """Turn the notes into the evidence package the writing stages read.
 
@@ -1366,9 +1518,25 @@ def structure_research(
         requirements[start : start + STRUCTURE_BATCH_SIZE]
         for start in range(0, len(requirements), STRUCTURE_BATCH_SIZE)
     ]
-    parts = [
-        _structure_batch(work_order, batch, notes, dependencies) for batch in batches
-    ]
+    cache = copy.deepcopy(kept_batches or {})
+    parts = []
+    batch_keys: list[str] = []
+    for batch in batches:
+        prompt = build_batch_prompt(work_order, batch, notes)
+        key = _fingerprint({"prompt": prompt, "sources": _batch_source_table(batch, notes), "schema": BATCH_SCHEMA, "version": 2})
+        batch_keys.append(key)
+        if key not in cache:
+            if before_call:
+                before_call()
+            part = _structure_batch(work_order, batch, notes, dependencies)
+            if not part.get("_retryable"):
+                cache[key] = part
+            # Persist usage even when this paid response was unusable.
+            if checkpoint:
+                checkpoint(copy.deepcopy(cache))
+        else:
+            part = cache[key]
+        parts.append(copy.deepcopy(part))
 
     sources, remap = _merge_sources(parts)
     claims = [claim for part in parts for claim in part["claims"]]
@@ -1376,7 +1544,23 @@ def structure_research(
         claim["source_ids"] = sorted(
             {remap.get(item, item) for item in _id_list(claim, "source_ids")}
         )
-    settled = _settle_premise(work_order, claims, dependencies)
+    premise_key = _fingerprint({"prompt": build_premise_prompt(work_order, claims), "schema": PREMISE_SCHEMA, "version": 1})
+    if premise_key in cache:
+        settled = cache[premise_key]
+    else:
+        if before_call:
+            before_call()
+        settled = _settle_premise(work_order, claims, dependencies)
+        if not settled.get("_retryable"):
+            cache[premise_key] = settled
+
+    # A cut question, an edited one or a re-gathered note all change the key
+    # its batch answers under, and nothing will ever hit the old entry again.
+    # Dropping them here is what stops the saved cache growing with every cut.
+    live = set(batch_keys) | {premise_key}
+    cache = {key: value for key, value in cache.items() if key in live}
+    if checkpoint:
+        checkpoint(copy.deepcopy(cache))
 
     return assemble_evidence(
         work_order,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/run_recorder.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/run_recorder.py
@@ -130,6 +130,8 @@ class RunRecorder:
             logger.warning("Prompt2Blog usage ledger write failed: %s", exc)
 
     def start_stage(self, run_id: str, stage: str) -> None:
+        if self.usage_tracker is not None:
+            self.usage_tracker.run_id = run_id
         self.active_stages[run_id] = stage
         self._open_attempt(run_id, stage)
         self.status_writer(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -96,6 +96,7 @@ WORK_ORDER_SCHEMA = require_non_empty({
                 "properties": {
                     "requirement_id": {"type": "string"},
                     "question": {"type": "string"},
+                    "search_group": {"type": "string"},
                     "kind": {"type": "string"},
                     "precision": {
                         "type": "string",
@@ -157,6 +158,13 @@ It fails if: {brief.fails_if}
 Write the questions that have to be answered before this can be written.
 
 Rules:
+- Assign the same short `search_group` to related questions that can be
+  researched from the same sources: one bus route's stations, fare and duration;
+  one museum's hours and admission; one restaurant shortlist's prices and hours.
+  These share retrieval, but remain separate questions and coverage decisions.
+  Do not group unrelated places or subjects. Leave it empty for a standalone question.
+- Research only facts the brief needs. Do not expand a two-day guide into an
+  exhaustive directory of alternatives. Prefer a focused shortlist.
 - Each question must be separately checkable by someone with a search engine.
   "Is Lima good value?" is not a question; "What does a one-bedroom in
   Miraflores rent for, and as of when?" is.
@@ -362,6 +370,7 @@ def _requirements_from(
                 question=question,
                 kind=kind,
                 precision=precision,
+                search_group=_safe_str(record.get("search_group")),
                 # A reference to an assumption nobody declared is dropped
                 # rather than fatal: the question is still worth asking, and
                 # the contract refuses a dangling id.

--- a/apps/ai-blog-writer/apps/backend/app/shared/model_calls.py
+++ b/apps/ai-blog-writer/apps/backend/app/shared/model_calls.py
@@ -165,6 +165,7 @@ def grounded_text(
     fallback_model: Optional[str] = None,
     model: Optional[str] = None,
     endpoint: str = "grounded",
+    correlation_id: str | None = None,
 ) -> Any:
     """A Google Search grounded call, reported under its job.
 
@@ -191,6 +192,7 @@ def grounded_text(
         model=resolved,
         endpoint=endpoint,
         grounded=True,
+        correlation_id=correlation_id,
     ) as observed:
         result = invoke_google_grounded_text(prompt, **kwargs)
         if result is not None:
@@ -202,6 +204,8 @@ def grounded_text(
                     "input_tokens": getattr(result, "input_tokens", 0) or 0,
                     "output_tokens": getattr(result, "output_tokens", 0) or 0,
                     "total_tokens": getattr(result, "total_tokens", 0) or 0,
+                    "output_token_details": {"reasoning": getattr(result, "reasoning_tokens", 0) or 0},
+                    "cached_input_tokens": getattr(result, "cached_input_tokens", 0) or 0,
                 }
             )
         else:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_v4.py
@@ -349,9 +349,8 @@ def test_the_gathered_notes_are_kept_so_a_retry_does_not_re_buy_them(isolated_db
     assert len(calls) == first, "the second pass reused the kept notes"
 
 
-def test_recutting_the_plan_throws_the_kept_notes_away(isolated_db):
-    """A re-cut plan asks different questions, and old notes are not answers
-    to them."""
+def test_recutting_the_plan_keeps_unchanged_notes(isolated_db):
+    """Removing a question does not change the answers to the others."""
     calls: list[str] = []
     services = _with_research(
         _services([{"done": False, "question": _question()}, AGREED, BRIEF_PAYLOAD, WORK_ORDER_PAYLOAD])
@@ -365,7 +364,7 @@ def test_recutting_the_plan_throws_the_kept_notes_away(isolated_db):
     apply_cut(run_id, services, struck_ids=["r3"])
     do_research(run_id, services)
 
-    assert len(calls) > 3, "the cut plan was researched again"
+    assert len(calls) == 3, "unchanged questions must not buy another search"
 
 
 def test_research_runs_and_says_whether_the_piece_can_be_written(isolated_db):

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
@@ -1,0 +1,207 @@
+"""Paid-work reuse and the Gemini schema boundary (#499). No network calls."""
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from app.features.prompt2blog import research_v4 as research
+from app.features.prompt2blog.contracts_v4 import WorkOrderRequirement
+from app.features.prompt2blog import llm as model_calls
+from utils.llm_client import VertexTextLLM
+from test_prompt2blog_research import _brief, _work_order, _evidence_payload, RecordingGather, StructureLLM
+
+
+def test_gemini_receives_schema_and_preserves_usage_when_shape_is_invalid():
+    requests = []
+    usage = {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12}
+
+    class Provider:
+        def generate(self, prompts, **kwargs):
+            requests.append(kwargs)
+            return SimpleNamespace(generations=[[SimpleNamespace(
+                text='{}', generation_info={"usage_metadata": usage})]])
+
+    adapter = VertexTextLLM(Provider(), "gemini-2.5-flash")
+    schema = {"type": "object", "properties": {"requirements": {"type": "array", "items": {"type": "string"}}}, "required": ["requirements"]}
+    with pytest.raises(ValueError, match="missing required"):
+        adapter.invoke_json("notes", input_schema=schema, thinking_budget=0)
+    assert requests[0]["response_schema"] == schema
+    assert requests[0]["response_mime_type"] == "application/json"
+    assert requests[0]["thinking_budget"] == 0
+    assert adapter.last_usage_metadata == usage
+
+
+def test_interruption_keeps_finished_search_and_only_buys_missing(monkeypatch):
+    monkeypatch.setattr(research, "P2B_V4_GATHER_CONCURRENCY", 1)
+    gather = RecordingGather()
+    deps = research.ResearchDependencies(gather, StructureLLM(_evidence_payload()))
+    saved = {}
+
+    def checkpoint(notes):
+        saved.update(notes)
+        raise RuntimeError("simulated interruption after durable write")
+
+    with pytest.raises(RuntimeError, match="interruption"):
+        research.gather_research(_brief(), _work_order(), deps, checkpoint=checkpoint)
+    assert len(saved) == len(gather.calls) == 1
+    notes = research.gather_research(_brief(), _work_order(), deps, kept_notes=saved)
+    assert len(notes) == len(gather.calls) == 2
+
+
+def test_question_edit_invalidates_only_its_notes_and_scope_edit_invalidates_all():
+    work = _work_order()
+    notes = {q.requirement_id: research.GatheredNotes("cited notes") for q in work.requirements}
+    stored = research.notes_stage_record(work, notes)
+    edited = work.model_copy(update={"requirements": [work.requirements[0].model_copy(update={"question": "New question"}), work.requirements[1]]})
+    assert set(research.notes_from_record(stored, edited)) == {"r2"}
+    assert research.notes_from_record(stored, work.model_copy(update={"brief_fingerprint": "changed"})) == {}
+
+
+def test_grouped_search_preserves_both_requirements_without_double_counting():
+    work = _work_order()
+    work = work.model_copy(update={"requirements": [q.model_copy(update={"search_group": "related"}) for q in work.requirements]})
+    gather = RecordingGather()
+    notes = research.gather_research(_brief(), work, research.ResearchDependencies(gather, None))
+    assert len(gather.calls) == 1
+    assert set(notes) == {"r1", "r2"}
+    assert sum(note.tokens or 0 for note in notes.values()) == 1200
+    assert all(q.question in gather.calls[0][0] for q in work.requirements)
+
+
+def test_structure_checkpoint_survives_failure_before_premise():
+    work = _work_order()
+    notes = {q.requirement_id: research.GatheredNotes("cited notes") for q in work.requirements}
+    model = StructureLLM(_evidence_payload())
+    deps = research.ResearchDependencies(RecordingGather(), model)
+    saved = {}
+
+    def checkpoint(batches):
+        saved.update(deepcopy(batches))
+        raise RuntimeError("interrupted after batch")
+
+    with pytest.raises(RuntimeError, match="interrupted"):
+        research.structure_research(work, notes, deps, checkpoint=checkpoint)
+    assert len(model.calls) == 1
+    research.structure_research(work, notes, deps, kept_batches=saved)
+    assert len(model.calls) == 2
+
+
+def test_schema_failure_is_metered_once_and_correlated(monkeypatch):
+    records = []
+    observations = []
+    from contextlib import contextmanager
+
+    class Adapter:
+        model_name = "gemini-2.5-flash"
+        last_usage_metadata = {"input_tokens": 5, "output_tokens": 2}
+
+        def invoke_json(self, prompt, **kwargs):
+            assert kwargs["thinking_budget"] == 0
+            raise ValueError("bad object")
+
+    @contextmanager
+    def observed(**kwargs):
+        observations.append(kwargs)
+        yield SimpleNamespace(record_usage=lambda usage: None)
+
+    monkeypatch.setattr(model_calls, "get_vertex_llm", lambda **kwargs: Adapter())
+    monkeypatch.setattr(model_calls, "observe_external_call", observed)
+    with pytest.raises(ValueError, match="bad object"):
+        model_calls._invoke_json_llm(prompt="notes", max_tokens=8192, temperature=0,
+            model_name="gemini-2.5-flash", job_id="p2b.research_structure", schema={"type": "object"},
+            correlation_id="run-499", usage_recorder=lambda model, usage: records.append(usage))
+    assert len(records) == len(observations) == 1
+    assert observations[0]["correlation_id"] == "run-499"
+
+
+def test_overlapping_intake_is_rejected_before_work_starts():
+    from fastapi import HTTPException
+    from app.features.prompt2blog.intake_lock import intake_lock
+    with intake_lock("run-499"):
+        with pytest.raises(HTTPException) as caught:
+            with intake_lock("run-499"):
+                pytest.fail("second request entered")
+        assert caught.value.status_code == 409
+        with intake_lock("different-run"):
+            pass
+    with intake_lock("run-499"):
+        pass
+
+
+def test_opaque_urls_are_copied_as_handles_and_restored_exactly():
+    url = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/" + "aB7_" * 300
+    work = _work_order()
+    notes = {q.requirement_id: research.GatheredNotes(f"Cited fact [{url}]", [url]) for q in work.requirements}
+    payload = _evidence_payload()
+    payload["sources"][0]["url"] = "URL1"
+    model = StructureLLM(payload)
+    result = research._structure_batch(work, work.requirements, notes,
+        research.ResearchDependencies(None, model))
+    assert not result.get("_retryable")
+    assert result["sources"][0]["url"] == url
+    assert url not in model.calls[0]["prompt"]
+    assert "URL1" in model.calls[0]["prompt"]
+    assert model.calls[0]["prompt"].count("Cited fact") == 1
+
+
+def test_invalid_batch_is_not_cached_but_its_receipt_is_checkpointed():
+    # An empty premise settles without a call while the batch is failing, so
+    # the first run's only call is the batch itself.
+    work = _work_order(
+        premise=[],
+        requirements=[
+            WorkOrderRequirement(
+                requirement_id="r1",
+                question="What do market stalls charge?",
+                kind="load_bearing",
+            ),
+            WorkOrderRequirement(
+                requirement_id="r2",
+                question="What is Huaca Pucllana like after dark?",
+                kind="texture",
+            ),
+        ],
+    )
+    notes = {q.requirement_id: research.GatheredNotes("notes") for q in work.requirements}
+    model = StructureLLM({"requirements": []})
+    snapshots = []
+    research.structure_research(work, notes, research.ResearchDependencies(None, model),
+        checkpoint=lambda cache: snapshots.append(deepcopy(cache)))
+    assert snapshots[0] == {}
+    model.payload = _evidence_payload()
+    research.structure_research(work, notes, research.ResearchDependencies(None, model),
+        kept_batches=snapshots[-1])
+    # The unusable batch, bought again, then the premise pass -- which the
+    # first run skipped, because an empty premise with no claims settles itself.
+    assert len(model.calls) == 3
+
+
+def test_cache_drops_entries_no_future_call_can_hit():
+    work = _work_order()
+    notes = {q.requirement_id: research.GatheredNotes("cited notes") for q in work.requirements}
+    model = StructureLLM(_evidence_payload())
+    snapshots = []
+    research.structure_research(work, notes, research.ResearchDependencies(None, model),
+        kept_batches={"stale-key-from-a-cut-question": {"claims": []}},
+        checkpoint=lambda cache: snapshots.append(deepcopy(cache)))
+    assert "stale-key-from-a-cut-question" not in snapshots[-1]
+    # One batch and one premise pass, and nothing carried from the cut plan.
+    assert len(snapshots[-1]) == 2
+
+    # The surviving entries are the ones a rerun of this same plan reuses.
+    model.calls.clear()
+    research.structure_research(work, notes, research.ResearchDependencies(None, model),
+        kept_batches=snapshots[-1])
+    assert model.calls == []
+
+
+def test_a_source_url_that_is_not_a_link_names_itself_in_the_failure(caplog):
+    work = _work_order()
+    notes = {q.requirement_id: research.GatheredNotes("Cited fact", ["https://example.pe/a"])
+             for q in work.requirements}
+    payload = _evidence_payload()
+    payload["sources"][0]["url"] = "www.example.pe"
+    result = research._structure_batch(work, work.requirements, notes,
+        research.ResearchDependencies(None, StructureLLM(payload)))
+    assert result["_retryable"] is True
+    assert "www.example.pe" in caplog.text

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_usage_accounting.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_usage_accounting.py
@@ -270,3 +270,15 @@ def test_recording_is_mutually_exclusive():
     assert ledger["successful_calls"] == 80
     assert len({call["seq"] for call in ledger["calls"]}) == 80
     assert ledger["totals"]["total_tokens"] == 80 * 15
+
+
+def test_grounded_thinking_is_billed_at_output_rate(monkeypatch):
+    result = _Result(input_tokens=100, output_tokens=50, total_tokens=350)
+    result.reasoning_tokens = 200
+    result.cached_input_tokens = 20
+    tracker = _grounded(monkeypatch, result)
+    totals = tracker.totals()
+    assert totals["output_tokens"] == 250
+    assert totals["reasoning_tokens"] == 200
+    assert totals["cached_input_tokens"] == 20
+    assert totals["total_tokens"] == 350

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
@@ -147,6 +147,7 @@ def test_runtime_request_keeps_the_commission_and_evidence_whole():
     for requirement in expected_work_order["requirements"]:
         requirement["assumption_ids"] = []
         requirement["precision"] = "exact"
+        requirement["search_group"] = ""
     assert runtime.work_order == expected_work_order
     assert runtime.brief == fixture["brief"]
     source = runtime.evidence["sources"][0]

--- a/apps/ai-blog-writer/packages/utils/src/utils/gemini_tools.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/gemini_tools.py
@@ -187,3 +187,35 @@ def _invoke_gemini_structured_tool(
     raise RuntimeError(
         f"Gemini structured writer returned no '{tool_name}' tool call (response_metadata={getattr(message, 'response_metadata', None)!r})"
     )
+
+
+def validate_json_shape(value: Any, schema: dict[str, Any], path: str = "response") -> None:
+    """Check the object/array/scalar contract after generation.
+
+    This checks the shape used by our hand-written response schemas, not the
+    entire JSON Schema language. Domain constraints remain Pydantic's job.
+    """
+    if value is None and schema.get("nullable"):
+        return
+    kind = schema.get("type")
+    types = {"object": dict, "array": list, "string": str, "boolean": bool,
+             "integer": int, "number": (int, float), "null": type(None)}
+    if kind in types and (not isinstance(value, types[kind]) or
+                          (kind in ("integer", "number") and isinstance(value, bool))):
+        raise ValueError(f"{path}: expected {kind}")
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValueError(f"{path}: value outside enum")
+    if isinstance(value, dict):
+        missing = set(schema.get("required", [])) - value.keys()
+        if missing:
+            raise ValueError(f"{path}: missing required fields {sorted(missing)}")
+        for key, child in schema.get("properties", {}).items():
+            if key in value:
+                validate_json_shape(value[key], child, f"{path}.{key}")
+    elif isinstance(value, list):
+        if len(value) < schema.get("minItems", 0):
+            raise ValueError(f"{path}: too few items")
+        for index, item in enumerate(value):
+            validate_json_shape(item, schema.get("items", {}), f"{path}[{index}]")
+    elif isinstance(value, str) and len(value) < schema.get("minLength", 0):
+        raise ValueError(f"{path}: too short")

--- a/apps/ai-blog-writer/packages/utils/src/utils/google_grounding.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/google_grounding.py
@@ -43,6 +43,8 @@ class GroundedGenerationResult:
     input_tokens: int | None = None
     output_tokens: int | None = None
     total_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    cached_input_tokens: int | None = None
 
 
 def _usage_counts(response: Any) -> tuple[int | None, int | None, int | None]:
@@ -327,4 +329,6 @@ def invoke_google_grounded_text(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
+        reasoning_tokens=response.get("usageMetadata", {}).get("thoughtsTokenCount"),
+        cached_input_tokens=response.get("usageMetadata", {}).get("cachedContentTokenCount"),
     )

--- a/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
@@ -1,6 +1,7 @@
 """Public provider-agnostic LLM facade."""
 
 import logging
+import json
 from typing import Any, Optional
 
 from langchain_google_vertexai import ChatVertexAI, VertexAI  # noqa: F401
@@ -17,6 +18,7 @@ from .anthropic_transport import (
 )
 from .gemini_tools import (  # noqa: F401
     Gemini3ChatTextLLM as Gemini3ChatTextLLM,
+    validate_json_shape,
     _gemini_chat_text as _gemini_chat_text,
     _gemini_tool_schema as _sanitize_gemini_tool_schema,
     _invoke_gemini_structured_tool as _invoke_gemini_tool,
@@ -262,11 +264,8 @@ class VertexTextLLM:
     in the spellings ``normalize_token_usage`` reads, thinking tokens and
     cached tokens included.
 
-    Deliberately narrow. It exposes ``invoke`` and ``model_name`` because that
-    is the entire surface every caller in this repo uses -- nothing chains
-    this as a Runnable -- and it deliberately does *not* expose ``invoke_json``,
-    so the schema-validated path keeps falling through to asking in prose for
-    providers that cannot enforce a schema.
+    JSON calls send the response schema to Gemini; text calls keep their
+    existing behavior and output ceiling.
     """
 
     def __init__(self, llm: Any, model_name: str) -> None:
@@ -279,6 +278,22 @@ class VertexTextLLM:
         self.last_usage_metadata = _usage_from_generation(result)
         generations = result.generations[0] if result.generations else []
         return str(generations[0].text if generations else '') or ''
+
+    def invoke_json(self, prompt: str, *, input_schema: dict[str, Any],
+                    thinking_budget: int | None = None) -> dict[str, Any]:
+        options: dict[str, Any] = {
+            "response_mime_type": "application/json",
+            "response_schema": _sanitize_gemini_tool_schema(input_schema),
+        }
+        if thinking_budget is not None and self.model_name == "gemini-2.5-flash":
+            options["thinking_budget"] = thinking_budget
+        result = self._llm.generate([prompt], **options)
+        self.last_usage_metadata = _usage_from_generation(result)
+        parsed = json.loads(result.generations[0][0].text)
+        if not isinstance(parsed, dict):
+            raise ValueError("Structured Gemini response must be an object")
+        validate_json_shape(parsed, input_schema)
+        return parsed
 
 
 def _usage_from_generation(result: Any) -> Optional[dict[str, Any]]:


### PR DESCRIPTION
Closes #499 — but not on the terms the issue states.

## What #499 claimed, and what the run actually holds

| | issue | stored run |
|---|---|---|
| research questions | ~17 | **47** |
| structuring calls | 20 | **13** |
| cost | $1.79 | **$1.012** in the run's ledger |
| why it died | search timeouts | **invalid source URLs + empty requirements list** |

The dashboard totals #499 quotes reproduce its numbers, but those events carry no run ids and some are synthetic test events, so neither $1.79 nor $1.012 is verified Google billing. Searches were **not** re-bought on retry — forcing a structuring failure and retrying an unchanged plan bought three searches, then still three. The retry waste is real but smaller than reported, and lived in cutting a plan, not retrying one.

## Three faults, one cause

**1. Gemini never got the schema.** `VertexTextLLM` deliberately withheld `invoke_json`, so structured research calls fell through to asking for JSON in prose — and the fallback *dropped* the schema rather than passing it another way. The run's saved final error is precisely that failure's output. Gemini now receives the schema; shape is validated after generation, because a Gemini tool schema cannot express `minLength` (12 constraints are dropped on every call).

**2. Nothing was kept.** A structuring failure discarded every finished search; cutting one question discarded the notes for all the others. Now searches checkpoint as each lands, batches checkpoint as each validates, and notes are keyed to a fingerprint of the question *plus* its editorial context — a cut keeps unchanged answers, an edited brief cannot reuse answers to a different article. The cache is pruned to the live plan each pass, without which it grew by a full set of batches per cut. Overlapping requests on one run are refused before spending.

**3. Cost was almost all output.** Structuring spent $0.805, of which **$0.424 was hidden thinking** on a job that extracts rather than reasons. Thinking off for structuring; related questions may share one search; opaque grounding-redirect URLs become short handles in the prompt and are restored from the table after — Gemini had been burning a whole response copying one out, returning truncated JSON.

## Measured, not projected

Paid run against the stored Barranco run's own saved notes (no searches bought), same 47 questions:

| | before | after |
|---|---|---|
| structuring cost | $0.805 | **$0.3049** |
| thinking tokens | 169,739 | **0** |
| calls | 13 | 13 |
| outcome | failed | **complete: 396 claims / 412 sources / 0 gaps** |
| coverage | — | 42 supported, 1 partial, 4 missing |

## What is not fixed

- **One batch of four still fails** on a source URL that is not a link (`Q9, Q10a–c` — the 4 "missing" above). Cause not established. Left failing deliberately, but it now names the offending value instead of reporting that something somewhere was not a valid URL. Handles did not cure it, so it is not the redirect-URL problem.
- **`thinking_budget` is keyed to the literal string `gemini-2.5-flash` in two places**, which cuts against the model gateway's "jobs, not models" design. If the dashboard reroutes `p2b.research_structure`, the thinking control silently disappears. Belongs in job config; not done here.
- The prose JSON fallback now appends the schema for **all** providers, Claude CLI included. Intended, but it changes those prompts.
- `@exclusive_run` on `/write` guards the request, not the background task it starts.

## Shipped as one PR, not three

The plan called for three. The three parts are one fault and are mechanically entangled in `research_v4.py` — the URL-handle change alters the cache key the checkpointing introduces. Splitting would mean rewriting working, tested code to manufacture seams. `test_prompt2blog_research_efficiency.py` is the map: one test per claim above.

Backend suite: 1379 passed, 0 failed.
