### PR TITLE
fix(p2b): the outline gets grouped facts, one budget, and each rule once

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -190,7 +190,9 @@ def _form_structure(form_instructions: str) -> str:
     )
 
 
-def _facts_by_subject(evidence: NormalizedEvidence) -> str:
+def _facts_by_subject(
+    evidence: NormalizedEvidence, work_order: Prompt2BlogWorkOrder
+) -> str:
     """The facts, grouped by what they are about.
 
     The outline used to be handed this ledger indexed by requirement id, and it
@@ -202,12 +204,35 @@ def _facts_by_subject(evidence: NormalizedEvidence) -> str:
     The requirement index still follows, because coverage has to stay
     checkable. It is second, and it is labelled as bookkeeping.
     """
+    # The work order's own search groups. They were written to say which
+    # questions can be answered from the same sources -- one route's stations,
+    # fare and duration; one museum's hours and admission -- so they already
+    # name subjects rather than questions, and no model call is needed to sort.
+    #
+    # This replaces `getattr(claim, "subject", "")`, which read a field
+    # `NormalizedClaim` has never had. The default swallowed it, every fact in
+    # every run landed under "General", and the grouping this function exists
+    # for has never once happened.
+    #
+    # It is not a perfect subject index: a group is still derived from what was
+    # researched together, so a plan with one group per section would come back
+    # coarser rather than differently shaped. It is the only real signal
+    # available without a classification call, and it beats one bucket.
+    group_of_requirement = {
+        item.requirement_id: _safe_str(item.search_group).replace("_", " ").strip()
+        for item in work_order.requirements
+    }
+
     by_subject: dict[str, list[str]] = {}
     for claim in evidence.claims:
