### PR TITLE
feat(p2b): something selects the evidence, and the last word is a person's

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -50,6 +50,7 @@ from ..gate_v4 import GateAnswerRefused
 from ..intake_v4 import (
     IntakeServices,
     blocking_questions,
+    review_selection,
     review_venues,
     answer_intake,
     apply_cut,
@@ -65,6 +66,7 @@ from ..intake_v4 import (
     recent_runs,
     reopen_intake,
     settle_gate,
+    settle_selection,
     settle_venue,
     writing_request,
 )
@@ -76,6 +78,7 @@ from .runs import (
     _run_pipeline_v3_background as _run_pipeline_v4_background,
 )
 from ..run_budget import RunTokenCeilingReached
+from ..selection_v4 import SelectionRefused
 from ..work_order_v4 import PlanTooLargeToFinish
 
 logger = logging.getLogger(__name__)
@@ -290,6 +293,13 @@ def _handle(action, *args, **kwargs) -> Any:
                 ),
                 "raw": error.raw[:2000],
             },
+        ) from error
+    except SelectionRefused as error:
+        # The operator asked the picker for something it cannot mean. Their
+        # move, their sentence back, and nothing was changed.
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "selection_refused", "message": str(error)},
         ) from error
     except RunTokenCeilingReached as error:
         # Not a server fault and not a retry: the run is over its ceiling and
@@ -530,6 +540,41 @@ class VenueMarkRequest(BaseModel):
     drop: bool = False
     dismiss: bool = False
     note: str | None = None
+
+
+class SelectionRequest(BaseModel):
+    """One move. Moving the line and marking one fact are separate decisions:
+    an override is about that fact and outlives the line moving past it."""
+
+    keep_count: int | None = None
+    rescue: str | None = None
+    drop: str | None = None
+    clear: str | None = None
+
+
+@router.get("/{run_id}/selection")
+def read_selection(run_id: str, _staff=Depends(require_staff)) -> JSONResponse:
+    """The facts this article would be written from, ranked, with the line."""
+    return JSONResponse(_handle(review_selection, run_id))
+
+
+@router.post("/{run_id}/selection")
+@exclusive_run
+def settle_the_selection(
+    run_id: str, request: SelectionRequest, _staff=Depends(require_staff)
+) -> JSONResponse:
+    """Move the line, or mark one fact. No model call: the operator decides."""
+    return JSONResponse(
+        _handle(
+            settle_selection,
+            run_id,
+            _services(run_id),
+            keep_count=request.keep_count,
+            rescue=request.rescue,
+            drop=request.drop,
+            clear=request.clear,
+        )
+    )
 
 
 @router.get("/{run_id}/venues")

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -662,6 +662,14 @@ def settle_gate(
             STATE_KEY: json.loads(evidence.model_dump_json()),
         },
     )
+    # A run that arrives here was blocked when research finished, so selection
+    # never ran -- `do_research` only selects on a dossier that can be written.
+    # Without this a run that was ever blocked writes from every claim it
+    # found, silently, which is the behaviour #534 exists to end. Found by the
+    # first real run: no test could catch it, because the gate is where a
+    # blocked run and a clean one stop being the same code path.
+    if verdict.can_write and load_selection(run_id) is None:
+        _select_evidence(run_id, services, load_brief(run_id), work_order, evidence)
     return verdict
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -86,6 +86,17 @@ from .polish_v4 import build_polish_prompt
 from .run_budget import enforce_run_budget
 from .run_recorder import RunRecorder
 from .support import _safe_dict, _safe_str
+from .options import default_target_word_count
+from .selection_v4 import (
+    SELECTION_STAGE,
+    SelectionRefused,
+    Selection,
+    SelectionDependencies,
+    apply_selection,
+    revise,
+    select_evidence,
+    shortlist,
+)
 from .work_order_v4 import (
     WORK_ORDER_STAGE,
     CutOutcome,
@@ -443,7 +454,83 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
             STATE_KEY: json.loads(evidence.model_dump_json()),
         },
     )
+    # Only for a run that can actually be written. Ranking the evidence of a
+    # blocked article is two model calls spent on a decision nobody will get to
+    # make, and the gate may still change what the dossier contains.
+    if verdict.can_write:
+        _select_evidence(run_id, services, brief, work_order, evidence)
     return verdict
+
+
+def _select_evidence(
+    run_id: str,
+    services: IntakeServices,
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    evidence: EvidencePackage,
+) -> Selection:
+    """Deduplicate and rank, and record where the line starts (#534).
+
+    Recorded apart from the dossier. The evidence stays exactly what research
+    returned, and which facts the article is written from stays a separate,
+    reversible editorial record that `writing_request` applies at the hand-off.
+    """
+    selection = select_evidence(
+        brief,
+        work_order,
+        evidence,
+        SelectionDependencies(llm=services.dependencies.llm),
+        target_word_count=default_target_word_count(),
+    )
+    _record(services, run_id, SELECTION_STAGE, selection.as_record())
+    return selection
+
+
+def review_selection(run_id: str) -> dict[str, Any]:
+    """The ranked shortlist and where the line sits, for the picker."""
+    selection = load_selection(run_id)
+    if selection is None:
+        return {"available": False, "claims": [], "keep_count": 0, "note": ""}
+    evidence = load_evidence(run_id)
+    return {
+        "available": True,
+        "claims": shortlist(evidence, load_work_order(run_id), selection),
+        "keep_count": selection.keep_count,
+        "target_word_count": selection.target_word_count,
+        "deduped": selection.deduped,
+        "ranked": selection.ranked,
+        "note": selection.note,
+    }
+
+
+def settle_selection(
+    run_id: str,
+    services: IntakeServices,
+    *,
+    keep_count: int | None = None,
+    rescue: str | None = None,
+    drop: str | None = None,
+    clear: str | None = None,
+) -> dict[str, Any]:
+    """Apply one of the operator's moves and hand the list back."""
+    selection = load_selection(run_id)
+    if selection is None:
+        raise SelectionRefused("Nothing has been selected for this run yet.")
+    revised = revise(
+        selection, keep_count=keep_count, rescue=rescue, drop=drop, clear=clear
+    )
+    _record(services, run_id, SELECTION_STAGE, revised.as_record())
+    return review_selection(run_id)
+
+
+def load_selection(run_id: str) -> Selection | None:
+    """The operator's editorial record, or None when nothing has selected.
+
+    None is not an empty selection. A run whose selection never ran writes from
+    every fact it found, exactly as it did before this existed.
+    """
+    record = _stage_data(run_id, SELECTION_STAGE)
+    return Selection.from_record(record) if record.get("order") else None
 
 
 def _strike_must_name(
@@ -892,6 +979,13 @@ def writing_request(run_id: str, *, length_id: str = "medium") -> Prompt2BlogV4R
             f"This run cannot be written yet: {verdict.reason}. "
             + " ".join(verdict.findings)
         )
