### PR TITLE
feat(p2b): compose gets the dossier without the bibliography it may not quote

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
@@ -71,6 +71,8 @@ class NormalizedEvidence(NormalizedModel):
     conflicts: list[dict[str, Any]]
     gaps: list[dict[str, Any]]
     records_text: str
+    # The same dossier without the bibliography compose may not quote.
+    compose_records_text: str = ""
 
     def refuted_assumption_ids(self) -> list[str]:
         """Premises research established are false.
@@ -188,6 +190,95 @@ def _normalize_claim(claim: EvidenceClaim) -> NormalizedClaim:
         as_of=claim.as_of.isoformat() if claim.as_of else None,
         confidence=claim.confidence,
     )
+
+
+# What `research_v4` writes when a source carried nothing worth recording. A
+# source whose only note is this one tells the writer nothing it is allowed to
+# use, and there were 55 of them in run 95a74dce.
+PLACEHOLDER_SOURCE_NOTE = "No note recorded for this source."
+
+
+def _has_substantive_note(source: NormalizedSource) -> bool:
+    return any(
+        note.strip() and note.strip() != PLACEHOLDER_SOURCE_NOTE
+        for note in source.notes
+    )
+
+
+def _compose_records_text(
+    sources: list[NormalizedSource],
+    claims: list[NormalizedClaim],
+    requirements: list[NormalizedRequirement],
+    premise_findings: list[NormalizedPremiseFinding],
+    conflicts: list[dict[str, Any]],
+    gaps: list[dict[str, Any]],
+) -> str:
+    """The same dossier, rendered for the stage forbidden to cite it.
+
+    Compose is told, in the same prompt, "Attribution is internal to these
+    records. Never carry it into the prose" -- and then handed a bibliography.
+    On run 95a74dce that was 12,299 characters of per-claim source lists
+    against 13,906 characters of actual claim prose, plus 12,564 characters of
+    Google grounding-redirect URLs it may not name and cannot open, plus the
+    placeholder note 55 times.
+
+    `_records_text` is unchanged and still feeds groundedness and the readiness
+    follow-up, which exist to check claims against their provenance and need
+    every one of those fields. This is a second projection of one dossier, not
+    a second dossier.
+
+    What survives here is what a writer may actually use: every claim, exactly
+    as written, with its date, confidence and questions; every requirement
+    status and gap; every premise verdict; every conflict, resolved or not.
+    Sources survive only where they carry a note somebody wrote -- an operator
+    settlement, a caveat, a limitation -- because that note changes how a fact
+    reads, and the claims that rest on them keep their link.
+    """
+    kept = {source.source_id for source in sources if _has_substantive_note(source)}
+
+    lines: list[str] = ["SOURCE NOTES"]
+    if kept:
+        for source in sources:
+            if source.source_id not in kept:
+                continue
+            lines.append(
+                f"- {source.source_id} | type: {source.source_type} "
+                f"| material: {source.material_type}"
+            )
+            lines.extend(f"    note: {note}" for note in source.notes)
+    else:
+        lines.append(
+            "- None. No source carried a caveat or a limitation that changes "
+            "how a fact below should be read."
+        )
+
+    lines.append("")
+    lines.append("CLAIMS")
+    if claims:
+        for claim in claims:
+            as_of = f" | as of {claim.as_of}" if claim.as_of else ""
+            # Only links to a source note the writer can read. An ordinary
+            # citation list has no reader-facing use and it may not be quoted.
+            noted = [item for item in claim.source_ids if item in kept]
+            note_link = f" | source notes: {', '.join(noted)}" if noted else ""
+            lines.append(
+                f"- {claim.claim_id} | {claim.text}"
+                f"{note_link}"
+                f" | requirements: {', '.join(claim.requirement_ids)}"
+                f"{as_of} | confidence: {claim.confidence}"
+            )
+    else:
+        lines.append("- None supplied.")
+
+    # Everything from requirement coverage onward is rendered by the canonical
+    # writer and spliced in unchanged, so the two projections cannot drift on
+    # the parts they share. Sources and claims are passed empty because this
+    # function has already written its own.
+    tail = _records_text([], [], requirements, premise_findings, conflicts, gaps)
+    heading = "REQUIREMENT COVERAGE"
+    lines.append("")
+    lines.append(heading + tail.split(heading, 1)[1])
+    return "\n".join(lines)
 
 
 def _records_text(
@@ -348,6 +439,9 @@ def normalize_evidence(
         conflicts=conflicts,
         gaps=gaps,
         records_text=_records_text(
+            sources, claims, requirements, premise_findings, conflicts, gaps
+        ),
+        compose_records_text=_compose_records_text(
             sources, claims, requirements, premise_findings, conflicts, gaps
         ),
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -132,7 +132,14 @@ def _brief_body(brief: ArticleBrief, work_order: Prompt2BlogWorkOrder) -> str:
     return "\n".join(lines)
 
 
-def _evidence_body(evidence: NormalizedEvidence) -> str:
+def _evidence_body(evidence: NormalizedEvidence, *, for_compose: bool = False) -> str:
+    """The policy, then the records.
+
+    `for_compose` selects the projection without the bibliography. The
+    canonical layer keeps the full rendering, because that layer is the run's
+    own record of what the evidence was, and groundedness and the readiness
+    follow-up read `records_text` directly and are untouched by this.
+    """
     return (
         f"{EVIDENCE_DISPOSITION_POLICY}\n\n"
         "These records are the only permitted source of fact. Use them exactly: "
@@ -150,7 +157,7 @@ def _evidence_body(evidence: NormalizedEvidence) -> str:
         "resolution is the fact, and the disagreement behind it is internal. "
         "Write the settled figure as a plain sentence. Never tell the reader "
         "that two records disagreed, which one was chosen, or why.\n\n"
-        f"{evidence.records_text}"
+        f"{evidence.compose_records_text if for_compose else evidence.records_text}"
     )
 
 
@@ -538,7 +545,7 @@ def assemble_v3_instructions(
                 ("brief", f"WHAT WE ARE MAKING\n{brief_body}"),
                 (
                     "evidence",
-                    f"THE FACTS YOU MAY USE\n{_evidence_body(evidence)}",
+                    f"THE FACTS YOU MAY USE\n{_evidence_body(evidence, for_compose=True)}",
                 ),
                 ("form", f"ARTICLE FORM — {form.label}\n{form_structure}"),
                 ("topic_modules", f"TOPIC MODULES\n{topic_modules_body}"),

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_compose_evidence.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_compose_evidence.py
@@ -1,0 +1,144 @@
+"""Compose gets the dossier without the bibliography it may not quote (#516).
+
+`records_text` is built once and read by compose, by groundedness and by the
+readiness follow-up. Compose is told "Attribution is internal to these records.
+Never carry it into the prose" and was then handed 12,299 characters of
+per-claim source lists and 12,564 characters of grounding-redirect URLs.
+Groundedness exists to check claims against exactly that provenance.
+
+So this is two projections of one dossier. These tests are the five cases the
+audit named, because each is a real thing from run 95a74dce that a careless cut
+would have destroyed.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.features.prompt2blog.contracts_v4 import Prompt2BlogV4Request
+from app.features.prompt2blog.evidence_v3 import normalize_evidence
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v4.json"
+)
+
+
+def _evidence(**package_overrides):
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    package = json.loads(json.dumps(fixture["evidence_package"]))
+    package.update(package_overrides)
+    request = Prompt2BlogV4Request.model_validate(
+        {
+            "schema_version": 4,
+            "brief": fixture["brief"],
+            "work_order": fixture["work_order"],
+            "evidence_package": package,
+            "profiles": {"length_id": "standard", "creativity_level": "medium"},
+        }
+    )
+    return normalize_evidence(request.work_order, request.evidence_package)
+
+
+def test_every_claim_survives_word_for_word():
+    evidence = _evidence()
+
+    for claim in evidence.claims:
+        assert claim.text in evidence.compose_records_text
+        assert claim.confidence in evidence.compose_records_text
+
+
+def test_coverage_premises_conflicts_and_gaps_are_byte_identical():
+    """The two projections must not drift on the parts they share."""
+    evidence = _evidence()
+    heading = "REQUIREMENT COVERAGE"
+
+    assert (
+        evidence.compose_records_text.split(heading, 1)[1]
+        == evidence.records_text.split(heading, 1)[1]
+    )
+
+
+def test_the_bibliography_compose_may_not_quote_is_gone():
+    evidence = _evidence()
+
+    assert "http" not in evidence.compose_records_text
+    assert "No note recorded for this source." not in evidence.compose_records_text
+    # And it is still there for the stage that verifies against it.
+    assert "http" in evidence.records_text
+
+
+def test_a_source_note_that_changes_how_a_fact_reads_is_kept():
+    """An operator settlement is the only thing saying which figure to use.
+
+    On run 95a74dce a source note carried the operator's own distance
+    settlement. A cut that removed it would leave two conflicting distances and
+    no instruction.
+    """
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    package = json.loads(json.dumps(fixture["evidence_package"]))
+    settlement = "Use 6.2 miles. The 10 km figure measures a different path."
+    package["sources"][0]["notes"] = [settlement]
+
+    evidence = _evidence(sources=package["sources"])
+
+    assert settlement in evidence.compose_records_text
+    # And the claims resting on it can still find it.
+    kept_id = evidence.sources[0].source_id
+    assert f"source notes: {kept_id}" in evidence.compose_records_text
+
+
+def test_a_source_carrying_only_a_placeholder_is_dropped_but_its_claims_stay():
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    package = json.loads(json.dumps(fixture["evidence_package"]))
+    package["sources"][0]["notes"] = ["No note recorded for this source."]
+
+    evidence = _evidence(sources=package["sources"])
+    text = evidence.compose_records_text
+
+    assert "SOURCE NOTES" in text
+    assert "None. No source carried a caveat" in text
+    for claim in evidence.claims:
+        assert claim.text in text
+
+
+def test_an_unresolved_conflict_is_never_silently_settled_or_dropped():
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    package = json.loads(json.dumps(fixture["evidence_package"]))
+    # A conflict is between claims, so the contract requires at least two --
+    # and claim/requirement mappings must agree in both directions.
+    second = dict(package["claims"][0], claim_id="c2")
+    package["claims"].append(second)
+    for requirement in package["requirements"]:
+        if requirement["requirement_id"] in second["requirement_ids"]:
+            requirement["claim_ids"] = sorted({*requirement["claim_ids"], "c2"})
+    package["conflicts"] = [
+        {
+            "conflict_id": "k1",
+            "summary": "Two sources give different distances.",
+            "claim_ids": ["c1", "c2"],
+            "resolution": "",
+        }
+    ]
+
+    text = _evidence(
+        claims=package["claims"],
+        requirements=package["requirements"],
+        conflicts=package["conflicts"],
+    ).compose_records_text
+
+    assert "Two sources give different distances." in text
+    assert "resolution: unresolved" in text
+
+
+def test_an_unsupported_requirement_keeps_its_status_and_gap():
+    evidence = _evidence()
+    text = evidence.compose_records_text
+
+    for requirement in evidence.requirements:
+        assert requirement.requirement_id in text
+        if requirement.gap:
+            assert requirement.gap in text

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
@@ -376,7 +376,18 @@ def test_compose_writes_from_evidence_records_and_never_from_source_prose():
     assert "`remaining_gaps` as internal metadata only" in normalized_prompt
     assert "unsupported point stays a visible gap" not in prompt
     assert "STYLE DIRECTIVE (REQUIRED)" in prompt
