### PR TITLE
feat(p2b): give every useful detail room to work

### DIFF
--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -355,6 +355,14 @@ Rule: the operator cuts it before research runs. Cutting a load-bearing question
 Related terms: Article Brief, Grounded Research.
 Do not confuse with: the Article Brief. The brief persists to the end; the work order persists only until research answers it.
 
+### Reader Payoff
+
+Definition: the one thing a section leaves its reader with, written into the outline as `reader_payoff` and checked against the finished draft by the audit. Its *kind* comes from the approved article form, declared in that form's frontmatter as `payoff`: a **decision** the reader can now make, an **answer** to a question they arrived with, or an **insight** about the subject they did not have.
+Rule: one per section, and no two sections may promise the same thing. A payoff that only restates its heading is reported, not enforced — whether a sentence adds anything to a heading is a judgement, and a plan is not thrown away over one line.
+Rule: a form that does not give advice is never asked for a decision. Forcing every section to end in a recommendation trades one formulaic shape for another.
+Related terms: Article Brief, Work Order.
+Do not confuse with: the Work Order requirement's `purpose`, which says why a *question* was asked of research. The reader payoff is about what a *section of prose* owes the person reading it.
+
 ### Questurian Voice
 
 Definition: the single file describing what a Questurian article is like — treats the reader as an adult with a decision to make, isn't selling anything, warmth is attention rather than adjectives, has a view and says it, never talks about itself. Paired with a separate, much shorter file of mechanical rules (price and date format, no fabricated experiences, sentence-case headings, no in-article attribution).

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -34,7 +34,12 @@ def _sanitize_section(raw: Any) -> dict[str, Any] | None:
         return None
     return {
         "heading": heading,
-        "purpose": _safe_str(record.get("purpose")) or "Purpose not stated.",
+        # Empty when the planner did not say, and left empty on purpose. The
+        # old field filled itself in with "Purpose not stated.", which is a
+        # sentence, so every downstream check saw a section that had stated
+        # its purpose. `validate_v3_outline` can only catch a missing payoff
+        # if a missing payoff still looks missing here.
+        "reader_payoff": _safe_str(record.get("reader_payoff")),
         "claim_ids": _string_list(record.get("claim_ids")),
         "target_words": max(0, _safe_int(record.get("target_words"), default=0)),
     }
@@ -162,6 +167,46 @@ def _names_subject(heading: str, primary_subject: str) -> bool:
     return bool(words) and _mentions(heading, words[0])
 
 
+# Words that carry no promise on their own. A payoff built only out of these
+# and the heading's own words has restated the heading, which is the exact
+# thing improvement 01 is about: the plan says a section exists and never says
+# what a reader leaves it with.
+_PAYOFF_FILLER = frozenset(
+    {
+        "a", "an", "and", "the", "this", "that", "these", "those", "of", "for",
+        "to", "in", "on", "at", "by", "with", "about", "from", "it", "its",
+        "is", "are", "be", "will", "can", "reader", "readers", "section",
+        "article", "piece", "explains", "explain", "covers", "cover", "covered",
+        "describes", "describe", "outlines", "outline", "gives", "give",
+        "provides", "provide", "shows", "show", "details", "detail",
+        "discusses", "discuss", "introduces", "introduce", "presents",
+        "present", "what", "which", "how", "why", "where", "when", "who",
+    }
+)
+
+
+def _payoff_words(text: str) -> set[str]:
+    return {
+        word
+        for word in re.findall(r"[\w']+", text.casefold())
+        if word not in _PAYOFF_FILLER
+    }
+
+
+def _restates_heading(heading: str, payoff: str) -> bool:
+    """Whether a payoff says only what its heading already said.
+
+    Deliberately generous to the planner. A payoff is only called a
+    restatement when, after filler and the heading's own words are removed,
+    it has nothing of its own left. "Covers the transport options" under
+    "Transport options" is caught; "Which transfer to book before 6am, and
+    what it costs" is not, and neither is a payoff that merely happens to
+    reuse the heading's nouns while going on to say something.
+    """
+    remaining = _payoff_words(payoff) - _payoff_words(heading)
+    return not remaining
+
+
 # Facts per hundred words above which a section stops being prose.
 #
 # Run 9e66bf84 gave one 200-word section 56 claims -- three and a half words
