### PR TITLE
fix(p2b): the seven writer-phase fixes

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -13,6 +13,10 @@ from typing import Any
 
 from ..support import _safe_dict, _safe_int, _safe_str
 
+# The shape every article used to be planned into, whatever form was
+# approved. Both are now the default only -- what a run actually uses comes
+# from its frozen structure policy (finding 07) -- and they stay here as the
+# fallback for a run that has none.
 MIN_OUTLINE_SECTIONS = 3
 MAX_OUTLINE_SECTIONS = 12
 
@@ -36,11 +40,15 @@ def _sanitize_section(raw: Any) -> dict[str, Any] | None:
     }
 
 
-def sanitize_v3_outline(parsed: dict[str, Any]) -> dict[str, Any]:
+def sanitize_v3_outline(
+    parsed: dict[str, Any],
+    *,
+    max_sections: int = MAX_OUTLINE_SECTIONS,
+) -> dict[str, Any]:
     sections_raw = parsed.get("sections")
     sections: list[dict[str, Any]] = []
     if isinstance(sections_raw, list):
-        for item in sections_raw[:MAX_OUTLINE_SECTIONS]:
+        for item in sections_raw[:max_sections]:
             section = _sanitize_section(item)
             if section:
                 sections.append(section)
@@ -170,6 +178,7 @@ def validate_v3_outline(
     work_order: dict[str, Any],
     claim_ids: set[str],
     target_word_count: int,
+    min_sections: int = MIN_OUTLINE_SECTIONS,
 ) -> tuple[bool, dict[str, Any]]:
     """Check a plan against the work order's scope and the writer's packet.
 
@@ -262,7 +271,10 @@ def validate_v3_outline(
     )
 
     checks = {
-        "enough_sections": len(sections) >= MIN_OUTLINE_SECTIONS,
+        # From the approved form, not from a constant. A Q&A or a column that
+        # divides into two sections is that form working, and failing the plan
+        # for it sent compose in with no plan at all.
+        "enough_sections": len(sections) >= min_sections,
         "headings_unique": len({s["heading"].casefold() for s in sections})
         == len(sections),
         "within_word_budget": within_budget,
@@ -275,6 +287,7 @@ def validate_v3_outline(
     diagnostics = {
         **checks,
         "section_count": len(sections),
+        "min_sections": min_sections,
         "planned_word_count": planned_words,
         "target_word_count": target_word_count,
         "unknown_claim_ids": unknown_claim_ids,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/sections.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/sections.py
@@ -1,0 +1,266 @@
+"""Stable section identity for an article, and edits applied in code.
+
+Finding 06: repair regenerated the whole article and was asked, in prose, to
+return every untouched section "exactly as it was, word for word". Nothing
+enforced it. The code measured which sections moved and recorded the answer,
+so a pass asked to fix one paragraph could rewrite the opening and the run
+would note it and carry on -- and keep-best would happily retain the broad
+rewrite whenever the audit liked the score.
+
+The fix is not a firmer instruction. It is that untargeted prose is never
+regenerated at all: repair returns replacements for the sections it is
+changing, and the rest of the document is the original bytes.
+
+Everything here is pure and deterministic. `split_markdown_sections` in
+`markdown.py` is unchanged and still keyed by heading -- it answers "did this
+move", where a collision between two identical headings is harmless. It is not
+safe as an edit address, which is what this module is for.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from ..support import _safe_dict, _safe_str
+
+# The block before the first `##`. It is a real part of the article -- often
+# the direct answer -- and it needs an address like everything else.
+OPENING_SECTION_ID = "s0"
+
+_H2 = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()[:12]
+
+
+@dataclass(frozen=True)
+class ArticleSection:
+    """One addressable piece of an article."""
+
+    section_id: str
+    # Empty for the opening block, which has no heading of its own.
+    heading: str
+    body: str
+
+    @property
+    def text_hash(self) -> str:
+        """Identity of the current text, so a stale edit can be spotted.
+
+        Over the body and the heading together: a pass that rewrote a heading
+        against the previous draft is as stale as one that rewrote the prose.
+        """
+        return _hash(f"{self.heading}\n{self.body}")
+
+    def render(self) -> str:
+        if not self.heading:
+            return self.body.strip()
+        return f"## {self.heading}\n\n{self.body}".strip() if self.body else (
+            f"## {self.heading}"
+        )
+
+
+def segment_article(content: str) -> list[ArticleSection]:
+    """Split an article into addressed sections, in document order.
+
+    Positional ids, not headings. Two sections can carry the same heading --
+    "Getting there" under two neighbourhoods is ordinary writing -- and a
+    heading-keyed address silently merges them, which would let a repair aimed
+    at one overwrite the other.
+
+    The opening block is always present, even when empty, so a draft that
+    begins straight on a heading still has somewhere to put an opening.
+    """
+    heading = ""
+    body: list[str] = []
+    sections: list[ArticleSection] = []
+
+    def flush() -> None:
+        sections.append(
+            ArticleSection(
+                section_id=f"s{len(sections)}",
+                heading=heading,
+                body="\n".join(body).strip(),
+            )
+        )
+
+    for line in _safe_str(content).split("\n"):
+        match = _H2.match(line)
+        if match:
+            flush()
+            heading = match.group(1).strip()
+            body = []
+            continue
+        body.append(line)
+    flush()
+    return sections
+
+
+def render_article(sections: list[ArticleSection]) -> str:
+    """Reassemble a document from its sections."""
+    return "\n\n".join(
+        rendered for section in sections if (rendered := section.render())
+    ).strip()
+
+
+def section_manifest(sections: list[ArticleSection]) -> str:
+    """What repair is shown so it can name what it wants to change."""
+    lines: list[str] = []
+    for section in sections:
+        label = section.heading or "(opening — no heading)"
+        words = len(section.body.split())
+        lines.append(
+            f"- {section.section_id} [{section.text_hash}] {label} "
+            f"({words} words)"
+        )
+    return "\n".join(lines) or "- (the draft has no sections)"
+
+
+def locate_claims(
+    sections: list[ArticleSection], claims: list[dict[str, Any]]
+) -> dict[str, list[str]]:
+    """Which section each flagged claim sits in, by quoted text.
+
+    Best effort, and deliberately not a gate: a checker that paraphrased its
+    own quote should not cost the run its repair. What it buys is a repair
+    prompt that can say "this section contains a claim you must delete"
+    instead of handing the whole list to a pass that has to search for them.
+    """
+    located: dict[str, list[str]] = {}
+    for claim in claims:
+        quote = _safe_str(_safe_dict(claim).get("claim"))
+        if not quote:
+            continue
+        needle = " ".join(quote.split()).casefold()
+        for section in sections:
+            haystack = " ".join(f"{section.heading} {section.body}".split()).casefold()
+            if needle and needle in haystack:
+                located.setdefault(section.section_id, []).append(quote)
+                break
+    return located
+
+
+@dataclass(frozen=True)
+class SectionEditResult:
+    """What a set of proposed replacements did, and what it was refused."""
+
+    content: str
+    applied: list[str]
+    rejected: list[dict[str, str]]
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.applied)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "applied_section_ids": list(self.applied),
+            "rejected": [dict(item) for item in self.rejected],
+        }
+
+
+def apply_section_replacements(
+    content: str,
+    replacements: Any,
+) -> SectionEditResult:
+    """Replace named sections in the original document; keep the rest byte-for-byte.
+
+    Every replacement is checked before anything is written:
+
+    - the id must name a section this draft has;
+    - it may name it only once, so two edits cannot silently race for the same
+      paragraph;
+    - `text_hash` must match what is there now, so an edit written against an
+      older draft is refused rather than applied to prose it never read.
+
+    A refused replacement drops out and the others still apply. A response
+    where nothing survives returns the original content unchanged, which is
+    the honest outcome: the draft the run already has is still saveable, and
+    keep-best is not handed a mangled document to score.
+    """
+    sections = segment_article(content)
+    by_id = {section.section_id: index for index, section in enumerate(sections)}
+
+    applied: list[str] = []
+    rejected: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    if not isinstance(replacements, list):
+        return SectionEditResult(
+            content=_safe_str(content),
+            applied=[],
+            rejected=[{"section_id": "", "reason": "sections is not a list"}],
+        )
+
+    for raw in replacements:
+        record = _safe_dict(raw)
+        section_id = _safe_str(record.get("section_id"))
+        if section_id not in by_id:
+            rejected.append(
+                {
+                    "section_id": section_id or "(missing)",
+                    "reason": "unknown section id",
+                }
+            )
+            continue
+        if section_id in seen:
+            rejected.append(
+                {"section_id": section_id, "reason": "named more than once"}
+            )
+            continue
+        seen.add(section_id)
+
+        index = by_id[section_id]
+        current = sections[index]
+        supplied_hash = _safe_str(record.get("text_hash"))
+        if supplied_hash and supplied_hash != current.text_hash:
+            rejected.append(
+                {
+                    "section_id": section_id,
+                    "reason": (
+                        f"stale text_hash {supplied_hash} for "
+                        f"{current.text_hash}"
+                    ),
+                }
+            )
+            continue
+
+        body = _safe_str(record.get("content"))
+        if not body.strip():
+            # Repair cannot delete a section. Removing one is a plan decision
+            # and this pass does not hold the plan; an empty body is far more
+            # likely to be a truncated response than a considered cut.
+            rejected.append(
+                {"section_id": section_id, "reason": "empty replacement body"}
+            )
+            continue
+
+        heading = _safe_str(record.get("heading"))
+        if current.heading and not heading:
+            heading = current.heading
+        if not current.heading and heading:
+            # The opening block has no heading, and a replacement that
+            # invents one would push a new `##` above the first section.
+            rejected.append(
+                {
+                    "section_id": section_id,
+                    "reason": "the opening block cannot take a heading",
+                }
+            )
+            continue
+
+        sections[index] = ArticleSection(
+            section_id=section_id, heading=heading, body=body.strip()
+        )
+        applied.append(section_id)
+
+    if not applied:
+        return SectionEditResult(
+            content=_safe_str(content), applied=[], rejected=rejected
+        )
+    return SectionEditResult(
+        content=render_article(sections), applied=applied, rejected=rejected
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/sections.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/sections.py
@@ -30,7 +30,10 @@ from ..support import _safe_dict, _safe_str
 # the direct answer -- and it needs an address like everything else.
 OPENING_SECTION_ID = "s0"
 
-_H2 = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
+# Exported: the style cleanup walks the same lines to work out which
+# section an error's line number falls in, and a second copy of this
+# rule that drifted would put an edit in the wrong place.
+H2_LINE = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
 
 
 def _hash(text: str) -> str:
@@ -88,7 +91,7 @@ def segment_article(content: str) -> list[ArticleSection]:
         )
 
     for line in _safe_str(content).split("\n"):
-        match = _H2.match(line)
+        match = H2_LINE.match(line)
         if match:
             flush()
             heading = match.group(1).strip()

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/style_cleanup.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/style_cleanup.py
@@ -34,12 +34,16 @@ from app.shared.text import validate_anti_ai_tells_markdown
 
 from ..dependencies import PipelineDependencies
 from ..support import _safe_dict, _safe_str
-from .sections import ArticleSection, apply_section_replacements, segment_article
+from .sections import (
+    H2_LINE,
+    ArticleSection,
+    apply_section_replacements,
+    segment_article,
+)
 
 logger = logging.getLogger(__name__)
 
 _LINE_PREFIX = re.compile(r"^Line (\d+):")
-_H2_LINE = re.compile(r"^##[ \t]+\S")
 
 STYLE_CLEANUP_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -126,7 +130,7 @@ def _section_line_spans(content: str) -> dict[str, tuple[int, int]]:
     start = 1
     lines = content.split("\n")
     for number, line in enumerate(lines, start=1):
-        if _H2_LINE.match(line):
+        if H2_LINE.match(line):
             spans[f"s{index}"] = (start, number - 1)
             index += 1
             start = number

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/style_cleanup.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/style_cleanup.py
@@ -1,0 +1,308 @@
+"""Style cleanup that edits sections instead of rewriting the article.
+
+Finding 05. The anti-AI enforcement pass is still wired in after compose and
+after repair (ADR 0032 says it was dropped; it was not, and a test in
+`test_prompt2blog_voice_files.py` has been recording that discrepancy). What
+it receives is the finished article and a list of style errors -- not the
+brief, not the facts, not the caveats attached to them. So a pass sent to
+remove an em dash is holding the whole document with no idea which of its
+sentences is carefully qualified, and "offered in March" can come back as
+"offers today" while the dash is duly gone.
+
+Two changes, and neither of them is a firmer instruction.
+
+The cheap deterministic half is unchanged: the validator still runs on every
+draft and still costs nothing. What changes is the expensive half. The errors
+carry line numbers, so the sections that actually contain them are known
+before any model is asked anything; only those are sent, only those may come
+back, and the rest of the document is untouched bytes. And what is sent with
+them is the repair lock -- the brief's scope and the limitations on the facts
+this article used -- so the pass can see what a qualification is for.
+
+A cleanup is advisory, and it stays advisory. One attempt. A result that is
+not cleaner than what it started with is discarded and the draft it was given
+is kept, because a style error is never worth a damaged fact.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from app.shared.text import validate_anti_ai_tells_markdown
+
+from ..dependencies import PipelineDependencies
+from ..support import _safe_dict, _safe_str
+from .sections import ArticleSection, apply_section_replacements, segment_article
+
+logger = logging.getLogger(__name__)
+
+_LINE_PREFIX = re.compile(r"^Line (\d+):")
+_H2_LINE = re.compile(r"^##[ \t]+\S")
+
+STYLE_CLEANUP_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["sections"],
+    "properties": {
+        "sections": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["section_id", "text_hash", "content"],
+                "properties": {
+                    "section_id": {"type": "string"},
+                    "text_hash": {"type": "string"},
+                    "heading": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+            },
+        }
+    },
+}
+
+STYLE_CLEANUP_PROMPT = """You are fixing style errors in one or more sections \
+of a finished article.
+
+Goal:
+Remove the listed errors and change nothing else.
+
+Return strict JSON only:
+{{
+  "sections": [
+    {{
+      "section_id": "string",
+      "text_hash": "string",
+      "content": "string"
+    }}
+  ]
+}}
+
+Rules:
+- Return one entry per section below, with its `section_id` and `text_hash`
+  copied exactly. `content` is the full replacement body for that section,
+  without its `##` heading line.
+- Fix only the listed errors. This is a style pass on prose somebody has
+  already checked for accuracy.
+- Change no fact. Not a date, a price, a currency, a duration, a number, a
+  place, a name, or a negation. "offered in March" does not become "offers
+  today" because the sentence around it was rephrased.
+- Keep every qualification exactly as it stands. An as-of date, a season, a
+  route only some operators run, a "for most travellers" -- each of those is
+  part of the fact and the article is not permitted to state the fact without
+  it. Removing one is a worse outcome than leaving the style error.
+- Keep first-hand experience in the words it is written in.
+- Never replace a dash with a comma-bracketed aside. Rewrite the sentence into
+  clean prose instead; length comes from subordination, and splitting a
+  sentence is the last resort.
+- Hyphenated compounds are rationed, not banned. When the count is over
+  budget, keep the ones where the hyphen is the word and rephrase the rest.
+  Never delete a hyphen or split a word in place.
+- Fix sourcing language by stating the fact as a plain sentence and deleting
+  the publication, never by swapping in another attribution verb. If a fact
+  cannot stand without a source named in the sentence, delete the sentence.
+- Fix a sentence that reports on the research by deleting it or by replacing
+  it with something the article does know. Never soften it into a vaguer
+  version of the same absence.
+- If an error cannot be fixed without changing a fact, leave that sentence
+  alone and fix the rest.
+
+{guard}
+
+SECTIONS TO FIX:
+{sections}
+"""
+
+
+def _section_line_spans(content: str) -> dict[str, tuple[int, int]]:
+    """First and last 1-based line number of each section, in the original text.
+
+    The same `## ` rule `segment_article` splits on, walked over the same
+    lines the validator numbered, so an error's line number lands in exactly
+    one section.
+    """
+    spans: dict[str, tuple[int, int]] = {}
+    index = 0
+    start = 1
+    lines = content.split("\n")
+    for number, line in enumerate(lines, start=1):
+        if _H2_LINE.match(line):
+            spans[f"s{index}"] = (start, number - 1)
+            index += 1
+            start = number
+    spans[f"s{index}"] = (start, len(lines))
+    return spans
+
+
+def sections_with_errors(
+    content: str, errors: list[str]
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Route each style error to the section whose lines it names.
+
+    Returns the per-section errors and the ones with no line number of their
+    own. The hyphenated-compound budget is the second kind: it is counted over
+    the whole document, so it belongs to every section that has compounds in
+    it rather than to one.
+    """
+    spans = _section_line_spans(content)
+    by_section: dict[str, list[str]] = {}
+    unplaced: list[str] = []
+    for error in errors:
+        match = _LINE_PREFIX.match(error)
+        if not match:
+            unplaced.append(error)
+            continue
+        line_number = int(match.group(1))
+        for section_id, (start, end) in spans.items():
+            if start <= line_number <= end:
+                by_section.setdefault(section_id, []).append(error)
+                break
+        else:  # pragma: no cover - a number outside every span cannot happen
+            unplaced.append(error)
+    return by_section, unplaced
+
+
+def _sections_block(
+    sections: list[ArticleSection],
+    errors_by_section: dict[str, list[str]],
+    unplaced: list[str],
+) -> str:
+    blocks: list[str] = []
+    for section in sections:
+        listed = errors_by_section.get(section.section_id)
+        if not listed:
+            continue
+        label = section.heading or "(opening — no heading)"
+        problems = "\n".join(f"  - {error}" for error in [*listed, *unplaced])
+        blocks.append(
+            f"SECTION {section.section_id} [{section.text_hash}] — {label}\n"
+            f"Errors:\n{problems}\n"
+            f"Current text:\n{section.body}"
+        )
+    return "\n\n".join(blocks)
+
+
+def clean_up_style(
+    content: str,
+    *,
+    dependencies: PipelineDependencies,
+    job_id: str,
+    model_name: str | None,
+    max_tokens: int,
+    context: str,
+    guard: str = "",
+) -> tuple[str, dict[str, Any]]:
+    """Fix the style errors in the sections that have them, or keep the draft.
+
+    Returns the content to use and a report. The report is the point of the
+    second return value: a cleanup that ran, found nothing it could fix, and
+    left the draft alone is a different outcome from one that never ran, and
+    the old whole-article pass could not tell them apart.
+    """
+    original = _safe_str(content).strip()
+    result = validate_anti_ai_tells_markdown(original)
+    if result.valid:
+        return original, {"status": "clean", "errors": []}
+
+    sections = segment_article(original)
+    errors_by_section, unplaced = sections_with_errors(original, result.errors)
+    if not errors_by_section:
+        # Every error is document-wide with nothing to attach it to. Nothing
+        # to send that would not be the whole article again, which is the
+        # thing this replaces.
+        logger.warning(
+            "%s has style errors with no section to place them in: %s",
+            context,
+            result.errors,
+        )
+        return original, {
+            "status": "unplaceable",
+            "errors": list(result.errors),
+            "sections_sent": [],
+        }
+
+    approved = list(errors_by_section)
+    prompt = STYLE_CLEANUP_PROMPT.format(
+        guard=guard or "No additional scope guard was supplied for this pass.",
+        sections=_sections_block(sections, errors_by_section, unplaced),
+    )
+    try:
+        parsed, _raw = dependencies.llm.invoke_json(
+            job_id=job_id,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=0.0,
+            model_name=model_name,
+            schema=STYLE_CLEANUP_SCHEMA,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Style is advisory. A cleanup that could not run never fails a run
+        # that already has an article.
+        logger.warning("%s style cleanup call failed: %s", context, exc)
+        return original, {
+            "status": "call_failed",
+            "errors": list(result.errors),
+            "sections_sent": approved,
+            "detail": str(exc),
+        }
+
+    proposed = _safe_dict(parsed).get("sections")
+    off_target: list[str] = []
+    if isinstance(proposed, list):
+        allowed = []
+        for raw in proposed:
+            section_id = _safe_str(_safe_dict(raw).get("section_id"))
+            if section_id in approved:
+                allowed.append(raw)
+            else:
+                off_target.append(section_id or "(missing)")
+        proposed = allowed
+    edit = apply_section_replacements(original, proposed)
+
+    if not edit.changed:
+        logger.warning(
+            "%s style cleanup changed nothing: %s", context, edit.rejected
+        )
+        return original, {
+            "status": "no_change",
+            "errors": list(result.errors),
+            "sections_sent": approved,
+            "off_target_sections": off_target,
+            "rejected": edit.as_dict()["rejected"],
+        }
+
+    after = validate_anti_ai_tells_markdown(edit.content)
+    if len(after.errors) >= len(result.errors):
+        # Not cleaner. The article it was given is the one the run keeps: a
+        # style pass has no licence to make a draft worse on its way to
+        # tidying it.
+        logger.warning(
+            "%s style cleanup did not reduce the errors (%d -> %d); keeping "
+            "the original",
+            context,
+            len(result.errors),
+            len(after.errors),
+        )
+        return original, {
+            "status": "rejected",
+            "errors": list(result.errors),
+            "errors_after": list(after.errors),
+            "sections_sent": approved,
+            "off_target_sections": off_target,
+        }
+
+    if after.errors:
+        # Advisory, not a loop. A second attempt on the same sections is the
+        # repeated-rewrite behaviour this replaces.
+        logger.warning(
+            "%s style cleanup left issues unresolved: %s", context, after.errors
+        )
+    return edit.content, {
+        "status": "applied",
+        "errors": list(result.errors),
+        "errors_after": list(after.errors),
+        "sections_sent": approved,
+        "sections_changed": list(edit.applied),
+        "off_target_sections": off_target,
+        "rejected": edit.as_dict()["rejected"],
+    }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/dependencies.py
@@ -38,15 +38,6 @@ class Prompt2BlogLLM(Protocol):
         schema: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], str]: ...
 
