### PR TITLE
fix(p2b): the premise guard speaks once a run, not once a batch

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -1396,21 +1396,31 @@ def _merge_sources(parts: list[dict[str, Any]]) -> tuple[list[dict], dict[str, s
 
 
 def assemble_evidence(
-    work_order: Prompt2BlogWorkOrder, payload: dict[str, Any]
+    work_order: Prompt2BlogWorkOrder,
+    payload: dict[str, Any],
+    *,
+    reconcile_premises: bool = True,
 ) -> EvidencePackage:
     """Normalise what the model sent, then hold it to the contract.
 
     Separate from the calls that produce it, because what arrives is repaired
     the same way whether it came back in one piece or eleven.
+
+    `reconcile_premises=False` is for a single batch. A premise verdict is
+    about the whole dossier and a batch sees four questions, so `BATCH_SCHEMA`
+    has no `premise_findings` and `build_batch_prompt` asks for none. Judging a
+    batch against the declared premises therefore finds every one of them
+    missing, every time, on runs where nothing is wrong -- and the warning that
+    says "nobody checked your premises" is the same warning either way. The
+    reconciliation belongs where the whole dossier exists, after
+    `_settle_premise` has run.
     """
     payload = _normalised_evidence(_safe_dict(payload))
     payload["schema_version"] = 4
     payload["work_order_fingerprint"] = work_order.work_order_fingerprint
     try:
-        return _reconcile_premise_findings(
-            record_detected_conflicts(EvidencePackage.model_validate(payload)),
-            work_order,
-        )
+        package = record_detected_conflicts(EvidencePackage.model_validate(payload))
+        return _reconcile_premise_findings(package, work_order) if reconcile_premises else package
     except ValidationError as error:
         raise ResearchUnusable(
             "; ".join(
@@ -1472,7 +1482,7 @@ def _structure_batch(
                 _raw,
             )
         part = _namespaced(parsed, ids[0])
-        package = assemble_evidence(work_order, part)
+        package = assemble_evidence(work_order, part, reconcile_premises=False)
         if {item.requirement_id for item in package.requirements} != set(ids):
             raise ResearchUnusable("Structuring did not return exactly the requested questions", _raw)
         return package.model_dump(mode="json")

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
@@ -11,6 +11,7 @@ re-run. Do not read a green run here as "research works".
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from datetime import date
@@ -962,6 +963,38 @@ def test_questions_are_structured_a_few_at_a_time():
 
     # Three batches over nine questions, plus the premise pass.
     assert len(llm.prompts) == 4
+
+
+def test_the_premise_guard_speaks_once_a_run_not_once_a_batch(caplog):
+    """The warning means "nobody checked your premises". It has to stay rare.
+
+    Run 03c6702f logged it four times in a row, once per structuring batch,
+    naming all eight declared assumptions each time -- on a run where the
+    premise pass had simply not happened yet. A batch cannot carry a premise
+    verdict, so judging one against the declared premises is a false alarm on
+    every healthy run, and it made the one real case (95a74dce, a genuinely
+    unanswered premise) indistinguishable from noise.
+    """
+    count = STRUCTURE_BATCH_SIZE * 2 + 1
+    deps, _llm = _per_question_deps(
+        {
+            f"r{index}": _one_question_payload(f"r{index}", f"https://example.pe/{index}")
+            for index in range(1, count + 1)
+        }
+    )
+    notes = {f"r{index}": GatheredNotes("Notes.") for index in range(1, count + 1)}
+
+    with caplog.at_level(logging.WARNING):
+        evidence = structure_research(_wide_work_order(count), notes, deps)
+
+    warnings = [
+        record for record in caplog.records
+        if "returned no premise verdict" in record.getMessage()
+    ]
+    # Three batches, and the fake premise pass answers nothing: still one.
+    assert len(warnings) == 1
+    # And the guard still did its job -- the declared premise has a verdict.
+    assert [finding.verdict for finding in evidence.premise_findings] == ["unverified"]
 
 
 def test_every_question_reaches_a_batch():


### PR DESCRIPTION
Closes #535.

## What was wrong

`_structure_batch` ended with `assemble_evidence(work_order, part)`, and `assemble_evidence` reconciles premises. But a batch cannot carry a premise verdict — `BATCH_SCHEMA` has no `premise_findings`, `build_batch_prompt` asks for none, and verdicts come from `_settle_premise`, which runs after every batch because a verdict is about the whole dossier and a batch sees four questions.

So on every run with declared assumptions, reconciliation ran once per batch against a payload that structurally cannot contain what it looks for, found all of them missing, logged the warning, and injected a fabricated `unverified` finding per assumption. Those findings were then discarded — `structure_research` builds the final package from `settled["premise_findings"]` and never reads `part["premise_findings"]`.

Run `03c6702f` logged it four times in a row, naming all eight declared assumptions each time. Eleven times, had it not hit the token ceiling first.

## The history the issue left unverified

Not load-bearing. Before `33a0a765` there was one structuring call and one reconciliation. That commit extracted the normalise → validate → reconcile block into `assemble_evidence` and reused it in both places; the batch call inherited the reconciliation rather than asking for it.

Same story for `record_detected_conflicts` at batch level — the final package takes `settled["conflicts"]`, so batch-level conflict detection is also discarded. Left alone here: it is wasted work, not a false alarm, and the final `assemble_evidence` still detects conflicts across the merged claims.

## The fix

Option 1 from the issue. `assemble_evidence` takes `reconcile_premises: bool = True`; `_structure_batch` passes `False` and gets the normalise-and-validate half it actually wants. The end-of-run reconciliation is untouched.

## Verified

- New test drives three batches with a premise pass that answers nothing, and asserts the warning fires **once**. Without the fix it logs four times (three batches + the real one) and the test fails.
- The test also asserts the declared premise still ends up `unverified`, so the guard still does its job.
- `pytest -k prompt2blog` green.