### PR TITLE
Prompt2Blog: research is planned against the room the article has

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/intake.py
@@ -79,7 +79,7 @@ from .runs import (
 )
 from ..run_budget import RunTokenCeilingReached
 from ..selection_v4 import SelectionRefused
-from ..work_order_v4 import PlanTooLargeToFinish
+from ..work_order_v4 import PlanHasNothingWorthReading, PlanTooLargeToFinish
 
 logger = logging.getLogger(__name__)
 
@@ -316,6 +316,15 @@ def _handle(action, *args, **kwargs) -> Any:
                 "message": error.projection.note,
                 "budget_projection": asdict(error.projection),
             },
+        ) from error
+    except PlanHasNothingWorthReading as error:
+        # Same 409, same reason, and answerable the same way: the plan is on
+        # the screen and the box for adding a question is under it. A run with
+        # no texture question stops at a gate that offers nothing to settle, so
+        # this is refused before the research rather than discovered after it.
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "plan_has_nothing_worth_reading", "message": str(error)},
         ) from error
     except ValidationError as error:
         # Anything a stage builds and the contracts refuse. Pydantic's own

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -235,6 +235,13 @@ class WorkOrderRequirement(V4ContractModel):
     requirement_id: str = Field(min_length=1)
     question: str = Field(min_length=1)
     kind: RequirementKind
+    # The question's job in this article, in one line: the sentence, comparison
+    # or decision the answer makes possible. Empty is allowed and is a finding
+    # -- a question whose purpose nobody could state is usually one the article
+    # has no room for, and often one no source can answer either. Not enforced
+    # here, because a model omitting a field is a compliance problem and
+    # refusing the plan over it would throw away good questions.
+    purpose: str = ""
     # What the article needs, which is not always what the question's wording
     # demands. Research is judged against this rather than against the phrasing.
     precision: RequirementPrecision = "exact"

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -327,7 +327,13 @@ def plan_research(run_id: str, services: IntakeServices) -> Prompt2BlogWorkOrder
     enforce_run_budget(_run_tokens_spent(run_id), stage=WORK_ORDER_STAGE)
     try:
         _open(services, run_id, WORK_ORDER_STAGE)
-        work_order = build_work_order(load_brief(run_id), services.dependencies)
+        work_order = build_work_order(
+            load_brief(run_id),
+            services.dependencies,
+            # The same number selection cuts the dossier down to, read from the
+            # same catalog entry, so the planner and the cut cannot drift.
+            target_word_count=default_target_word_count(),
+        )
     except WorkOrderUnusable as error:
         _record(
             services,
@@ -349,6 +355,7 @@ def plan_research(run_id: str, services: IntakeServices) -> Prompt2BlogWorkOrder
                 work_order,
                 tokens_spent=_run_tokens_spent(run_id),
                 cost_spent=_run_billed_cost(run_id),
+                target_word_count=default_target_word_count(),
             ),
             STATE_KEY: json.loads(work_order.model_dump_json()),
         },
@@ -384,6 +391,7 @@ def apply_cut(
                 outcome.warnings,
                 tokens_spent=_run_tokens_spent(run_id),
                 cost_spent=_run_billed_cost(run_id),
+                target_word_count=default_target_word_count(),
             ),
             STATE_KEY: json.loads(outcome.work_order.model_dump_json()),
         },
