### PR TITLE
fix(p2b): a colour row says why it is vivid, not why it is useless

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
@@ -646,7 +646,11 @@ def select_evidence(
     colour_ids = texture_claim_ids(work_order, evidence)
     colour = [claim for claim in survivors if claim.claim_id in colour_ids]
     texture_order, texture_reasons = _rank_texture(brief, work_order, colour, dependencies)
-    reasons = {**texture_reasons, **reasons}
+    # Colour's own reason wins for a colour claim. Both passes rank it, and the
+    # utility pass says what it is not -- run 4a56545b showed the operator "the
+    # hold-your-breath wish legend, folklore the piece can live without" beside
+    # a row kept precisely because it was the most vivid thing in the dossier.
+    reasons = {**reasons, **texture_reasons}
     texture_reserve = min(
         len(texture_order), int(round(keep_count * TEXTURE_SHARE))
     )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_selection.py
@@ -144,7 +144,7 @@ class _LLM:
             return {"groups": self.groups}, "{}"
         # The colour pass runs under the same job id and is told apart by its
         # prompt, exactly as the real one is.
-        if "make a place feel like a real place" in prompt:
+        if "THE DETAILS" in prompt:
             rows = self.texture or []
             return {"ranked": [{"claim_id": i, "why": "vivid"} for i in rows]}, "{}"
         if self.ranked is None:
@@ -638,3 +638,21 @@ def test_a_claim_that_also_proves_something_is_not_colour():
     )
 
     assert texture_claim_ids(work_order, evidence) == {"c5"}
+
+
+def test_a_colour_row_shows_why_it_is_vivid_not_why_it_is_useless():
+    """Both passes rank a colour claim, and the utility pass says what it is
+    not. Run 4a56545b put "folklore the piece can live without" beside a row
+    kept precisely because it was the most vivid thing in the dossier."""
+    evidence, work_order, colour = _mixed(load_bearing=4, texture=2)
+    llm = _LLM(
+        groups=[], ranked=[f"f{i}" for i in range(1, 7)], texture=["f1", "f2"]
+    )
+
+    selection = select_evidence(
+        _brief(), work_order, evidence, SelectionDependencies(llm=llm),
+        target_word_count=900,
+    )
+
+    assert selection.reasons[colour[0]] == "vivid"
+    assert selection.reasons["c1"] == "because"


### PR DESCRIPTION
Two small faults found while driving run `4a56545b`.

## The dismissal was winning

Both ranking passes rank a colour claim. The utility pass is answering a different question, so what it produces for a colour row is a reason that claim *isn't* useful. Merging the dictionaries the wrong way round showed that to the operator — on the row the reserve had just rescued as the most vivid thing in a 292-claim dossier:

> "A popular local tradition suggests that if a first-time visitor crosses the Puente de los Suspiros while holding their breath…"
> **why:** the hold-your-breath wish legend, folklore colour the piece can live without.

Colour's own reason now wins for a colour claim.

## The test double was green for the wrong reason

It recognised the colour prompt by the string `"make a place feel like a real place"`. The prompt says **"makes a place"**. The colour branch was never taken in any test.

They passed anyway: the fake fell through to the utility answer, whose labels (`f1`, `f2`, …) resolved through the *colour* handle map and produced a plausible-looking colour order by coincidence. Every texture test in #543 was passing without exercising the code it was written for.

The double now matches on a section heading that is actually in the prompt, and the new test asserts the reason precedence directly — it fails without the one-line fix.

Worth saying plainly: this is the second time in this feature that a handle map made a wrong answer look right. The first was the model inventing claim ids, in #540.