### PR TITLE
fix(p2b): a heading may name a context-only place, it may not be about one

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -82,6 +82,30 @@ def _mentions(text: str, name: str) -> bool:
     )
 
 
+_SUBJECT_LEAD_SKIP = {"the", "a", "an"}
+
+
+def _names_subject(heading: str, primary_subject: str) -> bool:
+    """Whether a heading names the article's own subject.
+
+    `_mentions` wants the whole phrase, with a comma shorthand for geography
+    ("Medellin, Colombia" matches a heading saying "Medellin"). A subject that
+    is not a place does not decompose that way: `primary_subject` was "Chifa
+    cuisine" and every heading said "Chifa", so nothing matched and headings
+    that plainly named the subject read as drift.
+
+    So the leading word counts too. "Chifa cuisine" is named by "Chifa";
+    "The Malecon" by "Malecon". An article is a poor fit for this check if its
+    subject's first word is a bare category noun, which is why it is only ever
+    used to *permit* a heading, never to condemn one.
+    """
+    if _mentions(heading, primary_subject):
+        return True
+    locality = primary_subject.split(",", maxsplit=1)[0]
+    words = [word for word in locality.split() if word.casefold() not in _SUBJECT_LEAD_SKIP]
+    return bool(words) and _mentions(heading, words[0])
+
+
 def validate_v3_outline(
     outline: dict[str, Any],
     *,
@@ -128,15 +152,26 @@ def validate_v3_outline(
         for reference in references
         if reference.get("role") == "context_only"
     ]
+    primary_subject = _safe_str(work_order.get("primary_subject"))
+    # A context-only place may be discussed inside a section and may not be
+    # what the section is about. Mentioning it is not being about it: a heading
+    # that names the subject as well is contrasting, not drifting.
+    #
+    # Run 90f348df was commissioned on the spine "the chifa worth eating is not
+    # in Barrio Chino", and the heading that states exactly that -- "Beyond
+    # Barrio Chino: Where Lima's Best Chifa Resides" -- was struck for naming
+    # Barrio Chino, along with three more. Four sections deleted and an article
+    # written round the holes. The rule was reading any mention as ownership.
     context_only_headings = sorted(
         {
             section["heading"]
             for section in sections
             for name in context_only
-            if name and _mentions(section["heading"], name)
+            if name
+            and _mentions(section["heading"], name)
+            and not _names_subject(section["heading"], primary_subject)
         }
     )
-    primary_subject = _safe_str(work_order.get("primary_subject"))
     # A well-built outline often names the subject once in its framing and then
     # relies on subject-specific detail in the sections ("El Poblado", "Museo de
     # Antioquia") rather than repeating the city in every heading. Genuine drift

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -325,3 +325,40 @@ def test_withdrawing_an_assumption_nobody_declared_is_refused():
             Prompt2BlogWorkOrder.model_validate(fixture["work_order"]),
             assumption_id="never-declared",
         )
+
+
+# --- a context-only place may be named in a heading, not owned by one ------
+
+
+def test_a_heading_may_contrast_with_a_context_only_place():
+    """Run 90f348df's spine was "the chifa worth eating is not in Barrio
+    Chino", and the heading saying exactly that was struck for naming Barrio
+    Chino. Four sections were deleted and the article written round the holes.
+    """
+    from app.features.prompt2blog.content.outline_v3 import _mentions, _names_subject
+
+    contexts = ["Barrio Chino, Lima, Peru", "Lima, Peru"]
+
+    def flagged(heading: str, subject: str = "Chifa cuisine") -> bool:
+        return any(_mentions(heading, c) for c in contexts) and not _names_subject(
+            heading, subject
+        )
+
+    # Names the context-only place AND the subject: contrast, not drift.
+    assert not flagged("Beyond Barrio Chino: Where Lima's Best Chifa Resides")
+    assert not flagged("Chifa's Prominence in Lima's Culinary Landscape")
+
+    # Genuinely about the context-only place. Still refused.
+    assert flagged("A History of Barrio Chino")
+    assert flagged("Where to Eat in Barrio Chino")
+
+
+def test_the_subject_is_recognised_by_its_leading_word():
+    """`_mentions` wants the whole phrase. `primary_subject` was "Chifa
+    cuisine" and every heading said "Chifa", so nothing matched."""
+    from app.features.prompt2blog.content.outline_v3 import _names_subject
+
+    assert _names_subject("Where the Best Chifa Is", "Chifa cuisine")
+    assert _names_subject("Walking the Malecon", "The Malecon")
+    assert _names_subject("Medellin After Dark", "Medellin, Colombia")
+    assert not _names_subject("Getting There by Taxi", "Chifa cuisine")


### PR DESCRIPTION
A context-only reference may be discussed inside a section and may never be what the section is about. The check read any *mention* as ownership.

Run `90f348df` was commissioned on the spine **"the chifa worth eating is not in Barrio Chino"**. The heading stating exactly that was struck for naming Barrio Chino:

```
outline repaired by dropping context-only sections:
  "Beyond Barrio Chino: Where Lima's Best Chifa Resides"
  "Chifa's Prominence in Lima's Culinary Landscape"
  "Getting to Madam Tusan from Lima's Tourist Areas"
  "Other Madam Tusan Locations in Lima"
```

Four sections deleted, the article written round the holes: 828 words scoring **4/10**. The one heading carrying the article's argument was the one the rule refused.

A heading naming the subject as well is contrasting, not drifting, and now passes. `A History of Barrio Chino` still fails, because that section really is about the place.

**Recognising the subject needed widening too.** `_mentions` wants the whole phrase, with a comma shorthand for geography (`Medellín, Colombia` matches a heading saying `Medellín`). A subject that is not a place does not decompose that way — `primary_subject` was `Chifa cuisine` and every heading said `Chifa`, so nothing matched. The leading word counts now, and it is only ever used to **permit** a heading, never to condemn one.

Note this is the second edge of #528. That fix corrected `primary_subject` (it is `Chifa cuisine` now, not `Lima, Peru`) and was verified working on this run — this is a different failure in the same rule.

Backend suite: 1446 passed, 0 failed.