### PR TITLE
fix(p2b): the subject is the subject, the output ceiling arrives, a handle is not a title

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
@@ -178,7 +178,7 @@ def _invoke_schema_json_llm(
         correlation_id=correlation_id,
         endpoint="invoke_json",
     ) as observed:
-        options = {"input_schema": schema}
+        options = {"input_schema": schema, "max_tokens": max_tokens}
         if job_id == "p2b.research_structure" and reported_model == "gemini-2.5-flash":
             options["thinking_budget"] = 0
         try:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -1195,6 +1195,11 @@ PREMISE_SCHEMA = require_non_empty({
 })
 
 
+# The shape `_batch_source_table` mints. A value matching it is a stand-in
+# for a link, never a fact about the source.
+_HANDLE = re.compile(r"URL\d+")
+
+
 def _batch_source_table(
     requirements: list[WorkOrderRequirement], notes: dict[str, GatheredNotes],
 ) -> dict[str, str]:
@@ -1453,6 +1458,13 @@ def _structure_batch(
             ):
                 unresolved.append(resolved)
             source["url"] = resolved
+            # The model reads `URL7` where a link used to be and reasonably
+            # uses it as the source's name too. Restoring only the url left 429
+            # of 543 titles in run 95a74dce reading "URL1", "URL2" -- a
+            # bibliography with no identifying information in it at all. A
+            # handle is never a title; say so rather than shipping one.
+            if _HANDLE.fullmatch(_safe_str(source.get("title"))):
+                source["title"] = "Untitled source"
         if unresolved:
             raise ResearchUnusable(
                 "Structuring returned source URLs that are not links: "

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -229,6 +229,20 @@ Rules:
   the article is about. Somewhere mentioned only for calibration is
   `context_only` and can never become a co-subject. Somewhere being weighed
   against the subject is a `comparator`.
+- **`primary_subject` is the thing the article is about, not the city it is
+  in.** The city is already in `Location` above. A piece about one clifftop
+  path has that path as its primary subject, not the capital it runs through.
+  Run a3c20e41 set `primary_subject` to "Lima, Peru" and filed the Malecón
+  itself, plus every district the walk crosses, as `context_only`. A
+  context-only reference may never be what a section is about, so the outline
+  was forbidden from naming the path or any district in a heading, all three of
+  its sections were rejected, and the article was written with no plan at all.
+- **A place inside the subject is part of it, not context.** The districts a
+  route crosses, the neighbourhoods an area guide covers, the rooms of a
+  building: those are the subject's own parts and the article is expected to
+  structure around them, so they are not `context_only`. Reserve
+  `context_only` for somewhere genuinely outside the piece that a fact is
+  measured against -- another city's rent, a nearby town's opening hours.
 """
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
@@ -239,3 +239,23 @@ def test_withdrawing_an_unrelated_assumption_keeps_the_searches_it_never_touched
         update={"premise": [item for item in work.premise if item.assumption_id != "a1"]}
     )
     assert set(research.notes_from_record(stored, without_a1)) == {"r2"}
+
+
+def test_the_output_ceiling_reaches_gemini_and_a_cut_off_reply_says_so():
+    """Callers passed `max_tokens` and `invoke_json` swallowed it, so
+    structuring ran on the provider default and came back cut off mid-string."""
+    requests = []
+
+    class Provider:
+        def generate(self, prompts, **kwargs):
+            requests.append(kwargs)
+            return SimpleNamespace(
+                generations=[[SimpleNamespace(text='{"a": "unterminat',
+                                              generation_info={})]]
+            )
+
+    adapter = VertexTextLLM(Provider(), "gemini-2.5-flash")
+    with pytest.raises(ValueError, match="stops mid-value"):
+        adapter.invoke_json("notes", input_schema={"type": "object"}, max_tokens=8192)
+
+    assert requests[0]["max_output_tokens"] == 8192

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_usage_monitor.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_usage_monitor.py
@@ -182,7 +182,17 @@ def test_with_no_monitor_configured_nothing_is_reported(monkeypatch):
 
 
 class _SchemaVertexAI(VertexAI):
-    def invoke_json(self, prompt: str, input_schema: dict[str, Any]) -> dict[str, Any]:
+    # Same signature the real adapters carry. A double that accepts less than
+    # the real thing hides a caller passing more -- which is how a dropped
+    # output ceiling truncated structuring for a day.
+    def invoke_json(
+        self,
+        prompt: str,
+        *,
+        input_schema: dict[str, Any],
+        max_tokens: int | None = None,
+        thinking_budget: int | None = None,
+    ) -> dict[str, Any]:
         return {"title": "ok"}
 
 

--- a/apps/ai-blog-writer/packages/utils/src/utils/claude_cli_llm.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/claude_cli_llm.py
@@ -130,8 +130,23 @@ class ClaudeCliTextLLM:
     def invoke(self, prompt: str) -> str:
         return self._call(prompt, None)["text"]
 
-    def invoke_json(self, prompt: str, *, input_schema: dict[str, Any]) -> Any:
+    def invoke_json(
+        self,
+        prompt: str,
+        *,
+        input_schema: dict[str, Any],
+        max_tokens: int | None = None,
+        thinking_budget: int | None = None,
+    ) -> Any:
         """Ask for JSON the transport validates, rather than JSON to parse.
+
+        `max_tokens` and `thinking_budget` are accepted and ignored. The CLI
+        takes neither: it has no output ceiling flag and no temperature or
+        thinking control. Accepting them keeps one call signature across
+        providers, so the caller does not have to know which provider it got --
+        and silently dropping an output ceiling is exactly what truncated
+        structuring on the Gemini path, so it is written down here rather than
+        discovered again.
 
         Present only on this provider, and callers detect it by asking whether
         it exists. That is what keeps the schema path opt-in per provider: a

--- a/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
@@ -280,16 +280,38 @@ class VertexTextLLM:
         return str(generations[0].text if generations else '') or ''
 
     def invoke_json(self, prompt: str, *, input_schema: dict[str, Any],
-                    thinking_budget: int | None = None) -> dict[str, Any]:
+                    thinking_budget: int | None = None,
+                    max_tokens: int | None = None) -> dict[str, Any]:
+        """One schema-enforced JSON call.
+
+        `max_tokens` has to be forwarded. Callers pass an output ceiling and
+        this method used to swallow it, so structuring ran on the provider
+        default and returned JSON cut off mid-string -- run a3c20e41 lost four
+        questions to "Unterminated string starting at line 468", 16,640
+        characters into a call whose caller had asked for 8,192 tokens.
+        """
         options: dict[str, Any] = {
             "response_mime_type": "application/json",
             "response_schema": _sanitize_gemini_tool_schema(input_schema),
         }
         if thinking_budget is not None and self.model_name == "gemini-2.5-flash":
             options["thinking_budget"] = thinking_budget
