### PR TITLE
feat(p2b): colour keeps a share of the desk instead of losing every time

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
@@ -76,10 +76,49 @@ CLAIMS_PER_HUNDRED_WORDS = 2.0
 # A short piece with a big dossier should still keep enough to write from.
 MIN_KEPT_CLAIMS = 8
 
+# How much of the keep-set is held for colour rather than proof.
+#
+# Ranking against the brief means ranking against the reader question, the
+# outcome and `fails_if`. Every one of those is a question about usefulness, so
+# a fact whose only job is to make a place feel like a place loses to a price
+# band every time. It is not that the ranker is wrong; it is that it was asked
+# one question and answered it.
+#
+# Measured on the ceviche run 8a7e9aa4: 23 texture claims in the dossier, two
+# selected. The best line in the whole run -- Canta Rana's dining room is
+# bare-bones and covered in football flags because the owner is Argentine --
+# ranked 59th of 151 and was cut. The article that came out was accurate,
+# useful and had nothing in it anybody would repeat to a friend.
+#
+# A fifth, because texture is seasoning. A piece that is one-fifth colour reads
+# as written by a person; one that is half colour has stopped answering the
+# question it was commissioned to answer.
+TEXTURE_SHARE = 0.2
+
 # One call each, and they read the same claim texts the writer would have. The
 # ceiling is generous because the input scales with the dossier.
 DEDUPE_MAX_TOKENS = 8_000
 RANK_MAX_TOKENS = 8_000
+
+
+def texture_claim_ids(
+    work_order: Prompt2BlogWorkOrder, evidence: EvidencePackage
+) -> set[str]:
+    """Claims whose only job is colour.
+
+    A claim that also answers a load-bearing question is doing load-bearing
+    work, whatever else it does, so only claims serving texture questions
+    exclusively are counted here. The work order already draws this line and
+    coverage already refuses a run with no texture answered; selection was the
+    one stage that could not see it.
+    """
+    kinds = {item.requirement_id: item.kind for item in work_order.requirements}
+    return {
+        claim.claim_id
+        for claim in evidence.claims
+        if claim.requirement_ids
+        and all(kinds.get(item) == "texture" for item in claim.requirement_ids)
+    }
 
 
 def target_claim_count(target_word_count: int, available: int) -> int:
