### PR TITLE
feat(p2b): a section has to say what the reader gets out of it

### DIFF
--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -355,6 +355,14 @@ Rule: the operator cuts it before research runs. Cutting a load-bearing question
 Related terms: Article Brief, Grounded Research.
 Do not confuse with: the Article Brief. The brief persists to the end; the work order persists only until research answers it.
 
+### Reader Payoff
+
+Definition: the one thing a section leaves its reader with, written into the outline as `reader_payoff` and checked against the finished draft by the audit. Its *kind* comes from the approved article form, declared in that form's frontmatter as `payoff`: a **decision** the reader can now make, an **answer** to a question they arrived with, or an **insight** about the subject they did not have.
+Rule: one per section, and no two sections may promise the same thing. A payoff that only restates its heading is reported, not enforced — whether a sentence adds anything to a heading is a judgement, and a plan is not thrown away over one line.
+Rule: a form that does not give advice is never asked for a decision. Forcing every section to end in a recommendation trades one formulaic shape for another.
+Related terms: Article Brief, Work Order.
+Do not confuse with: the Work Order requirement's `purpose`, which says why a *question* was asked of research. The reader payoff is about what a *section of prose* owes the person reading it.
+
 ### Questurian Voice
 
 Definition: the single file describing what a Questurian article is like — treats the reader as an adult with a decision to make, isn't selling anything, warmth is attention rather than adjectives, has a view and says it, never talks about itself. Paired with a separate, much shorter file of mechanical rules (price and date format, no fabricated experiences, sentence-case headings, no in-article attribution).

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -34,7 +34,12 @@ def _sanitize_section(raw: Any) -> dict[str, Any] | None:
         return None
     return {
         "heading": heading,
-        "purpose": _safe_str(record.get("purpose")) or "Purpose not stated.",
+        # Empty when the planner did not say, and left empty on purpose. The
+        # old field filled itself in with "Purpose not stated.", which is a
+        # sentence, so every downstream check saw a section that had stated
+        # its purpose. `validate_v3_outline` can only catch a missing payoff
+        # if a missing payoff still looks missing here.
+        "reader_payoff": _safe_str(record.get("reader_payoff")),
         "claim_ids": _string_list(record.get("claim_ids")),
         "target_words": max(0, _safe_int(record.get("target_words"), default=0)),
     }
@@ -162,6 +167,46 @@ def _names_subject(heading: str, primary_subject: str) -> bool:
     return bool(words) and _mentions(heading, words[0])
 
 
+# Words that carry no promise on their own. A payoff built only out of these
+# and the heading's own words has restated the heading, which is the exact
+# thing improvement 01 is about: the plan says a section exists and never says
+# what a reader leaves it with.
+_PAYOFF_FILLER = frozenset(
+    {
+        "a", "an", "and", "the", "this", "that", "these", "those", "of", "for",
+        "to", "in", "on", "at", "by", "with", "about", "from", "it", "its",
+        "is", "are", "be", "will", "can", "reader", "readers", "section",
+        "article", "piece", "explains", "explain", "covers", "cover", "covered",
+        "describes", "describe", "outlines", "outline", "gives", "give",
+        "provides", "provide", "shows", "show", "details", "detail",
+        "discusses", "discuss", "introduces", "introduce", "presents",
+        "present", "what", "which", "how", "why", "where", "when", "who",
+    }
+)
+
+
+def _payoff_words(text: str) -> set[str]:
+    return {
+        word
+        for word in re.findall(r"[\w']+", text.casefold())
+        if word not in _PAYOFF_FILLER
+    }
+
+
+def _restates_heading(heading: str, payoff: str) -> bool:
+    """Whether a payoff says only what its heading already said.
+
+    Deliberately generous to the planner. A payoff is only called a
+    restatement when, after filler and the heading's own words are removed,
+    it has nothing of its own left. "Covers the transport options" under
+    "Transport options" is caught; "Which transfer to book before 6am, and
+    what it costs" is not, and neither is a payoff that merely happens to
+    reuse the heading's nouns while going on to say something.
+    """
+    remaining = _payoff_words(payoff) - _payoff_words(heading)
+    return not remaining
+
+
 # Facts per hundred words above which a section stops being prose.
 #
 # Run 9e66bf84 gave one 200-word section 56 claims -- three and a half words
