### PR TITLE
fix(p2b): four places the pipeline argued with itself

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/brief_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/brief_v4.py
@@ -30,6 +30,7 @@ from .contracts_v4 import (
     BriefReader,
     GrillState,
 )
+from .editorial_catalog import EditorialCatalog, load_editorial_catalog
 from .grill_v4 import GrillDependencies
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str, _safe_str_list
@@ -79,7 +80,36 @@ BRIEF_SCHEMA = require_non_empty({
 })
 
 
-def build_brief_prompt(state: GrillState) -> str:
+def _form_exclusions(catalog: EditorialCatalog) -> str:
+    """Each form's own "Do not use when" clause, at the moment a form is chosen.
+
+    The forms carry these clauses and nothing has ever read them. Outline and
+    compose are projected only Reader promise, Required evidence, Allowed
+    structures and Failure modes, so a form chosen wrongly is invisible from
+    there on -- and it must stay invisible, because a writer free to depart
+    from an approved form is the thing approving one prevents.
+
+    So the clause belongs here, where the choice is still being made. Run
+    95a74dce called a single morning's walk a `destination-guide`, whose clause
+    reads "Do not use for a single practical problem, a day-by-day plan, or a
+    ranked list."
+    """
+    lines = []
+    for form in catalog.forms:
+        body = form.instructions.split("## Do not use when", 1)
+        if len(body) < 2:
+            continue
+        clause = body[1].split("\n## ", 1)[0].strip().replace("\n", " ")
+        if clause:
+            lines.append(f"- {form.id}: {clause}")
+    return "\n".join(lines)
+
+
+def build_brief_prompt(
+    state: GrillState, *, catalog: EditorialCatalog | None = None
+) -> str:
+    catalog = catalog or load_editorial_catalog()
+    form_exclusions = _form_exclusions(catalog)
     transcript = "\n\n".join(
         f"Q. {turn.question.ask}\nThey said: {turn.answer}" for turn in state.turns
     )
@@ -103,6 +133,9 @@ rather than leaving it blank.
   A walk through what a place offers is `destination-guide`; a ranked or
   grouped set of picks is `curated-list-best-of`; a day-by-day plan is
   `itinerary`; a how-much-does-it-cost piece is `cost-budget-breakdown`.
+  Each form says what it is NOT for. Read these before choosing, and do not
+  pick a form whose exclusion describes this piece:
+{form_exclusions}
 - `primary_reader` is who this is for, in a phrase -- who they are and what
   situation they are in, not a demographic bracket.
 - `reader_question` is the question in that reader's head, written the way
