### PR TITLE
feat(p2b): measure sentence openings, and stop ADR 0032 lying about the anti-AI pass

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -87,6 +87,13 @@ CONSTRAINT_MEASUREMENT_KEYS = frozenset(
         "repeated_sentence_pairs",
         "repeated_sentence_overlap",
         "repeated_sentence_note",
+        # Sentence openings, same rule: reported so an operator can look at the
+        # passage, never gated. A walking guide legitimately repeats place
+        # names and a threshold here would fight the form.
+        "opening_proper_noun_share",
+        "opening_longest_same_kind_run",
+        "opening_run_example",
+        "opening_kinds",
     }
 )
 
@@ -172,17 +179,142 @@ SENTENCE_BAND_WIDTH = 5
 SENTENCE_CLUSTER_SHARE = 0.45
 
 
+# Abbreviations whose full stop does not end a sentence. Without these a
+# splitter cuts "9:00 a.m. to 9:00 p.m." into three, which is how one count of
+# the same article reached 68 units and another 59 -- and why no number from
+# either was worth reporting.
+_ABBREVIATIONS = (
+    "a.m.",
+    "p.m.",
+    "e.g.",
+    "i.e.",
+    "etc.",
+    "vs.",
+    "approx.",
+    "St.",
+    "Mt.",
+    "Av.",
+    "No.",
+)
+
+
+def _sentences(content: str) -> list[str]:
+    """Every sentence of prose, headings and list markers excluded.
+
+    One splitter, shared by everything that counts sentences, because two
+    splitters produce two different articles' worth of numbers from the same
+    text and neither can be argued with.
+    """
+    body = "\n".join(
+        line for line in content.splitlines() if not line.lstrip().startswith("#")
+    )
+    guarded = body
+    for index, abbreviation in enumerate(_ABBREVIATIONS):
+        guarded = guarded.replace(abbreviation, f"\x00{index}\x00")
+    parts = re.split(r"(?<=[.!?])\s+", guarded)
+    sentences = []
+    for part in parts:
+        for index, abbreviation in enumerate(_ABBREVIATIONS):
+            part = part.replace(f"\x00{index}\x00", abbreviation)
+        part = part.strip().lstrip("*-\u2022 ").strip()
+        if len(part) > 3:
+            sentences.append(part)
+    return sentences
+
+
 def _sentence_lengths(content: str) -> list[int]:
     """Word counts for every sentence of prose, headings excluded.
 
     A heading is not a sentence and counting it drags the numbers toward the
     short end of an article that is merely well sectioned.
     """
-    body = "\n".join(
-        line for line in content.splitlines() if not line.lstrip().startswith("#")
-    )
-    sentences = [part.strip() for part in re.split(r"(?<=[.!?])\s+", body)]
-    return [len(_tokenize_words(part)) for part in sentences if len(part.strip()) > 3]
+    return [len(_tokenize_words(part)) for part in _sentences(content)]
+
+
+def measure_sentence_openings(content: str) -> dict[str, Any]:
+    """How many sentences begin the same way. Reported, never gated.
+
+    Run 95a74dce's article kept every surface anti-AI check at zero -- no em
+    dashes, no stock phrasing, no brochure adjectives -- and still read as a
+    machine wrote it, because almost every sentence opened by naming a place.
+    Four in a row were `[Park name], [description]`. A human writer tires of
+    their own rhythm; a model does not, and nothing here was counting.
+
+    Deliberately not a threshold. A walking guide legitimately repeats place
+    names, and an earlier "85% of sentences" figure came from an unspecified
+    splitter that another splitter disagreed with. This reports the share and
+    the longest run, and quotes the run so a person can look at the actual
+    passage and decide.
+    """
+    sentences = _sentences(content)
+    if not sentences:
+        return {
+            "opening_proper_noun_share": 0.0,
+            "opening_longest_same_kind_run": 0,
+            "opening_run_example": "",
+            "opening_kinds": {},
+        }
+
+    kinds = [_opening_kind(sentence) for sentence in sentences]
+    longest = current = 1
+    longest_end = 0
+    for index in range(1, len(kinds)):
+        if kinds[index] == kinds[index - 1] == "proper_noun":
+            current += 1
+            if current > longest:
+                longest, longest_end = current, index
+        else:
+            current = 1
+    example = ""
+    if longest > 1:
+        window = sentences[longest_end - longest + 1 : longest_end + 1]
+        example = " ".join(window)[:400]
+
+    counts: dict[str, int] = {}
+    for kind in kinds:
+        counts[kind] = counts.get(kind, 0) + 1
+    return {
+        "opening_proper_noun_share": round(
+            counts.get("proper_noun", 0) / len(sentences), 3
+        ),
+        "opening_longest_same_kind_run": longest if longest > 1 else 0,
+        "opening_run_example": example,
+        "opening_kinds": counts,
+    }
+
+
+_OPENING_FUNCTION_WORDS = {
+    "the", "a", "an", "this", "that", "these", "those", "it", "its", "they",
+    "there", "here", "you", "your", "we", "our", "i", "he", "she", "his", "her",
+    "if", "when", "while", "after", "before", "from", "at", "on", "in", "for",
+    "to", "by", "with", "about", "further", "continuing", "starting", "walking",
+    "most", "many", "some", "several", "both", "each", "every", "no", "not",
+    "and", "but", "or", "so", "because", "although", "though", "since",
+}
+
+
+def _opening_kind(sentence: str) -> str:
+    """What kind of word a sentence starts with.
+
+    A capitalised first word is not evidence of anything -- every sentence has
+    one. A proper noun opener is a capitalised word that is not a function word
+    and not a bare pronoun, which is what "Parque Bernales offers..." is and
+    "The path continues..." is not.
+    """
+    words = sentence.split()
+    if not words:
+        return "other"
+    first = words[0].strip("\"'\u201c\u2018([")
+    lowered = first.casefold().strip(".,;:")
+    if not first:
+        return "other"
+    if lowered in _OPENING_FUNCTION_WORDS:
+        return "function_word"
+    if first[0].isdigit():
+        return "number"
+    if first[0].isupper():
+        return "proper_noun"
+    return "other"
 
 
 def measure_sentence_spread(content: str) -> dict[str, Any]:
