### PR TITLE
feat(p2b): ask for one change to one section, and read it before it lands

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -48,7 +48,11 @@ them for the v2 fallback. Do not delete or renumber them.
 | `orchestrator_v3.py`, `graph/topology_v3.py` | The v3 run entrypoints and its shorter generation topology |
 | `resume_v3.py` | The state snapshot a failed v3 run is picked back up from |
 | `provenance.py` | Which chosen fact each passage of the finished article shares a figure or phrase with |
+<<<<<<< HEAD
 | `evaluation.py` | Frozen writing inputs, blind draft comparison, and per-criterion scoring |
+=======
+| `section_edit_v4.py` | One operator-asked improvement to one section, proposed against the frozen facts and applied only on acceptance |
+>>>>>>> 212da191 (feat(p2b): ask for one change to one section, and read it before it lands)
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -11,6 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from pydantic import BaseModel, Field
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.core import (
@@ -59,9 +60,19 @@ from ..provenance import (
     stored_confirmations,
 )
 from ..resume_v3 import plan_resume
+from ..section_edit_v4 import (
+    EDIT_ACTIONS,
+    SECTION_EDIT_STAGE,
+    EditHistory,
+    EditProposal,
+    apply_proposal,
+    propose_section_edit,
+    undo_last,
+)
 from ..run_recorder import RunRecorder
+from ..dependencies import dependencies_for_run
 from ..selection_v4 import selection_from_flags
-from ..support import _clean_string_list, _safe_str
+from ..support import _clean_string_list, _safe_dict, _safe_str
 
 router = APIRouter()
 
@@ -405,6 +416,145 @@ def confirm_provenance(
         run_id, PROVENANCE_STAGE, updated.model_dump(mode="json")
     )
     return JSONResponse(updated.model_dump(mode="json"))
+
+
+class SectionEditRequest(BaseModel):
+    """Which section, and which of the offered improvements."""
+
+    section_id: str = Field(min_length=1)
+    action_id: str = Field(min_length=1)
+
+
+def _finished_run(run_id: str) -> dict[str, Any]:
+    status = read_status(run_id)
+    if not status or status.get("feature") != FEATURE_NAME:
+        raise HTTPException(status_code=404, detail="Run not found.")
+    output = read_output(run_id)
+    if not output:
+        raise HTTPException(
+            status_code=404, detail="This run has not produced an article yet."
+        )
+    return output
+
+
+def _edit_history(run_id: str) -> EditHistory:
+    stored = _safe_dict(
+        _safe_dict(read_stage_result(run_id, SECTION_EDIT_STAGE)).get("data")
+    )
+    return EditHistory.model_validate(stored) if stored else EditHistory()
+
+
+def _save_article(run_id: str, output: dict[str, Any], markdown: str) -> None:
+    """Rewrite the article, leaving the pipeline's own record of it alone.
+
+    `write_artifact` takes the markdown out of the payload and stores it in its
+    own column, so the artifact -- what the pipeline produced and scored -- is
+    passed back unchanged. A hand edit changes the article; it does not change
+    the run's account of how the article was made.
+    """
+    RunRecorder().record_artifact(run_id, {**output["artifact"], "markdown": markdown})
+
+
+@router.get("/section-edit/actions", dependencies=[Depends(require_staff)])
+def section_edit_actions() -> JSONResponse:
+    """The improvements an editor may ask for.
+
+    A closed list rather than a free-text box. "Make this better" is a request
+    only a model with an opinion can satisfy, and the opinion it reaches for is
+    the house style of the internet; each of these names a specific defect.
+    """
+    return JSONResponse(
+        {
+            "actions": [
+                {"action_id": action.action_id, "label": action.label}
+                for action in EDIT_ACTIONS
+            ]
+        }
+    )
+
+
+@router.post("/section-edit/{run_id}", dependencies=[Depends(require_staff)])
+def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
+    """Ask for one change to one section. Nothing is written.
+
+    This is the one route here that spends money -- one model call per request
+    -- and it spends it on a section rather than an article.
+    """
+    output = _finished_run(run_id)
+    try:
+        packet = frozen_packet(run_id)
+    except PacketNotStored as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    artifact = _safe_dict(output["artifact"]).get("pipeline_v3") or {}
+    try:
+        proposal = propose_section_edit(
+            run_id=run_id,
+            content=output["markdown"],
+            section_id=request.section_id,
+            action_id=request.action_id,
+            brief=_safe_dict(_safe_dict(artifact).get("brief")),
+            packet=packet,
+            dependencies=dependencies_for_run(run_id),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return JSONResponse(proposal.model_dump(mode="json"))
+
+
+@router.post("/section-edit/{run_id}/apply", dependencies=[Depends(require_staff)])
+def apply_edit(
+    run_id: str,
+    proposal: EditProposal,
+    staff_id: str = Depends(staff_user_id),
+) -> JSONResponse:
+    """Write an accepted proposal into the draft.
+
+    A proposal read on one screen while another edit landed on the same section
+    is refused rather than applied over the top of it.
+    """
+    output = _finished_run(run_id)
+    result = apply_proposal(
+        content=output["markdown"],
+        proposal=proposal,
+        history=_edit_history(run_id),
+        editor=staff_id or "",
+        now=_now_iso(),
+    )
+    if not result.applied:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "That section has changed since this edit was proposed. "
+                "Read it again and ask for the change from where it is now."
+            ),
+        )
+    _save_article(run_id, output, result.markdown)
+    RunRecorder().record_stage(
+        run_id, SECTION_EDIT_STAGE, result.history.model_dump(mode="json")
+    )
+    return JSONResponse({"markdown": result.markdown, "edits": len(result.history.edits)})
+
+
+@router.post("/section-edit/{run_id}/undo", dependencies=[Depends(require_staff)])
+def undo_edit(run_id: str) -> JSONResponse:
+    """Put the draft back to what it was before the last applied edit."""
+    output = _finished_run(run_id)
+    undone = undo_last(_edit_history(run_id))
+    if undone is None:
+        # Not an error. Pressing undo on an unedited draft is a question with
+        # a plain answer.
+        return JSONResponse(
+            {"markdown": output["markdown"], "edits": 0, "undone": False}
+        )
+    markdown, history = undone
+    _save_article(run_id, output, markdown)
+    RunRecorder().record_stage(
+        run_id, SECTION_EDIT_STAGE, history.model_dump(mode="json")
+    )
+    return JSONResponse(
+        {"markdown": markdown, "edits": len(history.edits), "undone": True}
+    )
 
 
 @router.get("/drafts/{run_id}", response_class=HTMLResponse)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -1,0 +1,455 @@
