### PR TITLE
feat(p2b): notice what the editor keeps having to fix, and refuse to over-read it

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/CONTEXT.md
@@ -51,6 +51,7 @@ them for the v2 fallback. Do not delete or renumber them.
 | `evaluation.py` | Frozen writing inputs, blind draft comparison, and per-criterion scoring |
 | `section_edit_v4.py` | One operator-asked improvement to one section, proposed against the frozen facts and applied only on acceptance |
 | `article_memory.py` | What the rest of the draft already said, quoted from it, so a targeted edit does not repeat or contradict it |
+| `edit_patterns.py` | The same fix made across several articles, and the thresholds below which it is not a rule |
 | `content/` | Pure source-text, Markdown, and editorial-block transformations |
 | `quality.py` | Deterministic checks, sanitizers, and repair gating |
 | `llm.py`, `dependencies.py` | Shared-LLM adapter and explicit dependency bundle |

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -7,7 +7,7 @@ is what made a research pass look like an outage.
 """
 
 from contextlib import nullcontext
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.core import (
+    get_all_runs,
     read_all_stage_results,
     read_output,
     read_stage_result,
@@ -60,6 +61,13 @@ from ..provenance import (
     stored_confirmations,
 )
 from ..resume_v3 import plan_resume
+from ..edit_patterns import (
+    EDIT_PATTERN_RUN,
+    EDIT_PATTERN_STAGE,
+    PatternDecision,
+    outstanding,
+    review,
+)
 from ..section_edit_v4 import (
     EDIT_ACTIONS,
     SECTION_EDIT_STAGE,
@@ -425,6 +433,26 @@ class SectionEditRequest(BaseModel):
     action_id: str = Field(min_length=1)
 
 
+class ApplyEditRequest(BaseModel):
+    """An accepted proposal, and optionally why the editor wanted it.
+
+    The reason is optional and nothing is inferred from its absence. It is the
+    difference between "this one was wrong" and "we always want this", and only
+    a person knows which they meant.
+    """
+
+    proposal: EditProposal
+    reason: str = ""
+
+
+class PatternDecisionRequest(BaseModel):
+    pattern_id: str = Field(min_length=1)
+    # `adopted` means a person changed the voice file. `declined` means they
+    # read it and disagreed.
+    verdict: Literal["adopted", "declined"]
+    note: str = ""
+
+
 def _finished_run(run_id: str) -> dict[str, Any]:
     status = read_status(run_id)
     if not status or status.get("feature") != FEATURE_NAME:
@@ -511,7 +539,7 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
 @router.post("/section-edit/{run_id}/apply", dependencies=[Depends(require_staff)])
 def apply_edit(
     run_id: str,
-    proposal: EditProposal,
+    request: ApplyEditRequest,
     staff_id: str = Depends(staff_user_id),
 ) -> JSONResponse:
     """Write an accepted proposal into the draft.