@@ -263,11 +308,36 @@ def validate_v3_outline(
         *(
             value
             for section in sections
-            for value in (section["heading"], section["purpose"])
+            for value in (section["heading"], section["reader_payoff"])
         ),
     ]
     covers_primary_subject = not primary_subject or any(
         _covers_subject(value, primary_subject) for value in subject_fields
+    )
+
+    # What each section promises the reader, and whether it promised anything
+    # (improvement 01). A section with no payoff is a heading with facts under
+    # it, and two sections promising the same thing is one section.
+    missing_payoffs = sorted(
+        section["heading"] for section in sections if not section["reader_payoff"]
+    )
+    payoff_keys = [
+        " ".join(sorted(_payoff_words(section["reader_payoff"])))
+        for section in sections
+        if section["reader_payoff"]
+    ]
+    duplicate_payoffs = sorted(
+        {key for key in payoff_keys if payoff_keys.count(key) > 1 and key}
+    )
+    # Read, not enforced -- the same treatment `crowded_sections` gets, and for
+    # the same reason. Whether a sentence adds something to its heading is a
+    # judgement, and a plan thrown away over this one would cost an article its
+    # whole structure to fix a line of prose.
+    restated_payoffs = sorted(
+        section["heading"]
+        for section in sections
+        if section["reader_payoff"]
+        and _restates_heading(section["heading"], section["reader_payoff"])
     )
 
     checks = {
@@ -275,6 +345,8 @@ def validate_v3_outline(
         # divides into two sections is that form working, and failing the plan
         # for it sent compose in with no plan at all.
         "enough_sections": len(sections) >= min_sections,
+        "payoffs_stated": not missing_payoffs,
+        "payoffs_distinct": not duplicate_payoffs,
         "headings_unique": len({s["heading"].casefold() for s in sections})
         == len(sections),
         "within_word_budget": within_budget,
@@ -296,6 +368,9 @@ def validate_v3_outline(
         # find out whether narrowing the packet actually fixed it.
         "crowded_sections": crowded_sections,
         "context_only_headings": context_only_headings,
+        "missing_payoffs": missing_payoffs,
+        "duplicate_payoffs": duplicate_payoffs,
+        "restated_payoffs": restated_payoffs,
     }
     return all(checks.values()), diagnostics
 
@@ -394,7 +469,7 @@ def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
         budget = f" (~{target} words)" if target else ""
         claims = ", ".join(section["claim_ids"]) or "none"
         lines.append(f"{index}. {section['heading']}{budget}")
-        lines.append(f"   Purpose: {section['purpose']}")
+        lines.append(f"   What the reader gets: {section['reader_payoff']}")
         lines.append(f"   Evidence claims: {claims}")
 
     takeaway = _safe_str(outline.get("takeaway_focus"))
@@ -412,3 +487,26 @@ def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
         lines.extend(f"- {item}" for item in unsupported)
 
     return "\n".join(lines)
+
+
+def format_payoff_promises(outline: dict[str, Any]) -> str:
+    """The promises the plan made, for the stage that checks they were kept.
+
+    The auditor used to be asked to work out for itself what each section
+    should have done for the reader, which is a second opinion about the plan
+    rather than a check on the draft. The plan already said. Handing it over
+    turns "does this section do its job" from a judgement about what the job
+    might have been into a comparison against a written promise.
+    """
+    sections = outline.get("sections") or []
+    promises = [
+        f"{index}. {section['heading']} -> {section['reader_payoff']}"
+        for index, section in enumerate(sections, start=1)
+        if section.get("reader_payoff")
+    ]
+    if not promises:
+        # An honest absence. A run whose plan was rejected has no promises to
+        # check, and inventing some here would put the auditor back to guessing
+        # with an air of authority.
+        return "No section promises were recorded for this run."
+    return "\n".join(promises)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editorial_catalog.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editorial_catalog.py
@@ -59,6 +59,51 @@ class EditorialRule(CatalogModel):
 OpeningMode = Literal["direct-answer", "form-led"]
 ClosingMode = Literal["takeaways", "form-led"]
 
+# What one section owes the person reading it.
+#
+# Improvement 01: the outline already carried a `purpose` per section, and
+# nothing in the outline prompt ever said what a purpose was. So it came back
+# as a restatement of the heading -- "covers transport options" under a heading
+# about transport -- and a section could be planned, written and audited
+# without anybody naming what a reader gets out of it.
+#
+# Three kinds, not one, because the report is explicit that this must not turn
+# every form into advice. A profile that ends each section with a
+# recommendation is a worse profile, and forcing it to would trade one
+# formulaic shape for another.
+#
+# `decision`: the reader can now choose, book, or skip something.
+# `answer`:   a question the reader arrived with is now settled.
+# `insight`:  the reader understands something about the subject they did not.
+PayoffMode = Literal["decision", "answer", "insight"]
+
+# What the outline is asked for, and what the audit checks was delivered, in
+# each mode's own words. Kept next to the mode rather than in the prompt files
+# so the planning stage, the writing stage and the auditor cannot describe the
+# same obligation three different ways.
+PAYOFF_NOUNS: dict[str, str] = {
+    "decision": "decision the reader can make",
+    "answer": "question the reader arrived with, answered",
+    "insight": "thing the reader now understands about the subject",
+}
+
+PAYOFF_PLANNING_RULES: dict[str, str] = {
+    "decision": (
+        "one decision this section leaves the reader able to make -- what they "
+        "can now choose, book, skip or budget for, and on what basis"
+    ),
+    "answer": (
+        "one question this section settles for the reader, phrased as the "
+        "question they arrived with rather than as the topic it falls under"
+    ),
+    "insight": (
+        "one thing this section leaves the reader understanding about the "
+        "subject that they did not understand before it. Not a recommendation: "
+        "this form does not give advice, and a section that ends in one is "
+        "doing the wrong job"
+    ),
+}
+
 # The floor under `min_sections`. Below two there is no structure to plan and
 # `sections_changed` has nothing to scope a repair to.
 ABSOLUTE_MIN_SECTIONS = 2
@@ -86,6 +131,12 @@ class FormStructurePolicy(CatalogModel):
     closing: ClosingMode
     min_sections: int = Field(ge=ABSOLUTE_MIN_SECTIONS, le=ABSOLUTE_MAX_SECTIONS)
     max_sections: int = Field(ge=ABSOLUTE_MIN_SECTIONS, le=ABSOLUTE_MAX_SECTIONS)
+    # Defaulted on the model, required in the frontmatter. Those are different
+    # jobs: `_structure_policy` refuses a form file that omits it, so no form
+    # can quietly acquire a payoff kind it did not choose, while a run frozen
+    # before this existed still validates and resumes into the shape it was
+    # written under.
+    payoff: PayoffMode = "decision"
 
     @model_validator(mode="after")
     def _range_is_a_range(self) -> "FormStructurePolicy":
@@ -129,12 +180,35 @@ class FormStructurePolicy(CatalogModel):
             "count is a range, not a target to hit."
         )
 
+    def payoff_noun(self) -> str:
+        return PAYOFF_NOUNS[self.payoff]
+
+    def outline_payoff_rule(self) -> str:
+        return (
+            f"- `reader_payoff` is the point of the section. Write "
+            f"{PAYOFF_PLANNING_RULES[self.payoff]}. One sentence, in the "
+            "reader's terms. It is not a summary of what the section covers: "
+            "a heading already says that, and repeating it back is how a "
+            "section gets planned without ever earning its place."
+        )
+
+    def compose_payoff_rule(self) -> str:
+        return (
+            "- Each planned section states what the reader gets from it. That "
+            f"is the {self.payoff_noun()}, and the section has not done its "
+            "job until the prose actually delivers it -- not gestured at it, "
+            "and not left the reader to work it out from the facts. Where the "
+            "evidence cannot support the payoff as planned, say what it does "
+            "support and what is missing; do not manufacture the payoff."
+        )
+
     def compose_rules(self) -> str:
         """The structural obligations for one form, for the compose prompt."""
         return "\n".join(
             (
                 self.opening_rule(),
                 self.sections_rule(),
+                self.compose_payoff_rule(),
                 self.closing_rule(),
                 "- Structure is the form's to decide and the evidence rules "
                 "are not. A form never licenses an invented scene, quotation, "
@@ -165,6 +239,7 @@ class FormStructurePolicy(CatalogModel):
                 f"{self.max_sections} sections.",
                 f"- {opening}",
                 f"- {closing}",
+                self.outline_payoff_rule(),
             )
         )
 
@@ -353,7 +428,7 @@ def _rule_section(body: str, heading: str) -> str:
 
 
 def _structure_policy(metadata: dict[str, str], path: Path) -> FormStructurePolicy:
-    """Read `opening`, `sections` and `closing` off one form's frontmatter.
+    """Read `opening`, `sections`, `closing` and `payoff` off a form's frontmatter.
 
     Loudly. A malformed range or an unknown mode fails the catalog load, which
     fails at import in every test rather than producing an article shaped by a
@@ -372,6 +447,7 @@ def _structure_policy(metadata: dict[str, str], path: Path) -> FormStructurePoli
             closing=metadata["closing"],
             min_sections=low,
             max_sections=high,
+            payoff=metadata["payoff"],
         )
     except PydanticValidationError as exc:
         raise ValueError(f"Invalid structure policy in {path}: {exc}") from exc