@@ -539,6 +671,7 @@ def _build_constraint_checks(
         "word_count_estimate": word_count,
         "word_count_severity": word_count_severity,
         **measure_sentence_spread(content),
+        **measure_sentence_openings(content),
         **measure_repetition(content),
     }
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -182,3 +182,71 @@ def test_the_brief_writer_is_shown_what_each_form_is_not_for():
 
     assert "destination-guide: Do not use for a single practical problem" in exclusions
     assert len(exclusions.splitlines()) >= 10
+
+
+# --- Phase 4: sentence openings, measured the same way twice ---------------
+
+
+def test_the_splitter_does_not_cut_an_article_at_every_abbreviation():
+    """Two splitters gave 59 and 68 units for the same article, which is why
+    neither number was worth reporting."""
+    from app.features.prompt2blog.quality import _sentences
+
+    text = "The park is open 9:00 a.m. to 9:00 p.m. daily. Entry is free."
+
+    assert len(_sentences(text)) == 2
+
+
+def test_headings_and_list_markers_are_not_sentences():
+    from app.features.prompt2blog.quality import _sentences
+
+    text = "# A Heading\n\nThe path runs south.\n\n*   Malecon Pazos\n\n## Another\n"
+
+    assert _sentences(text) == ["The path runs south.", "Malecon Pazos"]
+
+
+def test_a_run_of_place_name_openings_is_reported_with_the_passage():
+    from app.features.prompt2blog.quality import measure_sentence_openings
+
+    metronome = (
+        "Parque de la Pera has a play area. Parque Bernales is wooded. "
+        "Parque Gandhi sits on the cliff. Parque Bicentenario opened in 2020."
+    )
+    varied = (
+        "The path has a play area. It runs on through woodland. "
+        "Further south the cliff drops away. You reach the 2020 park last."
+    )
+
+    flagged = measure_sentence_openings(metronome)
+    clean = measure_sentence_openings(varied)
+
+    assert flagged["opening_proper_noun_share"] == 1.0
+    assert flagged["opening_longest_same_kind_run"] == 4
+    assert "Parque de la Pera" in flagged["opening_run_example"]
+
+    assert clean["opening_proper_noun_share"] == 0.0
+    assert clean["opening_longest_same_kind_run"] == 0
+
+
+def test_a_capitalised_first_word_is_not_by_itself_a_place_name():
+    """Every sentence starts with a capital. Counting that would report 100%
+    for any prose and mean nothing."""
+    from app.features.prompt2blog.quality import measure_sentence_openings
+
+    result = measure_sentence_openings(
+        "The walk begins here. It ends there. You will want water."
+    )
+
+    assert result["opening_proper_noun_share"] == 0.0
+
+
+def test_the_openings_are_measurements_and_never_gate_a_run():
+    from app.features.prompt2blog.quality import (
+        CONSTRAINT_MEASUREMENT_KEYS,
+        HARD_CONSTRAINT_CHECK_KEYS,
+        measure_sentence_openings,
+    )
+
+    for key in measure_sentence_openings("A sentence about Lima."):
+        assert key in CONSTRAINT_MEASUREMENT_KEYS
+        assert key not in HARD_CONSTRAINT_CHECK_KEYS

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_voice_files.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_voice_files.py
@@ -81,3 +81,26 @@ def test_the_voice_says_what_a_good_piece_is_rather_than_only_what_is_banned():
     body = _voice()
     positives = ("It treats you", "Its warmth", "It has a view")
     assert all(phrase in body for phrase in positives)
