### PR TITLE
feat(p2b): a claim carries whether it reaches the writer

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -582,11 +582,43 @@ class EvidenceClaim(V4ContractModel):
     # the only way to clear an irrelevant entry meant the obvious move and the
     # safe move were different, which is the wrong way round.
     venue_dismissed: bool = False
+    # Whether this fact reaches the writer's desk (#534).
+    #
+    # Nothing used to decide. Run 9e66bf84 found 105 claims, the outline placed
+    # 102 of them, compose received all 105, and one 200-word section was
+    # handed 56 -- three and a half words per claim, at which density there is
+    # no sentence you can write except a list. The writer was not lazy; it was
+    # given an impossible instruction and did the only thing that satisfies it.
+    #
+    # Deselecting is an editorial decision, not a coverage one, so it must not
+    # be able to turn into one. This is a flag and never a deletion: the claim
+    # stays in the dossier, groundedness and the readiness follow-up keep
+    # reading every claim there is, and a requirement it supports stays
+    # supported. Only the two prompt projections the writer sees filter on it.
+    #
+    # Repair may not add a fact the previous draft did not have, so a claim cut
+    # here is a fact the article loses. That is the accepted cost, and the
+    # reason a person makes the cut rather than a model.
+    selected: bool = True
+    # This claim says the same thing as `merged_into`, which was kept instead.
+    #
+    # Deduplication chooses a survivor; it never writes new claim text. A
+    # merged claim composed by a model is prose asserting a fact, and a drifted
+    # date or price inside one would pass groundedness -- groundedness checks
+    # the draft against the claim, and the claim is the thing that moved. Every
+    # surviving claim is still verbatim what research returned.
+    merged_into: str = ""
 
     @model_validator(mode="after")
     def validate_unique_links(self) -> "EvidenceClaim":
         _require_unique(self.source_ids, "claim source reference")
         _require_unique(self.requirement_ids, "claim requirement reference")
+        if self.merged_into == self.claim_id:
+            raise ValueError("a claim cannot be merged into itself")
+        if self.merged_into and self.selected:
+            raise ValueError(
+                "a claim merged into another cannot also be selected"
+            )
         return self
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_v3.py
@@ -44,6 +44,12 @@ class NormalizedClaim(NormalizedModel):
     requirement_ids: list[str]
     as_of: str | None
     confidence: str
+    # Whether this fact reaches the writer (#534). `claims` here always holds
+    # every claim, because groundedness and the readiness follow-up check the
+    # draft against the whole dossier. Only the two projections the writer
+    # reads -- `compose_records_text` and the outline's facts-by-subject --
+    # filter on it.
+    selected: bool = True
 
 
 class NormalizedRequirement(NormalizedModel):
@@ -189,6 +195,7 @@ def _normalize_claim(claim: EvidenceClaim) -> NormalizedClaim:
         requirement_ids=list(claim.requirement_ids),
         as_of=claim.as_of.isoformat() if claim.as_of else None,
         confidence=claim.confidence,
+        selected=claim.selected,
     )
 
 