@@ -263,11 +308,36 @@ def validate_v3_outline(
         *(
             value
             for section in sections
-            for value in (section["heading"], section["purpose"])
+            for value in (section["heading"], section["reader_payoff"])
         ),
     ]
     covers_primary_subject = not primary_subject or any(
         _covers_subject(value, primary_subject) for value in subject_fields
+    )
+
+    # What each section promises the reader, and whether it promised anything
+    # (improvement 01). A section with no payoff is a heading with facts under
+    # it, and two sections promising the same thing is one section.
+    missing_payoffs = sorted(
+        section["heading"] for section in sections if not section["reader_payoff"]
+    )
+    payoff_keys = [
+        " ".join(sorted(_payoff_words(section["reader_payoff"])))
+        for section in sections
+        if section["reader_payoff"]
+    ]
+    duplicate_payoffs = sorted(
+        {key for key in payoff_keys if payoff_keys.count(key) > 1 and key}
+    )
+    # Read, not enforced -- the same treatment `crowded_sections` gets, and for
+    # the same reason. Whether a sentence adds something to its heading is a
+    # judgement, and a plan thrown away over this one would cost an article its
+    # whole structure to fix a line of prose.
+    restated_payoffs = sorted(
+        section["heading"]
+        for section in sections
+        if section["reader_payoff"]
+        and _restates_heading(section["heading"], section["reader_payoff"])
     )
 
     checks = {
@@ -275,6 +345,8 @@ def validate_v3_outline(
         # divides into two sections is that form working, and failing the plan
         # for it sent compose in with no plan at all.
         "enough_sections": len(sections) >= min_sections,
+        "payoffs_stated": not missing_payoffs,
+        "payoffs_distinct": not duplicate_payoffs,
         "headings_unique": len({s["heading"].casefold() for s in sections})
         == len(sections),
         "within_word_budget": within_budget,
@@ -296,6 +368,9 @@ def validate_v3_outline(
         # find out whether narrowing the packet actually fixed it.
         "crowded_sections": crowded_sections,
         "context_only_headings": context_only_headings,
+        "missing_payoffs": missing_payoffs,
+        "duplicate_payoffs": duplicate_payoffs,
+        "restated_payoffs": restated_payoffs,
     }
     return all(checks.values()), diagnostics
 
@@ -394,7 +469,7 @@ def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
         budget = f" (~{target} words)" if target else ""
         claims = ", ".join(section["claim_ids"]) or "none"
         lines.append(f"{index}. {section['heading']}{budget}")
-        lines.append(f"   Purpose: {section['purpose']}")
+        lines.append(f"   What the reader gets: {section['reader_payoff']}")
         lines.append(f"   Evidence claims: {claims}")
 
     takeaway = _safe_str(outline.get("takeaway_focus"))
@@ -412,3 +487,26 @@ def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
         lines.extend(f"- {item}" for item in unsupported)
 
     return "\n".join(lines)
+
+
+def format_payoff_promises(outline: dict[str, Any]) -> str:
+    """The promises the plan made, for the stage that checks they were kept.
+
+    The auditor used to be asked to work out for itself what each section
+    should have done for the reader, which is a second opinion about the plan
+    rather than a check on the draft. The plan already said. Handing it over
+    turns "does this section do its job" from a judgement about what the job
+    might have been into a comparison against a written promise.
+    """
+    sections = outline.get("sections") or []
+    promises = [
+        f"{index}. {section['heading']} -> {section['reader_payoff']}"
+        for index, section in enumerate(sections, start=1)
+        if section.get("reader_payoff")
+    ]
+    if not promises:
+        # An honest absence. A run whose plan was rejected has no promises to
+        # check, and inventing some here would put the auditor back to guessing
+        # with an air of authority.
+        return "No section promises were recorded for this run."
+    return "\n".join(promises)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/outline_v3.py
@@ -224,6 +224,7 @@ def validate_v3_outline(
     claim_ids: set[str],
     target_word_count: int,
     min_sections: int = MIN_OUTLINE_SECTIONS,
+    fact_roles: dict[str, str] | None = None,
 ) -> tuple[bool, dict[str, Any]]:
     """Check a plan against the work order's scope and the writer's packet.
 
@@ -236,6 +237,13 @@ def validate_v3_outline(
     wrong against this article -- and it would hand compose a section built on
     a claim that is not in its context, which is how a writer ends up
     inventing one.
+
+    `fact_roles` is the packet's own labelling of what each fact is for, and it
+    is what turns a crowded section from a number into advice: eight facts in a
+    hundred and forty words is a different problem when five of them are colour
+    the writer may simply leave out (improvement 04). Optional, because the
+    density reporting has to keep working for a selection made before roles
+    existed.
     """
     sections = outline.get("sections") or []
     planned_words = sum(_safe_int(s.get("target_words"), default=0) for s in sections)
@@ -253,6 +261,22 @@ def validate_v3_outline(
             if claim_id not in claim_ids
         }
     )
+    roles = fact_roles or {}
+
+    def _spare(section: dict[str, Any]) -> list[str]:
+        """The facts in this section whose job is colour.
+
+        The one thing that makes a crowded section actionable. `texture` is the
+        packet's own word for a fact chosen to carry the place rather than to
+        prove anything, so it is the one a writer can drop without losing an
+        obligation or a qualification.
+        """
+        return [
+            claim_id
+            for claim_id in section["claim_ids"]
+            if roles.get(claim_id) == "texture"
+        ]
+
     crowded_sections = [
         {
             "heading": section["heading"],
@@ -261,12 +285,30 @@ def validate_v3_outline(
             "claims_per_hundred_words": round(
                 len(section["claim_ids"]) * 100 / words, 1
             ),
+            # How much of the crowding the writer is allowed to relieve. A
+            # section carrying eight facts of which five are colour has room in
+            # it; one carrying eight load-bearing facts is over-planned, and
+            # needs a different plan rather than a lighter hand.
+            "spare_claims": _spare(section),
         }
         for section in sections
         if (words := _safe_int(section.get("target_words"), default=0)) > 0
         and len(section["claim_ids"]) * 100 / words
         > CROWDED_CLAIMS_PER_HUNDRED_WORDS
     ]
+
+    # The same fact planned into two sections. Not a scope error and never a
+    # reason to fail a plan -- a price can legitimately be recalled where it
+    # matters again -- but it is the cheapest repetition there is, and it was
+    # invisible: the article said the same thing twice and nothing in the run
+    # record said where it came from.
+    repeated_claims = [
+        {"claim_id": claim_id, "headings": headings}
+        for claim_id, headings in _repeated_placements(sections)
+    ]
+    placed = {
+        claim_id for section in sections for claim_id in section["claim_ids"]
+    }
 
     scope = _safe_dict(work_order.get("scope"))
     references = scope.get("references") or []
@@ -367,6 +409,12 @@ def validate_v3_outline(
         # this redesign exists for, and seeing it in the run record is how we
         # find out whether narrowing the packet actually fixed it.
         "crowded_sections": crowded_sections,
+        "repeated_claims": repeated_claims,
+        # Chosen for this article and placed nowhere. Reported so the distance
+        # between what an operator picked and what the plan uses is visible;
+        # never a failure, because "leave out what the piece is better without"
+        # is what the outline prompt asks for.
+        "unplaced_claims": sorted(claim_ids - placed),
         "context_only_headings": context_only_headings,
         "missing_payoffs": missing_payoffs,
         "duplicate_payoffs": duplicate_payoffs,
@@ -437,7 +485,81 @@ def outline_focus_only(outline: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
+# Facts per hundred words below which a section has room to explain rather
+# than merely to list. Deliberately lower than the crowding threshold: between
+# the two is the ordinary middle, where nothing needs saying either way.
+ROOMY_CLAIMS_PER_HUNDRED_WORDS = 2.0
+
+
+def _repeated_placements(
+    sections: list[dict[str, Any]],
+) -> list[tuple[str, list[str]]]:
+    """Facts the plan put in more than one section.
+
+    Shared by the diagnostics and by the section brief so the run record and
+    the writer cannot disagree about which facts are doubled.
+    """
+    placements: dict[str, list[str]] = {}
+    for section in sections:
+        for claim_id in section["claim_ids"]:
+            placements.setdefault(claim_id, []).append(section["heading"])
+    return [
+        (claim_id, headings)
+        for claim_id, headings in sorted(placements.items())
+        if len(headings) > 1
+    ]
+
+
+def _room_to_work(section: dict[str, Any], roles: dict[str, str]) -> str | None:
+    """One line telling the writer how much room this section actually has.
+
+    Improvement 04. The writer was handed a list of facts and a word budget and
+    left to reconcile them, and when they do not reconcile the only prose that
+    satisfies both is a catalogue: run 9e66bf84 planned 56 claims into 200
+    words, which is three and a half words each.
+
+    Advice, never a maximum. One complex fact can need more explanation than
+    five simple ones, so a number here cannot decide anything -- what it can do
+    is say which facts are droppable, which is the part the writer could not
+    know.
+    """
+    claims = section["claim_ids"]
+    words = _safe_int(section.get("target_words"), default=0)
+    if not claims or words <= 0:
+        return None
+
+    spare = [claim_id for claim_id in claims if roles.get(claim_id) == "texture"]
+    density = len(claims) * 100 / words
+    crowded = density > CROWDED_CLAIMS_PER_HUNDRED_WORDS
+
+    if crowded:
+        opening = (
+            f"{len(claims)} facts in ~{words} words is a list, not a section. "
+            "Explain the two or three that carry the point."
+        )
+    elif density <= ROOMY_CLAIMS_PER_HUNDRED_WORDS:
+        opening = (
+            f"{len(claims)} facts in ~{words} words. There is room here to say "
+            "what they mean, not only what they are."
+        )
+    else:
+        opening = f"{len(claims)} facts in ~{words} words."
+
+    if spare:
+        tail = f" Colour, droppable: {', '.join(spare)}."
+    elif crowded:
+        # Only worth saying where the writer would otherwise be looking for
+        # something to cut. On a section with room, "nothing is spare" is an
+        # answer to a question nobody asked.
+        tail = " Every fact here is load-bearing, so the room has to come from the prose."
+    else:
+        tail = ""
+    return f"   Room to work: {opening}{tail}"
+
+
+def format_v3_outline_for_prompt(
+    outline: dict[str, Any], *, fact_roles: dict[str, str] | None = None
+) -> str:
     """Render a validated plan as the section brief compose writes against."""
     sections = outline.get("sections") or []
     if not sections:
@@ -471,6 +593,22 @@ def format_v3_outline_for_prompt(outline: dict[str, Any]) -> str:
         lines.append(f"{index}. {section['heading']}{budget}")
         lines.append(f"   What the reader gets: {section['reader_payoff']}")
         lines.append(f"   Evidence claims: {claims}")
+        room = _room_to_work(section, fact_roles or {})
+        if room:
+            lines.append(room)
+
+    repeated = _repeated_placements(sections)
+    if repeated:
+        lines.append("")
+        lines.append(
+            "The same fact is planned into more than one section. State it "
+            "once, in the section that needs it most, unless the second use "
+            "genuinely does new work:"
+        )
+        lines.extend(
+            f"- {claim_id}: {' / '.join(headings)}"
+            for claim_id, headings in repeated
+        )
 
     takeaway = _safe_str(outline.get("takeaway_focus"))
     if takeaway:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editorial_catalog.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editorial_catalog.py
@@ -59,6 +59,51 @@ class EditorialRule(CatalogModel):
 OpeningMode = Literal["direct-answer", "form-led"]
 ClosingMode = Literal["takeaways", "form-led"]
 
+# What one section owes the person reading it.
+#
+# Improvement 01: the outline already carried a `purpose` per section, and
+# nothing in the outline prompt ever said what a purpose was. So it came back
+# as a restatement of the heading -- "covers transport options" under a heading
+# about transport -- and a section could be planned, written and audited
+# without anybody naming what a reader gets out of it.
+#
+# Three kinds, not one, because the report is explicit that this must not turn
+# every form into advice. A profile that ends each section with a
+# recommendation is a worse profile, and forcing it to would trade one
+# formulaic shape for another.
+#
+# `decision`: the reader can now choose, book, or skip something.
+# `answer`:   a question the reader arrived with is now settled.
+# `insight`:  the reader understands something about the subject they did not.
+PayoffMode = Literal["decision", "answer", "insight"]
+
+# What the outline is asked for, and what the audit checks was delivered, in
+# each mode's own words. Kept next to the mode rather than in the prompt files
+# so the planning stage, the writing stage and the auditor cannot describe the
+# same obligation three different ways.
+PAYOFF_NOUNS: dict[str, str] = {
+    "decision": "decision the reader can make",
+    "answer": "question the reader arrived with, answered",
+    "insight": "thing the reader now understands about the subject",
+}
+
+PAYOFF_PLANNING_RULES: dict[str, str] = {
+    "decision": (
+        "one decision this section leaves the reader able to make -- what they "
+        "can now choose, book, skip or budget for, and on what basis"
+    ),
+    "answer": (
+        "one question this section settles for the reader, phrased as the "
+        "question they arrived with rather than as the topic it falls under"
+    ),
+    "insight": (
+        "one thing this section leaves the reader understanding about the "
+        "subject that they did not understand before it. Not a recommendation: "
+        "this form does not give advice, and a section that ends in one is "
+        "doing the wrong job"
+    ),
+}
+
 # The floor under `min_sections`. Below two there is no structure to plan and
 # `sections_changed` has nothing to scope a repair to.
 ABSOLUTE_MIN_SECTIONS = 2
@@ -86,6 +131,12 @@ class FormStructurePolicy(CatalogModel):
     closing: ClosingMode
     min_sections: int = Field(ge=ABSOLUTE_MIN_SECTIONS, le=ABSOLUTE_MAX_SECTIONS)
     max_sections: int = Field(ge=ABSOLUTE_MIN_SECTIONS, le=ABSOLUTE_MAX_SECTIONS)
+    # Defaulted on the model, required in the frontmatter. Those are different
+    # jobs: `_structure_policy` refuses a form file that omits it, so no form
+    # can quietly acquire a payoff kind it did not choose, while a run frozen
+    # before this existed still validates and resumes into the shape it was
+    # written under.
+    payoff: PayoffMode = "decision"
 
     @model_validator(mode="after")
     def _range_is_a_range(self) -> "FormStructurePolicy":
@@ -129,12 +180,35 @@ class FormStructurePolicy(CatalogModel):
             "count is a range, not a target to hit."
         )
 
+    def payoff_noun(self) -> str:
+        return PAYOFF_NOUNS[self.payoff]
+
+    def outline_payoff_rule(self) -> str:
+        return (
+            f"- `reader_payoff` is the point of the section. Write "
+            f"{PAYOFF_PLANNING_RULES[self.payoff]}. One sentence, in the "
+            "reader's terms. It is not a summary of what the section covers: "
+            "a heading already says that, and repeating it back is how a "
+            "section gets planned without ever earning its place."
+        )
+
+    def compose_payoff_rule(self) -> str:
+        return (
+            "- Each planned section states what the reader gets from it. That "
+            f"is the {self.payoff_noun()}, and the section has not done its "
+            "job until the prose actually delivers it -- not gestured at it, "
+            "and not left the reader to work it out from the facts. Where the "
+            "evidence cannot support the payoff as planned, say what it does "
+            "support and what is missing; do not manufacture the payoff."
+        )
+
     def compose_rules(self) -> str:
         """The structural obligations for one form, for the compose prompt."""
         return "\n".join(
             (
                 self.opening_rule(),
                 self.sections_rule(),
+                self.compose_payoff_rule(),
                 self.closing_rule(),
                 "- Structure is the form's to decide and the evidence rules "
                 "are not. A form never licenses an invented scene, quotation, "
@@ -165,6 +239,7 @@ class FormStructurePolicy(CatalogModel):
                 f"{self.max_sections} sections.",
                 f"- {opening}",
                 f"- {closing}",
+                self.outline_payoff_rule(),
             )
         )
 
@@ -353,7 +428,7 @@ def _rule_section(body: str, heading: str) -> str:
 
 
 def _structure_policy(metadata: dict[str, str], path: Path) -> FormStructurePolicy:
-    """Read `opening`, `sections` and `closing` off one form's frontmatter.
+    """Read `opening`, `sections`, `closing` and `payoff` off a form's frontmatter.
 
     Loudly. A malformed range or an unknown mode fails the catalog load, which
     fails at import in every test rather than producing an article shaped by a
@@ -372,6 +447,7 @@ def _structure_policy(metadata: dict[str, str], path: Path) -> FormStructurePoli
             closing=metadata["closing"],
             min_sections=low,
             max_sections=high,
+            payoff=metadata["payoff"],
         )
     except PydanticValidationError as exc:
         raise ValueError(f"Invalid structure policy in {path}: {exc}") from exc
@@ -402,7 +478,7 @@ def _load_rule_directory(
         # somebody else's, which is finding 07 with an extra step. Required,
         # not defaulted.
         if forms:
-            required_keys |= {"opening", "sections", "closing"}
+            required_keys |= {"opening", "sections", "closing", "payoff"}
         missing_keys = required_keys - metadata.keys()
         extra_keys = metadata.keys() - required_keys - {"source_gate"}
         if missing_keys or extra_keys:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -14,7 +14,7 @@ Return strict JSON only:
   "sections": [
     {{
       "heading": "string",
-      "purpose": "string",
+      "reader_payoff": "string",
       "claim_ids": ["string"],
       "target_words": 0
     }}
@@ -28,6 +28,9 @@ Rules:
 {structure_rules}
 - Headings must be specific and distinct. No generic "Introduction" or
   "Conclusion" headings.
+- Every section must earn its place. Two sections may not promise the reader
+  the same thing; if they do, they are one section, or one of them has no
+  reason to exist.
 - Every section must name the claim_ids it rests on, using IDs from the facts
   below. Never cite a claim that is not there: what you are shown is the whole
   desk, and a fact outside it is one a person decided this article does not
@@ -225,6 +228,9 @@ Return strict JSON only:
   }},
   "fails_if_quote": "string",
   "fails_if_why": "string",
+  "unresolved_payoffs": [
+    {{"heading": "string", "why": "string"}}
+  ],
   "required_revisions": ["string"],
   "quality_summary": "string"
 }}