-    def enforce_anti_ai(
-        self,
-        text: str,
-        *,
-        model_name: str | None,
-        max_tokens: int,
-        context: str,
-    ) -> str: ...
-
 
 @dataclass(frozen=True)
 class DefaultPrompt2BlogLLM:
@@ -66,14 +57,6 @@ class DefaultPrompt2BlogLLM:
 
     def invoke_json(self, **kwargs: Any) -> tuple[dict[str, Any], str]:
         return llm._invoke_json_llm(
-            **kwargs,
-            usage_recorder=self.usage_tracker.record,
-            correlation_id=self.run_id or self.usage_tracker.run_id,
-        )
-
-    def enforce_anti_ai(self, text: str, **kwargs: Any) -> str:
-        return llm._enforce_anti_ai_markdown_with_model(
-            text,
             **kwargs,
             usage_recorder=self.usage_tracker.record,
             correlation_id=self.run_id or self.usage_tracker.run_id,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editorial_catalog.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editorial_catalog.py
@@ -6,7 +6,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ValidationError as PydanticValidationError
 
 from .config import (
     PROMPT2BLOG_FORMS_DIR,
@@ -55,8 +56,130 @@ class EditorialRule(CatalogModel):
     instructions: str = Field(min_length=1)
 
 
+OpeningMode = Literal["direct-answer", "form-led"]
+ClosingMode = Literal["takeaways", "form-led"]
+
+# The floor under `min_sections`. Below two there is no structure to plan and
+# `sections_changed` has nothing to scope a repair to.
+ABSOLUTE_MIN_SECTIONS = 2
+ABSOLUTE_MAX_SECTIONS = 12
+
+
+class FormStructurePolicy(CatalogModel):
+    """How one article form is allowed to be shaped.
+
+    Finding 07: every article was required to open with a 40-60 word direct
+    answer, carry at least three `##` headings, and close with takeaways --
+    rules written into the compose prompt, the outline schema and the outline
+    validator, all three of them blind to which form was approved. A service
+    guide wants exactly that shape. A profile, an essay and a Q&A do not, and
+    being marked down for not having it is what turned different briefs into
+    the same article.
+
+    Declared in each form's own frontmatter, so the form that says how a piece
+    is organized is also where its organization is written down, and resolved
+    once per run into the frozen instruction meta so outline, compose and the
+    deterministic checks read the same policy -- including after a resume.
+    """
+
+    opening: OpeningMode
+    closing: ClosingMode
+    min_sections: int = Field(ge=ABSOLUTE_MIN_SECTIONS, le=ABSOLUTE_MAX_SECTIONS)
+    max_sections: int = Field(ge=ABSOLUTE_MIN_SECTIONS, le=ABSOLUTE_MAX_SECTIONS)
+
+    @model_validator(mode="after")
+    def _range_is_a_range(self) -> "FormStructurePolicy":
+        if self.min_sections > self.max_sections:
+            raise ValueError("min_sections cannot exceed max_sections")
+        return self
+
+    def opening_rule(self) -> str:
+        if self.opening == "direct-answer":
+            return (
+                "- Open with a direct 40-60 word answer to the core reader "
+                "question, before the first `##` heading. The reader came for "
+                "that answer; everything after it is the support."
+            )
+        return (
+            "- Open the way this form opens. Use one of its allowed structures "
+            "and start on something concrete and supported -- a scene, a "
+            "figure, the claim you are about to argue. Do not bolt a "
+            "question-and-answer box onto a piece that is not answering a "
+            "lookup question, and do not warm up before the point either."
+        )
+
+    def closing_rule(self) -> str:
+        if self.closing == "takeaways":
+            return (
+                "- Close with a concise takeaway section. It synthesises "
+                "decisions the article already supported, in fresh wording "
+                "rather than copied sentences. Never let a material fact, "
+                "figure, or place appear there for the first time."
+            )
+        return (
+            "- End where the piece ends. This form does not take a takeaways "
+            "list, and appending one to reach a familiar shape weakens it. "
+            "The close still lands somewhere; it does not summarise."
+        )
+
+    def sections_rule(self) -> str:
+        return (
+            f"- Use between {self.min_sections} and {self.max_sections} `##` "
+            "headings, as many as the material actually divides into. The "
+            "count is a range, not a target to hit."
+        )
+
+    def compose_rules(self) -> str:
+        """The structural obligations for one form, for the compose prompt."""
+        return "\n".join(
+            (
+                self.opening_rule(),
+                self.sections_rule(),
+                self.closing_rule(),
+                "- Structure is the form's to decide and the evidence rules "
+                "are not. A form never licenses an invented scene, quotation, "
+                "voice, or detail to fill the shape it asks for.",
+            )
+        )
+
+    def outline_rules(self) -> str:
+        """The same policy, said to the stage that plans rather than writes."""
+        opening = (
+            "The article opens with a direct 40-60 word answer, which you do "
+            "not plan as a section: put its subject in `direct_answer_focus`."
+            if self.opening == "direct-answer"
+            else "This form does not use a direct-answer opening. Leave "
+            "`direct_answer_focus` empty and let the first section open the "
+            "piece the way the form's allowed structures do."
+        )
+        closing = (
+            "The article closes with takeaways, which you also do not plan as "
+            "a section: put their subject in `takeaway_focus`."
+            if self.closing == "takeaways"
+            else "This form does not close with takeaways. Leave "
+            "`takeaway_focus` empty."
+        )
+        return "\n".join(
+            (
+                f"- Plan at least {self.min_sections} and at most "
+                f"{self.max_sections} sections.",
+                f"- {opening}",
+                f"- {closing}",
+            )
+        )
+
+
+DEFAULT_STRUCTURE_POLICY = FormStructurePolicy(
+    opening="direct-answer",
+    closing="takeaways",
+    min_sections=3,
+    max_sections=12,
+)
+
+
 class ArticleFormRule(EditorialRule):
     source_requirements: list[SourceRequirement] = Field(default_factory=list)
+    structure: FormStructurePolicy
     # The direction step used to choose a form from `description` alone — one
     # summary line each. "Where to eat in Lima right now" became a News Report
     # because "reports a timely development" is a fair reading of "right now",
@@ -101,6 +224,7 @@ class EditorialCatalog(CatalogModel):
                     "source_requirements": item.source_requirements,
                     "use_when": item.use_when,
                     "do_not_use_when": item.do_not_use_when,
+                    "structure": item.structure.model_dump(),
                 }
                 for item in self.forms
             ],
@@ -228,6 +352,31 @@ def _rule_section(body: str, heading: str) -> str:
     return section.split("\n## ", 1)[0].strip()
 
 
+def _structure_policy(metadata: dict[str, str], path: Path) -> FormStructurePolicy:
+    """Read `opening`, `sections` and `closing` off one form's frontmatter.
+
+    Loudly. A malformed range or an unknown mode fails the catalog load, which
+    fails at import in every test rather than producing an article shaped by a
+    silently substituted default.
+    """
+    raw_range = metadata["sections"]
+    try:
+        low, high = (int(part) for part in raw_range.split("-", 1))
+    except ValueError as exc:
+        raise ValueError(
+            f"Form section range must be 'min-max': {path} ({raw_range!r})"
+        ) from exc
+    try:
+        return FormStructurePolicy(
+            opening=metadata["opening"],
+            closing=metadata["closing"],
+            min_sections=low,
+            max_sections=high,
+        )
+    except PydanticValidationError as exc:
+        raise ValueError(f"Invalid structure policy in {path}: {exc}") from exc
+
+
 def _load_rule_directory(
     directory: Path,
     *,
@@ -249,6 +398,11 @@ def _load_rule_directory(
     for path in files:
         metadata, body = _parse_rule_file(path)
         required_keys = {"id", "label", "summary", "order"}
+        # A form that does not declare its own structure would silently take
+        # somebody else's, which is finding 07 with an extra step. Required,
+        # not defaulted.
+        if forms:
+            required_keys |= {"opening", "sections", "closing"}
         missing_keys = required_keys - metadata.keys()
         extra_keys = metadata.keys() - required_keys - {"source_gate"}
         if missing_keys or extra_keys:
@@ -282,6 +436,7 @@ def _load_rule_directory(
                     source_requirements=[source_gate] if source_gate else [],
                     use_when=_rule_section(body, "## Use when"),
                     do_not_use_when=_rule_section(body, "## Do not use when"),
+                    structure=_structure_policy(metadata, path),
                 )
             )
         else:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -133,9 +133,21 @@ class V3StageContexts(InstructionModel):
     compose: StageContext
     audit: StageContext
     repair_lock: StageContext
+    # The facts repair may work from. Separate from `repair_lock`, which is
+    # the scope it may not move, because they answer different questions and
+    # the lock is quoted at the model as immutable.
+    #
+    # Defaulted rather than required so a run snapshotted before this existed
+    # still restores. Such a run repairs the way it always did: without the
+    # facts, which is finding 03.
+    repair_facts: StageContext = StageContext(
+        text="", included_sections=[], fingerprint=""
+    )
 
 
-StageContextName = Literal["outline", "compose", "audit", "repair_lock"]
+StageContextName = Literal[
+    "outline", "compose", "audit", "repair_lock", "repair_facts"
+]
 
 
 class V3InstructionSet(InstructionModel):
@@ -478,7 +490,8 @@ def _repair_lock_body(
             f"It fails if: {brief.fails_if}",
             *((limitations,) if limitations else ()),
             "Keep direct, specific prose for the named reader. Preserve the "
-            "approved form and scope. Do not add factual material, and do not "
+            "approved form and scope. The only facts you may use are the ones "
+            "listed under THE FACTS AVAILABLE TO THIS REPAIR, and you may not "
             "remove a limitation from a fact you keep.",
         )
     )
@@ -527,6 +540,7 @@ def stage_context_manifest(
             ("compose", contexts.compose),
             ("audit", contexts.audit),
             ("repair_lock", contexts.repair_lock),
+            ("repair_facts", contexts.repair_facts),
         )
     }
 
