### PR TITLE
feat(p2b): name the weak evidence before it becomes confident prose

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -43,6 +43,7 @@ them for the v2 fallback. Do not delete or renumber them.
 | `evidence_v3.py`, `instructions_v3.py` | V3 evidence normalization, canonical instruction layers, and stage-specific contexts |
 | `selection_v4.py`, `packet_v4.py` | Which facts this article is written from, and the deterministic view of them the writing stages read |
 | `research_readiness_v3.py`, `intake_v3.py` | The v3 research gate, its `needs_research` result, and v3 run input |
+| `evidence_health.py` | Deterministic read of the chosen facts: undated prices, unreachable sources, unsettled conflicts, a promise of currency the evidence cannot keep |
 | `stages/v3/`, `prompts/editorial_v3.py`, `content/outline_v3.py` | V3 writing stages, their prompts, and pure section-plan scope guards |
 | `orchestrator_v3.py`, `graph/topology_v3.py` | The v3 run entrypoints and its shorter generation topology |
 | `resume_v3.py` | The state snapshot a failed v3 run is picked back up from |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_health.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/evidence_health.py
@@ -1,0 +1,295 @@
+"""Weak input, named before confident prose is written from it.
+
+Improvement 08. The gate already asks whether the dossier answers the
+questions. It never asked whether the answers are the kind of answers this
+article can stand on -- so a menu price checked eighteen months ago and a menu
+price checked last week reach the writer looking identical, and the article
+states both in the present tense with equal confidence.
+
+Everything here is deterministic and free. It reads the frozen records and
+reports; it fetches nothing, asks no model, and never edits a packet. New
+research is a separate, deliberate act that changes the dossier and the
+selection before a new packet is frozen, which is the rule this must not
+quietly break.
+
+Why there is no expiry
+----------------------
+The obvious version of this is "flag anything older than N months", and it is
+wrong. How long a fact stays true depends entirely on what kind of fact it is:
+a museum's founding date does not go stale, a tasting-menu price goes stale in
+a season, and a bus timetable goes stale the day it changes. A universal
+threshold would either bury the operator in false alarms or miss the price that
+matters.
+
+So the comparison is against what the *article* promises. A piece whose seed
+says "right now" has promised the reader currency and is answerable for it; a
+piece about what a neighbourhood was like in 2019 has promised the opposite and
+must not be nagged for using historical facts. That is also why nothing here
+says a fact is false: a date is evidence about how much the article is
+claiming, never about whether the claim is true.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+from .contracts_v4 import ArticleBrief, EvidencePackage
+
+# Wording that makes a claim answerable for being current. Not a claim about
+# the subject -- a museum can charge an entry fee for fifty years -- but about
+# the *statement*: a price, an opening time, a fare, a schedule, an
+# availability. These are the sentences a reader acts on today.
+_TIME_SENSITIVE_CLAIM = re.compile(
+    r"""
+    \b(?:
+        price|prices|priced|pricing|cost|costs|fare|fares|fee|fees|rate|rates|
+        charge|charges|admission|ticket|tickets|
+        opens?|opening|closes?|closing|hours|schedule|schedules|timetable|
+        departs?|departure|departures|arrives?|frequency|
+        available|availability|open|closed|currently|booking|bookings|
+        menu|menus|offers?|discount|discounts|surcharge
+    )\b
+  | [$€£¥]\s?\d
+  | \b\d[\d,.]*\s?(?:USD|EUR|GBP|PEN|COP|MXN|BRL|CLP|ARS|soles?|pesos?)\b
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# Wording in the brief that promises the reader the article describes how
+# things are now. A promise, not a topic: "the best time to visit" is about
+# timing and promises nothing about currency; "what it costs right now" does.
+_CURRENCY_PROMISE = re.compile(
+    r"""
+    \b(?:
+        right\s+now|currently|current|today|these\s+days|at\s+the\s+moment|
+        this\s+year|this\s+season|latest|up[-\s]to[-\s]date|still|
+        as\s+of\s+now|nowadays|these\s+prices
+    )\b
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# The window inside which a dated fact is treated as answering a promise of
+# currency. Not an expiry on facts -- it is how recently something must have
+# been checked before an article may say "right now" about it, which is a
+# question about the promise rather than about the fact.
+#
+# Twelve months, because that is a season either side of any annual price
+# change, and because the alternative -- picking a number per kind of fact --
+# is a taxonomy nobody would maintain and the operator can already override by
+# reading the finding and deciding it does not matter.
+CURRENCY_PROMISE_MONTHS = 12
+
+
+def _months_between(earlier: date, later: date) -> int:
+    return (later.year - earlier.year) * 12 + (later.month - earlier.month)
+
+
+def is_time_sensitive(text: str) -> bool:
+    return bool(_TIME_SENSITIVE_CLAIM.search(text))
+
+
+def promises_currency(brief: ArticleBrief) -> bool:
+    """Whether this article has told the reader it describes how things are now.
+
+    Read off the seed, the reader's question and the outcome -- the three lines
+    that are a promise to a reader. `spine` and `fails_if` are the operator
+    talking to the pipeline about how to write it, and a spine that happens to
+    contain the word "current" is not a promise anybody made.
+    """
+    return any(
+        _CURRENCY_PROMISE.search(line)
+        for line in (brief.seed, brief.reader_question, brief.outcome)
+    )
+
+
+@dataclass(frozen=True)
+class HealthFinding:
+    """One thing about the evidence worth an operator's attention."""
+
+    kind: str
+    # What to look at. Claim ids, source ids, or a conflict id.
+    subject_ids: list[str]
+    detail: str
+    # True only where the article has promised something its evidence cannot
+    # support. Everything else here is worth reading and worth ignoring.
+    blocks_currency_promise: bool = False
+
+
+@dataclass
+class EvidenceHealth:
+    """What the deterministic read of the dossier found."""
+
+    findings: list[HealthFinding] = field(default_factory=list)
+    promises_currency: bool = False
+    checked_against: str = ""
+
+    @property
+    def unmet_promise(self) -> bool:
+        return any(finding.blocks_currency_promise for finding in self.findings)
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "promises_currency": self.promises_currency,
+            "checked_against": self.checked_against,
+            "unmet_promise": self.unmet_promise,
+            "findings": [
+                {
+                    "kind": finding.kind,
+                    "subject_ids": list(finding.subject_ids),
+                    "detail": finding.detail,
+                    "blocks_currency_promise": finding.blocks_currency_promise,
+                }
+                for finding in self.findings
+            ],
+            # Said in the record rather than left to whoever reads it. A list of
+            # dated facts under a heading like "evidence problems" is read as a
+            # list of wrong facts by the second person who sees it.
+            "means": (
+                "A date says how much an article is entitled to claim, never "
+                "whether a fact is true. Nothing here has been re-checked, and "
+                "an article that deliberately describes an earlier moment is "
+                "expected to rest on older facts."
+            ),
+        }
+
+
+def assess_evidence_health(
+    brief: ArticleBrief,
+    evidence: EvidencePackage,
+    *,
+    today: date,
+    selected_only: bool = True,
+) -> EvidenceHealth:
+    """Read the dossier for the trouble a date or a link can reveal.
+
+    `today` is passed rather than read, so the same dossier assessed twice
+    gives the same answer and a test does not have to travel in time.
+
+    `selected_only` because the question is about the article being written.
+    A stale price the operator already cut is not this article's problem, and
+    reporting it would bury the one that is.
+    """
+    claims = [
+        claim
+        for claim in evidence.claims
+        if claim.selected or not selected_only
+    ]
+    by_id = {claim.claim_id: claim for claim in claims}
+    sources = {source.source_id: source for source in evidence.sources}
+    promised = promises_currency(brief)
+    findings: list[HealthFinding] = []
+
+    # 1. A statement a reader acts on, with nothing saying when it was true.
+    undated = sorted(
+        claim.claim_id
+        for claim in claims
+        if claim.as_of is None and is_time_sensitive(claim.text)
+    )
+    if undated:
+        findings.append(
+            HealthFinding(
+                kind="undated_time_sensitive",
+                subject_ids=undated,
+                detail=(
+                    f"{len(undated)} chosen fact(s) state a price, a time or an "
+                    "availability without saying when that was true. The writer "
+                    "has nothing to date the sentence with, so it will read as "
+                    "current."
+                ),
+                # A promise of currency resting on facts that carry no date at
+                # all is the clearest version of this problem: there is not
+                # even a date to argue about.
+                blocks_currency_promise=promised,
+            )
+        )
+
+    # 2. A fact nobody can go back and re-check.
+    unverifiable = sorted(
+        claim.claim_id
+        for claim in claims
+        if all(
+            (source := sources.get(source_id)) is not None and source.url is None
+            for source_id in claim.source_ids
+        )
+    )
+    if unverifiable:
+        findings.append(
+            HealthFinding(
+                kind="no_source_to_return_to",
+                subject_ids=unverifiable,
+                detail=(
+                    f"{len(unverifiable)} chosen fact(s) rest only on sources "
+                    "with no address. Nobody can go back and see whether they "
+                    "still hold."
+                ),
+            )
+        )
+
+    # 3. Two chosen facts that disagree, with nobody having decided.
+    #
+    # The dossier records conflicts and a resolution when one was reached. An
+    # unresolved conflict whose claims are *both still chosen* hands the writer
+    # two statements that contradict each other and no instruction, and the
+    # writer will pick one silently. That is the case worth interrupting for --
+    # a conflict where the operator already deselected one side is settled.
+    for conflict in evidence.conflicts:
+        if conflict.resolution:
+            continue
+        still_chosen = sorted(
+            claim_id for claim_id in conflict.claim_ids if claim_id in by_id
+        )
+        if len(still_chosen) < 2:
+            continue
+        findings.append(
+            HealthFinding(
+                kind="unsettled_conflict",
+                subject_ids=still_chosen,
+                detail=(
+                    f"{conflict.summary} Both statements are still chosen and "
+                    "nothing says which is right, so the writer will pick one "
+                    "and not say that it did."
+                ),
+            )
+        )
+
+    # 4. The article promised currency; the evidence is older than the promise.
+    #
+    # Only ever asked of an article that made the promise. A piece about what a
+    # neighbourhood was like in 2019 rests on 2019 facts on purpose, and
+    # nagging it for that would train the operator to ignore all of this.
+    checked_against = ""
+    if promised:
+        dated = [
+            claim
+            for claim in claims
+            if claim.as_of is not None and is_time_sensitive(claim.text)
+        ]
+        if dated:
+            newest = max(claim.as_of for claim in dated)
+            checked_against = newest.isoformat()
+            age = _months_between(newest, today)
+            if age > CURRENCY_PROMISE_MONTHS:
+                findings.append(
+                    HealthFinding(
+                        kind="currency_promise_unmet",
+                        subject_ids=sorted(claim.claim_id for claim in dated),
+                        detail=(
+                            "This article promises the reader how things are "
+                            f"now, and the most recently checked price or time "
+                            f"on the desk is from {newest.isoformat()} -- "
+                            f"{age} months ago. Either research it again, or "
+                            "say plainly when these were true."
+                        ),
+                        blocks_currency_promise=True,
+                    )
+                )
+
+    return EvidenceHealth(
+        findings=findings,
+        promises_currency=promised,
+        checked_against=checked_against,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/intake_v4.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from datetime import date
 from typing import Any
 from uuid import uuid4
 
@@ -49,6 +50,7 @@ from .grill_v4 import (
 )
 from .coverage_v4 import CoverageVerdict, assess_coverage
 from .notes_v4 import PUNCH_LIST_STAGE, build_punch_list
+from .evidence_health import assess_evidence_health
 from .gate_v4 import (
     GateAnswerRefused,
     answer_requirement,
@@ -602,6 +604,20 @@ def review_selection(run_id: str) -> dict[str, Any]:
         # the operator can still do something about it. Empty when the choice
         # still describes what it was made from.
         "stale_reason": stale_reason(brief, work_order, evidence, selection),
+        # What is weak about the facts that are actually going to the writer
+        # (improvement 08). Here rather than at the gate because this is the
+        # last screen before prose exists and the first one that knows which
+        # facts were chosen -- a stale price the operator already cut is not
+        # this article's problem, and reporting it would bury the one that is.
+        #
+        # Advisory. Nothing here blocks: the operator can read that the newest
+        # price is eighteen months old and decide it does not matter, which is
+        # a judgement no deterministic check is entitled to make for them.
+        "evidence_health": assess_evidence_health(
+            brief,
+            apply_selection(evidence, selection),
+            today=date.today(),
+        ).as_record(),
     }
 
 

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_evidence_health.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_evidence_health.py
@@ -1,0 +1,402 @@
+"""Improvement 08: weak input, named before confident prose is written from it.
+
+The gate already asks whether the dossier answers the questions. It never asked
+whether the answers are the kind an article can stand on, so a menu price
+checked eighteen months ago and one checked last week reach the writer looking
+identical -- and the article states both in the present tense.
+
+The temptation here is an expiry, and it is wrong. How long a fact stays true
+depends on the fact: a founding date never goes stale, a tasting-menu price
+goes stale in a season. So the comparison is against what the *article*
+promised, and the tests that matter are the ones proving a piece which promised
+nothing is left alone.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.features.prompt2blog.contracts_v4 import (
+    ArticleBrief,
+    BriefReader,
+    EvidenceClaim,
+    EvidenceConflict,
+    EvidencePackage,
+    EvidenceRequirement,
+    EvidenceSource,
+)
+from app.features.prompt2blog.evidence_health import (
+    CURRENCY_PROMISE_MONTHS,
+    assess_evidence_health,
+    is_time_sensitive,
+    promises_currency,
+)
+
+TODAY = date(2026, 9, 7)
+
+
+def _brief(**overrides) -> ArticleBrief:
+    payload = dict(
+        brief_fingerprint="bf-1",
+        seed="Where to eat in Lima right now",
+        location="Lima, Peru",
+        form_id="service-guide",
+        reader=BriefReader(primary_reader="layover traveller", tags=[]),
+        reader_question="What does a good meal cost right now?",
+        outcome="book a table tonight",
+        spine="cheap beats famous",
+        fails_if="reads like a tourist board",
+    )
+    payload.update(overrides)
+    return ArticleBrief(**payload)
+
+
+def _source(source_id: str = "s1", **overrides) -> EvidenceSource:
+    payload = dict(
+        source_id=source_id,
+        title="Surquillo price survey",
+        publisher="Peru Retail",
+        url="https://example.pe/prices",
+        retrieved_at=date(2026, 8, 1),
+        source_type="reporting",
+        material_type="web",
+        notes=["Stall prices."],
+    )
+    payload.update(overrides)
+    return EvidenceSource(**payload)
+
+
+def _claim(claim_id: str, text: str, **overrides) -> EvidenceClaim:
+    payload = dict(
+        claim_id=claim_id,
+        text=text,
+        source_ids=["s1"],
+        requirement_ids=["r1"],
+        confidence="high",
+    )
+    payload.update(overrides)
+    return EvidenceClaim(**payload)
+
+
+def _evidence(claims, sources=None, conflicts=None) -> EvidencePackage:
+    return EvidencePackage(
+        work_order_fingerprint="wo-1",
+        sources=sources or [_source()],
+        claims=claims,
+        requirements=[
+            EvidenceRequirement(
+                requirement_id="r1",
+                status="supported",
+                claim_ids=[claim.claim_id for claim in claims],
+            )
+        ],
+        conflicts=conflicts or [],
+    )
+
+
+def _health(brief=None, evidence=None, today=TODAY, **kwargs):
+    return assess_evidence_health(
+        brief or _brief(),
+        evidence
+        or _evidence([_claim("c1", "Stall ceviche costs $8.", as_of=date(2026, 8, 1))]),
+        today=today,
+        **kwargs,
+    )
+
+
+def _kinds(health) -> set[str]:
+    return {finding.kind for finding in health.findings}
+
+
+# ---------------------------------------------------------------------------
+# What makes a statement answerable for being current
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Stall ceviche costs $8.",
+        "The museum opens at 09:00 on weekdays.",
+        "The airport bus departs every 20 minutes.",
+        "Tickets are 45 soles.",
+        "The tasting menu is currently unavailable.",
+    ],
+)
+def test_a_statement_a_reader_acts_on_today_is_time_sensitive(text):
+    assert is_time_sensitive(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Huaca Pucllana was built by the Lima culture.",
+        "Barranco sits south of Miraflores.",
+        "The neighbourhood is walkable and quiet after dark.",
+    ],
+)
+def test_a_statement_that_does_not_go_stale_is_not_flagged_as_time_sensitive(text):
+    assert is_time_sensitive(text) is False
+
+
+# ---------------------------------------------------------------------------
+# A promise, not a topic
+# ---------------------------------------------------------------------------
+
+
+def test_an_article_that_says_right_now_has_promised_currency():
+    assert promises_currency(_brief()) is True
+
+
+def test_an_article_about_an_earlier_moment_has_promised_the_opposite():
+    """And must not be nagged for resting on older facts.
+
+    Nagging it would train the operator to ignore all of this, which is the way
+    a diagnostic stops working without anybody switching it off.
+    """
+    snapshot = _brief(
+        seed="What Barranco was like before the boom",
+        reader_question="How had the neighbourhood changed by 2019?",
+        outcome="understand what was lost",
+    )
+    assert promises_currency(snapshot) is False
+
+
+def test_the_promise_is_read_off_the_lines_written_for_a_reader():
+    """`spine` and `fails_if` are the operator talking to the pipeline.
+
+    A spine that happens to contain the word "current" is not a promise
+    anybody made to a reader.
+    """
+    internal = _brief(
+        seed="Where to eat in Lima",
+        reader_question="Which stalls are worth the trip?",
+        outcome="pick a stall",
+        spine="the current consensus is wrong",
+        fails_if="fails if it ignores current prices",
+    )
+    assert promises_currency(internal) is False
+
+
+# ---------------------------------------------------------------------------
+# The four findings
+# ---------------------------------------------------------------------------
+
+
+def test_a_price_with_no_date_is_named():
+    health = _health(evidence=_evidence([_claim("c1", "Stall ceviche costs $8.")]))
+    assert "undated_time_sensitive" in _kinds(health)
+
+
+def test_a_fact_that_does_not_go_stale_needs_no_date():
+    health = _health(
+        evidence=_evidence([_claim("c1", "Huaca Pucllana sits in Miraflores.")])
+    )
+    assert "undated_time_sensitive" not in _kinds(health)
+
+
+def test_a_fact_nobody_can_return_to_is_named():
+    health = _health(
+        evidence=_evidence(
+            [_claim("c1", "The guide said the walk takes an hour.", as_of=TODAY)],
+            sources=[
+                _source(url=None, publisher=None, material_type="first-person-notes")
+            ],
+        )
+    )
+    assert "no_source_to_return_to" in _kinds(health)
+
+
+def test_a_fact_with_one_reachable_source_is_not_named():
+    health = _health(
+        evidence=_evidence(
+            [
+                _claim(
+                    "c1",
+                    "The walk takes an hour.",
+                    as_of=TODAY,
+                    source_ids=["s1", "s2"],
+                )
+            ],
+            sources=[
+                _source(),
+                _source(
+                    source_id="s2",
+                    url=None,
+                    publisher=None,
+                    material_type="first-person-notes",
+                ),
+            ],
+        )
+    )
+    assert "no_source_to_return_to" not in _kinds(health)
+
+
+def test_two_chosen_facts_that_disagree_with_nobody_deciding_are_named():
+    """The writer will pick one and not say that it did."""
+    health = _health(
+        evidence=_evidence(
+            [
+                _claim("c1", "Entry costs 15 soles.", as_of=TODAY),
+                _claim("c2", "Entry costs 30 soles.", as_of=TODAY),
+            ],
+            conflicts=[
+                EvidenceConflict(
+                    conflict_id="k1",
+                    claim_ids=["c1", "c2"],
+                    summary="Two prices are published for the same entry.",
+                )
+            ],
+        )
+    )
+    assert "unsettled_conflict" in _kinds(health)
+
+
+def test_a_conflict_somebody_settled_is_not_raised_again():
+    health = _health(
+        evidence=_evidence(
+            [
+                _claim("c1", "Entry costs 15 soles.", as_of=TODAY),
+                _claim("c2", "Entry costs 30 soles.", as_of=TODAY),
+            ],
+            conflicts=[
+                EvidenceConflict(
+                    conflict_id="k1",
+                    claim_ids=["c1", "c2"],
+                    summary="Two prices are published.",
+                    resolution="The 15-soles rate is the resident price.",
+                )
+            ],
+        )
+    )
+    assert "unsettled_conflict" not in _kinds(health)
+
+
+def test_a_conflict_the_operator_already_cut_one_side_of_is_settled():
+    """Deselecting one of two contradictory facts *is* the decision."""
+    health = _health(
+        evidence=_evidence(
+            [
+                _claim("c1", "Entry costs 15 soles.", as_of=TODAY),
+                _claim("c2", "Entry costs 30 soles.", as_of=TODAY, selected=False),
+            ],
+            conflicts=[
+                EvidenceConflict(
+                    conflict_id="k1",
+                    claim_ids=["c1", "c2"],
+                    summary="Two prices are published.",
+                )
+            ],
+        )
+    )
+    assert "unsettled_conflict" not in _kinds(health)
+
+
+# ---------------------------------------------------------------------------
+# The promise the evidence cannot keep
+# ---------------------------------------------------------------------------
+
+
+def test_a_promise_of_now_resting_on_old_prices_is_the_one_thing_that_interrupts():
+    old = date(2024, 1, 1)
+    health = _health(
+        evidence=_evidence([_claim("c1", "Stall ceviche costs $8.", as_of=old)])
+    )
+    assert "currency_promise_unmet" in _kinds(health)
+    assert health.unmet_promise is True
+    assert health.checked_against == "2024-01-01"
+
+
+def test_a_promise_of_now_resting_on_recent_prices_passes_quietly():
+    recent = date(2026, 6, 1)
+    health = _health(
+        evidence=_evidence([_claim("c1", "Stall ceviche costs $8.", as_of=recent)])
+    )
+    assert "currency_promise_unmet" not in _kinds(health)
+    assert health.unmet_promise is False
+
+
+def test_an_article_about_an_earlier_moment_may_rest_on_old_prices():
+    """The success criterion, stated as a test.
+
+    A snapshot article uses historical facts on purpose. This is the whole
+    reason the comparison is against the promise rather than against a
+    universal expiry.
+    """
+    snapshot = _brief(
+        seed="What Barranco cost before the boom",
+        reader_question="How had prices changed by 2019?",
+        outcome="understand what was lost",
+    )
+    health = _health(
+        brief=snapshot,
+        evidence=_evidence(
+            [_claim("c1", "A menu cost $4 then.", as_of=date(2019, 5, 1))]
+        ),
+    )
+    assert health.promises_currency is False
+    assert "currency_promise_unmet" not in _kinds(health)
+    assert health.unmet_promise is False
+
+
+def test_the_window_is_a_property_of_the_promise_not_of_the_fact():
+    """Just inside and just outside, on the same dossier.
+
+    Nothing about the fact changes across this line. What changes is whether an
+    article is entitled to say "right now" while resting on it.
+    """
+    inside = date(2026, 9, 7)
+    boundary = date(inside.year - 1, inside.month, 1)
+    fresh = _health(
+        evidence=_evidence([_claim("c1", "Ceviche costs $8.", as_of=boundary)]),
+        today=inside,
+    )
+    stale = _health(
+        evidence=_evidence(
+            [_claim("c1", "Ceviche costs $8.", as_of=date(2025, 8, 1))]
+        ),
+        today=inside,
+    )
+    assert CURRENCY_PROMISE_MONTHS == 12
+    assert "currency_promise_unmet" not in _kinds(fresh)
+    assert "currency_promise_unmet" in _kinds(stale)
+
+
+# ---------------------------------------------------------------------------
+# Scope, and what it refuses to say
+# ---------------------------------------------------------------------------
+
+
+def test_a_fact_the_operator_already_cut_is_not_this_articles_problem():
+    """Reporting it would bury the one that is."""
+    health = _health(
+        evidence=_evidence(
+            [
+                _claim("c1", "Ceviche costs $8.", as_of=TODAY),
+                _claim("c2", "Entry costs 30 soles.", selected=False),
+            ]
+        )
+    )
+    assert "undated_time_sensitive" not in _kinds(health)
+
+
+def test_the_record_says_what_a_date_is_not_evidence_of():
+    record = _health().as_record()
+    assert "never whether a fact is true" in record["means"]
+    assert "has been re-checked" in record["means"]
+
+
+def test_a_clean_dossier_produces_nothing_to_read():
+    health = _health()
+    assert health.findings == []
+    assert health.unmet_promise is False
+
+
+def test_nothing_here_changes_the_evidence():
+    """It reads records and reports. No enrichment, silent or otherwise."""
+    evidence = _evidence([_claim("c1", "Ceviche costs $8.")])
+    before = evidence.model_dump_json()
+    _health(evidence=evidence)
+    assert evidence.model_dump_json() == before

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/FactPicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/FactPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { readSelection, reviseSelection } from '../intake.api'
-import type { SelectableClaim, SelectionReview } from '../intake.types'
+import type { EvidenceHealth, SelectableClaim, SelectionReview } from '../intake.types'
 
 /**
  * Which facts the article is written from.
@@ -130,6 +130,51 @@ function FactList({
   )
 }
 
+
+/**
+ * What is weak about the facts that are about to reach the writer.
+ *
+ * This is the last screen before prose exists, which is the only place any of
+ * it is cheap to act on: once an article is written, an undated price has
+ * already been stated in the present tense and the fix is an edit rather than
+ * a decision.
+ *
+ * Deliberately not styled as a failure. Every finding here is worth reading and
+ * worth ignoring — an article about what a neighbourhood was like in 2019
+ * *should* rest on 2019 facts, and an operator who knows a price has not moved
+ * is right to leave it. The one exception is a piece that promised the reader
+ * how things are now and cannot keep that promise, which reads louder because
+ * the article is the thing making a claim it cannot support.
+ *
+ * The closing sentence is not decoration. A list of dated facts under a heading
+ * about evidence problems is read as a list of *wrong* facts by the second
+ * person who sees it, and nothing here has been re-checked.
+ */
+function EvidenceHealthNotice({ health }: { health?: EvidenceHealth }) {
+  if (!health || health.findings.length === 0) return null
+
+  return (
+    <section className="p2b-health" aria-label="What is weak about these facts">
+      <p className="p2b-label">Before this is written</p>
+      <ul className="p2b-health-findings">
+        {health.findings.map(finding => (
+          <li
+            key={finding.kind}
+            className={
+              finding.blocks_currency_promise
+                ? 'p2b-health-finding p2b-health-promise'
+                : 'p2b-health-finding'
+            }
+          >
+            {finding.detail}
+          </li>
+        ))}
+      </ul>
+      <p className="p2b-health-means">{health.means}</p>
+    </section>
+  )
+}
+
 export function FactPicker({ runId, onChanged }: FactPickerProps) {
   const [review, setReview] = useState<SelectionReview | null>(null)
   const [busy, setBusy] = useState(false)
@@ -225,6 +270,8 @@ export function FactPicker({ runId, onChanged }: FactPickerProps) {
            research happened to return, and cutting by it is not a decision. */
         <p className="p2b-facts-note">{review.note}</p>
       )}
+
+      <EvidenceHealthNotice health={review.evidence_health} />
 
       <label className="p2b-field p2b-facts-line">
         <span className="p2b-label">How many to keep</span>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/evidence-health.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/evidence-health.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EvidenceHealth, SelectionReview } from './intake.types'
+
+const readSelection = vi.fn()
+const reviseSelection = vi.fn()
+vi.mock('./intake.api', () => ({
+  readSelection: (...args: unknown[]) => readSelection(...args),
+  reviseSelection: (...args: unknown[]) => reviseSelection(...args),
+}))
+
+const { FactPicker } = await import('./components/FactPicker')
+
+/**
+ * What is weak about the facts about to reach the writer.
+ *
+ * The last screen before prose exists, which is the only place any of this is
+ * cheap to act on. Once an article is written, an undated price has already
+ * been stated in the present tense.
+ */
+
+const MEANS =
+  'A date says how much an article is entitled to claim, never whether a fact is true. Nothing here has been re-checked.'
+
+function health(overrides: Partial<EvidenceHealth> = {}): EvidenceHealth {
+  return {
+    promises_currency: true,
+    checked_against: '2024-01-01',
+    unmet_promise: false,
+    findings: [],
+    means: MEANS,
+    ...overrides,
+  }
+}
+
+function review(overrides: Partial<SelectionReview> = {}): SelectionReview {
+  return {
+    available: true,
+    keep_count: 1,
+    note: '',
+    claims: [
+      {
+        claim_id: 'c1',
+        text: 'Stall ceviche costs $8.',
+        rank: 1,
+        selected: true,
+        rescued: false,
+        dropped: false,
+        why: 'The price the piece turns on.',
+        questions: ['r1'],
+        merged_in: [],
+        confidence: 'high',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  readSelection.mockReset()
+  reviseSelection.mockReset()
+})
+
+describe('before this is written', () => {
+  it('names an undated price while it is still cheap to act on', async () => {
+    readSelection.mockResolvedValue(
+      review({
+        evidence_health: health({
+          findings: [
+            {
+              kind: 'undated_time_sensitive',
+              subject_ids: ['c1'],
+              detail:
+                '1 chosen fact states a price without saying when that was true.',
+              blocks_currency_promise: false,
+            },
+          ],
+        }),
+      }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={() => {}} />)
+
+    expect(
+      await screen.findByText(/states a price without saying when that was true/),
+    ).toBeInTheDocument()
+  })
+
+  it('never lets the findings be the last word', async () => {
+    // A list of dated facts under a heading about evidence problems is read as
+    // a list of wrong facts by the second person who sees it.
+    readSelection.mockResolvedValue(
+      review({
+        evidence_health: health({
+          findings: [
+            {
+              kind: 'undated_time_sensitive',
+              subject_ids: ['c1'],
+              detail: 'Something is undated.',
+              blocks_currency_promise: false,
+            },
+          ],
+        }),
+      }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={() => {}} />)
+
+    expect(
+      await screen.findByText(/never whether a fact is true/),
+    ).toBeInTheDocument()
+  })
+
+  it('reads louder only where the article promised what it cannot support', async () => {
+    readSelection.mockResolvedValue(
+      review({
+        evidence_health: health({
+          unmet_promise: true,
+          findings: [
+            {
+              kind: 'currency_promise_unmet',
+              subject_ids: ['c1'],
+              detail: 'This article promises how things are now.',
+              blocks_currency_promise: true,
+            },
+            {
+              kind: 'no_source_to_return_to',
+              subject_ids: ['c2'],
+              detail: 'Nobody can go back and see whether it still holds.',
+              blocks_currency_promise: false,
+            },
+          ],
+        }),
+      }),
+    )
+
+    render(<FactPicker runId="run-1" onChanged={() => {}} />)
+
+    const promise = await screen.findByText(/promises how things are now/)
+    const ordinary = screen.getByText(/Nobody can go back/)
+    expect(promise).toHaveClass('p2b-health-promise')
+    expect(ordinary).not.toHaveClass('p2b-health-promise')
+  })
+
+  it('says nothing at all about a clean dossier', async () => {
+    readSelection.mockResolvedValue(review({ evidence_health: health() }))
+
+    render(<FactPicker runId="run-1" onChanged={() => {}} />)
+
+    await screen.findByText(/findings, most useful first/)
+    expect(screen.queryByText('Before this is written')).not.toBeInTheDocument()
+  })
+
+  it('says nothing on a run recorded before any of this existed', async () => {
+    readSelection.mockResolvedValue(review())
+
+    render(<FactPicker runId="run-1" onChanged={() => {}} />)
+
+    await screen.findByText(/findings, most useful first/)
+    expect(screen.queryByText('Before this is written')).not.toBeInTheDocument()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -369,6 +369,28 @@ export interface SelectableClaim {
   confidence: string
 }
 
+export interface EvidenceHealthFinding {
+  kind:
+    | 'undated_time_sensitive'
+    | 'no_source_to_return_to'
+    | 'unsettled_conflict'
+    | 'currency_promise_unmet'
+  subject_ids: string[]
+  detail: string
+  /** The article promised something its evidence cannot support. */
+  blocks_currency_promise: boolean
+}
+
+export interface EvidenceHealth {
+  promises_currency: boolean
+  /** The most recent date on a price or a time, when the piece promised now. */
+  checked_against: string
+  unmet_promise: boolean
+  findings: EvidenceHealthFinding[]
+  /** Says what a date is and is not evidence of. Rendered, never dropped. */
+  means: string
+}
+
 export interface SelectionReview {
   /**
    * False on a run that never selected. That used to mean the article would be
@@ -390,5 +412,16 @@ export interface SelectionReview {
    * the hand-off would refuse with, shown while it can still be acted on.
    */
   stale_reason?: string
+  /**
+   * What is weak about the facts actually going to the writer — a price with
+   * no date on it, a fact nobody can go back and re-check, two chosen
+   * statements that disagree, or a promise of currency the evidence is too old
+   * to keep.
+   *
+   * Advisory, always. A date says how much the article is entitled to claim,
+   * never whether a fact is true, and the operator is the one who decides
+   * whether eighteen months matters for this piece.
+   */
+  evidence_health?: EvidenceHealth
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1431,3 +1431,45 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+
+/*
+ * What is weak about the facts about to reach the writer.
+ *
+ * Not styled as a failure. Every finding is worth reading and worth ignoring:
+ * an article about 2019 should rest on 2019 facts, and an operator who knows a
+ * price has not moved is right to leave it. Only a promise the evidence cannot
+ * keep gets the accent rule, because there the article is the thing making a
+ * claim it cannot support.
+ */
+.p2b-health {
+  margin: var(--space-4) 0 0;
+  padding: var(--space-3) var(--space-4);
+  background: var(--accent-softer);
+}
+
+.p2b-health-findings {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-4);
+}
+
+.p2b-health-finding {
+  margin: var(--space-2) 0 0;
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.p2b-health-promise {
+  padding-left: var(--space-3);
+  margin-left: calc(-1 * var(--space-3));
+  border-left: 2px solid var(--accent);
+  font-weight: 500;
+  list-style: none;
+}
+
+/* Never the last word. Nothing here has been re-checked. */
+.p2b-health-means {
+  margin: var(--space-3) 0 0;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+}


### PR DESCRIPTION
Improvement **08** from `docs/audits/prompt2blog-writer-improvements.html`. Branches from `main` — independent of the other open PRs.

## The problem

The gate already asks whether the dossier *answers the questions*. It never asked whether the answers are the kind an article can stand on. So a menu price checked eighteen months ago and one checked last week reach the writer looking identical — and the article states both in the present tense with equal confidence.

## Four findings, all deterministic and free

| Finding | What it catches |
|---|---|
| `undated_time_sensitive` | A price, a time, an availability with nothing saying when it was true. The writer has nothing to date the sentence with, so it reads as current. |
| `no_source_to_return_to` | A fact resting only on sources with no address. Nobody can go back and see whether it still holds. |
| `unsettled_conflict` | Two chosen statements that disagree with nothing saying which is right. The writer will pick one and not say that it did. |
| `currency_promise_unmet` | The article promised how things are *now* and the newest price on the desk is a year and a half old. |

## Why there is no expiry

The obvious version of this is "flag anything older than N months", and it is wrong. How long a fact stays true depends entirely on the fact — a founding date never goes stale, a tasting-menu price goes stale in a season, a timetable goes stale the day it changes. A universal threshold either buries the operator in false alarms or misses the price that matters.

**So the comparison is against what the article promised.** A piece whose seed says "right now" has told the reader it describes today and is answerable for that. A piece about what a neighbourhood was like in 2019 has promised the opposite and is not nagged for resting on 2019 facts — which is exactly how a diagnostic stops working without anybody switching it off.

The promise is read off the **seed, the reader's question and the outcome**, and deliberately *not* off `spine` or `fails_if`: those are the operator talking to the pipeline, and a spine containing the word "current" is not a promise anybody made to a reader.

## Where it runs

On the **selection review** — the last screen before prose exists, and the first that knows which facts were chosen.

A stale price the operator already cut is not this article's problem, and reporting it would bury the one that is. A conflict where one side has been deselected is settled, because deselecting *is* the decision.

## What it will not do

- **Nothing blocks.** The operator can read that the newest price is eighteen months old and decide it does not matter — a judgement no deterministic check is entitled to make for them.
- **Nothing is fetched.** No silent enrichment; new research remains a deliberate act that changes the dossier and the selection before a new packet is frozen.
- **Nothing calls a fact false.** Every payload and every screen carries the sentence saying a date is evidence about how much the article is *claiming*, never about whether the fact is *true*. A list of dated facts under a heading about evidence problems is read as a list of wrong facts by the second person who sees it.

Only `currency_promise_unmet` gets the accent rule in the UI — there the article itself is making a claim it cannot support.

## Verification

- 26 new backend tests, 5 new frontend tests. Two of them are the success criteria stated directly: a snapshot article may rest on old prices, and the twelve-month line is a property of the *promise* (same fact either side of it, only the entitlement changes).
- Backend **1651 passed**; frontend **149 files / 776 tests passed**; `tsc --noEmit` clean; flake8 clean.

No model calls were made. No pipeline was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)