### PR TITLE
fix(p2b): refuse a plan that cannot reach the writer, and show the price

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -29,6 +29,7 @@ Every route is staff-guarded because every one of them spends money.
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -75,6 +76,7 @@ from .runs import (
     _run_pipeline_v3_background as _run_pipeline_v4_background,
 )
 from ..run_budget import RunTokenCeilingReached
+from ..work_order_v4 import PlanTooLargeToFinish
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +295,18 @@ def _handle(action, *args, **kwargs) -> Any:
         # Not a server fault and not a retry: the run is over its ceiling and
         # says what it spent.
         raise HTTPException(status_code=409, detail=error.status.as_record()) from error
+    except PlanTooLargeToFinish as error:
+        # The same 409 shape, and for the same reason: not a fault, not a
+        # retry. The difference is that this one is answerable -- the plan is
+        # still on the screen and the cut is one click away.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "plan_too_large_to_finish",
+                "message": error.projection.note,
+                "budget_projection": asdict(error.projection),
+            },
+        ) from error
     except ValidationError as error:
         # Anything a stage builds and the contracts refuse. Pydantic's own
         # message is addressed to a developer and it subclasses ValueError, so

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -92,6 +92,7 @@ from .work_order_v4 import (
     WorkOrderUnusable,
     build_work_order,
     cut_work_order,
+    enforce_plan_fits,
     work_order_stage_record,
 )
 