-    assert "Instituto Nacional de Estadística e Informática" in prompt
+    # Compose used to receive the whole bibliography and is forbidden, in the
+    # same prompt, to use any of it: "Attribution is internal to these records.
+    # Never carry it into the prose." On run 95a74dce that was 12,299
+    # characters of per-claim source lists against 13,906 of claim prose, plus
+    # 12,564 characters of grounding-redirect URLs it cannot open (#516).
+    #
+    # The publisher goes with it. That is a real trade: compose can no longer
+    # weigh a fact by who published it. `confidence` on the claim is the
+    # channel for that, and it survives. Groundedness still receives the full
+    # rendering, because checking a claim against its provenance is the entire
+    # reason that stage exists.
+    assert "Instituto Nacional de Estadística e Informática" not in prompt
     assert "HOUSE STYLE" in prompt
     section_plan = prompt.split("SECTION PLAN:", 1)[1].split("COMPOSE AUTHORITY", 1)[0]
     assert "Evidence claims: c1" in section_plan


### PR DESCRIPTION
Phase 3 of `apps/ai-blog-writer/docs/audits/2026-09-05-writer-packet/PLAN.md`. Closes #516.

## The contradiction

Compose is told, in the same prompt:

> Attribution is internal to these records. Never carry it into the prose: no "sources report", no "outlets say", no "according to"…

