### PR TITLE
fix(p2b): budget in money, because a token is not a unit of cost

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/config.py
@@ -110,6 +110,30 @@ P2B_REPAIR_ESTIMATED_TOKENS = 90_000
 # nobody has watched. Re-derive it the first time one actually runs.
 P2B_RUN_TOKEN_BUDGET = 425_000
 
+# What one more repair attempt may cost, and what the run may spend before it
+# stops being worth one. In money, because a token is not a unit of cost.
+#
+# The token budget above treated a Gemini Flash token and a subscription Claude
+# token as the same currency. On the two runs that finished, two thirds of the
+# tokens were Claude drawing plan allowance -- free -- and both runs were
+# refused their repair. Chifa 3750891f shipped with a wrong opening time; the
+# ceviche run shipped six words over its word cap and scored 6 for it. Each
+# would have been a single repair call away, and each run had billed $0.37.
+#
+#   chifa   3750891f: $0.36 billed, $2.29 notional, 802,018 tokens
+#   ceviche 8a7e9aa4: $0.38 billed, $1.97 notional, 692,544 tokens
+#
+# So $2.00 is five times what a whole run bills, and a repair is a rounding
+# error against it. Set from measurement rather than from a round number, and
+# it is deliberately generous: the failure this replaces was a budget too tight
+# to fix a typo.
+P2B_RUN_COST_BUDGET_USD = 2.00
+
+# What a repair attempt bills. Both stored repairs were Claude, so they billed
+# nothing at all; this is the Gemini groundedness and audit re-run that follows
+# one. Re-derive it the first time a repair runs on a paid model.
+P2B_REPAIR_ESTIMATED_COST_USD = 0.10
+
 # The hard ceiling. Distinct from P2B_RUN_TOKEN_BUDGET above, which only asks
 # whether one more *rescue* is affordable: this asks whether the run may
 # continue at all, and refuses when it may not.
@@ -121,10 +145,25 @@ P2B_RUN_TOKEN_BUDGET = 425_000
 # question count (ADR 0030), and research is grounded web search. A bug that
 # asks forty questions should cost a known amount and then stop.
 #
-# Set at roughly twice the budget above so it never fires on a run that is
-# merely expensive; it exists for runaway, not for costly. The number is here,
-# in one place, so a ceiling set wrong is obvious rather than mysterious.
-P2B_RUN_TOKEN_CEILING = 650_000
+# It exists for runaway, not for costly, and it was set at twice the token
+# budget back when affordability was also measured in tokens. That basis is
+# gone -- affordability is `P2B_RUN_COST_BUDGET_USD` now -- and the old number
+# was firing on runs that were working:
+#
+#   chifa   3750891f: 802,018 tokens, $0.36 billed, finished
+#   ceviche 8a7e9aa4: 692,544 tokens, $0.38 billed, died at `quality_settle`
+#     -- the last node, after the article was written and audited, on the step
+#     that only picks which draft to keep.
+#
+# So the number is now set against what a working run actually costs rather
+# than against another budget: roughly two and a half times the longest one
+# observed. A bug that asks forty questions still stops. A run that merely has
+# a lot to say does not.
+#
+# It stays denominated in tokens on purpose. Money answers whether a run is
+# worth continuing; tokens answer whether it has stopped terminating, and a
+# loop on a cheap model is still a loop.
+P2B_RUN_TOKEN_CEILING = 2_000_000
 
 # How many times the grill may look something up *during* the interview, on
 # top of the one lookup it always makes on the seed.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/graph/state.py
@@ -52,6 +52,9 @@ class Prompt2BlogV3GraphState(TypedDict, total=False):
     # moment. Written by the audit stage, read by finalize and the operator UI.
     repair_decision: dict[str, Any]
     tokens_spent: int | None
+    # Money billed so far, Claude's subscription calls excluded because they
+    # bill nothing. The repair gate reads this rather than the tokens above.
+    billed_cost_usd: float | None
     best_rewrite: dict[str, Any]
     best_quality: dict[str, Any]
     best_quality_checks: dict[str, Any]

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -135,6 +135,24 @@ def _stage_data(run_id: str, stage: str) -> dict[str, Any]:
     return _safe_dict(_safe_dict(read_stage_result(run_id, stage)).get("data"))
 
 
