### PR TITLE
fix(p2b): compose is told how long the article is, and two receipts stop lying

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -1004,6 +1004,10 @@ def punch_list(run_id: str, services: IntakeServices) -> dict[str, Any]:
         return {"run_id": run_id, **{k: v for k, v in stored.items() if k != STATE_KEY}}
 
     article = finished_article(run_id)
+    # Open before the call, like every other stage: usage is filed against
+    # whichever stage is open when the model answers, and this one used to
+    # bill to `unattributed` while its own row claimed it cost nothing.
+    _open(services, run_id, PUNCH_LIST_STAGE)
     result = build_punch_list(
         brief=load_brief(run_id),
         title=article["title"],

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -98,6 +98,11 @@ Hard rules:
   hold each section to roughly its word budget. Depart from it only where the
   evidence makes a planned section unsupportable. Record that departure in
   remaining_gaps; never narrate missing research to the reader.
+- Write to the TARGET WORD COUNT below. The section budgets are how that total
+  is spent, not a smaller target: half the count is unfinished, not short.
+
+TARGET WORD COUNT:
+{target_word_count}
 
 SECTION PLAN:
 {outline}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -347,12 +347,20 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
 
     claims: list[dict[str, Any]] = []
     seen_claims: set[str] = set()
+    # What each claim asked for, kept aside because both lists below are
+    # filtered here and `requirement_ids` is rewritten again by the union.
+    # Without this a dropped claim can only be counted, never explained.
+    cited: dict[str, tuple[list[str], list[str]]] = {}
     for row in _rows(payload, "claims"):
         claim_id = _safe_str(_first(row, "claim_id", "id"))
         text = _safe_str(_first(row, "text", "statement", "claim"))
         if not claim_id or not text or claim_id in seen_claims:
             continue
         seen_claims.add(claim_id)
+        cited[claim_id] = (
+            _id_list(row, "source_ids", "sources"),
+            _id_list(row, "requirement_ids", "question_ids", "questions"),
+        )
         claims.append(
             {
                 **_only(row, EVIDENCE_CLAIM_FIELDS),
@@ -409,6 +417,23 @@ def _normalised_evidence(payload: dict[str, Any]) -> dict[str, Any]:
         if claim["source_ids"] and claim["requirement_ids"]
     ]
     if len(kept) != len(claims):
+        # Name what was lost. A count alone cannot tell a claim that cited a
+        # source the model never declared from one that answered a question in
+        # another batch, and those want opposite fixes. The dropped claim is
+        # gone from every stored artefact by the time anyone looks.
+        for claim in claims:
+            if claim["source_ids"] and claim["requirement_ids"]:
+                continue
+            claim_sources, claim_requirements = cited.get(claim["claim_id"], ([], []))
+            logger.warning(
+                "Dropped claim %s: cited sources %s, kept %s; "
+                "cited questions %s, kept %s",
+                claim["claim_id"],
+                sorted(claim_sources) or "none",
+                sorted(claim["source_ids"]) or "none",
+                sorted(claim_requirements) or "none",
+                sorted(claim["requirement_ids"]) or "none",
+            )
         logger.warning(
             "Dropped %s claim(s) with no usable source or question",
             len(claims) - len(kept),

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
@@ -12,7 +12,7 @@ from ...prompts.editorial_v3 import P2B_V3_COMPOSE_PROMPT
 from ...prompts.generation import SEO_SAFE_CONTENT_GENERATION_GUIDELINES
 from ...quality import _sanitize_rewrite
 from ...schemas import REWRITE_SCHEMA
-from ...support import _format_style_directive
+from ...support import _format_style_directive, _safe_dict, _target_word_count
 
 
 def run_v3_compose_stage(
@@ -32,6 +32,8 @@ def run_v3_compose_stage(
     style_directive = _format_style_directive(state["option_context"])
     prompt = P2B_V3_COMPOSE_PROMPT.format(
         outline=state["outline_text"],
+        target_word_count=_target_word_count(_safe_dict(state["option_context"]))
+        or "Not specified.",
         instructions=stage_context_text(state["stage_contexts"], "compose"),
         seo_guideline=SEO_SAFE_CONTENT_GENERATION_GUIDELINES,
         style_directive=style_directive,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -18,7 +18,7 @@ from ...instructions_v3 import stage_context_text
 from ...observability import _append_stage_trace
 from ...prompts.editorial_v3 import P2B_V3_OUTLINE_PROMPT
 from ...schemas import V3_OUTLINE_SCHEMA
-from ...support import _safe_dict, _safe_int
+from ...support import _safe_dict, _target_word_count
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +30,6 @@ EMPTY_OUTLINE: dict[str, Any] = {
     "brief_alignment": "Brief alignment not stated.",
     "unsupported_requirements": [],
 }
-
-
-def _target_word_count(state: Prompt2BlogV3GraphState) -> int:
-    length = _safe_dict(_safe_dict(state["option_context"]).get("length"))
-    return _safe_int(length.get("target_word_count"), default=0)
 
 
 def run_v3_outline_stage(
@@ -52,7 +47,7 @@ def run_v3_outline_stage(
     dependencies.recorder.start_stage(run_id, stage)
 
     evidence = state["evidence"]
-    target_word_count = _target_word_count(state)
+    target_word_count = _target_word_count(_safe_dict(state["option_context"]))
     outline = dict(EMPTY_OUTLINE)
     diagnostics: dict[str, Any] = {}
     accepted = False

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
@@ -109,6 +109,17 @@ def _format_hard_constraints(writing_brief: dict[str, Any]) -> str:
     return "\n\n".join(sections)
 
 
+def _target_word_count(option_context: dict[str, Any]) -> int:
+    """The whole-article word target the outline plans to and compose writes to.
+
+    Both stages need the same number from the same place. Compose used to see
+    only the per-section budgets inside the plan, and on run 95a74dce it wrote
+    377 words against a 900 target -- roughly half of every section -- leaving
+    repair to finish the article instead of improve it.
+    """
+    return _safe_int(_safe_dict(option_context.get("length")).get("target_word_count"))
+
+
 def _format_style_directive(option_context: dict[str, Any]) -> str:
     """Render the resolved tone, length, and brand voice guides as a required
     style block. These used to travel inside ``editorial_instructions``, which

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -82,3 +82,27 @@ def test_every_model_call_in_the_writing_graph_names_a_job(path):
             f"{path.name}: {call.group(1)} names no job, so the dashboard cannot "
             "route it and it fails outright when no model is picked"
         )
+
+
+# --- compose is told the whole-article target, not only section budgets -----
+
+
+def test_compose_and_outline_read_the_same_word_target():
+    from app.features.prompt2blog.support import _target_word_count
+
+    assert _target_word_count({"length": {"target_word_count": 900}}) == 900
+    assert _target_word_count({"length": {}}) == 0
+    assert _target_word_count({}) == 0
+
+
+def test_the_compose_prompt_carries_the_target_word_count():
+    from app.features.prompt2blog.prompts.editorial_v3 import (
+        P2B_V3_COMPOSE_PROMPT,
+        P2B_V3_OUTLINE_PROMPT,
+    )
+
+    # Outline always had this. Compose saw only the per-section budgets inside
+    # the plan, and wrote 377 words against a 900 target on run 95a74dce.
+    for prompt in (P2B_V3_COMPOSE_PROMPT, P2B_V3_OUTLINE_PROMPT):
+        assert "TARGET WORD COUNT:" in prompt
+        assert "{target_word_count}" in prompt

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
@@ -384,7 +384,13 @@ def test_compose_writes_from_evidence_records_and_never_from_source_prose():
     assert section_plan.index("What Lima costs now") < section_plan.index(
         "The tradeoffs behind the price"
     )
-    assert len(prompt) < 35_000
+    # A canary for prompt bloat, not a hard budget. Raised from 35,000 when
+    # compose was given the TARGET WORD COUNT block that outline already had:
+    # compose could see only the per-section budgets, and on run 95a74dce it
+    # wrote 377 words against a 900 target. The block and its one rule cost
+    # about 160 characters. Anything that moves this by thousands is the thing
+    # this line is watching for.
+    assert len(prompt) < 36_000
     assert updates["rewrite"]["improved_title"] == "What Lima costs now"
     assert recorder.recorded[0][0] == "stage_v3_compose"
 


### PR DESCRIPTION
Closes #503, closes #504. Addresses the root cause in #506.

All three found by driving one real v4 run end to end (`95a74dce`).

## Compose could not see the target word count

The outline prompt has a `TARGET WORD COUNT:` block. The compose prompt had none — only the per-section budgets carried inside the section plan.

| | words |
|---|---:|
| target | 900 |
| outline **planned** | 730 |
| compose **wrote** | 377 |

Compose delivered about half of every planned section. The audit then handed repair **twelve** required revisions, of which **one** was the ungrounded-claim fix and **eleven** were coverage instructions naming work-order ids:

```
List all districts the walk passes through, north to south (walk_districts_order).
Provide information on public restrooms (public_restrooms).
Describe the typical morning weather (morning_weather_lima).
...
```

Repair gets one attempt. That attempt went entirely to *finishing an unfinished article*, and it finished it by writing the checklist it was handed — which is where the published article's shape came from, including a redundant amenities section restating every restroom and kiosk already given district by district.

**It is not the voice and not the outline.** The outline is the strongest stage here: it carried the brief's spine into its own takeaway ("understand the contrast between the park above and the motorway below"), planned six specific sections, and produced a real working title.

Compose now gets the same block, via one helper in `support.py` that both stages call — beside `_format_style_directive`, which has the same shape — rather than two copies free to drift.

**No claim is made that this improves the prose.** A full-length first draft may read better or merely longer. That is a question for the next run.

## The punch list billed to `unattributed`

It was the last stage still calling the model before opening its stage — the exact fault `_open` exists for and documents:

> Every intake stage used to call the model first and open the stage after, so the call landed under `unattributed` and the stage row reported zero.

$0.0170 filed nowhere, while `stage_v4_punch_list` claimed it cost nothing.

## A dropped claim could only be counted

`assemble_evidence` drops a claim whose sources or questions do not survive. That is right — the comment above it explains why failing the dossier instead is worse. But it logged a bare number, and the claim is absent from every stored artefact by the time anyone looks. Run `95a74dce` dropped 19 and there was no way to tell:

- a claim citing a source the model never declared, from
- a claim answering a question in another batch

Those want opposite fixes. The cited ids are now kept aside **before** the filters and the union rewrite them — I checked, `requirement_ids` is reassigned by the union pass, so logging it there would have compared a list to itself — and each drop names what it asked for and what survived.

## Note on the size guard

`test_compose_writes_from_evidence_records...` asserts the compose prompt stays under 35,000 characters. The new block costs ~160, taking it to 35,060. Raised to 36,000 with a comment recording what was added and why. It is a canary for bloat; anything moving it by thousands is what it watches for.

Backend suite: 1398 passed, 0 failed.