+"""One section, one asked-for improvement, shown before it is applied.
+
+Improvement 07. An editor reading a finished draft can see that one paragraph
+hedges where it should choose, and the only tools available were to rewrite it
+by hand or to re-run the article. Repair is not that tool: it is driven by an
+audit, it fires once per run inside a token budget, and it decides for itself
+what to change.
+
+So: pick a section, pick one of a few things to ask for, read the proposal
+beside the original, and apply it or throw it away. Everything about the
+mechanism is borrowed from the repair work in #547 -- addressed sections, text
+hashes, replacements applied in code -- because that machinery already refuses
+the two failures that matter, an edit written against an older draft and an
+edit that touches prose nobody asked about.
+
+Three things this is not
+------------------------
+It is not a gate. Nothing runs it, nothing waits for it, and a run that never
+uses it is unaffected.
+
+It is not allowed to bring new facts. The edit is shown the frozen packet --
+the same facts the writer had -- and nothing else. A request the evidence
+cannot support comes back as a refusal with a reason, because the failure mode
+of an editor asking for a stronger recommendation is a model inventing the
+thing that would make it stronger.
+
+And it is not trusted. The proposal is checked for figures that appear neither
+in the original nor anywhere in the packet before a person is shown it, and the
+person still has to press apply.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .content.sections import ArticleSection, segment_article
+from .dependencies import PipelineDependencies
+from .provenance import _figures
+from .support import _safe_dict, _safe_str
+
+# Bumped when a stored edit history stops meaning what this code reads.
+SECTION_EDIT_SCHEMA_VERSION = 1
+
+# Where an article's edit history lives. Its own row: these are an operator's
+# later work on a finished run, and writing them into the pipeline artifact
+# would rewrite the record of what the pipeline itself produced.
+SECTION_EDIT_STAGE = "stage_v4_section_edits"
+
+
+# The things an editor actually asks for, as opposed to a free-text box.
+#
+# A free-text box was the obvious design and it is the wrong one. "Make this
+# better" is a request only a model with an opinion can satisfy, and the
+# opinion it reaches for is the house style of the internet. Each of these
+# names a specific defect and says what fixing it may not cost.
+@dataclass(frozen=True)
+class EditAction:
+    action_id: str
+    label: str
+    instruction: str
+
+
+EDIT_ACTIONS: tuple[EditAction, ...] = (
+    EditAction(
+        action_id="clarify_recommendation",
+        label="Make the recommendation clearer",
+        instruction=(
+            "This section lays out options without saying what separates them. "
+            "Say which suits whom and on what basis, using only the facts "
+            "supplied. If the facts do not support choosing between them, say "
+            "so in `could_not_do` and leave the section alone -- do not invent "
+            "the difference that would make a recommendation possible."
+        ),
+    ),
+    EditAction(
+        action_id="shorten",
+        label="Say it in fewer words",
+        instruction=(
+            "Cut the words this section does not need. Every figure, date, "
+            "qualification and named place in the original must still be there "
+            "afterwards: shortening is removing padding, never removing the "
+            "limits that change what a reader should do."
+        ),
+    ),
+    EditAction(
+        action_id="reduce_repetition",
+        label="Stop it repeating itself",
+        instruction=(
+            "This section explains the same thing more than once, or lists "
+            "items whose descriptions run to the same shape. Say each thing "
+            "once and vary what the sentences do. Losing a fact is not "
+            "de-duplication."
+        ),
+    ),
+    EditAction(
+        action_id="strengthen_comparison",
+        label="Make the comparison do more work",
+        instruction=(
+            "This section names things without comparing them. Say what each "
+            "is better and worse for, from the supplied facts only. Where the "
+            "facts support no comparison on some axis, leave that axis out "
+            "rather than asserting one."
+        ),
+    ),
+    EditAction(
+        action_id="explain_the_detail",
+        label="Explain a detail instead of listing more",
+        instruction=(
+            "This section stacks facts without saying what any of them mean. "
+            "Keep the two or three that carry the point and explain their "
+            "significance; the rest may go. Anything under the article's "
+            "must_name obligations stays."
+        ),
+    ),
+)
+
+EDIT_ACTIONS_BY_ID = {action.action_id: action for action in EDIT_ACTIONS}
+
+
+SECTION_EDIT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["revised"],
+    "properties": {
+        "revised": {"type": "string"},
+        "heading": {"type": "string"},
+        "what_changed": {"type": "string"},
+        # The refusal has to be as easy to return as the rewrite, or a model
+        # asked for something impossible writes something instead.
+        "could_not_do": {"type": "string"},
+    },
+}
+
+
+P2B_SECTION_EDIT_PROMPT = """\
+You are editing one section of a finished article, at an editor's request.
+
+Return strict JSON only:
+{{
+  "revised": "string",
+  "what_changed": "string",
+  "could_not_do": "string"
+}}
+
+What you were asked to do:
+{instruction}
+
+Hard rules:
+- Change this section and nothing else. You are not shown the rest of the
+  article and you are not editing it.
+- Every figure, date, price, duration and named place in `revised` must appear
+  either in the ORIGINAL SECTION below or in the FACTS AVAILABLE. You may not
+  introduce one from anywhere else, and you may not make a figure more precise,
+  more recent, or more general than the fact it comes from.
+- Keep the limits that change what a reader should do -- an as-of date, a
+  season, a route only some operators run. Drop only hedging that changes
+  nothing.
+- Never cite the facts. No claim IDs, no source names, no "(Source 1)". The
+  reader cannot see them.
+- If what you were asked for cannot be done with the facts available, put the
+  reason in `could_not_do` and return the original text unchanged in `revised`.
+  That is a correct answer. Writing something that only looks like what was
+  asked for is not.
+- `what_changed` is one sentence, for a person deciding whether to keep this.
+
+THE ARTICLE THIS SECTION BELONGS TO:
+{brief}
+
+FACTS AVAILABLE (the only facts you may use):
+{facts}
+
+ORIGINAL SECTION:
+{original}
+"""
+
+
+def _facts_block(packet: dict[str, Any]) -> str:
+    """The frozen packet, as the writer received it.
+
+    Whole rather than narrowed to the section. Narrowing would need a guess at
+    which facts this section rests on, and a guess that guessed wrong would
+    withhold the fact the editor is asking to have explained.
+    """
+    lines: list[str] = []
+    for fact in packet.get("facts") or []:
+        record = _safe_dict(fact)
+        text = _safe_str(record.get("text"))
+        if not text:
+            continue
+        as_of = _safe_str(record.get("as_of"))
+        note = _safe_str(record.get("operator_note"))
+        suffix = "".join(
+            part
+            for part in (
+                f" (as of {as_of})" if as_of else "",
+                f" [you noted: {note}]" if note else "",
+            )
+        )
+        lines.append(f"- {text}{suffix}")
+    for note in packet.get("notes") or []:
+        text = _safe_str(_safe_dict(note).get("text"))
+        if text:
+            lines.append(f"- LIMIT: {text}")
+    for material in packet.get("supplied_material") or []:
+        statement = _safe_str(_safe_dict(material).get("statement"))
+        if statement:
+            lines.append(f"- YOUR OWN NOTE, verbatim: {statement}")
+    return "\n".join(lines) or "No facts were recorded for this article."
+
+
+def _brief_block(brief: dict[str, Any]) -> str:
+    record = _safe_dict(brief)
+    parts = [
+        f"Headline: {_safe_str(record.get('seed'))}",
+        f"Reader: {_safe_str(_safe_dict(record.get('reader')).get('primary_reader'))}",
+        f"Their question: {_safe_str(record.get('reader_question'))}",
+        f"What they should be able to do: {_safe_str(record.get('outcome'))}",
+        f"It fails if: {_safe_str(record.get('fails_if'))}",
+    ]
+    must_name = [name for name in (record.get("must_name") or []) if _safe_str(name)]
+    if must_name:
+        parts.append(f"Must name: {', '.join(must_name)}")
+    return "\n".join(parts)
+
+
+class EditProposal(BaseModel):
+    """A change offered, not made."""
+
+    schema_version: int = SECTION_EDIT_SCHEMA_VERSION
+    run_id: str
+    section_id: str
+    heading: str = ""
+    action_id: str
+    # What the section said when this was proposed. `apply` refuses if it has
+    # moved since, so a proposal read on one screen cannot land on another.
+    text_hash: str
+    original: str
+    revised: str
+    what_changed: str = ""
+    could_not_do: str = ""
+    # Figures in the proposal that are in neither the original nor the packet.
+    # Deterministic, cheap, and the exact shape of the failure this invites: an
+    # editor asks for a stronger recommendation and gets a number that would
+    # make one.
+    introduced_figures: list[str] = Field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return self.revised.strip() != self.original.strip()
+
+
+def _packet_figures(packet: dict[str, Any]) -> set[str]:
+    text = " ".join(
+        _safe_str(_safe_dict(fact).get("text")) for fact in packet.get("facts") or []
+    )
+    material = " ".join(
+        _safe_str(_safe_dict(item).get("statement"))
+        for item in packet.get("supplied_material") or []
+    )
+    return _figures(f"{text} {material}")
+
+
+def find_section(content: str, section_id: str) -> ArticleSection | None:
+    for section in segment_article(content):
+        if section.section_id == section_id:
+            return section
+    return None
+
+
+def propose_section_edit(
+    *,
+    run_id: str,
+    content: str,
+    section_id: str,
+    action_id: str,
+    brief: dict[str, Any],
+    packet: dict[str, Any],
+    dependencies: PipelineDependencies,
+    model_name: str | None = None,
+) -> EditProposal:
+    """Ask for one change to one section. Nothing is written.
+
+    Raises rather than guessing when the section or the action is not one this
+    draft has: an editor who clicked something that no longer exists should be
+    told, not handed an edit to a different paragraph.
+    """
+    action = EDIT_ACTIONS_BY_ID.get(action_id)
+    if action is None:
+        raise ValueError(f"Unknown edit action '{action_id}'")
+    section = find_section(content, section_id)
+    if section is None:
+        raise ValueError(f"This draft has no section '{section_id}'")
+
+    original = section.render()
+    prompt = P2B_SECTION_EDIT_PROMPT.format(
+        instruction=action.instruction,
+        brief=_brief_block(brief),
+        facts=_facts_block(packet),
+        original=original,
+    )
+    parsed, _raw = dependencies.llm.invoke_json(
+        job_id="p2b.section_edit",
+        prompt=prompt,
+        max_tokens=2048,
+        temperature=0.2,
+        model_name=model_name,
+        schema=SECTION_EDIT_SCHEMA,
+    )
+    record = _safe_dict(parsed)
+    revised = _safe_str(record.get("revised")).strip()
+    could_not_do = _safe_str(record.get("could_not_do")).strip()
+    if not revised:
+        # An empty body is far more likely to be a truncated response than a
+        # considered cut, and this pass may not delete a section in any case.
+        revised = original
+        could_not_do = could_not_do or "The edit came back empty, so nothing changed."
+
+    introduced = sorted(
+        _figures(revised) - _figures(original) - _packet_figures(packet)
+    )
+    return EditProposal(
+        run_id=run_id,
+        section_id=section_id,
+        heading=section.heading,
+        action_id=action_id,
+        text_hash=section.text_hash,
+        original=original,
+        revised=revised,
+        what_changed=_safe_str(record.get("what_changed")),
+        could_not_do=could_not_do,
+        introduced_figures=introduced,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Applying, and taking it back
+# ---------------------------------------------------------------------------
+
+
+class AppliedEdit(BaseModel):
+    """One applied edit, and the whole draft as it was before it."""
+
+    section_id: str
+    action_id: str
+    applied_at: str = ""
+    editor: str = ""
+    what_changed: str = ""
+    # The entire previous markdown, not a patch. Undo has to be exact, and a
+    # patch that no longer applies is an undo that silently does not.
+    previous_markdown: str = ""
+
+
+class EditHistory(BaseModel):
+    schema_version: int = SECTION_EDIT_SCHEMA_VERSION
+    edits: list[AppliedEdit] = Field(default_factory=list)
+    # The draft as the pipeline produced it, before any hand edit. Kept
+    # separately from the undo stack: the report asks for the original draft to
+    # be retained, and an undo stack unwound one step at a time is not that.
+    original_markdown: str = ""
+
+
+@dataclass
+class ApplyResult:
+    markdown: str
+    history: EditHistory
+    rejected: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def applied(self) -> bool:
+        return not self.rejected
+
+
+def apply_proposal(
+    *,
+    content: str,
+    proposal: EditProposal,
+    history: EditHistory,
+    editor: str,
+    now: str,
+) -> ApplyResult:
+    """Write one accepted proposal into the draft, keeping what it replaced.
+
+    The hash check is the whole safety property: a proposal read on one screen
+    while another edit landed on the same section is refused rather than
+    applied over the top of it. `apply_section_replacements` already enforces
+    that, along with the rules that an edit may not empty a section and may not
+    give the opening block a heading.
+    """
+    from .content.sections import apply_section_replacements
+
+    result = apply_section_replacements(
+        content,
+        [
+            {
+                "section_id": proposal.section_id,
+                "text_hash": proposal.text_hash,
+                "heading": proposal.heading,
+                "content": _body_of(proposal.revised, proposal.heading),
+            }
+        ],
+    )
+    if not result.changed:
+        return ApplyResult(markdown=content, history=history, rejected=result.rejected)
+
+    updated = EditHistory(
+        # Recorded on the first hand edit and never again, so "the draft the
+        # pipeline produced" survives any number of later edits.
+        original_markdown=history.original_markdown or content,
+        edits=[
+            *history.edits,
+            AppliedEdit(
+                section_id=proposal.section_id,
+                action_id=proposal.action_id,
+                applied_at=now,
+                editor=editor,
+                what_changed=proposal.what_changed,
+                previous_markdown=content,
+            ),
+        ],
+    )
+    return ApplyResult(markdown=result.content, history=updated)
+
+
+def _body_of(rendered: str, heading: str) -> str:
+    """The prose under a heading, given a section rendered whole.
+
+    The model is shown the section as it appears in the article, heading and
+    all, because a heading is part of what it is being asked to judge. The
+    replacement machinery wants them apart.
+    """
+    text = rendered.strip()
+    if not heading:
+        return text
+    first, _, rest = text.partition("\n")
+    if first.strip().lstrip("#").strip() == heading.strip():
+        return rest.strip()
+    return text
+
+
+def undo_last(history: EditHistory) -> tuple[str, EditHistory] | None:
+    """Put the draft back to what it was before the last applied edit.
+
+    Returns None when there is nothing to undo, which the caller reports rather
+    than treating as a failure: pressing undo on an unedited draft is not an
+    error, it is a question with a plain answer.
+    """
+    if not history.edits:
+        return None
+    last = history.edits[-1]
+    return last.previous_markdown, EditHistory(
+        original_markdown=history.original_markdown,
+        edits=history.edits[:-1],
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edit.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edit.py
@@ -1,0 +1,331 @@
+"""Improvement 07: one section, one asked-for improvement, shown before applied.
+
+An editor reading a finished draft can see that one paragraph hedges where it
+should choose, and the only tools were to rewrite it by hand or re-run the
+article. Repair is not that tool: it is driven by an audit, it fires once per
+run inside a token budget, and it decides for itself what to change.
+
+The risk this invites is specific. An editor asks for a stronger recommendation
+and gets a number that would make one. So the tests here are mostly about the
+proposal being refused, checked, or shown rather than applied.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from app.features.prompt2blog.dependencies import PipelineDependencies
+from app.features.prompt2blog.section_edit_v4 import (
+    EDIT_ACTIONS,
+    EditHistory,
+    EditProposal,
+    apply_proposal,
+    propose_section_edit,
+    undo_last,
+)
+
+ARTICLE = """Lima is worth two extra nights.
+
+## Where to eat
+
+Market ceviche runs about $8. The tasting menus run to $95. Both are good.
+
+## Getting there
+
+The transfer takes 40 minutes."""
+
+BRIEF: dict[str, Any] = {
+    "seed": "Where to eat in Lima",
+    "reader": {"primary_reader": "layover traveller"},
+    "reader_question": "What does a good meal cost?",
+    "outcome": "pick a place tonight",
+    "fails_if": "reads like a tourist board",
+    "must_name": ["Surquillo market"],
+}
+
+PACKET: dict[str, Any] = {
+    "facts": [
+        {
+            "claim_id": "c1",
+            "text": "Stall ceviche in Surquillo market is priced around $8.",
+            "as_of": "2026-08-01",
+            "confidence": "high",
+        },
+        {
+            "claim_id": "c2",
+            "text": "Tasting menus in Miraflores run to $95.",
+            "confidence": "medium",
+        },
+    ],
+    "notes": [
+        {
+            "note_id": "n1",
+            "kind": "source_note",
+            "text": "Prices surveyed in August 2026; stalls vary.",
+            "claim_ids": ["c1"],
+        }
+    ],
+    "supplied_material": [
+        {"kind": "firsthand", "statement": "I waited 45 minutes on my visit"}
+    ],
+}
+
+
+@dataclass
+class FakeLLM:
+    json_response: dict[str, Any] = field(default_factory=dict)
+    prompts: list[str] = field(default_factory=list)
+
+    def invoke_json(self, *, prompt: str, **_kwargs) -> tuple[dict[str, Any], str]:
+        self.prompts.append(prompt)
+        return dict(self.json_response), "{}"
+
+
+def _ask(response: dict[str, Any], **overrides) -> tuple[EditProposal, str]:
+    """The proposal, and the prompt it was asked with."""
+    llm = FakeLLM(json_response=response)
+    kwargs = dict(
+        run_id="r1",
+        content=ARTICLE,
+        section_id="s1",
+        action_id="clarify_recommendation",
+        brief=BRIEF,
+        packet=PACKET,
+        dependencies=PipelineDependencies(llm=llm),
+    )
+    kwargs.update(overrides)
+    proposal = propose_section_edit(**kwargs)
+    return proposal, llm.prompts[0]
+
+
+def _propose(response: dict[str, Any], **overrides) -> EditProposal:
+    return _ask(response, **overrides)[0]
+
+
+# ---------------------------------------------------------------------------
+# What the editor may ask for
+# ---------------------------------------------------------------------------
+
+
+def test_the_actions_are_a_closed_list():
+    """A free-text box was the obvious design and it is the wrong one.
+
+    "Make this better" is a request only a model with an opinion can satisfy,
+    and the opinion it reaches for is the house style of the internet.
+    """
+    ids = {action.action_id for action in EDIT_ACTIONS}
+    assert ids == {
+        "clarify_recommendation",
+        "shorten",
+        "reduce_repetition",
+        "strengthen_comparison",
+        "explain_the_detail",
+    }
+
+
+def test_an_action_nobody_defined_is_refused():
+    with pytest.raises(ValueError, match="Unknown edit action"):
+        _propose({"revised": "x"}, action_id="make_it_pop")
+
+
+def test_a_section_this_draft_does_not_have_is_refused():
+    """An editor who clicked something that no longer exists is told so,
+
+    rather than handed an edit to a different paragraph.
+    """
+    with pytest.raises(ValueError, match="no section"):
+        _propose({"revised": "x"}, section_id="s9")
+
+
+# ---------------------------------------------------------------------------
+# The proposal is shown, not applied
+# ---------------------------------------------------------------------------
+
+
+def test_a_proposal_carries_the_original_beside_the_revision():
+    proposal = _propose(
+        {
+            "revised": "## Where to eat\n\nGo to the market stalls at $8.",
+            "what_changed": "Named the choice instead of listing both.",
+        }
+    )
+    assert "Both are good." in proposal.original
+    assert "Go to the market stalls" in proposal.revised
+    assert proposal.changed is True
+
+
+def test_the_proposal_records_the_text_it_was_written_against():
+    proposal = _propose({"revised": "## Where to eat\n\nGo to the stalls."})
+    from app.features.prompt2blog.section_edit_v4 import find_section
+
+    assert proposal.text_hash == find_section(ARTICLE, "s1").text_hash
+
+
+def test_nothing_is_written_by_proposing():
+    """The route that proposes spends a model call and touches no storage."""
+    proposal = _propose({"revised": "## Where to eat\n\nGo to the stalls."})
+    assert proposal.original in ARTICLE or proposal.original.strip() in ARTICLE
+    # The proposal is a value. Applying it is a separate, later decision.
+    assert isinstance(proposal, EditProposal)
+
+
+# ---------------------------------------------------------------------------
+# A request the evidence cannot support
+# ---------------------------------------------------------------------------
+
+
+def test_a_refusal_is_carried_rather_than_swallowed():
+    proposal = _propose(
+        {
+            "revised": "## Where to eat\n\nMarket ceviche runs about $8. "
+            "The tasting menus run to $95. Both are good.",
+            "could_not_do": "Nothing on the desk says which suits whom.",
+        }
+    )
+    assert proposal.could_not_do == "Nothing on the desk says which suits whom."
+    assert proposal.changed is False
+
+
+def test_an_empty_revision_keeps_the_section_and_says_why():
+    """Far more likely a truncated response than a considered cut.
+
+    This pass may not delete a section in any case.
+    """
+    proposal = _propose({"revised": "   "})
+    assert proposal.revised == proposal.original
+    assert "came back empty" in proposal.could_not_do
+
+
+def test_a_figure_from_nowhere_is_named_before_a_person_sees_it():
+    """The exact failure this feature invites.
+
+    An editor asks for a stronger recommendation, and a model supplies the
+    number that would make one.
+    """
+    proposal = _propose(
+        {
+            "revised": "## Where to eat\n\nGo to the stalls: $8 against $95, "
+            "and the queue is only 12 minutes.",
+        }
+    )
+    assert proposal.introduced_figures == ["12 minutes"]
+
+
+def test_figures_the_original_or_the_packet_already_carried_are_not_flagged():
+    proposal = _propose(
+        {
+            "revised": "## Where to eat\n\nGo to the stalls at $8 rather than "
+            "the $95 menus; I waited 45 minutes and it was worth it.",
+        }
+    )
+    assert proposal.introduced_figures == []
+
+
+# ---------------------------------------------------------------------------
+# What the model is shown
+# ---------------------------------------------------------------------------
+
+
+def test_the_edit_sees_the_frozen_facts_and_their_limits():
+    _proposal, prompt = _ask({"revised": "x"})
+    assert "Stall ceviche in Surquillo market is priced around $8." in prompt
+    assert "LIMIT: Prices surveyed in August 2026" in prompt
+    assert "YOUR OWN NOTE, verbatim: I waited 45 minutes" in prompt
+
+
+def test_the_edit_sees_only_its_own_section():
+    _proposal, prompt = _ask({"revised": "x"})
+    assert "Where to eat" in prompt
+    # It is not editing the rest of the article and is not shown it.
+    assert "The transfer takes 40 minutes." not in prompt
+
+
+def test_the_edit_is_told_a_refusal_is_a_correct_answer():
+    _proposal, prompt = _ask({"revised": "x"})
+    assert "That is a correct answer." in prompt
+
+
+# ---------------------------------------------------------------------------
+# Applying, and taking it back
+# ---------------------------------------------------------------------------
+
+
+def _applied(revised: str = "## Where to eat\n\nGo to the market stalls."):
+    proposal = _propose({"revised": revised, "what_changed": "Named the choice."})
+    return apply_proposal(
+        content=ARTICLE,
+        proposal=proposal,
+        history=EditHistory(),
+        editor="alan",
+        now="2026-09-07T00:00:00+00:00",
+    )
+
+
+def test_only_the_edited_section_changes():
+    """The success criterion, stated as a test."""
+    result = _applied()
+    assert result.applied is True
+    assert "Go to the market stalls." in result.markdown
+    assert "Lima is worth two extra nights." in result.markdown
+    assert "The transfer takes 40 minutes." in result.markdown
+    assert "Both are good." not in result.markdown
+
+
+def test_an_edit_written_against_an_older_draft_is_refused():
+    """A proposal read on one screen while another edit landed on the same
+
+    section must not be applied over the top of it.
+    """
+    proposal = _propose({"revised": "## Where to eat\n\nGo to the stalls."})
+    moved = ARTICLE.replace("Both are good.", "Both are fine.")
+
+    result = apply_proposal(
+        content=moved,
+        proposal=proposal,
+        history=EditHistory(),
+        editor="alan",
+        now="2026-09-07T00:00:00+00:00",
+    )
+
+    assert result.applied is False
+    assert result.markdown == moved
+    assert "stale text_hash" in result.rejected[0]["reason"]
+
+
+def test_undo_restores_the_previous_text_exactly():
+    result = _applied()
+    undone = undo_last(result.history)
+
+    assert undone is not None
+    markdown, history = undone
+    assert markdown == ARTICLE
+    assert history.edits == []
+
+
+def test_the_draft_the_pipeline_produced_survives_every_later_edit():
+    """Kept separately from the undo stack.
+
+    The report asks for the original draft to be retained, and an undo stack
+    unwound one step at a time is not that.
+    """
+    first = _applied()
+    second = apply_proposal(
+        content=first.markdown,
+        proposal=_propose(
+            {"revised": "## Where to eat\n\nThe stalls, at $8."},
+            content=first.markdown,
+        ),
+        history=first.history,
+        editor="alan",
+        now="2026-09-07T00:01:00+00:00",
+    )
+
+    assert len(second.history.edits) == 2
+    assert second.history.original_markdown == ARTICLE
+
+
+def test_undoing_an_unedited_draft_is_a_question_with_a_plain_answer():
+    assert undo_last(EditHistory()) is None

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ArticleScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ArticleScreen.tsx
@@ -5,6 +5,7 @@ import { buildStageArticleUrl } from '../../../blogArticles'
 import type { IntakeArticle, IntakeWriting } from '../intake.types'
 import { PolishPrompt } from './PolishPrompt'
 import { ProvenancePanel } from './ProvenancePanel'