and was then handed the whole bibliography. On run `95a74dce`:

| | chars |
|---|---:|
| claim prose (the facts) | 13,906 |
| `sources: ...` id lists | **12,299** |
| grounding-redirect URLs (44, median 299 chars) | **12,564** |
| `No note recorded for this source.` × 55 | 1,815 |

0.88 characters of citation per character of fact, under an explicit ban on using any of it.

## Why this is two renderings, not one smaller one

`records_text` is built once in `evidence_v3.py::_records_text` and read by compose, by `stages/v3/groundedness.py`, and by `research_readiness_v3.py`. **Groundedness exists to check claims against their provenance** — stripping the shared rendering would have quietly broken the one thing this pipeline is reliably good at.

`_records_text` is untouched. `_compose_records_text` is a second projection of the same dossier.

## Measured

| | before | after | cut |
|---|---:|---:|---:|
| evidence rendering | 66,172 | 30,933 | **53.3%** |
| whole compose context | 82,411 | 47,172 | **43%** |

Verified on the real run: zero redirect URLs, zero placeholder notes, **all 80 claim texts present**, the tail from `REQUIREMENT COVERAGE` onward **byte-identical**, and the operator's own distance settlement — the only instruction saying which of two conflicting figures to use — still there.

Everything from requirement coverage onward is spliced from the canonical writer rather than re-rendered, so the projections cannot drift on what they share.

## Not a cost saving

About **a quarter of a cent** per compose call. Justified by a prompt that no longer contradicts itself, not by money.

## The trade I am making explicit

**The publisher goes.** Compose can no longer weigh a fact by who reported it. `confidence` on the claim is the intended channel for that and it survives; groundedness keeps the full provenance.

An existing test asserted the publisher reached compose — a deliberate contrast with the outline, which never got it. I updated that test rather than deleting it, and it now records what changed and why.

## Tests

The five cases the audit named, each a real thing from run `95a74dce` that a careless cut would have destroyed:

- a source note that changes how a fact reads (the operator settlement) is kept, and claims keep their link to it
- a source carrying only the placeholder is dropped, and its claims stay
- an unresolved conflict is never silently settled or dropped
- an unsupported requirement keeps its status and gap
- every claim survives word for word; coverage, premises, conflicts and gaps are byte-identical

Backend suite: 1426 passed, 0 failed.