@@ -289,12 +295,20 @@ Rules:
 - Score honestly. A draft that merely avoids mistakes is a 7, not a 9. Being
   grounded, complete, and constraint-compliant is the floor this scale starts
   from, not what earns the top of it.
-- Reader decision support is a scored dimension, not a nicety. For each
-  section, ask what decision it lets the reader make and whether the draft
-  actually resolves it. A section that lays out options without saying what
-  separates them -- what each is better and worse for, and who should choose
-  which -- has covered its requirement without doing its job. Name any such
-  section in required_revisions.
+- SECTION PROMISES below is what the plan said each section would leave the
+  reader with. It is not yours to re-decide; your job is whether the draft
+  delivered it. For every promise that the prose does not keep, add an entry
+  to unresolved_payoffs naming that heading and one line on what is missing --
+  what the reader was going to be able to decide, or understand, or have
+  answered, and still cannot. Quote or paraphrase the specific gap; "does not
+  fully deliver" is not an answer anybody can act on.
+  A section that lays out options without saying what separates them -- what
+  each is better and worse for, and who should choose which -- has covered its
+  requirement without keeping its promise. Every unresolved payoff also
+  belongs in required_revisions, and unresolved payoffs weigh on
+  overall_score: a draft that leaves any of them open cannot score above 8.
+  Where the promises list says none were recorded, return an empty
+  unresolved_payoffs rather than inventing the promises you would have made.
 - A fact catalog is not coverage. Prose that walks a list of named items with
   their prices, hours, or figures attached, in sequence, without comparison or
   judgement, reads as a directory rather than an article. It can be entirely
@@ -323,6 +337,9 @@ GROUNDING VERDICT (authoritative on factual support):
 
 MEASURED CHECKS (counted, not judged):
 {measured_checks}
+
+SECTION PROMISES (what the plan said each section would give the reader):
+{section_promises}
 
 DRAFT TITLE:
 {rewritten_title}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -105,6 +105,17 @@ Hard rules:
 {structure_rules}
 - Follow the STYLE DIRECTIVE exactly. Tone, length, and brand voice are
   requirements, not suggestions.
+- You are not obliged to use every fact you were given. A section that names
+  ten things and judges none of them is a directory; three details you explain
+  are worth more than ten you list, and the reader can only act on the ones you
+  explained. Where the plan marks a fact as colour and droppable, dropping it
+  is a decision you are allowed to make. What you may never drop is an
+  obligation under must_name, or a limit that changes what the reader should
+  do.
+- The "Room to work" line under a section is advice and never a maximum. One
+  complicated fact can need more explaining than five simple ones, so the count
+  cannot decide anything for you; it is there because you cannot otherwise see
+  how much room the plan left you.
 - Follow the SECTION PLAN when one is provided: use its headings, in order, and
   hold each section to roughly its word budget. Depart from it only where the
   evidence makes a planned section unsupportable. Record that departure in

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/quality.py
@@ -849,6 +849,17 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
         "tone_match": _safe_bool(checks_raw.get("tone_match"), default=True),
     }
 
+    # Promises the plan made that the draft did not keep (improvement 01).
+    # Each needs a heading and a reason: an entry naming neither is an
+    # accusation nobody can act on, and repair would spend a call on it.
+    unresolved_payoffs = []
+    for item in parsed.get("unresolved_payoffs") or []:
+        record = _safe_dict(item)
+        heading = _safe_str(record.get("heading"))
+        why = _safe_str(record.get("why"))
+        if heading and why:
+            unresolved_payoffs.append({"heading": heading, "why": why})
+
     # A missing or unparseable score used to default to 6, which sits below the
     # repair threshold -- so a malformed audit response silently bought a full
     # article rewrite. Absent scores now default to neutral and are reported as
@@ -882,6 +893,11 @@ def _sanitize_quality(parsed: dict[str, Any]) -> dict[str, Any]:
         # an inventory (run b29d66b4).
         "fails_if_quote": _safe_str(parsed.get("fails_if_quote")),
         "fails_if_why": _safe_str(parsed.get("fails_if_why")),