+import { SectionEditor } from './SectionEditor'
 import { PunchList } from './PunchList'
 
 /**
@@ -70,10 +71,42 @@ function Measured({ checks }: { checks: Record<string, unknown> }) {
   )
 }
 
+
+/**
+ * The article's blocks, each carrying the id of the section it belongs to.
+ *
+ * The backend addresses sections positionally — the block before the first
+ * `##` is `s0` — so the only way this screen and an edit request can agree
+ * about which section is which is for both to count `##` headings in document
+ * order. Doing it here, once, keeps that counting out of the render.
+ */
+function addressedBlocks(markdown: string) {
+  let sectionIndex = 0
+  return markdown.split(/\n{2,}/).map((block, index) => {
+    const heading = block.startsWith('#')
+    if (heading) sectionIndex += 1
+    return {
+      key: index,
+      heading,
+      text: heading ? block.replace(/^#+\s*/, '') : block,
+      sectionId: `s${sectionIndex}`,
+    }
+  })
+}
+
 export function ArticleScreen({ runId, writing, article, onReopen, busy }: ArticleScreenProps) {
   // Which paragraph the operator asked about. Null until they ask: the map is
   // a finding aid and nothing about the article changes because it exists.
   const [asking, setAsking] = useState<string | null>(null)
+  // The article after hand edits. Null while it is still exactly what the
+  // pipeline produced, so nothing about this screen changes on a run nobody
+  // edited.
+  const [edited, setEdited] = useState<string | null>(null)
+  // Which section is open for editing, by the same positional id the backend
+  // addresses sections with: the block before the first `##` is s0.
+  const [editing, setEditing] = useState<{ id: string; heading: string } | null>(
+    null,
+  )
 
   if (writing.state === 'failed') {
     return (
@@ -118,25 +151,41 @@ export function ArticleScreen({ runId, writing, article, onReopen, busy }: Artic
 
       {article ? (
         <article className="p2b-article-body">
-          {article.markdown.split(/\n{2,}/).map((block, index) =>
-            block.startsWith('#') ? (
-              <h3 key={index}>{block.replace(/^#+\s*/, '')}</h3>
+          {addressedBlocks(edited ?? article.markdown).map(block =>
+            block.heading ? (
+              <h3 key={block.key}>
+                {block.text}
+                <button
+                  type="button"
+                  className="p2b-passage-source"
+                  aria-label={`Edit ${block.text}`}
+                  onClick={() =>
+                    setEditing({ id: block.sectionId, heading: block.text })
+                  }
+                >
+                  edit
+                </button>
+              </h3>
             ) : (
               // A button rather than a click handler on the paragraph: this is
               // an action, and an editor reading with a keyboard has the same
               // right to ask where a price came from as one with a mouse.
               <p
-                key={index}
+                key={block.key}
                 className={
-                  asking === block ? 'p2b-passage p2b-passage-asking' : 'p2b-passage'
+                  asking === block.text
+                    ? 'p2b-passage p2b-passage-asking'
+                    : 'p2b-passage'
                 }
               >
-                {block}
+                {block.text}
                 <button
                   type="button"
                   className="p2b-passage-source"
                   aria-label="Where did this passage come from?"
-                  onClick={() => setAsking(current => (current === block ? null : block))}
+                  onClick={() =>
+                    setAsking(current => (current === block.text ? null : block.text))
+                  }
                 >
                   source
                 </button>
@@ -150,6 +199,20 @@ export function ArticleScreen({ runId, writing, article, onReopen, busy }: Artic
 
       {asking && (
         <ProvenancePanel runId={runId} selected={asking} onClose={() => setAsking(null)} />
+      )}
+
+      {editing && (
+        <SectionEditor
+          runId={runId}
+          sectionId={editing.id}
+          heading={editing.heading}
+          onApplied={markdown => {
+            setEdited(markdown)
+            // The map described the prose that was there a moment ago.
+            setAsking(null)
+          }}
+          onClose={() => setEditing(null)}
+        />
       )}
 
       <PunchList runId={runId} />

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react'
+import {
+  applySectionEdit,
+  proposeSectionEdit,
+  readEditActions,
+  undoSectionEdit,
+} from '../intake.api'
+import type { SectionEditAction, SectionEditProposal } from '../intake.types'
+
+/**
+ * Ask for one improvement to one section, and read it before it lands.
+ *
+ * An editor can see that a paragraph hedges where it should choose, and until
+ * now the options were to rewrite it by hand or re-run the whole article.
+ * Repair is not that tool: it is driven by an audit, it fires once per run
+ * inside a token budget, and it decides for itself what to change.
+ *
+ * Three properties this screen exists to hold.
+ *
+ * Nothing lands unread. The proposal is shown beside the original and applying
+ * it is a second, separate press. A model call that produced something worse
+ * costs the price of the call and nothing else.
+ *
+ * A refusal reads as an answer, not an error. Asking for a clearer
+ * recommendation from evidence that supports no recommendation is a reasonable
+ * thing to have asked and an unreasonable thing to be given, so
+ * `could_not_do` is rendered as prominently as a revision would have been.
+ *
+ * And a figure that came from nowhere is called out above everything else. It
+ * is the specific way this feature fails: an editor asks for a stronger
+ * recommendation and a model supplies the number that would make one.
+ */
+
+interface SectionEditorProps {
+  runId: string
+  sectionId: string
+  heading: string
+  onApplied: (markdown: string) => void
+  onClose: () => void
+}
+
+export function SectionEditor({
+  runId,
+  sectionId,
+  heading,
+  onApplied,
+  onClose,
+}: SectionEditorProps) {
+  const [actions, setActions] = useState<SectionEditAction[]>([])
+  const [proposal, setProposal] = useState<SectionEditProposal | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let live = true
+    readEditActions()
+      .then(payload => live && setActions(payload.actions))
+      .catch((failure: Error) => live && setError(failure.message))
+    return () => {
+      live = false
+    }
+  }, [])
+
+  const ask = (actionId: string) => {
+    setBusy(true)
+    setError('')
+    proposeSectionEdit(runId, { section_id: sectionId, action_id: actionId })
+      .then(setProposal)
+      .catch((failure: Error) => setError(failure.message))
+      .finally(() => setBusy(false))
+  }
+
+  const keep = () => {
+    if (!proposal) return
+    setBusy(true)
+    applySectionEdit(runId, proposal)
+      .then(result => {
+        setProposal(null)
+        onApplied(result.markdown)
+      })
+      .catch((failure: Error) => setError(failure.message))
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <aside className="p2b-editor" aria-label={`Edit ${heading || 'the opening'}`}>
+      <p className="p2b-eyebrow">{heading || 'The opening'}</p>
+
+      {error && (
+        <p className="p2b-blocked" role="status">
+          {error}
+        </p>
+      )}
+
+      {!proposal && (
+        <div className="p2b-editor-actions">
+          {actions.map(action => (
+            <button
+              key={action.action_id}
+              type="button"
+              className="p2b-secondary"
+              disabled={busy}
+              onClick={() => ask(action.action_id)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {busy && !proposal && <p className="p2b-note">Drafting the change…</p>}
+
+      {proposal && (
+        <div className="p2b-editor-proposal">
+          {/* Above everything, including the prose. A number the evidence never
+              carried is the one thing here that must not be skimmed past. */}
+          {proposal.introduced_figures.length > 0 && (
+            <p className="p2b-editor-invented" role="status">
+              This draft introduces {proposal.introduced_figures.join(', ')}, which
+              is in neither the original nor the research. Do not keep it without
+              checking where it came from.
+            </p>
+          )}
+
+          {proposal.could_not_do && (
+            /* A refusal is an answer. Rendered where a revision would have been,
+               because an editor who asked for something the evidence cannot
+               support needs to read that rather than hunt for it. */
+            <p className="p2b-editor-refused">{proposal.could_not_do}</p>
+          )}
+
+          {proposal.what_changed && (
+            <p className="p2b-editor-summary">{proposal.what_changed}</p>
+          )}
+
+          <div className="p2b-editor-diff">
+            <section aria-label="The section now">
+              <p className="p2b-label">Now</p>
+              <pre>{proposal.original}</pre>
+            </section>
+            <section aria-label="The proposed replacement">
+              <p className="p2b-label">Proposed</p>
+              <pre>{proposal.revised}</pre>
+            </section>
+          </div>
+
+          <div className="p2b-intake-actions">
+            <button
+              type="button"
+              className="p2b-primary"
+              disabled={busy || proposal.revised.trim() === proposal.original.trim()}
+              onClick={keep}
+            >
+              Use this
+            </button>
+            <button
+              type="button"
+              className="p2b-secondary"
+              disabled={busy}
+              onClick={() => setProposal(null)}
+            >
+              Keep what I had
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="p2b-intake-actions">
+        <button
+          type="button"
+          className="p2b-secondary"
+          disabled={busy}
+          onClick={() => {
+            setBusy(true)
+            undoSectionEdit(runId)
+              .then(result => result.undone && onApplied(result.markdown))
+              .catch((failure: Error) => setError(failure.message))
+              .finally(() => setBusy(false))
+          }}
+        >
+          Undo the last change
+        </button>
+        <button type="button" className="p2b-secondary" onClick={onClose}>
+          Done
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -7,6 +7,8 @@ import type {
   IntakeState,
   ProvenanceReport,
   PunchList,
+  SectionEditAction,
+  SectionEditProposal,
   SelectionReview,
   VenueToCheck,
 } from './intake.types'
@@ -254,6 +256,64 @@ export async function confirmProvenance(
   })
   if (!response.ok) {
     throw await readError(response, 'Could not record that check.')
+  }
+}
+
+/** The improvements an editor may ask for. */
+export async function readEditActions(): Promise<{ actions: SectionEditAction[] }> {
+  const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/actions`)
+  if (!response.ok) {
+    throw await readError(response, 'Could not read the available edits.')
+  }
+  return (await response.json()) as { actions: SectionEditAction[] }
+}
+
+/** Ask for one change to one section. Spends a model call; writes nothing. */
+export async function proposeSectionEdit(
+  runId: string,
+  body: { section_id: string; action_id: string },
+): Promise<SectionEditProposal> {
+  const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw await readError(response, 'Could not draft that change.')
+  }
+  return (await response.json()) as SectionEditProposal
+}
+
+/** Write an accepted proposal into the draft. */
+export async function applySectionEdit(
+  runId: string,
+  proposal: SectionEditProposal,
+): Promise<{ markdown: string; edits: number }> {
+  const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}/apply`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(proposal),
+  })
+  if (!response.ok) {
+    throw await readError(response, 'Could not apply that change.')
+  }
+  return (await response.json()) as { markdown: string; edits: number }
+}
+
+/** Put the draft back to what it was before the last applied edit. */
+export async function undoSectionEdit(
+  runId: string,
+): Promise<{ markdown: string; edits: number; undone: boolean }> {
+  const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}/undo`, {
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw await readError(response, 'Could not undo the last change.')
+  }
+  return (await response.json()) as {
+    markdown: string
+    edits: number
+    undone: boolean
   }
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -328,6 +328,34 @@ export interface ProvenanceReport {
   summary: Record<string, unknown> & { means: string }
 }
 
+/** One improvement an editor may ask for. A closed list, not a text box. */
+export interface SectionEditAction {
+  action_id: string
+  label: string
+}
+
+/**
+ * A change offered, not made.
+ *
+ * `could_not_do` is as much of an answer as `revised`. A request the evidence
+ * cannot support must come back as a refusal with a reason, because the
+ * failure mode of asking for a stronger recommendation is a model inventing
+ * the thing that would make it stronger.
+ */
+export interface SectionEditProposal {
+  run_id: string
+  section_id: string
+  heading: string
+  action_id: string
+  text_hash: string
+  original: string
+  revised: string
+  what_changed: string
+  could_not_do: string
+  /** Figures in the revision that are in neither the original nor the packet. */
+  introduced_figures: string[]
+}
+
 /** The finished article. Its own call: the state is polled, this is not. */
 export interface IntakeArticle {
   run_id: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SectionEditProposal } from './intake.types'
+
+const readEditActions = vi.fn()
+const proposeSectionEdit = vi.fn()
+const applySectionEdit = vi.fn()
+const undoSectionEdit = vi.fn()
+vi.mock('./intake.api', () => ({
+  readEditActions: (...a: unknown[]) => readEditActions(...a),
+  proposeSectionEdit: (...a: unknown[]) => proposeSectionEdit(...a),
+  applySectionEdit: (...a: unknown[]) => applySectionEdit(...a),
+  undoSectionEdit: (...a: unknown[]) => undoSectionEdit(...a),
+}))
+
+const { SectionEditor } = await import('./components/SectionEditor')
+
+/**
+ * Asking for one change to one section.
+ *
+ * Three properties this screen exists to hold: nothing lands unread, a refusal
+ * reads as an answer rather than an error, and a figure that came from nowhere
+ * is called out above everything else.
+ */
+
+const ACTIONS = [
+  { action_id: 'clarify_recommendation', label: 'Make the recommendation clearer' },
+  { action_id: 'shorten', label: 'Say it in fewer words' },
+]
+
+function proposal(overrides: Partial<SectionEditProposal> = {}): SectionEditProposal {
+  return {
+    run_id: 'run-1',
+    section_id: 's1',
+    heading: 'Where to eat',
+    action_id: 'clarify_recommendation',
+    text_hash: 'abc123',
+    original: '## Where to eat\n\nBoth are good.',
+    revised: '## Where to eat\n\nGo to the stalls at $8.',
+    what_changed: 'Named the choice instead of listing both.',
+    could_not_do: '',
+    introduced_figures: [],
+    ...overrides,
+  }
+}
+
+function open() {
+  return render(
+    <SectionEditor
+      runId="run-1"
+      sectionId="s1"
+      heading="Where to eat"
+      onApplied={() => {}}
+      onClose={() => {}}
+    />,
+  )
+}
+
+beforeEach(() => {
+  readEditActions.mockReset()
+  proposeSectionEdit.mockReset()
+  applySectionEdit.mockReset()
+  undoSectionEdit.mockReset()
+  readEditActions.mockResolvedValue({ actions: ACTIONS })
+})
+
+describe('nothing lands unread', () => {
+  it('shows the proposal beside the original before anything is applied', async () => {
+    proposeSectionEdit.mockResolvedValue(proposal())
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+
+    await screen.findByLabelText('The proposed replacement')
+    expect(screen.getByLabelText('The section now')).toHaveTextContent(
+      'Both are good.',
+    )
+    // Proposing writes nothing. Applying is a second, separate press.
+    expect(applySectionEdit).not.toHaveBeenCalled()
+  })
+
+  it('applies only when the editor says to', async () => {
+    proposeSectionEdit.mockResolvedValue(proposal())
+    applySectionEdit.mockResolvedValue({ markdown: '# edited', edits: 1 })
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+    await userEvent.click(await screen.findByRole('button', { name: 'Use this' }))
+
+    await waitFor(() => expect(applySectionEdit).toHaveBeenCalledTimes(1))
+  })
+
+  it('lets the editor keep what they had without losing the draft', async () => {
+    proposeSectionEdit.mockResolvedValue(proposal())
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Keep what I had' }),
+    )
+
+    // Back to the list of things to ask for, nothing written.
+    expect(
+      await screen.findByRole('button', { name: 'Say it in fewer words' }),
+    ).toBeInTheDocument()
+    expect(applySectionEdit).not.toHaveBeenCalled()
+  })
+
+  it('will not offer to apply a revision that changed nothing', async () => {
+    proposeSectionEdit.mockResolvedValue(
+      proposal({ revised: '## Where to eat\n\nBoth are good.' }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+
+    expect(await screen.findByRole('button', { name: 'Use this' })).toBeDisabled()
+  })
+})
+
+describe('what it refuses to hide', () => {
+  it('reads a refusal as an answer', async () => {
+    // Asking for a clearer recommendation from evidence that supports none is a
+    // reasonable thing to have asked and an unreasonable thing to be given.
+    proposeSectionEdit.mockResolvedValue(
+      proposal({
+        revised: '## Where to eat\n\nBoth are good.',
+        could_not_do: 'Nothing on the desk says which suits whom.',
+      }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+
+    expect(
+      await screen.findByText('Nothing on the desk says which suits whom.'),
+    ).toBeInTheDocument()
+  })
+
+  it('calls out a figure that came from nowhere', async () => {
+    proposeSectionEdit.mockResolvedValue(
+      proposal({ introduced_figures: ['12 minutes'] }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+
+    expect(
+      await screen.findByText(/introduces 12 minutes, which is in neither/),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces a stale-section refusal instead of silently doing nothing', async () => {
+    proposeSectionEdit.mockResolvedValue(proposal())
+    applySectionEdit.mockRejectedValue(
+      new Error('That section has changed since this edit was proposed.'),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+    await userEvent.click(await screen.findByRole('button', { name: 'Use this' }))
+
+    expect(
+      await screen.findByText(/has changed since this edit was proposed/),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('taking it back', () => {
+  it('restores the draft when there is something to undo', async () => {
+    const applied = vi.fn()
+    undoSectionEdit.mockResolvedValue({
+      markdown: '# original',
+      edits: 0,
+      undone: true,
+    })
+    render(
+      <SectionEditor
+        runId="run-1"
+        sectionId="s1"
+        heading="Where to eat"
+        onApplied={applied}
+        onClose={() => {}}
+      />,
+    )
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Undo the last change' }),
+    )
+
+    await waitFor(() => expect(applied).toHaveBeenCalledWith('# original'))
+  })
+
+  it('changes nothing when there is nothing to undo', async () => {
+    const applied = vi.fn()
+    undoSectionEdit.mockResolvedValue({
+      markdown: '# original',
+      edits: 0,
+      undone: false,
+    })
+    render(
+      <SectionEditor
+        runId="run-1"
+        sectionId="s1"
+        heading="Where to eat"
+        onApplied={applied}
+        onClose={() => {}}
+      />,
+    )
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Undo the last change' }),
+    )
+
+    await waitFor(() => expect(undoSectionEdit).toHaveBeenCalled())
+    expect(applied).not.toHaveBeenCalled()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1577,3 +1577,72 @@
   font-size: 0.8125rem;
   line-height: 1.55;
 }
+
+/*
+ * Asking for one change to one section.
+ *
+ * The proposal is shown, never applied. Two panes side by side rather than an
+ * inline diff: an editor is judging whether the new prose reads better, and a
+ * word-level diff answers a different question — what moved — while making the
+ * prose harder to read as prose.
+ */
+.p2b-editor {
+  margin: var(--space-4) 0 0;
+  padding: var(--space-4) var(--space-5);
+  background: var(--panel-soft, var(--accent-softer));
+  border-left: 2px solid var(--accent);
+}
+
+.p2b-editor-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.p2b-editor-diff {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+.p2b-editor-diff pre {
+  margin: var(--space-1) 0 0;
+  padding: var(--space-3);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font: inherit;
+  line-height: 1.6;
+}
+
+.p2b-editor-summary {
+  margin: var(--space-3) 0 0;
+  color: var(--ink-light);
+}
+
+/*
+ * A refusal is an answer. Rendered where a revision would have been, because
+ * an editor who asked for something the evidence cannot support needs to read
+ * that rather than hunt for it.
+ */
+.p2b-editor-refused {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-3) var(--space-4);
+  background: var(--panel);
+  border-left: 2px solid var(--border);
+  font-style: italic;
+}
+
+/*
+ * Above everything, including the prose. A number the evidence never carried is
+ * the specific way this feature fails, and it must not be skimmed past.
+ */
+.p2b-editor-invented {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--accent);
+  font-weight: 500;
+}


### PR DESCRIPTION
Improvement **07** from `docs/audits/prompt2blog-writer-improvements.html`.

> **Stacked on [#551](https://github.com/Questurian/questurian/pull/551)** — base is `p2b/claim-provenance`, not `main`. This needs the frozen packet #551 records, and reuses its figure reader. Merge #551 first.

## The problem

An editor reading a finished draft can see that one paragraph hedges where it should choose. The only tools were to rewrite it by hand or re-run the article.

Repair is not that tool: it is driven by an audit, it fires once per run inside a token budget, and it decides for itself what to change.

## What this is

Pick a section → pick one of five things to ask for → read the proposal beside the original → apply it or throw it away.

The mechanism is entirely borrowed from the repair work in #547 — addressed sections, text hashes, replacements applied in code. That machinery already refuses the two failures that matter: an edit written against an older draft, and an edit that touches prose nobody asked about.

## A closed list, not a text box

"Make this better" is a request only a model with an opinion can satisfy, and the opinion it reaches for is the house style of the internet. Each action names a specific defect *and what fixing it may not cost*:

| Action | May not cost |
|---|---|
| Make the recommendation clearer | inventing the difference that would make one possible |
| Say it in fewer words | any figure, date, qualification or named place |
| Stop it repeating itself | a fact — losing one is not de-duplication |
| Make the comparison do more work | asserting an axis the evidence does not carry |
| Explain a detail instead of listing more | anything under `must_name` |

## Three refusals hold this up

**The edit sees the frozen packet and nothing else** — the same facts the writer had. A request the evidence cannot support comes back in `could_not_do` with the section unchanged. That path is as easy to take as the rewrite, and the prompt says outright that it is a correct answer. The failure mode of asking for a stronger recommendation is a model inventing the thing that would make it stronger.

**Every proposal is checked for figures from nowhere** — appearing in neither the original nor anywhere in the packet — deterministically, before a person is shown it. The UI puts that above everything including the prose. It reuses `provenance._figures`, so the two places in this codebase that decide what counts as a figure cannot drift apart.

**Nothing lands unread.** Proposing writes nothing. Applying is a separate press. The hash check refuses a proposal read on one screen while another edit landed on the same section.

## Undo, and the original

Undo restores the previous markdown **exactly**, not by patch — a patch that no longer applies is an undo that silently does not.

The draft the pipeline produced is kept **separately** from the undo stack. The report asks for the original draft to be retained, and an undo stack unwound one step at a time is not that.

Applying a hand edit rewrites the article's markdown and leaves the pipeline artifact alone. A hand edit changes the article; it does not change the run's account of how the article was made.

## Cost

One model call per request, on a section rather than an article. Nothing runs it, nothing waits for it, and a run that never uses it is unaffected — it is an optional editor tool, not a gate.

## Verification

- 18 new backend tests, 9 new frontend tests.
- Backend **1674 passed**; frontend **150 files / 789 tests passed**; `tsc --noEmit` clean; flake8 clean.

No model calls were made. No pipeline was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)