+
+
+def test_the_anti_ai_enforcement_pass_is_still_wired_in():
+    """ADR 0032 said this was dropped for Prompt2Blog. It never was.
+
+    The pass is what removes "mosaic-covered" and "six-month" from a draft
+    before anyone sees it, and it stopped working once already when the model
+    gateway migration left these calls without a job id. If it is ever removed
+    deliberately, amend ADR 0032 again and delete this test in the same change
+    -- do not delete it to make a cleanup pass go green.
+    """
+    from pathlib import Path
+
+    stages = Path(__file__).resolve().parents[1] / "app/features/prompt2blog/stages/v3"
+    compose = (stages / "compose.py").read_text()
+    repair = (stages / "audit_repair.py").read_text()
+
+    assert "enforce_anti_ai(" in compose
+    assert "enforce_anti_ai(" in repair
+    # And each still names its job, which is what broke in 3bdaef2f.
+    for source in (compose, repair):
+        call = source.split("enforce_anti_ai(", 1)[1].split("\n    )", 1)[0]
+        assert "job_id=" in call


### PR DESCRIPTION
Phase 4 of `apps/ai-blog-writer/docs/audits/2026-09-05-writer-packet/PLAN.md`. Closes #517, #519. #518 closed as not-a-defect.

## #518 first, because it changes the phase

I checked the corpus before implementing, and **the issue I filed was wrong on two counts**.

The "known-bad article scored 9" is `16872313` — **388 words against a Long profile's 1,400-word target**, blocked on `target_word_count_met`. It failed a *deterministic* check exactly as designed. Its prose was fine and the audit reasonably rated it 8, not the 9 I stated.

And `overall_score` did separate the two articles we have human judgement on:

| run | overall | human verdict |
|---|---:|---|
| `9923d1c1` | 9 | the agreed good Medellín piece |
| `95a74dce` | 5 | the dull park article |

Also: the audit **can** see the voice, via `_format_style_directive` — the `tone` option is `questurian-voice`. That kills my own "one line of code" suggestion from the analysis, and is why #511 narrowed the directive for compose only.

Consequence: **#520 is no longer blocked.** Detail in #518's thread.

## #517 — sentence openings, measured

Run `95a74dce` kept every surface anti-AI check at zero and still read as a machine wrote it, because sentence after sentence opened by naming a place.

| draft | proper-noun openers | longest unbroken run |
|---|---:|---:|
| 377-word (the one the owner preferred) | **25%** | **2** |
| 1,160-word | 44% | **11** |
| Phase 1, 917-word | 45% | 6 |

The short draft has the varied rhythm. That is the first evidence tying the owner's stated preference to something countable.

**This also corrects my own earlier numbers.** I reported 67% / 85% / 88% from an ad-hoc regex that counted `The Malecón walk...` as a place-name opener. The real figures are 25 / 44 / 45. Same direction, inflated magnitude.

Reported, never gated:

- a walking guide legitimately repeats place names, and a threshold would fight the form
- the earlier figure came from an unspecified splitter that another splitter disagreed with — 68 units against 59 for the same article

So this ships **one splitter**, shared with the existing spread measurement, that does not cut `9:00 a.m. to 9:00 p.m.` into three sentences. A capitalised first word is not counted as evidence, since every sentence has one — openers that are function words or numerals are excluded. The longest run is quoted into the receipt so a person can read the passage.

## #519 — the ADR was describing work that never happened

ADR 0032: *"The anti-AI enforcement pass is dropped for Prompt2Blog only."*

It was never dropped. `enforce_anti_ai` is wired into compose **and** repair, and the trace shows it removing "mosaic-covered" and "six-month" from the draft with a metered call in between. It also stopped and restarted without a decision — the gateway migration left both calls without a job id until #502 restored them.

**The decision is reversed rather than the code changed.** The pass is working; the paragraph never was. A test pins both call sites and says in its docstring that removing them requires amending the ADR in the same change — not deleting the test to make a cleanup go green.

Backend suite: 1419 passed, 0 failed.