@@ -402,7 +478,7 @@ def _load_rule_directory(
         # somebody else's, which is finding 07 with an extra step. Required,
         # not defaulted.
         if forms:
-            required_keys |= {"opening", "sections", "closing"}
+            required_keys |= {"opening", "sections", "closing", "payoff"}
         missing_keys = required_keys - metadata.keys()
         extra_keys = metadata.keys() - required_keys - {"source_gate"}
         if missing_keys or extra_keys:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -14,7 +14,7 @@ Return strict JSON only:
   "sections": [
     {{
       "heading": "string",
-      "purpose": "string",
+      "reader_payoff": "string",
       "claim_ids": ["string"],
       "target_words": 0
     }}
@@ -28,6 +28,9 @@ Rules:
 {structure_rules}
 - Headings must be specific and distinct. No generic "Introduction" or
   "Conclusion" headings.
+- Every section must earn its place. Two sections may not promise the reader
+  the same thing; if they do, they are one section, or one of them has no
+  reason to exist.
 - Every section must name the claim_ids it rests on, using IDs from the facts
   below. Never cite a claim that is not there: what you are shown is the whole
   desk, and a fact outside it is one a person decided this article does not
@@ -225,6 +228,9 @@ Return strict JSON only:
   }},
   "fails_if_quote": "string",
   "fails_if_why": "string",
+  "unresolved_payoffs": [
+    {{"heading": "string", "why": "string"}}
+  ],
   "required_revisions": ["string"],
   "quality_summary": "string"
 }}
@@ -289,12 +295,20 @@ Rules:
 - Score honestly. A draft that merely avoids mistakes is a 7, not a 9. Being
   grounded, complete, and constraint-compliant is the floor this scale starts
   from, not what earns the top of it.
-- Reader decision support is a scored dimension, not a nicety. For each
-  section, ask what decision it lets the reader make and whether the draft
-  actually resolves it. A section that lays out options without saying what
-  separates them -- what each is better and worse for, and who should choose
-  which -- has covered its requirement without doing its job. Name any such
-  section in required_revisions.
+- SECTION PROMISES below is what the plan said each section would leave the
+  reader with. It is not yours to re-decide; your job is whether the draft
+  delivered it. For every promise that the prose does not keep, add an entry
+  to unresolved_payoffs naming that heading and one line on what is missing --
+  what the reader was going to be able to decide, or understand, or have
+  answered, and still cannot. Quote or paraphrase the specific gap; "does not
+  fully deliver" is not an answer anybody can act on.
+  A section that lays out options without saying what separates them -- what
+  each is better and worse for, and who should choose which -- has covered its
+  requirement without keeping its promise. Every unresolved payoff also
+  belongs in required_revisions, and unresolved payoffs weigh on
+  overall_score: a draft that leaves any of them open cannot score above 8.
+  Where the promises list says none were recorded, return an empty
+  unresolved_payoffs rather than inventing the promises you would have made.
 - A fact catalog is not coverage. Prose that walks a list of named items with
   their prices, hours, or figures attached, in sequence, without comparison or
   judgement, reads as a directory rather than an article. It can be entirely
@@ -323,6 +337,9 @@ GROUNDING VERDICT (authoritative on factual support):
 
 MEASURED CHECKS (counted, not judged):
 {measured_checks}
+
+SECTION PROMISES (what the plan said each section would give the reader):
+{section_promises}
 
 DRAFT TITLE:
 {rewritten_title}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -849,6 +849,17 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
         "tone_match": _safe_bool(checks_raw.get("tone_match"), default=True),
     }
 
+    # Promises the plan made that the draft did not keep (improvement 01).
+    # Each needs a heading and a reason: an entry naming neither is an
+    # accusation nobody can act on, and repair would spend a call on it.
+    unresolved_payoffs = []
+    for item in parsed.get("unresolved_payoffs") or []:
+        record = _safe_dict(item)
+        heading = _safe_str(record.get("heading"))
+        why = _safe_str(record.get("why"))
+        if heading and why:
+            unresolved_payoffs.append({"heading": heading, "why": why})
+
     # A missing or unparseable score used to default to 6, which sits below the
     # repair threshold -- so a malformed audit response silently bought a full
     # article rewrite. Absent scores now default to neutral and are reported as
@@ -882,6 +893,11 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
         # an inventory (run b29d66b4).
         "fails_if_quote": _safe_str(parsed.get("fails_if_quote")),
         "fails_if_why": _safe_str(parsed.get("fails_if_why")),
+        # Kept as its own list as well as folded into the revisions. "How many
+        # promises did this draft leave open" is the measure improvement 01
+        # asks to track, and it is not recoverable from a flat list of
+        # revision sentences.
+        "unresolved_payoffs": unresolved_payoffs,
         "required_revisions": required_revisions,
         "quality_summary": _safe_str(parsed.get("quality_summary"))
         or "Quality summary not provided.",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/resume_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/resume_v3.py
