### PR TITLE
feat(p2b): a targeted edit knows what the rest of the article already said

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -50,6 +50,7 @@ them for the v2 fallback. Do not delete or renumber them.
 | `provenance.py` | Which chosen fact each passage of the finished article shares a figure or phrase with |
 | `evaluation.py` | Frozen writing inputs, blind draft comparison, and per-criterion scoring |
 | `section_edit_v4.py` | One operator-asked improvement to one section, proposed against the frozen facts and applied only on acceptance |
+| `article_memory.py` | What the rest of the draft already said, quoted from it, so a targeted edit does not repeat or contradict it |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -496,6 +496,12 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
             brief=_safe_dict(_safe_dict(artifact).get("brief")),
             packet=packet,
             dependencies=dependencies_for_run(run_id),
+            # The plan, for the section purposes the memory reads off it. A run
+            # whose outline was rejected has none, and the memory then rests on
+            # the excerpts alone rather than refusing.
+            outline=_safe_dict(
+                _safe_dict(read_stage_result(run_id, "stage_v3_outline")).get("data")
+            ).get("outline"),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/article_memory.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/article_memory.py
@@ -1,0 +1,280 @@
+"""What the rest of the article already said, for an edit that sees one section.
+
+Improvement 03. A section edit is shown its own section, the brief and the
+frozen facts, and nothing else. That is what keeps it from rewriting prose
+nobody asked about -- and it is also why it will happily explain the price
+range a second time, having no way to know the opening already did, or
+recommend the vegetarian option the conclusion already settled on.
+
+Built from what is already written down
+---------------------------------------
+The report says to start with the outline plus exact excerpts before adding
+summarisation, and that is what this is: no model call, nothing paraphrased.
+Every line of it is either a field the outline already recorded or a sentence
+copied verbatim out of the draft.
+
+A generated summary would be a fifth thing that can be wrong, arriving in the
+same prompt as the evidence and looking exactly like it. An excerpt can be
+badly *chosen*; it cannot say something the article does not say.
+
+What it is not
+--------------
+It is navigation, and the prompt that carries it says so. Facts and caveats
+come from the frozen packet, and the deterministic check on a proposal --
+figures appearing in neither the original section nor the packet -- deliberately
+does not consult this. So a figure that reaches an edit only through the memory
+is flagged as introduced, exactly as one invented outright would be. A mistaken
+memory cannot quietly become evidence; it can only waste a call.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .content.sections import ArticleSection, segment_article
+from .support import _safe_dict, _safe_str
+
+# How much of the opening travels. Enough to see what the piece committed to,
+# short enough that the memory does not become a second copy of the article
+# sitting in every edit prompt.
+THESIS_CHARACTERS = 400
+
+# The first line of a section, as written. One sentence is what an editor needs
+# to recognise a section they are not looking at.
+SECTION_EXCERPT_CHARACTERS = 200
+
+# How many sentences of recommendation travel. A piece that recommends
+# something in every paragraph is a piece whose recommendations are not the
+# thing an edit needs to avoid contradicting.
+MAX_DECISIONS = 8
+
+
+# Wording that marks a sentence as telling the reader what to do. Deliberately
+# narrow: a false positive costs a line in a prompt, and a false negative costs
+# the thing this exists to prevent -- an edit contradicting a recommendation the
+# article already made.
+_DECISION = re.compile(
+    r"""
+    \b(?:
+        go\s+to|book|choose|pick|skip|avoid|worth|not\s+worth|
+        stick\s+to|head\s+for|start\s+at|start\s+with|opt\s+for|
+        best\s+(?:bet|option|choice)|if\s+you|unless\s+you|
+        the\s+one\s+to|the\s+answer\s+is|do\s+not\s+bother
+    )\b
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# A run of capitalised words: a place, a venue, an institution. The article's
+# own vocabulary, found without asking anybody what it is about.
+_PROPER_RUN = re.compile(r"\b([A-Z][\w’'-]*(?:\s+(?:de|del|la|el|of|the)\s+|\s+)?){1,4}")
+
+# Capitalised words that start sentences and mean nothing on their own.
+_SENTENCE_STARTERS = frozenset(
+    """the a an this that these those it its there here they their you your we our
+    but and or if when where while after before once every each both either
+    for from with without into onto about across around at by in on to up
+    what which who how why so then still also only just even now today""".split()
+)
+
+
+def _sentences(text: str) -> list[str]:
+    parts = re.split(r"(?<=[.!?])\s+", " ".join(text.split()))
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _excerpt(text: str, limit: int) -> str:
+    """Whole sentences up to a limit, never a sentence cut in half.
+
+    A truncated sentence in a prompt reads as a fact stated incompletely, which
+    is a worse thing to hand a writer than one sentence fewer.
+    """
+    kept: list[str] = []
+    used = 0
+    for sentence in _sentences(text):
+        if kept and used + len(sentence) + 1 > limit:
+            break
+        kept.append(sentence)
+        used += len(sentence) + 1
+    return " ".join(kept)
+
+
+def _named_things(sections: list[ArticleSection]) -> list[str]:
+    """The names this article uses in more than one place.
+
+    Two sections naming the same restaurant is what makes it the article's
+    vocabulary rather than a passing mention, and it is the case an edit needs:
+    introducing a place the piece already introduced is one of the two
+    repetitions this exists to prevent.
+    """
+    per_section: list[set[str]] = []
+    for section in sections:
+        found: set[str] = set()
+        for sentence in _sentences(f"{section.heading}. {section.body}"):
+            # The first word of a sentence is capitalised for grammar, not for
+            # being a name, so it is only kept when it appears capitalised
+            # somewhere it did not have to be.
+            for match in _PROPER_RUN.finditer(sentence):
+                phrase = " ".join(match.group(0).split()).strip(" ,.;:'’-")
+                if not phrase or phrase.casefold() in _SENTENCE_STARTERS:
+                    continue
+                if len(phrase) < 4:
+                    continue
+                found.add(phrase)
+        per_section.append(found)
+
+    counted: dict[str, int] = {}
+    for found in per_section:
+        for phrase in found:
+            counted[phrase] = counted.get(phrase, 0) + 1
+    return sorted(phrase for phrase, count in counted.items() if count > 1)
+
+
+def _decisions(sections: list[ArticleSection]) -> list[dict[str, str]]:
+    """Sentences that tell the reader what to do, quoted where they sit.
+
+    Quoted rather than summarised. "The conclusion recommends the vegetarian
+    option" is a claim about the article; the sentence itself is the article,
+    and an edit can be asked not to contradict it without anybody having
+    restated it first.
+    """
+    found: list[dict[str, str]] = []
+    for section in sections:
+        for sentence in _sentences(section.body):
+            if len(found) >= MAX_DECISIONS:
+                return found
+            if _DECISION.search(sentence):
+                found.append(
+                    {
+                        "section_id": section.section_id,
+                        "heading": section.heading,
+                        "sentence": sentence,
+                    }
+                )
+    return found
+
+
+@dataclass
+class ArticleMemory:
+    """What the rest of the piece already did, in its own words."""
+
+    thesis: str = ""
+    planned_answer: str = ""
+    planned_close: str = ""
+    sections: list[dict[str, str]] = field(default_factory=list)
+    named_things: list[str] = field(default_factory=list)
+    decisions: list[dict[str, str]] = field(default_factory=list)
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            "thesis": self.thesis,
+            "planned_answer": self.planned_answer,
+            "planned_close": self.planned_close,
+            "sections": [dict(item) for item in self.sections],
+            "named_things": list(self.named_things),
+            "decisions": [dict(item) for item in self.decisions],
+        }
+
+    def for_prompt(self, *, excluding: str = "") -> str:
+        """The memory as an edit reads it, with the edited section left out.
+
+        Left out because an edit is already shown that section in full, and
+        including it twice invites a model to treat the excerpt as the thing
+        to preserve rather than the prose in front of it.
+        """
+        lines: list[str] = []
+        if self.thesis:
+            lines.append(f"The article opens: {self.thesis}")
+        if self.planned_answer:
+            lines.append(f"The opening was planned to answer: {self.planned_answer}")
+        if self.planned_close:
+            lines.append(f"The close was planned to land on: {self.planned_close}")
+
+        others = [
+            section for section in self.sections if section["section_id"] != excluding
+        ]
+        if others:
+            lines.append("")
+            lines.append("The other sections, and what each is for:")
+            for section in others:
+                label = section["heading"] or "(the opening)"
+                lines.append(f"- {label} — {section['payoff']}")
+                if section["opening_line"]:
+                    lines.append(f"    begins: {section['opening_line']}")
+
+        if self.named_things:
+            lines.append("")
+            lines.append(
+                "Named more than once already, so they have been introduced: "
+                + ", ".join(self.named_things)
+            )
+
+        decisions = [
+            decision for decision in self.decisions if decision["section_id"] != excluding
+        ]
+        if decisions:
+            lines.append("")
+            lines.append("What the article already tells the reader to do:")
+            lines.extend(
+                f"- {decision['heading'] or 'the opening'}: "
+                f"“{decision['sentence']}”"
+                for decision in decisions
+            )
+        return "\n".join(lines)
+
+
+def build_article_memory(
+    content: str, outline: dict[str, Any] | None = None
+) -> ArticleMemory:
+    """Read the draft and its plan into something an edit can navigate by.
+
+    Deterministic and free. The outline is optional: a run whose plan was
+    rejected still has an article, and the excerpts alone are most of the
+    value.
+    """
+    sections = segment_article(content)
+    plan = _safe_dict(outline)
+    planned = {
+        _safe_str(section.get("heading")).casefold(): section
+        for section in (plan.get("sections") or [])
+        if isinstance(section, dict)
+    }
+
+    described: list[dict[str, str]] = []
+    for section in sections:
+        # `segment_article` always produces an opening block so that a draft
+        # beginning straight on a heading has somewhere to put one. An empty
+        # one is scaffolding, not a section of the article, and listing it
+        # tells an edit about a part of the piece that does not exist.
+        if not section.heading and not section.body.strip():
+            continue
+        record = _safe_dict(planned.get(section.heading.casefold()))
+        # `reader_payoff` is what the plan calls it once improvement 01 lands;
+        # `purpose` is what it was called before. Read either, so this works on
+        # a run planned under whichever was current -- the alternative is a
+        # memory that silently loses every section purpose on older runs.
+        payoff = _safe_str(record.get("reader_payoff")) or _safe_str(
+            record.get("purpose")
+        )
+        described.append(
+            {
+                "section_id": section.section_id,
+                "heading": section.heading,
+                "payoff": payoff or "(the plan did not say)",
+                "opening_line": _excerpt(section.body, SECTION_EXCERPT_CHARACTERS),
+            }
+        )
+
+    opening = next(
+        (section for section in sections if not section.heading), None
+    )
+    return ArticleMemory(
+        thesis=_excerpt(opening.body, THESIS_CHARACTERS) if opening else "",
+        planned_answer=_safe_str(plan.get("direct_answer_focus")),
+        planned_close=_safe_str(plan.get("takeaway_focus")),
+        sections=described,
+        named_things=_named_things(sections),
+        decisions=_decisions(sections),
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from .article_memory import build_article_memory
 from .content.sections import ArticleSection, segment_article
 from .dependencies import PipelineDependencies
 from .provenance import _figures
@@ -165,6 +166,15 @@ Hard rules:
   asked for is not.
 - `what_changed` is one sentence, for a person deciding whether to keep this.
 
+WHAT THE REST OF THE ARTICLE ALREADY DOES (navigation, not evidence):
+This is here so you do not explain a second time what another section has
+already explained, and do not recommend something the article has already
+decided against. It is quoted from the draft, not summarised. It is NOT a
+source of facts: every figure and date you write must still come from the
+ORIGINAL SECTION or the FACTS AVAILABLE, and a number that appears only here
+is a number you may not use.
+{memory}
+
 THE ARTICLE THIS SECTION BELONGS TO:
 {brief}
 
@@ -279,6 +289,7 @@ def propose_section_edit(
     packet: dict[str, Any],
     dependencies: PipelineDependencies,
     model_name: str | None = None,
+    outline: dict[str, Any] | None = None,
 ) -> EditProposal:
     """Ask for one change to one section. Nothing is written.
 
@@ -294,8 +305,15 @@ def propose_section_edit(
         raise ValueError(f"This draft has no section '{section_id}'")
 
     original = section.render()
+    # Rebuilt from the draft as it is now, so an edit accepted a minute ago is
+    # already part of what the next one is told (improvement 03). Free and
+    # deterministic, which is why refreshing it costs nothing to do every time
+    # rather than being cached and going stale.
+    memory = build_article_memory(content, outline)
     prompt = P2B_SECTION_EDIT_PROMPT.format(
         instruction=action.instruction,
+        memory=memory.for_prompt(excluding=section_id)
+        or "This article has no other sections.",
         brief=_brief_block(brief),
         facts=_facts_block(packet),
         original=original,

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_article_memory.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_article_memory.py
@@ -1,0 +1,285 @@
+"""Improvement 03: what the rest of the article already said.
+
+A section edit is shown its own section, the brief and the frozen facts, and
+nothing else. That is what keeps it from rewriting prose nobody asked about --
+and it is also why it will happily explain the price range a second time,
+having no way to know the opening already did.
+
+The report says to start with the outline plus exact excerpts before adding
+summarisation, and that is what this is. A generated summary would be a fifth
+thing that can be wrong, arriving in the same prompt as the evidence and
+looking exactly like it. So the test that matters most here is the last one: a
+mistaken memory cannot become evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.features.prompt2blog.article_memory import (
+    MAX_DECISIONS,
+    build_article_memory,
+)
+from app.features.prompt2blog.dependencies import PipelineDependencies
+from app.features.prompt2blog.section_edit_v4 import propose_section_edit
+
+ARTICLE = """Two extra nights in Lima are worth it, and the reason is the food.
+The range runs from $8 at a market stall to $95 for a tasting menu.
+
+## Where to eat
+
+Go to Surquillo market for ceviche. Central is the tasting menu everyone names,
+and it is worth booking if that is what you came for.
+
+## What it costs
+
+Surquillo market sits at the cheap end. Budget $8 a head and you will eat well.
+
+## If you do not eat meat
+
+Stick to Surquillo market; the stalls do more with vegetables than Central
+does."""
+
+OUTLINE: dict[str, Any] = {
+    "direct_answer_focus": "Whether two extra nights are worth it.",
+    "takeaway_focus": "What decides it for a layover traveller.",
+    "sections": [
+        {
+            "heading": "Where to eat",
+            "reader_payoff": "Which place to book tonight.",
+        },
+        {"heading": "What it costs", "purpose": "Establish the price range."},
+    ],
+}
+
+
+def _memory(content: str = ARTICLE, outline: dict[str, Any] | None = OUTLINE):
+    return build_article_memory(content, outline)
+
+
+# ---------------------------------------------------------------------------
+# Built from what is already written down
+# ---------------------------------------------------------------------------
+
+
+def test_the_thesis_is_the_opening_quoted_not_described():
+    """An excerpt can be badly chosen; it cannot say something the article does not."""
+    memory = _memory()
+    assert memory.thesis.startswith("Two extra nights in Lima are worth it")
+    assert "$8" in memory.thesis
+
+
+def test_the_plan_supplies_what_the_opening_and_close_were_for():
+    memory = _memory()
+    assert memory.planned_answer == "Whether two extra nights are worth it."
+    assert memory.planned_close == "What decides it for a layover traveller."
+
+
+def test_a_section_purpose_is_read_under_either_name():
+    """`reader_payoff` after improvement 01; `purpose` before it.
+
+    Reading only the new one would silently lose every section purpose on runs
+    planned under the old.
+    """
+    payoffs = {section["heading"]: section["payoff"] for section in _memory().sections}
+    assert payoffs["Where to eat"] == "Which place to book tonight."
+    assert payoffs["What it costs"] == "Establish the price range."
+
+
+def test_a_section_the_plan_never_described_says_so():
+    payoffs = {section["heading"]: section["payoff"] for section in _memory().sections}
+    assert payoffs["If you do not eat meat"] == "(the plan did not say)"
+
+
+def test_a_run_whose_plan_was_rejected_still_has_a_memory():
+    memory = build_article_memory(ARTICLE, None)
+    assert memory.thesis
+    assert len(memory.sections) == 4
+    assert memory.planned_answer == ""
+
+
+def test_an_excerpt_is_never_a_sentence_cut_in_half():
+    """A truncated sentence in a prompt reads as a fact stated incompletely."""
+    memory = _memory()
+    for section in memory.sections:
+        if section["opening_line"]:
+            assert section["opening_line"].rstrip().endswith((".", "!", "?"))
+
+
+# ---------------------------------------------------------------------------
+# The two repetitions it exists to prevent
+# ---------------------------------------------------------------------------
+
+
+def test_a_name_the_article_uses_twice_is_recorded_as_introduced():
+    """Introducing a place the piece already introduced is the first one."""
+    assert "Surquillo" in " ".join(_memory().named_things)
+
+
+def test_a_name_used_once_is_not_the_articles_vocabulary():
+    """Two sections naming the same place is what makes it vocabulary.
+
+    A passing mention is not something a later edit has to avoid
+    re-introducing, and listing every capitalised word would drown the ones
+    that matter.
+    """
+    once = ARTICLE.replace("than Central\ndoes", "than the tasting menus\ndo")
+    memory = build_article_memory(once, None)
+
+    assert any(thing.startswith("Surquillo") for thing in memory.named_things)
+    assert not any(thing.startswith("Central") for thing in memory.named_things)
+
+
+def test_what_the_article_already_tells_the_reader_to_do_is_quoted():
+    """The second repetition: contradicting a recommendation already made."""
+    sentences = [decision["sentence"] for decision in _memory().decisions]
+    assert any("Go to Surquillo market" in sentence for sentence in sentences)
+    assert any("Stick to Surquillo market" in sentence for sentence in sentences)
+
+
+def test_a_recommendation_is_quoted_where_it_sits():
+    """Quoted rather than summarised.
+
+    "The conclusion recommends the vegetarian option" is a claim about the
+    article. The sentence itself is the article.
+    """
+    vegetarian = next(
+        decision
+        for decision in _memory().decisions
+        if "Stick to Surquillo" in decision["sentence"]
+    )
+    assert vegetarian["heading"] == "If you do not eat meat"
+
+
+def test_a_piece_that_recommends_in_every_line_does_not_send_all_of_them():
+    crowded = "## Everything\n\n" + " ".join(
+        f"Go to place {index}." for index in range(30)
+    )
+    assert len(build_article_memory(crowded, None).decisions) == MAX_DECISIONS
+
+
+# ---------------------------------------------------------------------------
+# What the edit is actually handed
+# ---------------------------------------------------------------------------
+
+
+def test_the_edited_section_is_left_out_of_its_own_memory():
+    """It is already shown that section in full.
+
+    Including it twice invites a model to treat the excerpt as the thing to
+    preserve rather than the prose in front of it.
+    """
+    rendered = _memory().for_prompt(excluding="s1")
+    assert "Where to eat" not in rendered
+    assert "What it costs" in rendered
+
+
+def test_the_other_sections_arrive_with_what_each_is_for():
+    rendered = _memory().for_prompt(excluding="s1")
+    assert "What it costs — Establish the price range." in rendered
+
+
+def test_an_empty_opening_block_is_not_reported_as_a_section():
+    """`segment_article` always makes one so a draft can begin on a heading.
+
+    An empty one is scaffolding, and listing it tells an edit about a part of
+    the piece that does not exist.
+    """
+    memory = build_article_memory("## Only\n\nOne section here.", None)
+
+    assert [section["heading"] for section in memory.sections] == ["Only"]
+    assert memory.for_prompt(excluding="s1").strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# A mistaken memory cannot become evidence
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeLLM:
+    json_response: dict[str, Any] = field(default_factory=dict)
+    prompts: list[str] = field(default_factory=list)
+
+    def invoke_json(self, *, prompt: str, **_kwargs) -> tuple[dict[str, Any], str]:
+        self.prompts.append(prompt)
+        return dict(self.json_response), "{}"
+
+
+PACKET: dict[str, Any] = {
+    "facts": [
+        {
+            "claim_id": "c1",
+            "text": "Stall ceviche in Surquillo market is priced around $8.",
+            "confidence": "high",
+        }
+    ],
+    "notes": [],
+    "supplied_material": [],
+}
+
+
+def _propose(revised: str, content: str = ARTICLE):
+    llm = FakeLLM(json_response={"revised": revised})
+    proposal = propose_section_edit(
+        run_id="r1",
+        content=content,
+        section_id="s1",
+        action_id="clarify_recommendation",
+        brief={"seed": "Where to eat in Lima"},
+        packet=PACKET,
+        dependencies=PipelineDependencies(llm=llm),
+        outline=OUTLINE,
+    )
+    return proposal, llm.prompts[0]
+
+
+def test_the_memory_reaches_the_edit_labelled_as_navigation():
+    _proposal, prompt = _propose("x")
+    assert "navigation, not evidence" in prompt
+    assert "a number that appears only here is a number you may not use" in prompt.replace(
+        "\n", " "
+    )
+
+
+def test_the_memory_tells_the_edit_what_the_article_already_decided():
+    _proposal, prompt = _propose("x")
+    assert "Stick to Surquillo market" in prompt
+    assert "already tells the reader to do" in prompt
+
+
+def test_a_figure_that_reached_the_edit_only_through_the_memory_is_still_flagged():
+    """The guard the report asks for, stated as a test.
+
+    $95 is in the article's opening and in no chosen fact. It travels in the
+    memory, so a model could pick it up from there -- and the deterministic
+    check deliberately does not consult the memory, so writing it into a
+    section that did not have it is flagged exactly as inventing it would be.
+    """
+    proposal, prompt = _propose(
+        "## Where to eat\n\nGo to Surquillo market; the tasting menus are $95."
+    )
+    assert "$95" in prompt  # it did travel, in the memory
+    assert proposal.introduced_figures == ["$95"]
+
+
+def test_a_figure_the_packet_carries_is_not_flagged():
+    proposal, _prompt = _propose(
+        "## Where to eat\n\nGo to Surquillo market; stalls are about $8."
+    )
+    assert proposal.introduced_figures == []
+
+
+def test_the_memory_is_rebuilt_from_the_draft_as_it_is_now():
+    """So an edit accepted a minute ago is part of what the next one is told.
+
+    Free and deterministic, which is why it is rebuilt every time rather than
+    cached and left to go stale.
+    """
+    edited = ARTICLE.replace(
+        "Stick to Surquillo market", "Book Central and ask for the vegetable menu"
+    )
+    _proposal, prompt = _propose("x", content=edited)
+    assert "Book Central and ask for the vegetable menu" in prompt
+    assert "Stick to Surquillo market" not in prompt

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edit.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edit.py
@@ -236,11 +236,19 @@ def test_the_edit_sees_the_frozen_facts_and_their_limits():
     assert "YOUR OWN NOTE, verbatim: I waited 45 minutes" in prompt
 
 
-def test_the_edit_sees_only_its_own_section():
+def test_the_edit_is_given_only_its_own_section_to_edit():
+    """The rest of the article reaches it as navigation, never as prose to edit.
+
+    Improvement 03 added the memory; what it must not do is make the other
+    sections look editable. They arrive under a heading that says they are not
+    evidence and not the thing being changed, and only the section under
+    ORIGINAL SECTION is offered for replacement.
+    """
     _proposal, prompt = _ask({"revised": "x"})
-    assert "Where to eat" in prompt
-    # It is not editing the rest of the article and is not shown it.
-    assert "The transfer takes 40 minutes." not in prompt
+    original = prompt.split("ORIGINAL SECTION:")[1]
+
+    assert "Where to eat" in original
+    assert "The transfer takes 40 minutes." not in original
 
 
 def test_the_edit_is_told_a_refusal_is_a_correct_answer():


### PR DESCRIPTION
Improvement **03** from `docs/audits/prompt2blog-writer-improvements.html`.

> **Stacked on [#553](https://github.com/Questurian/questurian/pull/553)** (which is stacked on [#551](https://github.com/Questurian/questurian/pull/551)). Base is `p2b/editor-section-edit`. Merge order: #551 → #553 → this.

## The problem

A section edit is shown its own section, the brief and the frozen facts, and nothing else. That is what keeps it from rewriting prose nobody asked about.

It is also why it will happily explain the price range a second time, having no way to know the opening already did — or recommend against something the conclusion already settled on.

## Built from what is already written down

The report says to *"start with outline plus exact excerpts before adding summarization"*, so **there is no model call and nothing is paraphrased**. Every line is either a field the outline already recorded or a sentence copied verbatim out of the draft.

A generated summary would be a fifth thing that can be wrong, arriving in the same prompt as the evidence and looking exactly like it. An excerpt can be badly *chosen*; it cannot say something the article does not say.

What it carries:

- **The opening, quoted** — what the piece committed to.
- **What the plan said each section is for** — read as `reader_payoff` or, failing that, `purpose`. Reading only the newer name would silently lose every section purpose on runs planned before improvement 01.
- **Names used in more than one place** — two sections naming the same restaurant is what makes it the article's vocabulary rather than a passing mention.
- **Sentences that already tell the reader what to do**, quoted where they sit. *"The conclusion recommends the vegetarian option"* is a claim **about** the article; the sentence itself **is** the article, and an edit can be asked not to contradict it without anybody having restated it first.

## The guard the report asks for

> *"Test that a mistaken memory summary cannot override evidence."*

Two mechanisms, and the second is the real one:

1. The memory arrives under a heading saying it is navigation and not evidence, and that a number appearing only there may not be used.
2. **The deterministic check on a proposal — figures in neither the original section nor the packet — does not consult the memory.**

So `$95`, which is in the article's opening and in no chosen fact, *does* travel in the memory — and is still flagged as introduced if an edit writes it into a section that did not have it. There is a test for exactly that. A mistaken memory cannot quietly become evidence; it can only waste a call.

## Refresh

Rebuilt from the draft as it stands on every request, so an edit accepted a minute ago is already part of what the next one is told. Being free is what makes refreshing the obvious thing to do rather than caching it and letting it go stale.

## One bug found while testing

`segment_article` always produces an opening block so a draft beginning straight on a heading has somewhere to put one. An empty one was being described to the edit as a section of the article.

## Verification

- 19 new backend tests. One existing test changed meaning and was rewritten rather than patched: the edit is no longer *unaware* of the other sections, it is no longer *offered* them to edit, and the test now asserts that against the `ORIGINAL SECTION` block.
- Backend **1693 passed**; `tsc --noEmit` clean; flake8 clean.

No model calls were made. No pipeline was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)