### PR TITLE
fix(p2b): the research questions are provenance, not a checklist

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -85,12 +85,29 @@ class V3InstructionSet(InstructionModel):
     instruction_meta: dict[str, Any]
 
 
-def _brief_body(brief: ArticleBrief, work_order: Prompt2BlogWorkOrder) -> str:
+def _brief_body(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    *,
+    include_requirements: bool = True,
+) -> str:
     """The brief and its work order, rendered for a prompt.
 
     The order here is still the v3 order. Leading with the brief, and reframing
     evidence as the facts you may use rather than the article's reason for
     existing, is A5 and lands with the compose rework.
+
+    `include_requirements` exists because the research questions are only ever
+    useful to one stage. They used to arrive everywhere under a bare
+    `Requirements:` heading with nothing saying what they were, and a plan can
+    now carry forty-four of them. A judge handed forty-four items called
+    requirements marks a draft down for each one missing; a repair pass handed
+    the same list adds them back, one paragraph each, and the article becomes a
+    coverage checklist. That is the mechanism behind #506, and the word is
+    ambiguous in both prompts: the audit uses "requirement" for a section's
+    job, and repair is told it may not change "the requirements" meaning the
+    approved scope. Only the outline needs the ids, because it must name the
+    `requirement_ids` each section serves.
     """
     references = "\n".join(
         f"- {reference.name} — {reference.role}"
@@ -122,8 +139,16 @@ def _brief_body(brief: ArticleBrief, work_order: Prompt2BlogWorkOrder) -> str:
         must_name,
         "Material the writer has:",
         material,
-        "Requirements:",
-        requirements,
+    ]
+    if include_requirements:
+        lines += [
+            "Questions research was sent to answer. These are provenance and "
+            "the ids you cite, not a checklist the article owes an answer to. "
+            "A question whose answer earned no place in the piece is not a "
+            "hole; what the article may say is the evidence, not this list.",
+            requirements,
+        ]
+    lines += [
         f"This piece fails if: {brief.fails_if}",
         "Context-only references may calibrate a fact or explain significance. "
         "They may never become co-subjects, recurring sections, rankings, or "
@@ -327,12 +352,16 @@ def _repair_lock_body(
     *,
     form_label: str,
 ) -> str:
+    """The scope this repair may not move, and nothing else.
+
+    The research questions used to be pasted here under `Requirements:`. They
+    are not scope -- the outcome, spine, reader question, form and `fails_if`
+    are -- and repair is separately forbidden to add facts, so the list could
+    only ever be read as a checklist to satisfy. See `_brief_body`.
+    """
     references = "\n".join(
         f"- {reference.name} — {reference.role}"
         for reference in work_order.scope.references
-    )
-    requirements = "\n".join(
-        f"- {item.requirement_id} — {item.question}" for item in work_order.requirements
     )
     must_name = "\n".join(f"- {item}" for item in brief.must_name)
     return "\n".join(
@@ -345,8 +374,6 @@ def _repair_lock_body(
             f"Core reader question: {brief.reader_question}",
             "Reference roles:",
             references,
-            "Requirements:",
-            requirements,
             "Must name:",
             must_name or "- None recorded.",
             f"It fails if: {brief.fails_if}",
@@ -477,7 +504,10 @@ def assemble_v3_instructions(
     ]
 
     form_structure = _form_structure(form.instructions)
-    brief_body = _brief_body(brief, work_order)
+    # The outline names the `requirement_ids` each section serves, so it is the
+    # one stage that needs them. Everywhere else the list is noise at best.
+    outline_brief_body = _brief_body(brief, work_order)
+    brief_body = _brief_body(brief, work_order, include_requirements=False)
     audience_body = _audience_body(brief, catalog)
     topic_modules_body = (
         "\n\n".join(module.instructions for module in active_modules)
@@ -497,7 +527,7 @@ def assemble_v3_instructions(
                 # give it a good plan and it writes well, give it an audit and
                 # it writes an excellent audit. This stage decides which.
                 ("voice", f"THE VOICE YOU ARE WRITING IN\n{catalog.voice.instructions}"),
-                ("brief", f"APPROVED BRIEF\n{brief_body}"),
+                ("brief", f"APPROVED BRIEF\n{outline_brief_body}"),
                 ("audience", f"AUDIENCE GUIDANCE\n{audience_body}"),
                 (
                     "form_structure",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -330,7 +330,7 @@ Rules:
   asked to be lengthened.
 - Repair prose and structure only. You may not create a fact, and you may not
   change the brief: not the form, the primary subject, the scope mode, the
-  reference roles, the requirements, or the exclusions.
+  reference roles, the approved scope, or the exclusions.
 - Never add factual material. Work only with facts already present in the
   previous draft. Apply the EVIDENCE DISPOSITION POLICY in the repair lock
   exactly, including deletion of every assertion under UNSUPPORTED CLAIMS.

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -442,3 +442,64 @@ def test_a_fact_answering_no_grouped_question_still_appears():
     assert len([line for line in block.splitlines() if line.startswith("- ")]) == len(
         normalize_evidence(stripped.work_order, stripped.evidence_package).claims
     )
+
+
+def test_only_the_outline_is_handed_the_bare_question_list():
+    """The list is provenance for one stage, and a checklist everywhere else.
+
+    A plan now runs to forty-four questions. Under a bare `Requirements:`
+    heading with nothing saying what they were, they reached compose, the audit
+    and the repair lock as well -- and both of those prompts already use the
+    word for something else: the audit calls a section's job its requirement,
+    and repair is told it may not change "the requirements" meaning the
+    approved scope. A judge marks a draft down for each of forty-four items it
+    cannot find; repair puts them back a paragraph at a time. That is #506.
+
+    Only the outline needs them, because it names the `requirement_ids` each
+    section serves.
+
+    This is about the bare list only. Compose still receives REQUIREMENT
+    COVERAGE from the evidence projection, which carries the same questions
+    with their status and says what it is -- it is how the writer knows to
+    write around an `unpublished` question rather than narrate the hole.
+    """
+    fixture = _fixture()
+    contexts = assemble_v3_instructions(_request()).stage_contexts
+    entries = [
+        f"- {item['requirement_id']} [{item['kind']}] — {item['question']}"
+        for item in fixture["work_order"]["requirements"]
+    ]
+    assert entries, "fixture must declare questions for this test to mean anything"
+
+    for entry in entries:
+        assert entry in contexts.outline.text
+    # And it is labelled, so the outline cannot read it as a coverage list.
+    assert "not a checklist" in _flat(contexts.outline.text)
+
+    for stage in (contexts.compose, contexts.audit, contexts.repair_lock):
+        assert "Requirements:" not in stage.text
+        for entry in entries:
+            assert entry not in stage.text
+    # The repair lock rendered them in its own shorter form. That is gone too.
+    for item in fixture["work_order"]["requirements"]:
+        assert (
+            f"- {item['requirement_id']} — {item['question']}"
+            not in contexts.repair_lock.text
+        )
+    # The audit is not left guessing: it still gets status per question.
+    assert "SUPPORT AND OMISSION" in contexts.audit.text
+
+
+def test_the_stages_without_the_questions_keep_the_rest_of_the_brief():
+    """Dropping the list must not take the scope lock with it."""
+    fixture = _fixture()
+    contexts = assemble_v3_instructions(_request()).stage_contexts
+
+    for stage in (contexts.compose, contexts.audit):
+        assert fixture["brief"]["fails_if"] in stage.text
+        assert "Primary subject: Lima" in stage.text
+        assert "- Medellín — context_only" in stage.text
+    lock = contexts.repair_lock.text
+    assert fixture["brief"]["outcome"] in lock
+    assert "Primary subject: Lima" in lock
+    assert "Do not add factual material." in lock


### PR DESCRIPTION
Groundwork for #534, and probably the mechanism behind #506.

## What was wrong

The work order's questions reached **four** stages under a bare `Requirements:` heading with nothing saying what the list was — `instructions_v3.py:99` (`_brief_body` → outline, compose, audit) and again in `_repair_lock_body` (→ repair). A plan now runs to 44 of them.

Both downstream prompts already use the word for something else:

- The audit prompt: *"has covered its requirement without doing its job."* A requirement there is a section's job.
- The repair prompt: *"you may not change ... the requirements"*, meaning the approved scope.

So a judge handed 44 items under that exact word marks the draft down for each one it cannot find, and repair puts them back a paragraph at a time. Coverage checklist, by construction.

## Who actually needs the list

Only the outline — `editorial_v3.py:34` requires it to name the `requirement_ids` each section serves.

Compose never reads a requirement id; it follows the SECTION PLAN. So for compose the list was noise sitting under a heading whose own prompt says *"Tone, length, and brand voice are requirements, not suggestions."*

## The change

- `_brief_body` takes `include_requirements`. The outline keeps the list, relabelled as provenance and the ids you cite, and told plainly that a question whose answer earned no place in the piece is not a hole.
- Compose and the audit get the brief without it. The audit is not left guessing — `_support_status` already gives it every question's status and gap, which is the thing it needs.
- `_repair_lock_body` drops it. The questions are not scope; the outcome, spine, reader question, form and `fails_if` are.
- The repair prompt's `not the requirements` → `not the approved scope`, since the word no longer has a referent in its lock.

## Deliberately left alone

Compose still receives **REQUIREMENT COVERAGE** from the evidence projection (`evidence_v3.py:_compose_records_text`), which carries the same questions with their status. That block says what it is and earns its place — it is how the writer knows to write *around* an `unpublished` question rather than narrate the hole. Whether it is also too long belongs to #534.

The canonical `APPROVED COMMISSION` layer keeps the full list. It is the run's record of the instruction set and is never sent to a model.

## Verified

- New test asserts the bare `- rN [kind] — question` rendering reaches the outline and none of compose, audit or the repair lock, that `Requirements:` is gone from all three, that the repair lock's own shorter form is gone too, and that the audit still gets `SUPPORT AND OMISSION`.
- A second test asserts dropping the list did not take the scope lock with it — `fails_if`, primary subject, reference roles and the no-new-facts rule all still present.
- Full backend suite green.