### PR TITLE
fix(p2b): the first real v4 run could not reach the writing graph

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -71,6 +71,14 @@ GRILL_RESEARCH_MAX_TOKENS = 4_096
 # real run: `{"done": false}` with nothing else is schema-valid and useless,
 # and the model took that gap. A schema that permits what the code refuses is
 # a schema that has not been written down properly.
+#
+# The reverse is a fault too, and this schema had it. `require_non_empty`
+# floors every required string at one character, so the same schema that
+# tells the model to leave `consensus` empty while asking also declared an
+# empty `consensus` invalid. Nothing enforced it until Gemini started being
+# sent the schema, and then the first turn of the first real run died on
+# `response.consensus: too short`. The state-dependent fields carry an
+# explicit `minLength: 0` below.
 # Flat on purpose.
 #
 # This was nested -- `question` as an object carrying `ask`, `recommendation`
@@ -85,14 +93,25 @@ NEXT_TURN_SCHEMA = require_non_empty({
     "type": "object",
     "properties": {
         "done": {"type": "boolean"},
-        "ask": {"type": "string"},
-        "recommendation": {"type": "string"},
+        # Required so the model always accounts for them, but explicitly
+        # allowed to be empty: which of these carries content depends on the
+        # turn, and `require_non_empty` would otherwise floor every one of
+        # them at a character. Asking fills `ask`; finishing fills
+        # `consensus`; neither is wrong to leave blank in the other state.
+        # "Exactly one of these is filled" is not a thing a JSON schema can
+        # say, so `_advance_once` is what refuses a turn that answers with
+        # nothing -- see the guard that raises on neither question nor
+        # consensus.
+        "ask": {"type": "string", "minLength": 0},
+        "recommendation": {"type": "string", "minLength": 0},
         "pushback": {"type": "string"},
         "topic": {"type": "string"},
-        "consensus": {"type": "string"},
+        "consensus": {"type": "string", "minLength": 0},
         "location": {"type": "string"},
         "markers_covered": {"type": "array", "items": {"type": "string"}},
-        "asks_about": {"type": "string"},
+        # Empty is the honest answer when the operator's line is genuinely
+        # ambiguous about what it asks about.
+        "asks_about": {"type": "string", "minLength": 0},
         "options": {
             "type": "array",
             "items": {

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -86,7 +86,7 @@ def _audit_v3_rewrite(
         rewritten_content=rewrite["improved_content"],
     )
     parsed, raw_response = dependencies.llm.invoke_json(
-            job_id="p2b.audit",
+        job_id="p2b.audit",
         prompt=prompt,
         max_tokens=1536,
         temperature=0.05,
@@ -261,7 +261,7 @@ def run_v3_repair_stage(
     # cheaper place to spend it, because it only runs on a draft that failed.
     repair_model = state.get("repair_model") or state["writing_model"]
     parsed, raw_response = dependencies.llm.invoke_json(
-            job_id="p2b.repair",
+        job_id="p2b.repair",
         prompt=prompt,
         max_tokens=6144,
         temperature=0.1,
@@ -286,6 +286,7 @@ def run_v3_repair_stage(
     # rewrite of it, not a separate judgement.
     repaired["improved_content"] = dependencies.llm.enforce_anti_ai(
         repaired["improved_content"],
+        job_id="p2b.repair",
         model_name=repair_model,
         max_tokens=6144,
         context="prompt2blog v3 repair",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
@@ -58,7 +58,7 @@ def run_v3_compose_stage(
     )
 
     parsed, raw_response = dependencies.llm.invoke_json(
-            job_id="p2b.compose",
+        job_id="p2b.compose",
         prompt=prompt,
         max_tokens=6144,
         temperature=state["compose_temperature"],
@@ -75,6 +75,7 @@ def run_v3_compose_stage(
     )
     rewrite["improved_content"] = dependencies.llm.enforce_anti_ai(
         rewrite["improved_content"],
+        job_id="p2b.compose",
         model_name=state["writing_model"],
         max_tokens=6144,
         context="prompt2blog v3 compose",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
@@ -42,7 +42,7 @@ def check_v3_groundedness(
     )
     try:
         parsed, raw_response = dependencies.llm.invoke_json(
-            job_id="p2b.groundedness",
+        job_id="p2b.groundedness",
             prompt=prompt,
             max_tokens=2048,
             temperature=0.0,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -68,7 +68,7 @@ def run_v3_outline_stage(
 
     try:
         parsed, raw_response = dependencies.llm.invoke_json(
-            job_id="p2b.outline",
+        job_id="p2b.outline",
             prompt=prompt,
             max_tokens=2048,
             temperature=0.1,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_build.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_build.py
@@ -230,11 +230,21 @@ def test_required_strings_cannot_be_empty_in_the_schema():
 def test_every_v4_schema_got_the_same_guard():
     # It was wrong in the same way in four places, so it is fixed as a shape
     # rather than as four instances.
+    #
+    # `consensus` used to be asserted here too, and that was the wrong field to
+    # generalise to. A brief's `primary_reader` is empty only when the model
+    # failed; the grill's `consensus` is empty on every turn it is still
+    # asking, because the prompt tells it to leave it so. The floor was
+    # harmless while nothing checked it and fatal the moment Gemini started
+    # being sent the schema -- the first real v4 run died on turn one with
+    # `response.consensus: too short`. The state-dependent fields are asserted
+    # in test_prompt2blog_schema_enforcement.py, which pins them open.
     from app.features.prompt2blog.grill_v4 import NEXT_TURN_SCHEMA
     from app.features.prompt2blog.research_v4 import EVIDENCE_SCHEMA
     from app.features.prompt2blog.work_order_v4 import WORK_ORDER_SCHEMA
 
-    assert NEXT_TURN_SCHEMA["properties"]["consensus"]["minLength"] == 1
+    options = NEXT_TURN_SCHEMA["properties"]["options"]["items"]
+    assert options["properties"]["text"]["minLength"] == 1
     assert WORK_ORDER_SCHEMA["properties"]["primary_subject"]["minLength"] == 1
     assert (
         EVIDENCE_SCHEMA["properties"]["sources"]["items"]["properties"]["title"][

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -1,0 +1,84 @@
+"""A required field the prompt tells the model to leave empty must stay empty-able.
+
+Gemini receives these schemas now, and the shape is checked after generation,
+so a floor the prompt contradicts is a run that dies on turn one rather than a
+comment nobody reads.
+"""
+import pytest
+
+from app.features.prompt2blog.grill_v4 import NEXT_TURN_SCHEMA
+from app.features.prompt2blog.research_v4 import BATCH_SCHEMA
+from utils.gemini_tools import validate_json_shape
+
+# The turn the grill actually sends while it is still asking: a question, and
+# every other slot accounted for but empty.
+ASKING_TURN = {
+    "done": False,
+    "ask": "Which stretch of the malecon do you mean?",
+    "recommendation": "Miraflores to Barranco, the continuous six miles.",
+    "consensus": "",
+    "markers_covered": [],
+    "asks_about": "",
+}
+
+
+def test_the_grill_can_answer_while_it_is_still_asking():
+    validate_json_shape(ASKING_TURN, NEXT_TURN_SCHEMA)
+
+
+def test_the_grill_can_answer_when_it_is_finished():
+    validate_json_shape(
+        {**ASKING_TURN, "done": True, "ask": "", "recommendation": "",
+         "consensus": "Six miles of clifftop park, free, Miraflores to Barranco."},
+        NEXT_TURN_SCHEMA,
+    )
+
+
+@pytest.mark.parametrize("field", ["done", "ask", "recommendation", "consensus",
+                                   "markers_covered", "asks_about"])
+def test_a_missing_field_is_still_refused(field):
+    with pytest.raises(ValueError, match="missing required"):
+        validate_json_shape({k: v for k, v in ASKING_TURN.items() if k != field},
+                            NEXT_TURN_SCHEMA)
+
+
+def test_research_keeps_its_floors_because_nothing_asks_it_for_a_blank():
+    with pytest.raises(ValueError, match="too short"):
+        validate_json_shape(
+            {"sources": [{"source_id": "", "title": "t", "retrieved_at": "2026-01-01",
+                          "source_type": "web", "material_type": "reporting",
+                          "url": "https://a.pe", "notes": ""}],
+             "claims": [], "requirements": [], "gaps": []},
+            BATCH_SCHEMA,
+        )
+
+
+# --- every model call in the writing graph names a job ---------------------
+#
+# The gateway migration was applied by matching `invoke_json(`, so the two
+# `enforce_anti_ai` calls were never given a job. `_resolved_model` refuses a
+# call that names neither a job nor a model, and `writing_model` is None
+# whenever the request does not pick one -- which is the ordinary case. The
+# first real v4 run since the gateway merge died in compose because of it, and
+# no test noticed, because nothing asserted the call sites were migrated.
+
+import re
+from pathlib import Path
+
+import pytest
+
+V3_STAGES = Path(__file__).resolve().parents[1] / "app/features/prompt2blog/stages/v3"
+
+
+@pytest.mark.parametrize("path", sorted(V3_STAGES.glob("*.py")), ids=lambda p: p.name)
+def test_every_model_call_in_the_writing_graph_names_a_job(path):
+    source = path.read_text()
+    for call in re.finditer(
+        r"dependencies\.llm\.(invoke_json|invoke_text|enforce_anti_ai)\((.*?)\n    \)",
+        source,
+        re.S,
+    ):
+        assert "job_id=" in call.group(2), (
+            f"{path.name}: {call.group(1)} names no job, so the dashboard cannot "
+            "route it and it fails outright when no model is picked"
+        )


### PR DESCRIPTION
Found by driving one real Prompt2Blog v4 run end to end (`95a74dce`). Two faults stopped it before a single word was written. **Neither could have been caught by the suite, because nothing in it makes a real model call.**

## 1. The grill died on turn one

```
ValueError: response.consensus: too short
```

`NEXT_TURN_SCHEMA` marks `ask` and `consensus` required, and `require_non_empty` floors every required string at one character. The prompt sitting beside it says the opposite:

> When you are still asking, fill `ask` … and leave `consensus` empty. When you are done, fill `consensus` and leave the others empty.

The schema has contradicted itself since it was written. It never mattered, because `VertexTextLLM` withheld `invoke_json` and the schema was never sent or enforced. #500 changed that, and a latent contradiction became a run that cannot start.

`ask`, `recommendation`, `consensus` and `asks_about` now carry an explicit `minLength: 0`. "Exactly one of these is filled" is not expressible in JSON Schema — `_advance_once` already refuses a turn that answers with neither, which is the right place for a state rule.

**One existing test asserted the bug** and had to change:

```python
assert NEXT_TURN_SCHEMA["properties"]["consensus"]["minLength"] == 1
```

That generalised from a real fault — a brief returning `primary_reader: ""` — to a field where empty is correct. A brief's `primary_reader` is blank only when the model failed; an empty `consensus` is what *asking looks like*. The assertion moves to `options[].text`, which genuinely cannot be blank.

## 2. Compose died — and this one predates #500

```
ValueError: A model call must name either a job or a model.
During task with name 'compose'
```

The model gateway migration (`3bdaef2f`) was applied by matching `invoke_json(`. That found **five** call sites in the writing graph. There are **seven**. The two it missed are `enforce_anti_ai` — the anti-AI-tells rewrite that runs after compose and again after repair, on every article.

They pass `model_name=state["writing_model"]` and nothing else. That resolves to `None` whenever the request names no model, which is the ordinary case. So **article writing has been broken on `main` since the gateway merge**, for every run, silently.

The find-and-replace left its own fingerprint on all five sites it did hit:

```python
    parsed, raw_response = dependencies.llm.invoke_json(
            job_id="p2b.compose",     # 12 spaces, not 8
        prompt=prompt,
```

Both `enforce_anti_ai` calls now name their job (`p2b.compose`, `p2b.repair`), and the five inserts are re-indented.

## Guard

`test_prompt2blog_schema_enforcement.py` adds:

- the grill can answer while asking **and** when finished, and a *missing* field is still refused
- research keeps its floors, because nothing asks it for a blank
- every `dependencies.llm.*` call in the writing graph names a job

The last one is verified to match all seven real call sites rather than passing on an empty regex match — the failure mode that would make it worthless.

## After this

The run reached the end: 858 words, `needs_revision`, $0.3833 for the whole thing including the grill, brief, work order, 16-question research and the writing graph. Backend suite 1394 passed, 0 failed.
