### PR TITLE
feat(p2b): a comparison set, so a prompt change can be judged

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -46,6 +46,7 @@ them for the v2 fallback. Do not delete or renumber them.
 | `stages/v3/`, `prompts/editorial_v3.py`, `content/outline_v3.py` | V3 writing stages, their prompts, and pure section-plan scope guards |
 | `orchestrator_v3.py`, `graph/topology_v3.py` | The v3 run entrypoints and its shorter generation topology |
 | `resume_v3.py` | The state snapshot a failed v3 run is picked back up from |
+| `evaluation.py` | Frozen writing inputs, blind draft comparison, and per-criterion scoring |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evaluation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evaluation.py
@@ -1,0 +1,1044 @@
+"""A repeatable way to ask whether a change made the articles better.
+
+Every writer-phase change so far has been argued from one run. That is not
+enough to decide anything: the same prompt on the same packet does not produce
+the same article twice, provider behaviour drifts, and the run somebody
+remembers is the one that stuck out. Improvement 06 in the writer-improvements
+report is the fix -- a small set of frozen inputs a candidate can be run
+against, scored by a person who cannot see which version wrote which draft.
+
+What is frozen
+--------------
+A **fixture** is one article's inputs, exactly as the writer would have
+received them: the approved brief, the work order, the researched dossier, and
+the operator's selection. It is captured from a run that already happened, so
+it is real editorial material rather than invented test data, and once written
+it never changes. That matters more than it sounds: the whole point is that the
+only thing differing between two drafts is the candidate.
+
+A **variant** is what is being tested -- a model route, a creativity level, and
+the revision of this code the drafts were written by. Prompt changes are not a
+field here on purpose. A prompt lives in the repository, so the revision *is*
+the prompt; recording a separate "prompt version" string would let the two
+disagree.
+
+A **sample** is one draft: a variant run against a fixture, with its article,
+its receipt, and how long it took.
+
+What is not decided here
+------------------------
+Nothing in this module scores prose, and nothing in it combines scores. The
+criteria are recorded separately and stay separate all the way to the report,
+because "better" is several different questions -- a draft can be more useful
+to a reader and quietly drop a caveat, and one number would hide exactly that
+trade. A person reads the drafts blind and fills the sheet in.
+
+Cost and latency are measured rather than scored. They come off the run's own
+receipt, so they are facts about what happened, not opinions about it.
+
+This module makes no model calls by itself. `run_sample` takes the executor
+that does, so the whole pipeline around it -- capture, blinding, scoring,
+reporting -- is testable without buying anything.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Literal, Protocol, Sequence
+
+from pydantic import BaseModel, Field, model_validator
+
+from .contracts_v4 import (
+    ArticleBrief,
+    EvidencePackage,
+    Prompt2BlogModelRouting,
+    Prompt2BlogV4Request,
+    Prompt2BlogWorkOrder,
+    Prompt2BlogWritingProfiles,
+)
+from .selection_v4 import Selection
+
+# Bumped when a stored file stops meaning what this code reads. An older file
+# is refused rather than reinterpreted: a comparison run against a fixture this
+# code has misunderstood produces a confident answer to the wrong question.
+EVAL_SCHEMA_VERSION = 1
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# What a fixture has to cover
+# ---------------------------------------------------------------------------
+
+# The properties an evaluation set has to contain before a comparison over it
+# says anything general. Each one is a case where writers are known to differ:
+# first-hand material is the one the checker used to call invented, a dated
+# fact is the one style cleanup used to un-date, a declared conflict is the one
+# a writer resolves silently, and a sparse dossier is where a thin brief either
+# admits the gap or fills it.
+#
+# Deliberately computed from the frozen request rather than typed by hand. A
+# label somebody assigns is a claim about a fixture; this is a reading of it.
+FixtureTrait = Literal[
+    "first_hand_material",
+    "dated_facts",
+    "declared_conflict",
+    "sparse_research",
+    "unsettled_requirement",
+    "must_name_obligation",
+]
+
+# Below this many selected claims, the writer is working from thin material and
+# the interesting question is what it does about the gap. Chosen from the
+# stored corpus: the runs that read as padded sat under it, the ones that read
+# as catalogues sat far above it.
+SPARSE_CLAIM_COUNT = 12
+
+
+def fixture_traits(
+    brief: ArticleBrief,
+    work_order: Prompt2BlogWorkOrder,
+    evidence: EvidencePackage,
+) -> list[str]:
+    """What this article's inputs would put a writer through."""
+    selected = [claim for claim in evidence.claims if claim.selected]
+    traits: list[str] = []
+    if brief.material:
+        traits.append("first_hand_material")
+    if any(claim.as_of is not None for claim in selected):
+        traits.append("dated_facts")
+    if evidence.conflicts:
+        traits.append("declared_conflict")
+    if len(selected) < SPARSE_CLAIM_COUNT:
+        traits.append("sparse_research")
+    if any(item.status != "supported" for item in evidence.requirements):
+        traits.append("unsettled_requirement")
+    if brief.must_name:
+        traits.append("must_name_obligation")
+    return traits
+
+
+class EvalFixture(BaseModel):
+    """One article's frozen inputs, and nothing about how it was written."""
+
+    schema_version: Literal[1] = EVAL_SCHEMA_VERSION
+    fixture_id: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    notes: str = ""
+    # The run this material came off, so a reader can go and look at what the
+    # pipeline actually did with it the first time.
+    captured_from_run: str = Field(min_length=1)
+    captured_at: str = Field(min_length=1)
+    request: Prompt2BlogV4Request
+    # The operator's editorial cut, held as its own record because that is how
+    # the pipeline holds it -- the dossier stays what research returned.
+    selection: dict[str, Any]
+
+    @property
+    def form_id(self) -> str:
+        return self.request.brief.form_id
+
+    @property
+    def length_id(self) -> str:
+        return self.request.profiles.length_id
+
+    @property
+    def selection_record(self) -> Selection:
+        return Selection.from_record(self.selection)
+
+    @property
+    def traits(self) -> list[str]:
+        return fixture_traits(
+            self.request.brief,
+            self.request.work_order,
+            self.request.evidence_package,
+        )
+
+
+def capture_fixture(
+    run_id: str,
+    *,
+    fixture_id: str,
+    label: str,
+    request: Prompt2BlogV4Request,
+    selection: Selection,
+    notes: str = "",
+    clock: Callable[[], str] = _now_iso,
+) -> EvalFixture:
+    """Freeze what a finished run handed its writer.
+
+    The request and selection are passed in rather than read here, so the one
+    place that knows how to reconstruct them from storage stays
+    `intake_v4.writing_request` and this cannot drift into a second, subtly
+    different reading of the same rows.
+    """
+    return EvalFixture(
+        fixture_id=fixture_id,
+        label=label,
+        notes=notes,
+        captured_from_run=run_id,
+        captured_at=clock(),
+        request=request,
+        selection=selection.as_record(),
+    )
+
+
+def coverage_report(fixtures: Sequence[EvalFixture]) -> dict[str, Any]:
+    """Which forms and which hard cases this set actually contains.
+
+    A comparison is only as general as its fixtures, and the failure mode is
+    quiet: six restaurant guides look like a healthy set and answer one
+    question six times. This names what is missing so the gap is visible before
+    a candidate is judged on it.
+    """
+    forms = sorted({fixture.form_id for fixture in fixtures})
+    present: set[str] = set()
+    for fixture in fixtures:
+        present.update(fixture.traits)
+    missing = [
+        trait for trait in FixtureTrait.__args__ if trait not in present  # type: ignore[attr-defined]
+    ]
+    return {
+        "fixtures": len(fixtures),
+        "forms": forms,
+        "traits_present": sorted(present),
+        "traits_missing": missing,
+        # Not a pass mark. One fixture per form and every trait covered is the
+        # floor for the result meaning anything beyond those fixtures; it is
+        # never evidence that the candidate is good.
+        "covers_every_trait": not missing,
+    }
+
+
+# ---------------------------------------------------------------------------
+# What is being compared
+# ---------------------------------------------------------------------------
+
+
+class EvalVariant(BaseModel):
+    """One candidate: a route, a temperature band, and the code that ran it."""
+
+    schema_version: Literal[1] = EVAL_SCHEMA_VERSION
+    variant_id: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    notes: str = ""
+    model_routing: Prompt2BlogModelRouting = Field(
+        default_factory=Prompt2BlogModelRouting
+    )
+    # Left unset to keep the fixture's own level. Set it only when the level is
+    # the thing under test, because changing two things at once makes the
+    # result unattributable.
+    creativity_level: str | None = None
+
+    def apply(self, request: Prompt2BlogV4Request) -> Prompt2BlogV4Request:
+        """This variant's version of a fixture's request.
+
+        A copy. The fixture on disk is the control and is never edited, which
+        is the only reason two samples can be said to share inputs.
+        """
+        profiles = request.profiles
+        if self.creativity_level:
+            profiles = Prompt2BlogWritingProfiles(
+                length_id=request.profiles.length_id,
+                creativity_level=self.creativity_level,  # type: ignore[arg-type]
+            )
+        return request.model_copy(
+            update={
+                "model_routing": self.model_routing,
+                "profiles": profiles,
+            }
+        )
+
+
+class SampleMeasurements(BaseModel):
+    """What the run cost, as opposed to what a reader thought of it."""
+
+    duration_seconds: float | None = None
+    calls: int | None = None
+    total_tokens: int | None = None
+    billed_cost_usd: float | None = None
+    word_count: int | None = None
+    # Present and non-empty means the pipeline itself said the article was not
+    # ready. A reader scoring prose should not have to rediscover that.
+    readiness_blockers: list[str] = Field(default_factory=list)
+    repair_outcome: str = ""
+
+
+class EvalSample(BaseModel):
+    """One draft, and everything measurable about producing it."""
+
+    schema_version: Literal[1] = EVAL_SCHEMA_VERSION
+    sample_id: str = Field(min_length=1)
+    fixture_id: str = Field(min_length=1)
+    variant_id: str = Field(min_length=1)
+    # The run row this draft was written under. Real, so every stage row,
+    # prompt and receipt is inspectable the ordinary way.
+    run_id: str = Field(min_length=1)
+    # The revision of this repository that wrote it. The prompts are in the
+    # tree, so this is what makes a sample reproducible; a sample captured on a
+    # dirty tree records that too, because it is not reproducible.
+    code_revision: str = ""
+    code_dirty: bool = False
+    started_at: str = Field(min_length=1)
+    finished_at: str = ""
+    status: Literal["completed", "failed"] = "completed"
+    error: str = ""
+    title: str = ""
+    markdown: str = ""
+    measurements: SampleMeasurements = Field(default_factory=SampleMeasurements)
+
+
+class SampleExecutor(Protocol):
+    """Runs one fixture through the real pipeline and returns its artifact.
+
+    A protocol rather than a direct call so the module around it can be tested
+    without spending money. The real one is `pipeline_executor` below.
+    """
+
+    def __call__(
+        self,
+        *,
+        run_id: str,
+        request: Prompt2BlogV4Request,
+        selection: Selection,
+    ) -> dict[str, Any]: ...
+
+
+def _word_count(markdown: str) -> int | None:
+    return len(markdown.split()) or None
+
+
+def sample_from_artifact(
+    artifact: dict[str, Any],
+    *,
+    sample_id: str,
+    fixture_id: str,
+    variant_id: str,
+    run_id: str,
+    started_at: str,
+    finished_at: str,
+    duration_seconds: float,
+    code_revision: str = "",
+    code_dirty: bool = False,
+) -> EvalSample:
+    """Read one `pipeline_v3` artifact into a sample.
+
+    Everything here is copied, never recomputed. The cost of an article is
+    whatever its own receipt says it was; a second calculation from token
+    counts would be a different number that looks like the same one.
+    """
+    article = artifact.get("improved_article") or {}
+    markdown = artifact.get("final_markdown") or ""
+    cost = artifact.get("run_cost") or {}
+    return EvalSample(
+        sample_id=sample_id,
+        fixture_id=fixture_id,
+        variant_id=variant_id,
+        run_id=run_id,
+        code_revision=code_revision,
+        code_dirty=code_dirty,
+        started_at=started_at,
+        finished_at=finished_at,
+        status="completed",
+        title=article.get("title") or "",
+        markdown=markdown,
+        measurements=SampleMeasurements(
+            duration_seconds=round(duration_seconds, 2),
+            calls=cost.get("calls"),
+            total_tokens=cost.get("total_tokens"),
+            billed_cost_usd=cost.get("billed_cost_usd"),
+            word_count=_word_count(markdown),
+            readiness_blockers=list(artifact.get("readiness_blockers") or []),
+            repair_outcome=str(artifact.get("repair_outcome") or ""),
+        ),
+    )
+
+
+def failed_sample(
+    error: str,
+    *,
+    sample_id: str,
+    fixture_id: str,
+    variant_id: str,
+    run_id: str,
+    started_at: str,
+    finished_at: str,
+    code_revision: str = "",
+    code_dirty: bool = False,
+) -> EvalSample:
+    """A variant that could not produce a draft, recorded rather than dropped.
+
+    A candidate that fails on one fixture and wins on the rest has not won. If
+    failures vanished from the set, that is exactly what it would look like.
+    """
+    return EvalSample(
+        sample_id=sample_id,
+        fixture_id=fixture_id,
+        variant_id=variant_id,
+        run_id=run_id,
+        code_revision=code_revision,
+        code_dirty=code_dirty,
+        started_at=started_at,
+        finished_at=finished_at,
+        status="failed",
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reading the drafts without knowing who wrote them
+# ---------------------------------------------------------------------------
+
+# The questions a reader is asked, one at a time. Kept apart on purpose: these
+# trade against each other, and a single "which is better" hides the trade.
+#
+# `unsupported_additions` and `caveat_retention` are the two that protect the
+# article's factual footing, and they are the ones a livelier draft tends to
+# lose. If a candidate wins usefulness and voice while losing these, the answer
+# is not that it won.
+SCORE_CRITERIA: tuple[str, ...] = (
+    "usefulness",
+    "unsupported_additions",
+    "caveat_retention",
+    "voice",
+    "repetition",
+    "edit_effort",
+)
+
+CRITERION_QUESTIONS: dict[str, str] = {
+    "usefulness": (
+        "Could a reader act on this? Name the decision each section helped "
+        "them make."
+    ),
+    "unsupported_additions": (
+        "Does anything here assert more than the evidence does? Higher is "
+        "cleaner."
+    ),
+    "caveat_retention": (
+        "Are the limits and dates that change a reader's decision still "
+        "present?"
+    ),
+    "voice": "Does this read as one Questurian piece, or as generated prose?",
+    "repetition": (
+        "Is anything explained twice, or listed where it should be judged? "
+        "Higher is less repetitive."
+    ),
+    "edit_effort": (
+        "How much work to publish this? Higher means less work."
+    ),
+}
+
+SCORE_MIN = 1
+SCORE_MAX = 5
+
+
+class BlindEntry(BaseModel):
+    """One draft as the reader sees it: a letter, and the prose."""
+
+    display_label: str = Field(min_length=1)
+    title: str = ""
+    markdown: str = ""
+    status: Literal["completed", "failed"] = "completed"
+    error: str = ""
+
+
+class BlindComparison(BaseModel):
+    """The sheet a reader is given. Carries no variant identity at all.
+
+    The mapping lives in `ComparisonKey`, written to a separate file. That is
+    the whole mechanism: the file the reader opens cannot tell them which draft
+    is the candidate, so it cannot be read carelessly and reveal it.
+    """
+
+    schema_version: Literal[1] = EVAL_SCHEMA_VERSION
+    comparison_id: str = Field(min_length=1)
+    created_at: str = Field(min_length=1)
+    fixture_id: str = Field(min_length=1)
+    fixture_label: str = ""
+    form_id: str = ""
+    # What the reader needs in order to judge the piece, and nothing more. The
+    # brief is the measure the article is written against, so withholding it
+    # would make the reading worse, not more blind.
+    seed: str = ""
+    reader_question: str = ""
+    fails_if: str = ""
+    criteria: list[str] = Field(default_factory=lambda: list(SCORE_CRITERIA))
+    entries: list[BlindEntry] = Field(default_factory=list)
+
+
+class ComparisonKey(BaseModel):
+    """Which letter was which variant. Never shown beside the drafts."""
+
+    schema_version: Literal[1] = EVAL_SCHEMA_VERSION
+    comparison_id: str = Field(min_length=1)
+    fixture_id: str = Field(min_length=1)
+    # display label -> sample id
+    mapping: dict[str, str] = Field(default_factory=dict)
+
+
+LETTERS = "ABCDEFGH"
+
+
+def blind_comparison(
+    fixture: EvalFixture,
+    samples: Sequence[EvalSample],
+    *,
+    comparison_id: str | None = None,
+    rng: random.Random | None = None,
+    clock: Callable[[], str] = _now_iso,
+) -> tuple[BlindComparison, ComparisonKey]:
+    """Shuffle the drafts behind letters and split off the answer.
+
+    Shuffled, not ordered by variant, because a reader who learns that A is
+    always the incumbent has stopped reading blind halfway through the second
+    fixture.
+
+    A failed sample still gets a letter. Hiding it would quietly turn the
+    comparison into "the fixtures this candidate survived".
+    """
+    if len(samples) < 2:
+        raise ValueError("a comparison needs at least two drafts to compare")
+    if len(samples) > len(LETTERS):
+        raise ValueError(f"at most {len(LETTERS)} drafts can be compared at once")
+    if any(sample.fixture_id != fixture.fixture_id for sample in samples):
+        raise ValueError("every draft in a comparison must come from one fixture")
+
+    ordered = list(samples)
+    (rng or random.Random()).shuffle(ordered)
+    identifier = comparison_id or f"cmp-{uuid.uuid4().hex[:12]}"
+    brief = fixture.request.brief
+    sheet = BlindComparison(
+        comparison_id=identifier,
+        created_at=clock(),
+        fixture_id=fixture.fixture_id,
+        fixture_label=fixture.label,
+        form_id=brief.form_id,
+        seed=brief.seed,
+        reader_question=brief.reader_question,
+        fails_if=brief.fails_if,
+        entries=[
+            BlindEntry(
+                display_label=LETTERS[index],
+                title=sample.title,
+                markdown=sample.markdown,
+                status=sample.status,
+                error=sample.error,
+            )
+            for index, sample in enumerate(ordered)
+        ],
+    )
+    key = ComparisonKey(
+        comparison_id=identifier,
+        fixture_id=fixture.fixture_id,
+        mapping={
+            LETTERS[index]: sample.sample_id for index, sample in enumerate(ordered)
+        },
+    )
+    return sheet, key
+
+
+class CriterionScore(BaseModel):
+    criterion: str = Field(min_length=1)
+    value: int = Field(ge=SCORE_MIN, le=SCORE_MAX)
+    note: str = ""
+
+
+class EntryScore(BaseModel):
+    display_label: str = Field(min_length=1)
+    scores: list[CriterionScore] = Field(default_factory=list)
+    # What the reader wanted to say about this draft that no number carries.
+    # Never aggregated; it is read alongside the report, which is the point.
+    note: str = ""
+
+    @model_validator(mode="after")
+    def validate_criteria(self) -> "EntryScore":
+        seen = [score.criterion for score in self.scores]
+        if len(seen) != len(set(seen)):
+            raise ValueError("each criterion may be scored once per draft")
+        unknown = sorted(set(seen) - set(SCORE_CRITERIA))
+        if unknown:
+            raise ValueError(f"unknown scoring criteria: {unknown}")
+        return self
+
+
+class ScoreSheet(BaseModel):
+    """One reader's answers for one comparison."""
+
+    schema_version: Literal[1] = EVAL_SCHEMA_VERSION
+    comparison_id: str = Field(min_length=1)
+    reviewer: str = Field(min_length=1)
+    created_at: str = Field(min_length=1)
+    entries: list[EntryScore] = Field(default_factory=list)
+    note: str = ""
+
+
+# ---------------------------------------------------------------------------
+# The result, and what it is allowed to claim
+# ---------------------------------------------------------------------------
+
+# How many fixtures a candidate has to win a criterion on before the result is
+# reported as a direction rather than as an observation. Three is not a
+# statistical threshold and is not presented as one; it is the point at which
+# "it happened once" stops being the obvious explanation.
+DIRECTION_MIN_FIXTURES = 3
+
+
+@dataclass(frozen=True)
+class CriterionOutcome:
+    criterion: str
+    # variant_id -> mean score across the fixtures that scored it
+    means: dict[str, float]
+    fixtures_scored: int
+    leader: str | None
+    # True only when one variant leads on every fixture scored, and there were
+    # enough of them. Anything else reads as "no direction", including a wide
+    # average built out of one big win and two losses.
+    consistent: bool
+
+    @property
+    def reportable_direction(self) -> bool:
+        return self.consistent and self.fixtures_scored >= DIRECTION_MIN_FIXTURES
+
+
+def unblind(
+    sheets: Sequence[ScoreSheet],
+    keys: Sequence[ComparisonKey],
+    samples: Sequence[EvalSample],
+) -> dict[str, Any]:
+    """Put the letters back to variants and report each criterion on its own.
+
+    No composite score is produced, here or anywhere downstream. The whole
+    reason the criteria are separate is that a candidate can buy usefulness
+    with unsupported additions, and a total would price that as a win.
+    """
+    key_by_comparison = {key.comparison_id: key for key in keys}
+    sample_by_id = {sample.sample_id: sample for sample in samples}
+
+    # criterion -> variant -> fixture -> value
+    gathered: dict[str, dict[str, dict[str, list[int]]]] = {}
+    fixtures_seen: set[str] = set()
+    unresolved: list[str] = []
+
+    for sheet in sheets:
+        key = key_by_comparison.get(sheet.comparison_id)
+        if key is None:
+            unresolved.append(sheet.comparison_id)
+            continue
+        for entry in sheet.entries:
+            sample_id = key.mapping.get(entry.display_label)
+            sample = sample_by_id.get(sample_id or "")
+            if sample is None:
+                unresolved.append(f"{sheet.comparison_id}:{entry.display_label}")
+                continue
+            fixtures_seen.add(sample.fixture_id)
+            for score in entry.scores:
+                by_variant = gathered.setdefault(score.criterion, {})
+                by_fixture = by_variant.setdefault(sample.variant_id, {})
+                by_fixture.setdefault(sample.fixture_id, []).append(score.value)
+
+    outcomes: list[CriterionOutcome] = []
+    for criterion in SCORE_CRITERIA:
+        by_variant = gathered.get(criterion)
+        if not by_variant:
+            continue
+        per_fixture: dict[str, dict[str, float]] = {}
+        means: dict[str, float] = {}
+        for variant_id, fixture_values in by_variant.items():
+            for fixture_id, values in fixture_values.items():
+                per_fixture.setdefault(fixture_id, {})[variant_id] = sum(values) / len(
+                    values
+                )
+            flattened = [
+                value for values in fixture_values.values() for value in values
+            ]
+            means[variant_id] = round(sum(flattened) / len(flattened), 2)
+
+        leader = max(means, key=lambda variant: means[variant]) if means else None
+        # A lead every fixture agrees with. One fixture where the candidate
+        # loses is enough to withdraw the claim, which is the behaviour the
+        # report needs: a change that helps four articles and hurts one has
+        # not been shown to be safe.
+        scored_fixtures = [
+            values for values in per_fixture.values() if len(values) > 1
+        ]
+        consistent = bool(scored_fixtures) and leader is not None and all(
+            values.get(leader, float("-inf")) >= max(values.values())
+            for values in scored_fixtures
+        )
+        outcomes.append(
+            CriterionOutcome(
+                criterion=criterion,
+                means=means,
+                fixtures_scored=len(per_fixture),
+                leader=leader,
+                consistent=consistent,
+            )
+        )
+
+    return {
+        "criteria": [
+            {
+                "criterion": outcome.criterion,
+                "question": CRITERION_QUESTIONS[outcome.criterion],
+                "means": outcome.means,
+                "fixtures_scored": outcome.fixtures_scored,
+                "leader": outcome.leader,
+                "consistent": outcome.consistent,
+                "reportable_direction": outcome.reportable_direction,
+            }
+            for outcome in outcomes
+        ],
+        "fixtures_scored": sorted(fixtures_seen),
+        "measurements": measurement_summary(samples),
+        # Named rather than silently skipped. A sheet whose key is missing is a
+        # scoring session that has to be repeated, not a smaller sample.
+        "unresolved": sorted(set(unresolved)),
+        "verdict": _verdict(outcomes, len(fixtures_seen)),
+    }
+
+
+def _verdict(outcomes: Sequence[CriterionOutcome], fixture_count: int) -> dict[str, Any]:
+    """What this comparison is entitled to say, in words.
+
+    Refuses to name a winner when the evidence does not support one. The
+    failure this exists to prevent is the ordinary one: a candidate wins two
+    criteria on two fixtures and gets rolled out as an improvement.
+    """
+    if fixture_count < DIRECTION_MIN_FIXTURES:
+        return {
+            "decision": "not enough evidence",
+            "reason": (
+                f"{fixture_count} fixture(s) scored; at least "
+                f"{DIRECTION_MIN_FIXTURES} are needed before a direction is "
+                "reported."
+            ),
+        }
+    directions = [outcome for outcome in outcomes if outcome.reportable_direction]
+    if not directions:
+        return {
+            "decision": "no direction",
+            "reason": (
+                "No criterion had one variant ahead on every fixture scored."
+            ),
+        }
+    guards = [
+        outcome
+        for outcome in directions
+        if outcome.criterion in {"unsupported_additions", "caveat_retention"}
+    ]
+    leaders = {outcome.leader for outcome in directions}
+    conflicted = len(leaders) > 1
+    return {
+        "decision": "direction found",
+        "leaders": sorted(leader for leader in leaders if leader),
+        "criteria_with_direction": [outcome.criterion for outcome in directions],
+        "factual_footing_criteria": [outcome.criterion for outcome in guards],
+        # Said out loud rather than left for a reader to notice. Different
+        # winners on different criteria is the normal result and it is not a
+        # tie to be broken by adding the scores up.
+        "reason": (
+            "Different variants lead different criteria; this is a trade, not "
+            "a winner."
+            if conflicted
+            else "One variant leads every criterion that showed a direction."
+        ),
+    }
+
+
+def measurement_summary(samples: Sequence[EvalSample]) -> dict[str, Any]:
+    """Cost, tokens, latency and failures per variant. Measured, not judged."""
+    by_variant: dict[str, list[EvalSample]] = {}
+    for sample in samples:
+        by_variant.setdefault(sample.variant_id, []).append(sample)
+
+    summary: dict[str, Any] = {}
+    for variant_id, variant_samples in sorted(by_variant.items()):
+        completed = [s for s in variant_samples if s.status == "completed"]
+
+        def mean(pick: Callable[[EvalSample], float | int | None]) -> float | None:
+            values = [
+                float(value)
+                for value in (pick(sample) for sample in completed)
+                if value is not None
+            ]
+            return round(sum(values) / len(values), 4) if values else None
+
+        summary[variant_id] = {
+            "samples": len(variant_samples),
+            "completed": len(completed),
+            "failed": len(variant_samples) - len(completed),
+            "mean_billed_cost_usd": mean(lambda s: s.measurements.billed_cost_usd),
+            "mean_total_tokens": mean(lambda s: s.measurements.total_tokens),
+            "mean_duration_seconds": mean(lambda s: s.measurements.duration_seconds),
+            "mean_word_count": mean(lambda s: s.measurements.word_count),
+            # Counted, not averaged. A draft the pipeline itself calls unready
+            # is a different kind of fact from a slow one.
+            "samples_with_readiness_blockers": sum(
+                1 for s in completed if s.measurements.readiness_blockers
+            ),
+        }
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Producing a draft, which is the part that costs money
+# ---------------------------------------------------------------------------
+
+# The prefix every evaluation run id carries. Evaluation runs land in the same
+# database as real ones -- that is what makes their stage rows, prompts and
+# receipts inspectable with the tools that already exist -- so they have to be
+# recognisable at a glance and filterable out of an operator's article list.
+EVAL_RUN_PREFIX = "eval-"
+
+
+def is_eval_run(run_id: str) -> bool:
+    return run_id.startswith(EVAL_RUN_PREFIX)
+
+
+def pipeline_executor(
+    *,
+    run_id: str,
+    request: Prompt2BlogV4Request,
+    selection: Selection,
+) -> dict[str, Any]:
+    """Run the real v3 writing graph and hand back its artifact.
+
+    Deliberately the same entrypoint an operator's run uses, with the same
+    packet build and the same recorder. An evaluation that ran a special path
+    would measure the special path.
+
+    Imported here rather than at module scope: the orchestrator pulls in the
+    stages, and the stages are what a test of this module wants to avoid
+    loading at all.
+    """
+    from .intake_v3 import prepare_v3_runtime_request
+    from .orchestrator_v3 import run_pipeline_v3
+    from .run_recorder import RunRecorder
+
+    runtime = prepare_v3_runtime_request(request, selection)
+    RunRecorder().queue(run_id)
+    run_pipeline_v3(run_id, runtime)
+
+    from app.core import read_stage_result
+
+    stored = read_stage_result(run_id, "pipeline_v3") or {}
+    artifact = stored.get("data") if isinstance(stored, dict) else None
+    if not isinstance(artifact, dict) or not artifact:
+        raise RuntimeError(
+            f"Run {run_id} finished without writing a pipeline_v3 artifact"
+        )
+    return artifact
+
+
+def code_revision() -> tuple[str, bool]:
+    """The commit these drafts were written by, and whether the tree was dirty.
+
+    A dirty tree is recorded rather than refused. Trying a change before
+    committing it is the ordinary way to use this; what must not happen is a
+    sample that claims to be reproducible from a commit that never contained
+    the change.
+    """
+    import subprocess
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=Path(__file__).resolve().parent,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+
+    revision = git("rev-parse", "HEAD")
+    dirty = bool(git("status", "--porcelain"))
+    return revision, dirty
+
+
+def run_sample(
+    fixture: EvalFixture,
+    variant: EvalVariant,
+    *,
+    executor: SampleExecutor = pipeline_executor,
+    clock: Callable[[], str] = _now_iso,
+    timer: Callable[[], float] | None = None,
+    run_id: str | None = None,
+    revision: tuple[str, bool] | None = None,
+) -> EvalSample:
+    """Write one draft from a frozen fixture under one variant.
+
+    This is the only function in the module that spends anything, and it spends
+    a full article's worth every time it is called. Callers are expected to
+    have said so out loud.
+
+    A failure is caught and recorded as a failed sample rather than raised. One
+    fixture the candidate cannot survive is a result about the candidate, and
+    losing the whole comparison to it would throw away the drafts already
+    bought.
+    """
+    import time
+
+    now = timer or time.monotonic
+    head, dirty = revision if revision is not None else code_revision()
+    sample_id = f"{fixture.fixture_id}.{variant.variant_id}.{uuid.uuid4().hex[:8]}"
+    identifier = run_id or f"{EVAL_RUN_PREFIX}{uuid.uuid4().hex[:12]}"
+    started_at = clock()
+    began = now()
+
+    try:
+        artifact = executor(
+            run_id=identifier,
+            request=variant.apply(fixture.request),
+            selection=fixture.selection_record,
+        )
+    except Exception as exc:  # noqa: BLE001 - recorded, not swallowed
+        return failed_sample(
+            f"{type(exc).__name__}: {exc}",
+            sample_id=sample_id,
+            fixture_id=fixture.fixture_id,
+            variant_id=variant.variant_id,
+            run_id=identifier,
+            started_at=started_at,
+            finished_at=clock(),
+            code_revision=head,
+            code_dirty=dirty,
+        )
+
+    return sample_from_artifact(
+        artifact,
+        sample_id=sample_id,
+        fixture_id=fixture.fixture_id,
+        variant_id=variant.variant_id,
+        run_id=identifier,
+        started_at=started_at,
+        finished_at=clock(),
+        duration_seconds=now() - began,
+        code_revision=head,
+        code_dirty=dirty,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Where it all lives
+# ---------------------------------------------------------------------------
+
+
+class EvalStore:
+    """Plain JSON files under one directory.
+
+    A directory rather than the pipeline database on purpose. Fixtures are
+    inputs to a decision and want to be diffable, reviewable and committable;
+    the database is where runs go, and runs are exactly what a fixture must
+    survive being deleted.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+
+    def _dir(self, name: str) -> Path:
+        path = self.root / name
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _write(self, path: Path, model: BaseModel) -> Path:
+        path.write_text(
+            json.dumps(model.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def _read_all(self, name: str, model: type[BaseModel]) -> list[Any]:
+        return [
+            model.model_validate_json(path.read_text(encoding="utf-8"))
+            for path in sorted(self._dir(name).glob("*.json"))
+        ]
+
+    # Fixtures -------------------------------------------------------------
+    def save_fixture(self, fixture: EvalFixture) -> Path:
+        return self._write(
+            self._dir("fixtures") / f"{fixture.fixture_id}.json", fixture
+        )
+
+    def fixtures(self) -> list[EvalFixture]:
+        return self._read_all("fixtures", EvalFixture)
+
+    def fixture(self, fixture_id: str) -> EvalFixture:
+        path = self._dir("fixtures") / f"{fixture_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"No evaluation fixture '{fixture_id}'")
+        return EvalFixture.model_validate_json(path.read_text(encoding="utf-8"))
+
+    # Variants -------------------------------------------------------------
+    def save_variant(self, variant: EvalVariant) -> Path:
+        return self._write(
+            self._dir("variants") / f"{variant.variant_id}.json", variant
+        )
+
+    def variants(self) -> list[EvalVariant]:
+        return self._read_all("variants", EvalVariant)
+
+    def variant(self, variant_id: str) -> EvalVariant:
+        path = self._dir("variants") / f"{variant_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"No evaluation variant '{variant_id}'")
+        return EvalVariant.model_validate_json(path.read_text(encoding="utf-8"))
+
+    # Samples --------------------------------------------------------------
+    def save_sample(self, sample: EvalSample) -> Path:
+        return self._write(self._dir("samples") / f"{sample.sample_id}.json", sample)
+
+    def samples(self) -> list[EvalSample]:
+        return self._read_all("samples", EvalSample)
+
+    # Comparisons ----------------------------------------------------------
+    def save_comparison(
+        self, sheet: BlindComparison, key: ComparisonKey
+    ) -> tuple[Path, Path]:
+        """The sheet and its answer, in two files.
+
+        Two files because the reader opens one directory. A single file with a
+        `key` field inside it is blind only until somebody scrolls.
+
+        Both are committed, so this blinds a careless reading rather than a
+        determined one -- somebody who wants to know which draft is the
+        candidate can go and read the key. That is the right trade for a
+        one-person workflow: the guard is against learning it by accident
+        while reading the drafts, which is how blinding actually fails here.
+        """
+        sheet_path = self._write(
+            self._dir("comparisons") / f"{sheet.comparison_id}.json", sheet
+        )
+        key_path = self._write(
+            self._dir("keys") / f"{key.comparison_id}.json", key
+        )
+        return sheet_path, key_path
+
+    def comparisons(self) -> list[BlindComparison]:
+        return self._read_all("comparisons", BlindComparison)
+
+    def comparison(self, comparison_id: str) -> BlindComparison:
+        path = self._dir("comparisons") / f"{comparison_id}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"No comparison '{comparison_id}'")
+        return BlindComparison.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def keys(self) -> list[ComparisonKey]:
+        return self._read_all("keys", ComparisonKey)
+
+    # Scores ---------------------------------------------------------------
+    def save_score_sheet(self, sheet: ScoreSheet) -> Path:
+        return self._write(
+            self._dir("scores") / f"{sheet.comparison_id}.{sheet.reviewer}.json", sheet
+        )
+
+    def score_sheets(self) -> list[ScoreSheet]:
+        return self._read_all("scores", ScoreSheet)
+
+    def report(self) -> dict[str, Any]:
+        return unblind(self.score_sheets(), self.keys(), self.samples())

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_evaluation.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_evaluation.py
@@ -1,0 +1,515 @@
+"""What the comparison set must not let a candidate get away with.
+
+The evaluation machinery exists to stop one flattering run being read as an
+improvement, so the tests that matter are the ones about refusing to conclude:
+a sheet that cannot leak which version wrote which draft, a criterion that
+never gets added to another criterion, and a verdict that says "not enough
+evidence" when that is the truth.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.prompt2blog.contracts_v4 import (
+    Prompt2BlogModelRouting,
+    Prompt2BlogV4Request,
+)
+from app.features.prompt2blog.evaluation import (
+    DIRECTION_MIN_FIXTURES,
+    SCORE_CRITERIA,
+    SPARSE_CLAIM_COUNT,
+    ComparisonKey,
+    EntryScore,
+    EvalFixture,
+    EvalStore,
+    EvalVariant,
+    ScoreSheet,
+    blind_comparison,
+    capture_fixture,
+    coverage_report,
+    fixture_traits,
+    measurement_summary,
+    run_sample,
+    unblind,
+)
+from app.features.prompt2blog.selection_v4 import selection_from_flags
+
+FIXTURE_PATH = (
+    Path(__file__).parents[3]
+    / "data"
+    / "fixtures"
+    / "prompt2blog"
+    / "lima-scope-drift-v4.json"
+)
+
+
+def _payload() -> dict:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _request(**overrides) -> Prompt2BlogV4Request:
+    raw = _payload()
+    payload = {
+        "schema_version": 4,
+        "brief": raw["brief"],
+        "work_order": raw["work_order"],
+        "evidence_package": raw["evidence_package"],
+        "profiles": {"length_id": "medium", "creativity_level": "medium"},
+    }
+    payload.update(overrides)
+    return Prompt2BlogV4Request.model_validate(payload)
+
+
+def _fixture(fixture_id: str = "lima", **overrides) -> EvalFixture:
+    request = overrides.pop("request", None) or _request()
+    selection = selection_from_flags(
+        request.brief,
+        request.work_order,
+        request.evidence_package,
+        target_word_count=900,
+        note="test fixture",
+    )
+    return capture_fixture(
+        "run-0001",
+        fixture_id=fixture_id,
+        label=overrides.pop("label", "Lima layover"),
+        request=request,
+        selection=selection,
+        clock=lambda: "2026-09-06T00:00:00+00:00",
+        **overrides,
+    )
+
+
+def _artifact(**overrides) -> dict:
+    payload = {
+        "improved_article": {"title": "Two extra nights", "content": "body"},
+        "final_markdown": "# Two extra nights\n\nthree words here",
+        "run_cost": {"calls": 8, "total_tokens": 90_000, "billed_cost_usd": 0.41},
+        "readiness_blockers": [],
+        "repair_outcome": "repaired",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Fixtures describe themselves
+# ---------------------------------------------------------------------------
+
+
+def test_traits_are_read_off_the_inputs_not_typed_by_hand():
+    request = _request()
+    traits = fixture_traits(
+        request.brief, request.work_order, request.evidence_package
+    )
+    # Properties of the stored file, not of anything this test arranged: the
+    # Lima dossier is well under the sparse line, its claims are dated, and one
+    # of its requirements never settled.
+    assert "sparse_research" in traits
+    assert "dated_facts" in traits
+    assert "unsettled_requirement" in traits
+    assert len(request.evidence_package.claims) < SPARSE_CLAIM_COUNT
+
+
+def test_first_hand_material_is_a_trait_of_the_brief():
+    raw = _payload()
+    assert not raw["brief"].get("material")
+    plain = _request()
+    assert "first_hand_material" not in fixture_traits(
+        plain.brief, plain.work_order, plain.evidence_package
+    )
+
+    raw["brief"]["material"] = [
+        {"kind": "firsthand", "statement": "I waited 45 minutes on my visit"}
+    ]
+    witnessed = _request(brief=raw["brief"])
+    # The one the grounding checker used to call invented. A comparison set
+    # with none of these has said nothing about the case that broke.
+    assert "first_hand_material" in fixture_traits(
+        witnessed.brief, witnessed.work_order, witnessed.evidence_package
+    )
+
+
+def test_a_dossier_with_no_dates_does_not_claim_dated_facts():
+    raw = _payload()
+    for claim in raw["evidence_package"]["claims"]:
+        claim.pop("as_of", None)
+    request = _request(evidence_package=raw["evidence_package"])
+    assert "dated_facts" not in fixture_traits(
+        request.brief, request.work_order, request.evidence_package
+    )
+
+
+def test_coverage_names_what_the_set_cannot_speak_for():
+    report = coverage_report([_fixture()])
+    # The point of the report is the gap, not the tally. A set with no
+    # conflicting evidence in it has said nothing about conflicting evidence,
+    # and this is where that becomes visible before a candidate is judged.
+    assert "declared_conflict" in report["traits_missing"]
+    assert report["covers_every_trait"] is False
+
+
+def test_a_fixture_round_trips_through_the_store(tmp_path):
+    store = EvalStore(tmp_path)
+    store.save_fixture(_fixture())
+    restored = store.fixture("lima")
+    assert restored.request.brief.brief_fingerprint == (
+        _request().brief.brief_fingerprint
+    )
+    assert restored.selection_record.selected_claim_ids()
+
+
+# ---------------------------------------------------------------------------
+# A variant changes the candidate, never the control
+# ---------------------------------------------------------------------------
+
+
+def test_applying_a_variant_leaves_the_fixture_untouched():
+    fixture = _fixture()
+    variant = EvalVariant(
+        variant_id="candidate",
+        label="opus writer",
+        model_routing=Prompt2BlogModelRouting(writing_model="claude-opus-5"),
+        creativity_level="high",
+    )
+    applied = variant.apply(fixture.request)
+
+    assert applied.model_routing.writing_model == "claude-opus-5"
+    assert applied.profiles.creativity_level == "high"
+    # The fixture on disk is the only reason two samples can be said to share
+    # inputs. If applying a variant edited it, the second variant would be run
+    # against the first one's request.
+    assert fixture.request.model_routing.writing_model is None
+    assert fixture.request.profiles.creativity_level == "medium"
+
+
+def test_a_variant_that_says_nothing_about_creativity_keeps_the_fixtures():
+    fixture = _fixture()
+    applied = EvalVariant(variant_id="baseline", label="main").apply(fixture.request)
+    assert applied.profiles.creativity_level == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Buying a draft
+# ---------------------------------------------------------------------------
+
+
+def test_a_sample_copies_the_runs_own_receipt():
+    fixture = _fixture()
+    variant = EvalVariant(variant_id="baseline", label="main")
+    sample = run_sample(
+        fixture,
+        variant,
+        executor=lambda **_: _artifact(),
+        revision=("abc123", False),
+    )
+    assert sample.status == "completed"
+    assert sample.measurements.billed_cost_usd == 0.41
+    assert sample.measurements.calls == 8
+    # Counted off the article, not off the outline's budget: what a draft cost
+    # and how long it is are facts about the draft.
+    assert sample.measurements.word_count == 7
+    assert sample.run_id.startswith("eval-")
+
+
+def test_a_variant_that_cannot_write_is_recorded_rather_than_lost():
+    def explode(**_):
+        raise RuntimeError("provider refused")
+
+    sample = run_sample(
+        _fixture(),
+        EvalVariant(variant_id="candidate", label="opus"),
+        executor=explode,
+        revision=("abc123", False),
+    )
+    # Dropping it would silently turn the comparison into "the fixtures this
+    # candidate survived", which is the flattering version of the question.
+    assert sample.status == "failed"
+    assert "provider refused" in sample.error
+    assert sample.markdown == ""
+
+
+def test_a_dirty_tree_is_recorded_because_it_is_not_reproducible():
+    sample = run_sample(
+        _fixture(),
+        EvalVariant(variant_id="baseline", label="main"),
+        executor=lambda **_: _artifact(),
+        revision=("abc123", True),
+    )
+    assert sample.code_revision == "abc123"
+    assert sample.code_dirty is True
+
+
+# ---------------------------------------------------------------------------
+# The reader cannot see who wrote what
+# ---------------------------------------------------------------------------
+
+
+def _samples(fixture: EvalFixture, *variant_ids: str) -> list:
+    return [
+        run_sample(
+            fixture,
+            EvalVariant(variant_id=variant_id, label=variant_id),
+            # Deliberately neutral prose. A draft that names its own variant
+            # would make the blinding assertions below pass for the wrong
+            # reason -- and would not be blind in real use either.
+            executor=lambda **_: _artifact(
+                improved_article={"title": "A layover worth taking", "content": "x"},
+                final_markdown="Two nights, and what they buy you.",
+            ),
+            revision=("abc123", False),
+        )
+        for variant_id in variant_ids
+    ]
+
+
+def test_the_sheet_carries_no_trace_of_which_variant_wrote_which_draft():
+    fixture = _fixture()
+    samples = _samples(fixture, "baseline", "candidate")
+    sheet, key = blind_comparison(fixture, samples, rng=random.Random(7))
+
+    serialized = json.dumps(sheet.model_dump(mode="json"))
+    # Not "the field is absent" but "the string does not occur", because a
+    # reader opens the file. A variant id in a note or a title would blind
+    # nothing.
+    assert "baseline" not in serialized
+    assert "candidate" not in serialized
+    assert set(key.mapping) == {"A", "B"}
+    assert set(key.mapping.values()) == {sample.sample_id for sample in samples}
+
+
+def test_the_letters_are_shuffled_so_a_reader_cannot_learn_the_order():
+    fixture = _fixture()
+    samples = _samples(fixture, "baseline", "candidate")
+    orders = {
+        tuple(
+            blind_comparison(fixture, samples, rng=random.Random(seed))[1].mapping[
+                letter
+            ]
+            for letter in ("A", "B")
+        )
+        for seed in range(12)
+    }
+    assert len(orders) == 2
+
+
+def test_a_failed_draft_still_gets_a_letter():
+    fixture = _fixture()
+    good = _samples(fixture, "baseline")[0]
+    bad = run_sample(
+        fixture,
+        EvalVariant(variant_id="candidate", label="c"),
+        executor=lambda **_: (_ for _ in ()).throw(RuntimeError("nope")),
+        revision=("abc123", False),
+    )
+    sheet, _ = blind_comparison(fixture, [good, bad], rng=random.Random(1))
+    assert {entry.status for entry in sheet.entries} == {"completed", "failed"}
+
+
+def test_one_draft_is_not_a_comparison():
+    fixture = _fixture()
+    with pytest.raises(ValueError, match="at least two"):
+        blind_comparison(fixture, _samples(fixture, "baseline"))
+
+
+def test_drafts_from_different_fixtures_cannot_be_compared():
+    first = _fixture("lima")
+    second = _fixture("bogota")
+    mixed = _samples(first, "baseline") + _samples(second, "candidate")
+    with pytest.raises(ValueError, match="one fixture"):
+        blind_comparison(first, mixed)
+
+
+def test_the_key_is_stored_apart_from_the_sheet(tmp_path):
+    fixture = _fixture()
+    store = EvalStore(tmp_path)
+    sheet, key = blind_comparison(
+        fixture, _samples(fixture, "baseline", "candidate"), rng=random.Random(3)
+    )
+    sheet_path, key_path = store.save_comparison(sheet, key)
+    # Two files, two directories. A single file with the answer inside it is
+    # blind only until somebody scrolls.
+    assert sheet_path.parent != key_path.parent
+    assert "baseline" not in sheet_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Scoring refuses the shapes that would hide a trade
+# ---------------------------------------------------------------------------
+
+
+def test_a_criterion_nobody_defined_is_refused():
+    with pytest.raises(ValidationError):
+        EntryScore(
+            display_label="A",
+            scores=[{"criterion": "vibes", "value": 5}],
+        )
+
+
+def test_a_criterion_cannot_be_scored_twice_for_one_draft():
+    with pytest.raises(ValidationError):
+        EntryScore(
+            display_label="A",
+            scores=[
+                {"criterion": "voice", "value": 5},
+                {"criterion": "voice", "value": 2},
+            ],
+        )
+
+
+def test_a_score_outside_the_scale_is_refused():
+    with pytest.raises(ValidationError):
+        EntryScore(display_label="A", scores=[{"criterion": "voice", "value": 9}])
+
+
+# ---------------------------------------------------------------------------
+# What a result is entitled to say
+# ---------------------------------------------------------------------------
+
+
+def _scored(
+    fixture_ids: list[str],
+    winner: dict[str, str],
+    *,
+    criteria: tuple[str, ...] = SCORE_CRITERIA,
+):
+    """One comparison per fixture, with `winner` naming who leads each one."""
+    sheets: list[ScoreSheet] = []
+    keys: list[ComparisonKey] = []
+    samples: list = []
+    for fixture_id in fixture_ids:
+        fixture = _fixture(fixture_id)
+        pair = _samples(fixture, "baseline", "candidate")
+        samples.extend(pair)
+        sheet, key = blind_comparison(
+            fixture, pair, comparison_id=f"cmp-{fixture_id}", rng=random.Random(0)
+        )
+        keys.append(key)
+        by_variant = {sample.variant_id: sample.sample_id for sample in pair}
+        ahead = winner[fixture_id]
+        entries = []
+        for letter, sample_id in key.mapping.items():
+            leading = sample_id == by_variant[ahead]
+            entries.append(
+                EntryScore(
+                    display_label=letter,
+                    scores=[
+                        {"criterion": name, "value": 5 if leading else 3}
+                        for name in criteria
+                    ],
+                )
+            )
+        sheets.append(
+            ScoreSheet(
+                comparison_id=sheet.comparison_id,
+                reviewer="alan",
+                created_at="2026-09-06T00:00:00+00:00",
+                entries=entries,
+            )
+        )
+    return sheets, keys, samples
+
+
+def test_two_fixtures_are_not_enough_to_report_a_direction():
+    sheets, keys, samples = _scored(
+        ["lima", "bogota"], {"lima": "candidate", "bogota": "candidate"}
+    )
+    result = unblind(sheets, keys, samples)
+    assert result["verdict"]["decision"] == "not enough evidence"
+    assert str(DIRECTION_MIN_FIXTURES) in result["verdict"]["reason"]
+
+
+def test_one_fixture_the_candidate_loses_withdraws_the_claim():
+    sheets, keys, samples = _scored(
+        ["lima", "bogota", "quito"],
+        {"lima": "candidate", "bogota": "candidate", "quito": "baseline"},
+    )
+    result = unblind(sheets, keys, samples)
+    # A change that helps two articles and hurts one has not been shown to be
+    # safe, however good the average looks.
+    assert result["verdict"]["decision"] == "no direction"
+    assert all(row["reportable_direction"] is False for row in result["criteria"])
+
+
+def test_a_consistent_lead_across_enough_fixtures_is_reported():
+    sheets, keys, samples = _scored(
+        ["lima", "bogota", "quito"],
+        {"lima": "candidate", "bogota": "candidate", "quito": "candidate"},
+    )
+    result = unblind(sheets, keys, samples)
+    assert result["verdict"]["decision"] == "direction found"
+    assert result["verdict"]["leaders"] == ["candidate"]
+
+
+def test_the_report_never_produces_one_number():
+    sheets, keys, samples = _scored(
+        ["lima", "bogota", "quito"],
+        {"lima": "candidate", "bogota": "candidate", "quito": "candidate"},
+    )
+    result = unblind(sheets, keys, samples)
+    reported = {row["criterion"] for row in result["criteria"]}
+    assert reported == set(SCORE_CRITERIA)
+    # The whole reason the criteria stay apart is that a candidate can buy
+    # usefulness with unsupported additions. Nothing anywhere in the result may
+    # offer a total that prices that as a win.
+    serialized = json.dumps(result, default=str)
+    for banned in ("overall", "total_score", "composite", "combined_score"):
+        assert banned not in serialized
+
+
+def test_a_sheet_whose_key_is_missing_is_named_not_ignored():
+    sheets, keys, samples = _scored(["lima"], {"lima": "candidate"})
+    result = unblind(sheets, [], samples)
+    # Dropping it would quietly shrink the evidence while the report still read
+    # as if every comparison had been counted.
+    assert result["unresolved"] == ["cmp-lima"]
+    assert result["criteria"] == []
+
+
+def test_the_factual_footing_criteria_are_named_in_the_verdict():
+    sheets, keys, samples = _scored(
+        ["lima", "bogota", "quito"],
+        {"lima": "candidate", "bogota": "candidate", "quito": "candidate"},
+        criteria=("usefulness", "unsupported_additions", "caveat_retention"),
+    )
+    verdict = unblind(sheets, keys, samples)["verdict"]
+    assert set(verdict["factual_footing_criteria"]) == {
+        "unsupported_additions",
+        "caveat_retention",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Measurements stay measurements
+# ---------------------------------------------------------------------------
+
+
+def test_failures_and_unready_drafts_are_counted_separately():
+    fixture = _fixture()
+    good = _samples(fixture, "candidate")[0]
+    unready = run_sample(
+        fixture,
+        EvalVariant(variant_id="candidate", label="c"),
+        executor=lambda **_: _artifact(readiness_blockers=["a claim is unchecked"]),
+        revision=("abc123", False),
+    )
+    failed = run_sample(
+        fixture,
+        EvalVariant(variant_id="candidate", label="c"),
+        executor=lambda **_: (_ for _ in ()).throw(RuntimeError("nope")),
+        revision=("abc123", False),
+    )
+    summary = measurement_summary([good, unready, failed])["candidate"]
+    assert summary["samples"] == 3
+    assert summary["completed"] == 2
+    assert summary["failed"] == 1
+    assert summary["samples_with_readiness_blockers"] == 1
+    # A draft that never existed must not drag the average cost of the drafts
+    # that did.
+    assert summary["mean_billed_cost_usd"] == 0.41

--- a/apps/ai-blog-writer/scripts/p2b-eval.py
+++ b/apps/ai-blog-writer/scripts/p2b-eval.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""The writing-quality comparison set: capture inputs, run candidates, read blind.
+
+Improvement 06 from the writer-improvements report. Before this, "did that
+prompt change make the articles better" was answered by remembering one run.
+This makes it answerable: freeze the inputs of articles that already happened,
+run two versions of the writer against the same frozen inputs, and read the
+drafts without knowing which is which.
+
+The logic lives in the backend
+(`app/features/prompt2blog/evaluation.py`) so it is unit-tested; this file is
+the way to drive it by hand.
+
+    # 1. Freeze what a finished run handed its writer.
+    python3 scripts/p2b-eval.py capture <run_id> --id lima-airport --label "Lima airport transfer"
+    python3 scripts/p2b-eval.py fixtures            # what the set covers, and what it is missing
+
+    # 2. Describe the versions being compared.
+    python3 scripts/p2b-eval.py variant baseline --label "main"
+    python3 scripts/p2b-eval.py variant candidate --label "opus writer" --writing-model claude-opus-5
+
+    # 3. Buy the drafts. THIS SPENDS MONEY -- one full article per pair.
+    python3 scripts/p2b-eval.py run --variant baseline --variant candidate --spend
+
+    # 4. Read them blind, then record what you thought.
+    python3 scripts/p2b-eval.py sheet --open
+    python3 scripts/p2b-eval.py score <comparison_id> --reviewer alan --from scores.json
+
+    # 5. What the set is entitled to conclude.
+    python3 scripts/p2b-eval.py report
+
+`capture`, `fixtures`, `sheet` and `report` are read-only and free. Only `run`
+calls a model, and it refuses to without `--spend`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+import webbrowser
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+# The same three entries `pyproject.toml` gives pytest, set before the app is
+# imported so this runs from a checkout with no installed package.
+for path in ("apps/backend", "packages/shared/src", "packages/utils/src"):
+    sys.path.insert(0, str(APP_ROOT / path))
+
+from app.features.prompt2blog.contracts_v4 import (  # noqa: E402
+    Prompt2BlogModelRouting,
+)
+from app.features.prompt2blog.evaluation import (  # noqa: E402
+    CRITERION_QUESTIONS,
+    SCORE_CRITERIA,
+    SCORE_MAX,
+    SCORE_MIN,
+    BlindComparison,
+    EvalStore,
+    EvalVariant,
+    ScoreSheet,
+    blind_comparison,
+    capture_fixture,
+    coverage_report,
+    run_sample,
+)
+from app.features.prompt2blog.intake_v4 import writing_request  # noqa: E402
+
+# Committed alongside the code. A fixture is an input to a decision about the
+# writer, so it belongs in review the same way a test does.
+STORE_ROOT = APP_ROOT / "data" / "evaluation" / "prompt2blog"
+# Generated pages, which are not. `data/runs/` is already gitignored.
+OUT_DIR = APP_ROOT / "data" / "runs"
+
+
+def store() -> EvalStore:
+    return EvalStore(STORE_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# capture
+# ---------------------------------------------------------------------------
+
+
+def cmd_capture(args: argparse.Namespace) -> None:
+    handoff = writing_request(args.run_id, length_id=args.length)
+    fixture = capture_fixture(
+        args.run_id,
+        fixture_id=args.id,
+        label=args.label,
+        request=handoff.request,
+        selection=handoff.selection,
+        notes=args.notes or "",
+    )
+    path = store().save_fixture(fixture)
+    print(f"Captured {fixture.fixture_id} from {args.run_id[:8]} -> {path}")
+    print(f"  form {fixture.form_id}  length {fixture.length_id}")
+    print(f"  traits: {', '.join(fixture.traits) or 'none'}")
+
+
+def cmd_fixtures(args: argparse.Namespace) -> None:
+    fixtures = store().fixtures()
+    if not fixtures:
+        print("No fixtures yet. Capture one:")
+        print("  p2b-eval.py capture <run_id> --id X --label Y")
+        return
+    for fixture in fixtures:
+        print(f"{fixture.fixture_id:<24} {fixture.form_id:<22} {fixture.label}")
+        print(
+            f"    from {fixture.captured_from_run[:8]}  "
+            f"{len(fixture.request.evidence_package.claims)} claims  "
+            f"traits: {', '.join(fixture.traits) or 'none'}"
+        )
+    report = coverage_report(fixtures)
+    print(f"\n{report['fixtures']} fixtures across {len(report['forms'])} forms.")
+    if report["traits_missing"]:
+        # Said plainly because it is the thing that makes a result narrower
+        # than it looks. Nothing here blocks on it.
+        print(
+            "  Not covered yet: " + ", ".join(report["traits_missing"]) + "."
+            "  A comparison over this set says nothing about those cases."
+        )
+    else:
+        print("  Every hard case is represented at least once.")
+
+
+# ---------------------------------------------------------------------------
+# variant
+# ---------------------------------------------------------------------------
+
+
+def cmd_variant(args: argparse.Namespace) -> None:
+    routing = Prompt2BlogModelRouting(
+        model_name=args.model_name,
+        writing_model=args.writing_model,
+        repair_model=args.repair_model,
+        audit_model=args.audit_model,
+        outline_model=args.outline_model,
+        groundedness_model=args.groundedness_model,
+        model_stack_id=args.model_stack_id,
+    )
+    variant = EvalVariant(
+        variant_id=args.id,
+        label=args.label or args.id,
+        notes=args.notes or "",
+        model_routing=routing,
+        creativity_level=args.creativity,
+    )
+    path = store().save_variant(variant)
+    print(f"Saved variant {variant.variant_id} -> {path}")
+
+
+def cmd_variants(args: argparse.Namespace) -> None:
+    for variant in store().variants():
+        routed = {
+            key: value
+            for key, value in variant.model_routing.model_dump().items()
+            if value
+        }
+        print(f"{variant.variant_id:<20} {variant.label}")
+        print(f"    routing: {routed or 'gateway defaults'}")
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    holder = store()
+    fixtures = (
+        [holder.fixture(name) for name in args.fixture]
+        if args.fixture
+        else holder.fixtures()
+    )
+    variants = [holder.variant(name) for name in args.variant]
+    if not fixtures:
+        sys.exit("No fixtures to run against.")
+    if len(variants) < 2:
+        sys.exit("Give at least two --variant ids; a comparison needs two drafts.")
+
+    planned = len(fixtures) * len(variants)
+    if not args.spend:
+        # The refusal is the point. Every draft is a full article's worth of
+        # model calls, and the last measured run cost $0.65 for the writing
+        # graph alone -- so an accidental `run` over six fixtures and two
+        # variants is real money.
+        print(
+            f"Would write {planned} articles "
+            f"({len(fixtures)} fixtures x {len(variants)} variants).\n"
+            "Nothing was bought. Re-run with --spend to actually write them."
+        )
+        for fixture in fixtures:
+            print(f"  {fixture.fixture_id:<24} {fixture.label}")
+        return
+
+    print(f"Writing {planned} articles. This spends money.")
+    for fixture in fixtures:
+        for variant in variants:
+            print(f"  {fixture.fixture_id} / {variant.variant_id} ...", flush=True)
+            sample = run_sample(fixture, variant)
+            holder.save_sample(sample)
+            if sample.status == "failed":
+                print(f"    failed: {sample.error}")
+                continue
+            measured = sample.measurements
+            print(
+                f"    {measured.word_count} words  "
+                f"${measured.billed_cost_usd or 0:.4f}  "
+                f"{measured.duration_seconds}s  run {sample.run_id}"
+            )
+            if measured.readiness_blockers:
+                print(f"    unready: {'; '.join(measured.readiness_blockers)}")
+
+
+# ---------------------------------------------------------------------------
+# compare and sheet
+# ---------------------------------------------------------------------------
+
+
+def cmd_compare(args: argparse.Namespace) -> None:
+    holder = store()
+    samples = holder.samples()
+    made = 0
+    for fixture in holder.fixtures():
+        if args.fixture and fixture.fixture_id not in args.fixture:
+            continue
+        # The newest sample per variant. Re-running a variant should compare
+        # the run you just bought, not the first one you ever bought.
+        newest: dict[str, Any] = {}
+        for sample in samples:
+            if sample.fixture_id != fixture.fixture_id:
+                continue
+            current = newest.get(sample.variant_id)
+            if current is None or sample.started_at > current.started_at:
+                newest[sample.variant_id] = sample
+        if len(newest) < 2:
+            continue
+        sheet, key = blind_comparison(fixture, list(newest.values()))
+        holder.save_comparison(sheet, key)
+        made += 1
+        print(
+            f"{sheet.comparison_id}  {fixture.fixture_id}  "
+            f"{len(sheet.entries)} drafts as {', '.join(e.display_label for e in sheet.entries)}"
+        )
+    if not made:
+        print("Nothing to compare: every fixture has fewer than two drafts.")
+
+
+def render_sheets(sheets: list[BlindComparison]) -> str:
+    """One page holding every blind comparison, with the scoring form.
+
+    Self-contained, because it is opened off the filesystem. The variant behind
+    each letter is not in this file at all -- not in a comment, not in a data
+    attribute -- so it cannot leak to a reader who opens the source.
+    """
+    criteria_rows = "".join(
+        f"<tr><th>{html.escape(name.replace('_', ' '))}</th>"
+        f"<td>{html.escape(CRITERION_QUESTIONS[name])}</td></tr>"
+        for name in SCORE_CRITERIA
+    )
+    blocks = []
+    for sheet in sheets:
+        drafts = "".join(
+            f"""<article class="draft">
+              <h3>Draft {html.escape(entry.display_label)}</h3>
+              {'<p class="failed">This version produced no draft: '
+               + html.escape(entry.error) + '</p>'
+               if entry.status == 'failed'
+               else '<h4>' + html.escape(entry.title) + '</h4><pre>'
+                    + html.escape(entry.markdown) + '</pre>'}
+            </article>"""
+            for entry in sheet.entries
+        )
+        labels = json.dumps([entry.display_label for entry in sheet.entries])
+        blocks.append(
+            f"""<section class="comparison" data-comparison="{html.escape(sheet.comparison_id)}"
+                      data-labels='{labels}'>
+              <p class="eyebrow">{html.escape(sheet.comparison_id)}</p>
+              <h2>{html.escape(sheet.fixture_label or sheet.fixture_id)}</h2>
+              <dl class="brief">
+                <dt>Headline</dt><dd>{html.escape(sheet.seed)}</dd>
+                <dt>Reader's question</dt><dd>{html.escape(sheet.reader_question)}</dd>
+                <dt>Fails if</dt><dd>{html.escape(sheet.fails_if)}</dd>
+                <dt>Form</dt><dd>{html.escape(sheet.form_id)}</dd>
+              </dl>
+              <div class="drafts">{drafts}</div>
+              <div class="scoring"></div>
+            </section>"""
+        )
+
+    return f"""<!doctype html>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Prompt2Blog blind comparison</title>
+<style>
+:root{{--background:#F5F0E8;--paper:#EFE9DE;--ink:#1A1A1A;--accent:#3B5BDB;--rule:#c9c2b7}}
+body{{margin:0;background:var(--background);color:var(--ink);
+  font:16px/1.6 system-ui,sans-serif}}
+main{{max-width:1200px;margin:auto;padding:40px 24px 80px}}
+h1,h2,h3{{font-family:Georgia,serif;letter-spacing:-.02em}}
+h1{{font-size:40px;margin:0 0 8px}}
+.eyebrow{{font:700 11px/1.5 system-ui;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--accent);margin:0}}
+.comparison{{border-top:3px double var(--ink);margin-top:44px;padding-top:20px}}
+.brief{{display:grid;grid-template-columns:150px 1fr;gap:4px 16px;background:var(--paper);
+  padding:16px 20px;font-size:14px;margin:0 0 20px}}
+.brief dt{{font-weight:700}} .brief dd{{margin:0}}
+.drafts{{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:24px}}
+.draft{{border-top:1px solid var(--rule);padding-top:12px;min-width:0}}
+.draft pre{{white-space:pre-wrap;overflow-wrap:anywhere;font:14px/1.65 Georgia,serif;
+  background:var(--paper);padding:16px}}
+.failed{{background:var(--paper);padding:12px;font-style:italic}}
+table{{width:100%;border-collapse:collapse;font-size:14px;margin-bottom:24px}}
+th,td{{text-align:left;vertical-align:top;padding:8px;border-bottom:1px solid var(--rule)}}
+.scoring{{margin-top:24px;background:var(--paper);padding:16px 20px}}
+.scoring label{{display:block;font-size:13px;margin:6px 0}}
+.scoring input[type=range]{{width:180px;vertical-align:middle}}
+.scoring textarea{{width:100%;min-height:60px;font:13px system-ui}}
+button{{font:600 14px system-ui;padding:8px 16px;background:var(--accent);color:#fff;
+  border:0;cursor:pointer}}
+#out{{width:100%;min-height:200px;font:12px ui-monospace,monospace;margin-top:12px}}
+</style>
+<main>
+<h1>Read these blind.</h1>
+<p>Which version wrote which draft is not in this file. Score each draft on its
+own, one question at a time; do not add the numbers up.
+{SCORE_MIN} is worst, {SCORE_MAX} is best, on every row.</p>
+<table><tbody>{criteria_rows}</tbody></table>
+{''.join(blocks)}
+<h2>Your answers</h2>
+<p>Fill the sliders above, press the button, and save this JSON. Then:
+<code>p2b-eval.py score &lt;comparison_id&gt; --reviewer you --from answers.json</code></p>
+<button id="collect">Collect answers</button>
+<textarea id="out" readonly></textarea>
+</main>
+<script>
+const CRITERIA = {json.dumps(list(SCORE_CRITERIA))};
+for (const section of document.querySelectorAll('.comparison')) {{
+  const labels = JSON.parse(section.dataset.labels);
+  section.querySelector('.scoring').innerHTML = labels.map(label => `
+    <fieldset><legend><strong>Draft ${{label}}</strong></legend>` +
+    CRITERIA.map(c => `<label>${{c.replace(/_/g,' ')}}
+      <input type="range" min="{SCORE_MIN}" max="{SCORE_MAX}" value="3"
+             data-label="${{label}}" data-criterion="${{c}}"
+             oninput="this.nextElementSibling.textContent=this.value">
+      <span>3</span></label>`).join('') +
+    `<label>note <textarea data-label="${{label}}" data-note="1"></textarea></label>
+    </fieldset>`).join('');
+}}
+document.getElementById('collect').onclick = () => {{
+  const sheets = [...document.querySelectorAll('.comparison')].map(section => ({{
+    comparison_id: section.dataset.comparison,
+    entries: JSON.parse(section.dataset.labels).map(label => ({{
+      display_label: label,
+      note: (section.querySelector(`textarea[data-label="${{label}}"]`) || {{}}).value || '',
+      scores: CRITERIA.map(c => ({{
+        criterion: c,
+        value: Number(section.querySelector(
+          `input[data-label="${{label}}"][data-criterion="${{c}}"]`).value)
+      }}))
+    }}))
+  }}));
+  document.getElementById('out').value = JSON.stringify(sheets, null, 2);
+}};
+</script>
+"""
+
+
+def cmd_sheet(args: argparse.Namespace) -> None:
+    holder = store()
+    sheets = holder.comparisons()
+    if args.comparison_id:
+        sheets = [s for s in sheets if s.comparison_id in args.comparison_id]
+    if not sheets:
+        sys.exit("No comparisons yet. Run `compare` after you have drafts.")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = OUT_DIR / "p2b-blind-comparison.html"
+    path.write_text(render_sheets(sheets), encoding="utf-8")
+    print(f"Wrote {path} ({len(sheets)} comparison(s))")
+    if args.open:
+        webbrowser.open(path.as_uri())
+
+
+# ---------------------------------------------------------------------------
+# score and report
+# ---------------------------------------------------------------------------
+
+
+def cmd_score(args: argparse.Namespace) -> None:
+    payload = json.loads(Path(args.source).read_text(encoding="utf-8"))
+    entries = payload if isinstance(payload, list) else [payload]
+    holder = store()
+    saved = 0
+    for item in entries:
+        comparison_id = item.get("comparison_id") or args.comparison_id
+        if not comparison_id:
+            sys.exit("Each answer block needs a comparison_id.")
+        if args.comparison_id and comparison_id != args.comparison_id:
+            continue
+        sheet = ScoreSheet(
+            comparison_id=comparison_id,
+            reviewer=args.reviewer,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            entries=item.get("entries") or [],
+            note=item.get("note") or "",
+        )
+        path = holder.save_score_sheet(sheet)
+        saved += 1
+        print(f"Saved {path}")
+    if not saved:
+        print("Nothing matched; no scores were saved.")
+
+
+def cmd_report(args: argparse.Namespace) -> None:
+    result = store().report()
+    verdict = result["verdict"]
+    print(f"\nVerdict: {verdict['decision']}")
+    print(f"  {verdict['reason']}")
+    if verdict.get("leaders"):
+        print(f"  ahead: {', '.join(verdict['leaders'])}")
+
+    print(f"\nFixtures scored: {', '.join(result['fixtures_scored']) or 'none'}")
+    if result["unresolved"]:
+        print(f"  UNRESOLVED (rescore these): {', '.join(result['unresolved'])}")
+
+    print("\nPer criterion, never added together:")
+    for row in result["criteria"]:
+        means = "  ".join(f"{k}={v}" for k, v in sorted(row["means"].items()))
+        direction = (
+            f"-> {row['leader']}"
+            if row["reportable_direction"]
+            else "-> no direction yet"
+        )
+        print(f"  {row['criterion']:<24} {means:<40} {direction}")
+
+    print("\nMeasured, not judged:")
+    for variant_id, measured in result["measurements"].items():
+        print(
+            f"  {variant_id:<20} {measured['completed']}/{measured['samples']} wrote  "
+            f"${measured['mean_billed_cost_usd'] or 0:.4f} avg  "
+            f"{measured['mean_word_count'] or 0:.0f} words  "
+            f"{measured['mean_duration_seconds'] or 0:.0f}s"
+        )
+        if measured["failed"]:
+            print(f"      {measured['failed']} failed to produce a draft")
+        if measured["samples_with_readiness_blockers"]:
+            print(
+                f"      {measured['samples_with_readiness_blockers']} draft(s) the "
+                "pipeline itself called unready"
+            )
+    print()
+
+
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    capture = subparsers.add_parser("capture", help="freeze a finished run's inputs")
+    capture.add_argument("run_id")
+    capture.add_argument("--id", required=True, help="fixture id")
+    capture.add_argument("--label", required=True)
+    capture.add_argument("--notes", default="")
+    capture.add_argument("--length", default="medium")
+    capture.set_defaults(func=cmd_capture)
+
+    fixtures = subparsers.add_parser("fixtures", help="what the set covers")
+    fixtures.set_defaults(func=cmd_fixtures)
+
+    variant = subparsers.add_parser("variant", help="describe a version to test")
+    variant.add_argument("id")
+    variant.add_argument("--label", default="")
+    variant.add_argument("--notes", default="")
+    variant.add_argument("--creativity", default=None)
+    for role in (
+        "model-name",
+        "writing-model",
+        "repair-model",
+        "audit-model",
+        "outline-model",
+        "groundedness-model",
+        "model-stack-id",
+    ):
+        variant.add_argument(f"--{role}", default=None)
+    variant.set_defaults(func=cmd_variant)
+
+    variants = subparsers.add_parser("variants", help="list versions")
+    variants.set_defaults(func=cmd_variants)
+
+    run = subparsers.add_parser("run", help="write drafts (spends money)")
+    run.add_argument("--fixture", action="append", default=[])
+    run.add_argument("--variant", action="append", default=[])
+    run.add_argument(
+        "--spend",
+        action="store_true",
+        help="actually call models; without it, this only prints the plan",
+    )
+    run.set_defaults(func=cmd_run)
+
+    compare = subparsers.add_parser("compare", help="blind the drafts you have")
+    compare.add_argument("--fixture", action="append", default=[])
+    compare.set_defaults(func=cmd_compare)
+
+    sheet = subparsers.add_parser("sheet", help="render the blind reading page")
+    sheet.add_argument("comparison_id", nargs="*")
+    sheet.add_argument("--open", action="store_true")
+    sheet.set_defaults(func=cmd_sheet)
+
+    score = subparsers.add_parser("score", help="record a reviewer's answers")
+    score.add_argument("comparison_id", nargs="?", default=None)
+    score.add_argument("--reviewer", required=True)
+    score.add_argument("--from", dest="source", required=True)
+    score.set_defaults(func=cmd_score)
+
+    report = subparsers.add_parser("report", help="what the set is entitled to say")
+    report.set_defaults(func=cmd_report)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Improvement **06** from `docs/audits/prompt2blog-writer-improvements.html`, and the one the roadmap puts first because everything after it needs a baseline to prove itself against.

## The problem

Every writer-phase change so far was argued from one run. That cannot decide anything: the same prompt on the same packet does not write the same article twice, provider behaviour drifts, and the run somebody remembers is the one that stuck out.

## What this adds

`app/features/prompt2blog/evaluation.py` plus `scripts/p2b-eval.py`.

- **Fixture** — one article's inputs exactly as the writer received them (brief, work order, dossier, selection), captured off a run that already happened and never edited afterwards. That is the only reason two drafts can be said to share inputs.
- **Variant** — a model route and a creativity level. Prompts are deliberately not a field: they live in the tree, so the recorded commit *is* the prompt. A dirty tree is recorded rather than refused.
- **Sample** — one draft, with its receipt.
- **Blind sheet** — the drafts behind shuffled letters, with the key in a separate file.

Fixtures describe themselves: `fixture_traits` reads first-hand material, dated facts, declared conflicts, a sparse dossier and an unsettled requirement off the request rather than off a label somebody typed, and `coverage_report` names which of those the set still cannot speak for.

## What it refuses to say

This is most of the point.

| Guard | Why |
| --- | --- |
| Criteria never combine | A draft can be more useful *and* quietly drop a caveat; one number prices that as a win. A test asserts no total appears anywhere in the result. |
| Under 3 scored fixtures → "not enough evidence" | One run is what we already had. |
| A single lost fixture withdraws the claim | A change that helps four articles and hurts one has not been shown to be safe. |
| A failed variant is recorded, not dropped | Otherwise the comparison becomes "the fixtures this candidate survived". |
| A sheet with no key is named unresolved | Silently skipping it shrinks the evidence while the report still reads as complete. |

The blind sheet carries no variant identity at all — not in a field, not in a title — and the test asserts the *string* does not occur, because a reader opens the file. Cost, tokens, latency and readiness blockers come off the run's own receipt and stay measurements, never scores.

## Cost

`run_sample` is the only thing here that spends money, and it takes the executor that does — so capture, blinding, scoring and reporting are all tested without buying anything. The CLI prints the plan and refuses to run without `--spend`.

## Usage

```bash
python3 scripts/p2b-eval.py capture <run_id> --id lima --label "Lima layover"
python3 scripts/p2b-eval.py fixtures          # what the set covers, and what it misses
python3 scripts/p2b-eval.py variant candidate --label "opus writer" --writing-model claude-opus-5
python3 scripts/p2b-eval.py run --variant baseline --variant candidate --spend
python3 scripts/p2b-eval.py compare && python3 scripts/p2b-eval.py sheet --open
python3 scripts/p2b-eval.py score <cmp_id> --reviewer alan --from answers.json
python3 scripts/p2b-eval.py report
```

## Verification

- 26 new tests in `test_prompt2blog_evaluation.py`.
- Full backend suite: **1651 passed**, 0 failed.
- flake8 clean on all three new files.
- Capture driven against a real stored run (`e001d48c`) reading a copy of `pipeline.db`; blind sheet rendered and its scoring form round-tripped through `score` into `report`, which correctly returned "not enough evidence" on one fixture.

No pipeline behaviour changes and no model calls were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)