+        # Kept as its own list as well as folded into the revisions. "How many
+        # promises did this draft leave open" is the measure improvement 01
+        # asks to track, and it is not recoverable from a flat list of
+        # revision sentences.
+        "unresolved_payoffs": unresolved_payoffs,
         "required_revisions": required_revisions,
         "quality_summary": _safe_str(parsed.get("quality_summary"))
         or "Quality summary not provided.",

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/resume_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/resume_v3.py
@@ -77,7 +77,13 @@ RESUME_HISTORY_STAGE = "pipeline_resume_v3"
 # the whole dossier -- the exact silent widening the packet exists to prevent.
 # Refused, and a refusal costs nothing: starting again is what happened before
 # resume existed at all.
-RESUME_SNAPSHOT_VERSION = 5
+#
+# 6: section payoffs (improvement 01). A version-5 snapshot's outline sections
+# carry `purpose`, and the formatters that hand the plan to compose and to the
+# audit read `reader_payoff`, so a resumed leg would fail on the field name --
+# or, if that were papered over, write from a plan whose promises the audit
+# would then check against nothing. Refused by version, which says why.
+RESUME_SNAPSHOT_VERSION = 6
 
 # State entries rebuilt on the way back in rather than stored. `request` is a
 # pydantic model and is written out under its own key; `completed` belongs to

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/schemas.py
@@ -74,7 +74,13 @@ V3_OUTLINE_SCHEMA: dict[str, Any] = {
                 "required": ["heading"],
                 "properties": {
                     "heading": {"type": "string"},
-                    "purpose": {"type": "string"},
+                    # Replaces `purpose`, which was in this schema and defined
+                    # nowhere, so it came back as the heading said twice
+                    # (improvement 01). Not added to `required`: the rule at
+                    # the top of this file holds, and a missing payoff is a
+                    # plan `validate_v3_outline` rejects with a reason rather
+                    # than a call the transport refuses without one.
+                    "reader_payoff": {"type": "string"},
                     "claim_ids": {"type": "array", "items": {"type": "string"}},
                     "target_words": {"type": "integer", "minimum": 0},
                 },

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -25,6 +25,7 @@ from ...quality import (
 )
 from ...quality_v3 import v3_constraint_brief
 from ...content.markdown import sections_changed
+from ...content.outline_v3 import format_payoff_promises
 from ...content.style_cleanup import clean_up_style
 from ...content.sections import (
     apply_section_replacements,
@@ -89,6 +90,10 @@ def _audit_v3_rewrite(
         style_directive=_format_style_directive(state["option_context"]),
         grounding_verdict=_json(groundedness),
         measured_checks=_measured_checks_block(computed_checks),
+        # What the plan promised, so the auditor compares the draft against a
+        # written commitment instead of against whatever it would have planned
+        # (improvement 01).
+        section_promises=format_payoff_promises(_safe_dict(state.get("outline"))),
         rewritten_title=rewrite["improved_title"],
         rewritten_content=rewrite["improved_content"],
     )
@@ -100,6 +105,17 @@ def _audit_v3_rewrite(
         model_name=state["audit_model"],
     )
     quality = _sanitize_quality(parsed)
+    # A promise the draft did not keep is a revision request, whether or not
+    # the auditor also wrote one. Repair reads `required_revisions` and nothing
+    # else, so an unresolved payoff that stayed in its own list would be
+    # recorded and never acted on.
+    for unresolved in quality["unresolved_payoffs"]:
+        instruction = (
+            f"The section \"{unresolved['heading']}\" does not deliver what "
+            f"the plan promised the reader: {unresolved['why']}"
+        )
+        if not any(unresolved["heading"] in item for item in quality["required_revisions"]):
+            quality["required_revisions"].append(instruction)
     # The auditor answered with a quote; this is where that becomes a verdict.
     fails_if = evaluate_fails_if(quality, rewrite["improved_content"])
     quality["fails_if_check"] = fails_if

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/outline.py
@@ -51,6 +51,14 @@ def run_v3_outline_stage(
     allowed_claim_ids = {
         fact["claim_id"] for fact in (state["packet"].get("facts") or [])
     }
+    # What each chosen fact is here to do, which is what turns a crowded
+    # section from a number into advice the writer can act on (improvement 04).
+    # Empty for a selection made before roles existed; the density reporting
+    # then still counts, it simply has nothing to call droppable.
+    fact_roles = {
+        fact["claim_id"]: fact.get("role") or ""
+        for fact in (state["packet"].get("facts") or [])
+    }
     target_word_count = _target_word_count(_safe_dict(state["option_context"]))
     # The approved form decides how many sections this article divides into,
     # and whether it plans a direct answer and takeaways at all. Frozen with
@@ -94,6 +102,7 @@ def run_v3_outline_stage(
             claim_ids=allowed_claim_ids,
             target_word_count=target_word_count,
             min_sections=structure.min_sections,
+            fact_roles=fact_roles,
         )
         if accepted:
             outline = candidate
@@ -111,6 +120,7 @@ def run_v3_outline_stage(
                     claim_ids=allowed_claim_ids,
                     target_word_count=target_word_count,
                     min_sections=structure.min_sections,
+                    fact_roles=fact_roles,
                 )
                 if repaired_accepted:
                     logger.warning(
@@ -182,5 +192,7 @@ def run_v3_outline_stage(
         "current_stage": stage,
         "outline": outline,
         "outline_accepted": accepted,
-        "outline_text": format_v3_outline_for_prompt(outline),
+        "outline_text": format_v3_outline_for_prompt(
+            outline, fact_roles=fact_roles
+        ),
     }

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/analysis.md
@@ -5,6 +5,7 @@ summary: Answers a real question about a place and commits to the answer.
 order: 2
 opening: form-led
 sections: 3-12
+payoff: answer
 closing: form-led
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/comparison.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/comparison.md
@@ -5,6 +5,7 @@ summary: Evaluates approved co-subjects against consistent criteria for a define
 order: 12
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/cost-budget-breakdown.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/cost-budget-breakdown.md
@@ -5,6 +5,7 @@ summary: Builds a dated, transparent budget from defined assumptions and sourced
 order: 15
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/curated-list-best-of.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/curated-list-best-of.md
@@ -5,6 +5,7 @@ summary: Selects and explains a bounded set of options using explicit editorial 
 order: 11
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/destination-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/destination-guide.md
@@ -5,6 +5,7 @@ summary: Gives a coherent planning overview of one approved destination.
 order: 8
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/explainer.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/explainer.md
@@ -5,6 +5,7 @@ summary: Makes a complex system, rule, event, or travel concept understandable.
 order: 3
 opening: direct-answer
 sections: 3-12
+payoff: answer
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/feature-profile.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/feature-profile.md
@@ -5,6 +5,7 @@ summary: Builds a reported narrative around a person, place, community, or pheno
 order: 4
 opening: form-led
 sections: 3-12
+payoff: insight
 closing: form-led
 source_gate: reported-people-scenes-quotations
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/how-to-checklist.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/how-to-checklist.md
@@ -5,6 +5,7 @@ summary: Guides readers through a bounded task with verified steps and checkpoin
 order: 14
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/interview-qa.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/interview-qa.md
@@ -5,6 +5,7 @@ summary: Presents attributable answers from a named interview around a focused r
 order: 5
 opening: form-led
 sections: 2-12
+payoff: answer
 closing: form-led
 source_gate: attributable-responses
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/itinerary.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/itinerary.md
@@ -5,6 +5,7 @@ summary: Sequences a realistic trip plan across an approved time window and geog
 order: 10
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/news-report.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/news-report.md
@@ -5,6 +5,7 @@ summary: Reports a timely development, what changed, and what readers should kno
 order: 1
 opening: direct-answer
 sections: 2-12
+payoff: answer
 closing: form-led
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/opinion-column.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/opinion-column.md
@@ -5,6 +5,7 @@ summary: Advances a clearly identified viewpoint using evidence and transparent 
 order: 6
 opening: form-led
 sections: 2-12
+payoff: insight
 closing: form-led
 ---
 

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/personal-essay-travelogue.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/personal-essay-travelogue.md
@@ -5,6 +5,7 @@ summary: Shapes supplied lived experience into a reflective journey grounded in 
 order: 7
 opening: form-led
 sections: 2-12
+payoff: insight
 closing: form-led
 source_gate: first-person-material
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/review.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/review.md
@@ -5,6 +5,7 @@ summary: Evaluates a specific experience, service, place, or product against dec
 order: 13
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 source_gate: documented-evaluation
 ---

--- a/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/service-guide.md
+++ b/apps/ai-blog-writer/apps/backend/data/prompt2blog/forms/service-guide.md
@@ -5,6 +5,7 @@ summary: Helps a defined reader solve one practical travel problem or decision.
 order: 9
 opening: direct-answer
 sections: 3-12
+payoff: decision
 closing: takeaways
 ---
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_form_structure.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_form_structure.py
@@ -100,8 +100,18 @@ def test_an_interview_may_divide_into_two_sections():
         {
             "working_title": "Two questions",
             "sections": [
-                {"heading": "On the route", "claim_ids": [], "target_words": 400},
-                {"heading": "On the price", "claim_ids": [], "target_words": 400},
+                {
+                    "heading": "On the route",
+                    "reader_payoff": "Which leg of the trip is worth the detour.",
+                    "claim_ids": [],
+                    "target_words": 400,
+                },
+                {
+                    "heading": "On the price",
+                    "reader_payoff": "Whether the fare quoted is the one to book.",
+                    "claim_ids": [],
+                    "target_words": 400,
+                },
             ],
         },
         max_sections=structure.max_sections,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_density.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_density.py
@@ -1,0 +1,307 @@
+"""Improvement 04: give every useful detail room to work.
+
+Run 9e66bf84 planned 56 claims into one 200-word section -- three and a half
+words per fact, at which density there is no sentence you can write except a
+list. `crowded_sections` already measured that and reported it to nobody who
+could act on it: the writer was handed a list of claims and a word budget and
+left to reconcile two things that do not reconcile.
+
+The report is explicit that this must extend the existing diagnostics rather
+than start a second density system, and that density stays advice and never a
+maximum -- one complicated fact can need more explaining than five simple ones,
+so a count cannot decide anything. What a count *can* do is say which facts are
+droppable, which is the part the writer had no way to know.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.content.outline_v3 import (
+    CROWDED_CLAIMS_PER_HUNDRED_WORDS,
+    ROOMY_CLAIMS_PER_HUNDRED_WORDS,
+    format_v3_outline_for_prompt,
+    sanitize_v3_outline,
+    validate_v3_outline,
+)
+
+WORK_ORDER: dict[str, Any] = {"primary_subject": "", "scope": {"references": []}}
+
+ROLES = {
+    "c1": "backbone",
+    "c2": "practical",
+    "c3": "texture",
+    "c4": "texture",
+    "c5": "texture",
+    "c6": "backbone",
+    "c7": "practical",
+    "c8": "texture",
+    "c9": "practical",
+}
+
+
+def _plan(*sections: tuple[str, list[str], int]) -> dict[str, Any]:
+    return sanitize_v3_outline(
+        {
+            "working_title": "What Lima costs now",
+            "sections": [
+                {
+                    "heading": heading,
+                    "reader_payoff": f"What to do about {heading.lower()}.",
+                    "claim_ids": claim_ids,
+                    "target_words": words,
+                }
+                for heading, claim_ids, words in sections
+            ],
+        }
+    )
+
+
+def _validate(plan: dict[str, Any], *, roles: dict[str, str] | None = ROLES):
+    # `min_sections=1` so these read as tests about density rather than about
+    # section counts, which the form policy owns and its own tests cover.
+    return validate_v3_outline(
+        plan,
+        work_order=WORK_ORDER,
+        claim_ids=set(ROLES),
+        target_word_count=0,
+        min_sections=1,
+        fact_roles=roles,
+    )
+
+
+CROWDED = ("Where to eat", ["c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"], 140)
+ROOMY = ("What it costs", ["c9"], 300)
+
+
+# ---------------------------------------------------------------------------
+# The count is not new. What it can now say is.
+# ---------------------------------------------------------------------------
+
+
+def test_a_crowded_section_names_the_facts_that_could_go():
+    _accepted, checks = _validate(_plan(CROWDED, ROOMY))
+    crowded = checks["crowded_sections"]
+
+    assert len(crowded) == 1
+    assert crowded[0]["heading"] == "Where to eat"
+    assert crowded[0]["claims"] == 8
+    # The half that makes the number actionable. Eight facts in 140 words is a
+    # different problem when four of them are colour.
+    assert crowded[0]["spare_claims"] == ["c3", "c4", "c5", "c8"]
+
+
+def test_a_crowded_section_of_load_bearing_facts_has_nothing_spare():
+    """Over-planned, not over-written.
+
+    A section carrying eight facts none of which is droppable needs a different
+    plan, not a lighter hand, and the diagnostics must not suggest otherwise by
+    offering a cut that does not exist.
+    """
+    _accepted, checks = _validate(
+        _plan(CROWDED, ROOMY),
+        roles={claim_id: "backbone" for claim_id in ROLES},
+    )
+    assert checks["crowded_sections"][0]["spare_claims"] == []
+
+
+def test_density_is_still_never_enforced():
+    """The rule this extends, unchanged.
+
+    A plan rejected for density would be a plan thrown away over an estimate,
+    and how many facts a paragraph carries depends on what they are.
+    """
+    accepted, checks = _validate(_plan(CROWDED, ROOMY))
+    assert accepted is True
+    assert checks["crowded_sections"]
+
+
+def test_a_selection_with_no_roles_still_counts_the_crowding():
+    """Runs whose selection predates roles keep the reporting they had.
+
+    It simply has nothing to call droppable, which is the honest answer rather
+    than a guess at which facts were colour.
+    """
+    _accepted, checks = _validate(_plan(CROWDED, ROOMY), roles=None)
+    assert checks["crowded_sections"][0]["claims"] == 8
+    assert checks["crowded_sections"][0]["spare_claims"] == []
+
+
+# ---------------------------------------------------------------------------
+# Repeated and unplaced facts
+# ---------------------------------------------------------------------------
+
+
+def test_a_fact_planned_into_two_sections_is_reported():
+    _accepted, checks = _validate(
+        _plan(("Where to eat", ["c1", "c2"], 300), ("What it costs", ["c1"], 300))
+    )
+    assert checks["repeated_claims"] == [
+        {"claim_id": "c1", "headings": ["Where to eat", "What it costs"]}
+    ]
+
+
+def test_repeating_a_fact_does_not_fail_the_plan():
+    """A price can legitimately be recalled where it matters again.
+
+    This is the cheapest repetition there is and it was invisible; making it
+    visible is the whole change. Making it fatal would be a different and worse
+    one.
+    """
+    accepted, _checks = _validate(
+        _plan(("Where to eat", ["c1", "c2"], 300), ("What it costs", ["c1"], 300))
+    )
+    assert accepted is True
+
+
+def test_facts_chosen_and_never_placed_are_named():
+    """The distance between what an operator picked and what the plan uses.
+
+    Never a failure: "leave out what the piece is better without" is what the
+    outline prompt asks for. It is reported so that gap stops being invisible.
+    """
+    accepted, checks = _validate(_plan(("Where to eat", ["c1", "c2"], 300), ROOMY))
+    assert accepted is True
+    assert checks["unplaced_claims"] == ["c3", "c4", "c5", "c6", "c7", "c8"]
+
+
+# ---------------------------------------------------------------------------
+# What the writer is actually told
+# ---------------------------------------------------------------------------
+
+
+def test_the_writer_is_told_a_crowded_section_is_a_list():
+    rendered = format_v3_outline_for_prompt(
+        _plan(CROWDED, ROOMY), fact_roles=ROLES
+    )
+    assert "8 facts in ~140 words is a list, not a section" in rendered
+    assert "Colour, droppable: c3, c4, c5, c8." in rendered
+
+
+def test_the_writer_is_told_where_there_is_room_to_explain():
+    rendered = format_v3_outline_for_prompt(
+        _plan(CROWDED, ROOMY), fact_roles=ROLES
+    )
+    assert "room here to say what they mean, not only what they are" in rendered
+
+
+def test_a_section_with_room_is_not_told_what_it_could_cut():
+    """"Nothing here is spare" answers a question nobody asked.
+
+    That line earns its place only where the writer is looking for something to
+    drop, which is a crowded section.
+    """
+    rendered = format_v3_outline_for_prompt(
+        _plan(("What it costs", ["c1"], 300)),
+        fact_roles={"c1": "backbone"},
+    )
+    assert "load-bearing" not in rendered
+
+
+def test_a_crowded_section_with_nothing_spare_says_where_the_room_comes_from():
+    rendered = format_v3_outline_for_prompt(
+        _plan(CROWDED),
+        fact_roles={claim_id: "backbone" for claim_id in ROLES},
+    )
+    assert "the room has to come from the prose" in rendered
+
+
+def test_the_writer_is_told_which_fact_is_planned_twice():
+    rendered = format_v3_outline_for_prompt(
+        _plan(("Where to eat", ["c1", "c2"], 300), ("What it costs", ["c1"], 300)),
+        fact_roles=ROLES,
+    )
+    assert "The same fact is planned into more than one section" in rendered
+    assert "- c1: Where to eat / What it costs" in rendered
+
+
+def test_a_plan_with_no_repetition_says_nothing_about_repetition():
+    rendered = format_v3_outline_for_prompt(
+        _plan(("Where to eat", ["c1"], 300), ("What it costs", ["c2"], 300)),
+        fact_roles=ROLES,
+    )
+    assert "planned into more than one section" not in rendered
+
+
+def test_a_section_with_no_budget_gets_no_advice_rather_than_a_wrong_number():
+    """Dividing by a budget nobody set would invent a density."""
+    rendered = format_v3_outline_for_prompt(
+        _plan(("Where to eat", ["c1", "c2"], 0)), fact_roles=ROLES
+    )
+    assert "Room to work" not in rendered
+
+
+def test_the_run_record_and_the_writer_agree_about_what_is_doubled():
+    """One helper, two readers.
+
+    The diagnostics and the section brief compute this from the same function,
+    so an operator reading the run record and the writer reading its plan can
+    never be looking at different lists.
+    """
+    plan = _plan(("Where to eat", ["c1", "c2"], 300), ("What it costs", ["c1"], 300))
+    _accepted, checks = _validate(plan)
+    rendered = format_v3_outline_for_prompt(plan, fact_roles=ROLES)
+    for repeated in checks["repeated_claims"]:
+        assert f"- {repeated['claim_id']}: " in rendered
+
+
+def test_the_two_thresholds_leave_an_ordinary_middle():
+    """Between them nothing needs saying either way.
+
+    A plan is not improved by being told that four facts in two hundred words
+    is four facts in two hundred words.
+    """
+    assert ROOMY_CLAIMS_PER_HUNDRED_WORDS < CROWDED_CLAIMS_PER_HUNDRED_WORDS
+    rendered = format_v3_outline_for_prompt(
+        _plan(("Where to eat", ["c1", "c2", "c3", "c4", "c5", "c6"], 200)),
+        fact_roles=ROLES,
+    )
+    assert "Room to work: 6 facts in ~200 words." in rendered
+    assert "is a list, not a section" not in rendered
+    assert "room here to say what they mean" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# The stage is what connects the packet's roles to both readers
+# ---------------------------------------------------------------------------
+
+
+def test_the_stage_reads_the_roles_off_the_packet():
+    """Neither the diagnostics nor the writer's brief can label a fact alone.
+
+    `texture` is a decision the selection recorded, and the outline stage is
+    the only place that has both the packet and the plan. If it stopped passing
+    the roles through, everything above would keep working and quietly stop
+    saying anything droppable.
+    """
+    from tests.test_prompt2blog_v3_writing_stages import (  # noqa: PLC0415
+        FakeLLM,
+        _dependencies,
+        _outline_payload,
+        _state,
+    )
+    from app.features.prompt2blog.stages.v3.outline import run_v3_outline_stage
+
+    payload = _outline_payload()
+    facts = [
+        {"claim_id": "c1", "role": "backbone"},
+        {"claim_id": "c2", "role": "texture"},
+        {"claim_id": "c3", "role": "texture"},
+    ]
+    # A three-section plan whose first section carries everything, in too few
+    # words to explain any of it.
+    payload["sections"][0]["claim_ids"] = ["c1", "c2", "c3"]
+    payload["sections"][0]["target_words"] = 60
+    payload["sections"][1]["claim_ids"] = ["c1"]
+    payload["sections"][1]["target_words"] = 420
+    payload["sections"][2]["claim_ids"] = []
+    payload["sections"][2]["target_words"] = 420
+    dependencies, recorder = _dependencies(FakeLLM(json_response=payload))
+
+    updates = run_v3_outline_stage(
+        _state(packet={"facts": facts}), dependencies
+    )
+
+    crowded = recorder.recorded[0][1]["checks"]["crowded_sections"]
+    assert crowded[0]["spare_claims"] == ["c2", "c3"]
+    assert "Colour, droppable: c2, c3." in updates["outline_text"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_payoff.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_payoff.py
@@ -1,0 +1,328 @@
+"""Improvement 01: a section has to say what the reader gets out of it.
+
+The outline already carried a `purpose` per section and nothing in the outline
+prompt ever said what a purpose was, so it came back as the heading restated --
+"covers the transport options" under a heading about transport options. A
+section could therefore be planned, written and audited without anybody ever
+naming what a reader leaves it with.
+
+What changed is small and in three places: the form declares which *kind* of
+payoff its sections owe, the plan has to state one per section, and the audit
+checks the draft against those written promises instead of inventing its own.
+"""
+
+from __future__ import annotations
+
+from typing import Any, get_args
+
+import pytest
+
+from app.features.prompt2blog.contracts_v4 import ArticleFormId
+from app.features.prompt2blog.content.outline_v3 import (
+    format_payoff_promises,
+    format_v3_outline_for_prompt,
+    sanitize_v3_outline,
+    validate_v3_outline,
+)
+from app.features.prompt2blog.editorial_catalog import (
+    PAYOFF_NOUNS,
+    FormStructurePolicy,
+    PayoffMode,
+    load_editorial_catalog,
+)
+from app.features.prompt2blog.quality import _sanitize_quality
+
+WORK_ORDER: dict[str, Any] = {
+    "primary_subject": "Lima",
+    "scope": {"references": []},
+}
+
+
+def _forms():
+    return {form.id: form for form in load_editorial_catalog().forms}
+
+
+def _plan(*sections: tuple[str, str]) -> dict[str, Any]:
+    return sanitize_v3_outline(
+        {
+            "working_title": "What Lima costs now",
+            "sections": [
+                {
+                    "heading": heading,
+                    "reader_payoff": payoff,
+                    "claim_ids": [],
+                    "target_words": 300,
+                }
+                for heading, payoff in sections
+            ],
+        }
+    )
+
+
+def _validate(plan: dict[str, Any]):
+    return validate_v3_outline(
+        plan,
+        work_order=WORK_ORDER,
+        claim_ids=set(),
+        target_word_count=0,
+    )
+
+
+GOOD_PLAN = (
+    ("What Lima costs now", "Whether a monthly budget stretches in Lima today."),
+    ("The tradeoffs behind the price", "Which tradeoff to accept for the price."),
+    ("How the picture changed", "Whether to move now or wait, given how costs moved."),
+)
+
+
+# ---------------------------------------------------------------------------
+# The form decides which kind of payoff, and every form has decided
+# ---------------------------------------------------------------------------
+
+
+def test_every_form_declares_what_its_sections_owe_the_reader():
+    forms = _forms()
+    assert set(forms) == set(get_args(ArticleFormId))
+    for form_id, form in forms.items():
+        assert form.structure.payoff in get_args(PayoffMode), form_id
+
+
+def test_a_form_file_that_omits_the_payoff_fails_the_catalog_load(tmp_path):
+    """Loudly, at import, rather than by silently substituting a default.
+
+    The model default exists so a run frozen before this shipped still
+    validates and resumes. A *form* acquiring a payoff kind it never chose is
+    a different thing, and the two must not share one lenience.
+    """
+    from app.features.prompt2blog.editorial_catalog import _structure_policy
+
+    metadata = {"opening": "form-led", "sections": "3-12", "closing": "form-led"}
+    with pytest.raises(KeyError):
+        _structure_policy(metadata, tmp_path / "made-up-form.md")
+
+
+def test_advice_is_not_forced_on_a_form_that_does_not_give_it():
+    """The report is explicit that this must not turn every form into advice.
+
+    A profile whose every section ends in a recommendation is a worse profile.
+    So the narrative forms ask for an insight and say so, and the planning rule
+    they receive says in as many words not to recommend anything.
+    """
+    forms = _forms()
+    assert forms["feature-profile"].structure.payoff == "insight"
+    assert forms["personal-essay-travelogue"].structure.payoff == "insight"
+    assert forms["service-guide"].structure.payoff == "decision"
+    assert forms["interview-qa"].structure.payoff == "answer"
+
+    profile_rule = forms["feature-profile"].structure.outline_payoff_rule()
+    assert "Not a recommendation" in profile_rule
+    assert "decision" not in profile_rule
+
+
+def test_the_planner_and_the_writer_are_told_the_same_thing():
+    """One rule, one owner. The #547 lesson, applied to a new rule.
+
+    Both stages read the noun off the same table, so the plan cannot be asked
+    for a decision while the prose is asked to deliver an insight.
+    """
+    for mode in get_args(PayoffMode):
+        policy = FormStructurePolicy(
+            opening="form-led",
+            closing="form-led",
+            min_sections=2,
+            max_sections=8,
+            payoff=mode,
+        )
+        assert PAYOFF_NOUNS[mode] in policy.compose_payoff_rule()
+        assert policy.outline_payoff_rule() in policy.outline_rules()
+        assert policy.compose_payoff_rule() in policy.compose_rules()
+
+
+# ---------------------------------------------------------------------------
+# The plan has to state one, and they have to differ
+# ---------------------------------------------------------------------------
+
+
+def test_a_plan_that_names_a_payoff_per_section_is_accepted():
+    accepted, checks = _validate(_plan(*GOOD_PLAN))
+    assert accepted is True
+    assert checks["payoffs_stated"] is True
+    assert checks["payoffs_distinct"] is True
+    assert checks["missing_payoffs"] == []
+
+
+def test_a_section_with_no_payoff_is_named_and_the_plan_refused():
+    plan = _plan(*GOOD_PLAN)
+    plan["sections"][1]["reader_payoff"] = ""
+    accepted, checks = _validate(plan)
+
+    assert accepted is False
+    assert checks["payoffs_stated"] is False
+    # Named, so an operator reading the run record knows which section, and so
+    # a later stage can say something more useful than "the plan was rejected".
+    assert checks["missing_payoffs"] == ["The tradeoffs behind the price"]
+
+
+def test_a_missing_payoff_stays_missing_rather_than_filling_itself_in():
+    """The old field defaulted to the sentence "Purpose not stated."
+
+    Which is a sentence, so every check downstream saw a section that had
+    stated its purpose. A missing payoff can only be caught if it still looks
+    missing after sanitizing.
+    """
+    plan = sanitize_v3_outline(
+        {"working_title": "T", "sections": [{"heading": "One", "claim_ids": []}]}
+    )
+    assert plan["sections"][0]["reader_payoff"] == ""
+
+
+def test_two_sections_promising_the_same_thing_are_one_section():
+    plan = _plan(
+        ("What Lima costs now", "Whether a monthly budget stretches in Lima today."),
+        ("The tradeoffs", "Which tradeoff to accept for the price."),
+        ("How the picture changed", "Whether a monthly budget stretches in Lima today."),
+    )
+    accepted, checks = _validate(plan)
+
+    assert accepted is False
+    assert checks["payoffs_distinct"] is False
+    assert checks["duplicate_payoffs"]
+
+
+def test_wording_a_promise_differently_does_not_make_it_a_different_promise():
+    """Compared on content words, not on the sentence.
+
+    Otherwise the rule is satisfied by rephrasing, which is the failure the
+    duplicate check exists to catch dressed up.
+    """
+    plan = _plan(
+        ("Costs", "Whether a monthly budget stretches in Lima today."),
+        ("Prices", "Whether, today, a monthly budget stretches in Lima."),
+        ("Change", "Whether to move now or wait, given how costs moved."),
+    )
+    _accepted, checks = _validate(plan)
+    assert checks["payoffs_distinct"] is False
+
+
+def test_a_payoff_that_only_restates_its_heading_is_reported_not_enforced():
+    """The same treatment `crowded_sections` gets, for the same reason.
+
+    Whether a sentence adds anything to its heading is a judgement, and a plan
+    thrown away over one line would cost the article its whole structure to fix
+    a sentence.
+    """
+    plan = _plan(
+        ("Transport options", "Covers the transport options."),
+        ("The tradeoffs behind the price", "Which tradeoff to accept for the price."),
+        ("How the picture changed", "Whether to move now or wait as costs moved."),
+    )
+    accepted, checks = _validate(plan)
+
+    assert accepted is True
+    assert checks["restated_payoffs"] == ["Transport options"]
+
+
+def test_a_real_promise_that_reuses_the_headings_words_is_not_a_restatement():
+    plan = _plan(
+        (
+            "Airport transfers",
+            "Which airport transfer to book before a 6am flight, and what it costs.",
+        ),
+        ("The tradeoffs behind the price", "Which tradeoff to accept for the price."),
+        ("How the picture changed", "Whether to move now or wait as costs moved."),
+    )
+    _accepted, checks = _validate(plan)
+    assert checks["restated_payoffs"] == []
+
+
+# ---------------------------------------------------------------------------
+# The promise travels to the writer, and then to the auditor
+# ---------------------------------------------------------------------------
+
+
+def test_the_writer_is_told_what_each_section_owes_the_reader():
+    rendered = format_v3_outline_for_prompt(_plan(*GOOD_PLAN))
+    assert "What the reader gets: Whether a monthly budget stretches" in rendered
+    assert "Purpose:" not in rendered
+
+
+def test_the_auditor_is_handed_the_promises_rather_than_inventing_them():
+    promises = format_payoff_promises(_plan(*GOOD_PLAN))
+    for heading, payoff in GOOD_PLAN:
+        assert f"{heading} -> {payoff}" in promises
+
+
+def test_a_run_with_no_plan_offers_the_auditor_no_promises_to_check():
+    """An honest absence.
+
+    A rejected plan has no promises. Inventing some here would put the auditor
+    back to guessing, with the authority of a list that looks recorded.
+    """
+    assert "No section promises were recorded" in format_payoff_promises(
+        {"sections": []}
+    )
+
+
+# ---------------------------------------------------------------------------
+# An unresolved promise becomes something repair can act on
+# ---------------------------------------------------------------------------
+
+
+def test_an_unresolved_payoff_survives_the_sanitizer_with_its_reason():
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "unresolved_payoffs": [
+                {
+                    "heading": "The tradeoffs behind the price",
+                    "why": "Lists three options and never says which suits whom.",
+                }
+            ],
+        }
+    )
+    assert quality["unresolved_payoffs"] == [
+        {
+            "heading": "The tradeoffs behind the price",
+            "why": "Lists three options and never says which suits whom.",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"heading": "", "why": "something is missing"},
+        {"heading": "A section", "why": ""},
+        {"heading": "A section"},
+        "not an object",
+    ],
+)
+def test_an_accusation_nobody_can_act_on_is_dropped(entry):
+    """Both halves or neither.
+
+    A heading with no reason is a complaint repair would spend a call failing
+    to satisfy, and a reason with no heading cannot be scoped to anything.
+    """
+    quality = _sanitize_quality(
+        {"overall_score": 8, "unresolved_payoffs": [entry]}
+    )
+    assert quality["unresolved_payoffs"] == []
+
+
+def test_the_count_of_open_promises_is_recoverable_from_the_audit():
+    """The measure improvement 01 asks to track.
+
+    "How many promises did this draft leave open" is not recoverable from a
+    flat list of revision sentences, which is why the list survives as its own
+    field as well as being folded into the revisions.
+    """
+    quality = _sanitize_quality(
+        {
+            "overall_score": 8,
+            "unresolved_payoffs": [
+                {"heading": "One", "why": "no decision reached"},
+                {"heading": "Two", "why": "the question is restated, not answered"},
+            ],
+        }
+    )
+    assert len(quality["unresolved_payoffs"]) == 2

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_quality_stages.py
@@ -722,7 +722,10 @@ def test_the_audit_scores_editing_burden_not_rule_compliance():
     assert "What remains is personalisation" in prompt
     assert "A fact catalog is not coverage" in prompt
     assert "cap overall_score at 7" in prompt
-    assert "Reader decision support is a scored dimension" in prompt
+    # The rule that used to ask the auditor to work out for itself what each
+    # section owed the reader. It now checks the plan's written promises
+    # instead (improvement 01).
+    assert "SECTION PROMISES below is what the plan said" in prompt
     assert "is the floor this scale starts" in prompt
 
 
@@ -941,3 +944,83 @@ def test_an_auditor_revision_about_length_survives_when_the_length_is_fine():
     assert recorder.recorded[0][1]["required_revisions"] == [
         "Shorten the opening paragraph."
     ]
+
+
+def test_the_plans_promises_reach_the_auditor():
+    """The auditor compares the draft against what the plan committed to.
+
+    It used to be asked what each section *should* have done for the reader,
+    which is a second opinion about the plan rather than a check on the draft.
+    """
+    llm = FakeLLM(json_response={"overall_score": 8, "quality_summary": "Fine."})
+    dependencies, _recorder = _dependencies(llm)
+    outline = {
+        "sections": [
+            {
+                "heading": "What Lima costs now",
+                "reader_payoff": "Whether a monthly budget stretches in Lima today.",
+            }
+        ]
+    }
+
+    run_v3_quality_audit_stage(_state(outline=outline), dependencies)
+
+    prompt = llm.prompts[0]
+    assert "SECTION PROMISES" in prompt
+    assert (
+        "What Lima costs now -> Whether a monthly budget stretches in Lima today."
+        in prompt
+    )
+
+
+def test_an_unresolved_promise_becomes_a_revision_repair_can_act_on():
+    """Repair reads `required_revisions` and nothing else.
+
+    An unresolved payoff that stayed in its own list would be recorded on the
+    run and never acted on, which is the quietest way for a check to do
+    nothing.
+    """
+    llm = FakeLLM(
+        json_response={
+            "overall_score": 8,
+            "required_revisions": [],
+            "unresolved_payoffs": [
+                {
+                    "heading": "The tradeoffs behind the price",
+                    "why": "Lists three options and never says which suits whom.",
+                }
+            ],
+            "quality_summary": "Fine.",
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_quality_audit_stage(_state(), dependencies)
+    revisions = updates["quality"]["required_revisions"]
+
+    assert any("The tradeoffs behind the price" in item for item in revisions)
+    assert any("never says which suits whom" in item for item in revisions)
+
+
+def test_a_promise_the_auditor_already_wrote_up_is_not_repeated():
+    llm = FakeLLM(
+        json_response={
+            "overall_score": 8,
+            "required_revisions": [
+                "Rewrite The tradeoffs behind the price so it names a winner."
+            ],
+            "unresolved_payoffs": [
+                {
+                    "heading": "The tradeoffs behind the price",
+                    "why": "Lists three options and never says which suits whom.",
+                }
+            ],
+            "quality_summary": "Fine.",
+        }
+    )
+    dependencies, _recorder = _dependencies(llm)
+
+    updates = run_v3_quality_audit_stage(_state(), dependencies)
+    revisions = updates["quality"]["required_revisions"]
+
+    assert len([r for r in revisions if "The tradeoffs behind the price" in r]) == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_v3_writing_stages.py
@@ -143,21 +143,21 @@ def _outline_payload(**overrides) -> dict[str, Any]:
         "sections": [
             {
                 "heading": "What Lima costs now",
-                "purpose": "Establish the current cost baseline for Lima.",
+                "reader_payoff": "Whether a monthly budget stretches in Lima today.",
                 "claim_ids": ["c1"],
                 "requirement_ids": ["r1"],
                 "target_words": 300,
             },
             {
                 "heading": "The tradeoffs behind the price",
-                "purpose": "Show the practical tradeoffs a resident meets.",
+                "reader_payoff": "Which tradeoff a resident should accept for the price.",
                 "claim_ids": ["c2"],
                 "requirement_ids": ["r2"],
                 "target_words": 300,
             },
             {
                 "heading": "How the picture changed",
-                "purpose": "Compare the current baseline with earlier reporting.",
+                "reader_payoff": "Whether to move now or wait, given how costs moved.",
                 "claim_ids": ["c3"],
                 "requirement_ids": ["r3"],
                 "target_words": 300,
@@ -191,8 +191,8 @@ def test_city_only_outline_wording_covers_city_country_primary_subject(
     work_order["scope"]["references"] = []
     payload = _outline_payload()
     payload["sections"][0]["heading"] = f"What {subject_mention} costs now"
-    payload["sections"][0]["purpose"] = (
-        f"Establish the current cost baseline for {subject_mention}."
+    payload["sections"][0]["reader_payoff"] = (
+        f"Whether a monthly budget stretches in {subject_mention} today."
     )
 
     accepted, diagnostics = validate_v3_outline(
@@ -262,7 +262,9 @@ def test_sections_may_carry_the_subject_implicitly_when_the_framing_names_it():
     implicit = _outline_payload()
     for section in implicit["sections"]:
         section["heading"] = section["heading"].replace("Lima", "the city")
-        section["purpose"] = section["purpose"].replace("Lima", "the city")
+        section["reader_payoff"] = section["reader_payoff"].replace(
+            "Lima", "the city"
+        )
 
     accepted, diagnostics = _validate(implicit)
 
@@ -426,14 +428,14 @@ def _five_section_payload() -> dict[str, Any]:
     payload["sections"] = payload["sections"] + [
         {
             "heading": "Where the money actually goes",
-            "purpose": "Break the monthly figure into what a resident pays.",
+            "reader_payoff": "Which line of the monthly figure to cut first.",
             "claim_ids": ["c1"],
             "requirement_ids": ["r1"],
             "target_words": 150,
         },
         {
             "heading": "What a long stay commits you to",
-            "purpose": "Say what the decision costs beyond money.",
+            "reader_payoff": "Whether the non-monetary cost is one to accept.",
             "claim_ids": ["c2"],
             "requirement_ids": ["r2"],
             "target_words": 150,
@@ -508,19 +510,36 @@ def test_a_plan_that_passes_is_not_touched():
     (Path(__file__).parent / 'fixtures/p2b-outline-rejections.json').read_text()
 ), ids=lambda case: case['run_id'])
 def test_recorded_outline_rejections(case):
+    """Real plans from real runs, checked against the scope rules that judged them.
+
+    These are captured model responses, kept verbatim -- their value is that
+    nobody wrote them to pass. They predate `reader_payoff`, so every one of
+    them now fails `payoffs_stated`, which is the new rule working rather than
+    a regression: a plan with no promise per section is exactly what
+    improvement 01 refuses. So the assertion is on the checks these runs were
+    recorded for, not on the overall verdict, and the payoff gap is asserted
+    separately so it cannot drift back to passing unnoticed.
+    """
     dependencies, recorder = _dependencies(FakeLLM(json_response=case['outline']))
     updates = run_v3_outline_stage(_state(
         work_order=case['work_order'],
         packet={'facts': [{'claim_id': cid} for cid in case['claim_ids']]},
     ), dependencies)
     assert recorder.recorded[0][1]['candidate_outline'] == sanitize_v3_outline(case['outline'])
-    expected = not case['run_id'].startswith('a3c20e41')
-    assert updates['outline_accepted'] is expected
-    if expected:
-        assert len(updates['outline']['sections']) == 6
-        assert 'Planned sections' in updates['outline_text']
-    else:
-        assert updates['outline']['sections'] == []
+    checks = recorder.recorded[0][1]['checks']
+
+    # Planned before section payoffs existed, so none of them states one.
+    assert checks['payoffs_stated'] is False
+    assert updates['outline_accepted'] is False
+
+    # a3c20e41 is the recording of a plan that organised two sections around a
+    # context-only place. That is the one check it misses; its claims resolve
+    # and it names its subject like the others.
+    assert checks['claims_resolve'] is True
+    assert checks['covers_primary_subject'] is True
+    assert checks['no_context_only_sections'] is not case['run_id'].startswith(
+        'a3c20e41'
+    )
 
 
 @pytest.mark.parametrize('title', ['El Centro transfers', 'Dorado transfers', 'International Airport transfers'])


### PR DESCRIPTION
Improvement **04** from `docs/audits/prompt2blog-writer-improvements.html`. Completes the roadmap's "First improvements" row.

> **Stacked on [#549](https://github.com/Questurian/questurian/pull/549)** — base is `p2b/section-reader-payoff`, not `main`. Both changes edit the same section brief, so stacking keeps this diff to just improvement 04. Merge #549 first.

## The problem

`crowded_sections` already measured this. Run `9e66bf84` planned **56 claims into one 200-word section** — three and a half words per fact, at which density there is no sentence you can write except a list.

The measurement went into the run record, where nobody who could act on it would see it. The writer was handed a list of claim ids and a word budget and left to reconcile two things that do not reconcile. The only prose that satisfies both is a catalogue.

## What changed

The report asks for the **existing** diagnostic to be extended, not for a second density system. So:

**`spare_claims`** — a crowded section now names the facts the selection itself labelled `texture` (chosen to carry the place, not to prove anything). This is the half that makes a count actionable: eight facts in 140 words is a different problem when four of them are colour. A section of eight load-bearing facts is *over-planned* — it needs a different plan, not a lighter hand, and the empty list says so.

**`repeated_claims`** — a fact planned into two sections. The cheapest repetition there is: the article said the same thing twice and nothing in the record said where it came from.

**`unplaced_claims`** — the distance between what the operator picked and what the plan uses.

Neither of the last two fails a plan. A price can legitimately be recalled where it matters again, and *"leave out what the piece is better without"* is already what the outline prompt asks for.

## What the writer is told

A `Room to work` line per section, built from the same helper the diagnostics use — so an operator reading the run record and the writer reading its plan can never be looking at different lists.

```
1. Where to eat (~140 words)
   What the reader gets: Which stall to pick before a 6am flight.
   Evidence claims: c1, c2, c3, c4, c5, c6, c7, c8
   Room to work: 8 facts in ~140 words is a list, not a section. Explain the
   two or three that carry the point. Colour, droppable: c3, c4, c5, c8.
2. What it costs (~300 words)
   Room to work: 2 facts in ~300 words. There is room here to say what they
   mean, not only what they are.

The same fact is planned into more than one section. State it once, in the
section that needs it most, unless the second use genuinely does new work:
- c1: Where to eat / What it costs
```

Between the two thresholds it prints the count and stops. A plan is not improved by being told that four facts in two hundred words is four facts in two hundred words.

## Compose gets permission it never had

To leave a fact out. Three details explained beat ten listed, and the reader can only act on the ones that were explained.

What it may **not** drop: an obligation under `must_name`, or a limit that changes what the reader should do. And the prompt says outright that the density line is advice and never a maximum — one complicated fact can need more explaining than five simple ones.

## Nothing here is enforced

Same treatment `crowded_sections` already had, same reason: a plan rejected over an estimate is a plan thrown away.

## Verification

- 17 new tests in `test_prompt2blog_section_density.py`, including one that pins the stage as the thing connecting the packet's roles to *both* readers — if it stopped passing them through, everything else would keep working and quietly stop saying anything droppable.
- Full backend suite: **1665 passed**, 0 failed.
- flake8 clean on every file touched.

No model calls were made. No pipeline was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)