@@ -77,7 +77,13 @@ RESUME_HISTORY_STAGE = "pipeline_resume_v3"
 # the whole dossier -- the exact silent widening the packet exists to prevent.
 # Refused, and a refusal costs nothing: starting again is what happened before
 # resume existed at all.
-RESUME_SNAPSHOT_VERSION = 5
+#
+# 6: section payoffs (improvement 01). A version-5 snapshot's outline sections
+# carry `purpose`, and the formatters that hand the plan to compose and to the
+# audit read `reader_payoff`, so a resumed leg would fail on the field name --
+# or, if that were papered over, write from a plan whose promises the audit
+# would then check against nothing. Refused by version, which says why.
+RESUME_SNAPSHOT_VERSION = 6
 
 # State entries rebuilt on the way back in rather than stored. `request` is a
 # pydantic model and is written out under its own key; `completed` belongs to

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -74,7 +74,13 @@ V3_OUTLINE_SCHEMA: dict[str, Any] = {
                 "required": ["heading"],
                 "properties": {
                     "heading": {"type": "string"},
-                    "purpose": {"type": "string"},
+                    # Replaces `purpose`, which was in this schema and defined
+                    # nowhere, so it came back as the heading said twice
+                    # (improvement 01). Not added to `required`: the rule at
+                    # the top of this file holds, and a missing payoff is a
+                    # plan `validate_v3_outline` rejects with a reason rather
+                    # than a call the transport refuses without one.
+                    "reader_payoff": {"type": "string"},
                     "claim_ids": {"type": "array", "items": {"type": "string"}},
                     "target_words": {"type": "integer", "minimum": 0},
                 },

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -25,6 +25,7 @@ from ...quality import (
 )
 from ...quality_v3 import v3_constraint_brief
 from ...content.markdown import sections_changed
+from ...content.outline_v3 import format_payoff_promises
 from ...content.style_cleanup import clean_up_style
 from ...content.sections import (
     apply_section_replacements,
@@ -89,6 +90,10 @@ def _audit_v3_rewrite(
         style_directive=_format_style_directive(state["option_context"]),
         grounding_verdict=_json(groundedness),
         measured_checks=_measured_checks_block(computed_checks),
+        # What the plan promised, so the auditor compares the draft against a
+        # written commitment instead of against whatever it would have planned
+        # (improvement 01).
+        section_promises=format_payoff_promises(_safe_dict(state.get("outline"))),
         rewritten_title=rewrite["improved_title"],
         rewritten_content=rewrite["improved_content"],
     )
@@ -100,6 +105,17 @@ def _audit_v3_rewrite(
         model_name=state["audit_model"],
     )
     quality = _sanitize_quality(parsed)
+    # A promise the draft did not keep is a revision request, whether or not
+    # the auditor also wrote one. Repair reads `required_revisions` and nothing
+    # else, so an unresolved payoff that stayed in its own list would be
+    # recorded and never acted on.
+    for unresolved in quality["unresolved_payoffs"]:
+        instruction = (
+            f"The section \"{unresolved['heading']}\" does not deliver what "
+            f"the plan promised the reader: {unresolved['why']}"
+        )
+        if not any(unresolved["heading"] in item for item in quality["required_revisions"]):
+            quality["required_revisions"].append(instruction)
     # The auditor answered with a quote; this is where that becomes a verdict.
     fails_if = evaluate_fails_if(quality, rewrite["improved_content"])
     quality["fails_if_check"] = fails_if

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
@@ -5,6 +5,7 @@ summary: Answers a real question about a place and commits to the answer.
 order: 2
 opening: form-led
 sections: 3-12
+payoff: answer
 closing: form-led
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/comparison.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/comparison.md
@@ -5,6 +5,7 @@ summary: Evaluates approved co-subjects against consistent criteria for a define
 order: 12
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/cost-budget-breakdown.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/cost-budget-breakdown.md
@@ -5,6 +5,7 @@ summary: Builds a dated, transparent budget from defined assumptions and sourced
 order: 15
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/curated-list-best-of.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/curated-list-best-of.md
@@ -5,6 +5,7 @@ summary: Selects and explains a bounded set of options using explicit editorial 
 order: 11
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/destination-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/destination-guide.md
@@ -5,6 +5,7 @@ summary: Gives a coherent planning overview of one approved destination.
 order: 8
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/explainer.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/explainer.md
@@ -5,6 +5,7 @@ summary: Makes a complex system, rule, event, or travel concept understandable.
 order: 3
 opening: direct-answer
 sections: 3-12
+payoff: answer
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/feature-profile.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/feature-profile.md
@@ -5,6 +5,7 @@ summary: Builds a reported narrative around a person, place, community, or pheno
 order: 4
 opening: form-led
 sections: 3-12
+payoff: insight
 closing: form-led
 source_gate: reported-people-scenes-quotations
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/how-to-checklist.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/how-to-checklist.md
@@ -5,6 +5,7 @@ summary: Guides readers through a bounded task with verified steps and checkpoin
 order: 14
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/interview-qa.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/interview-qa.md
@@ -5,6 +5,7 @@ summary: Presents attributable answers from a named interview around a focused r
 order: 5
 opening: form-led
 sections: 2-12
+payoff: answer
 closing: form-led
 source_gate: attributable-responses
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/itinerary.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/itinerary.md
@@ -5,6 +5,7 @@ summary: Sequences a realistic trip plan across an approved time window and geog
 order: 10
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/news-report.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/news-report.md
@@ -5,6 +5,7 @@ summary: Reports a timely development, what changed, and what readers should kno
 order: 1
 opening: direct-answer
 sections: 2-12
+payoff: answer
 closing: form-led
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/opinion-column.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/opinion-column.md
@@ -5,6 +5,7 @@ summary: Advances a clearly identified viewpoint using evidence and transparent 
 order: 6
 opening: form-led
 sections: 2-12
+payoff: insight
 closing: form-led
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/personal-essay-travelogue.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/personal-essay-travelogue.md
@@ -5,6 +5,7 @@ summary: Shapes supplied lived experience into a reflective journey grounded in 
 order: 7
 opening: form-led
 sections: 2-12
+payoff: insight
 closing: form-led
 source_gate: first-person-material
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/review.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/review.md
@@ -5,6 +5,7 @@ summary: Evaluates a specific experience, service, place, or product against dec
 order: 13
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 source_gate: documented-evaluation
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/service-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/service-guide.md
@@ -5,6 +5,7 @@ summary: Helps a defined reader solve one practical travel problem or decision.
 order: 9
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_form_structure.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_form_structure.py
@@ -100,8 +100,18 @@ def test_an_interview_may_divide_into_two_sections():
         {
             "working_title": "Two questions",
             "sections": [
-                {"heading": "On the route", "claim_ids": [], "target_words": 400},
-                {"heading": "On the price", "claim_ids": [], "target_words": 400},
+                {
+                    "heading": "On the route",
+                    "reader_payoff": "Which leg of the trip is worth the detour.",
+                    "claim_ids": [],
+                    "target_words": 400,
+                },
+                {
+                    "heading": "On the price",
+                    "reader_payoff": "Whether the fare quoted is the one to book.",
+                    "claim_ids": [],
+                    "target_words": 400,
+                },
             ],
         },
         max_sections=structure.max_sections,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_payoff.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_payoff.py
@@ -1,0 +1,328 @@
+"""Improvement 01: a section has to say what the reader gets out of it.
+
+The outline already carried a `purpose` per section and nothing in the outline
+prompt ever said what a purpose was, so it came back as the heading restated --
+"covers the transport options" under a heading about transport options. A
+section could therefore be planned, written and audited without anybody ever
+naming what a reader leaves it with.
+
+What changed is small and in three places: the form declares which *kind* of
+payoff its sections owe, the plan has to state one per section, and the audit
+checks the draft against those written promises instead of inventing its own.
+"""
+
+from __future__ import annotations
+
+from typing import Any, get_args
+
+import pytest
+
+from app.features.prompt2blog.contracts_v4 import ArticleFormId
+from app.features.prompt2blog.content.outline_v3 import (
+    format_payoff_promises,
+    format_v3_outline_for_prompt,
+    sanitize_v3_outline,
+    validate_v3_outline,
+)
+from app.features.prompt2blog.editorial_catalog import (
+    PAYOFF_NOUNS,
+    FormStructurePolicy,
+    PayoffMode,
+    load_editorial_catalog,
+)
+from app.features.prompt2blog.quality import _sanitize_quality
+
+WORK_ORDER: dict[str, Any] = {
+    "primary_subject": "Lima",
+    "scope": {"references": []},
+}
+
+
+def _forms():
+    return {form.id: form for form in load_editorial_catalog().forms}
+
+
+def _plan(*sections: tuple[str, str]) -> dict[str, Any]:
+    return sanitize_v3_outline(
+        {
+            "working_title": "What Lima costs now",
+            "sections": [
+                {
+                    "heading": heading,
+                    "reader_payoff": payoff,
+                    "claim_ids": [],
+                    "target_words": 300,
+                }
+                for heading, payoff in sections
+            ],
+        }
+    )
+
+
+def _validate(plan: dict[str, Any]):
+    return validate_v3_outline(
+        plan,
+        work_order=WORK_ORDER,
+        claim_ids=set(),
+        target_word_count=0,
+    )
+
+
+GOOD_PLAN = (
+    ("What Lima costs now", "Whether a monthly budget stretches in Lima today."),
+    ("The tradeoffs behind the price", "Which tradeoff to accept for the price."),
+    ("How the picture changed", "Whether to move now or wait, given how costs moved."),
+)
+
+
+# ---------------------------------------------------------------------------
+# The form decides which kind of payoff, and every form has decided
+# ---------------------------------------------------------------------------
+
+
+def test_every_form_declares_what_its_sections_owe_the_reader():
+    forms = _forms()
+    assert set(forms) == set(get_args(ArticleFormId))
+    for form_id, form in forms.items():
+        assert form.structure.payoff in get_args(PayoffMode), form_id
+
+
+def test_a_form_file_that_omits_the_payoff_fails_the_catalog_load(tmp_path):
+    """Loudly, at import, rather than by silently substituting a default.
+
+    The model default exists so a run frozen before this shipped still
+    validates and resumes. A *form* acquiring a payoff kind it never chose is
+    a different thing, and the two must not share one lenience.
+    """
+    from app.features.prompt2blog.editorial_catalog import _structure_policy
+
+    metadata = {"opening": "form-led", "sections": "3-12", "closing": "form-led"}
+    with pytest.raises(KeyError):
+        _structure_policy(metadata, tmp_path / "made-up-form.md")
+
+
+def test_advice_is_not_forced_on_a_form_that_does_not_give_it():
+    """The report is explicit that this must not turn every form into advice.
+
+    A profile whose every section ends in a recommendation is a worse profile.
+    So the narrative forms ask for an insight and say so, and the planning rule
+    they receive says in as many words not to recommend anything.
+    """
+    forms = _forms()
+    assert forms["feature-profile"].structure.payoff == "insight"
+    assert forms["personal-essay-travelogue"].structure.payoff == "insight"
+    assert forms["service-guide"].structure.payoff == "decision"
+    assert forms["interview-qa"].structure.payoff == "answer"
+
+    profile_rule = forms["feature-profile"].structure.outline_payoff_rule()
+    assert "Not a recommendation" in profile_rule
+    assert "decision" not in profile_rule
+
+
+def test_the_planner_and_the_writer_are_told_the_same_thing():
+    """One rule, one owner. The #547 lesson, applied to a new rule.
+
+    Both stages read the noun off the same table, so the plan cannot be asked
+    for a decision while the prose is asked to deliver an insight.
+    """
+    for mode in get_args(PayoffMode):
+        policy = FormStructurePolicy(
+            opening="form-led",
+            closing="form-led",
+            min_sections=2,
+            max_sections=8,
+            payoff=mode,
+        )
+        assert PAYOFF_NOUNS[mode] in policy.compose_payoff_rule()
+        assert policy.outline_payoff_rule() in policy.outline_rules()
+        assert policy.compose_payoff_rule() in policy.compose_rules()
+
+
+# ---------------------------------------------------------------------------
+# The plan has to state one, and they have to differ
+# ---------------------------------------------------------------------------
+
+
+def test_a_plan_that_names_a_payoff_per_section_is_accepted():
+    accepted, checks = _validate(_plan(*GOOD_PLAN))
+    assert accepted is True
+    assert checks["payoffs_stated"] is True
+    assert checks["payoffs_distinct"] is True
+    assert checks["missing_payoffs"] == []
+
+
+def test_a_section_with_no_payoff_is_named_and_the_plan_refused():
+    plan = _plan(*GOOD_PLAN)
+    plan["sections"][1]["reader_payoff"] = ""
+    accepted, checks = _validate(plan)
+
+    assert accepted is False
+    assert checks["payoffs_stated"] is False
+    # Named, so an operator reading the run record knows which section, and so
+    # a later stage can say something more useful than "the plan was rejected".
+    assert checks["missing_payoffs"] == ["The tradeoffs behind the price"]
+
+
+def test_a_missing_payoff_stays_missing_rather_than_filling_itself_in():
+    """The old field defaulted to the sentence "Purpose not stated."
+
+    Which is a sentence, so every check downstream saw a section that had
+    stated its purpose. A missing payoff can only be caught if it still looks
+    missing after sanitizing.
+    """
+    plan = sanitize_v3_outline(
+        {"working_title": "T", "sections": [{"heading": "One", "claim_ids": []}]}
+    )
+    assert plan["sections"][0]["reader_payoff"] == ""
+
+
+def test_two_sections_promising_the_same_thing_are_one_section():
+    plan = _plan(
+        ("What Lima costs now", "Whether a monthly budget stretches in Lima today."),
+        ("The tradeoffs", "Which tradeoff to accept for the price."),
+        ("How the picture changed", "Whether a monthly budget stretches in Lima today."),
+    )
+    accepted, checks = _validate(plan)
+
+    assert accepted is False
+    assert checks["payoffs_distinct"] is False
+    assert checks["duplicate_payoffs"]
+
+
+def test_wording_a_promise_differently_does_not_make_it_a_different_promise():
+    """Compared on content words, not on the sentence.
+
+    Otherwise the rule is satisfied by rephrasing, which is the failure the
+    duplicate check exists to catch dressed up.
+    """
+    plan = _plan(
+        ("Costs", "Whether a monthly budget stretches in Lima today."),
+        ("Prices", "Whether, today, a monthly budget stretches in Lima."),
+        ("Change", "Whether to move now or wait, given how costs moved."),
+    )
+    _accepted, checks = _validate(plan)
+    assert checks["payoffs_distinct"] is False
+
+
+def test_a_payoff_that_only_restates_its_heading_is_reported_not_enforced():
+    """The same treatment `crowded_sections` gets, for the same reason.
+
+    Whether a sentence adds anything to its heading is a judgement, and a plan
+    thrown away over one line would cost the article its whole structure to fix
+    a sentence.
+    """
+    plan = _plan(
+        ("Transport options", "Covers the transport options."),
+        ("The tradeoffs behind the price", "Which tradeoff to accept for the price."),
+        ("How the picture changed", "Whether to move now or wait as costs moved."),
+    )
+    accepted, checks = _validate(plan)
+
+    assert accepted is True
+    assert checks["restated_payoffs"] == ["Transport options"]
+
+
+def test_a_real_promise_that_reuses_the_headings_words_is_not_a_restatement():
+    plan = _plan(
+        (
+            "Airport transfers",
+            "Which airport transfer to book before a 6am flight, and what it costs.",
+        ),
+        ("The tradeoffs behind the price", "Which tradeoff to accept for the price."),
+        ("How the picture changed", "Whether to move now or wait as costs moved."),
+    )
+    _accepted, checks = _validate(plan)
+    assert checks["restated_payoffs"] == []
+
+
+# ---------------------------------------------------------------------------
+# The promise travels to the writer, and then to the auditor
+# ---------------------------------------------------------------------------
+
+
+def test_the_writer_is_told_what_each_section_owes_the_reader():
+    rendered = format_v3_outline_for_prompt(_plan(*GOOD_PLAN))
+    assert "What the reader gets: Whether a monthly budget stretches" in rendered
+    assert "Purpose:" not in rendered
+
+
+def test_the_auditor_is_handed_the_promises_rather_than_inventing_them():
+    promises = format_payoff_promises(_plan(*GOOD_PLAN))
+    for heading, payoff in GOOD_PLAN:
+        assert f"{heading} -> {payoff}" in promises
+
+
+def test_a_run_with_no_plan_offers_the_auditor_no_promises_to_check():
+    """An honest absence.
+
+    A rejected plan has no promises. Inventing some here would put the auditor
+    back to guessing, with the authority of a list that looks recorded.
+    """
+    assert "No section promises were recorded" in format_payoff_promises(
+        {"sections": []}
+    )
+
+
+# ---------------------------------------------------------------------------
+# An unresolved promise becomes something repair can act on
+# ---------------------------------------------------------------------------
+
+
+def test_an_unresolved_payoff_survives_the_sanitizer_with_its_reason():
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "unresolved_payoffs": [
+                {
+                    "heading": "The tradeoffs behind the price",
+                    "why": "Lists three options and never says which suits whom.",
+                }
+            ],
+        }
+    )
+    assert quality["unresolved_payoffs"] == [
+        {
+            "heading": "The tradeoffs behind the price",
+            "why": "Lists three options and never says which suits whom.",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"heading": "", "why": "something is missing"},
+        {"heading": "A section", "why": ""},
+        {"heading": "A section"},
+        "not an object",
+    ],
+)
+def test_an_accusation_nobody_can_act_on_is_dropped(entry):
+    """Both halves or neither.
+
+    A heading with no reason is a complaint repair would spend a call failing
+    to satisfy, and a reason with no heading cannot be scoped to anything.
+    """
+    quality = _sanitize_quality(
+        {"overall_score": 8, "unresolved_payoffs": [entry]}
+    )
+    assert quality["unresolved_payoffs"] == []
+
+
+def test_the_count_of_open_promises_is_recoverable_from_the_audit():
+    """The measure improvement 01 asks to track.
+
+    "How many promises did this draft leave open" is not recoverable from a
+    flat list of revision sentences, which is why the list survives as its own
+    field as well as being folded into the revisions.
+    """
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "unresolved_payoffs": [
+                {"heading": "One", "why": "no decision reached"},
+                {"heading": "Two", "why": "the question is restated, not answered"},
+            ],
+        }
+    )
+    assert len(quality["unresolved_payoffs"]) == 2

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -722,7 +722,10 @@ def test_the_audit_scores_editing_burden_not_rule_compliance():
     assert "What remains is personalisation" in prompt
     assert "A fact catalog is not coverage" in prompt
     assert "cap overall_score at 7" in prompt
