### PR TITLE
fix(p2b): an assumption is one checkable claim, and a refuted one has an exit

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/gate_v4.py
@@ -154,6 +154,64 @@ def answer_requirement(
     return EvidencePackage.model_validate(payload)
 
 
+def strike_assumption(
+    evidence: EvidencePackage,
+    work_order: "Prompt2BlogWorkOrder",
+    *,
+    assumption_id: str,
+) -> tuple[EvidencePackage, "Prompt2BlogWorkOrder"]:
+    """Withdraw an assumption the operator has read and rejected.
+
+    A refuted assumption blocks writing permanently -- correctly, when the
+    article really was commissioned about something that is not so. But run
+    b88081a0 was blocked by an assumption that bundled three claims: a park
+    length that research confirmed, a motorway length nobody had claimed, and
+    "the best free thing to do in Lima", which the research itself said was
+    subjective and could not be confirmed or refuted. One misread sub-claim,
+    and an article whose real premise had been confirmed twice could never be
+    written.
+
+    A blocked question already has five exits -- answer it, mark it
+    unpublished, mark it nonexistent, strike a must_name, omit it. A refuted
+    assumption had none, and the error told the operator that more research
+    would not help, which was true and useless.
+
+    So this is the same move at the same gate: the operator's call, recorded,
+    allowed to be wrong. The questions that rested on the assumption keep their
+    answers -- withdrawing a claim about the world does not unmake the facts
+    that were found -- and the finding is dropped so the same coverage function
+    that blocked can be asked again.
+    """
+    declared = {item.assumption_id for item in work_order.premise}
+    if assumption_id not in declared:
+        raise GateAnswerRefused(
+            f"{assumption_id} is not an assumption this work order declared."
+        )
+
+    order_payload = work_order.model_dump(mode="json")
+    order_payload["premise"] = [
+        item
+        for item in order_payload["premise"]
+        if item["assumption_id"] != assumption_id
+    ]
+    for requirement in order_payload["requirements"]:
+        requirement["assumption_ids"] = [
+            item for item in requirement["assumption_ids"] if item != assumption_id
+        ]
+
+    evidence_payload = evidence.model_dump(mode="json")
+    evidence_payload["premise_findings"] = [
+        item
+        for item in evidence_payload.get("premise_findings") or []
+        if item["assumption_id"] != assumption_id
+    ]
+
+    return (
+        EvidencePackage.model_validate(evidence_payload),
+        type(work_order).model_validate(order_payload),
+    )
+
+
 def omit_requirement(
     evidence: EvidencePackage,
     work_order: "Prompt2BlogWorkOrder",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -58,6 +58,7 @@ from .gate_v4 import (
     mark_unpublished,
     note_venue,
     omit_requirement,
+    strike_assumption,
     reask_requirement,
     suggested_move,
     venues_to_check,
@@ -663,6 +664,84 @@ def reask_question(
                 *(_stage_data(run_id, RESEARCH_STAGE).get("reasked") or []),
                 note,
             ],
+            STATE_KEY: json.loads(evidence.model_dump_json()),
+        },
+    )
+    return verdict
+
+
+def settle_premise(
+    run_id: str,
+    services: IntakeServices,
+    *,
+    assumption_id: str,
+    note: str,
+) -> CoverageVerdict:
+    """Withdraw an assumption research refuted. The operator's call, recorded.
+
+    No model call. A refuted premise is the one block with no exit: the error
+    says more research will not clear it, which is true, and leaves the run
+    permanently unwritable. Run b88081a0 hit it on an assumption bundling a
+    confirmed park length, a motorway length nobody claimed, and an opinion the
+    research itself called unconfirmable -- see #526.
+
+    The note is required. Withdrawing an assumption is a claim about the world
+    the operator is making instead of the research, and a wrong fact in the
+    finished article has to be traceable to the person who allowed it.
+    """
+    if not _safe_str(note):
+        raise ValueError(
+            "Say why the assumption is being withdrawn. This is a decision "
+            "about what is true, and it has to be attributable."
+        )
+
+    work_order = load_work_order(run_id)
+    evidence = load_evidence(run_id)
+    notes = _stage_data(run_id, RESEARCH_STAGE).get("notes") or {}
+
+    evidence, work_order = strike_assumption(
+        evidence, work_order, assumption_id=assumption_id
+    )
+    _record(
+        services,
+        run_id,
+        WORK_ORDER_STAGE,
+        {
+            **work_order_stage_record(
+                work_order, [], tokens_spent=_run_tokens_spent(run_id)
+            ),
+            STATE_KEY: json.loads(work_order.model_dump_json()),
+        },
+    )
+
+    verdict = assess_coverage(work_order, evidence)
+    _record(
+        services,
+        run_id,
+        RESEARCH_STAGE,
+        {
+            **research_stage_record(evidence, notes),
+            "coverage": verdict.as_record(),
+            "struck_assumptions": sorted(
+                {
+                    *(
+                        _stage_data(run_id, RESEARCH_STAGE).get("struck_assumptions")
+                        or []
+                    ),
+                    assumption_id,
+                }
+            ),
+            "struck_assumption_notes": {
+                **(
+                    _stage_data(run_id, RESEARCH_STAGE).get("struck_assumption_notes")
+                    or {}
+                ),
+                assumption_id: _safe_str(note),
+            },
+            # `research_stage_record` writes the summary, not the dossier.
+            # Omitting this wipes the evidence `load_evidence` reads and costs
+            # the run everything research paid for -- which is exactly what it
+            # did to run b88081a0 before this line existed.
             STATE_KEY: json.loads(evidence.model_dump_json()),
         },
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -698,11 +698,24 @@ def _fingerprint(value: Any) -> str:
 
 
 def requirement_fingerprint(work_order: Prompt2BlogWorkOrder, requirement: WorkOrderRequirement) -> str:
+    """What this question was asked under, so a changed context cannot reuse it.
+
+    Only the assumptions this question actually rests on. Fingerprinting the
+    whole premise meant withdrawing one misread assumption threw away every
+    saved search in the run, including searches for questions that never
+    depended on it -- run b88081a0 lost eighteen. An assumption a question does
+    not declare cannot have changed what its answer means.
+    """
+    depends_on = set(requirement.assumption_ids)
     return _fingerprint({
         "brief": work_order.brief_fingerprint,
         "subject": work_order.primary_subject,
         "scope": work_order.scope.model_dump(mode="json"),
-        "premise": [item.model_dump(mode="json") for item in work_order.premise],
+        "premise": [
+            item.model_dump(mode="json")
+            for item in work_order.premise
+            if item.assumption_id in depends_on
+        ],
         "requirement": requirement.model_dump(mode="json", exclude={"search_group"}),
     })
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -211,6 +211,18 @@ Rules:
   blocks of the Plaza Mayor". A false premise then comes back as a refuted
   premise, which is a finding, instead of as a failed question, which is a dead
   end.
+- **One claim per assumption.** An assumption is a thing that is true or false;
+  a sentence carrying three claims has no single answer, and one wrong part
+  refutes all of it. Run b88081a0 died on "the claims regarding a motorway at
+  the bottom of cliffs, a six-mile park on top, and the walk being the best
+  free thing to do are factually accurate" -- the park was confirmed, the
+  motorway was confirmed, and the whole assumption was refuted over a length
+  nobody had claimed. Split them: one statement, one fact, one verdict.
+- **Only write down what evidence could settle.** "The best free thing to do in
+  the city" is an opinion, and an opinion in `premise` can never come back
+  confirmed, so it blocks the article permanently. Taste, ranking and
+  significance belong in the brief, not here. If you cannot describe the search
+  that would prove an assumption wrong, it is not an assumption.
 - `references` must list every place the plan touches, and must include the
   subject itself. Roles are exactly `primary_subject`, `context_only` and
   `comparator`. Exactly one entry is the `primary_subject` -- that is the thing

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
@@ -205,3 +205,37 @@ def test_a_source_url_that_is_not_a_link_names_itself_in_the_failure(caplog):
         research.ResearchDependencies(None, StructureLLM(payload)))
     assert result["_retryable"] is True
     assert "www.example.pe" in caplog.text
+
+
+def test_withdrawing_an_unrelated_assumption_keeps_the_searches_it_never_touched():
+    """Striking one misread assumption used to discard every saved search.
+
+    `requirement_fingerprint` hashed the whole premise, so a question that
+    never declared an assumption still lost its answer when that assumption
+    was withdrawn. Run b88081a0 lost eighteen paid searches that way.
+    """
+    from app.features.prompt2blog.contracts_v4 import WorkOrderAssumption
+
+    work = _work_order(
+        premise=[
+            WorkOrderAssumption(assumption_id="a1", statement="Prices are published."),
+            WorkOrderAssumption(assumption_id="a2", statement="The bridge is open."),
+        ]
+    )
+    notes = {q.requirement_id: research.GatheredNotes("cited notes") for q in work.requirements}
+    stored = research.notes_stage_record(work, notes)
+
+    # r1 declares a1; r2 declares nothing. Withdraw a2, which neither uses.
+    without_a2 = work.model_copy(
+        update={"premise": [item for item in work.premise if item.assumption_id != "a2"]}
+    )
+
+    kept = research.notes_from_record(stored, without_a2)
+
+    assert set(kept) == {"r1", "r2"}, "an assumption nobody declared invalidated everything"
+
+    # Withdrawing a1 still invalidates r1, which does declare it.
+    without_a1 = work.model_copy(
+        update={"premise": [item for item in work.premise if item.assumption_id != "a1"]}
+    )
+    assert set(research.notes_from_record(stored, without_a1)) == {"r2"}

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -250,3 +250,78 @@ def test_the_openings_are_measurements_and_never_gate_a_run():
     for key in measure_sentence_openings("A sentence about Lima."):
         assert key in CONSTRAINT_MEASUREMENT_KEYS
         assert key not in HARD_CONSTRAINT_CHECK_KEYS
+
+
+# --- a refuted assumption is a decision, not a dead end (#526) -------------
+
+
+def test_the_work_order_is_told_one_claim_per_assumption():
+    """Run b88081a0 died on an assumption carrying three claims: a park length
+    research confirmed, a motorway length nobody claimed, and an opinion the
+    research itself called unconfirmable."""
+    from app.features.prompt2blog.work_order_v4 import build_work_order_prompt
+
+    prompt = build_work_order_prompt.__doc__ or ""
+    from app.features.prompt2blog import work_order_v4
+
+    source = work_order_v4.WORK_ORDER_PROMPT if hasattr(
+        work_order_v4, "WORK_ORDER_PROMPT"
+    ) else ""
+    text = (prompt + source).lower()
+    if not text.strip():
+        import inspect
+
+        text = inspect.getsource(build_work_order_prompt).lower()
+
+    assert "one claim per assumption" in text
+    assert "opinion" in text
+
+
+def test_an_operator_can_withdraw_an_assumption_and_the_facts_survive():
+    from app.features.prompt2blog.gate_v4 import strike_assumption
+    from test_prompt2blog_v3_instructions import _fixture
+    from app.features.prompt2blog.contracts_v4 import (
+        EvidencePackage,
+        Prompt2BlogWorkOrder,
+    )
+    import json as _json
+
+    fixture = _fixture()
+    order_payload = _json.loads(_json.dumps(fixture["work_order"]))
+    # The fixture predates premise; give it one, the way a real plan carries it.
+    order_payload["premise"] = [
+        {"assumption_id": "a1", "statement": "The market publishes its prices."}
+    ]
+    order_payload["requirements"][0]["assumption_ids"] = ["a1"]
+    work_order = Prompt2BlogWorkOrder.model_validate(order_payload)
+    evidence = EvidencePackage.model_validate(fixture["evidence_package"])
+    assumption = "a1"
+    claims_before = [claim.claim_id for claim in evidence.claims]
+
+    evidence, work_order = strike_assumption(
+        evidence, work_order, assumption_id=assumption
+    )
+
+    assert assumption not in {item.assumption_id for item in work_order.premise}
+    # The questions that rested on it keep their answers: withdrawing a claim
+    # about the world does not unmake the facts that were found.
+    assert [claim.claim_id for claim in evidence.claims] == claims_before
+    for requirement in work_order.requirements:
+        assert assumption not in requirement.assumption_ids
+
+
+def test_withdrawing_an_assumption_nobody_declared_is_refused():
+    from app.features.prompt2blog.gate_v4 import GateAnswerRefused, strike_assumption
+    from test_prompt2blog_v3_instructions import _fixture
+    from app.features.prompt2blog.contracts_v4 import (
+        EvidencePackage,
+        Prompt2BlogWorkOrder,
+    )
+
+    fixture = _fixture()
+    with pytest.raises(GateAnswerRefused, match="not an assumption"):
+        strike_assumption(
+            EvidencePackage.model_validate(fixture["evidence_package"]),
+            Prompt2BlogWorkOrder.model_validate(fixture["work_order"]),
+            assumption_id="never-declared",
+        )


### PR DESCRIPTION
Closes #526. Found by driving a real run; fixed and then verified on that same run.

## What happened

Run `b88081a0` researched cleanly, settled its gates, and refused to write:

```
premise_refuted. headline_claims_true was assumed and turned out not to be so.
More research will not change that.
```

The refusal was right. The assumption was not:

> The claims made in the headline regarding **a motorway at the bottom of cliffs**, **a six-mile park on top**, and **the walk being the best free thing to do in Lima** are factually accurate.

Research's own verdict on the three:

| claim | verdict |
|---|---|
| six-mile park | **confirmed** |
| motorway at the bottom of the cliffs | **confirmed** |
| the motorway is six miles | refuted — **and the seed never claimed it** |
| "best free thing to do" | *"subjective and cannot be factually confirmed or refuted"* |

The seed reads *"a motorway at the bottom of its cliffs and six miles of park on top"*. The six miles is the park. One misread sub-claim killed an article whose real premise had been confirmed twice — `continuous_park_path` ✅, `walk_is_significant` ✅.

## Three fixes

**1. One claim per assumption.** The brief prompt has carried this rule for `must_name` for months — *"one name per entry, never several in one string"* — because three obligations in one string can only be measured as one. Same fault, fixed in one place and not the other.

**2. Don't write down what evidence cannot settle.** "Best free thing to do" is an opinion. An opinion in `premise` can never come back confirmed, so it is a permanent block waiting to happen. Taste and ranking belong in the brief.

**3. A refuted assumption gets the exit a blocked question already had.** A question research could not answer has five moves — answer it, mark it unpublished, mark it nonexistent, strike a must_name, omit it. An assumption research *disproved* had none, and the error helpfully explained that more research would not help.

`settle_premise` withdraws one. It requires a written reason, because this is a claim about the world the operator is making instead of the research, and a wrong fact in a finished article has to be traceable to a person. The questions that rested on it keep their answers — withdrawing a claim about the world does not unmake the facts that were found.

Verified on the blocked run: `premise_refuted` → `ready_to_write`, no model call, and the article was then written.

## A fourth thing this exposed, from my own earlier PR

`requirement_fingerprint` (#500) hashed the **entire** premise, so withdrawing one misread assumption discarded **every saved search in the run** — including questions that never declared it. Run `b88081a0` lost eighteen. It now covers only the assumptions a requirement actually depends on, with a test proving an unrelated withdrawal keeps its searches and a related one still invalidates.

## And one I found the expensive way

The first version of `settle_premise` omitted the `STATE_KEY` line that `settle_gate` carries. Recording the decision overwrote the dossier with its own summary and **destroyed the research it existed to rescue** — about $0.20. The line is there now with a comment saying what it cost, because the next person copying this pattern will make the same mistake.

Backend suite: 1439 passed, 0 failed.