@@ -371,7 +372,8 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
     """
     if services.research is None:
         raise ValueError("Research is not configured for this run.")
-    enforce_run_budget(_run_tokens_spent(run_id), stage=RESEARCH_STAGE)
+    tokens_spent = _run_tokens_spent(run_id)
+    enforce_run_budget(tokens_spent, stage=RESEARCH_STAGE)
 
     brief = load_brief(run_id)
     work_order = load_work_order(run_id)
@@ -386,7 +388,18 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
         services.recorder.record_stage(run_id, NOTES_STAGE, notes_stage_record(work_order, notes))
 
     notes = notes_from_record(_stage_data(run_id, NOTES_STAGE), work_order) or {}
-    if len(notes) < len(work_order.requirements) or any(not note.text.strip() for note in notes.values()):
+    outstanding = [
+        item
+        for item in work_order.requirements
+        if not (item.requirement_id in notes and notes[item.requirement_id].text.strip())
+    ]
+    # The ceiling asks what this run has already spent. This asks what the
+    # gathering it is about to do will cost, which is the only part of the sum
+    # that can still be changed. Counted over the questions still without a
+    # note, so a resume is not charged again for notes it already paid for.
+    enforce_plan_fits(len(outstanding), tokens_spent)
+
+    if outstanding:
         _open(services, run_id, NOTES_STAGE)
         notes = gather_research(
             brief, work_order, services.research, record_progress,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -37,7 +37,11 @@ from .contracts_v4 import (
 )
 from pydantic import ValidationError
 
-from .config import P2B_REPAIR_ESTIMATED_TOKENS, P2B_RUN_TOKEN_BUDGET
+from .config import (
+    P2B_REPAIR_ESTIMATED_TOKENS,
+    P2B_RUN_TOKEN_BUDGET,
+    P2B_RUN_TOKEN_CEILING,
+)
 from .grill_v4 import GrillDependencies
 from .schema_guards import require_non_empty
 from .support import _safe_dict, _safe_str, _safe_str_list
@@ -741,7 +745,53 @@ class BudgetProjection:
     budget: int
     repair_affordable: bool
     questions_that_fit: int
+    # The hard ceiling, and whether this plan can reach an article at all.
+    # Distinct from `repair_affordable` above, which asks a smaller question: a
+    # run that cannot afford its repair still finishes and still publishes.
+    # A run that cannot finish stops mid-research with nothing to show, which
+    # is what run 03c6702f did -- 44 questions, 707,468 tokens spent gathering,
+    # dead before the writer.
+    ceiling: int
+    can_finish: bool
+    questions_that_finish: int
     note: str
+
+
+class PlanTooLargeToFinish(RuntimeError):
+    """This plan cannot reach an article, so research must not start.
+
+    `budget_projection` has always been able to say this. Nothing acted on it:
+    the number was written to the work order's stage record and never rendered,
+    and research started regardless. Run 03c6702f asked 44 questions, spent
+    707,468 tokens gathering answers to them, and died against the ceiling with
+    no draft -- after the operator had approved a plan whose own record already
+    said it would not fit.
+
+    Refusing here is cheap and reversible. The operator strikes questions with
+    the cut they already have, and the number of questions that would finish is
+    on the refusal.
+    """
+
+    def __init__(self, projection: "BudgetProjection") -> None:
+        super().__init__(projection.note)
+        self.projection = projection
+
+
+def enforce_plan_fits(question_count: int, tokens_spent: int | None) -> None:
+    """Stop before research when the plan projects past the hard ceiling.
+
+    Silent when the run has no token accounting, the same way
+    `budget_projection` and `check_run_budget` are: an unmetered run is not a
+    free one, but a ceiling nobody can measure is not one that can be enforced
+    either, and guessing zero would make it silently unenforceable.
+
+    Only the ceiling refuses. A plan that will finish but cannot afford its
+    repair is still the operator's to run -- it produces an article -- and it
+    stays a warning on the screen.
+    """
+    projection = budget_projection(question_count, tokens_spent)
+    if projection and not projection.can_finish:
+        raise PlanTooLargeToFinish(projection)
 
 
 def budget_projection(
@@ -766,8 +816,22 @@ def budget_projection(
         - tokens_spent
     )
     fits = max(0, room // RESEARCH_TOKENS_PER_QUESTION)
+    can_finish = total <= P2B_RUN_TOKEN_CEILING
+    finish_room = P2B_RUN_TOKEN_CEILING - WRITING_TOKENS_TYPICAL - tokens_spent
+    finishes = max(0, finish_room // RESEARCH_TOKENS_PER_QUESTION)
 
-    if affordable:
+    if not can_finish:
+        # Said first because it outranks everything below it. The others
+        # describe a run that publishes; this one describes a run that does
+        # not exist yet and cannot.
+        note = (
+            f"{question_count} questions projects to about {total:,} tokens, "
+            f"past the {P2B_RUN_TOKEN_CEILING:,} hard ceiling. This plan stops "
+            f"part-way through research and never reaches the writer, so there "
+            f"is no article at the end of it. About {finishes} questions would "
+            f"finish. Cut the plan before starting research."
+        )
+    elif affordable:
         note = (
             f"{question_count} questions projects to about {total:,} tokens "
             f"against a {P2B_RUN_TOKEN_BUDGET:,} ceiling, leaving room for "
@@ -803,6 +867,9 @@ def budget_projection(
         budget=P2B_RUN_TOKEN_BUDGET,
         repair_affordable=affordable,
         questions_that_fit=fits,
+        ceiling=P2B_RUN_TOKEN_CEILING,
+        can_finish=can_finish,
+        questions_that_finish=finishes,
         note=note,
     )
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -755,3 +755,59 @@ def test_the_projection_travels_on_the_stage_record():
     )
     assert record["budget_projection"]["budget"] == P2B_RUN_TOKEN_BUDGET
     assert work_order_stage_record(work_order)["budget_projection"] is None
+
+
+def test_a_plan_that_cannot_reach_the_writer_is_refused_before_research():
+    """Run 03c6702f: 44 questions, 707,468 spent gathering, dead before the
+    writer with no draft. Its own stage record already said it would not fit.
+
+    The soft budget only asks whether one more repair is affordable, and a run
+    that fails that still publishes. This asks whether there is an article at
+    the end of it at all, so it refuses rather than warns.
+    """
+    from app.features.prompt2blog.work_order_v4 import (
+        PlanTooLargeToFinish,
+        budget_projection,
+        enforce_plan_fits,
+    )
+
+    projection = budget_projection(44, 40_000)
+
+    assert projection.can_finish is False
+    assert projection.repair_affordable is False
+    assert "never reaches the writer" in projection.note
+    assert 0 < projection.questions_that_finish < 44
+    with pytest.raises(PlanTooLargeToFinish) as raised:
+        enforce_plan_fits(44, 40_000)
+    assert raised.value.projection.questions_that_finish == projection.questions_that_finish
+
+
+def test_a_plan_that_finishes_but_cannot_repair_is_allowed_through():
+    """The operator's call, not the system's. It produces an article."""
+    from app.features.prompt2blog.work_order_v4 import (
+        budget_projection,
+        enforce_plan_fits,
+    )
+
+    projection = budget_projection(14, 38_308)
+
+    assert projection.repair_affordable is False
+    assert projection.can_finish is True
+    enforce_plan_fits(14, 38_308)
+
+
+def test_an_unmetered_run_is_never_refused():
+    """A ceiling nobody can measure is not one that can be enforced, and
+    guessing zero would make it silently unenforceable -- the same discipline
+    `check_run_budget` and `budget_projection` already keep."""
+    from app.features.prompt2blog.work_order_v4 import (
+        budget_projection,
+        enforce_plan_fits,
+    )
+
+    assert budget_projection(44, None) is None
+    enforce_plan_fits(44, None)
+    # And nothing left to gather is nothing to refuse, so a resume whose notes
+    # are already paid for is not charged for them a second time.
+    enforce_plan_fits(0, 600_000)
+

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
@@ -41,6 +41,14 @@ export function WorkOrderScreen({
     item => item.kind === 'load_bearing' && !struck.includes(item.requirement_id),
   ).length
 
+  // The projection describes the plan as recorded, not the boxes ticked since.
+  // That is not stale: while anything is struck the primary action is Apply
+  // changes, which re-records it. It only gates the research button, and by
+  // then it is current.
+  const projection = workOrder.budget_projection
+  const pending = struck.length > 0 || added.trim().length > 0
+  const tooLarge = projection ? !projection.can_finish : false
+
   return (
     <section className="p2b-intake" aria-label="The research plan">
       <p className="p2b-eyebrow">What we&rsquo;ll go and find out</p>
@@ -101,6 +109,13 @@ export function WorkOrderScreen({
         </ul>
       )}
 
+      {projection && (
+        /* The number was always computed and written to the run. It was never
+           put in front of the person doing the cutting, so a plan that could
+           not finish was approved and then died in research. */
+        <p className={tooLarge ? 'p2b-blocked' : 'p2b-cost'}>{projection.note}</p>
+      )}
+
       {remainingLoadBearing === 0 && (
         <p className="p2b-blocked">
           Keep at least one of the questions the piece rests on &mdash; without any of
@@ -109,7 +124,7 @@ export function WorkOrderScreen({
       )}
 
       <div className="p2b-intake-actions">
-        {struck.length || added.trim() ? (
+        {pending ? (
           <button
             type="button"
             disabled={busy || remainingLoadBearing === 0}
@@ -122,7 +137,10 @@ export function WorkOrderScreen({
             Apply changes
           </button>
         ) : (
-          <button type="button" disabled={busy} onClick={onResearch}>
+          // A plan that cannot reach the writer has no research worth buying.
+          // The server refuses it too; this is so the refusal is not a
+          // surprise arriving after the button was pressed.
+          <button type="button" disabled={busy || tooLarge} onClick={onResearch}>
             Go and find this out
           </button>
         )}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -16,6 +16,7 @@ import { RunList } from './components/RunList'
 import { WorkOrderScreen } from './components/WorkOrderScreen'
 import type {
   IntakeBrief,
+  IntakeBudgetProjection,
   IntakeRunSummary,
   IntakeGrill,
   IntakeWorkOrder,
@@ -284,6 +285,24 @@ const WORK_ORDER: IntakeWorkOrder = {
   load_bearing_count: 1,
   texture_count: 1,
   cut_warnings: [],
+  budget_projection: null,
+}
+
+/** A plan that projects past the hard ceiling: it never reaches the writer. */
+const CANNOT_FINISH: IntakeBudgetProjection = {
+  question_count: 44,
+  spent: 40_000,
+  projected_research: 651_200,
+  projected_writing: 134_000,
+  projected_total: 825_200,
+  repair_reserve: 90_000,
+  budget: 425_000,
+  repair_affordable: false,
+  questions_that_fit: 0,
+  ceiling: 650_000,
+  can_finish: false,
+  questions_that_finish: 31,
+  note: '44 questions projects to about 825,200 tokens, past the 650,000 hard ceiling. This plan stops part-way through research and never reaches the writer, so there is no article at the end of it. About 31 questions would finish. Cut the plan before starting research.',
 }
 
 describe('the work order screen', () => {
@@ -305,6 +324,67 @@ describe('the work order screen', () => {
     fireEvent.click(screen.getByRole('button', { name: /apply changes/i }))
 
     expect(onCut).toHaveBeenCalledWith(['r2'], [])
+  })
+
+  it('shows what the plan will cost, because nobody ever saw the number', () => {
+    // It was computed and written to the run from the start, and never
+    // rendered. A plan that could not finish was approved and died in
+    // research, 707,468 tokens in, with no draft.
+    render(
+      <WorkOrderScreen
+        workOrder={{ ...WORK_ORDER, budget_projection: CANNOT_FINISH }}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/never reaches the writer/i)).toBeInTheDocument()
+  })
+
+  it('will not start research on a plan that cannot reach the writer', () => {
+    const onResearch = vi.fn()
+    render(
+      <WorkOrderScreen
+        workOrder={{ ...WORK_ORDER, budget_projection: CANNOT_FINISH }}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={onResearch}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /go and find this out/i })).toBeDisabled()
+    expect(onResearch).not.toHaveBeenCalled()
+  })
+
+  it('leaves a plan that merely cannot repair itself alone', () => {
+    // It publishes. That makes it the operator's call, not the system's.
+    render(
+      <WorkOrderScreen
+        workOrder={{
+          ...WORK_ORDER,
+          budget_projection: {
+            ...CANNOT_FINISH,
+            can_finish: true,
+            note: 'will not be able to repair itself',
+          },
+        }}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/repair itself/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /go and find this out/i }),
+    ).not.toBeDisabled()
   })
 
   it('will not let every load-bearing question be struck', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -83,6 +83,30 @@ export interface IntakeRequirement {
   bundled_note: string
 }
 
+/**
+ * What this plan is about to cost, beside the decision that changes it.
+ *
+ * Null when the run has no token accounting. An unmetered run is not a free
+ * one, but a cost nobody can measure is not one to state as fact.
+ */
+export interface IntakeBudgetProjection {
+  question_count: number
+  spent: number
+  projected_research: number
+  projected_writing: number
+  projected_total: number
+  repair_reserve: number
+  budget: number
+  /** False means the run publishes but cannot pay for a repair pass. */
+  repair_affordable: boolean
+  questions_that_fit: number
+  ceiling: number
+  /** False means the run dies part-way through research. There is no article. */
+  can_finish: boolean
+  questions_that_finish: number
+  note: string
+}
+
 export interface IntakeWorkOrder {
   work_order_fingerprint: string
   brief_fingerprint: string
@@ -91,6 +115,7 @@ export interface IntakeWorkOrder {
   load_bearing_count: number
   texture_count: number
   cut_warnings: string[]
+  budget_projection: IntakeBudgetProjection | null
 }
 
 export interface IntakeCoverage {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -452,6 +452,16 @@
   gap: var(--space-2);
 }
 
+/* What the plan costs, said quietly. Its refusing form is `.p2b-blocked`. */
+.p2b-cost {
+  margin: var(--space-4) 0 0;
+  padding: var(--space-4) var(--space-5);
+  background: var(--surface-muted, var(--accent-softer));
+  border-radius: var(--radius-md);
+  color: var(--ink-light);
+  font-size: 0.9375rem;
+}
+
 .p2b-blocked {
   margin: var(--space-4) 0 0;
   padding: var(--space-4) var(--space-5);


### PR DESCRIPTION
Groundwork for #534. Named there as *"the work order asks for too much."*

## What was wrong

`budget_projection` has been able to say a plan will not fit since it was written. Two things were missing, and together they cost a whole run:

1. **Nobody saw it.** The number is written to the work order's stage record and reaches the client in `intake_state`. `WorkOrderScreen.tsx` never rendered it — there is no `budget_projection` anywhere in the frontend.
2. **Nothing acted on it.** `do_research` checks `enforce_run_budget`, which asks what the run has *already* spent. Nothing asked what the plan it was about to run would cost.

Run `03c6702f` approved 44 questions, spent 707,468 tokens gathering answers to them, and died against the 650,000 ceiling with no draft. Its own stage record already said it would not fit.

## The refusal

`enforce_plan_fits` raises `PlanTooLargeToFinish` before gathering starts. The API returns the same 409 shape the ceiling already uses, with the projection attached — a product state, not a fault.

**Only the hard ceiling refuses.** `BudgetProjection` now carries `can_finish` beside `repair_affordable`, and they answer different questions:

| | means | what happens |
|---|---|---|
| `repair_affordable: false` | run publishes, cannot pay for a repair pass | warning; operator's call |
| `can_finish: false` | run dies mid-research, there is no article | refused |

Two guards against false refusals:

- Counted over the questions **still without a note**, not the whole work order, so a resume is not charged again for notes it already paid for.
- Silent on an unmetered run — the same discipline `check_run_budget` and `budget_projection` already keep. A ceiling nobody can measure is not one that can be enforced, and guessing zero would make it silently unenforceable.

## The price

The note renders on the work order screen beside the cut that changes it, and the research button is disabled when the plan cannot finish, so the server's refusal is not a surprise arriving after the click.

The note describes the plan **as recorded**, not the boxes ticked since. That is not stale: while anything is struck the primary action is Apply changes, which re-records it. What gates the button is always current.

## Verified

- 44 questions on 40,000 spent → `can_finish` false, note says *"never reaches the writer"*, `enforce_plan_fits` raises, and the exception carries the number of questions that would.
- 14 questions on 38,308 (run `b29d66b4`) → cannot repair itself but **is allowed through**.
- Unmetered run and a resume with nothing left to gather → both pass silently.
- Three frontend tests: the note renders, the button is disabled when the plan cannot finish, and a merely-unrepairable plan is left alone.
- Full backend suite, 753 vitest tests, and `tsc --noEmit` all green.