+
+    # The one place the editorial cut is applied (#534). Coverage is decided
+    # above it, on the whole dossier, so a deselected claim can never turn a
+    # supported question into a gate. A run with no selection writes from every
+    # fact it found, exactly as it did before this existed.
+    if selection := load_selection(run_id):
+        evidence = apply_selection(evidence, selection)
 
     return Prompt2BlogV4Request(
         brief=brief,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/options.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/options.py
@@ -15,6 +15,7 @@ from .config import (
 from .support import (
     _normalize_article_type_name,
     _safe_bool,
+    _safe_dict,
     _safe_int,
     _safe_str,
 )
@@ -193,6 +194,19 @@ def _find_option_or_raise(
         if _normalize_article_type_name(_safe_str(option.get("id"))) == normalized:
             return option
     raise RuntimeError(f"Unsupported {field_name}: '{option_id}'")
+
+
+def default_target_word_count() -> int:
+    """How long the article the pipeline is about to write is meant to be.
+
+    Nothing chooses a length: `writing_request` takes the default, so this is
+    the number compose will actually write to. Evidence selection needs it
+    before the writing request exists, to know how many facts a piece this size
+    can carry, and reading it from the same catalog entry is what stops the two
+    numbers drifting apart.
+    """
+    length = _default_option(_load_prompt2blog_option_catalog().get("lengths", []))
+    return _safe_int(_safe_dict(length).get("target_word_count"), default=0)
 
 
 def _default_option(options: list[dict[str, Any]]) -> dict[str, Any] | None:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
@@ -1,0 +1,619 @@
+"""Which facts the article is written from (#534).
+
+Research finds around a hundred facts. Until now nothing decided which of them
+the article needed, and the writer received all of them.
+
+Run 9e66bf84, the Lima chifa article, 1,155 words:
+
+    105 claims, 110 sources, from 13 requirements
+    the outline assigned  102 of 105 claims across 6 sections
+    compose received      105 of 105
+
+The outline did not select. It distributed -- it found a home for almost
+everything and called that a plan. One 200-word section was given 56 claims,
+which is three and a half words per claim, and there is no sentence you can
+write at that density except a list. The article read like a database because
+it was one.
+
+Three passes stand between research and the outline.
+
+**Deduplicate.** A model groups claims that are the same fact and names which
+one survives. It never writes new claim text: a merged claim composed by a
+model is prose asserting a fact, and a drifted date or price inside one would
+pass groundedness, because groundedness checks the draft against the claim and
+the claim is the thing that moved. Every survivor is verbatim what research
+returned, and it inherits the sources and questions of everything merged into
+it, so nothing loses its provenance.
+
+**Rank.** A model orders the survivors by how much they matter to *this* brief
+-- the reader question, the promise, and `fails_if`. Not by general interest: a
+fact can be true, well sourced and irrelevant here.
+
+**A person picks.** The operator sees the ranked list with a line drawn where
+the keep-set ends, moves the line, and rescues or drops individual claims. That
+step is the point and not a fallback. A model dropping a fact the article
+needed is a silent loss the operator discovers by reading a worse article; a
+person dropping it is a decision they made and can undo.
+
+Nothing here deletes. Selection is a flag on the claim, so groundedness and the
+readiness follow-up keep reading the whole dossier, a deselected claim leaves
+the writer's desk and never the record, and a question it supports stays
+supported. Deselecting is an editorial choice and must never become a coverage
+failure.
+
+Both model calls degrade rather than fail. When either comes back unusable the
+run keeps every claim, exactly as it behaved before this existed, and the
+record says which pass fell over -- an article written from all the evidence is
+worse than one written from the right quarter of it, and both are better than
+no article.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .contracts_v4 import ArticleBrief, EvidencePackage, Prompt2BlogWorkOrder
+from .schema_guards import require_non_empty
+from .support import _safe_dict, _safe_int, _safe_str
+
+logger = logging.getLogger(__name__)
+
+SELECTION_STAGE = "stage_v4_selection"
+
+# How many facts a hundred words of prose can carry and still be prose.
+#
+# Run 9e66bf84 ran at nine per hundred words across the article and 28 per
+# hundred in its worst section. Two is the density of writing that explains,
+# compares and decides rather than lists: a fact gets a clause of its own and
+# room for what it means. A 900-word article keeps around eighteen.
+#
+# Not a hard cap. It sets where the line starts; the operator moves it.
+CLAIMS_PER_HUNDRED_WORDS = 2.0
+
+# Below this the cut is not an editorial judgement, it is an empty article.
+# A short piece with a big dossier should still keep enough to write from.
+MIN_KEPT_CLAIMS = 8
+
+# One call each, and they read the same claim texts the writer would have. The
+# ceiling is generous because the input scales with the dossier.
+DEDUPE_MAX_TOKENS = 8_000
+RANK_MAX_TOKENS = 8_000
+
+
+def target_claim_count(target_word_count: int, available: int) -> int:
+    """Where the cut line starts, from the length the article is aiming at.
+
+    Derived rather than fixed, so it scales: a 2,500-word piece is allowed more
+    facts than a 400-word one, and the same constant explains both.
+    """
+    if available <= MIN_KEPT_CLAIMS:
+        return available
+    wanted = int(round(max(0, target_word_count) * CLAIMS_PER_HUNDRED_WORDS / 100))
+    return max(MIN_KEPT_CLAIMS, min(available, wanted))
+
+
+DEDUPE_SCHEMA = require_non_empty({
+    "type": "object",
+    "properties": {
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "keep": {"type": "string"},
+                    "same_as": {"type": "array", "items": {"type": "string"}},
+                    "why": {"type": "string"},
+                },
+                "required": ["keep", "same_as"],
+            },
+        },
+    },
+    "required": ["groups"],
+})
+
+RANK_SCHEMA = require_non_empty({
+    "type": "object",
+    "properties": {
+        "ranked": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "claim_id": {"type": "string"},
+                    "why": {"type": "string"},
+                },
+                "required": ["claim_id"],
+            },
+        },
+    },
+    "required": ["ranked"],
+})
+
+
+def build_dedupe_prompt(evidence: EvidencePackage) -> str:
+    """Group the claims that are the same fact. Nothing else."""
+    claims = "\n".join(
+        f"- {claim.claim_id} | {claim.text}" for claim in evidence.claims
+    )
+    return f"""\
+You are grouping research findings that say the same thing.
+
+The dossier below was gathered by several separate searches, so the same fact
+often arrives more than once in different words. Your only job is to say which
+claims are the same fact.
+
+CLAIMS
+{claims}
+
+Return strict JSON only:
+{{"groups": [{{"keep": "claim_id", "same_as": ["claim_id"], "why": "string"}}]}}
+
+Rules:
+- Only group claims asserting THE SAME FACT. Different wording, different
+  ordering, or a different level of politeness is the same fact.
+- `keep` is the claim that states it best: the most specific, the most precise
+  figure, the clearest sentence. You are choosing a survivor, not writing one.
+  Never invent or rewrite claim text.
+- A SUMMARY AND ITS DETAILS ARE NOT DUPLICATES. "Seven dishes define the
+  cuisine" and a claim describing one of those seven dishes are two different
+  facts at two levels of zoom. Both may be worth keeping and that is not your
+  decision. Leave them alone.
+- A general statement and a specific one are not duplicates. "Prices are low"
+  and "a plate costs 15 soles" are different facts.
+- Two claims about different places, dates, prices or people are never the same
+  fact, however similar the sentence.
+- Return only groups that actually contain a duplicate. A claim with no
+  duplicate does not need a group of its own.
+- Every id you return must be one of the ids above, and no id may appear twice
+  anywhere in your answer.
+"""
+
+
+def build_rank_prompt(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    claims: list[Any],
+) -> str:
+    """Order what survived by how much this particular article needs it."""
+    listed = "\n".join(f"- {claim.claim_id} | {claim.text}" for claim in claims)
+    return f"""\
+You are deciding which facts an article actually needs.
+
+Below is the brief the article was commissioned against, and the facts research
+found. Order the facts by how much THIS article needs them.
+
+THE ARTICLE
+Primary subject: {work_order.primary_subject}
+Core reader question: {brief.reader_question}
+The promise to keep: {brief.outcome}
+Spine: {brief.spine}
+Primary reader: {brief.reader.primary_reader}
+This piece fails if: {brief.fails_if}
+The seed it grew from: {brief.seed}
+
+THE FACTS
+{listed}
+
+Return strict JSON only:
+{{"ranked": [{{"claim_id": "string", "why": "string"}}]}}
+
+Rules:
+- Most needed first. The fact the article cannot be written without goes at the
+  top; the one it loses nothing by omitting goes at the bottom.
+- Rank against THIS brief, not against general interest. A fact can be true,
+  well sourced, and irrelevant here. Relevance is decided by the reader
+  question, the promise, and what the piece fails if it does not do.
+- A fact that answers the reader's actual decision outranks a fact that is
+  merely interesting background.
+- A claim that restates the seed, or confirms something the brief already
+  asserts, ranks low. The reader learns nothing from being told again what the
+  article's own premise already said.
+- A concrete figure, price, time, name or address a reader can act on
+  generally outranks a general characterisation.
+- `why` is one short sentence saying what the article uses this for. It is read
+  by a person choosing where to draw the line.
+- EVERY claim id above must appear exactly once. Ranking is ordering, not
+  selecting -- the cut is made by somebody else, after you.
+"""
+
+
+@dataclass
+class SelectionDependencies:
+    """The one model this needs, and which jobs it runs as."""
+
+    llm: Any
+    dedupe_job_id: str = "p2b.evidence_dedupe"
+    rank_job_id: str = "p2b.evidence_rank"
+    # None means the gateway answers for the jobs above, which is what makes
+    # both changeable from the dashboard.
+    model_name: str | None = None
+
+
+@dataclass
+class Selection:
+    """The ranked shortlist, the line, and the operator's changes to it.
+
+    Held apart from the dossier so the evidence stays what research returned
+    and the editorial decision stays a separate, reversible record.
+    """
+
+    # Survivors, most needed first. Deduplication's losers are not in here.
+    order: list[str] = field(default_factory=list)
+    # A merged claim, and the claim kept in its place.
+    merged: dict[str, str] = field(default_factory=dict)
+    # Where the line sits: how many from the top of `order` are kept.
+    keep_count: int = 0
+    # The operator's overrides. A claim below the line they want anyway, and
+    # one above it they do not. Both survive the line being moved, because they
+    # are decisions about that claim rather than about where the line is.
+    rescued: list[str] = field(default_factory=list)
+    dropped: list[str] = field(default_factory=list)
+    # One line per claim on why the ranker put it there, for the person picking.
+    reasons: dict[str, str] = field(default_factory=dict)
+    target_word_count: int = 0
+    # Which passes actually ran. A selection whose ranking fell over keeps
+    # every claim, and this is how the receipt says so rather than implying a
+    # judgement nobody made.
+    deduped: bool = False
+    ranked: bool = False
+    note: str = ""
+
+    def selected_claim_ids(self) -> set[str]:
+        """The claims that reach the writer."""
+        kept = set(self.order[: max(0, self.keep_count)])
+        kept |= {item for item in self.rescued if item in self.order}
+        kept -= set(self.dropped)
+        return kept
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "order": list(self.order),
+            "merged": dict(self.merged),
+            "keep_count": self.keep_count,
+            "rescued": list(self.rescued),
+            "dropped": list(self.dropped),
+            "reasons": dict(self.reasons),
+            "target_word_count": self.target_word_count,
+            "deduped": self.deduped,
+            "ranked": self.ranked,
+            "note": self.note,
+            "selected_claim_ids": sorted(self.selected_claim_ids()),
+        }
+
+    @classmethod
+    def from_record(cls, record: dict[str, Any]) -> "Selection":
+        record = _safe_dict(record)
+        return cls(
+            order=[_safe_str(item) for item in record.get("order") or [] if _safe_str(item)],
+            merged={
+                _safe_str(key): _safe_str(value)
+                for key, value in _safe_dict(record.get("merged")).items()
+            },
+            keep_count=_safe_int(record.get("keep_count"), default=0),
+            rescued=[_safe_str(item) for item in record.get("rescued") or [] if _safe_str(item)],
+            dropped=[_safe_str(item) for item in record.get("dropped") or [] if _safe_str(item)],
+            reasons={
+                _safe_str(key): _safe_str(value)
+                for key, value in _safe_dict(record.get("reasons")).items()
+            },
+            target_word_count=_safe_int(record.get("target_word_count"), default=0),
+            deduped=bool(record.get("deduped")),
+            ranked=bool(record.get("ranked")),
+            note=_safe_str(record.get("note")),
+        )
+
+
+def _rows(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = _safe_dict(payload).get(key)
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def _deduplicate(
+    evidence: EvidencePackage, dependencies: SelectionDependencies
+) -> tuple[dict[str, str], bool]:
+    """Loser claim id -> the claim kept in its place.
+
+    Never raises. A dedupe that fails leaves every claim standing, which is
+    exactly how the pipeline behaved before this existed.
+    """
+    known = {claim.claim_id for claim in evidence.claims}
+    try:
+        parsed, _raw = dependencies.llm.invoke_json(
+            job_id=dependencies.dedupe_job_id,
+            prompt=build_dedupe_prompt(evidence),
+            model_name=dependencies.model_name,
+            schema=DEDUPE_SCHEMA,
+            max_tokens=DEDUPE_MAX_TOKENS,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001 -- a lost dedupe costs nothing
+        logger.warning("Prompt2Blog evidence dedupe failed: %s", exc)
+        return {}, False
+
+    merged: dict[str, str] = {}
+    for group in _rows(parsed, "groups"):
+        survivor = _safe_str(group.get("keep"))
+        if survivor not in known or survivor in merged:
+            continue
+        for loser in group.get("same_as") or []:
+            loser = _safe_str(loser)
+            # Every guard here is the same guard: a claim is in exactly one
+            # group, is never merged into itself, and is never merged into
+            # something that was itself merged away. A cycle or a chain would
+            # leave a claim pointing at a claim nobody can see.
+            if loser in known and loser != survivor and loser not in merged:
+                merged[loser] = survivor
+    return {
+        loser: survivor
+        for loser, survivor in merged.items()
+        if survivor not in merged
+    }, True
+
+
+def _rank(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    survivors: list[Any],
+    dependencies: SelectionDependencies,
+) -> tuple[list[str], dict[str, str], bool]:
+    """Survivor ids most-needed-first, and one line each on why.
+
+    Never raises, and never loses a claim. A claim the ranker forgot is
+    appended in dossier order rather than dropped: an omission from a model is
+    not an editorial decision, and treating it as one would cut a fact nobody
+    chose to cut.
+    """
+    order = [claim.claim_id for claim in survivors]
+    try:
+        parsed, _raw = dependencies.llm.invoke_json(
+            job_id=dependencies.rank_job_id,
+            prompt=build_rank_prompt(brief, work_order, survivors),
+            model_name=dependencies.model_name,
+            schema=RANK_SCHEMA,
+            max_tokens=RANK_MAX_TOKENS,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001 -- an unranked list is still a list
+        logger.warning("Prompt2Blog evidence ranking failed: %s", exc)
+        return order, {}, False
+
+    remaining = set(order)
+    ranked: list[str] = []
+    reasons: dict[str, str] = {}
+    for row in _rows(parsed, "ranked"):
+        claim_id = _safe_str(row.get("claim_id"))
+        if claim_id in remaining:
+            remaining.discard(claim_id)
+            ranked.append(claim_id)
+            if why := _safe_str(row.get("why")):
+                reasons[claim_id] = why
+    if remaining:
+        logger.warning(
+            "Prompt2Blog ranking omitted %d of %d claims; keeping them at the "
+            "bottom rather than dropping them",
+            len(remaining),
+            len(order),
+        )
+    ranked.extend(item for item in order if item in remaining)
+    return ranked, reasons, True
+
+
+def select_evidence(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    evidence: EvidencePackage,
+    dependencies: SelectionDependencies,
+    *,
+    target_word_count: int,
+) -> Selection:
+    """Deduplicate, rank, and draw the line the operator will move."""
+    merged, deduped = _deduplicate(evidence, dependencies)
+    survivors = [claim for claim in evidence.claims if claim.claim_id not in merged]
+    order, reasons, ranked = _rank(brief, work_order, survivors, dependencies)
+
+    keep_count = target_claim_count(target_word_count, len(order))
+    notes = []
+    if not deduped:
+        notes.append("Deduplication did not run, so nothing was merged.")
+    if not ranked:
+        notes.append(
+            "Ranking did not run, so this order is the dossier's own and says "
+            "nothing about what the article needs."
+        )
+    if not deduped and not ranked:
+        # Neither pass ran. Drawing a line through an unranked list would cut
+        # facts by the order they were gathered in, which is not a decision.
+        keep_count = len(order)
+        notes.append("Every fact is kept, because nothing looked at them.")
+
+    return Selection(
+        order=order,
+        merged=merged,
+        keep_count=keep_count,
+        reasons=reasons,
+        target_word_count=target_word_count,
+        deduped=deduped,
+        ranked=ranked,
+        note=" ".join(notes),
+    )
+
+
+def apply_selection(
+    evidence: EvidencePackage, selection: Selection
+) -> EvidencePackage:
+    """Write the selection onto the dossier's claims.
+
+    A merged claim hands the survivor its sources and its questions before it
+    stands down, so deduplication cannot cost a claim its provenance and cannot
+    take a question's only answer away from it.
+
+    Requirement `claim_ids` are left exactly as research recorded them. They
+    are what the coverage verdict reads, and rewriting them here would turn an
+    editorial cut into a research failure -- the one thing selection must never
+    be able to do.
+
+    A claim the ranking never saw is kept. The gate can add one after selection
+    has run -- an operator answering a question themselves mints a claim
+    against a `firsthand` source -- and a fact somebody typed in to unblock the
+    article being silently cut from it, because a model that ran before they
+    typed it did not rank it, is the worst failure this could have.
+    """
+    survivor_of = dict(selection.merged)
+    ranked = set(selection.order)
+    chosen = selection.selected_claim_ids()
+
+    extra_sources: dict[str, list[str]] = {}
+    extra_requirements: dict[str, list[str]] = {}
+    by_id = {claim.claim_id: claim for claim in evidence.claims}
+    for loser, survivor in survivor_of.items():
+        if loser not in by_id or survivor not in by_id:
+            continue
+        extra_sources.setdefault(survivor, []).extend(by_id[loser].source_ids)
+        extra_requirements.setdefault(survivor, []).extend(by_id[loser].requirement_ids)
+
+    claims = []
+    for claim in evidence.claims:
+        merged_into = survivor_of.get(claim.claim_id, "")
+        selected = (
+            False
+            if merged_into
+            else claim.claim_id in chosen or claim.claim_id not in ranked
+        )
+        claims.append(
+            claim.model_copy(
+                update={
+                    "merged_into": merged_into,
+                    "selected": selected,
+                    "source_ids": _extended(
+                        claim.source_ids, extra_sources.get(claim.claim_id)
+                    ),
+                    "requirement_ids": _extended(
+                        claim.requirement_ids, extra_requirements.get(claim.claim_id)
+                    ),
+                }
+            )
+        )
+    return evidence.model_copy(update={"claims": claims})
+
+
+def _extended(existing: list[str], added: list[str] | None) -> list[str]:
+    """Existing order kept, anything new appended once. The contract rejects
+    a repeated reference, and a merged claim usually shares a question."""
+    if not added:
+        return list(existing)
+    out = list(existing)
+    for item in added:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def shortlist(
+    evidence: EvidencePackage,
+    work_order: Prompt2BlogWorkOrder,
+    selection: Selection,
+) -> list[dict[str, Any]]:
+    """The ranked list a person picks from, in order, with the line's effect.
+
+    One row per survivor. Deduplication's losers are not rows -- they are named
+    on the survivor that absorbed them, because "these three said the same
+    thing and this is the one we kept" is the useful shape, and three
+    near-identical rows to tick past is the shape that made the operator stop
+    reading.
+    """
+    by_id = {claim.claim_id: claim for claim in evidence.claims}
+    question_of = {
+        item.requirement_id: item.question for item in work_order.requirements
+    }
+    absorbed: dict[str, list[str]] = {}
+    for loser, survivor in selection.merged.items():
+        if loser in by_id:
+            absorbed.setdefault(survivor, []).append(by_id[loser].text)
+
+    chosen = selection.selected_claim_ids()
+    rows: list[dict[str, Any]] = []
+    for position, claim_id in enumerate(selection.order):
+        claim = by_id.get(claim_id)
+        if claim is None:
+            continue
+        rows.append(
+            {
+                "claim_id": claim_id,
+                "text": claim.text,
+                "rank": position + 1,
+                "selected": claim_id in chosen,
+                # So the operator can see when the line is not what decided it.
+                "rescued": claim_id in selection.rescued,
+                "dropped": claim_id in selection.dropped,
+                "why": selection.reasons.get(claim_id, ""),
+                "questions": [
+                    question_of[item]
+                    for item in claim.requirement_ids
+                    if item in question_of
+                ],
+                "merged_in": absorbed.get(claim_id, []),
+                "confidence": claim.confidence,
+            }
+        )
+    return rows
+
+
+class SelectionRefused(ValueError):
+    """The picker asked for something the selection cannot mean."""
+
+
+def revise(
+    selection: Selection,
+    *,
+    keep_count: int | None = None,
+    rescue: str | None = None,
+    drop: str | None = None,
+    clear: str | None = None,
+) -> Selection:
+    """One move from the picker. No model call; this is the operator's decision.
+
+    Moving the line and marking one claim are separate on purpose. An override
+    is about that claim, so it has to outlive the line moving past it -- an
+    operator who rescues a fact and then widens the cut has not un-rescued it.
+    """
+    moves = [keep_count is not None, bool(rescue), bool(drop), bool(clear)]
+    if sum(moves) != 1:
+        raise SelectionRefused("Say one thing: move the line, or mark one fact.")
+
+    known = set(selection.order)
+    for claim_id in (rescue, drop, clear):
+        if claim_id and claim_id not in known:
+            raise SelectionRefused(f"No fact called {claim_id} in this selection.")
+
+    rescued = [item for item in selection.rescued if item not in (rescue, drop, clear)]
+    dropped = [item for item in selection.dropped if item not in (rescue, drop, clear)]
+    if rescue:
+        rescued.append(rescue)
+    if drop:
+        dropped.append(drop)
+
+    line = selection.keep_count if keep_count is None else keep_count
+    if not 0 <= line <= len(selection.order):
+        raise SelectionRefused(
+            f"The line goes between 0 and {len(selection.order)} facts."
+        )
+
+    revised = Selection(
+        order=list(selection.order),
+        merged=dict(selection.merged),
+        keep_count=line,
+        rescued=rescued,
+        dropped=dropped,
+        reasons=dict(selection.reasons),
+        target_word_count=selection.target_word_count,
+        deduped=selection.deduped,
+        ranked=selection.ranked,
+        note=selection.note,
+    )
+    if not revised.selected_claim_ids():
+        raise SelectionRefused(
+            "Keep at least one fact — there is nothing to write from otherwise."
+        )
+    return revised

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
@@ -181,8 +181,9 @@ Rules:
   decision. Leave them alone.
 - A general statement and a specific one are not duplicates. "Prices are low"
   and "a plate costs 15 soles" are different facts.
-- Two claims about different places, dates, prices or people are never the same
-  fact, however similar the sentence.
+- Two claims about different places, dates, times, prices, hours or people are
+  never the same fact, however similar the sentence. Two opening times that
+  differ by fifteen minutes are a disagreement, not a repetition.
 - Return only groups that actually contain a duplicate. A claim with no
   duplicate does not need a group of its own.
 - Use the labels above exactly as written (f1, f2, ...). Never invent a
@@ -334,6 +335,26 @@ def _rows(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
     return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
 
 
+def _disputed_pairs(evidence: EvidencePackage) -> set[frozenset[str]]:
+    """Every pair of claims the dossier itself says disagree.
+
+    `record_detected_conflicts` already finds these and nothing downstream used
+    them. A conflict is the strongest possible evidence that two claims are not
+    the same fact -- it is the dossier saying so in as many words.
+    """
+    pairs: set[frozenset[str]] = set()
+    for conflict in evidence.conflicts:
+        ids = [
+            _safe_str(item)
+            for item in (getattr(conflict, "claim_ids", None) or [])
+            if _safe_str(item)
+        ]
+        for index, first in enumerate(ids):
+            for second in ids[index + 1 :]:
+                pairs.add(frozenset((first, second)))
+    return pairs
+
+
 def _deduplicate(
     evidence: EvidencePackage, dependencies: SelectionDependencies
 ) -> tuple[dict[str, str], bool]:
@@ -344,6 +365,10 @@ def _deduplicate(
     """
     _, from_handle = handles(list(evidence.claims))
     known = {claim.claim_id for claim in evidence.claims}
+    # Claims the dossier has already recorded as disagreeing with each other.
+    # Merging across one of these picks a winner in a factual dispute and
+    # deletes the loser from the writer's desk, silently.
+    disputed = _disputed_pairs(evidence)
     try:
         parsed, _raw = dependencies.llm.invoke_json(
             job_id=dependencies.dedupe_job_id,
@@ -369,6 +394,19 @@ def _deduplicate(
             # something that was itself merged away. A cycle or a chain would
             # leave a claim pointing at a claim nobody can see.
             if loser in known and loser != survivor and loser not in merged:
+                if frozenset((loser, survivor)) in disputed:
+                    # Run 3750891f: the dossier held Titi's Sunday opening as
+                    # both 12:30 and 12:45 and recorded the conflict. Dedupe
+                    # merged the correct claim into the wrong one, so the
+                    # writer only ever saw 12:45 while groundedness read the
+                    # whole dossier and failed the draft for it.
+                    logger.warning(
+                        "Prompt2Blog dedupe refused to merge %s into %s: the "
+                        "dossier records them as conflicting",
+                        loser,
+                        survivor,
+                    )
+                    continue
                 merged[loser] = survivor
     return {
         loser: survivor

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
@@ -132,10 +132,29 @@ RANK_SCHEMA = require_non_empty({
 })
 
 
+def handles(claims: list[Any]) -> tuple[dict[str, str], dict[str, str]]:
+    """Short names for the prompt, and the map back to real claim ids.
+
+    Claim ids are namespaced by the question that produced them, so they run to
+    76 characters -- `req_neighbourhood_chifa_characteristics:ncc_18`. Asked to
+    copy a hundred of those, a model shortens them: the first real ranking came
+    back correctly ordered, with good reasoning, and every id rewritten to
+    `ncc_18` or invented outright as `clm_titi_name`. Not one of 102 matched,
+    and the ranking was thrown away.
+
+    This is #499 again -- a model copies a short handle and the application
+    restores the real value -- and the same answer works. The handle carries no
+    meaning, so there is nothing in it to abbreviate.
+    """
+    to_handle = {claim.claim_id: f"f{index}" for index, claim in enumerate(claims, 1)}
+    return to_handle, {handle: real for real, handle in to_handle.items()}
+
+
 def build_dedupe_prompt(evidence: EvidencePackage) -> str:
     """Group the claims that are the same fact. Nothing else."""
+    to_handle, _ = handles(list(evidence.claims))
     claims = "\n".join(
-        f"- {claim.claim_id} | {claim.text}" for claim in evidence.claims
+        f"- {to_handle[claim.claim_id]} | {claim.text}" for claim in evidence.claims
     )
     return f"""\
 You are grouping research findings that say the same thing.
@@ -148,7 +167,7 @@ CLAIMS
 {claims}
 
 Return strict JSON only:
-{{"groups": [{{"keep": "claim_id", "same_as": ["claim_id"], "why": "string"}}]}}
+{{"groups": [{{"keep": "f1", "same_as": ["f7"], "why": "string"}}]}}
 
 Rules:
 - Only group claims asserting THE SAME FACT. Different wording, different
@@ -166,8 +185,10 @@ Rules:
   fact, however similar the sentence.
 - Return only groups that actually contain a duplicate. A claim with no
   duplicate does not need a group of its own.
-- Every id you return must be one of the ids above, and no id may appear twice
-  anywhere in your answer.
+- Use the labels above exactly as written (f1, f2, ...). Never invent a
+  label, never shorten one, and never use any other name for a claim.
+- Every label you return must be one of the labels above, and no label may
+  appear twice anywhere in your answer.
 """
 
 
@@ -177,7 +198,8 @@ def build_rank_prompt(
     claims: list[Any],
 ) -> str:
     """Order what survived by how much this particular article needs it."""
-    listed = "\n".join(f"- {claim.claim_id} | {claim.text}" for claim in claims)
+    to_handle, _ = handles(claims)
+    listed = "\n".join(f"- {to_handle[claim.claim_id]} | {claim.text}" for claim in claims)
     return f"""\
 You are deciding which facts an article actually needs.
 
@@ -197,7 +219,7 @@ THE FACTS
 {listed}
 
 Return strict JSON only:
-{{"ranked": [{{"claim_id": "string", "why": "string"}}]}}
+{{"ranked": [{{"claim_id": "f1", "why": "string"}}]}}
 
 Rules:
 - Most needed first. The fact the article cannot be written without goes at the
@@ -214,7 +236,9 @@ Rules:
   generally outranks a general characterisation.
 - `why` is one short sentence saying what the article uses this for. It is read
   by a person choosing where to draw the line.
-- EVERY claim id above must appear exactly once. Ranking is ordering, not
+- Use the labels above exactly as written (f1, f2, ...). Never invent a
+  label, never shorten one, and never use any other name for a claim.
+- EVERY label above must appear exactly once. Ranking is ordering, not
   selecting -- the cut is made by somebody else, after you.
 """
 
@@ -318,6 +342,7 @@ def _deduplicate(
     Never raises. A dedupe that fails leaves every claim standing, which is
     exactly how the pipeline behaved before this existed.
     """
+    _, from_handle = handles(list(evidence.claims))
     known = {claim.claim_id for claim in evidence.claims}
     try:
         parsed, _raw = dependencies.llm.invoke_json(
@@ -334,11 +359,11 @@ def _deduplicate(
 
     merged: dict[str, str] = {}
     for group in _rows(parsed, "groups"):
-        survivor = _safe_str(group.get("keep"))
+        survivor = from_handle.get(_safe_str(group.get("keep")), "")
         if survivor not in known or survivor in merged:
             continue
         for loser in group.get("same_as") or []:
-            loser = _safe_str(loser)
+            loser = from_handle.get(_safe_str(loser), "")
             # Every guard here is the same guard: a claim is in exactly one
             # group, is never merged into itself, and is never merged into
             # something that was itself merged away. A cycle or a chain would
@@ -366,6 +391,7 @@ def _rank(
     chose to cut.
     """
     order = [claim.claim_id for claim in survivors]
+    _, from_handle = handles(survivors)
     try:
         parsed, _raw = dependencies.llm.invoke_json(
             job_id=dependencies.rank_job_id,
@@ -383,7 +409,7 @@ def _rank(
     ranked: list[str] = []
     reasons: dict[str, str] = {}
     for row in _rows(parsed, "ranked"):
-        claim_id = _safe_str(row.get("claim_id"))
+        claim_id = from_handle.get(_safe_str(row.get("claim_id")), "")
         if claim_id in remaining:
             remaining.discard(claim_id)
             ranked.append(claim_id)
@@ -397,7 +423,11 @@ def _rank(
             len(order),
         )
     ranked.extend(item for item in order if item in remaining)
-    return ranked, reasons, True
+    # A call that returned is not a ranking that happened. The first real run
+    # came back with 102 rows and matched none of them, and this reported
+    # itself as ranked -- so a line was drawn at 18 through a list in the order
+    # research happened to return, which is not a decision anyone made.
+    return ranked, reasons, bool(ranked and not remaining == set(order))
 
 
 def select_evidence(
@@ -422,11 +452,13 @@ def select_evidence(
             "Ranking did not run, so this order is the dossier's own and says "
             "nothing about what the article needs."
         )
-    if not deduped and not ranked:
-        # Neither pass ran. Drawing a line through an unranked list would cut
-        # facts by the order they were gathered in, which is not a decision.
+    if not ranked:
+        # Drawing a line through an unranked list cuts facts by the order they
+        # were gathered in, which is not a decision anybody made. Deduplication
+        # succeeding does not rescue that: merging repeats says nothing about
+        # which of the survivors this article needs.
         keep_count = len(order)
-        notes.append("Every fact is kept, because nothing looked at them.")
+        notes.append("Every fact is kept, because nothing ordered them.")
 
     return Selection(
         order=order,
@@ -449,10 +481,14 @@ def apply_selection(
     stands down, so deduplication cannot cost a claim its provenance and cannot
     take a question's only answer away from it.
 
-    Requirement `claim_ids` are left exactly as research recorded them. They
-    are what the coverage verdict reads, and rewriting them here would turn an
-    editorial cut into a research failure -- the one thing selection must never
-    be able to do.
+    The requirement side of that link is mirrored, and only ever added to. The
+    contract requires the two directions to agree, so handing a survivor the
+    questions its merged claims answered without also naming it on those
+    questions produces a dossier that will not validate -- which is how the
+    first real run died at the hand-off. Nothing is ever removed from a
+    requirement here: a question can only gain a claim it is genuinely
+    supported by, so coverage after selection is never weaker than before it.
+    An editorial cut must not be able to become a research failure.
 
     A claim the ranking never saw is kept. The gate can add one after selection
     has run -- an operator answering a question themselves mints a claim
@@ -472,6 +508,11 @@ def apply_selection(
             continue
         extra_sources.setdefault(survivor, []).extend(by_id[loser].source_ids)
         extra_requirements.setdefault(survivor, []).extend(by_id[loser].requirement_ids)
+
+    gained: dict[str, set[str]] = {}
+    for survivor, requirement_ids in extra_requirements.items():
+        for requirement_id in requirement_ids:
+            gained.setdefault(requirement_id, set()).add(survivor)
 
     claims = []
     for claim in evidence.claims:
@@ -495,7 +536,20 @@ def apply_selection(
                 }
             )
         )
-    return evidence.model_copy(update={"claims": claims})
+    requirements = [
+        requirement.model_copy(
+            update={
+                "claim_ids": _extended(
+                    requirement.claim_ids,
+                    sorted(gained.get(requirement.requirement_id, ())),
+                )
+            }
+        )
+        if requirement.requirement_id in gained
+        else requirement
+        for requirement in evidence.requirements
+    ]
+    return evidence.model_copy(update={"claims": claims, "requirements": requirements})
 
 
 def _extended(existing: list[str], added: list[str] | None) -> list[str]:

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
@@ -1,0 +1,370 @@
+"""Which facts the article is written from (#534).
+
+What these prove: the same fact arriving twice becomes one, the order is what
+the brief needs rather than what research returned, the line is drawn from the
+article's length, the operator's moves stick, and none of it can cost the run
+a fact it needed or turn an editorial cut into a coverage failure.
+
+What they cannot prove: whether the ranking is any good. That is a question
+about a real model reading real evidence against a real brief, and a fake
+returning a canned order says nothing about it. The first real signal is a run
+that finishes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.prompt2blog.contracts_v4 import (
+    ArticleBrief,
+    BriefReader,
+    EvidenceClaim,
+    EvidencePackage,
+    EvidenceRequirement,
+    EvidenceSource,
+    Prompt2BlogWorkOrder,
+    WorkOrderReference,
+    WorkOrderRequirement,
+    WorkOrderScope,
+)
+from app.features.prompt2blog.selection_v4 import (
+    MIN_KEPT_CLAIMS,
+    Selection,
+    SelectionDependencies,
+    SelectionRefused,
+    apply_selection,
+    revise,
+    select_evidence,
+    shortlist,
+    target_claim_count,
+)
+
+
+def _brief() -> ArticleBrief:
+    return ArticleBrief(
+        brief_fingerprint="bf-1",
+        seed="Chifa is Lima's second cuisine.",
+        location="Lima",
+        spine="What chifa is and where to eat it.",
+        reader_question="Where should I eat chifa in Lima?",
+        outcome="The reader picks a chifa and goes.",
+        fails_if="It lists restaurants without saying which to choose.",
+        reader=BriefReader(primary_reader="A first-time visitor with two nights."),
+        must_name=[],
+        material=[],
+        topic_module_ids=[],
+        form_id="analysis",
+    )
+
+
+def _work_order() -> Prompt2BlogWorkOrder:
+    return Prompt2BlogWorkOrder(
+        work_order_fingerprint="wo-1",
+        brief_fingerprint="bf-1",
+        primary_subject="Lima",
+        scope=WorkOrderScope(
+            mode="single_subject",
+            references=[WorkOrderReference(name="Lima", role="primary_subject")],
+        ),
+        premise=[],
+        requirements=[
+            WorkOrderRequirement(
+                requirement_id="r1", question="What is chifa?", kind="load_bearing"
+            ),
+        ],
+    )
+
+
+def _package(count: int) -> EvidencePackage:
+    return EvidencePackage(
+        schema_version=4,
+        work_order_fingerprint="wo-1",
+        sources=[
+            EvidenceSource(
+                source_id=f"s{index}",
+                url=f"https://example.pe/{index}",
+                title=f"Source {index}",
+                publisher="Example",
+                source_type="official",
+                material_type="web",
+                retrieved_at="2026-09-01",
+                notes=["Retrieved for this run."],
+            )
+            for index in range(1, count + 1)
+        ],
+        claims=[
+            EvidenceClaim(
+                claim_id=f"c{index}",
+                text=f"Fact number {index} about chifa in Lima.",
+                source_ids=[f"s{index}"],
+                requirement_ids=["r1"],
+                confidence="high",
+            )
+            for index in range(1, count + 1)
+        ],
+        requirements=[
+            EvidenceRequirement(
+                requirement_id="r1",
+                status="supported",
+                claim_ids=[f"c{index}" for index in range(1, count + 1)],
+            )
+        ],
+        premise_findings=[],
+        conflicts=[],
+        gaps=[],
+    )
+
+
+class _LLM:
+    """Answers the two calls by which schema it was handed."""
+
+    def __init__(self, *, groups: list[dict] | None = None, ranked: list[str] | None = None):
+        self.groups = groups
+        self.ranked = ranked
+        self.jobs: list[str] = []
+        self.prompts: list[str] = []
+
+    def invoke_json(self, *, prompt: str, job_id: str = "", **_kwargs: Any):
+        self.jobs.append(job_id)
+        self.prompts.append(prompt)
+        if job_id.endswith("dedupe"):
+            if self.groups is None:
+                raise RuntimeError("the dedupe model is having a day")
+            return {"groups": self.groups}, "{}"
+        if self.ranked is None:
+            raise RuntimeError("the ranking model is having a day")
+        return {"ranked": [{"claim_id": item, "why": "because"} for item in self.ranked]}, "{}"
+
+
+def _select(evidence: EvidencePackage, llm: _LLM, *, words: int = 900) -> Selection:
+    return select_evidence(
+        _brief(),
+        _work_order(),
+        evidence,
+        SelectionDependencies(llm=llm),
+        target_word_count=words,
+    )
+
+
+def test_the_line_comes_from_how_long_the_article_is():
+    """Run 9e66bf84 ran at nine claims per hundred words across the article and
+    28 per hundred in its worst section. There is no sentence you can write at
+    that density except a list."""
+    assert target_claim_count(900, available=100) == 18
+    assert target_claim_count(2500, available=100) == 50
+    # Never more than there are, and never so few it is not an article.
+    assert target_claim_count(2500, available=12) == 12
+    assert target_claim_count(100, available=100) == MIN_KEPT_CLAIMS
+
+
+def test_the_same_fact_twice_becomes_one_and_keeps_both_its_sources():
+    """Deduplication must not lose provenance. A merged claim hands the
+    survivor its sources and its questions before it stands down."""
+    evidence = _package(3)
+    llm = _LLM(groups=[{"keep": "c1", "same_as": ["c2"]}], ranked=["c1", "c3"])
+
+    selection = _select(evidence, llm)
+    applied = apply_selection(evidence, selection)
+    by_id = {claim.claim_id: claim for claim in applied.claims}
+
+    assert selection.merged == {"c2": "c1"}
+    assert by_id["c2"].merged_into == "c1"
+    assert by_id["c2"].selected is False
+    assert by_id["c1"].source_ids == ["s1", "s2"]
+    # The claim text is never rewritten. Every survivor is verbatim research.
+    assert by_id["c1"].text == "Fact number 1 about chifa in Lima."
+
+
+def test_dedupe_never_leaves_a_claim_pointing_at_a_claim_nobody_can_see():
+    """A chain or a cycle would merge a claim into one that was itself merged
+    away, and the survivor the operator is shown would not exist."""
+    evidence = _package(3)
+    llm = _LLM(
+        groups=[
+            {"keep": "c1", "same_as": ["c2"]},
+            # c1 merged away here. Following both would leave c2 orphaned.
+            {"keep": "c3", "same_as": ["c1"]},
+        ],
+        ranked=["c1", "c2", "c3"],
+    )
+
+    selection = _select(evidence, llm)
+
+    for survivor in selection.merged.values():
+        assert survivor not in selection.merged
+
+
+def test_a_claim_the_ranker_forgot_is_kept_not_cut():
+    """An omission from a model is not an editorial decision. Treating one as
+    a cut would drop a fact nobody chose to drop."""
+    evidence = _package(12)
+    llm = _LLM(groups=[], ranked=["c5", "c3"])
+
+    selection = _select(evidence, llm)
+
+    assert set(selection.order) == {f"c{index}" for index in range(1, 13)}
+    assert selection.order[:2] == ["c5", "c3"]
+
+
+def test_a_failed_pass_keeps_every_fact_and_says_which_one_fell_over():
+    """Degrade, not fail. An article written from all the evidence is worse
+    than one written from the right quarter of it, and both beat no article."""
+    evidence = _package(40)
+
+    both_down = _select(evidence, _LLM(groups=None, ranked=None))
+    assert both_down.deduped is False and both_down.ranked is False
+    assert both_down.keep_count == 40, "an unranked order is not a ranking to cut"
+    assert "nothing looked at them" in both_down.note
+
+    rank_only = _select(evidence, _LLM(groups=None, ranked=[f"c{i}" for i in range(1, 41)]))
+    assert rank_only.deduped is False and rank_only.ranked is True
+    assert rank_only.keep_count == 18
+    assert "Deduplication did not run" in rank_only.note
+
+
+def test_a_deselected_claim_leaves_the_desk_and_never_the_record():
+    """The rule that makes the cut safe, and the one it must never break: a
+    question its claim supported is still supported."""
+    evidence = _package(40)
+    llm = _LLM(groups=[], ranked=[f"c{index}" for index in range(1, 41)])
+
+    applied = apply_selection(evidence, _select(evidence, llm))
+    selected = [claim for claim in applied.claims if claim.selected]
+
+    assert len(applied.claims) == 40, "nothing is deleted"
+    assert len(selected) == 18
+    assert applied.requirements[0].claim_ids == [f"c{i}" for i in range(1, 41)]
+
+
+def test_a_fact_added_after_the_ranking_still_reaches_the_writer():
+    """The gate can mint a claim after selection has run -- an operator
+    answering a question themselves. A fact somebody typed in to unblock the
+    article being silently cut from it is the worst failure this could have."""
+    evidence = _package(40)
+    llm = _LLM(groups=[], ranked=[f"c{index}" for index in range(1, 41)])
+    selection = _select(evidence, llm)
+
+    late = evidence.claims[0].model_copy(
+        update={"claim_id": "opc-1", "text": "What the operator found themselves."}
+    )
+    evidence = evidence.model_copy(update={"claims": [*evidence.claims, late]})
+    applied = apply_selection(evidence, selection)
+
+    assert next(c for c in applied.claims if c.claim_id == "opc-1").selected is True
+
+
+def test_the_ranker_is_told_what_the_piece_fails_if_it_does_not_do():
+    """Ranking is against this brief, not against general interest."""
+    evidence = _package(3)
+    llm = _LLM(groups=[], ranked=["c1", "c2", "c3"])
+
+    _select(evidence, llm)
+
+    rank_prompt = llm.prompts[-1]
+    assert _brief().fails_if in rank_prompt
+    assert _brief().reader_question in rank_prompt
+    assert _brief().seed in rank_prompt
+    assert llm.jobs == ["p2b.evidence_dedupe", "p2b.evidence_rank"]
+
+
+def test_dedupe_is_told_a_summary_and_its_details_are_not_duplicates():
+    """The case that would destroy the article's best material: one claim
+    listing seven dishes and four describing four of them are two levels of
+    zoom, not a duplicate."""
+    evidence = _package(2)
+    llm = _LLM(groups=[], ranked=["c1", "c2"])
+
+    _select(evidence, llm)
+
+    assert "SUMMARY AND ITS DETAILS ARE NOT DUPLICATES" in llm.prompts[0]
+    assert "Never invent or rewrite claim text" in llm.prompts[0]
+
+
+def _ranked(count: int = 40, keep: int = 18) -> Selection:
+    return Selection(
+        order=[f"c{index}" for index in range(1, count + 1)],
+        keep_count=keep,
+        ranked=True,
+        deduped=True,
+        reasons={"c1": "The reader cannot choose without it."},
+        target_word_count=900,
+    )
+
+
+def test_moving_the_line_changes_what_is_kept():
+    selection = revise(_ranked(), keep_count=5)
+
+    assert selection.selected_claim_ids() == {f"c{index}" for index in range(1, 6)}
+
+
+def test_a_rescue_outlives_the_line_moving_past_it():
+    """The override is a decision about that fact, not about where the line is.
+    An operator who rescues a fact and then widens the cut has not un-rescued
+    it, and one who narrows the cut has not lost it."""
+    selection = revise(_ranked(), rescue="c30")
+    assert "c30" in selection.selected_claim_ids()
+
+    widened = revise(selection, keep_count=35)
+    assert "c30" in widened.selected_claim_ids()
+
+    narrowed = revise(widened, keep_count=3)
+    assert narrowed.selected_claim_ids() == {"c1", "c2", "c3", "c30"}
+
+
+def test_a_drop_survives_the_line_too_and_can_be_undone():
+    selection = revise(_ranked(), drop="c2")
+    assert "c2" not in selection.selected_claim_ids()
+
+    assert "c2" in revise(selection, clear="c2").selected_claim_ids()
+
+
+def test_the_picker_refuses_what_it_cannot_mean():
+    with pytest.raises(SelectionRefused):
+        revise(_ranked(), keep_count=5, drop="c2")
+    with pytest.raises(SelectionRefused):
+        revise(_ranked())
+    with pytest.raises(SelectionRefused):
+        revise(_ranked(), rescue="c99")
+    with pytest.raises(SelectionRefused):
+        revise(_ranked(), keep_count=99)
+    # And it will not leave the writer with nothing to write from.
+    with pytest.raises(SelectionRefused):
+        revise(_ranked(), keep_count=0)
+
+
+def test_the_shortlist_names_what_a_survivor_absorbed():
+    """Three near-identical rows to tick past is the shape that made the
+    operator stop reading. One row saying what it stands for is the useful
+    one."""
+    evidence = _package(3)
+    selection = Selection(
+        order=["c1", "c3"],
+        merged={"c2": "c1"},
+        keep_count=1,
+        ranked=True,
+        deduped=True,
+        reasons={"c1": "Answers the reader's question directly."},
+    )
+
+    rows = shortlist(evidence, _work_order(), selection)
+
+    assert [row["claim_id"] for row in rows] == ["c1", "c3"]
+    assert rows[0]["rank"] == 1 and rows[0]["selected"] is True
+    assert rows[0]["merged_in"] == ["Fact number 2 about chifa in Lima."]
+    assert rows[0]["why"] == "Answers the reader's question directly."
+    assert rows[0]["questions"] == ["What is chifa?"]
+    assert rows[1]["selected"] is False
+
+
+def test_the_shortlist_says_when_the_line_was_not_what_decided_it():
+    evidence = _package(3)
+    selection = revise(
+        Selection(order=["c1", "c2", "c3"], keep_count=1, ranked=True), rescue="c3"
+    )
+
+    rows = {row["claim_id"]: row for row in shortlist(evidence, _work_order(), selection)}
+
+    assert rows["c3"]["rescued"] is True and rows["c3"]["selected"] is True
+    assert rows["c2"]["rescued"] is False and rows["c2"]["selected"] is False

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
@@ -163,7 +163,7 @@ def test_the_same_fact_twice_becomes_one_and_keeps_both_its_sources():
     """Deduplication must not lose provenance. A merged claim hands the
     survivor its sources and its questions before it stands down."""
     evidence = _package(3)
-    llm = _LLM(groups=[{"keep": "c1", "same_as": ["c2"]}], ranked=["c1", "c3"])
+    llm = _LLM(groups=[{"keep": "f1", "same_as": ["f2"]}], ranked=["f1", "f3"])
 
     selection = _select(evidence, llm)
     applied = apply_selection(evidence, selection)
@@ -183,11 +183,11 @@ def test_dedupe_never_leaves_a_claim_pointing_at_a_claim_nobody_can_see():
     evidence = _package(3)
     llm = _LLM(
         groups=[
-            {"keep": "c1", "same_as": ["c2"]},
-            # c1 merged away here. Following both would leave c2 orphaned.
-            {"keep": "c3", "same_as": ["c1"]},
+            {"keep": "f1", "same_as": ["f2"]},
+            # f1 merged away here. Following both would leave f2 orphaned.
+            {"keep": "f3", "same_as": ["f1"]},
         ],
-        ranked=["c1", "c2", "c3"],
+        ranked=["f1", "f2", "f3"],
     )
 
     selection = _select(evidence, llm)
@@ -200,7 +200,7 @@ def test_a_claim_the_ranker_forgot_is_kept_not_cut():
     """An omission from a model is not an editorial decision. Treating one as
     a cut would drop a fact nobody chose to drop."""
     evidence = _package(12)
-    llm = _LLM(groups=[], ranked=["c5", "c3"])
+    llm = _LLM(groups=[], ranked=["f5", "f3"])
 
     selection = _select(evidence, llm)
 
@@ -216,9 +216,9 @@ def test_a_failed_pass_keeps_every_fact_and_says_which_one_fell_over():
     both_down = _select(evidence, _LLM(groups=None, ranked=None))
     assert both_down.deduped is False and both_down.ranked is False
     assert both_down.keep_count == 40, "an unranked order is not a ranking to cut"
-    assert "nothing looked at them" in both_down.note
+    assert "nothing ordered them" in both_down.note
 
-    rank_only = _select(evidence, _LLM(groups=None, ranked=[f"c{i}" for i in range(1, 41)]))
+    rank_only = _select(evidence, _LLM(groups=None, ranked=[f"f{i}" for i in range(1, 41)]))
     assert rank_only.deduped is False and rank_only.ranked is True
     assert rank_only.keep_count == 18
     assert "Deduplication did not run" in rank_only.note
@@ -228,7 +228,7 @@ def test_a_deselected_claim_leaves_the_desk_and_never_the_record():
     """The rule that makes the cut safe, and the one it must never break: a
     question its claim supported is still supported."""
     evidence = _package(40)
-    llm = _LLM(groups=[], ranked=[f"c{index}" for index in range(1, 41)])
+    llm = _LLM(groups=[], ranked=[f"f{index}" for index in range(1, 41)])
 
     applied = apply_selection(evidence, _select(evidence, llm))
     selected = [claim for claim in applied.claims if claim.selected]
@@ -243,7 +243,7 @@ def test_a_fact_added_after_the_ranking_still_reaches_the_writer():
     answering a question themselves. A fact somebody typed in to unblock the
     article being silently cut from it is the worst failure this could have."""
     evidence = _package(40)
-    llm = _LLM(groups=[], ranked=[f"c{index}" for index in range(1, 41)])
+    llm = _LLM(groups=[], ranked=[f"f{index}" for index in range(1, 41)])
     selection = _select(evidence, llm)
 
     late = evidence.claims[0].model_copy(
@@ -258,7 +258,7 @@ def test_a_fact_added_after_the_ranking_still_reaches_the_writer():
 def test_the_ranker_is_told_what_the_piece_fails_if_it_does_not_do():
     """Ranking is against this brief, not against general interest."""
     evidence = _package(3)
-    llm = _LLM(groups=[], ranked=["c1", "c2", "c3"])
+    llm = _LLM(groups=[], ranked=["f1", "f2", "f3"])
 
     _select(evidence, llm)
 
@@ -274,7 +274,7 @@ def test_dedupe_is_told_a_summary_and_its_details_are_not_duplicates():
     listing seven dishes and four describing four of them are two levels of
     zoom, not a duplicate."""
     evidence = _package(2)
-    llm = _LLM(groups=[], ranked=["c1", "c2"])
+    llm = _LLM(groups=[], ranked=["f1", "f2"])
 
     _select(evidence, llm)
 
@@ -368,3 +368,97 @@ def test_the_shortlist_says_when_the_line_was_not_what_decided_it():
 
     assert rows["c3"]["rescued"] is True and rows["c3"]["selected"] is True
     assert rows["c2"]["rescued"] is False and rows["c2"]["selected"] is False
+
+
+def test_the_models_are_given_short_labels_not_long_claim_ids():
+    """Claim ids are namespaced by their question and run to 76 characters.
+    Asked to copy a hundred of those, the first real run's ranker came back
+    correctly ordered, with good reasoning, and every id rewritten from
+    `req_neighbourhood_chifa_characteristics:ncc_18` to `ncc_18`. None of 102
+    matched. This is #499 again and takes the same answer."""
+    evidence = _package(3)
+    long_ids = [
+        claim.model_copy(update={"claim_id": f"req_a_very_long_question_name:{claim.claim_id}"})
+        for claim in evidence.claims
+    ]
+    evidence = evidence.model_copy(
+        update={
+            "claims": long_ids,
+            "requirements": [
+                evidence.requirements[0].model_copy(
+                    update={"claim_ids": [claim.claim_id for claim in long_ids]}
+                )
+            ],
+        }
+    )
+    llm = _LLM(groups=[{"keep": "f1", "same_as": ["f2"]}], ranked=["f2", "f1"])
+
+    selection = _select(evidence, llm)
+
+    for prompt in llm.prompts:
+        assert "req_a_very_long_question_name" not in prompt
+        assert "- f1 |" in prompt
+    # And the handles come back as the real ids, not as themselves.
+    assert selection.merged == {
+        "req_a_very_long_question_name:c2": "req_a_very_long_question_name:c1"
+    }
+    # Ranking's labels are numbered over the SURVIVORS, so f2 is the second
+    # claim still standing (c3) rather than the second claim in the dossier
+    # (c2, which was merged away). Sharing one numbering across both calls
+    # would silently point the ranking at the wrong facts.
+    assert selection.order == [
+        "req_a_very_long_question_name:c3",
+        "req_a_very_long_question_name:c1",
+    ]
+
+
+def test_a_ranking_that_matched_nothing_is_not_a_ranking():
+    """The exact shape of the first real run's failure: 102 rows returned, none
+    of them a claim. Reporting that as ranked drew a line at 18 through a list
+    in the order research happened to return it, which is not a decision."""
+    evidence = _package(40)
+    llm = _LLM(groups=[], ranked=["nonsense_1", "nonsense_2"])
+
+    selection = _select(evidence, llm)
+
+    assert selection.ranked is False
+    assert selection.keep_count == 40, "an unranked order is not a ranking to cut"
+    assert "Ranking did not run" in selection.note
+
+
+def test_a_merge_leaves_the_dossier_still_valid():
+    """The contract requires claim->requirement and requirement->claim to
+    agree. Handing a survivor the questions its merged claims answered without
+    naming it on those questions produces a package that will not validate --
+    which is how the first real run died, at the hand-off, after research was
+    already paid for."""
+    evidence = _package(3)
+    # c2 answers a different question from c1, and is merged into it.
+    claims = [
+        evidence.claims[0],
+        evidence.claims[1].model_copy(update={"requirement_ids": ["r2"]}),
+        evidence.claims[2],
+    ]
+    evidence = evidence.model_copy(
+        update={
+            "claims": claims,
+            "requirements": [
+                evidence.requirements[0].model_copy(update={"claim_ids": ["c1", "c3"]}),
+                EvidenceRequirement(
+                    requirement_id="r2", status="supported", claim_ids=["c2"]
+                ),
+            ],
+        }
+    )
+    llm = _LLM(groups=[{"keep": "f1", "same_as": ["f2"]}], ranked=["f1", "f2"])
+
+    applied = apply_selection(evidence, _select(evidence, llm))
+
+    # Revalidating is the whole test: this is what the hand-off does.
+    EvidencePackage.model_validate(applied.model_dump(mode="json"))
+    survivor = next(c for c in applied.claims if c.claim_id == "c1")
+    assert set(survivor.requirement_ids) == {"r1", "r2"}
+    r2 = next(r for r in applied.requirements if r.requirement_id == "r2")
+    # Added to, never taken from: r2 keeps c2 and gains the claim that absorbed
+    # it, so coverage after selection is never weaker than before it.
+    assert set(r2.claim_ids) == {"c1", "c2"}

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
@@ -21,6 +21,7 @@ from app.features.prompt2blog.contracts_v4 import (
     ArticleBrief,
     BriefReader,
     EvidenceClaim,
+    EvidenceConflict,
     EvidencePackage,
     EvidenceRequirement,
     EvidenceSource,
@@ -462,3 +463,38 @@ def test_a_merge_leaves_the_dossier_still_valid():
     # Added to, never taken from: r2 keeps c2 and gains the claim that absorbed
     # it, so coverage after selection is never weaker than before it.
     assert set(r2.claim_ids) == {"c1", "c2"}
+
+
+def test_dedupe_will_not_merge_two_claims_the_dossier_says_disagree():
+    """Run 3750891f held Chifa Titi's Sunday opening as both 12:30 and 12:45,
+    and recorded the conflict. Dedupe merged the correct claim into the wrong
+    one -- the sentences are nearly identical -- so the writer only ever saw
+    12:45, while groundedness reads the whole dossier and failed the draft for
+    a claim the writer had no way to check.
+
+    A recorded conflict is the dossier saying in as many words that two claims
+    are not the same fact. Merging across one picks a winner in a factual
+    dispute and deletes the loser from the writer's desk, silently.
+    """
+    evidence = _package(3)
+    evidence = evidence.model_copy(
+        update={
+            "conflicts": [
+                EvidenceConflict(
+                    conflict_id="conflict_1",
+                    claim_ids=["c1", "c2"],
+                    summary="Two different opening times for the same restaurant.",
+                )
+            ]
+        }
+    )
+    llm = _LLM(
+        # The model tries to merge the disputed pair and an undisputed one.
+        groups=[{"keep": "f1", "same_as": ["f2", "f3"]}],
+        ranked=["f1", "f2", "f3"],
+    )
+
+    selection = _select(evidence, llm)
+
+    assert "c2" not in selection.merged, "a disputed claim must keep its own voice"
+    assert selection.merged == {"c3": "c1"}, "an undisputed merge still happens"

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/FactPicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/FactPicker.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from 'react'
+import { readSelection, reviseSelection } from '../intake.api'
+import type { SelectableClaim, SelectionReview } from '../intake.types'
+
+/**
+ * Which facts the article is written from.
+ *
+ * Run 9e66bf84 found 105 facts and nothing ever decided which of them the
+ * article needed. The outline placed 102 of them and one 200-word section was
+ * handed 56 — three and a half words per fact, at which density there is no
+ * sentence you can write except a list. The article read like a database
+ * because it was one.
+ *
+ * A model has merged the repeats and put these in order. Where the line falls
+ * is a starting point, from how long the article is meant to be. This screen
+ * exists so a person moves it.
+ *
+ * The human step is the point and not a fallback. A model dropping a fact the
+ * article needed is a silent loss discovered by reading a worse article; a
+ * person dropping it is a decision they made and can undo. Repair may not add
+ * a fact the draft did not have, so a cut fact really is gone from this
+ * article — which is exactly why the last word is not a model's.
+ *
+ * Nothing here deletes. A fact left out stays in the dossier, stays checkable,
+ * and still answers whatever question it answered. Not a gate: skippable by
+ * doing nothing.
+ */
+
+interface FactPickerProps {
+  runId: string
+  onChanged: () => void
+}
+
+function Fact({
+  claim,
+  busy,
+  onMark,
+}: {
+  claim: SelectableClaim
+  busy: boolean
+  onMark: (body: { rescue?: string; drop?: string; clear?: string }) => void
+}) {
+  const overridden = claim.rescued || claim.dropped
+  return (
+    <li
+      className={`p2b-fact${claim.selected ? '' : ' p2b-fact-cut'}`}
+      data-testid={`fact-${claim.claim_id}`}
+    >
+      <span className="p2b-fact-rank">{claim.rank}</span>
+      <div className="p2b-fact-body">
+        <p className="p2b-fact-text">{claim.text}</p>
+        {claim.why && <p className="p2b-fact-why">{claim.why}</p>}
+        {claim.merged_in.length > 0 && (
+          /* Said rather than hidden: the operator should be able to see that
+             three findings became this one, and what the other two said. */
+          <p className="p2b-fact-merged">
+            Also said by {claim.merged_in.length}{' '}
+            {claim.merged_in.length === 1 ? 'other finding' : 'other findings'}:{' '}
+            {claim.merged_in.join(' · ')}
+          </p>
+        )}
+      </div>
+      <div className="p2b-fact-actions">
+        {overridden ? (
+          <button
+            type="button"
+            className="p2b-secondary"
+            disabled={busy}
+            onClick={() => onMark({ clear: claim.claim_id })}
+          >
+            {claim.rescued ? 'Kept by hand — undo' : 'Cut by hand — undo'}
+          </button>
+        ) : claim.selected ? (
+          <button
+            type="button"
+            className="p2b-secondary"
+            disabled={busy}
+            onClick={() => onMark({ drop: claim.claim_id })}
+          >
+            Leave it out
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="p2b-secondary"
+            disabled={busy}
+            onClick={() => onMark({ rescue: claim.claim_id })}
+          >
+            Keep it anyway
+          </button>
+        )}
+      </div>
+    </li>
+  )
+}
+
+export function FactPicker({ runId, onChanged }: FactPickerProps) {
+  const [review, setReview] = useState<SelectionReview | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    let live = true
+    void readSelection(runId)
+      .then(next => live && setReview(next))
+      .catch(() => live && setReview(null))
+    return () => {
+      live = false
+    }
+  }, [runId])
+
+  async function send(body: {
+    keep_count?: number
+    rescue?: string
+    drop?: string
+    clear?: string
+  }) {
+    setBusy(true)
+    setError('')
+    try {
+      setReview(await reviseSelection(runId, body))
+      onChanged()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'That did not work.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!review?.available || review.claims.length === 0) {
+    return null
+  }
+
+  const kept = review.claims.filter(claim => claim.selected).length
+  const total = review.claims.length
+
+  return (
+    <section className="p2b-facts" aria-label="Which facts the article uses">
+      <p className="p2b-eyebrow">What the article will be written from</p>
+
+      <p className="p2b-facts-summary">
+        {kept} of {total} findings, most useful first.{' '}
+        {review.target_word_count
+          ? `About ${review.target_word_count} words of article.`
+          : null}
+      </p>
+
+      {review.note && (
+        /* When a pass fell over, say so. An order nobody ranked is the order
+           research happened to return, and cutting by it is not a decision. */
+        <p className="p2b-facts-note">{review.note}</p>
+      )}
+
+      <label className="p2b-field p2b-facts-line">
+        <span className="p2b-label">How many to keep</span>
+        <input
+          type="range"
+          min={1}
+          max={total}
+          value={review.keep_count}
+          disabled={busy}
+          aria-label="How many findings to keep"
+          onChange={event => void send({ keep_count: Number(event.target.value) })}
+        />
+        <span className="p2b-facts-count">{review.keep_count}</span>
+      </label>
+
+      {error && <p className="p2b-blocked">{error}</p>}
+
+      <ul className="p2b-fact-list">
+        {(open ? review.claims : review.claims.filter(claim => claim.selected)).map(
+          claim => (
+            <Fact
+              key={claim.claim_id}
+              claim={claim}
+              busy={busy}
+              onMark={body => void send(body)}
+            />
+          ),
+        )}
+      </ul>
+
+      <button type="button" className="p2b-secondary" onClick={() => setOpen(!open)}>
+        {open
+          ? 'Hide what is being left out'
+          : `Show the ${total - kept} being left out`}
+      </button>
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ResearchScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ResearchScreen.tsx
@@ -1,4 +1,5 @@
 import type { IntakeResearch } from '../intake.types'
+import { FactPicker } from './FactPicker'
 import { VenueCheck } from './VenueCheck'
 
 /**
@@ -131,6 +132,13 @@ export function ResearchScreen({
 
       {/* Liveness, not a gate. Skippable in one click. */}
       {canWrite && <VenueCheck runId={runId} onChanged={onChanged} />}
+
+      {/* Which of the findings the article is actually written from (#534).
+          Here rather than on a screen of its own: the run already stops on
+          this page before Write it, so this is more of the one stop rather
+          than a second one. Also not a gate — doing nothing accepts the cut
+          the ranking proposed. */
+      canWrite && <FactPicker runId={runId} onChanged={onChanged} />}
 
       <div className="p2b-intake-actions">
         {canWrite ? (

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/fact-picker.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/fact-picker.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const readSelection = vi.fn()
+const reviseSelection = vi.fn()
+vi.mock('./intake.api', async importOriginal => ({
+  ...(await importOriginal<typeof import('./intake.api')>()),
+  readSelection: (...args: unknown[]) => readSelection(...args),
+  reviseSelection: (...args: unknown[]) => reviseSelection(...args),
+}))
+import { FactPicker } from './components/FactPicker'
+import type { SelectableClaim, SelectionReview } from './intake.types'
+
+/**
+ * What the picker owes the person using it (#534).
+ *
+ * The one thing it must never do is make the cut invisible. Run 9e66bf84's
+ * article read like a database because 105 facts reached the writer and
+ * nothing decided which of them it needed; a picker that hides what it left
+ * out replaces one silent decision with another.
+ */
+
+function claim(overrides: Partial<SelectableClaim> = {}): SelectableClaim {
+  return {
+    claim_id: 'c1',
+    text: 'A chifa plate runs about 25 soles in Barrio Chino.',
+    rank: 1,
+    selected: true,
+    rescued: false,
+    dropped: false,
+    why: 'The reader cannot choose without a price.',
+    questions: ['What does chifa cost?'],
+    merged_in: [],
+    confidence: 'high',
+    ...overrides,
+  }
+}
+
+function review(overrides: Partial<SelectionReview> = {}): SelectionReview {
+  return {
+    available: true,
+    keep_count: 1,
+    target_word_count: 900,
+    deduped: true,
+    ranked: true,
+    note: '',
+    claims: [
+      claim(),
+      claim({
+        claim_id: 'c2',
+        text: 'Chifa is widely considered Lima’s second cuisine.',
+        rank: 2,
+        selected: false,
+        why: 'Restates the seed.',
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+describe('the fact picker', () => {
+  it('says how many facts the article keeps, out of how many there are', async () => {
+    readSelection.mockResolvedValue(review())
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+
+    expect(await screen.findByText(/1 of 2 findings/i)).toBeInTheDocument()
+  })
+
+  it('shows what is being left out when asked, rather than hiding it', async () => {
+    // A cut nobody can see is the same silent decision, made by a model.
+    readSelection.mockResolvedValue(review())
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+    await screen.findByText(/1 of 2 findings/i)
+
+    expect(screen.queryByTestId('fact-c2')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /show the 1 being left out/i }))
+
+    expect(screen.getByTestId('fact-c2')).toBeInTheDocument()
+  })
+
+  it('moves the line', async () => {
+    readSelection.mockResolvedValue(review())
+    reviseSelection.mockResolvedValue(review({ keep_count: 2 }))
+    const onChanged = vi.fn()
+
+    render(<FactPicker runId="run-1" onChanged={onChanged} />)
+    await screen.findByText(/1 of 2 findings/i)
+
+    fireEvent.change(screen.getByLabelText(/how many findings to keep/i), {
+      target: { value: '2' },
+    })
+
+    await waitFor(() =>
+      expect(reviseSelection).toHaveBeenCalledWith('run-1', { keep_count: 2 }),
+    )
+    expect(onChanged).toHaveBeenCalled()
+  })
+
+  it('keeps one fact by hand without moving the line', async () => {
+    readSelection.mockResolvedValue(review())
+    reviseSelection.mockResolvedValue(review())
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+    await screen.findByText(/1 of 2 findings/i)
+    fireEvent.click(screen.getByRole('button', { name: /show the 1 being left out/i }))
+    fireEvent.click(screen.getByRole('button', { name: /keep it anyway/i }))
+
+    await waitFor(() =>
+      expect(reviseSelection).toHaveBeenCalledWith('run-1', { rescue: 'c2' }),
+    )
+  })
+
+  it('offers to undo a fact kept by hand, not to keep it twice', async () => {
+    readSelection.mockResolvedValue(
+      review({
+        keep_count: 1,
+        claims: [claim(), claim({ claim_id: 'c2', rank: 2, selected: true, rescued: true })],
+      }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+
+    expect(await screen.findByRole('button', { name: /kept by hand/i })).toBeInTheDocument()
+  })
+
+  it('names the findings a survivor absorbed', async () => {
+    readSelection.mockResolvedValue(
+      review({
+        claims: [claim({ merged_in: ['The same fact, differently worded.'] })],
+        keep_count: 1,
+      }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+
+    expect(
+      await screen.findByText(/also said by 1 other finding/i),
+    ).toBeInTheDocument()
+  })
+
+  it('says when a pass fell over, because then the order is not a ranking', async () => {
+    readSelection.mockResolvedValue(
+      review({ ranked: false, keep_count: 2, note: 'Ranking did not run.' }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+
+    expect(await screen.findByText('Ranking did not run.')).toBeInTheDocument()
+  })
+
+  it('renders nothing on a run that never selected', async () => {
+    readSelection.mockResolvedValue({
+      available: false,
+      claims: [],
+      keep_count: 0,
+      note: '',
+    })
+
+    const { container } = render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement())
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -6,6 +6,7 @@ import type {
   IntakeRunSummary,
   IntakeState,
   PunchList,
+  SelectionReview,
   VenueToCheck,
 } from './intake.types'
 
@@ -245,3 +246,33 @@ export function markVenue(
 ): Promise<IntakeState> {
   return post(`${INTAKE}/${runId}/venues`, body)
 }
+
+/** The facts this article would be written from, ranked, with the line. */
+export async function readSelection(runId: string): Promise<SelectionReview> {
+  const response = await apiFetch(`${INTAKE}/${runId}/selection`)
+  if (!response.ok) {
+    throw await readError(response, 'Could not read the facts for this article.')
+  }
+  return (await response.json()) as SelectionReview
+}
+
+/**
+ * Move the line, or mark one fact. Exactly one per call — an override is about
+ * that fact and outlives the line moving past it, so the two are separate
+ * decisions rather than one combined write.
+ */
+export async function reviseSelection(
+  runId: string,
+  body: { keep_count?: number; rescue?: string; drop?: string; clear?: string },
+): Promise<SelectionReview> {
+  const response = await apiFetch(`${INTAKE}/${runId}/selection`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw await readError(response, 'Could not change which facts are kept.')
+  }
+  return (await response.json()) as SelectionReview
+}
+

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -310,3 +310,35 @@ export interface IntakeRunSummary {
   stage_label: string
   updated_at: string
 }
+
+/** One fact on the shortlist, and where the line leaves it (#534). */
+export interface SelectableClaim {
+  claim_id: string
+  text: string
+  /** 1 is the fact the article most needs. */
+  rank: number
+  selected: boolean
+  /** True when this fact is kept despite sitting below the line. */
+  rescued: boolean
+  /** True when it is cut despite sitting above it. */
+  dropped: boolean
+  /** One line from the ranker on what the article uses this for. */
+  why: string
+  questions: string[]
+  /** Facts that said the same thing and stood down in favour of this one. */
+  merged_in: string[]
+  confidence: string
+}
+
+export interface SelectionReview {
+  /** False on a run that never selected. It writes from every fact it found. */
+  available: boolean
+  claims: SelectableClaim[]
+  keep_count: number
+  target_word_count?: number
+  deduped?: boolean
+  ranked?: boolean
+  /** Says which pass fell over, when one did. Empty on a clean selection. */
+  note: string
+}
+

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1291,3 +1291,100 @@
 .p2b-run-live .p2b-run-meta {
   color: var(--accent);
 }
+
+/* Which facts the article is written from (#534). Deliberately quieter than
+   the venue check beside it: that one asks a question, this one shows a
+   decision already made and offers to change it. */
+.p2b-facts {
+  margin: var(--space-6) 0 0;
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border);
+}
+
+.p2b-facts-summary {
+  margin: var(--space-2) 0 0;
+  color: var(--muted);
+  font-size: 0.9375rem;
+}
+
+.p2b-facts-note {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-3) var(--space-4);
+  background: var(--accent-softer);
+  border-radius: var(--radius-md);
+  color: var(--ink-light);
+  font-size: 0.875rem;
+}
+
+.p2b-facts-line {
+  margin-top: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.p2b-facts-line input[type='range'] {
+  flex: 1;
+}
+
+.p2b-facts-count {
+  min-width: 2.5ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+.p2b-fact-list {
+  margin: var(--space-4) 0 var(--space-4);
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.p2b-fact {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--surface-muted, var(--accent-softer));
+}
+
+/* Shown, not hidden. A fact being left out is a decision the operator should
+   be able to see and reverse, not something that quietly disappears. */
+.p2b-fact-cut {
+  background: transparent;
+  border: 1px dashed var(--border);
+  opacity: 0.65;
+}
+
+.p2b-fact-rank {
+  min-width: 2.5ch;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.875rem;
+}
+
+.p2b-fact-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.p2b-fact-text {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.9375rem;
+}
+
+.p2b-fact-why,
+.p2b-fact-merged {
+  margin: var(--space-2) 0 0;
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+.p2b-fact-actions {
+  flex-shrink: 0;
+}

--- a/packages/model-gateway/src/model_gateway/jobs.json
+++ b/packages/model-gateway/src/model_gateway/jobs.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "note": "Every model call this monorepo makes, and what each one runs on when nothing overrides it. This file is the registry AND the checked-in fallback, in one place, because two files would need a test to keep them in step and would still drift between the moment one changed and the moment anyone ran it. Read by model_gateway/jobs.py in Python and by the dashboard in TypeScript -- one source, two runtimes. defaultModel null means the job reaches an API with no model behind it.",
-  "writerNote": "Prompt2Blog's reasoning runs on Claude, its bulk work on Gemini. Every one of these jobs sat on gemini-2.5-flash from 2026-07-25, the day the Anthropic credit ran out, and stayed there after the subscription path was switched on because nothing revisited the default -- so every v4 article was interviewed, planned and drafted by the cheapest model in the table. The split now: p2b.grill gets Opus because the interview decides what the article is and every later stage inherits it, and it is seven calls. Brief, outline, compose and repair get Sonnet at medium -- prose and judgement, but not worth an Opus tier each. Everything else is Gemini, and each has a reason. p2b.audit is the independent judge: a Claude draft graded by a Claude judge is marked by a model that shares its blind spots. p2b.grill_research and p2b.research_gather are grounded_text calls that need Google search grounding, which the Claude CLI path does not have. p2b.research_structure, p2b.work_order and p2b.groundedness are mechanical shaping and checking: structuring on Claude spent 437k tokens of a 650k run ceiling on one run and the run died in research without reaching the writer.",
+  "writerNote": "Prompt2Blog's reasoning runs on Claude, its bulk work on Gemini. Every one of these jobs sat on gemini-2.5-flash from 2026-07-25, the day the Anthropic credit ran out, and stayed there after the subscription path was switched on because nothing revisited the default -- so every v4 article was interviewed, planned and drafted by the cheapest model in the table. The split now: p2b.grill gets Opus because the interview decides what the article is and every later stage inherits it, and it is seven calls. Brief, outline, compose and repair get Sonnet at medium -- prose and judgement, but not worth an Opus tier each. Everything else is Gemini, and each has a reason. p2b.audit is the independent judge: a Claude draft graded by a Claude judge is marked by a model that shares its blind spots. p2b.grill_research and p2b.research_gather are grounded_text calls that need Google search grounding, which the Claude CLI path does not have. p2b.research_structure, p2b.work_order and p2b.groundedness are mechanical shaping and checking: structuring on Claude spent 437k tokens of a 650k run ceiling on one run and the run died in research without reaching the writer. p2b.evidence_dedupe and p2b.evidence_rank are the two passes that decide which facts reach the writer (#534). Dedupe is Gemini for the same reason research_structure is: it compares sentences and groups the ones asserting the same fact, which is shape rather than judgement, and it reads every claim in the dossier so it is the more expensive input of the two. Rank is Sonnet at medium, the tier the brief and the outline already sit on, because ordering a hundred facts against a reader question and a fails_if is the same kind of judgement the outline makes -- and it is not Opus because a person reads the result and moves the line, so a ranking that is merely good is corrected in one click rather than paid for twice.",
   "capturedOn": "2026-09-04",
   "jobs": [
     {
@@ -115,6 +115,22 @@
       "summary": "Shape gathered prose into sources and claims. Shape, not judgement.",
       "site": "features/prompt2blog/research_v4.py",
       "defaultModel": "gemini-2.5-flash"
+    },
+    {
+      "id": "p2b.evidence_dedupe",
+      "app": "ai-blog-writer",
+      "call": "json",
+      "summary": "Group the research findings that say the same fact. Grouping, not judgement.",
+      "site": "features/prompt2blog/selection_v4.py",
+      "defaultModel": "gemini-2.5-flash"
+    },
+    {
+      "id": "p2b.evidence_rank",
+      "app": "ai-blog-writer",
+      "call": "json",
+      "summary": "Order the surviving facts by how much this brief needs them.",
+      "site": "features/prompt2blog/selection_v4.py",
+      "defaultModel": "claude-sonnet-5-medium"
     },
     {
       "id": "listicle.search",


### PR DESCRIPTION
Closes #534. Stacked on #539 (which is stacked on #537) — it needs the `selected` flag those PRs put on a claim.

## Why

Research found 105 facts on run `9e66bf84` and nothing ever decided which of them the article needed. The outline placed 102 across six sections, compose received all 105, and one 200-word section was handed **56** — three and a half words per claim. There is no sentence you can write at that density except a list. The writer was not lazy; it was handed an impossible instruction and did the only thing that satisfies it.

## Three passes between research and the outline

**1. Deduplicate** — `p2b.evidence_dedupe`, Gemini. Groups claims that are the same fact and names which one survives.

It **never writes claim text**. A merged claim composed by a model is prose asserting a fact, and a drifted date or price inside one would pass groundedness — groundedness checks the draft against the claim, and the claim is the thing that moved. The survivor inherits the sources and questions of everything merged into it, so deduplication cannot cost a fact its provenance.

The prompt says in capitals that **a summary and its details are not duplicates**. Your example — one claim listing seven dishes, four more describing four of them — is two levels of zoom. Merging those would have destroyed the article's best material.

**2. Rank** — `p2b.evidence_rank`, Sonnet medium. Orders survivors against *this* brief: the reader question, the promise, `fails_if`. Not general interest — a fact can be true, well sourced and irrelevant. A claim the ranker omits is kept at the bottom, never dropped: an omission from a model is not an editorial decision.

**3. A person picks** — `FactPicker`. The ranked list with a line where the keep-set ends, drawn from the article's length at two claims per hundred words (900 words → 18). Move the line, or keep/cut one fact by hand. An override is about *that fact*, so it survives the line moving past it — rescue a fact, then widen the cut, and it is still rescued.

What is being left out is one click away, never hidden. A cut nobody can see is the same silent decision, made by a model instead.

## Routing, and why

| job | model | reason |
|---|---|---|
| `p2b.evidence_dedupe` | `gemini-2.5-flash` | Compares sentences and groups the ones asserting the same fact. Shape, not judgement — the same reason `research_structure` is Gemini. It reads every claim, so it is the more expensive input. |
| `p2b.evidence_rank` | `claude-sonnet-5-medium` | Ordering facts against a reader question and a `fails_if` is the judgement the outline already makes, on the tier the outline already sits on. **Not Opus**: a person reads the result and moves the line, so a merely-good ranking is corrected in one click rather than paid for twice. |

Both recorded in the file's `writerNote`. Verified live — `curl localhost:4500/api/settings/v1/models` returns both jobs at those models.

## Not a new gate

The run already stops on the research screen before **Write it**. This sits beside `VenueCheck` on that same stop, so ADR-0030 is untouched: doing nothing accepts the cut the ranking proposed.

## The three rules that keep it safe

Selection is applied at the hand-off in `writing_request`, never written back to the dossier.

- **Fact-checking keeps everything.** Coverage is decided above the selection, on every claim. `records_text` is untouched.
- **A deselected claim leaves the writer's desk and never the record.** A question it supported stays `supported`.
- **Selection is not research readiness.** A claim minted *after* the ranking — an operator answering a question themselves at the gate — is kept, not cut by a model that ran before they typed it. That would have been the worst failure this could have.

## Degrade, not fail

Either call coming back unusable keeps every fact and records which pass fell over. When **neither** ran, the line is not drawn at all — cutting an unranked list cuts by the order research happened to return, which is not a decision.

## Verified

- 15 backend tests: the line from the word budget, provenance kept across a merge, no merge chains or cycles, a forgotten claim kept, a failed pass keeping everything, a deselected claim still supporting its question, a late claim surviving, and the two prompts carrying `fails_if` and the summary-vs-details rule.
- 8 frontend tests: the count, showing what is left out, moving the line, keeping one by hand, offering undo on an override, naming what a survivor absorbed, saying when a pass fell over, and rendering nothing on a run that never selected.
- Backend suite, 758 vitest tests, `tsc --noEmit`, and 89 model-gateway tests all green.

## What this does not do

It does not shrink the work order — that is #538. And the effect on an actual article is arithmetic on a stored prompt, not a measured result: **no run has finished yet.** The first real signal is a completed Lima chifa run.