@@ -709,7 +717,10 @@ def settle_gate(
             WORK_ORDER_STAGE,
             {
                 **work_order_stage_record(
-                    work_order, [cost], tokens_spent=_run_tokens_spent(run_id)
+                    work_order,
+                    [cost],
+                    tokens_spent=_run_tokens_spent(run_id),
+                    target_word_count=default_target_word_count(),
                 ),
                 STATE_KEY: json.loads(work_order.model_dump_json()),
             },
@@ -801,7 +812,10 @@ def reask_question(
         WORK_ORDER_STAGE,
         {
             **work_order_stage_record(
-                work_order, [note], tokens_spent=_run_tokens_spent(run_id)
+                work_order,
+                [note],
+                tokens_spent=_run_tokens_spent(run_id),
+                target_word_count=default_target_word_count(),
             ),
             STATE_KEY: json.loads(work_order.model_dump_json()),
         },
@@ -898,7 +912,10 @@ def settle_premise(
         WORK_ORDER_STAGE,
         {
             **work_order_stage_record(
-                work_order, [], tokens_spent=_run_tokens_spent(run_id)
+                work_order,
+                [],
+                tokens_spent=_run_tokens_spent(run_id),
+                target_word_count=default_target_word_count(),
             ),
             STATE_KEY: json.loads(work_order.model_dump_json()),
         },

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -106,6 +106,7 @@ from .work_order_v4 import (
     build_work_order,
     cut_work_order,
     enforce_plan_fits,
+    enforce_plan_has_texture,
     work_order_stage_record,
 )
 
@@ -440,6 +441,11 @@ def do_research(run_id: str, services: IntakeServices) -> CoverageVerdict:
     # that can still be changed. Counted over the questions still without a
     # note, so a resume is not charged again for notes it already paid for.
     enforce_plan_fits(len(outstanding), tokens_spent, _run_billed_cost(run_id))
+    # Asked of the whole plan rather than of what is outstanding, so a resume
+    # that has already paid for its notes is judged on the same plan it started
+    # with. A run with no texture question stops at the gate either way; this
+    # says so while it still costs nothing.
+    enforce_plan_has_texture(work_order)
 
     if outstanding:
         _open(services, run_id, NOTES_STAGE)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/research_v4.py
@@ -1483,8 +1483,45 @@ def _structure_batch(
             )
         part = _namespaced(parsed, ids[0])
         package = assemble_evidence(work_order, part, reconcile_premises=False)
-        if {item.requirement_id for item in package.requirements} != set(ids):
-            raise ResearchUnusable("Structuring did not return exactly the requested questions", _raw)
+        answered = {item.requirement_id for item in package.requirements}
+        unanswered = set(ids) - answered
+        if unanswered:
+            raise ResearchUnusable(
+                "Structuring did not answer "
+                + ", ".join(sorted(unanswered)),
+                _raw,
+            )
+        # An extra answer is not a failure. Notes are gathered per search
+        # group and a batch is a slice of one, so the notes in front of the
+        # model routinely cover questions this batch did not ask about, and it
+        # answers what it was given -- correctly.
+        #
+        # This was set equality. Run bogota-replan-0906 asked about four
+        # rideshare questions, got all four right plus `req_rideshare_time_usaquen`
+        # from the same group, and had the whole batch recorded `missing` /
+        # `nothing_found`; the TransMilenio batch went the same way on
+        # `req_transmilenio_time_chapinero`. Eight correct, paid-for answers
+        # thrown away, the gate blocked, and the operator told to answer
+        # questions by hand whose answers were sitting in the notes. Retrying
+        # reproduced it exactly, because nothing about it was random.
+        #
+        # Extras are dropped rather than kept: every requirement is in exactly
+        # one batch, so the one this answered early is recorded by its own
+        # batch, and keeping it here would file the same requirement twice.
+        extra = answered - set(ids)
+        if extra:
+            logger.info(
+                "Structuring answered %s beyond the batch it was asked about; "
+                "kept the %s requested and left those to their own batch",
+                ", ".join(sorted(extra)),
+                len(ids),
+            )
+            record = package.model_dump(mode="json")
+            record["requirements"] = [
+                item for item in record["requirements"]
+                if item["requirement_id"] in set(ids)
+            ]
+            return record
         return package.model_dump(mode="json")
     except Exception as exc:  # noqa: BLE001 -- one hole beats the whole plan
         logger.warning("Structuring failed for %s: %s", ", ".join(ids), exc)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/selection_v4.py
@@ -121,6 +121,25 @@ def texture_claim_ids(
     }
 
 
+def article_fact_budget(target_word_count: int) -> int:
+    """How many facts an article this long has room for, before any dossier.
+
+    Split out of `target_claim_count` because the number is needed twice, at
+    opposite ends of the run. Selection needs it against a dossier it can
+    count. The research planner needs it before a single question has been
+    asked, and there is nothing to count yet -- which is exactly the gap that
+    let run e23257c0 buy 57 questions, find 431 facts, and hand the writer the
+    same eighteen a 15-question run handed it.
+
+    Two definitions of "how many facts fit" would drift, and the one the
+    planner reads would be the one nobody checked.
+    """
+    return max(
+        MIN_KEPT_CLAIMS,
+        int(round(max(0, target_word_count) * CLAIMS_PER_HUNDRED_WORDS / 100)),
+    )
+
+
 def target_claim_count(target_word_count: int, available: int) -> int:
     """Where the cut line starts, from the length the article is aiming at.
 
@@ -129,8 +148,7 @@ def target_claim_count(target_word_count: int, available: int) -> int:
     """
     if available <= MIN_KEPT_CLAIMS:
         return available
-    wanted = int(round(max(0, target_word_count) * CLAIMS_PER_HUNDRED_WORDS / 100))
-    return max(MIN_KEPT_CLAIMS, min(available, wanted))
+    return min(available, article_fact_budget(target_word_count))
 
 
 DEDUPE_SCHEMA = require_non_empty({

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -898,6 +898,49 @@ class PlanTooLargeToFinish(RuntimeError):
         self.projection = projection
 
 
+class PlanHasNothingWorthReading(RuntimeError):
+    """This plan asks for nothing a reader would enjoy, so research must not start.
+
+    `assess_coverage` refuses a dossier with no texture answered. A work order
+    with no texture question cannot answer one, so a plan like this is a run
+    that spends its whole research budget and then stops at a gate offering
+    nothing to settle: `blocking_questions` enumerates unanswered load-bearing
+    questions and refuted premises, and a `nothing_worth_reading` verdict has
+    neither. The operator gets a blocked run and an empty list.
+
+    New with the length constraint, and predicted by the handoff that asked for
+    it: told the article has room for eighteen facts, the planner cuts colour
+    first, because colour is the least necessary-looking thing on the list. One
+    of four samples on run e23257c0 came back with 31 questions and no texture
+    at all.
+
+    Refused here rather than warned about, for the same reason
+    `PlanTooLargeToFinish` is: this is not a worse article, it is no article.
+    And it is refused on the screen where the operator can add a question in
+    one text box, rather than after the research has been bought.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "This plan asks for nothing a reader would enjoy -- every question "
+            "proves something and none of them puts a reader anywhere. The run "
+            "would spend its research and then stop at a gate with nothing to "
+            "settle. Add a question about what somewhere is like before "
+            "starting research."
+        )
+
+
+def enforce_plan_has_texture(work_order: Prompt2BlogWorkOrder) -> None:
+    """Stop before research when nothing in the plan is worth reading.
+
+    Deliberately not part of `enforce_plan_fits`: that one answers a question
+    about money and tokens and is silent on an unmetered run. This one is about
+    the plan itself, and is just as true when nobody is counting.
+    """
+    if not any(item.kind == "texture" for item in work_order.requirements):
+        raise PlanHasNothingWorthReading()
+
+
 def enforce_plan_fits(
     question_count: int,
     tokens_spent: int | None,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/work_order_v4.py
@@ -46,6 +46,7 @@ from .config import (
 )
 from .grill_v4 import GrillDependencies
 from .schema_guards import require_non_empty
+from .selection_v4 import article_fact_budget
 from .support import _safe_dict, _safe_str, _safe_str_list
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,7 @@ WORK_ORDER_SCHEMA = require_non_empty({
                 "properties": {
                     "requirement_id": {"type": "string"},
                     "question": {"type": "string"},
+                    "purpose": {"type": "string"},
                     "search_group": {"type": "string"},
                     "kind": {"type": "string"},
                     "precision": {
@@ -111,7 +113,7 @@ WORK_ORDER_SCHEMA = require_non_empty({
                     },
                     "assumption_ids": {"type": "array", "items": {"type": "string"}},
                 },
-                "required": ["requirement_id", "question", "kind"],
+                "required": ["requirement_id", "question", "purpose", "kind"],
             },
         },
     },
@@ -131,7 +133,50 @@ class CutOutcome:
     warnings: list[str]
 
 
-def build_work_order_prompt(brief: ArticleBrief) -> str:
+def _length_block(target_word_count: int) -> str:
+    """How long the article is, and how many facts that leaves room for.
+
+    Empty when nothing resolved a length, which is the same silence the planner
+    ran under before this existed: a made-up number here would be worse than no
+    number, because the planner would weigh it.
+
+    Deliberately not a ratio. The owner pushed back on "900 words -> N
+    questions" and was right: a head-to-head needs evidence for both sides, a
+    service guide needs every option ranked, a piece about one place needs far
+    less, and the form decides which of those this is. What the planner was
+    missing is not a divisor -- it is the fact that the article throws almost
+    everything away. Run e23257c0 asked 57 questions, found 431 facts and
+    delivered the same eighteen that run 2197ccc4 delivered off fifteen
+    questions. Roughly 39 of its 57 questions bought research no reader could
+    ever have seen.
+    """
+    if target_word_count <= 0:
+        return ""
+    facts = article_fact_budget(target_word_count)
+    return f"""
+HOW LONG THE ARTICLE IS, AND HOW MUCH IT CAN HOLD
+About {target_word_count:,} words, which has room for roughly {facts} facts.
+
+Everything research finds is cut down to about that many before the writer
+sees it. A question whose answer could not be one of those {facts} facts buys
+research nobody reads. Four transport modes x three zones x (fare, time) is
+twenty-four questions written in one line, and an article this length cannot
+print twelve fare-and-time pairs.
+
+This is a constraint you weigh, not a number you divide by. There is no ratio
+of words to questions, and no cap on how many you may ask. The form decides
+how many it takes -- a comparison has two sides to evidence, a service guide
+has options a reader chooses between, a piece about one place needs far less
+than either. The length decides how much of what you find can be printed. Plan
+questions the article has room to use.
+"""
+
+
+def build_work_order_prompt(
+    brief: ArticleBrief,
+    *,
+    target_word_count: int = 0,
+) -> str:
     must_name = "\n".join(f"- {item}" for item in brief.must_name) or "- Nothing named."
     material = (
         "\n".join(f"- [{item.kind}] {item.statement}" for item in brief.material)
@@ -161,7 +206,7 @@ Must name:
 What the writer already has:
 {material}
 It fails if: {brief.fails_if}
-
+{_length_block(target_word_count)}
 Write the questions that have to be answered before this can be written.
 
 Rules:
@@ -170,6 +215,18 @@ Rules:
   one museum's hours and admission; one restaurant shortlist's prices and hours.
   These share retrieval, but remain separate questions and coverage decisions.
   Do not group unrelated places or subjects. Leave it empty for a standalone question.
+- **Every question says what it is for.** `purpose` is one line naming the
+  question's job in this article: the sentence, the comparison or the decision
+  the answer makes possible. "Fixes the fare the reader counts out at the taxi
+  rank" is a job. "Useful transport background" is not, and neither is
+  restating the question.
+  Write the purpose first, and drop the question if you cannot write one. A
+  question with no nameable job is a question the article has no room for, and
+  it is usually also a question no source can answer: five of run e23257c0's
+  fifty-seven asked for per-company figures on something that is not
+  per-company -- the travel time from an airport, quoted per taxi firm. Nobody
+  publishes that, nobody could have said what it was for, and all five blocked
+  the run and had to be struck by hand before it could be written.
 - Research only facts the brief needs. Do not expand a two-day guide into an
   exhaustive directory of alternatives. Prefer a focused shortlist.
 - Each question must be separately checkable by someone with a search engine.
@@ -414,6 +471,7 @@ def _requirements_from(
     """
     requirements: list[WorkOrderRequirement] = []
     dropped = 0
+    unstated = 0
     for raw in _listed(payload, "requirements", "questions"):
         record = _safe_dict(raw)
         question = _safe_str(_first(record, "question", "query", "text", "ask"))
@@ -439,6 +497,16 @@ def _requirements_from(
         precision = _safe_str(_first(record, "precision", "exactness"))
         if precision not in set(get_args(RequirementPrecision)):
             precision = "exact"
+        # Kept, never dropped. A question with no stated job is a signal worth
+        # having in front of the operator, but a model omitting a field is a
+        # compliance problem and not evidence the question is bad -- this
+        # parser exists because `p2b.work_order` renames and drops fields
+        # constantly, and refusing a specific, checkable question over a blank
+        # would be the same mistake as refusing one for arriving under the name
+        # `questions`.
+        purpose = _safe_str(_first(record, "purpose", "why", "job", "rationale"))
+        if not purpose:
+            unstated += 1
         requirements.append(
             WorkOrderRequirement(
                 requirement_id=_safe_str(
@@ -446,6 +514,7 @@ def _requirements_from(
                 )
                 or f"r{len(requirements) + 1}",
                 question=question,
+                purpose=purpose,
                 kind=kind,
                 precision=precision,
                 search_group=_safe_str(record.get("search_group")),
@@ -466,6 +535,17 @@ def _requirements_from(
         logger.warning(
             "Dropped %s research question(s) the parser could not read; kept %s",
             dropped,
+            len(requirements),
+        )
+    if unstated:
+        # Worth a line of its own. The planner is asked to write the purpose
+        # before deciding the question is worth asking, so questions arriving
+        # without one mean either the model skipped the field or it skipped the
+        # thinking, and the second is the case where the operator should read
+        # the plan more carefully than usual.
+        logger.warning(
+            "%s of %s research question(s) came back with no stated purpose",
+            unstated,
             len(requirements),
         )
     return requirements
@@ -504,11 +584,18 @@ def _assemble(
 def build_work_order(
     brief: ArticleBrief,
     dependencies: GrillDependencies,
+    *,
+    target_word_count: int = 0,
 ) -> Prompt2BlogWorkOrder:
-    """Turn the brief into checkable questions. One structured call, no browsing."""
+    """Turn the brief into checkable questions. One structured call, no browsing.
+
+    `target_word_count` is how long the article will be. Zero means nothing
+    resolved a length and the planner is told nothing, which is how it has
+    always run.
+    """
     parsed, _raw = dependencies.llm.invoke_json(
             job_id="p2b.work_order",
-        prompt=build_work_order_prompt(brief),
+        prompt=build_work_order_prompt(brief, target_word_count=target_word_count),
         model_name=dependencies.model_name,
         schema=WORK_ORDER_SCHEMA,
         max_tokens=2_048,
@@ -613,9 +700,15 @@ def cut_work_order(
         existing.add(new_id)
         kept.append(
             # An operator's own question is load-bearing: they would not have
-            # added it to be decorative.
+            # added it to be decorative. Its purpose is that they asked for it,
+            # said in those words rather than left blank -- a blank here reads
+            # on the screen as the planner failing to state a job, which is a
+            # different thing and the only thing a blank is supposed to mean.
             WorkOrderRequirement(
-                requirement_id=new_id, question=cleaned, kind="load_bearing"
+                requirement_id=new_id,
+                question=cleaned,
+                purpose="Asked for by the operator.",
+                kind="load_bearing",
             )
         )
 
@@ -773,6 +866,16 @@ class BudgetProjection:
     can_finish: bool
     questions_that_finish: int
     note: str
+    # Editorial room, which is a different budget from money and tokens and was
+    # the one nothing reported. Run e23257c0's projection said its 57 questions
+    # "fit" -- true about money, silent about the fact that the article had
+    # room for eighteen of the 431 facts they found.
+    #
+    # Zero and empty when no length was resolved. Said beside the money note
+    # rather than folded into it: a plan can be affordable and still buy
+    # research nobody will read, and the operator is owed both sentences.
+    fact_budget: int
+    editorial_note: str
 
 
 class PlanTooLargeToFinish(RuntimeError):
@@ -820,6 +923,7 @@ def budget_projection(
     question_count: int,
     tokens_spent: int | None,
     cost_spent: float | None = None,
+    target_word_count: int = 0,
 ) -> BudgetProjection | None:
     """Say what this plan will cost before it is paid for.
 
@@ -891,6 +995,19 @@ def budget_projection(
             f"This is the budget being too low for the pipeline as it now "
             f"bills, not the plan being too large."
         )
+    facts = article_fact_budget(target_word_count) if target_word_count > 0 else 0
+    editorial_note = (
+        (
+            f"{question_count} questions, against an article with room for "
+            f"about {facts} facts. Research returns several facts per question, "
+            f"so those are not the same count -- but everything past the {facts} "
+            f"is cut before the writer sees it. Run e23257c0 asked 57 questions, "
+            f"found 431 facts and delivered the same eighteen as a 15-question "
+            f"run."
+        )
+        if facts
+        else ""
+    )
     return BudgetProjection(
         question_count=question_count,
         spent=tokens_spent,
@@ -907,6 +1024,8 @@ def budget_projection(
         can_finish=can_finish,
         questions_that_finish=finishes,
         note=note,
+        fact_budget=facts,
+        editorial_note=editorial_note,
     )
 
 
@@ -915,10 +1034,11 @@ def work_order_stage_record(
     warnings: list[str] | None = None,
     tokens_spent: int | None = None,
     cost_spent: float | None = None,
+    target_word_count: int = 0,
 ) -> dict[str, Any]:
     """What the run keeps about the plan the operator approved."""
     projection = budget_projection(
-        len(work_order.requirements), tokens_spent, cost_spent
+        len(work_order.requirements), tokens_spent, cost_spent, target_word_count
     )
     return {
         # What this plan is about to cost, next to the decision that changes
@@ -933,6 +1053,11 @@ def work_order_stage_record(
             {
                 "requirement_id": item.requirement_id,
                 "question": item.question,
+                # Empty when the planner did not say. Shown rather than
+                # counted: a question that cannot name its job in the article
+                # is the one the operator should be striking, and they are
+                # already reading this screen line by line.
+                "purpose": item.purpose,
                 "kind": item.kind,
                 "precision": item.precision,
                 # Empty for a question that reads as one. Shown beside the

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_intake_v4.py
@@ -42,7 +42,10 @@ from app.features.prompt2blog.research_v4 import (
     ResearchDependencies,
 )
 from app.features.prompt2blog.run_recorder import RunRecorder
-from app.features.prompt2blog.work_order_v4 import WORK_ORDER_STAGE
+from app.features.prompt2blog.work_order_v4 import (
+    WORK_ORDER_STAGE,
+    PlanHasNothingWorthReading,
+)
 
 SEED = "Lima is no longer simply the stopover before Machu Picchu"
 FIRSTHAND = "I was there 4 days last year. mostly ate."
@@ -356,7 +359,12 @@ def test_the_gathered_notes_are_kept_so_a_retry_does_not_re_buy_them(isolated_db
 
 
 def test_recutting_the_plan_keeps_unchanged_notes(isolated_db):
-    """Removing a question does not change the answers to the others."""
+    """Removing a question does not change the answers to the others.
+
+    Strikes `r2` rather than the texture question: a plan with no texture
+    question left is refused before research, so cutting `r3` would test the
+    refusal rather than the notes.
+    """
     calls: list[str] = []
     services = _with_research(
         _services([{"done": False, "question": _question()}, AGREED, BRIEF_PAYLOAD, WORK_ORDER_PAYLOAD])
@@ -367,10 +375,34 @@ def test_recutting_the_plan_keeps_unchanged_notes(isolated_db):
     run_id = _to_work_order(services)
     do_research(run_id, services)
 
-    apply_cut(run_id, services, struck_ids=["r3"])
+    apply_cut(run_id, services, struck_ids=["r2"])
     do_research(run_id, services)
 
     assert len(calls) == 3, "unchanged questions must not buy another search"
+
+
+def test_a_plan_with_nothing_worth_reading_is_refused_before_research(isolated_db):
+    """The gate already refuses a dossier with no texture answered, and a plan
+    with no texture question cannot answer one. What made that a trap is that
+    `blocking_questions` offers nothing to settle for that verdict, so the
+    operator reached a blocked run, an empty list, and the whole research bill.
+
+    The length constraint makes this reachable by accident: told the article
+    has room for eighteen facts, the planner cuts colour first. One of four
+    samples on run e23257c0 came back with 31 questions and no texture at all.
+    """
+    services = _with_research(
+        _services([{"done": False, "question": _question()}, AGREED, BRIEF_PAYLOAD, WORK_ORDER_PAYLOAD])
+    )
+    run_id = _to_work_order(services)
+
+    apply_cut(run_id, services, struck_ids=["r3"])
+
+    with pytest.raises(PlanHasNothingWorthReading) as raised:
+        do_research(run_id, services)
+    # Says what to do about it, on the screen that can still do it.
+    assert "nothing a reader would enjoy" in str(raised.value)
+    assert "before starting research" in str(raised.value)
 
 
 def test_research_runs_and_says_whether_the_piece_can_be_written(isolated_db):

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_research.py
@@ -1092,3 +1092,126 @@ def test_the_premise_pass_sees_the_claims_and_nothing_else():
     assert "WHAT RESEARCH ESTABLISHED" in premise_prompt
     assert "Something established for r1." in premise_prompt
     assert "Notes one." not in premise_prompt
+
+
+# --- an extra answer is not a failed batch (run bogota-replan-0906) ---------
+
+
+class OverAnsweringLLM:
+    """Answers the batch it was asked about, and one question from elsewhere.
+
+    Exactly what the real model does. Notes are gathered per search group and
+    a batch is a slice of one, so the notes in front of the model cover
+    questions this batch did not ask about, and it answers them too.
+    """
+
+    def __init__(self, extra_id: str):
+        self.extra_id = extra_id
+        self.prompts: list[str] = []
+
+    def invoke_json(self, *, prompt: str, **_kwargs):
+        self.prompts.append(prompt)
+        asked = [
+            requirement_id
+            for requirement_id in (f"r{index}" for index in range(1, 20))
+            if f"- {requirement_id} [" in prompt
+        ]
+        if not asked:
+            return {"premise_findings": [], "conflicts": []}, "{}"
+        merged: dict[str, Any] = {"sources": [], "claims": [], "requirements": []}
+        for requirement_id in [*asked, self.extra_id]:
+            payload = _one_question_payload(
+                requirement_id, f"https://example.pe/{requirement_id}"
+            )
+            merged["sources"].append(
+                {**payload["sources"][0], "source_id": f"s-{requirement_id}"}
+            )
+            merged["claims"].append(
+                {
+                    **payload["claims"][0],
+                    "claim_id": f"c-{requirement_id}",
+                    "source_ids": [f"s-{requirement_id}"],
+                }
+            )
+            merged["requirements"].append(
+                {**payload["requirements"][0], "claim_ids": [f"c-{requirement_id}"]}
+            )
+        return merged, "{}"
+
+
+def test_one_extra_answer_does_not_bin_the_whole_batch():
+    """Run bogota-replan-0906 died on this, twice in one run.
+
+    The check was set equality. A batch asked about four rideshare questions,
+    got all four right plus `req_rideshare_time_usaquen` from the same search
+    group, and had all four recorded `missing` / `nothing_found`. Eight
+    correct, already-paid-for answers thrown away, the gate blocked on them,
+    and `suggested_move` told the operator "nothing relevant came back --
+    answer it yourself, or drop it" about answers sitting in the notes.
+
+    Retrying reproduced it exactly. Nothing about it was random, so nothing
+    about it would ever have cleared on its own.
+    """
+    count = STRUCTURE_BATCH_SIZE + 1
+    work_order = _wide_work_order(count)
+    # The extra is a real question in the work order, from another batch.
+    llm = OverAnsweringLLM(extra_id=f"r{count}")
+    deps = ResearchDependencies(gather=RecordingGather(), structure_llm=llm)
+    notes = {f"r{index}": GatheredNotes("Notes.") for index in range(1, count + 1)}
+
+    evidence = structure_research(work_order, notes, deps)
+
+    answered = {
+        item.requirement_id: item.status for item in evidence.requirements
+    }
+    assert all(
+        answered[f"r{index}"] == "supported" for index in range(1, count + 1)
+    ), f"a correct batch was discarded over an extra answer: {answered}"
+
+
+def test_a_batch_that_leaves_a_question_out_still_fails():
+    """The check that matters is that everything asked for came back. Loosening
+    set equality must not loosen that -- a question the model silently skipped
+    is a real hole, and the operator meets it at the gate."""
+    count = STRUCTURE_BATCH_SIZE
+    work_order = _wide_work_order(count)
+
+    class SkippingLLM:
+        prompts: list[str] = []
+
+        def invoke_json(self, *, prompt: str, **_kwargs):
+            asked = [
+                requirement_id
+                for requirement_id in (f"r{index}" for index in range(1, count + 1))
+                if f"- {requirement_id} [" in prompt
+            ]
+            if not asked:
+                return {"premise_findings": [], "conflicts": []}, "{}"
+            merged: dict[str, Any] = {"sources": [], "claims": [], "requirements": []}
+            # Answers all but the last question it was asked about.
+            for requirement_id in asked[:-1]:
+                payload = _one_question_payload(
+                    requirement_id, f"https://example.pe/{requirement_id}"
+                )
+                merged["sources"].append(
+                    {**payload["sources"][0], "source_id": f"s-{requirement_id}"}
+                )
+                merged["claims"].append(
+                    {
+                        **payload["claims"][0],
+                        "claim_id": f"c-{requirement_id}",
+                        "source_ids": [f"s-{requirement_id}"],
+                    }
+                )
+                merged["requirements"].append(
+                    {**payload["requirements"][0], "claim_ids": [f"c-{requirement_id}"]}
+                )
+            return merged, "{}"
+
+    deps = ResearchDependencies(gather=RecordingGather(), structure_llm=SkippingLLM())
+    notes = {f"r{index}": GatheredNotes("Notes.") for index in range(1, count + 1)}
+
+    evidence = structure_research(work_order, notes, deps)
+
+    answered = {item.requirement_id: item.status for item in evidence.requirements}
+    assert answered[f"r{count}"] == "missing"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_intake.py
@@ -139,16 +139,18 @@ def test_runtime_request_keeps_the_commission_and_evidence_whole():
     runtime = runtime_for(_request(evidence_package=_ready_evidence()))
 
     # A commission written before the direction step declared its premise still
-    # runs. The empty premise, the empty assumption_ids and the `exact`
-    # precision are the defaults filling in, not the runtime losing anything
-    # the fixture carried. `exact` is the default on purpose: a plan that never
-    # said how precise it needed to be behaves as it always did.
+    # runs. The empty premise, the empty assumption_ids, the empty purpose and
+    # the `exact` precision are the defaults filling in, not the runtime losing
+    # anything the fixture carried. `exact` is the default on purpose: a plan
+    # that never said how precise it needed to be behaves as it always did, and
+    # a plan that never said what a question was for is read the same way.
     expected_work_order = deepcopy(fixture["work_order"])
     expected_work_order["premise"] = []
     for requirement in expected_work_order["requirements"]:
         requirement["assumption_ids"] = []
         requirement["precision"] = "exact"
         requirement["search_group"] = ""
+        requirement["purpose"] = ""
     assert runtime.work_order == expected_work_order
     assert runtime.brief == fixture["brief"]
     source = runtime.evidence["sources"][0]

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_work_order.py
@@ -841,3 +841,159 @@ def test_an_unmetered_run_is_never_refused():
     # are already paid for is not charged for them a second time.
     enforce_plan_fits(0, 600_000)
 
+
+# --- the length the article is, and the room that leaves --------------------
+#
+# Runs 2197ccc4 and e23257c0, on this branch, ended the same way and cost very
+# differently:
+#
+#     2197ccc4: 15 questions,  98 facts found, 18 reached the writer, ~$0.245
+#     e23257c0: 57 questions, 431 facts found, 18 reached the writer,  $0.67
+#
+# Per question they behaved identically -- about 10,000 characters of notes
+# each. Run 2 did not dig deeper; it asked 3.8x as many questions, because
+# nothing told the planner the article had room for eighteen facts.
+
+
+def test_the_planner_is_told_how_long_the_article_is_and_what_that_holds():
+    flat = " ".join(build_work_order_prompt(_brief(), target_word_count=900).split())
+
+    assert "About 900 words" in flat
+    # 2 facts per hundred words, the same constant selection cuts the dossier
+    # down with.
+    assert "room for roughly 18 facts" in flat
+
+
+def test_the_length_is_a_constraint_and_never_a_ratio():
+    """The owner refused a fixed "900 words -> N questions" rule and was right.
+    A comparison needs both sides evidenced, a service guide needs the options
+    a reader chooses between, a piece about one place needs far less. The form
+    decides the count; the length decides how much of it can be printed."""
+    flat = " ".join(build_work_order_prompt(_brief(), target_word_count=900).split())
+
+    assert "not a number you divide by" in flat
+    assert "no cap on how many you may ask" in flat
+
+
+def test_a_run_with_no_resolved_length_tells_the_planner_nothing():
+    """The silence the planner has always run under. A made-up number would be
+    worse than none, because it would be weighed."""
+    flat = " ".join(build_work_order_prompt(_brief()).split())
+
+    assert "HOW LONG THE ARTICLE IS" not in flat
+    assert "room for roughly" not in flat
+
+
+def test_the_planner_reads_the_same_fact_budget_selection_cuts_to():
+    """Two definitions of "how many facts fit" would drift, and the one the
+    planner reads is the one nobody would check."""
+    from app.features.prompt2blog.selection_v4 import (
+        article_fact_budget,
+        target_claim_count,
+    )
+
+    assert article_fact_budget(900) == 18
+    assert article_fact_budget(2_500) == 50
+    # The same number, against a dossier big enough not to bind it.
+    assert target_claim_count(900, available=100) == article_fact_budget(900)
+
+
+def test_the_projection_reports_editorial_room_beside_the_money():
+    """`budget_projection` said run e23257c0's 57 questions "fit". True about
+    money, and silent about the article having room for eighteen of the 431
+    facts they bought."""
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(57, 38_308, 0.1, 900)
+
+    assert projection.fact_budget == 18
+    assert "57 questions" in projection.editorial_note
+    assert "room for about 18 facts" in projection.editorial_note
+    # The money sentence is untouched. A plan can be affordable and still buy
+    # research nobody will read, and the operator is owed both sentences.
+    assert "inside the" in projection.note
+
+
+def test_no_resolved_length_means_no_editorial_note():
+    from app.features.prompt2blog.work_order_v4 import budget_projection
+
+    projection = budget_projection(57, 38_308)
+
+    assert projection.fact_budget == 0
+    assert projection.editorial_note == ""
+
+
+def test_the_editorial_room_never_refuses_a_plan():
+    """Change 1 is a constraint the planner weighs and a number the operator
+    reads. It is not a cap, and a plan that asks for more than the article can
+    print is still the operator's to run."""
+    from app.features.prompt2blog.work_order_v4 import enforce_plan_fits
+
+    enforce_plan_fits(57, 38_308, 0.1)
+
+
+# --- every question says what it is for -------------------------------------
+
+
+def test_the_planner_is_told_to_name_each_question_s_job():
+    flat = " ".join(build_work_order_prompt(_brief()).split())
+
+    assert "Every question says what it is for." in flat
+    assert "drop the question if you cannot write one" in flat
+
+
+def test_the_purpose_survives_to_the_screen():
+    payload = _payload()
+    payload["requirements"][0]["purpose"] = (
+        "Fixes the price the reader compares the tasting menus against."
+    )
+    work_order = build_work_order(_brief(), _deps(payload))
+
+    record = work_order_stage_record(work_order)
+    purposes = {item["requirement_id"]: item["purpose"] for item in record["requirements"]}
+
+    assert purposes["r1"] == (
+        "Fixes the price the reader compares the tasting menus against."
+    )
+    assert purposes["r2"] == ""
+
+
+def test_a_question_with_no_stated_purpose_is_kept_not_dropped():
+    """A model omitting a field is a compliance problem, not evidence the
+    question is bad. This parser exists because `p2b.work_order` renames and
+    drops fields constantly -- run b78a9fe8 lost six specific, checkable
+    questions to the word `query`. Refusing one for a blank `purpose` would be
+    the same mistake in a new field.
+    """
+    work_order = build_work_order(_brief(), _deps(_payload()))
+
+    assert len(work_order.requirements) == 3
+    assert all(item.purpose == "" for item in work_order.requirements)
+
+
+def test_the_purpose_is_read_under_whichever_name_the_model_used():
+    payload = _payload()
+    payload["requirements"][0].pop("purpose", None)
+    payload["requirements"][0]["why"] = "Anchors the cheap-beats-famous comparison."
+    work_order = build_work_order(_brief(), _deps(payload))
+
+    assert work_order.requirements[0].purpose == (
+        "Anchors the cheap-beats-famous comparison."
+    )
+
+
+def test_an_operator_s_own_question_carries_its_own_purpose():
+    """A blank reads on the screen as the planner failing to state a job. The
+    operator adding a question is a different thing, and the only thing a blank
+    is supposed to mean."""
+    outcome = cut_work_order(
+        build_work_order(_brief(), _deps(_payload())),
+        _brief(),
+        struck_ids=[],
+        added_questions=["Which market days are busiest?"],
+    )
+
+    added = outcome.work_order.requirements[-1]
+
+    assert added.question == "Which market days are busiest?"
+    assert added.purpose == "Asked for by the operator."

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
@@ -80,6 +80,20 @@ export function WorkOrderScreen({
                    the run for want of a figure nobody publishes. */
                 <span className="p2b-kind">roughly is enough</span>
               )}
+              {item.purpose ? (
+                /* What the answer is for, beside the question it pays for.
+                   The operator is striking questions here, and "does this
+                   article need this?" is unanswerable from the question
+                   alone. */
+                <p className="p2b-question-purpose">{item.purpose}</p>
+              ) : (
+                !isStruck && (
+                  <p className="p2b-question-note">
+                    No stated job in the article. Worth a second look before
+                    buying it.
+                  </p>
+                )
+              )}
               {item.bundled_note && !isStruck && (
                 <p className="p2b-question-note">{item.bundled_note}</p>
               )}
@@ -114,6 +128,13 @@ export function WorkOrderScreen({
            put in front of the person doing the cutting, so a plan that could
            not finish was approved and then died in research. */
         <p className={tooLarge ? 'p2b-blocked' : 'p2b-cost'}>{projection.note}</p>
+      )}
+
+      {projection?.editorial_note && (
+        /* The other budget. The money projection said run e23257c0's 57
+           questions "fit", which was true and silent about the article having
+           room for eighteen of the 431 facts they bought. */
+        <p className="p2b-cost">{projection.editorial_note}</p>
       )}
 
       {remainingLoadBearing === 0 && (

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/WorkOrderScreen.tsx
@@ -41,6 +41,14 @@ export function WorkOrderScreen({
     item => item.kind === 'load_bearing' && !struck.includes(item.requirement_id),
   ).length
 
+  // A plan with no colour question left cannot answer one, and the gate
+  // refuses a dossier with nothing anybody would enjoy reading. That verdict
+  // offers nothing to settle, so the run would buy its whole research and then
+  // stop dead. Said here, where a question is one text box away.
+  const remainingTexture = workOrder.requirements.filter(
+    item => item.kind === 'texture' && !struck.includes(item.requirement_id),
+  ).length
+
   // The projection describes the plan as recorded, not the boxes ticked since.
   // That is not stale: while anything is struck the primary action is Apply
   // changes, which re-records it. It only gates the research button, and by
@@ -137,6 +145,15 @@ export function WorkOrderScreen({
         <p className="p2b-cost">{projection.editorial_note}</p>
       )}
 
+      {remainingTexture === 0 && remainingLoadBearing > 0 && (
+        <p className="p2b-blocked">
+          Nothing here would be a pleasure to read &mdash; every question proves
+          something and none of them puts a reader anywhere. The research would be
+          bought and the run would stop before writing. Add a question about what
+          somewhere is like.
+        </p>
+      )}
+
       {remainingLoadBearing === 0 && (
         <p className="p2b-blocked">
           Keep at least one of the questions the piece rests on &mdash; without any of
@@ -161,7 +178,11 @@ export function WorkOrderScreen({
           // A plan that cannot reach the writer has no research worth buying.
           // The server refuses it too; this is so the refusal is not a
           // surprise arriving after the button was pressed.
-          <button type="button" disabled={busy || tooLarge} onClick={onResearch}>
+          <button
+            type="button"
+            disabled={busy || tooLarge || remainingTexture === 0}
+            onClick={onResearch}
+          >
             Go and find this out
           </button>
         )}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -270,6 +270,7 @@ const WORK_ORDER: IntakeWorkOrder = {
     {
       requirement_id: 'r1',
       question: 'What do stalls charge?',
+      purpose: 'Fixes the price the tasting menus are compared against.',
       kind: 'load_bearing',
       precision: 'exact',
       bundled_note: '',
@@ -277,6 +278,7 @@ const WORK_ORDER: IntakeWorkOrder = {
     {
       requirement_id: 'r2',
       question: 'What is it like at night?',
+      purpose: '',
       kind: 'texture',
       precision: 'approximate',
       bundled_note: '',
@@ -304,6 +306,8 @@ const CANNOT_FINISH: IntakeBudgetProjection = {
   ceiling: 650_000,
   can_finish: false,
   questions_that_finish: 31,
+  fact_budget: 0,
+  editorial_note: '',
   note: '44 questions projects to about 825,200 tokens, past the 650,000 hard ceiling. This plan stops part-way through research and never reaches the writer, so there is no article at the end of it. About 31 questions would finish. Cut the plan before starting research.',
 }
 
@@ -384,6 +388,74 @@ describe('the work order screen', () => {
     )
 
     expect(screen.getByText(/repair itself/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /go and find this out/i }),
+    ).not.toBeDisabled()
+  })
+
+  it('says what each question is for, beside the question', () => {
+    // "Does this article need this?" is unanswerable from the question alone,
+    // and the operator is being asked exactly that on this screen.
+    render(
+      <WorkOrderScreen
+        workOrder={WORK_ORDER}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByText(/fixes the price the tasting menus are compared against/i),
+    ).toBeInTheDocument()
+  })
+
+  it('flags a question that never named its job', () => {
+    // Kept, not hidden and not dropped: a question with no nameable job is
+    // usually one the article has no room for, and often one no source can
+    // answer. Five such questions blocked run e23257c0 and were struck by hand.
+    render(
+      <WorkOrderScreen
+        workOrder={WORK_ORDER}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/no stated job in the article/i)).toBeInTheDocument()
+  })
+
+  it('says how much editorial room the article has, not just how much money', () => {
+    // The money projection said run e23257c0's 57 questions "fit". True, and
+    // silent about the article having room for eighteen of the 431 facts.
+    render(
+      <WorkOrderScreen
+        workOrder={{
+          ...WORK_ORDER,
+          budget_projection: {
+            ...CANNOT_FINISH,
+            can_finish: true,
+            note: 'inside the budget',
+            fact_budget: 18,
+            editorial_note: '57 questions, against an article with room for about 18 facts.',
+          },
+        }}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/room for about 18 facts/i)).toBeInTheDocument()
+    // It reports. It never refuses: there is no cap on how many questions a
+    // plan may ask, and the form decides how many it takes.
     expect(
       screen.getByRole('button', { name: /go and find this out/i }),
     ).not.toBeDisabled()

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -461,6 +461,52 @@ describe('the work order screen', () => {
     ).not.toBeDisabled()
   })
 
+  it('will not buy research for a plan with nothing worth reading', () => {
+    // The gate refuses a dossier with no colour in it, and offers nothing to
+    // settle when it does, so the run would spend its whole research budget
+    // and stop dead. The length constraint makes this reachable by accident:
+    // told the article has room for eighteen facts, the planner cuts colour
+    // first.
+    const onResearch = vi.fn()
+    render(
+      <WorkOrderScreen
+        workOrder={{
+          ...WORK_ORDER,
+          requirements: WORK_ORDER.requirements.filter(item => item.kind !== 'texture'),
+        }}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={onResearch}
+      />,
+    )
+
+    expect(screen.getByText(/nothing here would be a pleasure to read/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /go and find this out/i })).toBeDisabled()
+    expect(onResearch).not.toHaveBeenCalled()
+  })
+
+  it('says so as soon as the last colour question is struck', () => {
+    // Before the cut is applied, not after the research is bought.
+    render(
+      <WorkOrderScreen
+        workOrder={WORK_ORDER}
+        warnings={[]}
+        busy={false}
+        onCut={vi.fn()}
+        onReopen={vi.fn()}
+        onResearch={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText(/pleasure to read/i)).not.toBeInTheDocument()
+    // r2 is the texture question in this fixture.
+    fireEvent.click(screen.getAllByRole('checkbox')[1])
+
+    expect(screen.getByText(/nothing here would be a pleasure to read/i)).toBeInTheDocument()
+  })
+
   it('will not let every load-bearing question be struck', () => {
     render(
       <WorkOrderScreen

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -69,6 +69,13 @@ export interface IntakeBrief {
 export interface IntakeRequirement {
   requirement_id: string
   question: string
+  /**
+   * What this question is for: the sentence, comparison or decision its answer
+   * makes possible. Empty when the planner did not say, which is worth reading
+   * as a signal — a question that cannot name its job in the article is
+   * usually one the article has no room for.
+   */
+  purpose: string
   kind: 'load_bearing' | 'texture'
   /**
    * How exact the article needs this. `exact` for a figure a reader acts on,
@@ -112,6 +119,15 @@ export interface IntakeBudgetProjection {
   can_finish: boolean
   questions_that_finish: number
   note: string
+  /**
+   * How many facts an article this long has room for. Zero when no length was
+   * resolved. This is the budget nothing used to report: a plan can be well
+   * inside its money budget and still buy research the article has no room to
+   * print.
+   */
+  fact_budget: number
+  /** Empty when `fact_budget` is zero. */
+  editorial_note: string
 }
 
 export interface IntakeWorkOrder {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -440,6 +440,18 @@
   padding-left: var(--space-3);
 }
 
+/*
+ * What a question is for. Quieter than `.p2b-question-note`, which flags a
+ * problem: this is ordinary information the operator needs on every line, and
+ * a rule down the side of all of them would be a page of stripes.
+ */
+.p2b-question-purpose {
+  margin: var(--space-1) 0 0;
+  color: var(--ink-light);
+  font-size: 0.875rem;
+  line-height: 1.55;
+}
+
 .p2b-cut-warnings {
   margin: var(--space-4) 0 0;
   padding: var(--space-4) var(--space-5);

--- a/apps/ai-blog-writer/docs/plans/p2b-research-scope-handoff.md
+++ b/apps/ai-blog-writer/docs/plans/p2b-research-scope-handoff.md
@@ -158,9 +158,68 @@ the numbers do not show, and it endangers something the numbers do show works.
 
 ---
 
-## How to verify it worked — not yet done
+## What the re-plan measured — done 2026-09-06
 
-**This is the outstanding work.** Nothing below has been run. Both briefs are
+The planning half is measured. **The research half is not**: nothing below was
+re-researched, so facts found, conflicts retained and texture claims are still
+open, and those are where the real risk sits.
+
+Both stored briefs were re-planned off a copy of `pipeline.db`, four to five
+plans each, on `p2b.work_order` as it now ships. About $0.35 of Gemini.
+
+| run | plan | questions | texture | share |
+|---|---|---:|---:|---:|
+| 2197ccc4 | stored (before both changes) | 15 | 4 | 27% |
+| 2197ccc4 | purpose only, no length | 20 | 3 | 15% |
+| 2197ccc4 | shipped, 900 words | 18 / 15 / 13 | 3 / 4 / 6 | 17–46% |
+| e23257c0 | stored (before both changes) | **57** | 8 | 14% |
+| e23257c0 | purpose only, no length | 44 | 2 | 5% |
+| e23257c0 | shipped, 900 words | **25 / 31 / 36** | 4 / 0 / 5 | 0–16% |
+
+**Change 1 is doing the work, not change 2.** Asking each question to name its
+job took run 2 from 57 to 44. Naming the length took it to the twenties and
+thirties. If only one of these survives, it is the length.
+
+**The named fault is gone.** Questions asking for travel time *per taxi
+company* — the five no source could answer, struck by hand before run 2 could
+be written — went 6 → 3 → **0** as the constraint was added.
+
+**Compliance is not the problem the risks section feared.** 107 of 107
+questions across every plan came back with a stated purpose, on
+`gemini-2.5-flash`. `p2b.work_order` does not need moving up a tier for this.
+
+**Run 1 did not shrink, and was not meant to.** 15 stored against 13, 15 and 18
+— the constraint does not crush a plan that was already the right size, which
+was the thing most worth checking.
+
+### The one regression, and it is the one that was predicted
+
+**A plan can now come back with zero texture questions.** e23257c0 sample B
+did: 31 questions, none of them texture. That is not a duller article, it is a
+blocked run — `assess_coverage` sets `can_write=False` and
+`nothing_worth_reading` when no texture question is answered, and no texture
+questions means none can be. "Texture is the first thing to die" was right.
+
+Nothing in the contract requires a texture question and nothing should: the
+prompt asks for texture and the operator can add one. What is missing is that
+**nobody is told before the money is spent.** `texture_count` is already on the
+work order stage record; the gate says "nothing here would be a pleasure to
+read" only after research has been bought. That sentence belongs on the cut
+screen, next to the budget note, for exactly the reason the budget note is
+there: run 03c6702f died against a ceiling its own stage record had already
+predicted. Not built.
+
+### Read the counts as a spread, not a number
+
+Four samples of the identical shipped configuration on run 2 gave 18, 25, 31
+and 36. One plan is an anecdote. Anything claiming "the change saves N
+questions" from a single run is reading noise.
+
+---
+
+## How to verify the rest of it
+
+**Still outstanding: nothing has been re-researched.** Both briefs are
 stored, so this is a before/after on identical input, not a new topic. Re-plan and re-research runs `2197ccc4` and `e23257c0` and compare:
 
 - **question count** — expect run 2 to fall substantially, run 1 barely at all

--- a/apps/ai-blog-writer/docs/plans/p2b-research-scope-handoff.md
+++ b/apps/ai-blog-writer/docs/plans/p2b-research-scope-handoff.md
@@ -1,13 +1,17 @@
 # Handoff: narrowing what research asks for
 
 Written 2026-09-06 at the end of a long session, for whoever picks this up.
-Branch `p2b-research-redesign`, 13 commits, 1518 backend tests and 765
-frontend tests green, `tsc` clean.
+Written on branch `p2b-research-redesign` (13 commits, 1518 backend tests and
+765 frontend tests green, `tsc` clean); that work is now on `main`.
 
-Two changes are proposed and **not built**. Everything else described here is
-shipped and verified. Read "What I got wrong" before you start — I reasoned my
-way to two wrong answers on this exact question before measuring, and the
-measurement is at the bottom.
+Two changes were proposed here and are now **built** (2026-09-06, 1530 backend
+tests and 768 frontend tests green, `tsc` clean). They have **not been measured
+on a real run** — "How to verify it worked" below is the outstanding work, and
+until it has been done neither change is known to have helped.
+
+Read "What I got wrong" before you touch this. I reasoned my way to two wrong
+answers on this exact question before measuring, and the measurement is at the
+bottom.
 
 ---
 
@@ -68,11 +72,20 @@ be omitted by hand before the run could be written.
 
 ## The two changes
 
-### 1. Tell the planner how long the article is
+### 1. Tell the planner how long the article is — built
 
-`build_work_order` (`work_order_v4.py`) does not know the target length. Give
-it the resolved word count and the fact budget that follows from it, and ask it
-to plan questions the article has room to use.
+`build_work_order` (`work_order_v4.py`) did not know the target length. It now
+takes `target_word_count`, and `plan_research` passes
+`default_target_word_count()` — the same catalog entry selection reads, so the
+two cannot drift. The prompt gains one block naming the length and the fact
+budget that follows from it, placed directly under the brief and above "Write
+the questions".
+
+The fact budget is `article_fact_budget` in `selection_v4.py`, split out of
+`target_claim_count` so there is one definition of "how many facts fit". The
+planner needs it before a question has been asked, where there is no dossier to
+count; selection needs it against one it can count. Two definitions would
+drift, and the one the planner reads would be the one nobody checked.
 
 **This is not a ratio and must not become one.** The owner pushed back on a
 fixed "900 words → N questions" rule and was right: a head-to-head comparison
@@ -84,19 +97,35 @@ does the owner.
 
 There is already a `budget_projection` on the work order stage that reports
 question count against a cost budget. It said run 2's 57 questions "fits",
-which was true about money and silent about editorial room. That projection is
-the natural place to also report the fact budget.
+which was true about money and silent about editorial room. It now carries
+`fact_budget` and an `editorial_note` alongside — a second sentence, not a
+rewrite of the money one, because a plan can be affordable and still buy
+research the article has no room to print. Both are rendered on the cut screen.
+Neither refuses anything: `enforce_plan_fits` is untouched, and there is still
+no cap on how many questions a plan may ask.
 
-### 2. Make each question say what it is for
+### 2. Make each question say what it is for — built
 
-Add `purpose` to `WorkOrderRequirement` — one line on why the article needs
-this answer. A question that cannot name its job in the article does not get
-bought.
+`WorkOrderRequirement` now carries `purpose` — one line on the question's job
+in this article. The prompt asks for it, requires it in the schema, and tells
+the planner to write it first and drop the question if it cannot be written.
+It also kills the five unanswerable questions: a question whose purpose cannot
+be stated without inventing a use is the same question that no source can
+answer.
 
-This is the plan's own design (`docs/plans/`, and the research redesign plan
-the owner supplied). It also kills the five unanswerable questions: a question
-whose purpose cannot be stated without inventing a use is the same question
-that no source can answer.
+**A missing purpose does not drop the question.** That was a deliberate call
+against the wording above ("does not get bought"). A model omitting a field is
+a compliance problem, not evidence the question is bad, and this parser exists
+because `p2b.work_order` renames and drops fields constantly — run b78a9fe8
+lost six specific, checkable questions to the word `query`. So the gate is the
+operator's, where it already was: the purpose is shown under each question on
+the cut screen, and a question with none says so in the flag position. If real
+runs show the planner routinely leaving it blank, that is the compliance signal
+the risks section predicted, and the fix is the model tier, not a parser that
+throws questions away.
+
+An operator's own added question gets "Asked for by the operator." rather than
+a blank, because a blank on that screen means something specific.
 
 The plan pairs `purpose` with `answer_boundary` — what makes an answer
 sufficient. **I recommend deferring `answer_boundary`.** See below.
@@ -129,10 +158,10 @@ the numbers do not show, and it endangers something the numbers do show works.
 
 ---
 
-## How to verify it worked
+## How to verify it worked — not yet done
 
-Both briefs are stored, so this is a before/after on identical input, not a new
-topic. Re-plan and re-research runs `2197ccc4` and `e23257c0` and compare:
+**This is the outstanding work.** Nothing below has been run. Both briefs are
+stored, so this is a before/after on identical input, not a new topic. Re-plan and re-research runs `2197ccc4` and `e23257c0` and compare:
 
 - **question count** — expect run 2 to fall substantially, run 1 barely at all
 - **facts found** and **facts selected** — selected must stay 18; if facts


### PR DESCRIPTION
Builds the two changes the handoff in `docs/plans/p2b-research-scope-handoff.md` proposed and left unbuilt, measures them, and fixes the two failures that measuring exposed.

## The problem

Two articles, same pipeline, same outcome:

|  | 2197ccc4 | e23257c0 |
|---|---:|---:|
| questions asked | 15 | 57 |
| facts found | 98 | 431 |
| **facts that reached the writer** | **18** | **18** |
| real money (Gemini) | ~$0.245 | $0.67 |

Per question both runs behaved identically. Run 2 did not dig deeper — it asked 3.8x as many questions, because nothing had ever told the planner that a 900-word article keeps eighteen facts.

## What changed

**`build_work_order` is told the length.** It takes `target_word_count`; `plan_research` passes `default_target_word_count()`, the same catalog entry selection cuts the dossier down with, so the two cannot drift. The budget itself is `article_fact_budget`, split out of `target_claim_count` because the planner needs it before there is a dossier to count.

Not a ratio and not a cap — the form decides how many questions it takes, the length decides how much of the answer can be printed. `enforce_plan_fits` is untouched.

**Every question carries a `purpose`.** One line on its job in the article. A missing purpose does not drop the question: a model omitting a field is a compliance problem, not evidence the question is bad, and this parser exists because `p2b.work_order` renames and drops fields constantly. It is shown under each question on the cut screen instead.

**`budget_projection` reports editorial room** beside the money, rather than folded into it.

## What measuring found

Both stored briefs re-planned four to five times each, then run e23257c0 driven end to end.

| run | plan | questions |
|---|---|---:|
| 2197ccc4 | stored | 15 |
| 2197ccc4 | shipped | 18 / 15 / 13 |
| e23257c0 | stored | **57** |
| e23257c0 | purpose only, no length | 44 |
| e23257c0 | shipped | **18 / 25 / 31 / 36 / 42** |

Change 1 carries this, not change 2: the purpose field alone took run 2 from 57 to 44; the length took it to the twenties and thirties. Run 1, already the right size, did not shrink. Questions asking travel time per taxi company — which no source carries, and which were struck by hand before run 2 could be written — went 6 -> 3 -> 0.

**The counts are a spread, not a number.** Five samples of the identical configuration gave 18 through 42. The change helps on average and does not reliably stop mechanical expansion.

107 of 107 questions came back with a stated purpose on `gemini-2.5-flash`, so the compliance risk the handoff predicted did not appear.

## The two failures it exposed

**A plan can come back with no texture question** — one sample did, 31 questions and no colour at all. `assess_coverage` refuses a dossier with no texture answered and `blocking_questions` offers nothing to settle for that verdict, so that run buys its whole research and stops dead. Refused now on the cut screen, where adding a question is one text box away.

**An extra answer was binning the whole structuring batch.** Not caused by this change, and the more serious of the two. The check was set equality between the requirement ids returned and the ids asked about. Both failing batches on the end-to-end run answered all four questions correctly plus one more from the same search group — notes are gathered per search group and a batch is a slice of one — and had all four recorded `missing` / `nothing_found`. Eight correct, already-paid-for answers discarded, and because `cause` is hardcoded `nothing_found` on that path the operator was told "nothing relevant came back — answer it yourself, or drop it" about answers sitting in the notes. Retrying reproduced it exactly.

## The end-to-end run

Run `bogota-replan-0906`, same stored brief, same writing model:

|  | original | new |
|---|---:|---:|
| questions | 57 | 42 |
| facts found | 431 | 292 |
| facts used | 18 | 18 |
| words | 916 | 955 |
| Gemini | $0.67 | **$0.59** |

The new article carries fares and journey times per zone, which the original had none of, and drops the September 2015 Uber/Duolingo detail the original used to advise a 2026 traveller.

Both runs finish `needs_revision`, and both had their outline rejected on `covers_primary_subject` — the open issue the handoff already records as deprioritised. Neither is addressed here.

## Verification

1531 backend tests, 770 frontend, `tsc` clean, flake8 and eslint clean on changed files. The structuring fix is pinned by reverting the source alone: the new test fails with the original error and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)