@@ -708,6 +722,26 @@ def assemble_v3_instructions(
                 ("form", f"ARTICLE FORM — {form.label}\n{form_structure}"),
                 ("audience", f"AUDIENCE GUIDANCE\n{audience_body}"),
                 ("house_style", f"HOUSE STYLE\n{catalog.house_rules.instructions}"),
+            ]
+        ),
+        # Finding 03. Repair used to receive the previous draft, a list of
+        # revisions, and a scope lock -- and was told never to add factual
+        # material, including researched material. So a revision like "compare
+        # these restaurants on price" was unsatisfiable whenever the first
+        # draft happened to leave the price out: the fact was chosen, frozen,
+        # and sitting in the packet the repair pass could not see. What came
+        # back was repetition, vague judgement, or an unresolved revision.
+        #
+        # It is the same list compose was given, from the same frozen packet.
+        # The editorial cut still holds: a fact nobody chose is still not
+        # available, and repair still cannot invent one.
+        repair_facts=_stage_context(
+            parts=[
+                (
+                    "facts",
+                    "THE FACTS AVAILABLE TO THIS REPAIR\n"
+                    + _packet_evidence_body(packet),
+                ),
             ]
         ),
         repair_lock=_stage_context(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/instructions_v3.py
@@ -2,18 +2,32 @@
 
 from __future__ import annotations
 
+import logging
+
 from hashlib import sha256
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from .contracts_v4 import ArticleBrief, Prompt2BlogV4Request, Prompt2BlogWorkOrder
-from .editorial_catalog import EditorialCatalog, load_editorial_catalog
+from .editorial_catalog import (
+    DEFAULT_STRUCTURE_POLICY,
+    EditorialCatalog,
+    FormStructurePolicy,
+    load_editorial_catalog,
+)
 from .evidence_v3 import NormalizedEvidence, normalize_evidence
 from .packet_v4 import WritingPacket
 
+logger = logging.getLogger(__name__)
+
 INSTRUCTION_SCHEMA_VERSION = 5
 
+# The one authority order in the system. It used to be stated twice -- here,
+# and again in prose at the top of `house-rules.md` -- in two vocabularies
+# ("approved commission" against "approved brief"), which is how a rule ends up
+# with two owners and neither of them current. House style no longer states an
+# order; it is the lowest layer of this one.
 PRECEDENCE = (
     "verified evidence",
     "approved brief",
@@ -22,6 +36,38 @@ PRECEDENCE = (
     "audience guidance",
     "house style",
 )
+
+# What each layer is actually allowed to decide. The bare list above says which
+# wins; it never said what any of them owns, so "the form controls structure"
+# and "house style controls structure" could both look true to a reader of the
+# assembled prompt.
+PRECEDENCE_OWNERSHIP = (
+    "The facts and their stated limits control every factual claim. Nothing "
+    "below may widen, flatten, or date a claim differently.",
+    "The approved brief controls intent: subject, scope, promise, and what "
+    "this piece fails if it does.",
+    "The article form controls structure: how it opens, how it is divided, "
+    "how it closes.",
+    "Topic modules and audience guidance adjust emphasis only.",
+    "House style controls expression, and only where nothing above has "
+    "already decided.",
+)
+
+
+def precedence_block(role: str) -> str:
+    """The authority order, written out once, for one stage's prompt."""
+    order = " > ".join(PRECEDENCE)
+    return "\n".join(
+        (
+            role,
+            "",
+            f"AUTHORITY ORDER: {order}.",
+            *(f"- {line}" for line in PRECEDENCE_OWNERSHIP),
+            "A lower layer may refine emphasis. It may never add a subject, "
+            "comparator, factual claim, or obligation that conflicts with a "
+            "higher one.",
+        )
+    )
 
 _HEADLINE_HEADING = "## Headline note"
 _OUTLINE_FORM_HEADINGS = (
@@ -578,10 +624,10 @@ def assemble_v3_instructions(
             parts=[
                 (
                     "outline_authority",
-                    "OUTLINE AUTHORITY\nThe approved brief controls scope; the "
-                    "facts control available support; the form structure "
-                    "controls organization; the voice controls what kind of "
-                    "piece this is.",
+                    precedence_block(
+                        "OUTLINE AUTHORITY\nYou are planning, not writing. The "
+                        "voice below says what kind of piece this is."
+                    ),
                 ),
                 # The single largest change in the spec. Compose is obedient:
                 # give it a good plan and it writes well, give it an audit and
@@ -623,10 +669,10 @@ def assemble_v3_instructions(
             parts=[
                 (
                     "compose_authority",
-                    "COMPOSE AUTHORITY\nThe brief says what you are making. The "
-                    "facts below are the material you may make it from, and "
-                    "they constrain every factual claim absolutely. Form and "
-                    "style rules control expression.",
+                    precedence_block(
+                        "COMPOSE AUTHORITY\nThe brief says what you are making. "
+                        "The facts below are the material you may make it from."
+                    ),
                 ),
                 # The brief first, and evidence reframed. Evidence still binds
                 # the facts; it stops being the reason the article exists,
@@ -651,9 +697,11 @@ def assemble_v3_instructions(
             parts=[
                 (
                     "audit_authority",
-                    "AUDIT AUTHORITY\nJudge brief fidelity, form fit, reader "
-                    "service, and style. Treat the grounding verdict as final "
-                    "on support.",
+                    precedence_block(
+                        "AUDIT AUTHORITY\nJudge brief fidelity, form fit, reader "
+                        "service, and style against this order. Treat the "
+                        "grounding verdict as final on support."
+                    ),
                 ),
                 ("brief", f"APPROVED BRIEF\n{brief_body}"),
                 ("support", _packet_support_body(packet)),
@@ -697,5 +745,38 @@ def assemble_v3_instructions(
             "brief_fingerprint": brief.brief_fingerprint,
             "work_order_fingerprint": work_order.work_order_fingerprint,
             "evidence_receipt": evidence.receipt(),
+            # Resolved once, here, and frozen with the rest of the run's
+            # instructions. Outline, compose and the deterministic checks all
+            # read this rather than each resolving the form again -- and a
+            # resumed leg reads the policy the draft was written under, not
+            # whatever the form file says today.
+            "structure_policy": form.structure.model_dump(),
         },
     )
+
+
+def resolve_structure_policy(
+    instructions: dict[str, Any] | None,
+) -> FormStructurePolicy:
+    """The structure policy one run was frozen with.
+
+    Falls back to the old universal shape -- direct answer, three-plus
+    headings, takeaways -- when a run has no policy recorded, which is every
+    run started before forms carried one. That is deliberately the pre-change
+    behaviour rather than a refusal: an old run resumed after this shipped
+    should finish the article it started.
+    """
+    meta = _safe_meta(instructions).get("structure_policy")
+    if not isinstance(meta, dict) or not meta:
+        logger.warning(
+            "No structure policy recorded for this run; using the default shape"
+        )
+        return DEFAULT_STRUCTURE_POLICY
+    return FormStructurePolicy.model_validate(meta)
+
+
+def _safe_meta(instructions: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(instructions, dict):
+        return {}
+    meta = instructions.get("instruction_meta")
+    return meta if isinstance(meta, dict) else {}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/llm.py
@@ -6,7 +6,6 @@ from typing import Any, Protocol
 
 from app.shared.api_usage import observe_external_call, provider_for_llm
 from app.shared.model_calls import resolve
-from app.shared.text import enforce_anti_ai_tells_markdown
 from utils import get_vertex_llm, parse_json_response
 from .pricing import MEASURED_COST_KEY
 from .support import _safe_str
@@ -135,31 +134,6 @@ def _usage_with_measured_cost(llm: Any) -> Any:
     if cost is None or not isinstance(usage, dict):
         return usage
     return {**usage, MEASURED_COST_KEY: cost}
-
-
-def _enforce_anti_ai_markdown_with_model(
-    text: str,
-    *,
-    model_name: str | None,
-    max_tokens: int,
-    context: str,
-    usage_recorder: UsageRecorder | None = None,
-    job_id: str | None = None,
-    correlation_id: str | None = None,
-) -> str:
-    return enforce_anti_ai_tells_markdown(
-        text,
-        repair=lambda repair_prompt: _invoke_text_llm(
-            prompt=repair_prompt,
-            max_tokens=max_tokens,
-            temperature=0.1,
-            model_name=model_name,
-            usage_recorder=usage_recorder,
-            job_id=job_id,
-            correlation_id=correlation_id,
-        ),
-        context=context,
-    )
 
 
 # The parse error names what went wrong, so the excerpt only has to show the

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/packet_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/packet_v4.py
@@ -400,3 +400,58 @@ def build_packet(
             for item in brief.material
         ],
     )
+
+
+# What the checker is told about first-hand material, once, so the writer's
+# desk and the checker's desk describe it the same way.
+NO_SUPPLIED_MATERIAL = (
+    "None. Every factual statement in this draft must rest on the evidence "
+    "records above."
+)
+
+
+def supplied_material_text(packet: WritingPacket | dict[str, Any] | None) -> str:
+    """The operator's own words, rendered for a stage that is not compose.
+
+    Finding 01: compose received `brief.material` and grounding did not, so a
+    checker reading only the web records had no way to tell a legitimate
+    first-hand observation from an invented one. It could only call it
+    unsupported -- and repair is instructed to delete unsupported assertions,
+    which is how the one thing in the article nobody else could have written
+    gets removed.
+
+    Verbatim and by id, from the frozen packet rather than from the live
+    brief, so a resumed run checks the draft against the material the draft
+    was actually written from.
+
+    This is a hand-off, not a verification: the material is supplied
+    experience, not an independently checked fact, and the caller's prompt is
+    responsible for saying so.
+    """
+    if packet is None:
+        return NO_SUPPLIED_MATERIAL
+    if isinstance(packet, dict):
+        material = [
+            item if isinstance(item, dict) else {}
+            for item in (packet.get("supplied_material") or [])
+        ]
+        items = [
+            PacketMaterial(
+                kind=str(entry.get("kind") or "").strip() or "material",
+                statement=str(entry.get("statement") or "").strip(),
+                note=str(entry.get("note") or "").strip(),
+            )
+            for entry in material
+        ]
+        items = [item for item in items if item.statement]
+    else:
+        items = [item for item in packet.supplied_material if item.statement.strip()]
+
+    if not items:
+        return NO_SUPPLIED_MATERIAL
+
+    return "\n".join(
+        f"- material_{index} [{item.kind}] {item.statement}"
+        + (f" ({item.note})" if item.note else "")
+        for index, item in enumerate(items, start=1)
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -157,18 +157,42 @@ What does NOT count:
 - Uncertainty or qualification that the evidence record itself states.
 - Restatement or paraphrase of something a record does say.
 - Advice framed as judgement rather than fact.
+- Anything the SUPPLIED MATERIAL below covers, within the scope it states.
+
+First-hand material:
+The writer was given the material below by the person commissioning the
+article. It is their own experience, stated in their own words. It is not a
+web source and it was never sent to research, so no evidence record will
+mention it. Treat it as support, at the scope it states and no wider.
+- A statement resting on supplied material is supported, including a
+  paraphrase that keeps its scope. "I waited 45 minutes on my visit" supports
+  "the wait ran about forty-five minutes on a recent visit".
+- A statement that widens it into a general rule is NOT supported. The same
+  material does not support "everyone waits 45 minutes" or "expect a
+  45-minute wait".
+- Supplied material is experience, not a verified fact. Do not treat it as
+  confirming, correcting, or overriding an evidence record. Where the two
+  disagree, say so in `assessment`; do not resolve it and do not raise a
+  claim purely because they differ.
 
 Rules:
 - severity is "high" when a reader could be misled into a booking, spending,
   legal, or safety decision. Otherwise "low".
 - Quote the claim as it appears in the draft.
 - grounded is true only when there are no high-severity unsupported claims.
+- `grounded: false` requires at least one high-severity entry saying why.
+- severity is exactly "high" or "low". No other value is accepted.
+- `assessment` is always a non-empty sentence, including when nothing is
+  unsupported.
 - Do not rewrite the article.
 
 {evidence_disposition_policy}
 
 EVIDENCE RECORDS:
 {evidence_records}
+
+SUPPLIED MATERIAL (first-hand, from the commissioner):
+{supplied_material}
 
 DRAFT TITLE:
 {rewritten_title}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -25,7 +25,7 @@ Return strict JSON only:
 }}
 
 Rules:
-- Plan at least 3 and at most 12 sections.
+{structure_rules}
 - Headings must be specific and distinct. No generic "Introduction" or
   "Conclusion" headings.
 - Every section must name the claim_ids it rests on, using IDs from the facts
@@ -75,8 +75,14 @@ Return strict JSON only:
 }}
 
 Hard rules:
-- Every factual statement must trace to a claim in the evidence records.
-  Preserve attribution, dates, units, geography, and stated uncertainty.
+- Every figure, date, rule, price, duration, capacity, and named entity must
+  trace to a fact you were given. Preserve its dates, units, geography, and
+  the limits it states. General background a well-informed writer would state
+  without looking it up needs no fact behind it, and it is also not where this
+  article's value is.
+- Keep a limit that changes what the reader should do -- an as-of date, a
+  season, a route only some operators run. Drop confidence language that
+  changes nothing: no "it seems", no "arguably", no grading your own certainty.
 - Never invent a bridge fact, scene, quotation, experience, statistic, price,
   consensus, or practical detail. Follow the EVIDENCE DISPOSITION POLICY in
   the compose context exactly.
@@ -93,12 +99,7 @@ Hard rules:
 - Answer the core reader question and deliver the stated reader outcome.
 - Keep to the brief's spine, and name everything under must_name.
 - improved_content must not contain a `#` H1.
-- Use at least 3 `##` headings.
-- Include one direct 40-60 word answer near the top.
-- Include a concise takeaway section near the end. It synthesises the
-  decisions the article already supported, in fresh wording rather than copied
-  sentences. Never let a material fact, figure, or place appear there for the
-  first time.
+{structure_rules}
 - Follow the STYLE DIRECTIVE exactly. Tone, length, and brand voice are
   requirements, not suggestions.
 - Follow the SECTION PLAN when one is provided: use its headings, in order, and

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -334,40 +334,73 @@ DRAFT CONTENT:
 P2B_V3_REPAIR_PROMPT = """You are running a repair pass on a commissioned article.
 
 Goal:
-Fix the prose and structure the auditor flagged, without changing what the
-article is or what it claims.
+Fix what the auditor flagged, by replacing only the sections that need it.
 
 Return strict JSON only:
 {{
   "improved_title": "string",
-  "improved_content": "string",
+  "sections": [
+    {{
+      "section_id": "string",
+      "text_hash": "string",
+      "heading": "string",
+      "content": "string",
+      "claim_ids": ["string"]
+    }}
+  ],
   "brief_alignment_summary": "string",
   "improvements_applied": ["string"],
   "remaining_gaps": ["string"]
 }}
 
+How editing works here:
+- The article is listed below as a SECTION MAP. Return an entry only for a
+  section you are actually changing. Every section you do not return is kept
+  exactly as it is; you do not need to repeat it, and repeating it unchanged
+  only risks damaging it.
+- Copy `section_id` and `text_hash` from the map exactly. An entry whose id is
+  unknown, whose hash does not match, or which names the same section twice is
+  discarded, and the section keeps its current text.
+- `content` is the full replacement body for that section, without its `##`
+  heading line. `heading` changes the heading; omit it to keep the current one.
+  The opening block has no heading — leave `heading` empty for it.
+- You cannot add a section, delete one, or reorder them. That is a planning
+  decision and this pass does not hold the plan. Change length inside the
+  sections that exist.
+- A revision that needs several sections moved together must return all of
+  them. Do not fix half of a structural problem.
+
+Facts:
+- THE FACTS AVAILABLE below are the facts a person chose for this article.
+  You may use any of them, including ones the first draft left out — that is
+  the point of this list. Using a fact the draft omitted is not inventing one.
+- For every entry, `claim_ids` names the facts you added to that section which
+  were not already in it. An id that is not on the list is rejected with the
+  section.
+- You may not use anything else. No fact from anywhere but that list, and no
+  detail you are filling in from your own knowledge.
+- Preserve every limitation attached to a fact you use. A caveat is what makes
+  the fact true; dropping it turns a correct sentence into a confident wrong
+  one, and nothing downstream can put it back.
+- Naming a claim id does not license a sentence that says more than the claim
+  does. The draft is checked against the evidence again after this pass.
+
 Rules:
 - Resolve each required revision directly.
-- Change only the sections a revision is about. Return every other section
-  exactly as it was, word for word. A section nobody complained about is
-  working prose, and rewriting it to improve it is how a repair makes an
-  article worse.
 - A revision that states a length change gives the direction and the number of
   words. Move that way. Never lengthen a draft asked to be cut, or cut one
   asked to be lengthened.
-- Repair prose and structure only. You may not create a fact, and you may not
-  change the brief: not the form, the primary subject, the scope mode, the
-  reference roles, the approved scope, or the exclusions.
-- Never add factual material. Work only with facts already present in the
-  previous draft. Apply the EVIDENCE DISPOSITION POLICY in the repair lock
-  exactly, including deletion of every assertion under UNSUPPORTED CLAIMS.
+- Do not change the brief: not the form, the primary subject, the scope mode,
+  the reference roles, the approved scope, or the exclusions.
+- Apply the EVIDENCE DISPOSITION POLICY in the repair lock exactly, including
+  deletion of every assertion under UNSUPPORTED CLAIMS. Delete them; never
+  hedge, attribute, or label them.
 - Never promote a context-only reference, add a comparator, or broaden scope to
   satisfy a revision.
 - Never cite evidence records in the prose: no claim IDs, no source IDs, no
   numbered references, and no naming the outlet or publication a fact came
   from. An actor or institution in the story may be named; the reporter of it
   may not.
-- Keep complete article prose with clear `##` / `###` structure.
 
 REQUIRED REVISIONS:
 {required_revisions}
@@ -375,11 +408,19 @@ REQUIRED REVISIONS:
 UNSUPPORTED CLAIMS:
 {unsupported_claims}
 
+SECTIONS CONTAINING A FLAGGED CLAIM:
+{flagged_sections}
+
+SECTION MAP:
+{section_map}
+
 PREVIOUS TITLE:
 {previous_title}
 
 PREVIOUS CONTENT:
 {previous_content}
+
+{facts}
 
 {instructions}
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -888,52 +888,123 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+class GroundednessMalformed(ValueError):
+    """The checker answered, but not with a verdict anyone can read.
+
+    Raised rather than normalised. The whole point of finding 02 is that a
+    response nobody can read used to arrive downstream wearing a pass: `{}`
+    became `checked: true, grounded: true`, and an article nothing had checked
+    carried the stamp of one that had.
+    """
+
+
+# The only two severities the prompt offers. A third value means the response
+# was not written against the contract, and guessing which one it meant is how
+# a high-severity finding becomes a low one.
+_GROUNDEDNESS_SEVERITIES = ("high", "low")
+
+
+def _groundedness_claims(parsed: dict[str, Any]) -> list[dict[str, str]]:
+    """Read the findings list, or refuse the whole response.
+
+    One unreadable entry refuses everything. A findings list is a set of
+    reasons a draft should not ship, and silently dropping the entry that
+    could not be parsed shortens exactly that list.
+    """
+    claims_raw = parsed.get("unsupported_claims")
+    if not isinstance(claims_raw, list):
+        raise GroundednessMalformed("unsupported_claims is not a list")
+
+    claims: list[dict[str, str]] = []
+    for item in claims_raw:
+        if not isinstance(item, dict):
+            raise GroundednessMalformed("a finding is not an object")
+        claim = _safe_str(item.get("claim"))
+        if not claim:
+            raise GroundednessMalformed("a finding names no claim")
+        severity = _safe_str(item.get("severity")).lower()
+        if severity not in _GROUNDEDNESS_SEVERITIES:
+            raise GroundednessMalformed(f"unknown severity: {severity or 'missing'}")
+        claims.append(
+            {
+                "claim": claim,
+                "reason": _safe_str(item.get("reason")) or "Reason not stated.",
+                "severity": severity,
+            }
+        )
+    return claims
+
+
 def _sanitize_groundedness(parsed: dict[str, Any]) -> dict[str, Any]:
-    """Normalise the grounding check.
+    """Read the grounding check, or refuse it.
 
     The audit scored `too_close_to_source`, the plagiarism direction. Nothing
     checked the opposite direction: claims in the draft that the sources do not
     support. For travel content -- visa rules, prices, safety guidance -- that
     is the more consequential failure.
-    """
-    claims_raw = parsed.get("unsupported_claims")
-    claims: list[dict[str, str]] = []
-    if isinstance(claims_raw, list):
-        for item in claims_raw:
-            record = _safe_dict(item)
-            claim = _safe_str(record.get("claim"))
-            if not claim:
-                continue
-            severity = _safe_str(record.get("severity")).lower()
-            claims.append(
-                {
-                    "claim": claim,
-                    "reason": _safe_str(record.get("reason")) or "Reason not stated.",
-                    "severity": "high" if severity == "high" else "low",
-                }
-            )
 
+    Every field the verdict rests on is required, because the alternative is
+    the finding-02 behaviour: absence read as agreement. A response that fails
+    any of these is a `GroundednessMalformed`, and the stage turns that into
+    `unchecked` -- which readiness already treats as a blocker -- rather than
+    into a pass.
+
+    One normalisation survives, in the safe direction only: a response that
+    says `grounded: true` while naming a high-severity finding is trusted on
+    the finding. That keeps the finding on the record for repair to act on,
+    and it cannot manufacture a pass. The other direction -- `grounded: false`
+    with nothing to point at -- is refused, because a fail nobody can act on
+    and a pass are the same thing by the time repair reads it.
+    """
+    if not isinstance(parsed, dict) or not parsed:
+        raise GroundednessMalformed("empty response")
+
+    grounded_raw = parsed.get("grounded")
+    if not isinstance(grounded_raw, bool):
+        raise GroundednessMalformed("grounded is not a boolean")
+
+    assessment = _safe_str(parsed.get("assessment"))
+    if not assessment:
+        raise GroundednessMalformed("assessment is missing")
+
+    claims = _groundedness_claims(parsed)
     high_severity = [claim for claim in claims if claim["severity"] == "high"]
+    if not grounded_raw and not high_severity:
+        raise GroundednessMalformed(
+            "grounded is false but no high-severity claim explains why"
+        )
+
+    grounded = not high_severity
     return {
         "checked": True,
-        "grounded": not high_severity,
-        "assessment": _safe_str(parsed.get("assessment"))
-        or "Grounding assessment not provided.",
+        "grounded": grounded,
+        "status": "supported" if grounded else "unsupported",
+        "assessment": assessment,
         "unsupported_claims": claims,
         "high_severity_count": len(high_severity),
     }
 
 
-def unchecked_groundedness() -> dict[str, Any]:
-    """Result used when the grounding check could not run.
+def unchecked_groundedness(reason: str = "") -> dict[str, Any]:
+    """Result used when the grounding check could not run, or could not be read.
 
     Treated as grounded so a checker outage degrades the signal rather than
-    blocking the run, but recorded as unchecked so it is visible.
+    blocking the run, but recorded as unchecked so it is visible -- and
+    readiness reads `checked`, so an unchecked draft is never called verified.
+
+    `reason` says which of the two happened. "The provider failed" and "the
+    provider answered with something unreadable" are different problems with
+    different fixes, and the row that only says `checked: false` cannot tell
+    them apart.
     """
     return {
         "checked": False,
         "grounded": True,
-        "assessment": "Grounding check did not run.",
+        "status": "unchecked",
+        "assessment": "Grounding check did not run."
+        if not reason
+        else f"Grounding could not be completed: {reason}",
+        "unchecked_reason": reason,
         "unsupported_claims": [],
         "high_severity_count": 0,
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -144,3 +144,33 @@ EDITORIAL_AUGMENTATION_SCHEMA: dict[str, Any] = {
         },
     },
 }
+
+
+# The grounding call used to be asked in prose with nothing enforcing the
+# shape, and `{}` came back looking like a pass (finding 02). The schema is the
+# cheap half of the fix on providers that enforce one; `_sanitize_groundedness`
+# is the half that runs everywhere, and it is the one the verdict rests on.
+#
+# Stricter than the others on purpose. Everything named here is something the
+# verdict cannot be read without, so a schema that let it through would only be
+# moving the refusal one stage later.
+GROUNDEDNESS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["grounded", "assessment", "unsupported_claims"],
+    "properties": {
+        "grounded": {"type": "boolean"},
+        "assessment": {"type": "string"},
+        "unsupported_claims": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["claim", "reason", "severity"],
+                "properties": {
+                    "claim": {"type": "string"},
+                    "reason": {"type": "string"},
+                    "severity": {"type": "string", "enum": ["high", "low"]},
+                },
+            },
+        },
+    },
+}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -115,6 +115,39 @@ REWRITE_SCHEMA: dict[str, Any] = {
     },
 }
 