-    assert "Reader decision support is a scored dimension" in prompt
+    # The rule that used to ask the auditor to work out for itself what each
+    # section owed the reader. It now checks the plan's written promises
+    # instead (improvement 01).
+    assert "SECTION PROMISES below is what the plan said" in prompt
     assert "is the floor this scale starts" in prompt
 
 
@@ -941,3 +944,83 @@ def test_an_auditor_revision_about_length_survives_when_the_length_is_fine():
     assert recorder.recorded[0][1]["required_revisions"] == [
         "Shorten the opening paragraph."
     ]
+
+
+def test_the_plans_promises_reach_the_auditor():
+    """The auditor compares the draft against what the plan committed to.
+
+    It used to be asked what each section *should* have done for the reader,
+    which is a second opinion about the plan rather than a check on the draft.
+    """
+    llm = FakeLLM(json_response={"overall_score": 8, "quality_summary": "Fine."})
+    dependencies, _recorder = _dependencies(llm)
+    outline = {
+        "sections": [
+            {
+                "heading": "What Lima costs now",
+                "reader_payoff": "Whether a monthly budget stretches in Lima today.",
+            }
+        ]
+    }
+
+    run_v3_quality_audit_stage(_state(outline=outline), dependencies)
+
+    prompt = llm.prompts[0]
+    assert "SECTION PROMISES" in prompt
+    assert (
+        "What Lima costs now -> Whether a monthly budget stretches in Lima today."
+        in prompt
+    )
+
+
+def test_an_unresolved_promise_becomes_a_revision_repair_can_act_on():
+    """Repair reads `required_revisions` and nothing else.
+
+    An unresolved payoff that stayed in its own list would be recorded on the
+    run and never acted on, which is the quietest way for a check to do
+    nothing.
+    """
+    llm = FakeLLM(
+        json_response={
+            "overall_score": 8,
+            "required_revisions": [],
+            "unresolved_payoffs": [
+                {
+                    "heading": "The tradeoffs behind the price",
+                    "why": "Lists three options and never says which suits whom.",
+                }
+            ],
+            "quality_summary": "Fine.",
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_quality_audit_stage(_state(), dependencies)
+    revisions = updates["quality"]["required_revisions"]
+
+    assert any("The tradeoffs behind the price" in item for item in revisions)
+    assert any("never says which suits whom" in item for item in revisions)
+
+
+def test_a_promise_the_auditor_already_wrote_up_is_not_repeated():
+    llm = FakeLLM(
+        json_response={
+            "overall_score": 8,
+            "required_revisions": [
+                "Rewrite The tradeoffs behind the price so it names a winner."
+            ],
+            "unresolved_payoffs": [
+                {
+                    "heading": "The tradeoffs behind the price",
+                    "why": "Lists three options and never says which suits whom.",
+                }
+            ],
+            "quality_summary": "Fine.",
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_quality_audit_stage(_state(), dependencies)
+    revisions = updates["quality"]["required_revisions"]
+
+    assert len([r for r in revisions if "The tradeoffs behind the price" in r]) == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
@@ -143,21 +143,21 @@ def _outline_payload(**overrides) -> dict[str, Any]:
         "sections": [
             {
                 "heading": "What Lima costs now",
-                "purpose": "Establish the current cost baseline for Lima.",
+                "reader_payoff": "Whether a monthly budget stretches in Lima today.",
                 "claim_ids": ["c1"],
                 "requirement_ids": ["r1"],
                 "target_words": 300,
             },
             {
                 "heading": "The tradeoffs behind the price",
-                "purpose": "Show the practical tradeoffs a resident meets.",
+                "reader_payoff": "Which tradeoff a resident should accept for the price.",
                 "claim_ids": ["c2"],
                 "requirement_ids": ["r2"],
                 "target_words": 300,
             },
             {
                 "heading": "How the picture changed",
-                "purpose": "Compare the current baseline with earlier reporting.",
+                "reader_payoff": "Whether to move now or wait, given how costs moved.",
                 "claim_ids": ["c3"],
                 "requirement_ids": ["r3"],
                 "target_words": 300,
@@ -191,8 +191,8 @@ def test_city_only_outline_wording_covers_city_country_primary_subject(
     work_order["scope"]["references"] = []
     payload = _outline_payload()
     payload["sections"][0]["heading"] = f"What {subject_mention} costs now"
-    payload["sections"][0]["purpose"] = (
-        f"Establish the current cost baseline for {subject_mention}."
+    payload["sections"][0]["reader_payoff"] = (
+        f"Whether a monthly budget stretches in {subject_mention} today."
     )
 
     accepted, diagnostics = validate_v3_outline(
@@ -262,7 +262,9 @@ def test_sections_may_carry_the_subject_implicitly_when_the_framing_names_it():
     implicit = _outline_payload()
     for section in implicit["sections"]:
         section["heading"] = section["heading"].replace("Lima", "the city")
-        section["purpose"] = section["purpose"].replace("Lima", "the city")
+        section["reader_payoff"] = section["reader_payoff"].replace(
+            "Lima", "the city"
+        )
 
     accepted, diagnostics = _validate(implicit)
 
@@ -426,14 +428,14 @@ def _five_section_payload() -> dict[str, Any]:
     payload["sections"] = payload["sections"] + [
         {
             "heading": "Where the money actually goes",
-            "purpose": "Break the monthly figure into what a resident pays.",
+            "reader_payoff": "Which line of the monthly figure to cut first.",
             "claim_ids": ["c1"],
             "requirement_ids": ["r1"],
             "target_words": 150,
         },
         {
             "heading": "What a long stay commits you to",
-            "purpose": "Say what the decision costs beyond money.",
+            "reader_payoff": "Whether the non-monetary cost is one to accept.",
             "claim_ids": ["c2"],
             "requirement_ids": ["r2"],
             "target_words": 150,
@@ -508,19 +510,36 @@ def test_a_plan_that_passes_is_not_touched():
     (Path(__file__).parent / 'fixtures/p2b-outline-rejections.json').read_text()
 ), ids=lambda case: case['run_id'])
 def test_recorded_outline_rejections(case):
+    """Real plans from real runs, checked against the scope rules that judged them.
+
+    These are captured model responses, kept verbatim -- their value is that
+    nobody wrote them to pass. They predate `reader_payoff`, so every one of
+    them now fails `payoffs_stated`, which is the new rule working rather than
+    a regression: a plan with no promise per section is exactly what
+    improvement 01 refuses. So the assertion is on the checks these runs were
+    recorded for, not on the overall verdict, and the payoff gap is asserted
+    separately so it cannot drift back to passing unnoticed.
+    """
     dependencies, recorder = _dependencies(FakeLLM(json_response=case['outline']))
     updates = run_v3_outline_stage(_state(
         work_order=case['work_order'],
         packet={'facts': [{'claim_id': cid} for cid in case['claim_ids']]},
     ), dependencies)
     assert recorder.recorded[0][1]['candidate_outline'] == sanitize_v3_outline(case['outline'])
-    expected = not case['run_id'].startswith('a3c20e41')
-    assert updates['outline_accepted'] is expected
-    if expected:
-        assert len(updates['outline']['sections']) == 6
-        assert 'Planned sections' in updates['outline_text']
-    else:
-        assert updates['outline']['sections'] == []
+    checks = recorder.recorded[0][1]['checks']
+
+    # Planned before section payoffs existed, so none of them states one.
+    assert checks['payoffs_stated'] is False
+    assert updates['outline_accepted'] is False
+
+    # a3c20e41 is the recording of a plan that organised two sections around a
+    # context-only place. That is the one check it misses; its claims resolve
+    # and it names its subject like the others.
+    assert checks['claims_resolve'] is True
+    assert checks['covers_primary_subject'] is True
+    assert checks['no_context_only_sections'] is not case['run_id'].startswith(
+        'a3c20e41'
+    )
 
 
 @pytest.mark.parametrize('title', ['El Centro transfers', 'Dorado transfers', 'International Airport transfers'])


### PR DESCRIPTION
Improvement **01** from `docs/audits/prompt2blog-writer-improvements.html`.

## The problem

The outline already carried a `purpose` per section — and **nothing in the outline prompt ever said what a purpose was.** So it came back as the heading restated ("covers the transport options" under a heading about transport options), and a section could be planned, written and audited without anybody naming what a reader leaves it with.

The audit had a rule about this, and it asked the auditor to work out for itself what each section *should* have done. That is a second opinion about the plan, not a check on the draft.

## What changed

`purpose` becomes `reader_payoff`, and it is defined.

**The form decides which kind**, the way structure now does (finding 07). Each form declares `payoff` in its own frontmatter:

| Kind | Forms | What a section owes |
|---|---|---|
| `decision` | service-guide, comparison, itinerary, review, how-to, curated-list, destination-guide, cost-breakdown | the reader can now choose, book, skip, budget |
| `answer` | analysis, explainer, news-report, interview-qa | a question they arrived with is settled |
| `insight` | feature-profile, personal-essay, opinion-column | they understand something they did not |

Three kinds and not one, because **the report is explicit this must not turn every form into advice.** A profile whose every section ends in a recommendation is a worse profile — so the narrative forms' planning rule says in as many words not to recommend anything.

Required in the frontmatter (no form can acquire a payoff kind it did not choose); defaulted on the model (a run frozen before this still validates and resumes).

**The plan has to state one per section**, and two sections may not promise the same thing — if they do, they are one section. Both enforced. Duplicates are compared on content words, so rephrasing does not satisfy the rule.

A payoff that only **restates its heading** is reported, not enforced — the same treatment `crowded_sections` gets, and for the same reason: whether a sentence adds anything to a heading is a judgement, and a plan thrown away over one line would cost an article its whole structure to fix a sentence.

The sanitizer leaves a missing payoff **empty** rather than filling in `"Purpose not stated."` — the old default was a sentence, so every check downstream read it as one.

**The promises travel.** Compose is told each section owes its payoff and must not manufacture one the evidence cannot support. The audit is handed the list and asked only whether the draft kept them, returning `unresolved_payoffs` with a heading and a specific reason each. Those are folded into `required_revisions` (repair reads nothing else) *and* kept as their own list — "how many promises did this draft leave open" is the measure the report asks to track, and it is not recoverable from a flat list of revision sentences.

## Two judgement calls worth review

1. **The schema keeps `reader_payoff` optional at the transport.** `schemas.py` documents that `required` must not outrun the sanitizer, or a recoverable omission becomes a failed call. A missing payoff is a plan `validate_v3_outline` rejects *with a reason* instead.

2. **The recorded-rejection fixtures are left verbatim** — their value is that nobody wrote them to pass. They predate the field, so every one now fails `payoffs_stated`. That test now asserts the checks those runs were captured for, and asserts the payoff gap separately so it cannot drift back to passing unnoticed.

## Resume

Snapshot version **5 → 6**. A version-5 outline carries `purpose`; a resumed leg would either fail on the field name or write from a plan whose promises the audit then checks against nothing.

## Verification

- 23 new tests (20 in `test_prompt2blog_section_payoff.py`, 3 in the audit stage tests).
- Full backend suite: **1648 passed**, 0 failed.
- flake8 clean on every file touched (the two remaining hits in the writing/quality stage tests are pre-existing on `main`).

No model calls were made. No pipeline was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)