-        # The source's own subject line is the best grouping available without
-        # asking a model to classify facts, which would be a call to save a
-        # sort.
-        subject = _safe_str(getattr(claim, "subject", "")) or "General"
+        subject = next(
+            (
+                group_of_requirement[requirement_id]
+                for requirement_id in claim.requirement_ids
+                if group_of_requirement.get(requirement_id)
+            ),
+            "",
+        ) or "General"
         as_of = f" (as of {claim.as_of})" if claim.as_of else ""
         by_subject.setdefault(subject, []).append(
             f"- {claim.claim_id} — {claim.text}{as_of} [{claim.confidence}]"
@@ -443,7 +468,7 @@ def assemble_v3_instructions(
                     "form_structure",
                     f"ARTICLE FORM STRUCTURE — {form.label}\n{form_structure}",
                 ),
-                ("facts", _facts_by_subject(evidence)),
+                ("facts", _facts_by_subject(evidence, work_order)),
                 (
                     "outline_rules",
                     "PLANNING RULES\n"
@@ -456,10 +481,14 @@ def assemble_v3_instructions(
                     # A4. Compose is separately required to add an opening and
                     # takeaways -- about 165 words nobody counts -- so a plan
                     # that budgets the full target overshoots by construction.
-                    "- Your section budgets must leave room for an opening and "
-                    "a closing takeaways section, which you do not plan and "
-                    "which cost roughly 165 words together. Budget the "
-                    "sections to the target minus that.\n"
+                    # The reserve is now subtracted before the prompt is built
+                    # and arrives as SECTION BUDGET: this rule and the template
+                    # used to give the model two different totals and ask it to
+                    # reconcile them, which is why run 95a74dce planned 730
+                    # against a 900 target, twice.
+                    "- The SECTION BUDGET already excludes the opening and the "
+                    "closing takeaways, which you do not plan. Budget to it "
+                    "exactly; do not subtract anything further.\n"
                     "- Group sections by subject. One section per research "
                     "question is a research plan, not an article.",
                 ),

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -41,14 +41,19 @@ Rules:
 - If the brief asks for something the evidence cannot support, list it in
   unsupported_requirements instead of planning a section that would need an
   invented fact.
-- target_words across all sections should total roughly the target word count.
+- target_words across all sections should total roughly the SECTION BUDGET
+  below, which is already the target minus the opening and takeaways you
+  do not plan. Do not subtract anything yourself.
 - brief_alignment must explain in one or two sentences how this structure
   answers the core reader question for the primary subject.
 
 {instructions}
 
-TARGET WORD COUNT:
+TARGET WORD COUNT (the whole article):
 {target_word_count}
+
+SECTION BUDGET (what your sections must total):
+{section_budget}
 """
 
 P2B_V3_COMPOSE_PROMPT = """\

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
@@ -29,7 +29,9 @@ def run_v3_compose_stage(
     run_id = state["run_id"]
     dependencies.recorder.start_stage(run_id, stage)
 
-    style_directive = _format_style_directive(state["option_context"])
+    style_directive = _format_style_directive(
+        state["option_context"], keys=("length",)
+    )
     prompt = P2B_V3_COMPOSE_PROMPT.format(
         outline=state["outline_text"],
         target_word_count=_target_word_count(_safe_dict(state["option_context"]))

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -18,7 +18,7 @@ from ...instructions_v3 import stage_context_text
 from ...observability import _append_stage_trace
 from ...prompts.editorial_v3 import P2B_V3_OUTLINE_PROMPT
 from ...schemas import V3_OUTLINE_SCHEMA
-from ...support import _safe_dict, _target_word_count
+from ...support import _safe_dict, _section_budget, _target_word_count
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,8 @@ def run_v3_outline_stage(
     prompt = P2B_V3_OUTLINE_PROMPT.format(
         instructions=stage_context_text(state["stage_contexts"], "outline"),
         target_word_count=target_word_count or "Not specified.",
+        section_budget=_section_budget(_safe_dict(state["option_context"]))
+        or "Not specified.",
     )
 
     try:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/support.py
@@ -109,6 +109,27 @@ def _format_hard_constraints(writing_brief: dict[str, Any]) -> str:
     return "\n\n".join(sections)
 
 
+# Compose writes an opening and a closing takeaways section that the outline
+# does not plan and nobody budgets. The outline used to be told to subtract
+# this itself, in a rule that contradicted its own template -- see
+# `_section_budget`.
+UNPLANNED_WORDS = 165
+
+
+def _section_budget(option_context: dict[str, Any]) -> int:
+    """What the outline's sections must total, reserve already removed.
+
+    The outline template asked for section budgets totalling the target while
+    the injected planning rules asked for the target minus the reserve. Run
+    95a74dce planned 730 against a 900 target in both passes -- 900 - 165 = 735
+    -- so it was obeying the more specific of two conflicting instructions and
+    getting it right. Doing the subtraction here leaves one number in the
+    prompt and none of the arithmetic with the model.
+    """
+    target = _target_word_count(option_context)
+    return max(0, target - UNPLANNED_WORDS) if target else 0
+
+
 def _target_word_count(option_context: dict[str, Any]) -> int:
     """The whole-article word target the outline plans to and compose writes to.
 
@@ -120,13 +141,23 @@ def _target_word_count(option_context: dict[str, Any]) -> int:
     return _safe_int(_safe_dict(option_context.get("length")).get("target_word_count"))
 
 
-def _format_style_directive(option_context: dict[str, Any]) -> str:
+def _format_style_directive(
+    option_context: dict[str, Any], *, keys: tuple[str, ...] | None = None
+) -> str:
     """Render the resolved tone, length, and brand voice guides as a required
     style block. These used to travel inside ``editorial_instructions``, which
     every prompt renders under the header "NARRATIVE FOCUS (OPTIONAL)" -- so the
     whole tone guide reached the model labelled optional. Built from
     ``option_context`` rather than the writing brief so the runtime-run path
-    gets the same directive as a full run."""
+    gets the same directive as a full run.
+
+    ``keys`` narrows what is rendered. Compose passes ``("length",)`` because
+    its stage context already carries the voice and the writing conventions as
+    their own sections, and this block was repeating both of them -- 3,474
+    duplicated characters in run 95a74dce. Audit and repair pass nothing and
+    keep the whole directive: neither has a `voice` section, so for those two
+    this block is the only place the voice reaches the model at all.
+    """
     context = _safe_dict(option_context)
 
     sections: list[str] = []
@@ -135,6 +166,8 @@ def _format_style_directive(option_context: dict[str, Any]) -> str:
         ("length", "Length"),
         ("brand_voice", "Brand voice"),
     ):
+        if keys is not None and key not in keys:
+            continue
         option = _safe_dict(context.get(key))
         instructions = _safe_str(option.get("instructions"))
         if not instructions:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -104,5 +104,30 @@ def test_the_compose_prompt_carries_the_target_word_count():
     # Outline always had this. Compose saw only the per-section budgets inside
     # the plan, and wrote 377 words against a 900 target on run 95a74dce.
     for prompt in (P2B_V3_COMPOSE_PROMPT, P2B_V3_OUTLINE_PROMPT):
-        assert "TARGET WORD COUNT:" in prompt
+        assert "TARGET WORD COUNT" in prompt
         assert "{target_word_count}" in prompt
+
+    # The outline also gets the reserved figure its sections must total, so it
+    # is never asked to reconcile two numbers.
+    assert "{section_budget}" in P2B_V3_OUTLINE_PROMPT
+    assert "{section_budget}" not in P2B_V3_COMPOSE_PROMPT
+
+
+# --- the outline's facts arrive grouped, and the grouping is a real field ---
+
+
+def test_facts_reach_the_outline_under_more_than_one_heading():
+    """`getattr(claim, "subject", "")` read a field that has never existed.
+
+    `NormalizedClaim` carries claim_id, text, source_ids, requirement_ids,
+    as_of and confidence. The default swallowed the miss, so every fact in
+    every run landed under "General" and the grouping this function exists for
+    never once happened.
+    """
+    from app.features.prompt2blog.evidence_v3 import NormalizedClaim
+
+    assert not hasattr(NormalizedClaim, "subject")
+    assert "subject" not in NormalizedClaim.model_fields, (
+        "if a real subject field is added, group on it directly rather than "
+        "through the work order's search groups"
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -312,11 +312,23 @@ def test_the_outline_budget_leaves_room_for_what_compose_adds():
 
     The plan budgeted the full target while compose was separately required to
     add an opening and takeaways that nobody counted.
+
+    The reserve is now subtracted before the prompt is built rather than asked
+    for in prose. The old wording survived beside the template rule that
+    contradicted it, and run 95a74dce planned 730 against a 900 target twice --
+    900 - 165 -- because it obeyed the more specific of the two.
     """
+    from app.features.prompt2blog.support import UNPLANNED_WORDS, _section_budget
+
+    assert _section_budget({"length": {"target_word_count": 900}}) == 900 - UNPLANNED_WORDS
+    assert _section_budget({"length": {"target_word_count": 0}}) == 0
+    assert _section_budget({}) == 0
+
     outline = _flat(assemble_v3_instructions(_request()).stage_contexts.outline.text)
 
-    assert "roughly 165 words" in outline
-    assert "Budget the sections to the target minus that." in outline
+    # The model is given the reserved number, never the subtraction.
+    assert "do not subtract anything further" in outline.lower()
+    assert "target minus that" not in outline
 
 
 def test_compose_leads_with_the_brief_and_treats_evidence_as_material():
@@ -366,3 +378,67 @@ def test_the_audit_prompt_asks_whether_the_draft_walks_into_it():
     # Freehand text, so an auditor that cannot apply it must leave it alone
     # rather than invent a reading.
     assert "it is not a gate" in prompt
+
+
+def test_the_outline_gets_its_facts_under_more_than_one_heading():
+    """The grouping existed and never ran.
+
+    `_facts_by_subject` read `claim.subject` through a getattr default, and
+    `NormalizedClaim` has no such field, so every fact in every run landed
+    under "General" -- the exact shape the function was written to prevent.
+    It now groups on the work order's own search groups, which say which
+    questions share sources rather than which question was asked.
+    """
+    fixture = _fixture()
+    package = json.loads(json.dumps(fixture["evidence_package"]))
+    # The shared fixture has one claim against one question, so it cannot show
+    # a split. Give it a second fact against a second question rather than
+    # editing a file the other tests in here read.
+    first = package["claims"][0]
+    second = dict(first, claim_id="c2", requirement_ids=["r2"])
+    package["claims"].append(second)
+    for requirement in package["requirements"]:
+        if requirement["requirement_id"] == "r2":
+            requirement.update(status="supported", claim_ids=["c2"], gap="")
+
+    work_order = json.loads(json.dumps(fixture["work_order"]))
+    for requirement in work_order["requirements"]:
+        requirement["search_group"] = (
+            "getting around" if requirement["requirement_id"] == "r1" else "prices"
+        )
+
+    request = _request(work_order=work_order, evidence_package=package)
+    facts = assemble_v3_instructions(request).stage_contexts.outline.text
+    block = facts[facts.index("FACTS AVAILABLE, BY SUBJECT"):]
+    block = block[: block.index("COVERAGE BOOKKEEPING")]
+
+    headings = [
+        line
+        for line in block.splitlines()
+        if line and not line.startswith("- ") and line != "FACTS AVAILABLE, BY SUBJECT"
+    ]
+
+    assert headings == ["getting around", "prices"]
+    assert "General" not in headings
+
+
+def test_a_fact_answering_no_grouped_question_still_appears():
+    """Grouping must never be a filter.
+
+    A work order planned before #500 carries no search groups at all, so this
+    is also the honest description of what those runs still get: one bucket,
+    every fact present.
+    """
+    request = _request()
+    stripped = request.model_copy(deep=True)
+    for requirement in stripped.work_order.requirements:
+        requirement.search_group = ""
+
+    facts = assemble_v3_instructions(stripped).stage_contexts.outline.text
+    block = facts[facts.index("FACTS AVAILABLE, BY SUBJECT"):]
+    block = block[: block.index("COVERAGE BOOKKEEPING")]
+
+    assert "General" in block
+    assert len([line for line in block.splitlines() if line.startswith("- ")]) == len(
+        normalize_evidence(stripped.work_order, stripped.evidence_package).claims
+    )


### PR DESCRIPTION
Phase 1 of `apps/ai-blog-writer/docs/audits/2026-09-05-writer-packet/PLAN.md`. Closes #509, #510, #511.

Three faults in the path that decides the article's shape. All three are instructions the system already had and was defeating.

## #509 — the grouping never ran

```python
subject = _safe_str(getattr(claim, "subject", "")) or "General"
```

`NormalizedClaim` carries `claim_id, text, source_ids, requirement_ids, as_of, confidence`. There is no `subject`, and the default swallowed it, so **every fact in every run landed under "General"** since the grouping was written.

Its own docstring says what that costs:

> The outline used to be handed this ledger indexed by requirement id, and it did the obvious thing: one section per question. **That is why the Lima article's spine was its own research plan.**

Now grouped on the work order's `search_group`, which says which questions share sources — one route's stations and fare, one museum's hours and admission. Those name subjects rather than questions, and need no classification call. On run `95a74dce`: **five groups instead of one** — walk overview 34 claims, practicalities 15, poi north to south 11, scenic views 10, weather 10.

Honest limitation, recorded in the code comment and in a test: a search group still describes what was researched *together*, so a plan with one section per group would come back coarser rather than differently shaped. It is the only real signal available without a classification call. A work order planned before search groups existed still gets one bucket, and a test says so.

## #510 — two totals, and the model had to reconcile them

| | |
|---|---|
| outline template | "target_words across all sections should total roughly the target word count" |
| injected planning rules | "Budget the sections to the target minus that [~165 words]" |

**900 − 165 = 735.** The outline planned **730**, in both passes. It was obeying the more specific rule and getting it right — the earlier claim that it under-planned by 10% was wrong.

The reserve is now subtracted in `_section_budget` before the prompt is built. The outline gets `TARGET WORD COUNT` (the whole article) and `SECTION BUDGET` (what its sections must total). Neither prompt asks the model to do arithmetic.

## #511 — the voice sent twice

The compose stage context carries `voice` and `writing_conventions`; the style directive rendered the same two bodies again. **3,474 duplicated characters**, matching the audit's figure exactly.

Compose now takes only the length profile from that block — 3,710 chars down to 156.

**Audit and repair keep the whole directive on purpose.** Neither has a `voice` stage-context section, so for those two the style directive is the only place the voice reaches the model at all. Stripping it globally would have made #518 worse. That is why this is a per-caller change rather than a change to the shared helper's default.

## Tests

Two existing tests asserted the old wording and were rewritten to assert the mechanism instead: the reserve is applied, and the model is never asked to subtract. New tests cover facts landing under more than one heading, an ungrouped work order still yielding every fact under General, and the compose prompt carrying its own target.

Backend suite: 1402 passed, 0 failed.

## Next

One paid run on the same Malecón seed. Nothing else changed, so nothing else can explain a difference in the outline's shape.