@@ -520,12 +548,17 @@ def apply_edit(
     is refused rather than applied over the top of it.
     """
     output = _finished_run(run_id)
+    artifact = _safe_dict(_safe_dict(output["artifact"]).get("pipeline_v3"))
     result = apply_proposal(
         content=output["markdown"],
-        proposal=proposal,
+        proposal=request.proposal,
         history=_edit_history(run_id),
         editor=staff_id or "",
         now=_now_iso(),
+        reason=request.reason,
+        # So a correction that only ever happens on one kind of piece cannot
+        # later be read as a rule about all of them (improvement 05).
+        form_id=_safe_str(_safe_dict(artifact.get("brief")).get("form_id")),
     )
     if not result.applied:
         raise HTTPException(
@@ -561,6 +594,79 @@ def undo_edit(run_id: str) -> JSONResponse:
     return JSONResponse(
         {"markdown": markdown, "edits": len(history.edits), "undone": True}
     )
+
+
+@router.get("/edit-patterns", dependencies=[Depends(require_staff)])
+def read_edit_patterns() -> JSONResponse:
+    """What the accepted edits keep saying, across every article.
+
+    Not hung off a run. A pattern is about the writer across articles, and
+    attaching it to whichever run happened to be open when it was noticed would
+    lose it.
+
+    Reads and counts; changes nothing. The Questurian Voice file is edited by a
+    person, and silently learning a new instruction is the failure this feature
+    is one wrong turn away from.
+    """
+    histories: dict[str, Any] = {}
+    for row in get_all_runs(feature=FEATURE_NAME):
+        run_id = _safe_str(row.get("run_id"))
+        stored = _safe_dict(
+            _safe_dict(read_stage_result(run_id, SECTION_EDIT_STAGE)).get("data")
+        )
+        if stored.get("edits"):
+            histories[run_id] = stored
+
+    reviewed = review(histories)
+    decisions = [
+        PatternDecision(**_safe_dict(item))
+        for item in _safe_dict(
+            _safe_dict(
+                read_stage_result(EDIT_PATTERN_RUN, EDIT_PATTERN_STAGE)
+            ).get("data")
+        ).get("decisions")
+        or []
+    ]
+    reviewed["outstanding"] = outstanding(reviewed, decisions)
+    reviewed["decided"] = [
+        {"pattern_id": item.pattern_id, "verdict": item.verdict, "note": item.note}
+        for item in decisions
+    ]
+    return JSONResponse(reviewed)
+
+
+@router.post("/edit-patterns/decide", dependencies=[Depends(require_staff)])
+def decide_edit_pattern(
+    request: PatternDecisionRequest,
+    staff_id: str = Depends(staff_user_id),
+) -> JSONResponse:
+    """Record that a person answered a pattern, so it stops being offered.
+
+    `adopted` means they changed the voice file themselves. Nothing here writes
+    to it: this route records a decision and never a rule.
+    """
+    stored = _safe_dict(
+        _safe_dict(read_stage_result(EDIT_PATTERN_RUN, EDIT_PATTERN_STAGE)).get("data")
+    )
+    kept = [
+        item
+        for item in stored.get("decisions") or []
+        if _safe_dict(item).get("pattern_id") != request.pattern_id
+    ]
+    decisions = [
+        *kept,
+        {
+            "pattern_id": request.pattern_id,
+            "verdict": request.verdict,
+            "decided_at": _now_iso(),
+            "decided_by": staff_id or "",
+            "note": request.note,
+        },
+    ]
+    RunRecorder().record_stage(
+        EDIT_PATTERN_RUN, EDIT_PATTERN_STAGE, {"decisions": decisions}
+    )
+    return JSONResponse({"decisions": decisions})
 
 
 @router.get("/drafts/{run_id}", response_class=HTMLResponse)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/edit_patterns.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/edit_patterns.py
@@ -1,0 +1,371 @@
+"""What the editor keeps having to fix, and when that is worth a rule.
+
+Improvement 05. Every accepted section edit is a person saying the writer got
+something wrong and this is what right looks like. One of those is a
+correction. Twenty of the same shape, across different articles and different
+forms, is a gap in the house voice -- and until now that signal existed only in
+somebody's memory of having made the same edit before.
+
+The whole design is about the difference between those two things.
+
+Why it refuses to speak
+-----------------------
+The roadmap puts this last and says to wait until enough genuine edit history
+exists to distinguish taste from recurring failure. That waiting is written into
+the code rather than left as a note: below the thresholds this returns a
+refusal naming what is still missing. It ships now and declines to draw
+conclusions now, which is different from not shipping.
+
+Two thresholds, and they guard different mistakes. Enough *distinct runs*,
+because the same operator fixing the same article three times is one opinion
+held loudly. Enough *distinct forms*, because a correction appropriate to a
+service guide is not a rule about profiles -- the report says so directly, and
+a voice file is read by every form there is.
+
+Nothing here writes a rule
+--------------------------
+It produces evidence and, at most, a suggestion. The Questurian Voice file is
+changed by a person editing it, and this records only whether a suggestion was
+taken up so the same one is not offered forever. Silently learning a new
+instruction is the failure this feature is one wrong turn away from, and the
+turn is not taken.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .section_edit_v4 import AppliedEdit, EDIT_ACTIONS_BY_ID
+
+# Bumped when a stored decision stops meaning what this code reads.
+EDIT_PATTERN_SCHEMA_VERSION = 1
+
+# Where an operator's answers to suggestions live. Not on a run: a pattern is
+# about the writer across articles, and hanging it off whichever run happened
+# to be open when it was noticed would lose it.
+EDIT_PATTERN_STAGE = "prompt2blog_edit_patterns"
+EDIT_PATTERN_RUN = "prompt2blog-editorial"
+
+# How many separate articles must show the same fix before it is a pattern.
+#
+# Three, and it is a floor rather than a finding. Two is a coincidence with a
+# witness. This does not make three a proof -- the point of the number is that
+# below it the question is not worth asking, not that above it the answer is
+# yes.
+MIN_RUNS_FOR_A_PATTERN = 3
+
+# How many different forms it must have happened on before it can be proposed
+# as a change to the one voice everything shares.
+#
+# A correction appropriate to one article should not become a universal rule,
+# and a voice file is read by every form there is. A pattern seen on one form
+# is reported as exactly that -- something about how this pipeline writes
+# service guides -- and is not offered as a voice change.
+MIN_FORMS_FOR_A_VOICE_RULE = 2
+
+# How much of the group is withheld when a suggestion is drawn from it. The
+# report asks for comparison on held-out examples rather than on the excerpts
+# that motivated the rule, and a rule checked only against what produced it
+# cannot fail.
+HELD_OUT_SHARE = 0.3
+
+
+def _normalise(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+# What actually changed, said in a way that can be counted. Not a diff: a diff
+# of two paragraphs is unique every time and would put every edit in its own
+# group. These are the shapes an edit takes, and two edits sharing one are two
+# edits doing the same kind of work.
+_SHAPE_TESTS: tuple[tuple[str, str], ...] = (
+    ("shortened", "the replacement is materially shorter"),
+    ("lengthened", "the replacement is materially longer"),
+    ("hedge_removed", "hedging in the original is gone from the replacement"),
+    ("choice_named", "the replacement names a choice the original did not"),
+    ("comparison_added", "the replacement compares where the original listed"),
+    ("rephrased", "about the same length, no other shape matched"),
+)
+
+_HEDGES = re.compile(
+    r"\b(?:might|maybe|perhaps|arguably|somewhat|fairly|quite|it\s+seems|"
+    r"tends?\s+to|generally|typically|often|can\s+be|could\s+be)\b",
+    re.IGNORECASE,
+)
+_CHOICE = re.compile(
+    r"\b(?:go\s+to|book|choose|pick|skip|avoid|stick\s+to|the\s+one\s+to|"
+    r"best\s+(?:bet|option|choice)|opt\s+for|if\s+you)\b",
+    re.IGNORECASE,
+)
+_COMPARISON = re.compile(
+    r"\b(?:better|worse|cheaper|faster|closer|quieter|rather\s+than|"
+    r"instead\s+of|whereas|while|against|compared)\b",
+    re.IGNORECASE,
+)
+
+# What counts as an edit having changed the length rather than the wording.
+# Both floors, because either alone gets it wrong: a proportional test calls a
+# five-word sentence gaining one word a 20% expansion, and an absolute test
+# calls twenty words off a thousand-word section nothing.
+LENGTH_SHIFT = 0.15
+LENGTH_SHIFT_WORDS = 5
+
+
+def edit_shape(before: str, after: str) -> str:
+    """The kind of work one edit did, in a word two edits can share.
+
+    Deliberately coarse. A finer classification would be more accurate about
+    each edit and useless for the only question being asked, which is whether
+    the same thing keeps happening.
+
+    The editorial moves are tested before length, and that ordering is the
+    whole of the classifier. Length is the least informative thing about an
+    edit -- naming a choice usually makes a passage longer and removing hedging
+    usually makes it shorter -- so testing it first put every editorial move
+    into the two piles that say least about it.
+    """
+    gained_choice = bool(_CHOICE.search(after)) and not _CHOICE.search(before)
+    gained_comparison = bool(_COMPARISON.search(after)) and not _COMPARISON.search(
+        before
+    )
+    lost_hedging = bool(_HEDGES.search(before)) and not _HEDGES.search(after)
+
+    # Most specific first. A passage that gained a recommendation *and* lost
+    # its hedging did one editorial thing, and it is the recommendation.
+    if gained_choice:
+        return "choice_named"
+    if gained_comparison:
+        return "comparison_added"
+    if lost_hedging:
+        return "hedge_removed"
+
+    before_words = len(before.split())
+    after_words = len(after.split())
+    delta = after_words - before_words
+    if before_words and abs(delta) >= LENGTH_SHIFT_WORDS:
+        shift = delta / before_words
+        if shift <= -LENGTH_SHIFT:
+            return "shortened"
+        if shift >= LENGTH_SHIFT:
+            return "lengthened"
+    return "rephrased"
+
+
+@dataclass(frozen=True)
+class Occurrence:
+    """One accepted edit, reduced to what a pattern is counted from."""
+
+    run_id: str
+    form_id: str
+    action_id: str
+    shape: str
+    before: str
+    after: str
+    reason: str = ""
+    applied_at: str = ""
+
+
+@dataclass
+class EditPattern:
+    """The same kind of fix, made more than once."""
+
+    action_id: str
+    shape: str
+    occurrences: list[Occurrence] = field(default_factory=list)
+
+    @property
+    def runs(self) -> list[str]:
+        return sorted({item.run_id for item in self.occurrences})
+
+    @property
+    def forms(self) -> list[str]:
+        return sorted({item.form_id for item in self.occurrences if item.form_id})
+
+    @property
+    def reasons(self) -> list[str]:
+        return sorted({item.reason for item in self.occurrences if item.reason})
+
+    @property
+    def enough_history(self) -> bool:
+        return len(self.runs) >= MIN_RUNS_FOR_A_PATTERN
+
+    @property
+    def can_be_a_voice_rule(self) -> bool:
+        return self.enough_history and len(self.forms) >= MIN_FORMS_FOR_A_VOICE_RULE
+
+    def split_for_review(self) -> tuple[list[Occurrence], list[Occurrence]]:
+        """The examples a rule may be drawn from, and the ones it is checked on.
+
+        Held out by run, not by occurrence: two edits from the same article are
+        the same evidence twice, and holding one of them back would leave a
+        "held-out" example the rule had effectively already seen.
+        """
+        runs = self.runs
+        holdout_count = max(1, round(len(runs) * HELD_OUT_SHARE))
+        held_back = set(runs[-holdout_count:])
+        motivating = [item for item in self.occurrences if item.run_id not in held_back]
+        held_out = [item for item in self.occurrences if item.run_id in held_back]
+        # Never hold back so much that nothing is left to reason from.
+        if not motivating:
+            return self.occurrences, []
+        return motivating, held_out
+
+    def as_record(self) -> dict[str, Any]:
+        motivating, held_out = self.split_for_review()
+        action = EDIT_ACTIONS_BY_ID.get(self.action_id)
+        return {
+            "pattern_id": f"{self.action_id}:{self.shape}",
+            "action_id": self.action_id,
+            "action_label": action.label if action else self.action_id,
+            "shape": self.shape,
+            "shape_meaning": dict(_SHAPE_TESTS).get(self.shape, ""),
+            "occurrences": len(self.occurrences),
+            "runs": self.runs,
+            "forms": self.forms,
+            "reasons_given": self.reasons,
+            "enough_history": self.enough_history,
+            "can_be_a_voice_rule": self.can_be_a_voice_rule,
+            # Named separately so the two refusals do not read as one. A
+            # single-form pattern is a real finding about how this pipeline
+            # writes that form; it is only a voice rule that it cannot be.
+            "why_not_a_voice_rule": self._refusal(),
+            "motivating_examples": [
+                {"run_id": item.run_id, "before": item.before, "after": item.after}
+                for item in motivating
+            ],
+            "held_out_examples": [
+                {"run_id": item.run_id, "before": item.before, "after": item.after}
+                for item in held_out
+            ],
+        }
+
+    def _refusal(self) -> str:
+        if not self.enough_history:
+            missing = MIN_RUNS_FOR_A_PATTERN - len(self.runs)
+            return (
+                f"Seen on {len(self.runs)} article(s). {missing} more would make "
+                "this worth asking about; below that, the same fix twice is a "
+                "coincidence with a witness."
+            )
+        if len(self.forms) < MIN_FORMS_FOR_A_VOICE_RULE:
+            forms = ", ".join(self.forms) or "one form"
+            return (
+                f"Only ever on {forms}. That is a real finding about how this "
+                "pipeline writes that form, and not a rule about every article "
+                "-- the voice file is read by all of them."
+            )
+        return ""
+
+
+def gather_occurrences(
+    histories: dict[str, Any],
+    forms: dict[str, str] | None = None,
+) -> list[Occurrence]:
+    """Read accepted edits out of stored run histories.
+
+    `histories` is run id to that run's stored edit history. `forms` supplies
+    the form for runs recorded before the form travelled with the edit; an
+    unknown form stays empty rather than being guessed, because guessing it is
+    how a single-form pattern becomes a voice rule.
+    """
+    known_forms = forms or {}
+    occurrences: list[Occurrence] = []
+    for run_id, stored in histories.items():
+        record = stored if isinstance(stored, dict) else {}
+        for raw in record.get("edits") or []:
+            edit = AppliedEdit.model_validate(raw)
+            if not edit.before or not edit.after:
+                # Recorded before the section text travelled with the edit.
+                # Counted for nothing rather than counted as a rephrase.
+                continue
+            if _normalise(edit.before) == _normalise(edit.after):
+                continue
+            occurrences.append(
+                Occurrence(
+                    run_id=run_id,
+                    form_id=edit.form_id or known_forms.get(run_id, ""),
+                    action_id=edit.action_id,
+                    shape=edit_shape(edit.before, edit.after),
+                    before=edit.before,
+                    after=edit.after,
+                    reason=edit.reason,
+                    applied_at=edit.applied_at,
+                )
+            )
+    return occurrences
+
+
+def group_patterns(occurrences: list[Occurrence]) -> list[EditPattern]:
+    """The same action and the same shape, gathered.
+
+    Ordered by how many separate articles show it, because that is the only
+    axis on which one pattern is more worth a person's attention than another.
+    """
+    grouped: dict[tuple[str, str], EditPattern] = {}
+    for item in occurrences:
+        key = (item.action_id, item.shape)
+        pattern = grouped.setdefault(
+            key, EditPattern(action_id=item.action_id, shape=item.shape)
+        )
+        pattern.occurrences.append(item)
+    return sorted(
+        grouped.values(),
+        key=lambda pattern: (-len(pattern.runs), -len(pattern.occurrences), pattern.action_id),
+    )
+
+
+def review(
+    histories: dict[str, Any],
+    forms: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """What the accepted edits say, and what they are not yet entitled to say."""
+    occurrences = gather_occurrences(histories, forms)
+    patterns = group_patterns(occurrences)
+    ready = [pattern for pattern in patterns if pattern.can_be_a_voice_rule]
+    return {
+        "schema_version": EDIT_PATTERN_SCHEMA_VERSION,
+        "edits_read": len(occurrences),
+        "articles_edited": len({item.run_id for item in occurrences}),
+        "patterns": [pattern.as_record() for pattern in patterns],
+        "ready_for_review": [pattern.as_record()["pattern_id"] for pattern in ready],
+        "means": (
+            "A pattern is the same kind of fix made on several articles. It is "
+            "evidence that the writer keeps needing the same correction, not "
+            "proof that the voice file is wrong -- an editor's taste is also a "
+            "pattern. Nothing here changes any rule: the Questurian Voice file "
+            "is edited by a person, and this only records whether a suggestion "
+            "was taken up so the same one is not offered forever."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# What a person decided about a pattern
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PatternDecision:
+    pattern_id: str
+    # `adopted` means a person changed the voice file. `declined` means they
+    # read it and disagreed. Both stop it being offered again; only one of them
+    # means the writer will improve.
+    verdict: str
+    decided_at: str = ""
+    decided_by: str = ""
+    note: str = ""
+
+
+def outstanding(
+    reviewed: dict[str, Any], decisions: list[PatternDecision]
+) -> list[dict[str, Any]]:
+    """Patterns ready for a person, minus the ones a person has answered."""
+    settled = {decision.pattern_id for decision in decisions}
+    return [
+        pattern
+        for pattern in reviewed.get("patterns") or []
+        if pattern.get("can_be_a_voice_rule")
+        and pattern.get("pattern_id") not in settled
+    ]

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -368,6 +368,19 @@ class AppliedEdit(BaseModel):
     # The entire previous markdown, not a patch. Undo has to be exact, and a
     # patch that no longer applies is an undo that silently does not.
     previous_markdown: str = ""
+    # The one section, before and after, and why the operator wanted it
+    # (improvement 05). The whole-draft copy above is for undo and is the wrong
+    # shape for reading a pattern out of: what recurs is a kind of sentence
+    # being replaced by another kind, and that is only visible at this size.
+    before: str = ""
+    after: str = ""
+    # Typed by the operator, and optional. A reason is the difference between
+    # "this one was wrong" and "we always want this", and nothing should be
+    # inferred from its absence.
+    reason: str = ""
+    # Which form the article was, so a correction that only ever happens on one
+    # kind of piece cannot be read as a rule about all of them.
+    form_id: str = ""
 
 
 class EditHistory(BaseModel):
@@ -397,6 +410,8 @@ def apply_proposal(
     history: EditHistory,
     editor: str,
     now: str,
+    reason: str = "",
+    form_id: str = "",
 ) -> ApplyResult:
     """Write one accepted proposal into the draft, keeping what it replaced.
 
@@ -435,6 +450,10 @@ def apply_proposal(
                 editor=editor,
                 what_changed=proposal.what_changed,
                 previous_markdown=content,
+                before=proposal.original,
+                after=proposal.revised,
+                reason=reason,
+                form_id=form_id,
             ),
         ],
     )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_patterns.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_patterns.py
@@ -1,0 +1,310 @@
+"""Improvement 05: what the editor keeps having to fix.
+
+Every accepted section edit is a person saying the writer got something wrong
+and this is what right looks like. One of those is a correction. Twenty of the
+same shape, across different articles and different forms, is a gap in the house
+voice.
+
+The whole design is the difference between those two things, so most of these
+tests are about refusing to draw a conclusion: from too few articles, from one
+form, or from evidence that has already been used to draw it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.prompt2blog.edit_patterns import (
+    MIN_FORMS_FOR_A_VOICE_RULE,
+    MIN_RUNS_FOR_A_PATTERN,
+    Occurrence,
+    PatternDecision,
+    edit_shape,
+    gather_occurrences,
+    group_patterns,
+    outstanding,
+    review,
+)
+
+HEDGED = (
+    "## Where to eat\n\nBoth are arguably good, and it might come down to "
+    "what you generally prefer on the day."
+)
+CHOSEN = (
+    "## Where to eat\n\nGo to Surquillo market. Central is the one to book "
+    "only if a tasting menu is what you came for."
+)
+
+
+def _edit(**overrides) -> dict[str, Any]:
+    payload = dict(
+        section_id="s1",
+        action_id="clarify_recommendation",
+        applied_at="2026-09-07T00:00:00+00:00",
+        editor="alan",
+        what_changed="Named the choice.",
+        previous_markdown="(whole draft)",
+        before=HEDGED,
+        after=CHOSEN,
+        reason="it kept hedging instead of choosing",
+        form_id="service-guide",
+    )
+    payload.update(overrides)
+    return payload
+
+
+def _histories(count: int, **overrides) -> dict[str, Any]:
+    return {
+        f"run-{index}": {"edits": [_edit(**overrides)]} for index in range(count)
+    }
+
+
+# ---------------------------------------------------------------------------
+# The shape of an edit, in a word two edits can share
+# ---------------------------------------------------------------------------
+
+
+def test_naming_a_choice_where_there_was_none_is_its_own_shape():
+    assert edit_shape(HEDGED, CHOSEN) == "choice_named"
+
+
+def test_removing_hedging_without_changing_length_is_its_own_shape():
+    before = "It might arguably be quite good."
+    after = "It is very good indeed at that."
+    assert edit_shape(before, after) == "hedge_removed"
+
+
+def test_a_materially_shorter_replacement_is_a_cut():
+    before = " ".join(["word"] * 40)
+    after = " ".join(["word"] * 20)
+    assert edit_shape(before, after) == "shortened"
+
+
+def test_a_longer_replacement_that_names_a_choice_is_about_the_choice():
+    """Length is the side effect. Grouping it as `lengthened` would put the
+
+    same editorial move in two piles.
+    """
+    before = "Both places serve ceviche."
+    after = (
+        "Both places serve ceviche, and if you have one meal you should go to "
+        "the market rather than the dining room, because that is where the "
+        "cooking is."
+    )
+    assert edit_shape(before, after) == "choice_named"
+
+
+def test_an_edit_that_matched_nothing_is_a_rephrase_not_a_guess():
+    before = "The market sits in Surquillo."
+    after = "Surquillo is where the market sits."
+    assert edit_shape(before, after) == "rephrased"
+
+
+# ---------------------------------------------------------------------------
+# Reading accepted edits
+# ---------------------------------------------------------------------------
+
+
+def test_edits_are_grouped_by_the_kind_of_work_they_did():
+    patterns = group_patterns(gather_occurrences(_histories(3)))
+    assert len(patterns) == 1
+    assert patterns[0].action_id == "clarify_recommendation"
+    assert patterns[0].shape == "choice_named"
+    assert patterns[0].runs == ["run-0", "run-1", "run-2"]
+
+
+def test_an_edit_recorded_before_the_section_text_travelled_counts_for_nothing():
+    """Rather than counting as a rephrase.
+
+    Runs edited before improvement 05 have an action and no before/after.
+    Reading them as evidence of anything would put a shape on edits nobody can
+    see.
+    """
+    occurrences = gather_occurrences({"run-0": {"edits": [_edit(before="", after="")]}})
+    assert occurrences == []
+
+
+def test_an_edit_that_changed_only_whitespace_is_not_a_pattern():
+    occurrences = gather_occurrences(
+        {"run-0": {"edits": [_edit(after=HEDGED.replace("\n\n", "\n\n  "))]}}
+    )
+    assert occurrences == []
+
+
+def test_an_unknown_form_stays_unknown_rather_than_being_guessed():
+    """Guessing it is how a single-form pattern becomes a voice rule."""
+    occurrences = gather_occurrences({"run-0": {"edits": [_edit(form_id="")]}})
+    assert occurrences[0].form_id == ""
+
+
+# ---------------------------------------------------------------------------
+# The two refusals
+# ---------------------------------------------------------------------------
+
+
+def test_two_articles_is_a_coincidence_with_a_witness():
+    pattern = group_patterns(gather_occurrences(_histories(2)))[0]
+    assert pattern.enough_history is False
+    assert pattern.can_be_a_voice_rule is False
+    assert "coincidence with a witness" in pattern.as_record()["why_not_a_voice_rule"]
+
+
+def test_the_same_fix_on_one_form_is_a_finding_about_that_form():
+    """A correction appropriate to a service guide is not a rule about profiles.
+
+    The voice file is read by every form there is, so this refusal is separate
+    from the not-enough-history one and says something different.
+    """
+    pattern = group_patterns(gather_occurrences(_histories(4)))[0]
+    assert pattern.enough_history is True
+    assert pattern.can_be_a_voice_rule is False
+    record = pattern.as_record()
+    assert "service-guide" in record["why_not_a_voice_rule"]
+    assert "not a rule about every article" in record["why_not_a_voice_rule"]
+
+
+def test_enough_articles_across_enough_forms_is_worth_asking_about():
+    histories = {
+        "run-0": {"edits": [_edit(form_id="service-guide")]},
+        "run-1": {"edits": [_edit(form_id="service-guide")]},
+        "run-2": {"edits": [_edit(form_id="comparison")]},
+        "run-3": {"edits": [_edit(form_id="destination-guide")]},
+    }
+    pattern = group_patterns(gather_occurrences(histories))[0]
+
+    assert pattern.can_be_a_voice_rule is True
+    assert pattern.as_record()["why_not_a_voice_rule"] == ""
+
+
+def test_the_thresholds_are_floors_not_findings():
+    """Above them the question is worth asking. That is all they mean."""
+    assert MIN_RUNS_FOR_A_PATTERN == 3
+    assert MIN_FORMS_FOR_A_VOICE_RULE == 2
+    reviewed = review(_histories(4))
+    assert "not proof that the voice file is wrong" in reviewed["means"]
+
+
+def test_one_operator_editing_one_article_repeatedly_is_one_opinion():
+    """Counted by article, not by edit.
+
+    The same person fixing the same piece three times is one opinion held
+    loudly, and counting edits would let it clear the bar alone.
+    """
+    histories = {"run-0": {"edits": [_edit(), _edit(section_id="s2"), _edit(section_id="s3")]}}
+    pattern = group_patterns(gather_occurrences(histories))[0]
+
+    assert len(pattern.occurrences) == 3
+    assert pattern.runs == ["run-0"]
+    assert pattern.enough_history is False
+
+
+# ---------------------------------------------------------------------------
+# Held-out examples
+# ---------------------------------------------------------------------------
+
+
+def test_some_examples_are_held_back_from_whatever_rule_is_drawn():
+    """A rule checked only against what produced it cannot fail."""
+    pattern = group_patterns(gather_occurrences(_histories(6)))[0]
+    motivating, held_out = pattern.split_for_review()
+
+    assert motivating and held_out
+    assert len(motivating) + len(held_out) == 6
+
+
+def test_examples_are_held_out_by_article_not_by_edit():
+    """Two edits from the same article are the same evidence twice.
+
+    Holding one of them back would leave a "held-out" example the rule had
+    effectively already seen.
+    """
+    histories = {
+        f"run-{index}": {"edits": [_edit(), _edit(section_id="s2")]}
+        for index in range(4)
+    }
+    pattern = group_patterns(gather_occurrences(histories))[0]
+    motivating, held_out = pattern.split_for_review()
+
+    motivating_runs = {item.run_id for item in motivating}
+    held_out_runs = {item.run_id for item in held_out}
+    assert motivating_runs & held_out_runs == set()
+
+
+def test_a_pattern_is_never_held_out_into_nothing():
+    pattern = group_patterns(gather_occurrences(_histories(MIN_RUNS_FOR_A_PATTERN)))[0]
+    motivating, _held_out = pattern.split_for_review()
+    assert motivating
+
+
+# ---------------------------------------------------------------------------
+# Nothing here writes a rule
+# ---------------------------------------------------------------------------
+
+
+def test_the_review_says_it_changes_nothing():
+    """Silently learning a new instruction is the failure this is one wrong
+
+    turn away from. The refusal is written into the payload rather than left to
+    whoever reads it.
+    """
+    means = review(_histories(4))["means"]
+    assert "Nothing here changes any rule" in means
+    assert "edited by a person" in means
+
+
+def test_an_editors_taste_is_also_a_pattern_and_the_payload_says_so():
+    assert "an editor's taste is also a pattern" in review(_histories(4))["means"]
+
+
+def test_a_pattern_a_person_answered_stops_being_offered():
+    histories = {
+        "run-0": {"edits": [_edit(form_id="service-guide")]},
+        "run-1": {"edits": [_edit(form_id="comparison")]},
+        "run-2": {"edits": [_edit(form_id="destination-guide")]},
+    }
+    reviewed = review(histories)
+    assert len(outstanding(reviewed, [])) == 1
+
+    settled = [
+        PatternDecision(
+            pattern_id="clarify_recommendation:choice_named", verdict="adopted"
+        )
+    ]
+    assert outstanding(reviewed, settled) == []
+
+
+@pytest.mark.parametrize("verdict", ["adopted", "declined"])
+def test_both_answers_stop_it_being_offered_and_only_one_improves_anything(verdict):
+    histories = {
+        "run-0": {"edits": [_edit(form_id="service-guide")]},
+        "run-1": {"edits": [_edit(form_id="comparison")]},
+        "run-2": {"edits": [_edit(form_id="destination-guide")]},
+    }
+    settled = [
+        PatternDecision(
+            pattern_id="clarify_recommendation:choice_named", verdict=verdict
+        )
+    ]
+    assert outstanding(review(histories), settled) == []
+
+
+def test_a_pattern_below_threshold_is_reported_but_never_offered():
+    """Visible, so an operator can see it forming. Not actionable yet."""
+    reviewed = review(_histories(2))
+    assert reviewed["patterns"]
+    assert reviewed["ready_for_review"] == []
+    assert outstanding(reviewed, []) == []
+
+
+def test_the_reasons_the_operator_typed_travel_with_the_pattern():
+    pattern = group_patterns(gather_occurrences(_histories(3)))[0]
+    assert pattern.reasons == ["it kept hedging instead of choosing"]
+
+
+def test_an_edit_with_no_reason_is_not_read_as_having_one():
+    """Nothing is inferred from the absence of a reason."""
+    pattern = group_patterns(gather_occurrences(_histories(3, reason="")))[0]
+    assert pattern.reasons == []
+    assert isinstance(pattern.occurrences[0], Occurrence)

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
@@ -50,6 +50,10 @@ export function SectionEditor({
   const [proposal, setProposal] = useState<SectionEditProposal | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
+  // Why the editor wanted this, in their words. Optional, and never inferred:
+  // one accepted edit is a correction, and only the person making it knows
+  // whether they meant "this one was wrong" or "we always want this".
+  const [reason, setReason] = useState('')
 
   useEffect(() => {
     let live = true
@@ -73,9 +77,10 @@ export function SectionEditor({
   const keep = () => {
     if (!proposal) return
     setBusy(true)
-    applySectionEdit(runId, proposal)
+    applySectionEdit(runId, proposal, reason)
       .then(result => {
         setProposal(null)
+        setReason('')
         onApplied(result.markdown)
       })
       .catch((failure: Error) => setError(failure.message))
@@ -143,6 +148,17 @@ export function SectionEditor({
               <pre>{proposal.revised}</pre>
             </section>
           </div>
+
+          <label className="p2b-field">
+            <span className="p2b-label">Why you wanted this (optional)</span>
+            <input
+              type="text"
+              value={reason}
+              disabled={busy}
+              placeholder="e.g. it kept hedging instead of choosing"
+              onChange={event => setReason(event.target.value)}
+            />
+          </label>
 
           <div className="p2b-intake-actions">
             <button

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -284,15 +284,22 @@ export async function proposeSectionEdit(
   return (await response.json()) as SectionEditProposal
 }
 
-/** Write an accepted proposal into the draft. */
+/**
+ * Write an accepted proposal into the draft.
+ *
+ * `reason` is optional and nothing is inferred from its absence. It is the
+ * difference between "this one was wrong" and "we always want this", and only
+ * the person pressing the button knows which they meant.
+ */
 export async function applySectionEdit(
   runId: string,
   proposal: SectionEditProposal,
+  reason = '',
 ): Promise<{ markdown: string; edits: number }> {
   const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}/apply`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(proposal),
+    body: JSON.stringify({ proposal, reason }),
   })
   if (!response.ok) {
     throw await readError(response, 'Could not apply that change.')


### PR DESCRIPTION
Improvement **05** — the last of the eight.

> **Stacked on [#554](https://github.com/Questurian/questurian/pull/554)**. Chain: #551 → #553 → #554 → this. It counts the edit history those branches record.

## The problem

Every accepted section edit is a person saying the writer got something wrong and *this* is what right looks like.

One of those is a correction. Twenty of the same shape, across different articles and different forms, is a gap in the house voice. Until now that signal existed only in somebody's memory of having made the same edit before.

**The whole design is the difference between those two things.**

## Capture

An applied edit now carries the section **before and after**, the **form** the article was, and an **optional reason** the operator typed.

The whole-draft copy that already existed is for undo and is the wrong shape to read a pattern out of — what recurs is a kind of sentence being replaced by another kind, and that is only visible at section size.

Nothing is inferred from a missing reason. It is the difference between *"this one was wrong"* and *"we always want this"*, and only a person knows which they meant.

## Group

By what the edit did, in a word coarse enough for two edits to share: a choice named where there was none, a comparison added, hedging removed, a cut, an expansion, a rephrase.

**The editorial moves are tested before length, and that ordering is the whole of the classifier.** Naming a choice usually makes a passage longer; removing hedging usually makes it shorter. Testing length first put every editorial move into the two piles that say least about it. Found while writing the tests, which is what they were for.

## Refuse — this is the point

| Threshold | Guards against |
|---|---|
| **3 distinct articles**, counted by article and never by edit | the same person fixing the same piece three times, which is one opinion held loudly |
| **2 distinct forms** before it may be proposed as a voice change | a correction appropriate to a service guide becoming a rule about profiles — the voice file is read by every form there is |

A single-form pattern is still **reported**, as exactly what it is: something about how this pipeline writes that form. The two refusals are named separately because they say different things.

Some evidence is **held back** from whatever rule is drawn from it — by article, not by edit, because two edits from the same piece are the same evidence twice and a rule checked only against what produced it cannot fail.

## On the roadmap's "wait"

The roadmap says to wait until enough genuine edit history exists to distinguish taste from recurring failure. **That waiting is in the code rather than in a note**: below the thresholds this returns a refusal naming what is still missing.

It ships now and declines to draw conclusions now. Those are different things.

## Nothing here writes a rule

The Questurian Voice file is edited by a person. These routes record only whether a suggestion was taken up, so the same one is not offered forever — `adopted` and `declined` both stop it being offered, and only one of them means the writer will improve.

Silently learning a new instruction is the failure this feature is one wrong turn away from. The payload says so in its own words rather than leaving it to whoever reads it, including that an editor's taste is also a pattern.

## Verification

- 25 new backend tests.
- Backend **1718 passed**; frontend **150 files / 789 tests passed**; `tsc --noEmit` clean; flake8 clean.

No model calls were made. No pipeline was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)