@@ -244,6 +283,57 @@ Rules:
 """
 
 
+def build_texture_prompt(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    claims: list[Any],
+) -> str:
+    """Order the colour by how much of the place it carries.
+
+    A separate question from the main ranking, deliberately. Asked which facts
+    the article needs, a model correctly answers with prices and opening hours.
+    Colour has to be judged on what it is for, or it is judged on what it is
+    not.
+    """
+    to_handle, _ = handles(claims)
+    listed = "\n".join(f"- {to_handle[claim.claim_id]} | {claim.text}" for claim in claims)
+    return f"""\
+You are choosing the details that make a piece of writing worth reading.
+
+Below are facts about {work_order.primary_subject} that carry no practical
+information -- no prices, no addresses, no opening hours. They are the colour.
+Order them by how much each one makes a place feel like a real place a person
+could walk into.
+
+THE ARTICLE
+Primary subject: {work_order.primary_subject}
+Core reader question: {brief.reader_question}
+Primary reader: {brief.reader.primary_reader}
+
+THE DETAILS
+{listed}
+
+Return strict JSON only:
+{{"ranked": [{{"claim_id": "f1", "why": "string"}}]}}
+
+Rules:
+- Most vivid and most specific first. A detail somebody would repeat to a
+  friend goes at the top.
+- SPECIFIC BEATS EVALUATIVE, ALWAYS. "The walls are covered in football flags
+  because the owner is Argentine" is worth ten of "the atmosphere is lively and
+  authentic". A sentence that could describe a hundred places describes none.
+- A named thing, an odd fact, a number nobody expected, something a person did:
+  these are what a reader remembers. Adjectives are not.
+- Rank low anything that is a definition, a category, or a general truth about
+  the cuisine or the city. That is reference material wearing colour's clothes.
+- Rank low anything that reads as marketing: "beloved", "hidden gem",
+  "must-visit", "world-renowned".
+- Use the labels above exactly as written (f1, f2, ...). Never invent a label,
+  never shorten one, and never use any other name for a claim.
+- EVERY label above must appear exactly once. This is ordering, not selecting.
+"""
+
+
 @dataclass
 class SelectionDependencies:
     """The one model this needs, and which jobs it runs as."""
@@ -277,6 +367,12 @@ class Selection:
     dropped: list[str] = field(default_factory=list)
     # One line per claim on why the ranker put it there, for the person picking.
     reasons: dict[str, str] = field(default_factory=dict)
+    # Claims whose only job is colour, best first, judged on how much of the
+    # place they carry rather than on what they prove.
+    texture_order: list[str] = field(default_factory=list)
+    # How many of `keep_count` are held for them. Held, not added: the operator
+    # asked for this many facts and gets this many.
+    texture_reserve: int = 0
     target_word_count: int = 0
     # Which passes actually ran. A selection whose ranking fell over keeps
     # every claim, and this is how the receipt says so rather than implying a
@@ -286,8 +382,20 @@ class Selection:
     note: str = ""
 
     def selected_claim_ids(self) -> set[str]:
-        """The claims that reach the writer."""
-        kept = set(self.order[: max(0, self.keep_count)])
+        """The claims that reach the writer, colour included.
+
+        Filling straight down the ranked list is what starved the article: the
+        ranking answers "what does this piece need", so the top of it is prices
+        and hours all the way down. The reserve takes the best colour first and
+        fills the rest from the top of the list, which keeps the total at the
+        number the operator asked for and stops the cut being decided by one
+        criterion answering for two.
+        """
+        keep = max(0, self.keep_count)
+        reserve = min(self.texture_reserve, keep, len(self.texture_order))
+        colour = self.texture_order[:reserve]
+        rest = [item for item in self.order if item not in set(colour)]
+        kept = set(colour) | set(rest[: max(0, keep - len(colour))])
         kept |= {item for item in self.rescued if item in self.order}
         kept -= set(self.dropped)
         return kept
@@ -300,6 +408,8 @@ class Selection:
             "rescued": list(self.rescued),
             "dropped": list(self.dropped),
             "reasons": dict(self.reasons),
+            "texture_order": list(self.texture_order),
+            "texture_reserve": self.texture_reserve,
             "target_word_count": self.target_word_count,
             "deduped": self.deduped,
             "ranked": self.ranked,
@@ -323,6 +433,10 @@ class Selection:
                 _safe_str(key): _safe_str(value)
                 for key, value in _safe_dict(record.get("reasons")).items()
             },
+            texture_order=[
+                _safe_str(item) for item in record.get("texture_order") or [] if _safe_str(item)
+            ],
+            texture_reserve=_safe_int(record.get("texture_reserve"), default=0),
             target_word_count=_safe_int(record.get("target_word_count"), default=0),
             deduped=bool(record.get("deduped")),
             ranked=bool(record.get("ranked")),
@@ -468,6 +582,50 @@ def _rank(
     return ranked, reasons, bool(ranked and not remaining == set(order))
 
 
+def _rank_texture(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    claims: list[Any],
+    dependencies: SelectionDependencies,
+) -> tuple[list[str], dict[str, str]]:
+    """Colour, best first. Never raises; an empty order simply reserves nothing.
+
+    Runs as `p2b.evidence_rank` rather than a job of its own. It is the same
+    work -- ordering evidence against a brief -- over a subset with a different
+    question, and two jobs that would always route to the same model are noise
+    in a registry whose point is that each entry is a decision.
+    """
+    if not claims:
+        return [], {}
+    order = [claim.claim_id for claim in claims]
+    _, from_handle = handles(claims)
+    try:
+        parsed, _raw = dependencies.llm.invoke_json(
+            job_id=dependencies.rank_job_id,
+            prompt=build_texture_prompt(brief, work_order, claims),
+            model_name=dependencies.model_name,
+            schema=RANK_SCHEMA,
+            max_tokens=RANK_MAX_TOKENS,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001 -- colour is the cheapest thing to lose
+        logger.warning("Prompt2Blog texture ranking failed: %s", exc)
+        return order, {}
+
+    remaining = set(order)
+    ranked: list[str] = []
+    reasons: dict[str, str] = {}
+    for row in _rows(parsed, "ranked"):
+        claim_id = from_handle.get(_safe_str(row.get("claim_id")), "")
+        if claim_id in remaining:
+            remaining.discard(claim_id)
+            ranked.append(claim_id)
+            if why := _safe_str(row.get("why")):
+                reasons[claim_id] = why
+    ranked.extend(item for item in order if item in remaining)
+    return ranked, reasons
+
+
 def select_evidence(
     brief: ArticleBrief,
     work_order: Prompt2BlogWorkOrder,
@@ -482,6 +640,17 @@ def select_evidence(
     order, reasons, ranked = _rank(brief, work_order, survivors, dependencies)
 
     keep_count = target_claim_count(target_word_count, len(order))
+
+    # Colour is ranked separately because it is judged on a different question.
+    # Only survivors: a merged claim is off the desk however vivid it was.
+    colour_ids = texture_claim_ids(work_order, evidence)
+    colour = [claim for claim in survivors if claim.claim_id in colour_ids]
+    texture_order, texture_reasons = _rank_texture(brief, work_order, colour, dependencies)
+    reasons = {**texture_reasons, **reasons}
+    texture_reserve = min(
+        len(texture_order), int(round(keep_count * TEXTURE_SHARE))
+    )
+
     notes = []
     if not deduped:
         notes.append("Deduplication did not run, so nothing was merged.")
@@ -503,6 +672,8 @@ def select_evidence(
         merged=merged,
         keep_count=keep_count,
         reasons=reasons,
+        texture_order=texture_order,
+        texture_reserve=texture_reserve,
         target_word_count=target_word_count,
         deduped=deduped,
         ranked=ranked,
@@ -640,6 +811,9 @@ def shortlist(
                 "rescued": claim_id in selection.rescued,
                 "dropped": claim_id in selection.dropped,
                 "why": selection.reasons.get(claim_id, ""),
+                # So the operator can see which rows are here as colour, and
+                # that cutting one costs the piece something other than a fact.
+                "texture": claim_id in set(selection.texture_order),
                 "questions": [
                     question_of[item]
                     for item in claim.requirement_ids
@@ -699,6 +873,10 @@ def revise(
         rescued=rescued,
         dropped=dropped,
         reasons=dict(selection.reasons),
+        # Carried, or the operator's first click would quietly delete the
+        # reserve and starve the article of colour again.
+        texture_order=list(selection.texture_order),
+        texture_reserve=selection.texture_reserve,
         target_word_count=selection.target_word_count,
         deduped=selection.deduped,
         ranked=selection.ranked,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
@@ -40,6 +40,7 @@ from app.features.prompt2blog.selection_v4 import (
     select_evidence,
     shortlist,
     target_claim_count,
+    texture_claim_ids,
 )
 
 
@@ -121,9 +122,16 @@ def _package(count: int) -> EvidencePackage:
 class _LLM:
     """Answers the two calls by which schema it was handed."""
 
-    def __init__(self, *, groups: list[dict] | None = None, ranked: list[str] | None = None):
+    def __init__(
+        self,
+        *,
+        groups: list[dict] | None = None,
+        ranked: list[str] | None = None,
+        texture: list[str] | None = None,
+    ):
         self.groups = groups
         self.ranked = ranked
+        self.texture = texture
         self.jobs: list[str] = []
         self.prompts: list[str] = []
 
@@ -134,6 +142,11 @@ class _LLM:
             if self.groups is None:
                 raise RuntimeError("the dedupe model is having a day")
             return {"groups": self.groups}, "{}"
+        # The colour pass runs under the same job id and is told apart by its
+        # prompt, exactly as the real one is.
+        if "make a place feel like a real place" in prompt:
+            rows = self.texture or []
+            return {"ranked": [{"claim_id": i, "why": "vivid"} for i in rows]}, "{}"
         if self.ranked is None:
             raise RuntimeError("the ranking model is having a day")
         return {"ranked": [{"claim_id": item, "why": "because"} for item in self.ranked]}, "{}"
@@ -498,3 +511,130 @@ def test_dedupe_will_not_merge_two_claims_the_dossier_says_disagree():
 
     assert "c2" not in selection.merged, "a disputed claim must keep its own voice"
     assert selection.merged == {"c3": "c1"}, "an undisputed merge still happens"
+
+
+def _mixed(load_bearing: int, texture: int):
+    """A dossier with both kinds, and a work order that says which is which."""
+    total = load_bearing + texture
+    evidence = _package(total)
+    colour = [f"c{index}" for index in range(load_bearing + 1, total + 1)]
+    evidence = evidence.model_copy(
+        update={
+            "claims": [
+                claim.model_copy(update={"requirement_ids": ["r_colour"]})
+                if claim.claim_id in colour
+                else claim
+                for claim in evidence.claims
+            ],
+            "requirements": [
+                evidence.requirements[0].model_copy(
+                    update={"claim_ids": [f"c{i}" for i in range(1, load_bearing + 1)]}
+                ),
+                EvidenceRequirement(
+                    requirement_id="r_colour", status="supported", claim_ids=colour
+                ),
+            ],
+        }
+    )
+    work_order = _work_order().model_copy(
+        update={
+            "requirements": [
+                *_work_order().requirements,
+                WorkOrderRequirement(
+                    requirement_id="r_colour",
+                    question="What is the room like?",
+                    kind="texture",
+                ),
+            ]
+        }
+    )
+    return evidence, work_order, colour
+
+
+def test_colour_keeps_a_share_of_the_desk_instead_of_losing_every_time():
+    """Ranking against the brief means ranking against the reader question, the
+    outcome and fails_if -- three questions about usefulness. A fact whose only
+    job is to make a place feel like a place loses to a price band every time.
+
+    Measured on run 8a7e9aa4: 23 texture claims in the dossier, 2 selected. The
+    best line in it -- Canta Rana's dining room covered in football flags
+    because the owner is Argentine -- ranked 59th of 151 and was cut.
+    """
+    evidence, work_order, colour = _mixed(load_bearing=40, texture=10)
+    # The utility ranker does what it did in the wild: all the colour last.
+    llm = _LLM(
+        groups=[],
+        ranked=[f"f{i}" for i in range(1, 51)],
+        texture=[f"f{i}" for i in range(1, 11)],
+    )
+
+    selection = select_evidence(
+        _brief(), work_order, evidence, SelectionDependencies(llm=llm),
+        target_word_count=900,
+    )
+    kept = selection.selected_claim_ids()
+
+    assert selection.keep_count == 18
+    assert len(kept) == 18, "the reserve holds slots, it does not add them"
+    assert len(kept & set(colour)) == 4, "a fifth of 18, rounded"
+    # And without the reserve every one of them would have been cut.
+    assert all(claim not in selection.order[:18] for claim in colour)
+
+
+def test_the_operators_moves_do_not_quietly_delete_the_reserve():
+    """The first click used to rebuild the selection without it."""
+    evidence, work_order, colour = _mixed(load_bearing=40, texture=10)
+    llm = _LLM(
+        groups=[],
+        ranked=[f"f{i}" for i in range(1, 51)],
+        texture=[f"f{i}" for i in range(1, 11)],
+    )
+    selection = select_evidence(
+        _brief(), work_order, evidence, SelectionDependencies(llm=llm),
+        target_word_count=900,
+    )
+
+    widened = revise(selection, keep_count=30)
+
+    assert widened.texture_reserve == selection.texture_reserve
+    assert len(widened.selected_claim_ids() & set(colour)) >= 4
+
+
+def test_the_colour_pass_is_asked_a_different_question_from_the_ranking():
+    """Judged on usefulness, colour is correctly judged useless. It has to be
+    judged on what it is for."""
+    evidence, work_order, _colour = _mixed(load_bearing=6, texture=4)
+    llm = _LLM(groups=[], ranked=[f"f{i}" for i in range(1, 11)], texture=["f1"])
+
+    select_evidence(
+        _brief(), work_order, evidence, SelectionDependencies(llm=llm),
+        target_word_count=900,
+    )
+
+    colour_prompt = next(p for p in llm.prompts if "real place" in p)
+    assert "SPECIFIC BEATS EVALUATIVE" in colour_prompt
+    assert "football flags" in colour_prompt
+    assert "beloved" in colour_prompt, "marketing language is named and demoted"
+    # And the practical claims are not in it: this pass only sees colour.
+    assert "- f5 |" not in colour_prompt
+
+
+def test_a_claim_that_also_proves_something_is_not_colour():
+    """A claim answering a load-bearing question is doing load-bearing work,
+    whatever else it does. Counting it as colour would spend the reserve on
+    facts that were never at risk."""
+    evidence, work_order, _colour = _mixed(load_bearing=3, texture=2)
+    both = evidence.claims[3].model_copy(update={"requirement_ids": ["r1", "r_colour"]})
+    evidence = evidence.model_copy(
+        update={
+            "claims": [*evidence.claims[:3], both, evidence.claims[4]],
+            "requirements": [
+                evidence.requirements[0].model_copy(
+                    update={"claim_ids": ["c1", "c2", "c3", "c4"]}
+                ),
+                evidence.requirements[1],
+            ],
+        }
+    )
+
+    assert texture_claim_ids(work_order, evidence) == {"c5"}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/FactPicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/FactPicker.tsx
@@ -49,6 +49,12 @@ function Fact({
       <span className="p2b-fact-rank">{claim.rank}</span>
       <div className="p2b-fact-body">
         <p className="p2b-fact-text">{claim.text}</p>
+        {claim.texture && (
+          /* Named, because the reserve is the only reason it is here. An
+             operator cutting it should know they are cutting the colour, not
+             trimming a duplicate. */
+          <span className="p2b-fact-colour">colour</span>
+        )}
         {claim.why && <p className="p2b-fact-why">{claim.why}</p>}
         {claim.merged_in.length > 0 && (
           /* Said rather than hidden: the operator should be able to see that

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/fact-picker.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/fact-picker.test.tsx
@@ -162,4 +162,28 @@ describe('the fact picker', () => {
 
     await waitFor(() => expect(container).toBeEmptyDOMElement())
   })
+
+  it('marks the rows that are there for colour', async () => {
+    // Cutting one of these costs the piece something a price band cannot
+    // replace, so the operator has to be able to see which they are.
+    readSelection.mockResolvedValue(
+      review({
+        keep_count: 2,
+        claims: [
+          claim(),
+          claim({
+            claim_id: 'c2',
+            rank: 2,
+            selected: true,
+            texture: true,
+            text: 'The walls are covered in football flags; the owner is Argentine.',
+          }),
+        ],
+      }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={vi.fn()} />)
+
+    expect(await screen.findByText('colour')).toBeInTheDocument()
+  })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -327,6 +327,13 @@ export interface SelectableClaim {
   questions: string[]
   /** Facts that said the same thing and stood down in favour of this one. */
   merged_in: string[]
+  /**
+   * A detail whose only job is colour. Ranked on how much of the place it
+   * carries rather than on what it proves, and holding one of the reserved
+   * slots — so cutting it costs the piece something a price band cannot
+   * replace.
+   */
+  texture?: boolean
   confidence: string
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1388,3 +1388,17 @@
 .p2b-fact-actions {
   flex-shrink: 0;
 }
+
+/* A detail kept for colour rather than proof. Quiet: it labels a row, it does
+   not decorate one. */
+.p2b-fact-colour {
+  display: inline-block;
+  margin-bottom: var(--space-2);
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  color: var(--muted);
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
The article reads as informative and not as a pleasure. This is why.

## Measured, on the ceviche run `8a7e9aa4`

```
texture claims in the dossier:  23
texture claims selected:         2
total claims selected:          30
```

The best line in the whole run — *"Canta Rana's dining room is bare-bones and reflects the Argentina-born owner's passion for fútbol, walls adorned with logos and flags"* — ranked **59th of 151**. Below the cut.

That's a football-shrine ceviche joint in Barranco, found by research, and it never reached the writer.

## Why it happened

Ranking is against the brief: the reader question, the outcome, `fails_if`. All three ask *is this useful*. A fact whose only job is to make a place feel like a place answers none of them, so it loses to a price band every time.

The ranker was not wrong. It was asked one question and answered it. The fault is that selection let one answer decide everything.

## The fix is not a "be fun" instruction

That is how you get corny — a model told to be fun writes jokes. The material was already there, already true, and already sourced. The pipeline binned it.

The work order **already** labels every question `load_bearing` or `texture`. Coverage **already** refuses a run with no texture answered. Selection was the one stage blind to the distinction.

- **A claim is colour only when every question it answers is texture.** One that also answers a load-bearing question is doing load-bearing work whatever else it does, and was never at risk. Spending the reserve on those would fix nothing.
- **Colour gets its own ranking pass, asked a different question:** how much of the place does this carry. The prompt says *specific beats evaluative* in as many words — football flags over "lively and authentic" — and demotes definitions, categories, and marketing words ("beloved", "hidden gem").
- **A fifth of the keep-set is reserved.** Held, not added: the operator asked for that many facts and gets that many. `TEXTURE_SHARE = 0.2` carries its reasoning in the file — texture is seasoning, and a piece that is half colour has stopped answering its commission.
- **The reserve survives the operator's moves.** Without that, the first click on the slider rebuilt the selection and starved it again.
- **The picker labels those rows** so cutting one is a visible choice rather than a trim.

## Routing

Runs as `p2b.evidence_rank`, not a new job. It is the same work — ordering evidence against a brief — over a subset with a different question, and two registry entries that would always route to the same model are noise in a registry whose point is that each entry is a decision. No `jobs.json` change, so no dashboard restart needed.

## Verified

- The wild failure reproduced: a utility ranking that puts all ten colour claims last keeps **4 of them** through the reserve, and the total stays at 18. Without the reserve every one is cut — the test asserts that too.
- Widening the cut preserves the reserve.
- The colour pass sees only colour claims and carries the specific-beats-evaluative rule.
- A claim answering both kinds of question is not counted as colour.
- Backend suite, vitest, `tsc --noEmit` green.

## What this does not claim

That the next article will be fun. It restores material that was being thrown away; whether the writer uses it well is the next run's question.