@@ -133,8 +166,28 @@ def _material_from(payload: dict[str, Any], state: GrillState) -> list[BriefMate
     does not match a real answer is dropped and logged: a "first-hand" claim
     the operator never made is worse than no material at all, because nothing
     downstream will ever check it.
+
+    An answer that became one of the brief's own fields is a commissioning
+    decision, not evidence, and is dropped too. Run 95a74dce filed six of them
+    as `interview` -- the reader, the spine, the outcome and the failure line,
+    1,349 characters of instructions restated as facts. `interview` is the one
+    kind the evidence policy lets the writer assert with no source ("First-hand
+    material is the writer's own knowledge: state it directly, as fact"), so
+    the misfiling hands editorial intent the standing of reported fact. Those
+    answers already reach every stage as the fields they became.
+
+    The exact-quote check stays exactly as it was. This only removes answers
+    the brief is already carrying.
     """
     answers = {turn.answer for turn in state.turns}
+    # These are the payload's own key names -- BRIEF_SCHEMA keeps
+    # `primary_reader` at the top level, not nested under a reader object.
+    commissioned = {
+        _safe_str(payload.get(key))
+        for key in ("primary_reader", "reader_question", "outcome", "spine", "fails_if")
+    }
+    commissioned.discard("")
+
     material: list[BriefMaterial] = []
     for raw in payload.get("material") or []:
         record = _safe_dict(raw)
@@ -145,6 +198,13 @@ def _material_from(payload: dict[str, Any], state: GrillState) -> list[BriefMate
         if quoted not in answers:
             logger.warning(
                 "Dropping brief material that does not quote a real answer: %r",
+                quoted[:80],
+            )
+            continue
+        if quoted in commissioned:
+            logger.info(
+                "Dropping brief material that is a commissioning decision, not "
+                "evidence: %r",
                 quoted[:80],
             )
             continue

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -190,6 +190,34 @@ def _form_structure(form_instructions: str) -> str:
     )
 
 
+def _support_status(evidence: NormalizedEvidence) -> str:
+    """Which questions the evidence actually answered.
+
+    The audit sees the work order's questions and a single grounding verdict,
+    and cannot tell a draft that forgot available material from one that
+    correctly omitted a question nothing supports. On run 95a74dce it read
+    `water_refill_points` in the requirements, did not know research had
+    filed it unsupported, and told repair to add water-fountain information --
+    which repair is forbidden to invent. The revision could not be satisfied
+    by the stage it was addressed to, in any run.
+
+    A status line answers that. The evidence ledger itself is 66,000
+    characters and is not the way to tell the audit this.
+    """
+    lines = ["SUPPORT AND OMISSION"]
+    for requirement in evidence.requirements:
+        gap = f" — {requirement.gap}" if requirement.gap else ""
+        lines.append(f"- {requirement.requirement_id}: {requirement.status}{gap}")
+    lines.append(
+        "\nA question whose status is not `supported` has no evidence behind it. "
+        "A draft that omits it is correct, and asking for it in "
+        "required_revisions asks repair for a fact it is forbidden to invent. "
+        "If the omission matters, say the article needs more research rather "
+        "than more writing."
+    )
+    return "\n".join(lines)
+
+
 def _facts_by_subject(
     evidence: NormalizedEvidence, work_order: Prompt2BlogWorkOrder
 ) -> str:
@@ -531,6 +559,7 @@ def assemble_v3_instructions(
                     "on support.",
                 ),
                 ("brief", f"APPROVED BRIEF\n{brief_body}"),
+                ("support", _support_status(evidence)),
                 ("form", f"ARTICLE FORM — {form.label}\n{form_structure}"),
                 ("audience", f"AUDIENCE GUIDANCE\n{audience_body}"),
                 ("house_style", f"HOUSE STYLE\n{catalog.house_rules.instructions}"),

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -953,6 +953,12 @@ def finished_article(run_id: str) -> dict[str, Any]:
         or _safe_str(article.get("content")),
         "pipeline_status": _safe_str(finalize.get("pipeline_status")) or None,
         "readiness_blockers": finalize.get("readiness_blockers") or [],
+        # `needs_revision` alone cannot say whether repair looked and found
+        # nothing or was never offered the chance. On run 95a74dce it was the
+        # second: the budget was spent before the writing graph reached it.
+        "repair_outcome": _safe_dict(
+            _stage_data(run_id, "pipeline_v3").get("repair_outcome")
+        ),
         "constraint_checks": _safe_dict(finalize.get("constraint_checks")),
         "word_count": finalize.get("word_count_estimate"),
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/finalize.py
@@ -15,6 +15,33 @@ from ...quality_v3 import v3_constraint_brief
 from ...support import _safe_dict, _safe_str
 
 
+_REPAIR_REASONS = {
+    "draft_passed_audit": "Repair did not run: the draft passed the audit.",
+    "attempt_limit_reached": "Repair ran out of attempts.",
+    "token_budget_reached": (
+        "Repair was skipped: the run's token budget was already spent before "
+        "the writing graph reached it. This is an accounting outcome, not a "
+        "judgement about the draft."
+    ),
+    "repairable_problems_found": "Repair ran.",
+}
+
+
+def _repair_outcome(state: dict[str, Any]) -> dict[str, Any]:
+    """What happened to repair, in words the receipt can carry."""
+    decision = _safe_dict(state.get("repair_decision"))
+    reason = _safe_str(decision.get("reason"))
+    return {
+        "route": _safe_str(decision.get("route")),
+        "reason": reason,
+        "attempts_used": decision.get("attempts_used"),
+        "ran": bool(state.get("repair_applied")),
+        "explanation": _REPAIR_REASONS.get(
+            reason, "Repair's outcome was not recorded."
+        ),
+    }
+
+
 def run_v3_finalize_stage(
     state: Prompt2BlogV3GraphState,
     dependencies: PipelineDependencies,
@@ -98,6 +125,13 @@ def run_v3_finalize_stage(
         "resume_count": state.get("resume_count", 0),
         "pipeline_status": pipeline_status,
         "readiness_blockers": list(verdict.blockers),
+        # Why the article stopped where it did. `needs_revision` with no repair
+        # attempt reads like a quality verdict and on run 95a74dce was an
+        # accounting one: the run had spent 444,405 tokens against a 425,000
+        # budget before the writing graph started, so repair was skipped
+        # outright. An operator reading the receipt could not tell that the
+        # article was never offered a repair pass.
+        "repair_outcome": _repair_outcome(state),
         "brief": brief,
         "work_order": work_order,
         "form": {

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_build.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_brief_build.py
@@ -392,3 +392,47 @@ def test_the_failure_says_what_is_missing_in_words():
     assert "what the piece is built on" in str(error.value)
     assert "what would make it a failure" in str(error.value)
     assert error.value.raw, "what came back has to travel with the failure"
+
+
+def test_a_commissioning_answer_is_not_filed_as_evidence():
+    """Run 95a74dce filed six of them as `interview`, 1,349 characters.
+
+    `interview` is the one kind the evidence policy lets the writer assert with
+    no source, so an editorial instruction filed there gains the standing of a
+    reported fact. Those answers already reach every stage as the brief fields
+    they became.
+    """
+    from app.features.prompt2blog.brief_v4 import _material_from
+
+    spine = "The walk itself, north to south, in the order your feet meet it."
+    state = _agreed(
+        turns=[
+            _turn("q1", "What is the spine?", spine),
+            _turn("q2", "Anything of your own?", FIRSTHAND),
+        ]
+    )
+    payload = {
+        "spine": spine,
+        "material": [
+            {"kind": "interview", "quoted_answer": spine},
+            {"kind": "firsthand", "quoted_answer": FIRSTHAND},
+        ],
+    }
+
+    material = _material_from(payload, state)
+
+    assert [item.statement for item in material] == [FIRSTHAND], (
+        "the spine is an instruction the brief already carries, not evidence"
+    )
+
+
+def test_the_exact_quote_safeguard_is_untouched():
+    """A paraphrase of a real answer is still dropped."""
+    from app.features.prompt2blog.brief_v4 import _material_from
+
+    state = _agreed(turns=[_turn("q1", "Anything of your own?", FIRSTHAND)])
+    payload = {
+        "material": [{"kind": "firsthand", "quoted_answer": FIRSTHAND[:-1] + " roughly."}]
+    }
+
+    assert _material_from(payload, state) == []

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -131,3 +131,54 @@ def test_facts_reach_the_outline_under_more_than_one_heading():
         "if a real subject field is added, group on it directly rather than "
         "through the work order's search groups"
     )
+
+
+# --- Phase 2: the pipeline stops arguing with itself -----------------------
+
+
+def test_the_audit_is_told_which_questions_the_evidence_answered():
+    """It asked repair to add water-fountain information that research had
+    already filed unsupported, and repair is forbidden to invent facts."""
+    from app.features.prompt2blog.instructions_v3 import _support_status
+
+    class _Requirement:
+        def __init__(self, rid, status, gap=""):
+            self.requirement_id, self.status, self.gap = rid, status, gap
+
+    class _Evidence:
+        requirements = [
+            _Requirement("r1", "supported"),
+            _Requirement("water_refill_points", "unpublished", "No public fountains found."),
+        ]
+
+    text = _support_status(_Evidence())
+
+    assert "r1: supported" in text
+    assert "water_refill_points: unpublished — No public fountains found." in text
+    assert "forbidden to invent" in text
+
+
+def test_a_skipped_repair_says_why_rather_than_only_needs_revision():
+    from app.features.prompt2blog.stages.v3.finalize import _repair_outcome
+
+    skipped = _repair_outcome(
+        {"repair_decision": {"route": "settle", "reason": "token_budget_reached"}}
+    )
+    assert skipped["ran"] is False
+    assert "token budget was already spent" in skipped["explanation"]
+
+    passed = _repair_outcome(
+        {"repair_decision": {"route": "settle", "reason": "draft_passed_audit"}}
+    )
+    assert "passed the audit" in passed["explanation"]
+    assert skipped["explanation"] != passed["explanation"]
+
+
+def test_the_brief_writer_is_shown_what_each_form_is_not_for():
+    from app.features.prompt2blog.brief_v4 import _form_exclusions
+    from app.features.prompt2blog.editorial_catalog import load_editorial_catalog
+
+    exclusions = _form_exclusions(load_editorial_catalog())
+
+    assert "destination-guide: Do not use for a single practical problem" in exclusions
+    assert len(exclusions.splitlines()) >= 10


### PR DESCRIPTION
Phase 2 of `apps/ai-blog-writer/docs/audits/2026-09-05-writer-packet/PLAN.md`. Closes #512, #513, #514, #515.

None of these shrinks anything. They stop stages issuing instructions the receiving stage cannot obey.

## #512 — the audit ordered repair to invent facts

The audit saw the work order's questions and one grounding verdict, and nothing saying which questions the evidence actually answered. On run `95a74dce` it read `water_refill_points` in the requirements, did not know research had filed it **unsupported**, and told repair to add water-fountain information — which repair is forbidden to invent, in that run or any other.

It now gets a `support` section: one status line per requirement with the recorded gap, and the rule stated plainly —

> A question whose status is not `supported` has no evidence behind it. A draft that omits it is correct, and asking for it in required_revisions asks repair for a fact it is forbidden to invent. If the omission matters, say the article needs more research rather than more writing.

A status list, deliberately **not** the 66,000-character ledger.

## #513 — the brief filed the operator's own instructions as evidence

Run `95a74dce` carried six `interview` entries, 1,349 characters, restating the reader, the spine, the outcome and the failure line. All of those already reach every stage as the brief fields they became.

`interview` is the one kind the evidence policy lets the writer assert with no source:

> First-hand material is the writer's own knowledge: state it directly, as fact, with no attribution.

So editorial intent was being given the standing of reported fact. An answer that became one of the brief's own fields is now dropped from `material`.

**The exact-quote safeguard is untouched** — it still proves the words are the operator's, and a paraphrase is still refused. A test covers that separately, because weakening it while fixing the classification is the obvious way to get this wrong.

## #514 — each form says what it is not for, and nothing read it

`destination-guide` carries:

> Do not use for a single practical problem, a day-by-day plan, or a ranked list.

Run `95a74dce` used it for one morning's walk along one path.

Outline and compose are projected only Reader promise, Required evidence, Allowed structures and Failure modes — **and that stays as it is.** A writer free to depart from an approved form is exactly what approving one prevents. So the clause now reaches the stage that *picks* the form, where a wrong choice is still cheap to change. All 15 forms, 3,945 characters.

## #515 — a skipped repair looked like a quality verdict

`needs_revision` with no repair attempt cannot say whether repair looked and found nothing or was never offered the chance. On the second writing pass it was the second: the run had spent 444,405 tokens against a 425,000 budget before the writing graph started.

The receipt now carries the route, the reason, and a sentence:

> Repair was skipped: the run's token budget was already spent before the writing graph reached it. This is an accounting outcome, not a judgement about the draft.

Deliberately **not** done here: raising the budget, or deciding whether a discarded writing attempt should count against the attempt that replaced it. That question is real and is recorded in #515's thread rather than answered by a number change.

## Notes

- `_form_exclusions` had to be a local before the f-string, not a `.replace` after it — the first version interpolated `{form_exclusions}` as a variable and broke seven tests.
- `primary_reader` lives at the top level of the brief payload, not nested under `reader`; the first version of #513 read the wrong path.

Backend suite: 1409 passed, 0 failed.
