### PR TITLE
fix(p2b): a question researched alone has to stand alone

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass
 from typing import Any, get_args
 
@@ -194,6 +195,18 @@ Rules:
   detail, something that puts the reader somewhere. Ask for texture: a dossier
   with nothing a reader would enjoy is a real gap, not a success.
 - At least one question must be load_bearing.
+- **Every question is researched on its own, by someone who cannot see the
+  others.** So a question may never point at another question, and may never
+  carry a blank for somebody to fill in. Both come back unanswered, every time:
+  run 36ade5ea asked "the general atmosphere of the restaurant identified in
+  'req_restaurant_1_name'" three times and got `missing` three times, which
+  left the dossier with no texture at all and blocked the article. Run 90f348df
+  wrote "[RECOMMENDED CHIFA RESTAURANT NAME]" into its own questions and
+  declared, as an assumption, that someone would replace it.
+  If you do not yet know which restaurant, ask for the thing itself -- "the
+  dining rooms of the best regarded chifa restaurants in San Isidro and
+  Miraflores, and who eats in them" -- not for a detail about an answer you
+  have not got.
 - Do not write a question whose answer the writer already has above.
 - Anything you are assuming without being able to check it goes in `premise`,
   with the questions that rest on it listing its id. An assumption nobody wrote
@@ -350,6 +363,29 @@ def _premise_from(payload: dict[str, Any]) -> list[WorkOrderAssumption]:
     return premise
 
 
+# A blank for somebody to fill in, and a pointer at another question. Both
+# describe an answer this question does not have, and every question is
+# researched alone by someone who cannot see the others, so both come back
+# `missing`. Run 36ade5ea lost all three of its texture questions to the second
+# form and was refused for having nothing worth reading; run 90f348df wrote the
+# first form into its questions and then declared, as an assumption, that
+# someone would replace it.
+_PLACEHOLDER = re.compile(r"\[[A-Z0-9 _\-]{3,}\]")
+_POINTS_AT_ANOTHER_QUESTION = re.compile(
+    r"\b(?:identified|named|found|listed|determined|selected|chosen)\s+in\b"
+    r"|\b(?:from|in)\s+(?:question|requirement)\b"
+    r"|\breq_[a-z0-9_]+\b",
+    re.IGNORECASE,
+)
+
+
+def _answerable_alone(question: str) -> bool:
+    """Whether one researcher, seeing only this question, could answer it."""
+    return not (
+        _PLACEHOLDER.search(question) or _POINTS_AT_ANOTHER_QUESTION.search(question)
+    )
+
+
 def _requirements_from(
     payload: dict[str, Any],
     declared: set[str] | None = None,
@@ -377,6 +413,16 @@ def _requirements_from(
         question = _safe_str(_first(record, "question", "query", "text", "ask"))
         kind = _safe_str(record.get("kind"))
         if not question or kind not in {"load_bearing", "texture"}:
+            dropped += 1
+            continue
+        if not _answerable_alone(question):
+            # Dropped rather than repaired: the question is about an answer
+            # nobody has yet, and guessing which one would invent the plan.
+            logger.warning(
+                "Dropping a question that depends on another question's "
+                "answer: %r",
+                question[:120],
+            )
             dropped += 1
             continue
         assumption_ids = _safe_str_list(

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -362,3 +362,34 @@ def test_the_subject_is_recognised_by_its_leading_word():
     assert _names_subject("Walking the Malecon", "The Malecon")
     assert _names_subject("Medellin After Dark", "Medellin, Colombia")
     assert not _names_subject("Getting There by Taxi", "Chifa cuisine")
+
+
+# --- a question is researched alone, so it must stand alone ----------------
+
+
+def test_a_question_pointing_at_another_question_is_dropped():
+    """Run 36ade5ea asked "the atmosphere of the restaurant identified in
+    'req_restaurant_1_name'" three times, got `missing` three times, and was
+    refused for having nothing worth reading."""
+    from app.features.prompt2blog.work_order_v4 import _answerable_alone
+
+    assert not _answerable_alone(
+        "Describe the atmosphere of the restaurant identified in 'req_restaurant_1_name'."
+    )
+    assert not _answerable_alone("What does the dish named in question 2 cost?")
+    assert not _answerable_alone(
+        "What are the opening hours of [RECOMMENDED CHIFA RESTAURANT NAME]?"
+    )
+    assert not _answerable_alone("The price of the hotel selected in req_hotel_pick.")
+
+
+def test_a_question_that_stands_on_its_own_is_kept():
+    from app.features.prompt2blog.work_order_v4 import _answerable_alone
+
+    assert _answerable_alone(
+        "What do the dining rooms of the best regarded chifa restaurants in San "
+        "Isidro and Miraflores look like, and who eats in them?"
+    )
+    assert _answerable_alone("What does a plate of lomo saltado cost in Lima in 2026?")
+    # A bracketed aside is not a placeholder.
+    assert _answerable_alone("What are the hours of Chifa Titi [San Isidro]?")


### PR DESCRIPTION
Every question is researched on its own, by a call that cannot see the others. Two shapes therefore come back `missing` every time, and the work order kept writing both.

## What it cost

**Run `36ade5ea`** asked this, three times, as all three of its texture questions:

> Describe the general atmosphere and typical clientele of the restaurant identified in **'req_restaurant_1_name'**

All three came back `missing`, and the run was refused at the gate:

```
nothing_worth_reading. Every answer proves something and none of it
puts a reader anywhere.
```

Twenty-four load-bearing answers and no article, because the only questions that would have put a reader anywhere were about an answer nobody had yet.

**Run `90f348df`** wrote `[RECOMMENDED CHIFA RESTAURANT NAME]` into its own questions, then declared as a premise that someone would replace it — which research refuted, while separately finding the restaurants it was asking about.

## The fix

The prompt now names both shapes, with these runs as the examples, and says what to ask instead: **the thing itself**, not a detail about an answer you have not got.

`_answerable_alone` also drops them at parse time. The prompt has asked for separately checkable questions since it was written and got these anyway, so the rule is enforced rather than requested.

Dropped rather than repaired — the question is about an answer nobody has, and guessing which one would invent the plan.

Backend suite: 1448 passed, 0 failed.