+def _run_billed_cost(run_id: str) -> float | None:
+    """Money this run has billed, or None when nothing is counting.
+
+    Only `rate-table` calls. A `measured` price is what the Claude Code CLI
+    says the same work would cost at API rates; those calls draw the plan
+    holder's allowance and bill nothing, so counting them would price a plan
+    against money nobody will be charged.
+    """
+    calls = _stage_data(run_id, "usage_ledger").get("calls")
+    if not isinstance(calls, list):
+        return None
+    return sum(
+        float(call.get("cost_usd") or 0.0)
+        for call in calls
+        if isinstance(call, dict) and call.get("cost_basis") == "rate-table"
+    )
+
+
 def _run_tokens_spent(run_id: str) -> int | None:
     """What this run has spent so far, or None when nothing is counting.
 
@@ -326,7 +344,9 @@ def plan_research(run_id: str, services: IntakeServices) -> Prompt2BlogWorkOrder
         WORK_ORDER_STAGE,
         {
             **work_order_stage_record(
-                work_order, tokens_spent=_run_tokens_spent(run_id)
+                work_order,
+                tokens_spent=_run_tokens_spent(run_id),
+                cost_spent=_run_billed_cost(run_id),
             ),
             STATE_KEY: json.loads(work_order.model_dump_json()),
         },
@@ -361,6 +381,7 @@ def apply_cut(
                 outcome.work_order,
                 outcome.warnings,
                 tokens_spent=_run_tokens_spent(run_id),
+                cost_spent=_run_billed_cost(run_id),
             ),
             STATE_KEY: json.loads(outcome.work_order.model_dump_json()),
         },
@@ -408,7 +429,7 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
     # gathering it is about to do will cost, which is the only part of the sum
     # that can still be changed. Counted over the questions still without a
     # note, so a resume is not charged again for notes it already paid for.
-    enforce_plan_fits(len(outstanding), tokens_spent)
+    enforce_plan_fits(len(outstanding), tokens_spent, _run_billed_cost(run_id))
 
     if outstanding:
         _open(services, run_id, NOTES_STAGE)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/policies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/policies.py
@@ -15,6 +15,8 @@ from .config import (
     P2B_AUGMENTATION_MIN_RETENTION_RATIO,
     P2B_REPAIR_ESTIMATED_TOKENS,
     P2B_REPAIR_MAX_ATTEMPTS,
+    P2B_REPAIR_ESTIMATED_COST_USD,
+    P2B_RUN_COST_BUDGET_USD,
     P2B_RUN_TOKEN_BUDGET,
 )
 from .quality import (
@@ -172,6 +174,12 @@ class RepairDecision:
     tokens_spent: int | None
     tokens_per_attempt: int
     token_budget: int
+    # What the run actually billed, and what one more attempt bills. Kept
+    # beside the token figures rather than replacing them: tokens still say
+    # whether a run is running away, money says whether it is worth continuing.
+    billed_cost_usd: float | None = None
+    cost_per_attempt: float = 0.0
+    cost_budget_usd: float = 0.0
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -181,6 +189,9 @@ class RepairDecision:
             "attempts_used": self.attempts_used,
             "attempts_allowed": self.attempts_allowed,
             "tokens_spent": self.tokens_spent,
+            "billed_cost_usd": self.billed_cost_usd,
+            "cost_per_attempt": self.cost_per_attempt,
+            "cost_budget_usd": self.cost_budget_usd,
             "tokens_per_attempt": self.tokens_per_attempt,
             "token_budget": self.token_budget,
         }
@@ -195,11 +206,19 @@ def decide_repair(state: dict[str, Any]) -> RepairDecision:
     2. The attempt allowance is used up. One automatic attempt, not two: the
        second was buying score points at a whole extra repair chain's price.
     3. The run has spent so much already that the next attempt would carry it
-       past `P2B_RUN_TOKEN_BUDGET`. Refusing here is what makes a bad run's
+       past `P2B_RUN_COST_BUDGET_USD`. Refusing here is what makes a bad run's
        cost predictable instead of open-ended.
 
-    A run with no token tracker (every test double) skips only the third
-    check; it behaves exactly as it did before the budget existed.
+    That third check is in money, and only money that was billed. It used to be
+    in tokens, which treated a Gemini Flash token and a subscription Claude
+    token as the same currency -- and on both runs that finished, two thirds of
+    the tokens were Claude drawing plan allowance rather than billing anything.
+    Both were refused their repair while having spent $0.37. One shipped a
+    wrong opening time and the other shipped six words over its word cap and
+    was scored 6 for it; each was one repair call from being right.
+
+    A run with no cost tracker (every test double) skips only the third check;
+    it behaves exactly as it did before the budget existed.
     """
     quality = _safe_dict(state.get("quality"))
     checks = _safe_dict(state.get("quality_checks"))