@@ -227,14 +234,19 @@ def _compose_records_text(
     every one of those fields. This is a second projection of one dossier, not
     a second dossier.
 
-    What survives here is what a writer may actually use: every claim, exactly
-    as written, with its date, confidence and questions; every requirement
-    status and gap; every premise verdict; every conflict, resolved or not.
+    What survives here is what a writer may actually use: every selected claim,
+    exactly as written, with its date, confidence and questions; every
+    requirement status and gap; every premise verdict; every conflict, resolved
+    or not.
     Sources survive only where they carry a note somebody wrote -- an operator
     settlement, a caveat, a limitation -- because that note changes how a fact
     reads, and the claims that rest on them keep their link.
     """
     kept = {source.source_id for source in sources if _has_substantive_note(source)}
+    # The one place the selection is applied. A deselected claim is still in
+    # the dossier, still checked, and still supports whatever it supported --
+    # it is simply not on the writer's desk (#534).
+    claims = [claim for claim in claims if claim.selected]
 
     lines: list[str] = ["SOURCE NOTES"]
     if kept:
@@ -274,7 +286,15 @@ def _compose_records_text(
     # writer and spliced in unchanged, so the two projections cannot drift on
     # the parts they share. Sources and claims are passed empty because this
     # function has already written its own.
-    tail = _records_text([], [], requirements, premise_findings, conflicts, gaps)
+    tail = _records_text(
+        [],
+        [],
+        requirements,
+        premise_findings,
+        conflicts,
+        gaps,
+        visible_claim_ids={claim.claim_id for claim in claims},
+    )
     heading = "REQUIREMENT COVERAGE"
     lines.append("")
     lines.append(heading + tail.split(heading, 1)[1])
@@ -288,7 +308,21 @@ def _records_text(
     premise_findings: list[NormalizedPremiseFinding],
     conflicts: list[dict[str, Any]],
     gaps: list[dict[str, Any]],
+    *,
+    visible_claim_ids: set[str] | None = None,
 ) -> str:
+    """The dossier, rendered.
+
+    `visible_claim_ids` narrows the coverage bookkeeping to the claims the
+    reader of this projection can actually see, and is only ever passed by the
+    compose projection. Without it, coverage would name claim ids that are not
+    in the CLAIMS block above it, and a writer told a question is closed by
+    facts it cannot find is a writer being asked for a fact it does not have --
+    the checklist behaviour, arriving by a different door.
+
+    Left None everywhere else, so the canonical projection that groundedness
+    and the readiness follow-up read is byte-identical to what it always was.
+    """
     lines: list[str] = ["SOURCES"]
     if sources:
         for source in sources:
@@ -317,7 +351,19 @@ def _records_text(
     lines.append("")
     lines.append("REQUIREMENT COVERAGE")
     for requirement in requirements:
-        claim_ids = ", ".join(requirement.claim_ids) or "none"
+        visible = (
+            [item for item in requirement.claim_ids if item in visible_claim_ids]
+            if visible_claim_ids is not None
+            else list(requirement.claim_ids)
+        )
+        # Said in words rather than as "none", which on a `supported` question
+        # would read as a contradiction. Nothing is missing: the answer exists
+        # and was not chosen for this article.
+        claim_ids = ", ".join(visible) or (
+            "none kept for this article"
+            if visible_claim_ids is not None and requirement.claim_ids
+            else "none"
+        )
         gap = f" | gap: {requirement.gap}" if requirement.gap else ""
         # The status word alone left the writer to guess what `unpublished`
         # means for the draft. Spelled out here, because the one thing it must

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -284,7 +284,11 @@ def _facts_by_subject(
     }
 
     by_subject: dict[str, list[str]] = {}
-    for claim in evidence.claims:
+    # The outline plans from what the writer will have, not from the dossier.
+    # Run 9e66bf84's outline placed 102 of 105 claims across six sections and
+    # gave one of them 56 against a 200-word budget -- it did not select, it
+    # distributed, and called that a plan (#534).
+    for claim in (item for item in evidence.claims if item.selected):
         subject = next(
             (
                 group_of_requirement[requirement_id]
@@ -312,8 +316,15 @@ def _facts_by_subject(
             "section plan)",
         )
     )
+    visible = {claim.claim_id for claim in evidence.claims if claim.selected}
     for requirement in evidence.requirements:
-        claims = ", ".join(requirement.claim_ids) or "none"
+        kept = [item for item in requirement.claim_ids if item in visible]
+        # Never a bare "none" where the question does have answers: the outline
+        # would read that as a hole to plan around rather than as facts that
+        # were not chosen.
+        claims = ", ".join(kept) or (
+            "none kept for this article" if requirement.claim_ids else "none"
+        )
         gap = f" | gap: {requirement.gap}" if requirement.gap else ""
         lines.append(
             f"- {requirement.requirement_id} [{requirement.status}] "

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -503,3 +503,82 @@ def test_the_stages_without_the_questions_keep_the_rest_of_the_brief():
     assert fixture["brief"]["outcome"] in lock
     assert "Primary subject: Lima" in lock
     assert "Do not add factual material." in lock
+
+def _two_claim_request(*, second_selected: bool):
+    """The fixture plus a second claim on the same question, one of them cut."""
+    fixture = _fixture()
+    package = fixture["evidence_package"]
+    first = package["claims"][0]
+    second = {
+        **first,
+        "claim_id": "c2",
+        "text": "A second fact about the same question, differently useful.",
+        "selected": second_selected,
+    }
+    package = {
+        **package,
+        "claims": [first, second],
+        "requirements": [
+            {**item, "claim_ids": ["c1", "c2"]}
+            if item["requirement_id"] == "r1"
+            else item
+            for item in package["requirements"]
+        ],
+    }
+    return _request(evidence_package=package), second
+
+
+def test_a_deselected_claim_never_reaches_the_writer():
+    """Run 9e66bf84 handed compose 105 of 105 claims and one 200-word section
+    56 of them -- three and a half words per claim, at which density there is
+    no sentence you can write except a list (#534)."""
+    request, cut = _two_claim_request(second_selected=False)
+    contexts = assemble_v3_instructions(request).stage_contexts
+
+    assert cut["text"] not in contexts.compose.text
+    assert cut["text"] not in contexts.outline.text
+    # The claim it was cut beside is still there, so this is a selection and
+    # not an empty dossier.
+    assert "c1" in contexts.compose.text
+
+
+def test_a_deselected_claim_is_still_in_the_dossier_for_checking():
+    """The rule that makes the cut safe. Groundedness and the readiness
+    follow-up read `records_text`, so deselecting removes a fact from the
+    writer's desk and never from the record -- nothing becomes unverifiable,
+    and a supported question stays supported."""
+    request, cut = _two_claim_request(second_selected=False)
+
+    evidence = normalize_evidence(request.work_order, request.evidence_package)
+
+    assert [claim.claim_id for claim in evidence.claims] == ["c1", "c2"]
+    assert cut["text"] in evidence.records_text
+    assert cut["text"] not in evidence.compose_records_text
+    assert evidence.receipt()["requirement_status"]["r1"] == "supported"
+
+
+def test_coverage_never_tells_the_writer_a_question_has_no_answers():
+    """A `supported` question whose claims were all cut must not render as
+    "claims: none". The writer would read that as a hole to fill, ask for the
+    fact, and be refused it -- the checklist behaviour arriving by a different
+    door."""
+    fixture = _fixture()
+    package = {
+        **fixture["evidence_package"],
+        "claims": [{**fixture["evidence_package"]["claims"][0], "selected": False}],
+    }
+    request = _request(evidence_package=package)
+
+    evidence = normalize_evidence(request.work_order, request.evidence_package)
+
+    assert "none kept for this article" in evidence.compose_records_text
+    # And the canonical projection is untouched: it still names the claim.
+    assert "claims: c1" in evidence.records_text
+
+
+def test_the_outline_plans_from_what_the_writer_will_have():
+    request, cut = _two_claim_request(second_selected=True)
+    outline = assemble_v3_instructions(request).stage_contexts.outline.text
+
+    assert cut["text"] in outline
+

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v4_contracts.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v4_contracts.py
@@ -225,3 +225,47 @@ def test_the_seed_is_kept_but_is_not_a_title():
     brief = _brief()
     assert brief.seed.startswith("Lima is no longer")
     assert not hasattr(brief, "original_title")
+
+
+def test_a_claim_merged_into_another_cannot_also_be_selected():
+    """Deduplication chooses a survivor. Keeping both on the writer's desk is
+    the duplication it exists to remove, so the contract refuses it (#534)."""
+    with pytest.raises(ValidationError):
+        EvidenceClaim(
+            claim_id="c2",
+            text="The same fact, differently worded.",
+            source_ids=["s1"],
+            requirement_ids=["r1"],
+            confidence="high",
+            merged_into="c1",
+            selected=True,
+        )
+
+
+def test_a_claim_cannot_be_merged_into_itself():
+    with pytest.raises(ValidationError):
+        EvidenceClaim(
+            claim_id="c1",
+            text="A fact.",
+            source_ids=["s1"],
+            requirement_ids=["r1"],
+            confidence="high",
+            merged_into="c1",
+            selected=False,
+        )
+
+
+def test_a_claim_is_selected_until_something_says_otherwise():
+    """Nothing selects yet. Until the picker exists, every claim reaches the
+    writer exactly as it always did."""
+    claim = EvidenceClaim(
+        claim_id="c1",
+        text="A fact.",
+        source_ids=["s1"],
+        requirement_ids=["r1"],
+        confidence="high",
+    )
+
+    assert claim.selected is True
+    assert claim.merged_into == ""
+


### PR DESCRIPTION
Groundwork for #534. **Nothing selects yet** — every claim defaults to selected, so this changes no article. It puts the seam where selection will act, and turns the three rules that keep selection safe into structure rather than a discipline.

## Why

Run `9e66bf84` found 105 claims. The outline placed **102 of them** across six sections, compose received all 105, and one 200-word section was handed **56** — three and a half words per claim, at which density there is no sentence you can write except a list. Nothing ever decided which facts the article needed.

## What this adds

`EvidenceClaim` gains two fields:

- **`selected`** — whether this fact reaches the writer's desk.
- **`merged_into`** — the claim kept in its place when two say the same thing.

Deduplication will choose a survivor and **never write new claim text**. A merged claim composed by a model is prose asserting a fact, and a drifted date or price inside one would pass groundedness — groundedness checks the draft against the claim, and the claim is the thing that moved. Every surviving claim stays verbatim what research returned. The contract refuses a claim merged into itself, and one that is both merged and selected.

## Where it applies

Exactly two projections filter on it, and they are the two the writer reads:

| projection | reader | filters? |
|---|---|---|
| `compose_records_text` | compose | yes |
| `_facts_by_subject` | outline | yes |
| `records_text` | groundedness, readiness follow-up | **no** |

So the issue's three "must stay true" rules hold by construction: fact-checking keeps everything, a deselected claim leaves the writer's desk and never the record, and a question it supports stays `supported`.

## One thing that needed care

Coverage bookkeeping names the claim ids behind each question. Narrowed to what each projection can see — otherwise the writer is told a question is closed by facts it cannot find, which is a request for a fact it does not have. Where narrowing empties a question that does have answers, it renders `none kept for this article` rather than `none`: on a `supported` question a bare `none` reads as a hole to fill.

## Verified

- A deselected claim reaches neither compose nor the outline; the one beside it still does.
- The same claim is still in `records_text`, still in `evidence.claims`, and its requirement is still `supported`.
- A `supported` question with every claim cut renders `none kept for this article` in the compose projection and `claims: c1` unchanged in the canonical one.
- Contract tests for both new validators, and one asserting a claim is selected until something says otherwise.
- Full backend suite green.