+# Repair no longer returns a whole article. It returns replacements for the
+# sections it is changing, and `apply_section_replacements` writes them into
+# the original document -- which is what makes "change only what was flagged"
+# a property of the code rather than a request in a prompt (finding 06).
+#
+# `improved_content` is deliberately absent: a model that can still return one
+# will, and the whole point is that it cannot hand back prose for sections
+# nobody asked about.
+REPAIR_SECTIONS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["sections"],
+    "properties": {
+        "improved_title": {"type": "string"},
+        "sections": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["section_id", "text_hash", "content"],
+                "properties": {
+                    "section_id": {"type": "string"},
+                    "text_hash": {"type": "string"},
+                    "heading": {"type": "string"},
+                    "content": {"type": "string"},
+                    "claim_ids": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+        "brief_alignment_summary": {"type": "string"},
+        "improvements_applied": {"type": "array", "items": {"type": "string"}},
+        "remaining_gaps": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
 EDITORIAL_COMPONENT_NAMES = (
     "pull_quote",
     "in_the_know_box",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -27,6 +27,7 @@ does not have to guess, so the canonical names are pinned and the alias table
 is left to keep serving the providers still being asked in prose.
 """
 
+import json
 from typing import Any
 
 # Compose requires at least three `##` headings, so `sections` is required --
@@ -84,6 +85,21 @@ V3_OUTLINE_SCHEMA: dict[str, Any] = {
         "unsupported_requirements": {"type": "array", "items": {"type": "string"}},
     },
 }
+
+
+def v3_outline_schema(*, min_sections: int, max_sections: int) -> dict[str, Any]:
+    """The outline shape for one run's approved form.
+
+    `minItems` used to be a literal 3 for every form, which is finding 07 in
+    the one place a provider enforces rather than requests: a Q&A that divides
+    into two was refused by the transport before any of our own checks could
+    have an opinion.
+    """
+    schema = json.loads(json.dumps(V3_OUTLINE_SCHEMA))
+    schema["properties"]["sections"]["minItems"] = min_sections
+    schema["properties"]["sections"]["maxItems"] = max_sections
+    return schema
+
 
 # Shared by compose and by repair: both return a whole rewritten article, and
 # both go through _sanitize_rewrite.

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -229,7 +229,7 @@ def _screen_section_edits(
     raw_sections: Any,
     *,
     allowed_claim_ids: set[str],
-) -> tuple[list[Any], list[dict[str, str]]]:
+) -> tuple[Any, list[dict[str, str]]]:
     """Drop edits that cite a fact this article was not written from.
 
     Finding 03 gives repair the packet and permission to use it. The boundary
@@ -242,7 +242,10 @@ def _screen_section_edits(
     that cannot be checked at all.
     """
     if not isinstance(raw_sections, list):
-        return [], []
+        # Handed straight on rather than flattened to an empty list, so the
+        # edit report says the response was the wrong shape instead of
+        # reporting a repair that proposed nothing.
+        return raw_sections, []
     kept: list[Any] = []
     rejected: list[dict[str, str]] = []
     for raw in raw_sections:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -25,6 +25,7 @@ from ...quality import (
 )
 from ...quality_v3 import v3_constraint_brief
 from ...content.markdown import sections_changed
+from ...content.style_cleanup import clean_up_style
 from ...content.sections import (
     apply_section_replacements,
     locate_claims,
@@ -363,14 +364,18 @@ def run_v3_repair_stage(
     # A pass that changed nothing is now a visible outcome instead of a draft
     # that looks repaired.
     touched = sections_changed(previous_content, repaired["improved_content"])
-    # The same model that just wrote this text: the enforcement pass is another
-    # rewrite of it, not a separate judgement.
-    repaired["improved_content"] = dependencies.llm.enforce_anti_ai(
+    # And the style cleanup edits sections too (finding 05), on the same model
+    # that just wrote the text: this is another pass over it, not a separate
+    # judgement. It is given the repair lock, so the caveats a repaired
+    # sentence is carrying are visible to the pass tidying it.
+    repaired["improved_content"], style_report = clean_up_style(
         repaired["improved_content"],
+        dependencies=dependencies,
         job_id="p2b.repair",
         model_name=repair_model,
-        max_tokens=6144,
+        max_tokens=4096,
         context="prompt2blog v3 repair",
+        guard=stage_context_text(state["stage_contexts"], "repair_lock"),
     )
     _append_stage_trace(
         state["trace"],
@@ -381,6 +386,7 @@ def run_v3_repair_stage(
             "attempt": attempt,
             "sections_touched": touched,
             "section_edits": edit_report,
+            "style_cleanup": style_report,
         },
         prompt=prompt,
         raw_response=raw_response,
@@ -397,6 +403,7 @@ def run_v3_repair_stage(
             "required_revisions": required_revisions,
             "unsupported_claims": unsupported_claims,
             "section_edits": edit_report,
+            "style_cleanup": style_report,
             "raw_response": raw_response,
         },
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -25,8 +25,14 @@ from ...quality import (
 )
 from ...quality_v3 import v3_constraint_brief
 from ...content.markdown import sections_changed
-from ...schemas import REWRITE_SCHEMA
-from ...support import _format_style_directive, _json
+from ...content.sections import (
+    apply_section_replacements,
+    locate_claims,
+    section_manifest,
+    segment_article,
+)
+from ...schemas import REPAIR_SECTIONS_SCHEMA
+from ...support import _format_style_directive, _json, _safe_dict, _safe_str
 
 
 # The measurements are deterministic and cheap, so they run before the audit
@@ -209,15 +215,69 @@ def run_v3_quality_audit_stage(
     return updates
 
 
+def _packet_claim_ids(state: Prompt2BlogV3GraphState) -> set[str]:
+    packet = state.get("packet") or {}
+    return {
+        _safe_str(fact.get("claim_id"))
+        for fact in (packet.get("facts") or [])
+        if isinstance(fact, dict) and _safe_str(fact.get("claim_id"))
+    }
+
+
+def _screen_section_edits(
+    raw_sections: Any,
+    *,
+    allowed_claim_ids: set[str],
+) -> tuple[list[Any], list[dict[str, str]]]:
+    """Drop edits that cite a fact this article was not written from.
+
+    Finding 03 gives repair the packet and permission to use it. The boundary
+    that makes that safe is that the packet is the whole permission: an id
+    from the wider dossier names a fact a person deliberately cut, and an id
+    that names nothing at all is a fact the model supplied itself.
+
+    An id is not proof the sentence means what the claim means -- grounding
+    runs again on the assembled article for that. This only refuses the ones
+    that cannot be checked at all.
+    """
+    if not isinstance(raw_sections, list):
+        return [], []
+    kept: list[Any] = []
+    rejected: list[dict[str, str]] = []
+    for raw in raw_sections:
+        record = _safe_dict(raw)
+        cited = [
+            _safe_str(item)
+            for item in (record.get("claim_ids") or [])
+            if _safe_str(item)
+        ]
+        unknown = sorted(set(cited) - allowed_claim_ids)
+        if unknown:
+            rejected.append(
+                {
+                    "section_id": _safe_str(record.get("section_id")) or "(missing)",
+                    "reason": f"cites facts outside the packet: {', '.join(unknown)}",
+                }
+            )
+            continue
+        kept.append(raw)
+    return kept, rejected
+
+
 def run_v3_repair_stage(
     state: Prompt2BlogV3GraphState,
     dependencies: PipelineDependencies,
 ) -> dict[str, Any]:
-    """Repair prose and structure only.
+    """Repair the sections the auditor named, and only those.
 
-    Repair can never create a fact or change the brief, so an unsupported
-    claim is deleted rather than hedged or replaced. Research gaps remain
-    metadata; the reader never sees the pipeline narrate its own absence.
+    Two findings meet here. Repair no longer returns a whole article (06): it
+    returns replacements for named sections, and the code applies them to the
+    original document, so prose nobody complained about is the original bytes
+    rather than a promise. And it can now reach the facts a person chose for
+    this article (03), including the ones the first draft left out, which is
+    what makes a revision like "support the comparison" answerable at all.
+
+    The draft it produces is re-grounded and re-audited exactly as before.
     """
     stage = "stage_v3_repair"
     run_id = state["run_id"]
@@ -246,16 +306,24 @@ def run_v3_repair_stage(
         ]
     unsupported_claims = list(groundedness["unsupported_claims"])
 
+    previous_content = rewrite["improved_content"]
+    sections = segment_article(previous_content)
+    flagged = locate_claims(sections, unsupported_claims)
+
     prompt = P2B_V3_REPAIR_PROMPT.format(
         required_revisions=_json(required_revisions),
         unsupported_claims=_json(unsupported_claims),
+        flagged_sections=_json(flagged) if flagged else "None located by quote.",
+        section_map=section_manifest(sections),
         previous_title=rewrite["improved_title"],
-        previous_content=rewrite["improved_content"],
+        previous_content=previous_content,
+        facts=stage_context_text(state["stage_contexts"], "repair_facts")
+        or "THE FACTS AVAILABLE TO THIS REPAIR\n- None recorded for this run.",
         instructions=stage_context_text(state["stage_contexts"], "repair_lock"),
         style_directive=_format_style_directive(state["option_context"]),
     )
-    # Repair rewrites the whole article, so it runs on a prose model -- the
-    # writer's, unless the route named a different one.
+    # Repair rewrites prose, so it runs on a prose model -- the writer's,
+    # unless the route named a different one.
     #
     # Worth being separable from the draft: the two are not the same job. The
     # draft writes into an open space; repair is handed a list of required
@@ -269,22 +337,32 @@ def run_v3_repair_stage(
         max_tokens=6144,
         temperature=0.1,
         model_name=repair_model,
-        schema=REWRITE_SCHEMA,
+        schema=REPAIR_SECTIONS_SCHEMA,
     )
+    parsed_dict = _safe_dict(parsed)
+    screened, cited_rejections = _screen_section_edits(
+        parsed_dict.get("sections"),
+        allowed_claim_ids=_packet_claim_ids(state),
+    )
+    edit = apply_section_replacements(previous_content, screened)
+    edit_report = {
+        **edit.as_dict(),
+        "rejected": [*edit.as_dict()["rejected"], *cited_rejections],
+        "section_count": len(sections),
+    }
+
     repaired = _sanitize_rewrite(
-        parsed,
+        {
+            **parsed_dict,
+            "improved_content": edit.content,
+        },
         fallback_title=rewrite["improved_title"],
-        fallback_content=rewrite["improved_content"],
+        fallback_content=previous_content,
     )
-    # Repair may change what the auditor named and nothing else. Checked rather
-    # than trusted: the point of scoping repair is that it cannot damage
-    # working prose, and a pass that quietly rewrites a section nobody
-    # complained about has done exactly that. Recorded rather than rejected --
-    # keep-best already refuses a worse draft, and refusing here would throw
-    # away a repair that fixed the real problem too.
-    touched = sections_changed(
-        rewrite["improved_content"], repaired["improved_content"]
-    )
+    # Which sections moved, from the applied edits rather than from a diff.
+    # A pass that changed nothing is now a visible outcome instead of a draft
+    # that looks repaired.
+    touched = sections_changed(previous_content, repaired["improved_content"])
     # The same model that just wrote this text: the enforcement pass is another
     # rewrite of it, not a separate judgement.
     repaired["improved_content"] = dependencies.llm.enforce_anti_ai(
@@ -299,7 +377,11 @@ def run_v3_repair_stage(
         state["include_debug"],
         stage=stage,
         model_name=repair_model,
-        input_payload={"attempt": attempt, "sections_touched": touched},
+        input_payload={
+            "attempt": attempt,
+            "sections_touched": touched,
+            "section_edits": edit_report,
+        },
         prompt=prompt,
         raw_response=raw_response,
         parsed=parsed,
@@ -309,17 +391,21 @@ def run_v3_repair_stage(
         run_id,
         stage,
         {
-            "repair_applied": True,
+            "repair_applied": edit.changed,
             "attempt": attempt,
             "rewrite": repaired,
             "required_revisions": required_revisions,
             "unsupported_claims": unsupported_claims,
+            "section_edits": edit_report,
             "raw_response": raw_response,
         },
     )
     return {
         "current_stage": stage,
-        "repair_applied": True,
+        # False when every proposed edit was refused. The run still continues
+        # -- the existing draft is intact and saveable -- but the receipt does
+        # not claim a repair that did not happen.
+        "repair_applied": edit.changed,
         "repair_attempts": attempt,
         "rewrite": repaired,
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
@@ -10,6 +10,7 @@ from ...instructions_v3 import resolve_structure_policy, stage_context_text
 from ...observability import _append_stage_trace
 from ...prompts.editorial_v3 import P2B_V3_COMPOSE_PROMPT
 from ...prompts.generation import SEO_SAFE_CONTENT_GENERATION_GUIDELINES
+from ...content.style_cleanup import clean_up_style
 from ...quality import _sanitize_rewrite
 from ...schemas import REWRITE_SCHEMA
 from ...support import _format_style_directive, _safe_dict, _target_word_count
@@ -85,18 +86,28 @@ def run_v3_compose_stage(
         fallback_title=state["brief"]["seed"],
         fallback_content="",
     )
-    rewrite["improved_content"] = dependencies.llm.enforce_anti_ai(
+    # Style cleanup, scoped to the sections that actually failed (finding 05).
+    # It used to hand the whole article back to a model with the error list
+    # and nothing else -- no brief, no facts, no caveats -- which is how a
+    # pass sent to remove an em dash could flatten a carefully dated sentence.
+    rewrite["improved_content"], style_report = clean_up_style(
         rewrite["improved_content"],
+        dependencies=dependencies,
         job_id="p2b.compose",
         model_name=state["writing_model"],
-        max_tokens=6144,
+        max_tokens=4096,
         context="prompt2blog v3 compose",
+        guard=stage_context_text(state["stage_contexts"], "repair_lock"),
     )
 
     dependencies.recorder.record_stage(
         run_id,
         stage,
-        {"rewrite": rewrite, "raw_response": raw_response},
+        {
+            "rewrite": rewrite,
+            "style_cleanup": style_report,
+            "raw_response": raw_response,
+        },
     )
     _append_stage_trace(
         state["trace"],
@@ -110,6 +121,7 @@ def run_v3_compose_stage(
             "structure_policy": structure.model_dump(),
             "style_directive": style_directive,
             "prompt_sizes": prompt_sizes,
+            "style_cleanup": style_report,
         },
         prompt=prompt,
         raw_response=raw_response,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/compose.py
@@ -6,7 +6,7 @@ from app.shared.prompts import ANTI_AI_TELLS_FULL
 
 from ...dependencies import PipelineDependencies
 from ...graph.state import Prompt2BlogV3GraphState
-from ...instructions_v3 import stage_context_text
+from ...instructions_v3 import resolve_structure_policy, stage_context_text
 from ...observability import _append_stage_trace
 from ...prompts.editorial_v3 import P2B_V3_COMPOSE_PROMPT
 from ...prompts.generation import SEO_SAFE_CONTENT_GENERATION_GUIDELINES
@@ -32,8 +32,15 @@ def run_v3_compose_stage(
     style_directive = _format_style_directive(
         state["option_context"], keys=("length",)
     )
+    # The approved form's own shape, not one shape for every article. Compose
+    # used to require a direct answer, three headings and closing takeaways
+    # whatever the brief asked for, which is why a profile and a service guide
+    # came back looking like the same piece (finding 07).
+    structure = resolve_structure_policy(state.get("instructions"))
+    structure_rules = structure.compose_rules()
     prompt = P2B_V3_COMPOSE_PROMPT.format(
         outline=state["outline_text"],
+        structure_rules=structure_rules,
         target_word_count=_target_word_count(_safe_dict(state["option_context"]))
         or "Not specified.",
         instructions=stage_context_text(state["stage_contexts"], "compose"),
@@ -54,6 +61,7 @@ def run_v3_compose_stage(
         "seo_guideline": len(SEO_SAFE_CONTENT_GENERATION_GUIDELINES),
         "style_directive": len(style_directive),
         "anti_ai_rules": len(ANTI_AI_TELLS_FULL),
+        "structure_rules": len(structure_rules),
         "total": len(prompt),
     }
     # What the template itself costs, once everything it carries is subtracted.
@@ -99,6 +107,7 @@ def run_v3_compose_stage(
             "brief_fingerprint": state["brief"]["brief_fingerprint"],
             "form_id": state["brief"]["form_id"],
             "outline_accepted": state.get("outline_accepted", False),
+            "structure_policy": structure.model_dump(),
             "style_directive": style_directive,
             "prompt_sizes": prompt_sizes,
         },

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
@@ -9,10 +9,35 @@ from ...dependencies import PipelineDependencies
 from ...graph.state import Prompt2BlogV3GraphState
 from ...instructions_v3 import EVIDENCE_DISPOSITION_POLICY
 from ...observability import _append_stage_trace
+from ...packet_v4 import supplied_material_text
 from ...prompts.editorial_v3 import P2B_V3_GROUNDEDNESS_PROMPT
-from ...quality import _sanitize_groundedness, unchecked_groundedness
+from ...quality import (
+    GroundednessMalformed,
+    _sanitize_groundedness,
+    unchecked_groundedness,
+)
+from ...schemas import GROUNDEDNESS_SCHEMA
 
 logger = logging.getLogger(__name__)
+
+# One retry, not a loop. A malformed verdict is usually a formatting slip the
+# same call gets right the second time; a checker that cannot answer the
+# contract twice is not going to answer it on the fifth attempt, and every
+# further attempt spends the repair budget on the stage that is not writing.
+GROUNDEDNESS_MALFORMED_ATTEMPTS = 2
+
+# Appended for the retry only. The first call is asked in the ordinary way; a
+# response that failed validation gets told which contract it missed, because
+# "return JSON" is what it already did.
+_MALFORMED_RETRY_NOTE = """
+YOUR PREVIOUS RESPONSE WAS REJECTED:
+{reason}
+
+Return the object exactly as specified above. `grounded` must be a boolean,
+`assessment` must be a non-empty sentence, and every entry in
+`unsupported_claims` must carry `claim`, `reason`, and a `severity` of
+exactly "high" or "low". If nothing is unsupported, return an empty list and
+`grounded: true` -- never `grounded: false` with no claim explaining it."""
 
 
 def check_v3_groundedness(
@@ -27,54 +52,105 @@ def check_v3_groundedness(
     V2 compared a draft with cleaned source prose, which had already lost
     publisher, date, and qualification. V3 compares it with the records
     themselves, so an overstated date or a widened claim is visible.
+
+    The checker also reads the first-hand material the writer was given
+    (finding 01). Without it the two halves of the run were looking at
+    different desks: compose could legitimately use "I waited 45 minutes" from
+    the brief, and the checker, seeing no record of it, could only call it
+    invented -- after which repair is instructed to delete it.
     """
     run_id = state["run_id"]
-    prompt = P2B_V3_GROUNDEDNESS_PROMPT.format(
+    base_prompt = P2B_V3_GROUNDEDNESS_PROMPT.format(
         evidence_disposition_policy=EVIDENCE_DISPOSITION_POLICY,
         evidence_records=state["evidence"]["records_text"],
+        supplied_material=supplied_material_text(state.get("packet")),
         rewritten_title=rewrite["improved_title"],
         rewritten_content=rewrite["improved_content"],
     )
 
+    groundedness_model = state.get("groundedness_model")
+    prompt = base_prompt
     raw_response = ""
-    groundedness_model = state.get(
-        "groundedness_model"
-    )
-    try:
-        parsed, raw_response = dependencies.llm.invoke_json(
-            job_id="p2b.groundedness",
-            prompt=prompt,
-            max_tokens=2048,
-            temperature=0.0,
-            model_name=groundedness_model,
-        )
-        groundedness = _sanitize_groundedness(parsed)
+    rejected: list[str] = []
+
+    for attempt in range(1, GROUNDEDNESS_MALFORMED_ATTEMPTS + 1):
+        try:
+            parsed, raw_response = dependencies.llm.invoke_json(
+                job_id="p2b.groundedness",
+                prompt=prompt,
+                max_tokens=2048,
+                temperature=0.0,
+                model_name=groundedness_model,
+                schema=GROUNDEDNESS_SCHEMA,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # A dead account is not a checker outage. Degrading here would
+            # record "the check did not run" -- which reads as a checker
+            # problem -- and then spend the next stage's call on the same
+            # exhausted credential.
+            if is_fatal_provider_fault(exc):
+                raise
+            logger.warning("Prompt2Blog v3 groundedness check failed: %s", exc)
+            groundedness = unchecked_groundedness(f"provider call failed: {exc}")
+            _append_stage_trace(
+                state["trace"],
+                state["include_debug"],
+                stage=stage,
+                model_name=groundedness_model,
+                prompt=prompt,
+                error=str(exc),
+                output=groundedness,
+            )
+            break
+
+        try:
+            groundedness = _sanitize_groundedness(parsed)
+        except GroundednessMalformed as exc:
+            # Recorded, not swallowed. A run whose checker never produced a
+            # readable verdict should say so on its own receipt rather than
+            # arrive at finalize looking like a run nobody checked for no
+            # reason.
+            reason = str(exc)
+            rejected.append(reason)
+            logger.warning(
+                "Prompt2Blog v3 groundedness response rejected (attempt %d): %s",
+                attempt,
+                reason,
+            )
+            _append_stage_trace(
+                state["trace"],
+                state["include_debug"],
+                stage=stage,
+                model_name=groundedness_model,
+                input_payload={"attempt": attempt},
+                prompt=prompt,
+                raw_response=raw_response,
+                parsed=parsed,
+                error=f"malformed groundedness response: {reason}",
+            )
+            if attempt < GROUNDEDNESS_MALFORMED_ATTEMPTS:
+                prompt = base_prompt + _MALFORMED_RETRY_NOTE.format(reason=reason)
+                continue
+            groundedness = unchecked_groundedness(
+                f"checker returned an unreadable verdict ({'; '.join(rejected)})"
+            )
+            break
+
         _append_stage_trace(
             state["trace"],
             state["include_debug"],
             stage=stage,
             model_name=groundedness_model,
+            input_payload={"attempt": attempt},
             prompt=prompt,
             raw_response=raw_response,
             parsed=parsed,
             output=groundedness,
         )
-    except Exception as exc:  # noqa: BLE001
-        # A dead account is not a checker outage. Degrading here would record
-        # "the check did not run" -- which reads as a checker problem -- and
-        # then spend the next stage's call on the same exhausted credential.
-        if is_fatal_provider_fault(exc):
-            raise
-        logger.warning("Prompt2Blog v3 groundedness check failed: %s", exc)
-        groundedness = unchecked_groundedness()
-        _append_stage_trace(
-            state["trace"],
-            state["include_debug"],
-            stage=stage,
-            model_name=groundedness_model,
-            prompt=prompt,
-            error=str(exc),
-        )
+        break
+
+    if rejected:
+        groundedness = {**groundedness, "rejected_responses": rejected}
 
     dependencies.recorder.record_stage(
         run_id,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -14,10 +14,10 @@ from ...content.outline_v3 import (
 )
 from ...dependencies import PipelineDependencies
 from ...graph.state import Prompt2BlogV3GraphState
-from ...instructions_v3 import stage_context_text
+from ...instructions_v3 import resolve_structure_policy, stage_context_text
 from ...observability import _append_stage_trace
 from ...prompts.editorial_v3 import P2B_V3_OUTLINE_PROMPT
-from ...schemas import V3_OUTLINE_SCHEMA
+from ...schemas import v3_outline_schema
 from ...support import _safe_dict, _section_budget, _target_word_count
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,10 @@ def run_v3_outline_stage(
         fact["claim_id"] for fact in (state["packet"].get("facts") or [])
     }
     target_word_count = _target_word_count(_safe_dict(state["option_context"]))
+    # The approved form decides how many sections this article divides into,
+    # and whether it plans a direct answer and takeaways at all. Frozen with
+    # the run's instructions, so a resumed leg plans to the same shape.
+    structure = resolve_structure_policy(state.get("instructions"))
     outline = dict(EMPTY_OUTLINE)
     candidate = dict(EMPTY_OUTLINE)
     diagnostics: dict[str, Any] = {}
@@ -63,6 +67,7 @@ def run_v3_outline_stage(
 
     prompt = P2B_V3_OUTLINE_PROMPT.format(
         instructions=stage_context_text(state["stage_contexts"], "outline"),
+        structure_rules=structure.outline_rules(),
         target_word_count=target_word_count or "Not specified.",
         section_budget=_section_budget(_safe_dict(state["option_context"]))
         or "Not specified.",
@@ -75,14 +80,20 @@ def run_v3_outline_stage(
             max_tokens=2048,
             temperature=0.1,
             model_name=outline_model,
-            schema=V3_OUTLINE_SCHEMA,
+            schema=v3_outline_schema(
+                min_sections=structure.min_sections,
+                max_sections=structure.max_sections,
+            ),
         )
-        candidate = sanitize_v3_outline(parsed)
+        candidate = sanitize_v3_outline(
+            parsed, max_sections=structure.max_sections
+        )
         accepted, diagnostics = validate_v3_outline(
             candidate,
             work_order=state["work_order"],
             claim_ids=allowed_claim_ids,
             target_word_count=target_word_count,
+            min_sections=structure.min_sections,
         )
         if accepted:
             outline = candidate
@@ -99,6 +110,7 @@ def run_v3_outline_stage(
                     work_order=state["work_order"],
                     claim_ids=allowed_claim_ids,
                     target_word_count=target_word_count,
+                    min_sections=structure.min_sections,
                 )
                 if repaired_accepted:
                     logger.warning(
@@ -162,6 +174,7 @@ def run_v3_outline_stage(
             "repaired": repaired,
             "dropped_headings": dropped_headings,
             "checks": diagnostics,
+            "structure_policy": structure.model_dump(),
             "raw_response": raw_response,
         },
     )

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
@@ -3,6 +3,9 @@ id: analysis
 label: Analysis
 summary: Answers a real question about a place and commits to the answer.
 order: 2
+opening: form-led
+sections: 3-12
+closing: form-led
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/comparison.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/comparison.md
@@ -3,6 +3,9 @@ id: comparison
 label: Comparison
 summary: Evaluates approved co-subjects against consistent criteria for a defined choice.
 order: 12
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/cost-budget-breakdown.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/cost-budget-breakdown.md
@@ -3,6 +3,9 @@ id: cost-budget-breakdown
 label: "Cost & Budget Breakdown"
 summary: Builds a dated, transparent budget from defined assumptions and sourced costs.
 order: 15
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/curated-list-best-of.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/curated-list-best-of.md
@@ -3,6 +3,9 @@ id: curated-list-best-of
 label: Curated List/Best Of
 summary: Selects and explains a bounded set of options using explicit editorial criteria.
 order: 11
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/destination-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/destination-guide.md
@@ -3,6 +3,9 @@ id: destination-guide
 label: Destination Guide
 summary: Gives a coherent planning overview of one approved destination.
 order: 8
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/explainer.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/explainer.md
@@ -3,6 +3,9 @@ id: explainer
 label: Explainer
 summary: Makes a complex system, rule, event, or travel concept understandable.
 order: 3
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/feature-profile.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/feature-profile.md
@@ -3,6 +3,9 @@ id: feature-profile
 label: Feature/Profile
 summary: Builds a reported narrative around a person, place, community, or phenomenon.
 order: 4
+opening: form-led
+sections: 3-12
+closing: form-led
 source_gate: reported-people-scenes-quotations
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/how-to-checklist.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/how-to-checklist.md
@@ -3,6 +3,9 @@ id: how-to-checklist
 label: How-To/Checklist
 summary: Guides readers through a bounded task with verified steps and checkpoints.
 order: 14
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/interview-qa.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/interview-qa.md
@@ -3,6 +3,9 @@ id: interview-qa
 label: Interview/Q&A
 summary: Presents attributable answers from a named interview around a focused reader question.
 order: 5
+opening: form-led
+sections: 2-12
+closing: form-led
 source_gate: attributable-responses
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/itinerary.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/itinerary.md
@@ -3,6 +3,9 @@ id: itinerary
 label: Itinerary
 summary: Sequences a realistic trip plan across an approved time window and geography.
 order: 10
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/news-report.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/news-report.md
@@ -3,6 +3,9 @@ id: news-report
 label: News Report
 summary: Reports a timely development, what changed, and what readers should know now.
 order: 1
+opening: direct-answer
+sections: 2-12
+closing: form-led
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/opinion-column.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/opinion-column.md
@@ -3,6 +3,9 @@ id: opinion-column
 label: Opinion/Column
 summary: Advances a clearly identified viewpoint using evidence and transparent reasoning.
 order: 6
+opening: form-led
+sections: 2-12
+closing: form-led
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/personal-essay-travelogue.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/personal-essay-travelogue.md
@@ -3,6 +3,9 @@ id: personal-essay-travelogue
 label: Personal Essay/Travelogue
 summary: Shapes supplied lived experience into a reflective journey grounded in real events.
 order: 7
+opening: form-led
+sections: 2-12
+closing: form-led
 source_gate: first-person-material
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/review.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/review.md
@@ -3,6 +3,9 @@ id: review
 label: Review
 summary: Evaluates a specific experience, service, place, or product against declared criteria.
 order: 13
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 source_gate: documented-evaluation
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/service-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/service-guide.md
@@ -3,6 +3,9 @@ id: service-guide
 label: Service Guide
 summary: Helps a defined reader solve one practical travel problem or decision.
 order: 9
+opening: direct-answer
+sections: 3-12
+closing: takeaways
 ---
 
 ## Use when

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/house-rules.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/house-rules.md
@@ -1,23 +1,19 @@
 ---
 id: house-rules
 label: Prompt2Blog house rules
-summary: Sets publication-wide standards for authority, scope, evidence, usefulness, and prose.
+summary: Sets publication-wide standards for brief fidelity, evidence, usefulness, and prose.
 order: 1
 ---
 
 # Prompt2Blog house rules
 
-## Authority order
+## Brief fidelity
 
-Follow this order: verified evidence, approved commission, article-form rules, topic modules, audience guidance, then house style. A lower layer may refine emphasis but cannot add a subject, comparator, factual claim, or obligation that conflicts with a higher layer.
-
-## Commission fidelity
-
-Preserve original title, location, approved direction, primary subject, scope mode, reference roles, requirements, and exclusions. Answer the core reader question. Context-only references may calibrate a fact or explain significance; they cannot become co-subjects, recurring sections, rankings, or verdicts. Do not change form because source material suggests another article.
+Preserve the approved brief: location, spine, primary subject, scope mode, reference roles, and everything under must name. Answer the core reader question and deliver the promised outcome. Context-only references may calibrate a fact or explain significance; they cannot become co-subjects, recurring sections, rankings, or verdicts. Do not change form because source material suggests another article.
 
 ## Evidence discipline
 
-Use only claims supported by the evidence package. Preserve source meaning, dates, geography, units, uncertainty, and conflicts. Attribution is internal to the evidence record: the prose never names a source, outlet, publication, or site. Never invent a bridge fact, scene, quotation, experience, statistic, price, consensus, or practical detail. Missing support remains a visible gap. Prefer a narrower true article over a complete-looking unsupported one.
+Use only claims the facts you were given support. Preserve their meaning, dates, geography, units, and stated uncertainty. Attribution is internal to the evidence record: the prose never names a source, outlet, publication, or site. Never invent a bridge fact, scene, quotation, experience, statistic, price, consensus, or practical detail. A point the evidence does not support is left out of the article — not hedged, not labelled unconfirmed, not narrated as something research could not establish. Prefer a narrower true article over a complete-looking unsupported one.
 
 ## Reader service
 
@@ -29,8 +25,4 @@ Use direct, specific language and varied, readable paragraphs. Lead sections wit
 
 ## Safety and fairness
 
-Do not overstate medical, legal, financial, immigration, safety, accessibility, or environmental advice. Identify the deciding authority and limits. Describe people and communities precisely, without exoticism or treating one voice as representative. Disclose uncertainty and material conflicts.
-
-## Completion standard
-
-Every required question must be supported, explicitly partial, or missing. A draft is ready only when its central answer, structure, factual claims, headline, and practical guidance remain inside the approved commission and verified evidence.
+Do not overstate medical, legal, financial, immigration, safety, accessibility, or environmental advice. Identify the deciding authority and limits. Describe people and communities precisely, without exoticism or treating one voice as representative. State a limit that changes what the reader should do; a material conflict the evidence leaves unsettled is not written as settled.

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/voice/questurian-voice.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/voice/questurian-voice.md
@@ -39,8 +39,12 @@ makes it and says what the call costs.
 no restating the heading. It respects that you came for something.
 
 **It knows the difference between what it knows and what it's guessing** — and
-leaves the second thing out. It never hedges, never armours a claim, never asks
-you to grade its confidence.
+leaves the second thing out. What it does know, it says plainly and with its
+real limits attached: the price as of a month, the route only two operators
+run, the hours that change out of season. A limit that would change your
+decision is part of the fact, not a hedge on it. What it never does is pad a
+claim it cannot stand behind — no "it seems", no "arguably", no asking you to
+grade how sure it is.
 
 **It never talks about itself.** Not about its research, not about how it knows
 something, not about what it couldn't find out. The reader is here for the

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_form_structure.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_form_structure.py
@@ -1,0 +1,176 @@
+"""Finding 07: the article's shape now comes from its approved form.
+
+Every article used to open with a 40-60 word direct answer, carry at least
+three `##` headings, and close with takeaways. That is a service guide. It was
+also a profile, an essay, a column and a Q&A, because the rule lived in the
+compose prompt, the outline schema and the outline validator, none of which
+had ever been told which form was approved.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, get_args
+
+import pytest
+
+from app.features.prompt2blog.contracts_v4 import ArticleFormId, Prompt2BlogV4Request
+from app.features.prompt2blog.content.outline_v3 import (
+    sanitize_v3_outline,
+    validate_v3_outline,
+)
+from app.features.prompt2blog.editorial_catalog import (
+    DEFAULT_STRUCTURE_POLICY,
+    FormStructurePolicy,
+    load_editorial_catalog,
+)
+from app.features.prompt2blog.instructions_v3 import resolve_structure_policy
+from app.features.prompt2blog.schemas import v3_outline_schema
+from tests.prompt2blog_packet_support import runtime_for
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v4.json"
+)
+
+
+def _forms() -> dict[str, Any]:
+    return {form.id: form for form in load_editorial_catalog().forms}
+
+
+def _runtime_for_form(form_id: str):
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    fixture["brief"]["form_id"] = form_id
+    return runtime_for(
+        Prompt2BlogV4Request.model_validate(
+            {
+                "schema_version": 4,
+                "brief": fixture["brief"],
+                "work_order": fixture["work_order"],
+                "evidence_package": fixture["evidence_package"],
+                "profiles": {"length_id": "medium", "creativity_level": "medium"},
+            }
+        )
+    )
+
+
+def test_every_form_declares_its_own_structure():
+    forms = _forms()
+    assert set(forms) == set(get_args(ArticleFormId))
+    for form_id, form in forms.items():
+        assert isinstance(form.structure, FormStructurePolicy), form_id
+
+
+def test_a_service_guide_keeps_the_answer_and_the_takeaways():
+    rules = _forms()["service-guide"].structure.compose_rules()
+
+    assert "direct 40-60 word answer" in rules
+    assert "takeaway section" in rules
+
+
+def test_a_profile_is_not_forced_into_the_service_guide_shape():
+    structure = _forms()["feature-profile"].structure
+    rules = structure.compose_rules()
+
+    assert structure.opening == "form-led"
+    assert structure.closing == "form-led"
+    assert "40-60 word answer" not in rules
+    assert "Close with a concise takeaway section" not in rules
+    # It still has to open on something real. "Form-led" is not "start
+    # wherever"; that would trade one bad default for no default at all.
+    assert "concrete and supported" in rules
+
+
+def test_no_form_licenses_invented_material_to_fill_its_shape():
+    for form_id, form in _forms().items():
+        assert "never licenses an invented scene" in form.structure.compose_rules(), (
+            form_id
+        )
+
+
+def test_an_interview_may_divide_into_two_sections():
+    structure = _forms()["interview-qa"].structure
+    assert structure.min_sections == 2
+
+    outline = sanitize_v3_outline(
+        {
+            "working_title": "Two questions",
+            "sections": [
+                {"heading": "On the route", "claim_ids": [], "target_words": 400},
+                {"heading": "On the price", "claim_ids": [], "target_words": 400},
+            ],
+        },
+        max_sections=structure.max_sections,
+    )
+    accepted, checks = validate_v3_outline(
+        outline,
+        work_order={"primary_subject": "", "scope": {"references": []}},
+        claim_ids=set(),
+        target_word_count=0,
+        min_sections=structure.min_sections,
+    )
+
+    assert checks["enough_sections"] is True
+    assert accepted is True
+
+
+def test_the_same_two_section_plan_still_fails_a_service_guide():
+    structure = _forms()["service-guide"].structure
+    outline = sanitize_v3_outline(
+        {
+            "working_title": "Two sections",
+            "sections": [
+                {"heading": "One", "claim_ids": [], "target_words": 400},
+                {"heading": "Two", "claim_ids": [], "target_words": 400},
+            ],
+        },
+        max_sections=structure.max_sections,
+    )
+    _accepted, checks = validate_v3_outline(
+        outline,
+        work_order={"primary_subject": "", "scope": {"references": []}},
+        claim_ids=set(),
+        target_word_count=0,
+        min_sections=structure.min_sections,
+    )
+
+    assert checks["enough_sections"] is False
+
+
+def test_the_provider_schema_follows_the_form_too():
+    # The one place a provider refuses rather than asks. A literal minItems of
+    # 3 rejected a valid two-section Q&A before any of our checks ran.
+    schema = v3_outline_schema(min_sections=2, max_sections=9)
+    sections = schema["properties"]["sections"]
+
+    assert sections["minItems"] == 2
+    assert sections["maxItems"] == 9
+    # And building one never edits the shared constant.
+    from app.features.prompt2blog.schemas import V3_OUTLINE_SCHEMA
+
+    assert V3_OUTLINE_SCHEMA["properties"]["sections"]["minItems"] == 3
+
+
+@pytest.mark.parametrize("form_id", ["service-guide", "feature-profile"])
+def test_the_resolved_policy_is_frozen_with_the_run(form_id: str):
+    runtime = _runtime_for_form(form_id)
+    recorded = runtime.instructions["instruction_meta"]["structure_policy"]
+
+    assert recorded == _forms()[form_id].structure.model_dump()
+    # And a resumed leg reads it back rather than resolving the form again.
+    assert resolve_structure_policy(runtime.instructions) == _forms()[
+        form_id
+    ].structure
+
+
+def test_a_run_with_no_recorded_policy_keeps_the_old_shape():
+    """Every run started before forms carried a policy. Those should finish."""
+    assert resolve_structure_policy({}) == DEFAULT_STRUCTURE_POLICY
+    assert resolve_structure_policy(None) == DEFAULT_STRUCTURE_POLICY
+    assert (
+        resolve_structure_policy({"instruction_meta": {}}) == DEFAULT_STRUCTURE_POLICY
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_groundedness.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from app.features.prompt2blog.quality import (
+    GroundednessMalformed,
     _sanitize_groundedness,
     _should_run_repair,
     unchecked_groundedness,
@@ -16,58 +19,113 @@ PASSING_CHECKS = {
 }
 
 
+def _verdict(**overrides):
+    payload = {
+        "grounded": True,
+        "assessment": "Nothing unsupported.",
+        "unsupported_claims": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_high_severity_claim_marks_the_draft_ungrounded():
     result = _sanitize_groundedness(
-        {
-            "grounded": True,
-            "assessment": "One invented fee.",
-            "unsupported_claims": [
+        _verdict(
+            grounded=True,
+            assessment="One invented fee.",
+            unsupported_claims=[
                 {
                     "claim": "The reciprocity fee is $160.",
                     "reason": "No source states a fee.",
                     "severity": "high",
                 }
             ],
-        }
+        )
     )
 
     # The model claiming grounded=true does not override a high-severity find.
+    # Normalising in this direction cannot manufacture a pass, and it keeps the
+    # finding on the record for repair.
     assert result["grounded"] is False
+    assert result["status"] == "unsupported"
     assert result["high_severity_count"] == 1
 
 
 def test_low_severity_claims_do_not_block_the_draft():
     result = _sanitize_groundedness(
-        {
-            "unsupported_claims": [
+        _verdict(
+            assessment="One soft generalisation.",
+            unsupported_claims=[
                 {
                     "claim": "Mornings are quieter.",
                     "reason": "General background.",
                     "severity": "low",
                 }
             ],
-        }
+        )
     )
 
     assert result["grounded"] is True
+    assert result["status"] == "supported"
     assert result["high_severity_count"] == 0
     assert len(result["unsupported_claims"]) == 1
 
 
-def test_unknown_severity_is_treated_as_low():
-    result = _sanitize_groundedness(
-        {"unsupported_claims": [{"claim": "Something", "severity": "critical"}]}
-    )
+def test_empty_response_cannot_become_a_pass():
+    # Finding 02, in one line: `{}` used to arrive downstream as
+    # checked=true, grounded=true.
+    with pytest.raises(GroundednessMalformed):
+        _sanitize_groundedness({})
 
-    assert result["unsupported_claims"][0]["severity"] == "low"
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"assessment": "Fine.", "unsupported_claims": []},
+        {"grounded": "yes", "assessment": "Fine.", "unsupported_claims": []},
+        {"grounded": True, "unsupported_claims": []},
+        {"grounded": True, "assessment": "", "unsupported_claims": []},
+        {"grounded": True, "assessment": "Fine."},
+        {"grounded": True, "assessment": "Fine.", "unsupported_claims": {}},
+    ],
+)
+def test_missing_or_mistyped_fields_are_refused(payload):
+    with pytest.raises(GroundednessMalformed):
+        _sanitize_groundedness(payload)
 
 
-def test_claims_without_text_are_dropped():
-    result = _sanitize_groundedness(
-        {"unsupported_claims": [{"reason": "orphan"}, None, {"claim": "Real claim"}]}
-    )
+def test_unknown_severity_is_refused_rather_than_downgraded():
+    # It used to become "low", which is a high-severity finding silently
+    # turned into one that does not block the draft.
+    with pytest.raises(GroundednessMalformed):
+        _sanitize_groundedness(
+            _verdict(
+                grounded=False,
+                unsupported_claims=[
+                    {"claim": "Something", "reason": "x", "severity": "critical"}
+                ],
+            )
+        )
 
-    assert [claim["claim"] for claim in result["unsupported_claims"]] == ["Real claim"]
+
+def test_claims_without_text_refuse_the_whole_response():
+    with pytest.raises(GroundednessMalformed):
+        _sanitize_groundedness(
+            _verdict(
+                unsupported_claims=[
+                    {"reason": "orphan", "severity": "low"},
+                    {"claim": "Real claim", "reason": "x", "severity": "low"},
+                ]
+            )
+        )
+
+
+def test_false_verdict_with_no_explanation_is_refused():
+    with pytest.raises(GroundednessMalformed):
+        _sanitize_groundedness(
+            _verdict(grounded=False, assessment="Not grounded.", unsupported_claims=[])
+        )
 
 
 def test_ungrounded_draft_triggers_repair():
@@ -90,7 +148,15 @@ def test_failed_check_degrades_to_grounded_but_is_recorded_as_unchecked():
     # A checker outage must not block a run, but must be visible.
     assert result["grounded"] is True
     assert result["checked"] is False
+    assert result["status"] == "unchecked"
     assert not _should_run_repair(
         {"audit_complete": True, "overall_score": 9},
         {**PASSING_CHECKS, "claims_grounded": result["grounded"]},
     )
+
+
+def test_unchecked_result_records_why_it_could_not_run():
+    result = unchecked_groundedness("checker returned an unreadable verdict")
+
+    assert result["unchecked_reason"] == "checker returned an unreadable verdict"
+    assert "unreadable verdict" in result["assessment"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_schema_enforcement.py
@@ -67,14 +67,29 @@ from pathlib import Path
 
 import pytest
 
-V3_STAGES = Path(__file__).resolve().parents[1] / "app/features/prompt2blog/stages/v3"
+# The whole package, not only `stages/v3`. The style cleanup call moved out of
+# the stage files when it stopped being a whole-article rewrite (finding 05),
+# and a guard that only looked at stages would have stopped covering it on the
+# way -- which is the same shape of miss it was written for.
+P2B_PACKAGE = Path(__file__).resolve().parents[1] / "app/features/prompt2blog"
+P2B_MODULES = [
+    path
+    for path in sorted(P2B_PACKAGE.rglob("*.py"))
+    if "dependencies.llm." in path.read_text()
+]
 
 
-@pytest.mark.parametrize("path", sorted(V3_STAGES.glob("*.py")), ids=lambda p: p.name)
+def test_the_job_id_guard_actually_finds_the_call_sites():
+    """A glob that matches nothing passes every assertion under it."""
+    names = {path.name for path in P2B_MODULES}
+    assert {"compose.py", "audit_repair.py", "style_cleanup.py"} <= names
+
+
+@pytest.mark.parametrize("path", P2B_MODULES, ids=lambda p: p.name)
 def test_every_model_call_in_the_writing_graph_names_a_job(path):
     source = path.read_text()
     for call in re.finditer(
-        r"dependencies\.llm\.(invoke_json|invoke_text|enforce_anti_ai)\((.*?)\n    \)",
+        r"dependencies\.llm\.(invoke_json|invoke_text)\((.*?)\n    \)",
         source,
         re.S,
     ):

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edits.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edits.py
@@ -1,0 +1,178 @@
+"""Findings 06 and 03: repair changes what it named, and can reach the facts.
+
+06 was an unenforced boundary. Repair regenerated the whole article and was
+asked in prose to return untouched sections "word for word"; the code measured
+which ones moved and recorded the answer. A pass asked to fix one paragraph
+could rewrite the opening, and keep-best would retain it whenever the auditor
+liked the score.
+
+03 was the other half: repair could not see the facts a person chose for this
+article, so a revision like "support the comparison" was unanswerable whenever
+the first draft happened to leave the fact out.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.content.sections import (
+    apply_section_replacements,
+    locate_claims,
+    render_article,
+    section_manifest,
+    segment_article,
+)
+
+ARTICLE = """The short answer is that the airport taxi is worth it before 6am.
+
+## Getting there
+
+The rail link runs every twenty minutes.
+
+## What it costs
+
+A fare is about USD 9 as of March 2026.
+
+## Getting there
+
+The bus takes an hour longer."""
+
+
+def _edit(section_id: str, content: str, **extra):
+    section = next(
+        item for item in segment_article(ARTICLE) if item.section_id == section_id
+    )
+    return {
+        "section_id": section_id,
+        "text_hash": section.text_hash,
+        "content": content,
+        **extra,
+    }
+
+
+def test_the_opening_block_is_addressable():
+    sections = segment_article(ARTICLE)
+
+    assert sections[0].section_id == "s0"
+    assert sections[0].heading == ""
+    assert "worth it before 6am" in sections[0].body
+
+
+def test_two_sections_sharing_a_heading_get_different_ids():
+    """A heading-keyed address would merge these and let one edit hit both."""
+    sections = segment_article(ARTICLE)
+    repeated = [item for item in sections if item.heading == "Getting there"]
+
+    assert len(repeated) == 2
+    assert repeated[0].section_id != repeated[1].section_id
+    assert repeated[0].text_hash != repeated[1].text_hash
+
+
+def test_a_round_trip_with_no_edits_returns_the_same_document():
+    assert render_article(segment_article(ARTICLE)) == ARTICLE.strip()
+
+
+def test_only_the_named_section_changes():
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s2", "A fare is about USD 9 as of March 2026, one way.")]
+    )
+
+    assert result.applied == ["s2"]
+    assert result.rejected == []
+    # Everything else is the original bytes, not a promise that it is.
+    before = segment_article(ARTICLE)
+    after = segment_article(result.content)
+    for index in (0, 1, 3):
+        assert after[index].body == before[index].body
+        assert after[index].heading == before[index].heading
+
+
+def test_an_unknown_id_is_refused():
+    result = apply_section_replacements(
+        ARTICLE, [{"section_id": "s99", "content": "Invented section."}]
+    )
+
+    assert result.applied == []
+    assert result.content == ARTICLE
+    assert result.rejected[0]["reason"] == "unknown section id"
+
+
+def test_naming_the_same_section_twice_is_refused_the_second_time():
+    result = apply_section_replacements(
+        ARTICLE,
+        [_edit("s1", "First rewrite."), _edit("s1", "Second rewrite.")],
+    )
+
+    assert result.applied == ["s1"]
+    assert "First rewrite." in result.content
+    assert "Second rewrite." not in result.content
+    assert result.rejected[0]["reason"] == "named more than once"
+
+
+def test_a_stale_hash_is_refused():
+    """An edit written against an older draft never lands on newer prose."""
+    result = apply_section_replacements(
+        ARTICLE,
+        [
+            {
+                "section_id": "s1",
+                "text_hash": "deadbeef1234",
+                "content": "Rewritten from a draft that no longer exists.",
+            }
+        ],
+    )
+
+    assert result.applied == []
+    assert result.content == ARTICLE
+    assert "stale text_hash" in result.rejected[0]["reason"]
+
+
+def test_an_empty_body_is_refused_rather_than_deleting_a_section():
+    result = apply_section_replacements(ARTICLE, [_edit("s1", "   ")])
+
+    assert result.applied == []
+    assert "## Getting there" in result.content
+    assert result.rejected[0]["reason"] == "empty replacement body"
+
+
+def test_the_opening_cannot_grow_a_heading():
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s0", "New opening.", heading="Introduction")]
+    )
+
+    assert result.applied == []
+    assert result.rejected[0]["reason"] == "the opening block cannot take a heading"
+
+
+def test_a_response_that_is_not_a_list_leaves_the_draft_alone():
+    result = apply_section_replacements(ARTICLE, {"section_id": "s1"})
+
+    assert result.content == ARTICLE
+    assert result.changed is False
+
+
+def test_a_heading_may_be_changed_with_its_section():
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s2", "About USD 9.", heading="What the fare costs")]
+    )
+
+    assert "## What the fare costs" in result.content
+    assert "## What it costs" not in result.content
+
+
+def test_the_manifest_gives_the_model_an_id_and_a_hash_for_each_section():
+    manifest = section_manifest(segment_article(ARTICLE))
+
+    assert "(opening — no heading)" in manifest
+    for section in segment_article(ARTICLE):
+        assert f"- {section.section_id} [{section.text_hash}]" in manifest
+
+
+def test_flagged_claims_are_pointed_at_the_section_they_sit_in():
+    located = locate_claims(
+        segment_article(ARTICLE),
+        [
+            {"claim": "A fare is about USD 9 as of March 2026.", "severity": "high"},
+            {"claim": "Nothing in the draft says this.", "severity": "high"},
+        ],
+    )
+
+    assert located == {"s2": ["A fare is about USD 9 as of March 2026."]}

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_style_cleanup.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_style_cleanup.py
@@ -1,0 +1,223 @@
+"""Finding 05: a style pass must not be able to change a fact.
+
+The old pass received the finished article and a list of style errors, and
+nothing else -- no brief, no facts, no caveats. So a call sent to remove one em
+dash held the whole document, could not tell a carefully dated sentence from a
+stylistic tic, and "offered in March" could come back as "offers today" with
+the dash duly gone.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.features.prompt2blog.content.sections import segment_article
+from app.features.prompt2blog.content.style_cleanup import (
+    clean_up_style,
+    sections_with_errors,
+)
+from app.features.prompt2blog.dependencies import PipelineDependencies
+
+# The em dash in "wait — about" is the style error. The as-of date two
+# sections away is the thing that must survive it.
+ARTICLE = """The airport taxi is the one to take before 6am.
+
+## Getting there
+
+The rail link runs every twenty minutes, so the wait — about ten minutes —
+is short.
+
+## What it costs
+
+A single fare was COP 38,000 (about USD 9) as of March 2026."""
+
+
+@dataclass
+class FakeRecorder:
+    def start_stage(self, *_args, **_kwargs) -> None: ...
+
+    def record_stage(self, *_args, **_kwargs) -> None: ...
+
+
+@dataclass
+class FakeLLM:
+    response: Any = field(default_factory=dict)
+    prompts: list[str] = field(default_factory=list)
+    raises: Exception | None = None
+
+    def invoke_json(self, *, prompt: str, **_kwargs) -> tuple[Any, str]:
+        self.prompts.append(prompt)
+        if self.raises:
+            raise self.raises
+        return self.response, json.dumps(self.response)
+
+
+def _dependencies(llm: FakeLLM) -> PipelineDependencies:
+    return PipelineDependencies(llm=llm, recorder=FakeRecorder())
+
+
+def _clean(llm: FakeLLM, content: str = ARTICLE, **kwargs):
+    return clean_up_style(
+        content,
+        dependencies=_dependencies(llm),
+        job_id="p2b.compose",
+        model_name="test-writer",
+        max_tokens=1024,
+        context="test",
+        **kwargs,
+    )
+
+
+def _hash_of(section_id: str, content: str = ARTICLE) -> str:
+    return next(
+        item for item in segment_article(content) if item.section_id == section_id
+    ).text_hash
+
+
+def test_a_clean_draft_never_reaches_a_model():
+    llm = FakeLLM()
+    clean = "## Getting there\n\nThe rail link runs every twenty minutes."
+
+    content, report = _clean(llm, clean)
+
+    assert llm.prompts == []
+    assert report["status"] == "clean"
+    assert content == clean
+
+
+def test_only_the_failing_section_is_sent():
+    llm = FakeLLM(response={"sections": []})
+
+    _content, report = _clean(llm)
+
+    assert report["sections_sent"] == ["s1"]
+    prompt = llm.prompts[0]
+    assert "SECTION s1" in prompt
+    assert "SECTION s2" not in prompt
+    # The section carrying the dated price was never shown to the pass, which
+    # is the strongest form of "it cannot change that fact".
+    assert "COP 38,000" not in prompt
+
+
+def test_the_scope_guard_travels_with_the_pass():
+    llm = FakeLLM(response={"sections": []})
+
+    _content, _report = _clean(llm, guard="COMPACT SCOPE AND STYLE LOCK\nKeep it.")
+
+    assert "COMPACT SCOPE AND STYLE LOCK" in llm.prompts[0]
+
+
+def test_a_fix_replaces_its_section_and_nothing_else():
+    llm = FakeLLM(
+        response={
+            "sections": [
+                {
+                    "section_id": "s1",
+                    "text_hash": _hash_of("s1"),
+                    "content": (
+                        "The rail link runs every twenty minutes, so the wait "
+                        "of about ten minutes is short."
+                    ),
+                }
+            ]
+        }
+    )
+
+    content, report = _clean(llm)
+
+    assert report["status"] == "applied"
+    assert report["errors_after"] == []
+    assert "—" not in content
+    # The dated price is byte-for-byte what it was.
+    assert (
+        "A single fare was COP 38,000 (about USD 9) as of March 2026." in content
+    )
+    assert "The airport taxi is the one to take before 6am." in content
+
+
+def test_an_edit_to_a_section_that_was_not_sent_is_refused():
+    llm = FakeLLM(
+        response={
+            "sections": [
+                {
+                    "section_id": "s2",
+                    "text_hash": _hash_of("s2"),
+                    "content": "A single fare is about USD 9 today.",
+                }
+            ]
+        }
+    )
+
+    content, report = _clean(llm)
+
+    assert report["off_target_sections"] == ["s2"]
+    assert "as of March 2026" in content
+    assert "today" not in content
+
+
+def test_a_result_that_is_not_cleaner_is_discarded():
+    llm = FakeLLM(
+        response={
+            "sections": [
+                {
+                    "section_id": "s1",
+                    "text_hash": _hash_of("s1"),
+                    # Two em dashes where there were two, plus a new one.
+                    "content": "The link runs — often — and the wait — is short.",
+                }
+            ]
+        }
+    )
+
+    content, report = _clean(llm)
+
+    assert report["status"] == "rejected"
+    assert content == ARTICLE.strip()
+
+
+def test_a_failed_call_keeps_the_draft_and_says_so():
+    llm = FakeLLM(raises=RuntimeError("provider down"))
+
+    content, report = _clean(llm)
+
+    assert report["status"] == "call_failed"
+    assert content == ARTICLE.strip()
+
+
+def test_a_stale_hash_leaves_the_draft_alone():
+    llm = FakeLLM(
+        response={
+            "sections": [
+                {
+                    "section_id": "s1",
+                    "text_hash": "000000000000",
+                    "content": "Rewritten against a draft that no longer exists.",
+                }
+            ]
+        }
+    )
+
+    content, report = _clean(llm)
+
+    assert report["status"] == "no_change"
+    assert content == ARTICLE.strip()
+
+
+def test_errors_are_routed_to_the_section_whose_lines_they_name():
+    placed, unplaced = sections_with_errors(
+        ARTICLE,
+        [
+            "Line 1: em dash is not allowed.",
+            "Line 5: em dash is not allowed.",
+            "Line 10: em dash is not allowed.",
+            "Hyphenated compounds are over budget.",
+        ],
+    )
+
+    assert placed["s0"] == ["Line 1: em dash is not allowed."]
+    assert placed["s1"] == ["Line 5: em dash is not allowed."]
+    assert placed["s2"] == ["Line 10: em dash is not allowed."]
+    # A document-wide count belongs to no single section.
+    assert unplaced == ["Hyphenated compounds are over budget."]

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -200,6 +200,9 @@ def test_there_is_no_headline_context_because_nothing_writes_a_headline():
         "compose",
         "audit",
         "repair_lock",
+        # The facts repair may work from, kept separate from the scope it may
+        # not move. Finding 03: repair could not reach the chosen facts at all.
+        "repair_facts",
     }
 
 
@@ -494,10 +497,13 @@ def test_the_stages_without_the_questions_keep_the_rest_of_the_brief():
     lock = contexts.repair_lock.text
     assert fixture["brief"]["outcome"] in lock
     assert "Primary subject: Lima" in lock
-    assert "Do not add factual material" in _flat(lock)
+    # It used to say "do not add factual material" full stop, which made a
+    # revision like "support the comparison" unanswerable whenever the first
+    # draft dropped the fact. The boundary is now the packet, not silence.
+    assert "listed under THE FACTS AVAILABLE TO THIS REPAIR" in _flat(lock)
+    assert "may not remove a limitation from a fact you keep" in _flat(lock)
     # And repair may not quietly straighten a hedged sentence while rewriting:
-    # it is forbidden to add anything, so it could never put the caveat back.
-    assert "do not remove a limitation from a fact you keep" in _flat(lock)
+    # a caveat it dropped is one nothing downstream can put back.
 
 
 def _two_claim_request(*, second_selected: bool):

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_instructions.py
@@ -352,7 +352,10 @@ def test_compose_leads_with_the_brief_and_treats_evidence_as_material():
     assert "WHAT WE ARE MAKING" in compose
     assert "THE FACTS YOU MAY USE" in compose
     assert compose.index("WHAT WE ARE MAKING") < compose.index("THE FACTS YOU MAY USE")
-    assert "constrain every factual claim absolutely" in _flat(compose)
+    # The authority order is now written out once, in one place, with what
+    # each layer actually owns. This is the line that says the facts win.
+    assert "control every factual claim" in _flat(compose)
+    assert "AUTHORITY ORDER: verified evidence > approved brief" in _flat(compose)
 
 
 def test_compose_is_given_the_voice_and_the_conventions():

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_pipeline.py
@@ -211,6 +211,19 @@ class SpentTokens:
         }
 
 
+def _first_section_edit(repair_prompt: str) -> dict[str, Any]:
+    """Answer the SECTION MAP the way a model that read it would."""
+    lines = repair_prompt.split("SECTION MAP:\n", 1)[1].splitlines()
+    first = next(line for line in lines if line.startswith("- s"))
+    section_id, bracketed = first[2:].split(" ", 1)
+    text_hash = bracketed.split("[", 1)[1].split("]", 1)[0]
+    return {
+        "section_id": section_id,
+        "text_hash": text_hash,
+        "content": "Repaired opening paragraph for the Lima cost article.",
+    }
+
+
 @dataclass
 class ScriptedLLM:
     quality_scores: list[int]
@@ -272,7 +285,16 @@ class ScriptedLLM:
         if "repair pass" in prompt:
             self.prompts.append(("repair", prompt))
             self._record_model("repair", model_name)
-            return DRAFT, json.dumps(DRAFT)
+            # Repair returns section replacements now, not a whole article, so
+            # the scripted one has to answer the way the real contract does:
+            # read the id and the hash off the SECTION MAP in the prompt.
+            payload = {
+                "improved_title": DRAFT["improved_title"],
+                "sections": [_first_section_edit(prompt)],
+                "improvements_applied": ["Tightened the opening section."],
+                "remaining_gaps": [],
+            }
+            return payload, json.dumps(payload)
         self.prompts.append(("compose", prompt))
         self._record_model("compose", model_name)
         return DRAFT, json.dumps(DRAFT)
@@ -315,7 +337,13 @@ def test_the_lima_brief_runs_end_to_end_through_the_graph():
         "r3": "supported",
     }
     contexts = payload["debug"]["stage_contexts"]
-    assert set(contexts) == {"outline", "compose", "audit", "repair_lock"}
+    assert set(contexts) == {
+        "outline",
+        "compose",
+        "audit",
+        "repair_lock",
+        "repair_facts",
+    }
     assert contexts["compose"]["character_count"] > contexts["audit"]["character_count"]
     assert len(contexts["compose"]["fingerprint"]) == 64
     assert "instruction_text" not in payload["debug"]
@@ -545,7 +573,13 @@ def test_a_low_score_spends_a_repair_pass_and_re_checks_grounding():
     assert recorder.order.count("stage_v3_groundedness") == 2
     assert recorder.order.count("stage_v3_quality_audit") == 2
     repair_prompt = next(prompt for kind, prompt in llm.prompts if kind == "repair")
-    assert "you may not change the brief" in " ".join(repair_prompt.split())
+    assert "Do not change the brief" in " ".join(repair_prompt.split())
+    # Finding 06: repair replaces named sections, and the code applies them.
+    edits = recorder.stages["stage_v3_repair"]["section_edits"]
+    assert edits["applied_section_ids"] == ["s0"]
+    assert edits["rejected"] == []
+    # Finding 03: and it can reach the facts a person chose for this article.
+    assert "THE FACTS AVAILABLE TO THIS REPAIR" in repair_prompt
 
 
 def test_a_weak_draft_buys_one_repair_and_then_asks_for_a_human():

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -501,6 +501,18 @@ def test_a_repair_that_names_a_section_it_was_not_given_changes_nothing():
     assert updates["repair_applied"] is False
 
 
+def test_a_repair_response_of_the_wrong_shape_is_recorded_as_one():
+    state = _repair_state()
+    llm = FakeLLM(json_response={"sections": "a whole article, as prose"})
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_repair_stage(state, dependencies)
+
+    assert updates["repair_applied"] is False
+    rejected = recorder.recorded[0][1]["section_edits"]["rejected"]
+    assert rejected[0]["reason"] == "sections is not a list"
+
+
 def test_repair_is_shown_the_chosen_facts_it_may_recover():
     """Finding 03. The packet reaches repair, so an omitted fact is available."""
     state = _repair_state()

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -394,8 +394,7 @@ def test_repair_is_told_it_may_not_create_facts_or_change_the_commission():
 
     prompt = llm.prompts[0]
     normalized_prompt = " ".join(prompt.split())
-    assert "Repair prose and structure only" in prompt
-    assert "you may not change the brief" in normalized_prompt
+    assert "Do not change the brief" in prompt
     assert "Never promote a context-only reference" in prompt
     assert "UNSUPPORTED CLAIMS" in prompt
     assert "Rent averages 900 dollars." in prompt
@@ -412,6 +411,167 @@ def test_repair_is_told_it_may_not_create_facts_or_change_the_commission():
     assert recorder.recorded[0][1]["unsupported_claims"][0]["severity"] == "high"
     assert len(prompt) < 20_000
     assert updates["repair_attempts"] == 1
+
+
+def _repair_state(**overrides):
+    state = _state(
+        rewrite={
+            "improved_title": "What Lima costs now",
+            "improved_content": (
+                "The short answer is that rent decides it.\n\n"
+                "## What Lima costs now\n\nBody about Lima costs.\n\n"
+                "## What decides the answer\n\nBody about the tradeoffs."
+            ),
+            "improvements_applied": [],
+            "remaining_gaps": [],
+        },
+        quality={"required_revisions": ["Tighten the opening."]},
+        groundedness={
+            "checked": True,
+            "grounded": True,
+            "high_severity_count": 0,
+            "unsupported_claims": [],
+        },
+    )
+    state.update(overrides)
+    return state
+
+
+def _section_of(state, section_id: str):
+    from app.features.prompt2blog.content.sections import segment_article
+
+    return next(
+        item
+        for item in segment_article(state["rewrite"]["improved_content"])
+        if item.section_id == section_id
+    )
+
+
+def test_repair_replaces_one_section_and_leaves_the_others_byte_for_byte():
+    """Finding 06. The boundary is the code, not the sentence asking for it."""
+    state = _repair_state()
+    target = _section_of(state, "s1")
+    llm = FakeLLM(
+        json_response={
+            "improved_title": "What Lima costs now",
+            "sections": [
+                {
+                    "section_id": "s1",
+                    "text_hash": target.text_hash,
+                    "content": "A tighter body about Lima costs.",
+                }
+            ],
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_repair_stage(state, dependencies)
+
+    content = updates["rewrite"]["improved_content"]
+    assert "A tighter body about Lima costs." in content
+    assert "The short answer is that rent decides it." in content
+    assert "Body about the tradeoffs." in content
+    assert "Body about Lima costs." not in content
+    assert recorder.recorded[0][1]["section_edits"]["applied_section_ids"] == ["s1"]
+
+
+def test_a_repair_that_names_a_section_it_was_not_given_changes_nothing():
+    state = _repair_state()
+    llm = FakeLLM(
+        json_response={
+            "sections": [
+                {
+                    "section_id": "s9",
+                    "text_hash": "whatever",
+                    "content": "A section this draft does not have.",
+                }
+            ]
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_repair_stage(state, dependencies)
+
+    # The existing draft survives intact and is still saveable; the receipt
+    # does not claim a repair that did not happen.
+    assert (
+        updates["rewrite"]["improved_content"]
+        == state["rewrite"]["improved_content"]
+    )
+    assert updates["repair_applied"] is False
+
+
+def test_repair_is_shown_the_chosen_facts_it_may_recover():
+    """Finding 03. The packet reaches repair, so an omitted fact is available."""
+    state = _repair_state()
+    llm = FakeLLM(json_response={"sections": []})
+    dependencies, _recorder = _dependencies(llm)
+
+    run_v3_repair_stage(state, dependencies)
+
+    prompt = llm.prompts[0]
+    assert "THE FACTS AVAILABLE TO THIS REPAIR" in prompt
+    assert "SECTION MAP:" in prompt
+    # The claim text itself, verbatim from the frozen packet.
+    for fact in state["packet"]["facts"]:
+        assert fact["text"] in prompt
+
+
+def test_an_edit_citing_a_fact_outside_the_packet_is_refused():
+    """The permission is the packet, and only the packet.
+
+    An id from the wider dossier names a fact a person deliberately cut; an id
+    that names nothing is a fact the model supplied itself. Both undo the
+    editorial decision the packet exists to hold.
+    """
+    state = _repair_state()
+    target = _section_of(state, "s1")
+    llm = FakeLLM(
+        json_response={
+            "sections": [
+                {
+                    "section_id": "s1",
+                    "text_hash": target.text_hash,
+                    "content": "A body citing a fact nobody chose.",
+                    "claim_ids": ["c-not-in-the-packet"],
+                }
+            ]
+        }
+    )
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_repair_stage(state, dependencies)
+
+    assert "A body citing a fact nobody chose." not in (
+        updates["rewrite"]["improved_content"]
+    )
+    rejected = recorder.recorded[0][1]["section_edits"]["rejected"]
+    assert "outside the packet" in rejected[0]["reason"]
+
+
+def test_an_edit_citing_a_chosen_fact_is_applied():
+    state = _repair_state()
+    target = _section_of(state, "s1")
+    chosen = state["packet"]["facts"][0]["claim_id"]
+    llm = FakeLLM(
+        json_response={
+            "sections": [
+                {
+                    "section_id": "s1",
+                    "text_hash": target.text_hash,
+                    "content": "A body that finally uses the omitted comparison.",
+                    "claim_ids": [chosen],
+                }
+            ]
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_repair_stage(state, dependencies)
+
+    assert "finally uses the omitted comparison" in (
+        updates["rewrite"]["improved_content"]
+    )
 
 
 def test_settling_restores_the_best_draft_and_its_own_grounding_verdict():

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -182,6 +182,107 @@ def test_grounding_compares_the_draft_with_the_exact_evidence_records():
     assert recorder.recorded[0][0] == "stage_v3_groundedness"
 
 
+def test_grounding_reads_the_first_hand_material_the_writer_was_given():
+    """Finding 01. Compose saw `brief.material`; the checker did not."""
+    llm = FakeLLM(
+        json_response={
+            "grounded": True,
+            "assessment": "Everything traces to a record or to supplied material.",
+            "unsupported_claims": [],
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+    state = _state()
+    state["packet"] = {
+        **state["packet"],
+        "supplied_material": [
+            {
+                "kind": "observation",
+                "statement": "I waited 45 minutes at the airport taxi rank.",
+                "note": "August 2026",
+            }
+        ],
+    }
+
+    run_v3_groundedness_stage(state, dependencies)
+
+    prompt = llm.prompts[0]
+    assert "SUPPLIED MATERIAL" in prompt
+    assert "I waited 45 minutes at the airport taxi rank." in prompt
+    assert "August 2026" in prompt
+    # The scope rule travels with it, or the checker has no way to tell the
+    # observation from the generalisation it does not support.
+    assert "does not support" in prompt
+
+
+def test_grounding_without_material_says_so_rather_than_leaving_a_hole():
+    llm = FakeLLM(
+        json_response={
+            "grounded": True,
+            "assessment": "Everything traces to a record.",
+            "unsupported_claims": [],
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    run_v3_groundedness_stage(_state(), dependencies)
+
+    assert "SUPPLIED MATERIAL" in llm.prompts[0]
+    assert "must rest on the evidence records" in llm.prompts[0]
+
+
+def test_an_unreadable_verdict_is_retried_once_then_recorded_as_unchecked():
+    """Finding 02. `{}` used to arrive downstream as a verified pass."""
+
+    class MalformedLLM(FakeLLM):
+        def invoke_json(self, *, prompt: str, **_kwargs):
+            self.prompts.append(prompt)
+            return {}, "{}"
+
+    llm = MalformedLLM()
+    dependencies, recorder = _dependencies(llm)
+
+    updates = run_v3_groundedness_stage(_state(), dependencies)
+
+    assert len(llm.prompts) == 2
+    assert "YOUR PREVIOUS RESPONSE WAS REJECTED" in llm.prompts[1]
+    groundedness = updates["groundedness"]
+    assert groundedness["checked"] is False
+    assert groundedness["status"] == "unchecked"
+    assert len(groundedness["rejected_responses"]) == 2
+    assert recorder.recorded[0][1]["groundedness"]["checked"] is False
+
+
+def test_a_retried_verdict_that_parses_is_used():
+    class RecoveringLLM(FakeLLM):
+        responses = [
+            {},
+            {
+                "grounded": True,
+                "assessment": "Second answer parses.",
+                "unsupported_claims": [],
+            },
+        ]
+
+        def invoke_json(self, *, prompt: str, **_kwargs):
+            self.prompts.append(prompt)
+            import json as _json
+
+            payload = self.responses[len(self.prompts) - 1]
+            return payload, _json.dumps(payload)
+
+    llm = RecoveringLLM()
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_groundedness_stage(_state(), dependencies)
+
+    assert updates["groundedness"]["checked"] is True
+    assert updates["groundedness"]["status"] == "supported"
+    # The rejected first answer stays on the record even though the run
+    # recovered: a checker that needs two attempts is worth seeing.
+    assert updates["groundedness"]["rejected_responses"] == ["empty response"]
+
+
 def test_grounding_failure_degrades_to_unchecked_instead_of_failing_the_run():
     class ExplodingLLM(FakeLLM):
         def invoke_json(self, *, prompt: str, **_kwargs):

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_voice_files.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_voice_files.py
@@ -83,14 +83,22 @@ def test_the_voice_says_what_a_good_piece_is_rather_than_only_what_is_banned():
     assert all(phrase in body for phrase in positives)
 
 
-def test_the_anti_ai_enforcement_pass_is_still_wired_in():
+def test_the_style_backstop_is_still_wired_in_and_is_section_scoped():
     """ADR 0032 said this was dropped for Prompt2Blog. It never was.
 
-    The pass is what removes "mosaic-covered" and "six-month" from a draft
+    The backstop is what removes "mosaic-covered" and "six-month" from a draft
     before anyone sees it, and it stopped working once already when the model
-    gateway migration left these calls without a job id. If it is ever removed
-    deliberately, amend ADR 0032 again and delete this test in the same change
-    -- do not delete it to make a cleanup pass go green.
+    gateway migration left these calls without a job id. It is worth keeping.
+
+    What was not worth keeping is the shape it had: the whole article handed
+    to a model with a list of style errors and nothing else, which is finding
+    05. It is now `clean_up_style`, which sends only the sections carrying an
+    error and gives the pass the scope lock so it can see what a qualification
+    is for. ADR 0032 is amended to say so.
+
+    If this is ever removed deliberately, amend the ADR again and delete this
+    test in the same change -- do not delete it to make a cleanup pass go
+    green.
     """
     from pathlib import Path
 
@@ -98,9 +106,15 @@ def test_the_anti_ai_enforcement_pass_is_still_wired_in():
     compose = (stages / "compose.py").read_text()
     repair = (stages / "audit_repair.py").read_text()
 
-    assert "enforce_anti_ai(" in compose
-    assert "enforce_anti_ai(" in repair
-    # And each still names its job, which is what broke in 3bdaef2f.
     for source in (compose, repair):
-        call = source.split("enforce_anti_ai(", 1)[1].split("\n    )", 1)[0]
+        assert "clean_up_style(" in source
+        call = source.split("clean_up_style(", 1)[1].split("\n    )", 1)[0]
+        # Each still names its job, which is what broke in 3bdaef2f.
         assert "job_id=" in call
+        # And each hands the pass the scope and caveats the old one never saw.
+        assert "guard=" in call
+
+    # The whole-article rewrite is gone from the writer path. Other pipelines
+    # still call the shared helper; Prompt2Blog does not.
+    assert "enforce_anti_ai(" not in compose
+    assert "enforce_anti_ai(" not in repair

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_writing_contract.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_writing_contract.py
@@ -1,0 +1,163 @@
+"""Finding 04: the active writing instructions have to agree with each other.
+
+Compose received, in one prompt, "gaps are internal metadata only" and "missing
+support remains a visible gap"; "preserve stated uncertainty" and "it never
+hedges"; a brief that defines the article and house rules still talking about
+commissions, requirements and exclusions.
+
+Precedence language does not fix that. A model handed two contradictory
+directions obeys one of them, and which one is not ours to choose. These tests
+read the prompts that are actually assembled, for real forms, and check that
+the contradictions are gone rather than ranked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.features.prompt2blog.config import (
+    PROMPT2BLOG_HOUSE_RULES_FILE,
+    PROMPT2BLOG_VOICE_FILE,
+)
+from app.features.prompt2blog.contracts_v4 import Prompt2BlogV4Request
+from app.features.prompt2blog.editorial_catalog import load_editorial_catalog
+from app.features.prompt2blog.instructions_v3 import (
+    PRECEDENCE,
+    resolve_structure_policy,
+)
+from app.features.prompt2blog.prompts.editorial_v3 import P2B_V3_COMPOSE_PROMPT
+from tests.prompt2blog_packet_support import runtime_for
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v4.json"
+)
+
+# One from each half of the catalogue: a form that wants the answer-first shape
+# and a form that does not.
+REPRESENTATIVE_FORMS = ("service-guide", "feature-profile", "personal-essay-travelogue")
+
+
+def _compose_prompt(form_id: str) -> str:
+    """The prompt compose actually sends, template and context together."""
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    fixture["brief"]["form_id"] = form_id
+    runtime = runtime_for(
+        Prompt2BlogV4Request.model_validate(
+            {
+                "schema_version": 4,
+                "brief": fixture["brief"],
+                "work_order": fixture["work_order"],
+                "evidence_package": fixture["evidence_package"],
+                "profiles": {"length_id": "medium", "creativity_level": "medium"},
+            }
+        )
+    )
+    structure = resolve_structure_policy(runtime.instructions)
+    return P2B_V3_COMPOSE_PROMPT.format(
+        outline="No plan.",
+        structure_rules=structure.compose_rules(),
+        target_word_count="900",
+        instructions=runtime.instructions["stage_contexts"]["compose"]["text"],
+        seo_guideline="",
+        style_directive="",
+    )
+
+
+def _flat(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+@pytest.mark.parametrize("form_id", REPRESENTATIVE_FORMS)
+def test_no_prompt_asks_to_hide_and_to_show_the_same_gap(form_id: str):
+    prompt = _flat(_compose_prompt(form_id))
+
+    # The policy that owns this says: omit it, and record it as internal
+    # metadata. Nothing may also ask for it on the page.
+    assert "internal metadata only" in prompt
+    assert "visible gap" not in prompt
+    assert "remains a visible gap" not in prompt
+
+
+@pytest.mark.parametrize("form_id", REPRESENTATIVE_FORMS)
+def test_no_prompt_both_preserves_and_forbids_uncertainty(form_id: str):
+    prompt = _flat(_compose_prompt(form_id))
+
+    assert "never hedges" not in prompt
+    # What replaced it: the distinction the pipeline actually wants.
+    assert "supported uncertainty: preserve its exact scope" in prompt
+
+
+@pytest.mark.parametrize("form_id", REPRESENTATIVE_FORMS)
+def test_the_prompt_describes_this_article_not_an_old_commission_form(form_id: str):
+    prompt = _flat(_compose_prompt(form_id))
+
+    # v4 has no requirements list and no exclusions list; the brief is the
+    # article. House rules used to demand both be "preserved", which is a
+    # revision repair could never satisfy.
+    assert "exclusions" not in prompt
+    assert "every required question must be supported" not in prompt
+
+
+@pytest.mark.parametrize("form_id", REPRESENTATIVE_FORMS)
+def test_one_authority_order_and_it_says_what_each_layer_owns(form_id: str):
+    prompt = _compose_prompt(form_id)
+    order = " > ".join(PRECEDENCE)
+
+    assert prompt.count(f"AUTHORITY ORDER: {order}") == 1
+    assert "control every factual claim" in prompt
+    assert "The approved brief controls intent" in prompt
+    assert "The article form controls structure" in prompt
+    assert "House style controls expression" in prompt
+
+
+def test_house_style_no_longer_states_a_second_authority_order():
+    house = PROMPT2BLOG_HOUSE_RULES_FILE.read_text(encoding="utf-8").lower()
+
+    assert "## authority order" not in house
+    assert "follow this order" not in house
+    # And it no longer carries the completion standard, which was the
+    # research-question checklist wearing a readiness hat. Readiness is
+    # `policies.py`.
+    assert "completion standard" not in house
+
+
+def test_the_voice_keeps_a_limit_that_changes_the_reader_s_decision():
+    voice = PROMPT2BLOG_VOICE_FILE.read_text(encoding="utf-8")
+
+    assert "never hedges" not in voice
+    # The positive half has to survive the edit: this is still the file that
+    # says leave the guess out.
+    assert "leaves the second thing out" in voice
+    assert "part of the fact, not a hedge on it" in voice
+
+
+def test_compose_asks_for_what_grounding_actually_enforces():
+    """The audit's evidence boundary, in one assertion.
+
+    "Every factual statement must trace to a claim" is stricter than the
+    checker, which exempts general background and judgement. A rule nothing
+    enforces trains the writer to ignore the ones that are enforced.
+    """
+    assert "Every factual statement must trace" not in P2B_V3_COMPOSE_PROMPT
+    assert "General background a well-informed writer would state" in (
+        P2B_V3_COMPOSE_PROMPT
+    )
+
+
+def test_attribution_has_one_answer_across_the_active_rules():
+    catalog = load_editorial_catalog()
+    house = _flat(catalog.house_rules.instructions)
+    conventions = _flat(catalog.writing_conventions.instructions)
+
+    for body in (house, conventions):
+        assert "never names a source" in body or "never in the article" in body
+    # Compose used to ask, in its own hard rules, to "preserve attribution"
+    # three lines above being told attribution never reaches the prose.
+    assert "preserve attribution" not in _flat(P2B_V3_COMPOSE_PROMPT)

--- a/apps/ai-blog-writer/docs/adr/0032-one-questurian-voice.md
+++ b/apps/ai-blog-writer/docs/adr/0032-one-questurian-voice.md
@@ -42,6 +42,22 @@ once, at compose. Every other consumer keeps the enforcement pass, because they
 do not receive the compose-prompt rework that replaces it and would otherwise
 lose a backstop and gain nothing. Edits to the rule text itself are shared.
 
+> **Amended (writer audit, finding 05).** This was never carried out. The
+> whole-article enforcement pass stayed wired in after compose and after
+> repair, and a test recorded the discrepancy rather than resolving it. It is
+> now replaced rather than dropped, because the backstop turned out to be
+> worth keeping and the rewrite was not.
+>
+> Prompt2Blog runs `content/style_cleanup.py`. The deterministic validator is
+> unchanged and still free. What changed is the expensive half: the errors
+> carry line numbers, so only the sections containing them are sent, only
+> those may be returned, and the rest of the article is untouched bytes. The
+> pass is also given the repair lock -- the brief's scope and the limitations
+> on the facts this article used -- which the old one never saw, so it can
+> tell a qualification from a stylistic tic. One attempt; a result that is not
+> cleaner than what it was given is discarded, and the draft is re-grounded
+> either way. Other consumers still call `enforce_anti_ai_tells_markdown`.
+
 **URL2Blog and YouTube2Blog are deleted, not left to break.** Removing the
 shared tone list and changing the shared voice rules leaves them looking
 completely usable while failing mid-run or, worse, quietly producing worse
@@ -59,6 +75,10 @@ response.
 - The house rules are no longer uniform across pipelines. This reverses an
   earlier deliberate choice to keep them in one shared place, and is scoped to
   the enforcement pass rather than the rule text to keep the divergence small.
+- Prompt2Blog's cleanup can now leave a style error unresolved. That is the
+  trade the amendment above makes deliberately: an unresolved em dash is
+  visible in the run record and costs a reader nothing, where a stripped
+  as-of date is invisible and costs them the fact.
 - The tone dropdown disappears from the composer. Any stored run referencing a
   `tone_id` is unreadable, which is already true under ADR 0031.
 - Voice quality becomes editable by a person in one file, in English, without


### PR DESCRIPTION
Implements all seven fixes from `apps/ai-blog-writer/docs/audits/prompt2blog-writer-solutions.html`, in the build order that document specifies.

Backend suite: **1625 passed** (1567 on `main` before this branch — 58 new tests).

## Grounding integrity — solutions 2 and 1

`{}` used to arrive downstream as `checked: true, grounded: true`: the sanitizer computed success from the absence of high-severity claims, so a response nobody could read was a pass. `_sanitize_groundedness` now refuses anything it cannot read as a verdict, the stage retries once with the reason, and what survives is `unchecked` — which readiness already treats as a blocker. An unknown severity is refused rather than silently downgraded to "low"; `grounded: false` with nothing to point at is refused too. One normalisation stays, in the safe direction only: `grounded: true` alongside a high-severity finding is still read as ungrounded, because that keeps the finding for repair and cannot manufacture a pass.

The checker also reads the first-hand material the writer was given. Compose received `brief.material` while grounding saw only the web records, so "I waited 45 minutes" was invented as far as the checker could tell — after which repair is instructed to delete it. The material travels from the frozen packet, verbatim, with the rule that it supports its own scope and not a generalisation of it.

## One writing contract — solutions 4 and 7

Compose was handed "gaps are internal metadata only" beside "missing support remains a visible gap", "preserve stated uncertainty" beside a voice that "never hedges", and a v4 brief beside house rules still preserving requirements and exclusions. Precedence language does not settle that. Each rule now has one owner: house style keeps expression and drops its own authority order and its research-question completion standard, the voice distinguishes a limit that changes the reader's decision from padding, and the authority order is written out once with what every layer actually owns.

And the article's shape comes from its approved form. Every piece used to open with a 40-60 word direct answer, carry three-plus headings and close with takeaways — rules living in the compose prompt, the outline schema and the outline validator, none of which knew which form was approved. Each form now declares `opening`, `sections` and `closing` in its own frontmatter; the policy is resolved once, frozen in the run's instruction meta so a resume plans the same shape, and read by all three.

## Safe repair — solutions 6 and 3

Repair regenerated the whole article and was asked, in prose, to return every untouched section "word for word". The code measured which ones moved and recorded the answer, so a pass asked to fix one paragraph could rewrite the opening and keep-best would retain it whenever the audit liked the score. Now repair returns replacements for named sections and `apply_section_replacements` writes them into the original document. Ids are positional, so two sections sharing a heading cannot be confused; a text hash refuses an edit written against an older draft; an unknown id, a duplicate, or an empty body drops out. A response where nothing survives leaves the run its existing draft and says `repair_applied` was false.

On top of that, repair now receives the same frozen packet compose did, so a revision like "support the comparison" is answerable when the first draft left the price out. An edit naming a claim id outside the packet is refused; an id inside it is not proof the sentence means the same thing, which is why grounding still re-reads the assembled article.

## Safer style cleanup — solution 5

ADR 0032 said the anti-AI enforcement pass was dropped for Prompt2Blog. It never was, and a test recorded the discrepancy instead of resolving it. Keeping the backstop was right; its shape was not — it received the finished article and a list of style errors and nothing else, so a call sent to remove one em dash held the whole document with no way to tell a carefully dated sentence from a stylistic tic.

`content/style_cleanup.py` replaces it. The deterministic validator is unchanged and still free. The errors carry line numbers, so only the sections containing them are sent, only those may be returned, and the rest of the article is untouched bytes. The pass is handed the repair lock as well. One attempt: a result that is not cleaner than what it started with is discarded. ADR 0032 is amended in the same change, as its own test asked.

## Two things worth knowing

- **A run started before this can still finish.** Runs with no frozen structure policy fall back to the old universal shape rather than refusing to resume.
- **None of this has been exercised against a real model.** Every test here is deterministic and no paid call was made. The section-edit contract in particular is a new prompt shape, and a real run is the only thing that will show whether the writing models answer the SECTION MAP correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)