@@ -208,6 +227,8 @@ def decide_repair(state: dict[str, Any]) -> RepairDecision:
     tokens_spent = (
         _safe_int(tokens_spent, default=0) if isinstance(tokens_spent, int) else None
     )
+    cost_spent = state.get("billed_cost_usd")
+    cost_spent = float(cost_spent) if isinstance(cost_spent, (int, float)) else None
     problems = evaluate_readiness(
         quality=quality,
         checks=checks,
@@ -224,6 +245,9 @@ def decide_repair(state: dict[str, Any]) -> RepairDecision:
             tokens_spent=tokens_spent,
             tokens_per_attempt=P2B_REPAIR_ESTIMATED_TOKENS,
             token_budget=P2B_RUN_TOKEN_BUDGET,
+            billed_cost_usd=cost_spent,
+            cost_per_attempt=P2B_REPAIR_ESTIMATED_COST_USD,
+            cost_budget_usd=P2B_RUN_COST_BUDGET_USD,
         )
 
     if not _should_run_repair(quality, checks):
@@ -231,10 +255,10 @@ def decide_repair(state: dict[str, Any]) -> RepairDecision:
     if attempts >= P2B_REPAIR_MAX_ATTEMPTS:
         return verdict("settle", "attempt_limit_reached")
     if (
-        tokens_spent is not None
-        and tokens_spent + P2B_REPAIR_ESTIMATED_TOKENS > P2B_RUN_TOKEN_BUDGET
+        cost_spent is not None
+        and cost_spent + P2B_REPAIR_ESTIMATED_COST_USD > P2B_RUN_COST_BUDGET_USD
     ):
-        return verdict("settle", "token_budget_reached")
+        return verdict("settle", "cost_budget_reached")
     return verdict("repair", "repairable_problems_found")
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -603,6 +603,37 @@ class Prompt2BlogTokenUsageTracker:
         }
 
 
+def run_billed_cost_usd(llm: Any) -> float | None:
+    """Money this run has actually spent, or None when nothing is counting.
+
+    Only `rate-table` calls. A `measured` price comes from the Claude Code CLI
+    and is what the same work would have cost at API rates -- the calls draw the
+    plan holder's allowance rather than billing per token, so counting them here
+    would refuse a run its repair over money nobody was charged.
+
+    Measured on two full runs: chifa 3750891f spent $0.36 billed beside $2.29
+    notional, and ceviche 8a7e9aa4 $0.38 beside $1.97. Both were refused their
+    repair by a budget denominated in tokens, in which the free two thirds of
+    the run counted the same as the paid third.
+
+    None rather than 0.0 for a caller with no tracker, for the same reason
+    `run_tokens_spent` returns None: nothing counting is not nothing spent.
+    """
+    tracker = getattr(llm, "usage_tracker", None)
+    ledger = getattr(tracker, "ledger", None)
+    if not callable(ledger):
+        return None
+    try:
+        return sum(
+            float(call.get("cost_usd") or 0.0)
+            for call in ledger().get("calls", [])
+            if call.get("cost_basis") == COST_BASIS_RATE_TABLE
+        )
+    except Exception as exc:  # pragma: no cover -- telemetry only
+        logger.warning("Prompt2Blog cost read failed: %s", exc)
+        return None
+
+
 def run_tokens_spent(llm: Any) -> int | None:
     """Tokens this run has spent so far, or None when nothing is counting.
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -7,7 +7,7 @@ from ...graph.state import Prompt2BlogV3GraphState
 from ...instructions_v3 import stage_context_text
 from ...observability import _append_stage_trace
 from ...policies import decide_repair, is_better_quality
-from ...pricing import run_tokens_spent
+from ...pricing import run_billed_cost_usd, run_tokens_spent
 from ...prompts.editorial_v3 import (
     P2B_V3_QUALITY_AUDIT_PROMPT,
     P2B_V3_REPAIR_PROMPT,
@@ -170,6 +170,9 @@ def run_v3_quality_audit_stage(
         # Read after the audit call, so the gate below judges the spend the run
         # has actually reached rather than the one it had before this stage.
         "tokens_spent": run_tokens_spent(dependencies.llm),
+        # What the run has actually billed. The repair decision reads this;
+        # tokens stay for the runaway ceiling and the receipt.
+        "billed_cost_usd": run_billed_cost_usd(dependencies.llm),
     }
     if is_better_quality(quality, state.get("best_quality")):
         updates["best_rewrite"] = rewrite

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -38,7 +38,9 @@ from .contracts_v4 import (
 from pydantic import ValidationError
 
 from .config import (
+    P2B_REPAIR_ESTIMATED_COST_USD,
     P2B_REPAIR_ESTIMATED_TOKENS,
+    P2B_RUN_COST_BUDGET_USD,
     P2B_RUN_TOKEN_BUDGET,
     P2B_RUN_TOKEN_CEILING,
 )
@@ -723,6 +725,18 @@ MIN_WORKABLE_QUESTIONS = 5
 # 173,801. Writing was counted correctly even on the runs whose intake was not.
 WRITING_TOKENS_TYPICAL = 134_000
 
+# What one research question bills, and what the writing leg bills, in money.
+# Billed only: the Claude stages draw subscription allowance and charge
+# nothing, so counting them would price a plan the operator will never pay for.
+#
+#   chifa   3750891f: 15 questions, $0.108 research ($0.0072 each), $0.114 writing
+#   ceviche 8a7e9aa4: 20 questions, $0.205 research ($0.0103 each), $0.047 writing
+#
+# Two points again, and rounded up to the dearer of them, because a projection
+# that flatters the plan is the one that lets a run start it cannot finish.
+RESEARCH_COST_PER_QUESTION_USD = 0.011
+WRITING_COST_TYPICAL_USD = 0.12
+
 
 @dataclass(frozen=True)
 class BudgetProjection:
@@ -743,6 +757,10 @@ class BudgetProjection:
     projected_total: int
     repair_reserve: int
     budget: int
+    # What this plan is projected to bill, and whether a repair still fits
+    # inside the money budget. `questions_that_fit` is derived from money too.
+    projected_cost_usd: float
+    cost_budget_usd: float
     repair_affordable: bool
     questions_that_fit: int
     # The hard ceiling, and whether this plan can reach an article at all.
@@ -777,7 +795,11 @@ class PlanTooLargeToFinish(RuntimeError):
         self.projection = projection
 
 
-def enforce_plan_fits(question_count: int, tokens_spent: int | None) -> None:
+def enforce_plan_fits(
+    question_count: int,
+    tokens_spent: int | None,
+    cost_spent: float | None = None,
+) -> None:
     """Stop before research when the plan projects past the hard ceiling.
 
     Silent when the run has no token accounting, the same way