+        if max_tokens is not None:
+            options["max_output_tokens"] = max_tokens
         result = self._llm.generate([prompt], **options)
         self.last_usage_metadata = _usage_from_generation(result)
-        parsed = json.loads(result.generations[0][0].text)
+        text = result.generations[0][0].text
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as error:
+            # A truncated response is an output-ceiling problem, not a bad
+            # model. Say which, so the next person does not go looking at the
+            # prompt.
+            raise ValueError(
+                f"Gemini returned JSON that stops mid-value after {len(text)} "
+                f"characters ({error}). The output ceiling was "
+                f"{max_tokens or 'the provider default'}."
+            ) from error
         if not isinstance(parsed, dict):
             raise ValueError("Structured Gemini response must be an object")
         validate_json_shape(parsed, input_schema)


### PR DESCRIPTION
Three faults a complete seed-to-article run turned up. Closes #528, #508, and the truncation half of #501.

## #528 — the article's own subject was filed as context

Run `a3c20e41`:

```
primary subject:  Lima, Peru
  context_only    Malecón          ← what the article is about
  context_only    Miraflores
  context_only    Barranco
```

The rule the outline is held to: *"Context-only references … may never become co-subjects, recurring sections, rankings, or verdicts."*

So an article whose spine is *"the walk itself, north to south, each district the path crosses gets its stretch"* was **forbidden from naming a single one of those districts in a heading**. All three sections rejected, compose wrote with no plan, 534 words against a 900 target.

The work order is now told `primary_subject` is the thing the article is about, not the city it sits in — `Location` already carries the city — and that a place **inside** the subject is part of it, not context. The districts a route crosses are what the piece structures around; `context_only` is for somewhere genuinely outside it that a fact is measured against.

## The truncation half of #501

`invoke_json` never forwarded `max_tokens`. Callers pass an output ceiling; my #500 signature swallowed it. So structuring ran on the provider default and returned JSON cut off mid-string:

```
Unterminated string starting at: line 468 column 14 (char 16640)
```

16,640 characters into a call whose caller had asked for **8,192 tokens**. Four questions lost on that run, and the same failure appears earlier in the day.

Forwarded now. A `JSONDecodeError` becomes a message naming the length and the ceiling in force, so the next person does not go looking at the prompt. The Claude adapter accepts the argument and **documents that it drops it** — the CLI has no output flag, and silently dropping this is the bug being fixed.

This does not close #501 outright: the invalid-source-URL failure is a separate mode and stays open.

## #508 — a handle is not a title

#500 swapped long grounding URLs for `URL7`-style handles and restored only `source["url"]`. The model reasonably used the handle as the source's **name** too — 429 of 543 titles in run `95a74dce` read `URL1`, `URL2`. A title matching the handle shape is now refused rather than shipped.

## One test double was lying

`_SchemaVertexAI` in the usage-monitor tests accepted a narrower signature than the real adapters, which is how a caller passing an extra argument went unnoticed. It carries the real signature now, with a comment saying why that matters.

Backend suite: 1442 passed, 0 failed.
