### PR TITLE
fix(p2b): stop sending a per-call output ceiling that lowers the real one

### DIFF
--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research_efficiency.py
@@ -241,9 +241,14 @@ def test_withdrawing_an_unrelated_assumption_keeps_the_searches_it_never_touched
     assert set(research.notes_from_record(stored, without_a1)) == {"r2"}
 
 
-def test_the_output_ceiling_reaches_gemini_and_a_cut_off_reply_says_so():
-    """Callers passed `max_tokens` and `invoke_json` swallowed it, so
-    structuring ran on the provider default and came back cut off mid-string."""
+def test_the_per_call_ceiling_is_not_sent_and_a_cut_off_reply_still_says_so():
+    """The ceiling is set when the model is built, not per call.
+
+    `get_vertex_llm` runs the caller's number through
+    `_resolve_generation_max_tokens`, which raises it to a floor. Sending the
+    caller's own smaller number again per call lowers it -- which cut an
+    outline call to 255 characters of unterminated JSON.
+    """
     requests = []
 
     class Provider:
@@ -258,4 +263,6 @@ def test_the_output_ceiling_reaches_gemini_and_a_cut_off_reply_says_so():
     with pytest.raises(ValueError, match="stops mid-value"):
         adapter.invoke_json("notes", input_schema={"type": "object"}, max_tokens=8192)
 
-    assert requests[0]["max_output_tokens"] == 8192
+    assert "max_output_tokens" not in requests[0], (
+        "sending this per call lowers the ceiling the model was built with"
+    )

--- a/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/llm_client.py
@@ -284,11 +284,18 @@ class VertexTextLLM:
                     max_tokens: int | None = None) -> dict[str, Any]:
         """One schema-enforced JSON call.
 
-        `max_tokens` has to be forwarded. Callers pass an output ceiling and
-        this method used to swallow it, so structuring ran on the provider
-        default and returned JSON cut off mid-string -- run a3c20e41 lost four
-        questions to "Unterminated string starting at line 468", 16,640
-        characters into a call whose caller had asked for 8,192 tokens.
+        `max_tokens` is accepted and deliberately NOT sent. The ceiling is
+        already set when the model is built: `get_vertex_llm` passes it through
+        `_resolve_generation_max_tokens`, which raises it to a floor. Sending
+        the caller's own smaller number per call therefore *lowers* the
+        ceiling, and doing that cut the outline call to 255 characters of
+        unterminated JSON against a limit it never came close to.
+
+        This method forwarded it for one commit, and that is why the argument
+        is still in the signature rather than removed: callers pass it, the
+        Claude adapter accepts it, and a reader deserves to find out here that
+        it is intentionally dropped rather than discover it again the way I
+        did.
         """
         options: dict[str, Any] = {
             "response_mime_type": "application/json",
@@ -296,8 +303,6 @@ class VertexTextLLM:
         }
         if thinking_budget is not None and self.model_name == "gemini-2.5-flash":
             options["thinking_budget"] = thinking_budget
-        if max_tokens is not None:
-            options["max_output_tokens"] = max_tokens
         result = self._llm.generate([prompt], **options)
         self.last_usage_metadata = _usage_from_generation(result)
         text = result.generations[0][0].text
@@ -309,8 +314,7 @@ class VertexTextLLM:
             # prompt.
             raise ValueError(
                 f"Gemini returned JSON that stops mid-value after {len(text)} "
-                f"characters ({error}). The output ceiling was "
-                f"{max_tokens or 'the provider default'}."
+                f"characters ({error})."
             ) from error
         if not isinstance(parsed, dict):
             raise ValueError("Structured Gemini response must be an object")


### PR DESCRIPTION
Reverts the `max_output_tokens` forwarding from #529. It was backwards and I shipped it.

The ceiling is already applied when the model is built — `get_vertex_llm` passes the caller's number through `_resolve_generation_max_tokens`, which **raises** it to a floor. Sending the caller's own smaller number again per call therefore **lowers** the real ceiling.

On the outline stage that swapped a large ceiling for 2,048 and produced:

```
Gemini returned JSON that stops mid-value after 255 characters. The output ceiling was 2048.
```

A worse failure than the one I was fixing, on a run that had been working.

The original truncation at 16,640 characters was therefore **never** a dropped ceiling. Its cause is still unknown and belongs with #501, which stays open.

The argument stays in the signature — callers pass it, the Claude adapter accepts it — and is now documented as deliberately dropped, at the place someone would look for it. The clearer `JSONDecodeError` message stays; it no longer claims to know the ceiling.

Backend suite: 1442 passed, 0 failed.