@@ -789,13 +811,15 @@ def enforce_plan_fits(question_count: int, tokens_spent: int | None) -> None:
     repair is still the operator's to run -- it produces an article -- and it
     stays a warning on the screen.
     """
-    projection = budget_projection(question_count, tokens_spent)
+    projection = budget_projection(question_count, tokens_spent, cost_spent)
     if projection and not projection.can_finish:
         raise PlanTooLargeToFinish(projection)
 
 
 def budget_projection(
-    question_count: int, tokens_spent: int | None
+    question_count: int,
+    tokens_spent: int | None,
+    cost_spent: float | None = None,
 ) -> BudgetProjection | None:
     """Say what this plan will cost before it is paid for.
 
@@ -808,14 +832,24 @@ def budget_projection(
 
     research = question_count * RESEARCH_TOKENS_PER_QUESTION
     total = tokens_spent + research + WRITING_TOKENS_TYPICAL
-    affordable = total + P2B_REPAIR_ESTIMATED_TOKENS <= P2B_RUN_TOKEN_BUDGET
-    room = (
-        P2B_RUN_TOKEN_BUDGET
-        - P2B_REPAIR_ESTIMATED_TOKENS
-        - WRITING_TOKENS_TYPICAL
-        - tokens_spent
+    # Affordability is a question about money. Tokens answer the different
+    # question below -- whether this plan terminates -- and conflating the two
+    # is what refused two $0.37 runs their repair.
+    projected_cost = (
+        (cost_spent or 0.0)
+        + question_count * RESEARCH_COST_PER_QUESTION_USD
+        + WRITING_COST_TYPICAL_USD
     )
-    fits = max(0, room // RESEARCH_TOKENS_PER_QUESTION)
+    affordable = (
+        projected_cost + P2B_REPAIR_ESTIMATED_COST_USD <= P2B_RUN_COST_BUDGET_USD
+    )
+    cost_room = (
+        P2B_RUN_COST_BUDGET_USD
+        - P2B_REPAIR_ESTIMATED_COST_USD
+        - WRITING_COST_TYPICAL_USD
+        - (cost_spent or 0.0)
+    )
+    fits = max(0, int(cost_room // RESEARCH_COST_PER_QUESTION_USD))
     can_finish = total <= P2B_RUN_TOKEN_CEILING
     finish_room = P2B_RUN_TOKEN_CEILING - WRITING_TOKENS_TYPICAL - tokens_spent
     finishes = max(0, finish_room // RESEARCH_TOKENS_PER_QUESTION)
@@ -833,15 +867,15 @@ def budget_projection(
         )
     elif affordable:
         note = (
-            f"{question_count} questions projects to about {total:,} tokens "
-            f"against a {P2B_RUN_TOKEN_BUDGET:,} ceiling, leaving room for "
-            f"the one repair attempt."
+            f"{question_count} questions projects to about ${projected_cost:.2f} "
+            f"and {total:,} tokens, inside the ${P2B_RUN_COST_BUDGET_USD:.2f} "
+            f"budget with room for the one repair attempt."
         )
     elif fits >= MIN_WORKABLE_QUESTIONS:
         note = (
-            f"{question_count} questions projects to about {total:,} tokens. "
-            f"With the {P2B_REPAIR_ESTIMATED_TOKENS:,} a repair costs, that "
-            f"passes the {P2B_RUN_TOKEN_BUDGET:,} ceiling, so this article "
+            f"{question_count} questions projects to about ${projected_cost:.2f}. "
+            f"With the ${P2B_REPAIR_ESTIMATED_COST_USD:.2f} a repair costs, that "
+            f"passes the ${P2B_RUN_COST_BUDGET_USD:.2f} budget, so this article "
             f"will not be able to repair itself. About {fits} questions would "
             f"leave room."
         )
@@ -850,12 +884,12 @@ def budget_projection(
         # 370,114. No plan worth writing fits, which makes this a question
         # about the ceiling rather than about the plan.
         note = (
-            f"{question_count} questions projects to about {total:,} tokens, "
-            f"past the {P2B_RUN_TOKEN_BUDGET:,} ceiling once the "
-            f"{P2B_REPAIR_ESTIMATED_TOKENS:,} a repair costs is counted. Only "
-            f"about {fits} questions would fit, which is not an article. This "
-            f"is the ceiling being too low for the pipeline as it now bills, "
-            f"not the plan being too large."
+            f"{question_count} questions projects to about ${projected_cost:.2f}, "
+            f"past the ${P2B_RUN_COST_BUDGET_USD:.2f} budget once the "
+            f"${P2B_REPAIR_ESTIMATED_COST_USD:.2f} a repair costs is counted. "
+            f"Only about {fits} questions would fit, which is not an article. "
+            f"This is the budget being too low for the pipeline as it now "
+            f"bills, not the plan being too large."
         )
     return BudgetProjection(
         question_count=question_count,
@@ -865,6 +899,8 @@ def budget_projection(
         projected_total=total,
         repair_reserve=P2B_REPAIR_ESTIMATED_TOKENS,
         budget=P2B_RUN_TOKEN_BUDGET,
+        projected_cost_usd=round(projected_cost, 4),
+        cost_budget_usd=P2B_RUN_COST_BUDGET_USD,
         repair_affordable=affordable,
         questions_that_fit=fits,
         ceiling=P2B_RUN_TOKEN_CEILING,
@@ -878,9 +914,12 @@ def work_order_stage_record(
     work_order: Prompt2BlogWorkOrder,
     warnings: list[str] | None = None,
     tokens_spent: int | None = None,
+    cost_spent: float | None = None,
 ) -> dict[str, Any]:
     """What the run keeps about the plan the operator approved."""
-    projection = budget_projection(len(work_order.requirements), tokens_spent)
+    projection = budget_projection(
+        len(work_order.requirements), tokens_spent, cost_spent
+    )
     return {
         # What this plan is about to cost, next to the decision that changes
         # it. The cut step had no price on it, so the difference between a run

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_gate.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_quality_gate.py
@@ -6,6 +6,8 @@ from app.features.prompt2blog.config import (
     P2B_AUGMENTATION_MIN_RETENTION_RATIO,
     P2B_REPAIR_ESTIMATED_TOKENS,
     P2B_REPAIR_MAX_ATTEMPTS,
+    P2B_REPAIR_ESTIMATED_COST_USD,
+    P2B_RUN_COST_BUDGET_USD,
     P2B_RUN_TOKEN_BUDGET,
 )
 from app.features.prompt2blog.graph.topology_v3 import (
@@ -83,18 +85,46 @@ def test_only_one_repair_attempt_is_automatic():
     assert decision.reason == "attempt_limit_reached"
 
 
-def test_gate_refuses_a_repair_that_would_break_the_token_budget():
+def test_gate_refuses_a_repair_that_would_break_the_cost_budget():
     state = {
         "quality": {"audit_complete": True, "overall_score": 3},
         "quality_checks": PASSING_CHECKS,
         "repair_attempts": 0,
-        "tokens_spent": P2B_RUN_TOKEN_BUDGET - P2B_REPAIR_ESTIMATED_TOKENS + 1,
+        "billed_cost_usd": P2B_RUN_COST_BUDGET_USD - P2B_REPAIR_ESTIMATED_COST_USD + 0.01,
     }
 
     decision = decide_repair(state)
     assert decision.route == "settle"
-    assert decision.reason == "token_budget_reached"
+    assert decision.reason == "cost_budget_reached"
     assert route_quality_gate(state) == "settle"
+
+
+def test_a_run_that_spent_tokens_but_no_money_still_gets_its_repair():
+    """The failure this replaces. Both finished runs spent ~700,000 tokens and
+    billed $0.37, because two thirds of the tokens were subscription Claude
+    drawing plan allowance. Both were refused their repair; one shipped a wrong
+    opening time, the other six words over its word cap."""
+    state = {
+        "quality": {"audit_complete": True, "overall_score": 3},
+        "quality_checks": PASSING_CHECKS,
+        "repair_attempts": 0,
+        "tokens_spent": 692_544,
+        "billed_cost_usd": 0.38,
+    }
+
+    assert decide_repair(state).route == "repair"
+
+
+def test_a_run_with_no_cost_tracker_is_not_refused_on_money_it_cannot_measure():
+    """Every test double, and the same discipline the token gate kept: nothing
+    counting is not nothing spent, but it is not a refusal either."""
+    state = {
+        "quality": {"audit_complete": True, "overall_score": 3},
+        "quality_checks": PASSING_CHECKS,
+        "repair_attempts": 0,
+    }
+
+    assert decide_repair(state).route == "repair"
 
 
 def test_gate_still_buys_the_first_repair_inside_the_budget():
@@ -102,7 +132,7 @@ def test_gate_still_buys_the_first_repair_inside_the_budget():
         "quality": {"audit_complete": True, "overall_score": 3},
         "quality_checks": PASSING_CHECKS,
         "repair_attempts": 0,
-        "tokens_spent": P2B_RUN_TOKEN_BUDGET - P2B_REPAIR_ESTIMATED_TOKENS,
+        "billed_cost_usd": P2B_RUN_COST_BUDGET_USD - P2B_REPAIR_ESTIMATED_COST_USD,
     }
 
     assert decide_repair(state).route == "repair"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
@@ -15,7 +15,10 @@ from fastapi import BackgroundTasks, HTTPException
 
 import app.features.prompt2blog.api.runs as runs_api
 import app.features.prompt2blog.routes as prompt2blog_routes
-from app.features.prompt2blog.config import P2B_RUN_TOKEN_BUDGET
+from app.features.prompt2blog.config import (
+    P2B_RUN_COST_BUDGET_USD,
+    P2B_RUN_TOKEN_BUDGET,
+)
 from app.features.prompt2blog.contracts_v4 import Prompt2BlogV4Request
 from app.features.prompt2blog.dependencies import PipelineDependencies
 from app.features.prompt2blog.intake_v3 import prepare_v3_runtime_request
@@ -189,12 +192,23 @@ class SpentTokens:
     Deliberately not a whole `UsageLedger`: a full one would make
     `PipelineDependencies` try to wire this run's recorder for per-stage
     attribution, which the recording fake here does not support.
+
+    `billed_usd` is what the repair gate actually reads. It is separate from
+    the tokens because two thirds of a real run's tokens are subscription
+    Claude, which bills nothing -- the pair here is what let a $0.37 run be
+    refused its repair for being 700,000 tokens long.
     """
 
     total_tokens: int
+    billed_usd: float = 0.0
 
     def totals(self) -> dict[str, int]:
         return {"total_tokens": self.total_tokens}
+
+    def ledger(self) -> dict[str, Any]:
+        return {
+            "calls": [{"cost_usd": self.billed_usd, "cost_basis": "rate-table"}]
+        }
 
 
 @dataclass
@@ -554,7 +568,9 @@ def test_a_weak_draft_buys_one_repair_and_then_asks_for_a_human():
 def test_an_expensive_run_stops_before_buying_a_repair():
     llm = ScriptedLLM(
         quality_scores=[4],
-        usage_tracker=SpentTokens(total_tokens=P2B_RUN_TOKEN_BUDGET),
+        usage_tracker=SpentTokens(
+            total_tokens=P2B_RUN_TOKEN_BUDGET, billed_usd=P2B_RUN_COST_BUDGET_USD
+        ),
     )
     recorder = RecordingRecorder()
 
@@ -567,8 +583,8 @@ def test_an_expensive_run_stops_before_buying_a_repair():
     assert "stage_v3_repair" not in recorder.order
     assert recorder.order.count("stage_v3_quality_audit") == 1
     decision = state["response_payload"]["quality_review"]["repair_decision"]
-    assert decision["reason"] == "token_budget_reached"
-    assert decision["tokens_spent"] == P2B_RUN_TOKEN_BUDGET
+    assert decision["reason"] == "cost_budget_reached"
+    assert decision["billed_cost_usd"] == P2B_RUN_COST_BUDGET_USD
     # The article still comes back -- as the operator's problem, not as a
     # failure and not as something worth another 90,000 tokens.
     assert state["response_payload"]["pipeline_status"] == "needs_revision"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -690,14 +690,30 @@ def test_the_projection_lands_on_the_run_that_produced_it():
 
 
 def test_a_plan_that_cannot_repair_itself_says_so():
+    """Driven by money spent, not tokens. Run b29d66b4 was refused its repair
+    on 379,508 tokens; in money that same plan bills about $0.27 and can afford
+    one easily. What cannot afford a repair is a run that has actually spent."""
+    from app.features.prompt2blog.config import P2B_RUN_COST_BUDGET_USD
     from app.features.prompt2blog.work_order_v4 import budget_projection
 
-    projection = budget_projection(14, 38_308)
+    projection = budget_projection(14, 38_308, cost_spent=P2B_RUN_COST_BUDGET_USD - 0.20)
 
     assert projection.repair_affordable is False
     assert "will not be able to repair itself" in projection.note or (
         "past the" in projection.note
     )
+
+
+def test_the_run_that_was_refused_its_repair_would_now_get_one():
+    """The failure this replaces, in its own numbers. Both finished runs billed
+    about $0.37 across roughly 700,000 tokens, because two thirds of those
+    tokens were subscription Claude billing nothing. Both were refused."""
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(20, 692_544, cost_spent=0.38)
+
+    assert projection.repair_affordable is True
+    assert projection.can_finish is True
 
 
 def test_a_small_plan_on_a_fresh_run_can_afford_its_repair():
@@ -706,7 +722,7 @@ def test_a_small_plan_on_a_fresh_run_can_afford_its_repair():
     projection = budget_projection(3, 5_000)
 
     assert projection.repair_affordable is True
-    assert "leaving room for the one repair attempt" in projection.note
+    assert "room for the one repair attempt" in projection.note
 
 
 def test_the_note_blames_the_ceiling_when_no_workable_plan_fits():
@@ -719,11 +735,13 @@ def test_the_note_blames_the_ceiling_when_no_workable_plan_fits():
     from app.features.prompt2blog.config import P2B_RUN_TOKEN_BUDGET
     from app.features.prompt2blog.work_order_v4 import budget_projection
 
-    projection = budget_projection(9, P2B_RUN_TOKEN_BUDGET - 150_000)
+    from app.features.prompt2blog.config import P2B_RUN_COST_BUDGET_USD
+
+    projection = budget_projection(9, 275_000, cost_spent=P2B_RUN_COST_BUDGET_USD - 0.18)
 
     assert projection.repair_affordable is False
     assert projection.questions_that_fit < 5
-    assert "ceiling being too low" in projection.note
+    assert "budget being too low" in projection.note
 
 
 def test_a_normal_plan_can_afford_its_repair_at_the_current_ceiling():
@@ -771,14 +789,24 @@ def test_a_plan_that_cannot_reach_the_writer_is_refused_before_research():
         enforce_plan_fits,
     )
 
-    projection = budget_projection(44, 40_000)
+    # 44 questions no longer fails this: with the ceiling set against what a
+    # working run costs rather than against another budget, that plan finishes
+    # -- which is what the two runs it refused would have done. The refusal is
+    # now a guard for a plan that genuinely cannot terminate.
+    assert budget_projection(44, 40_000).can_finish is True
+
+    projection = budget_projection(130, 40_000)
 
     assert projection.can_finish is False
-    assert projection.repair_affordable is False
+    # Affordable and unfinishable at the same time, which is now a coherent
+    # state rather than a contradiction: $1.55 of Gemini is cheap, and a plan
+    # that cannot terminate is still a plan that cannot terminate. The two
+    # guards answer different questions and that is the point.
+    assert projection.repair_affordable is True
     assert "never reaches the writer" in projection.note
-    assert 0 < projection.questions_that_finish < 44
+    assert 0 < projection.questions_that_finish < 130
     with pytest.raises(PlanTooLargeToFinish) as raised:
-        enforce_plan_fits(44, 40_000)
+        enforce_plan_fits(130, 40_000)
     assert raised.value.projection.questions_that_finish == projection.questions_that_finish
 
 
@@ -789,11 +817,13 @@ def test_a_plan_that_finishes_but_cannot_repair_is_allowed_through():
         enforce_plan_fits,
     )
 
-    projection = budget_projection(14, 38_308)
+    from app.features.prompt2blog.config import P2B_RUN_COST_BUDGET_USD
+
+    projection = budget_projection(14, 38_308, cost_spent=P2B_RUN_COST_BUDGET_USD - 0.20)
 
     assert projection.repair_affordable is False
     assert projection.can_finish is True
-    enforce_plan_fits(14, 38_308)
+    enforce_plan_fits(14, 38_308, cost_spent=P2B_RUN_COST_BUDGET_USD - 0.20)
 
 
 def test_an_unmetered_run_is_never_refused():

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -297,6 +297,8 @@ const CANNOT_FINISH: IntakeBudgetProjection = {
   projected_total: 825_200,
   repair_reserve: 90_000,
   budget: 425_000,
+  projected_cost_usd: 1.05,
+  cost_budget_usd: 2.0,
   repair_affordable: false,
   questions_that_fit: 0,
   ceiling: 650_000,

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -97,6 +97,13 @@ export interface IntakeBudgetProjection {
   projected_total: number
   repair_reserve: number
   budget: number
+  /**
+   * What this plan is projected to bill, and the budget it is judged against.
+   * Money, not tokens: two thirds of a run's tokens are subscription Claude,
+   * which bills nothing.
+   */
+  projected_cost_usd: number
+  cost_budget_usd: number
   /** False means the run publishes but cannot pay for a repair pass. */
   repair_affordable: boolean
   questions_that_fit: number


### PR DESCRIPTION
Closes #541. Demonstrated twice, on two finished runs.

## The failure

| run | tokens | billed | notional (subscription) | outcome |
|---|---:|---:|---:|---|
| chifa `3750891f` | 802,018 | **$0.36** | $2.29 | repair refused — shipped a wrong opening time |
| ceviche `8a7e9aa4` | 692,544 | **$0.38** | $1.97 | repair refused — shipped 6 words over its cap, scored 6 for it |

Both articles were one repair call from being right. Both had billed 37 cents. The gate counted tokens, and two thirds of a real run's tokens are Claude drawing subscription allowance — free — so it refused repairs over money nobody was charged.

## The money was already there

`pricing.py` has recorded `cost_usd` and `cost_basis` per call since the ledger was written. `MEASURED_COST_NOTE` already says a subscription price is *"a comparable estimate of what the same work would cost at API rates — not a charge."* The distinction was understood and written down. Nothing read it.

- **`run_billed_cost_usd`** sums `rate-table` calls only. Subscription Claude stays recorded, stays on the receipt, and stops gating anything.
- **`decide_repair`** reads it — `cost_budget_reached` against `P2B_RUN_COST_BUDGET_USD = $2.00`. Five times what a whole run bills. Deliberately generous: the failure it replaces was a budget too tight to fix a typo.
- **`budget_projection`** projects money too, from measured costs (`$0.011`/question, `$0.12` writing leg) rather than a round number. Both constants carry the two runs they came from.

## The ceiling stays in tokens, and moves

`P2B_RUN_TOKEN_CEILING`: 650,000 → **2,000,000**.

Money answers whether a run is *worth continuing*. Tokens answer whether it has *stopped terminating* — and a loop on a cheap model is still a loop. The old number was set at twice a token budget that no longer exists, and it killed the ceviche run at `quality_settle`: the last node, after the article was written and audited, on the step that only picks which draft to keep.

The new number is set against what a working run actually costs — about 2.5× the longest observed.

## One consequence, said plainly

With the ceiling set this way, **the plan-size refusal from #538 no longer fires on 44 questions.** That plan finishes now, which is what the two runs it refused would have done. The refusal remains a guard for a plan that genuinely cannot terminate (130 questions), and a test pins both branches.

It also means "affordable but unfinishable" is now a reachable state — $1.55 of Gemini across a plan that can't complete. That is coherent rather than contradictory: the two guards answer different questions, which is the entire point of the change.

## Verified

- The exact failure: 692,544 tokens and $0.38 billed now returns `repair`.
- A run with no cost tracker is not refused on money it cannot measure — same discipline the token gate kept.
- The refusal still fires when money really is gone.
- The pipeline test that asserted an expensive run stops now drives it with billed dollars and still stops.
- Backend suite, 131 p2b vitest tests, `tsc --noEmit` green.