### PR TITLE
style(p2b): put job_id back at its siblings' indent

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
@@ -42,7 +42,7 @@ def check_v3_groundedness(
     )
     try:
         parsed, raw_response = dependencies.llm.invoke_json(
-        job_id="p2b.groundedness",
+            job_id="p2b.groundedness",
             prompt=prompt,
             max_tokens=2048,
             temperature=0.0,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -68,7 +68,7 @@ def run_v3_outline_stage(
 
     try:
         parsed, raw_response = dependencies.llm.invoke_json(
-        job_id="p2b.outline",
+            job_id="p2b.outline",
             prompt=prompt,
             max_tokens=2048,
             temperature=0.1,


### PR DESCRIPTION
Follow-up to #502. That PR re-indented the gateway migration's scripted inserts, but the sweep assumed every call site sat at the same depth. `outline.py` and `groundedness.py` call `invoke_json` inside a `try:`, so their arguments are one level deeper — and the sweep moved `job_id` *out* of line rather than into it.

Cosmetic only; Python never minded, and the calls were correct either way. Correcting it because #502 claimed the opposite.