### PR TITLE
Protect every edit: the editor's safety boundary, and an honest receipt

### DIFF
--- a/apps/ai-blog-writer/apps/backend/app/core/database.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/database.py
@@ -19,6 +19,43 @@ _BUSY_TIMEOUT_SECONDS = 5.0
 
 
 @contextmanager
+def transaction() -> Generator[sqlite3.Connection, None, None]:
+    """A connection that holds the write lock for the whole block.
+
+    `get_db_connection` is a deferred transaction: a `SELECT` inside it takes
+    no lock, so two callers can both read a row, both decide their write is
+    safe against what they read, and both write -- the second silently over
+    the first. That is fine for the pipeline, which owns a run while it is
+    running, and it is not fine for an editor, where two browser tabs are two
+    processes editing the same article.
+
+    `BEGIN IMMEDIATE` takes the write lock on entry. The second caller blocks
+    on the busy timeout, and when it gets in it reads the row the first one
+    wrote -- so a compare-and-swap on a revision is a real check rather than a
+    check against a value that has already moved.
+
+    Autocommit is turned off at the driver level (`isolation_level=None`) so
+    the BEGIN/COMMIT here are the only transaction boundaries and Python's
+    implicit ones cannot open a second, deferred one underneath.
+    """
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(DB_PATH), timeout=_BUSY_TIMEOUT_SECONDS)
+    conn.row_factory = sqlite3.Row
+    conn.isolation_level = None
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield conn
+        conn.execute("COMMIT")
+    except BaseException:
+        conn.execute("ROLLBACK")
+        raise
+    finally:
+        conn.close()
+
+
+@contextmanager
 def get_db_connection() -> Generator[sqlite3.Connection, None, None]:
     """
     Get a database connection with auto-commit.
@@ -82,6 +119,7 @@ def ensure_core_tables() -> None:
                 markdown TEXT NOT NULL,
                 artifact TEXT NOT NULL,
                 created_at TEXT NOT NULL,
+                article_revision INTEGER NOT NULL DEFAULT 0,
                 synced_to_payload INTEGER DEFAULT 0,
                 payload_article_id INTEGER,
                 synced_at TEXT,
@@ -120,6 +158,16 @@ def ensure_core_tables() -> None:
             conn.execute("ALTER TABLE outputs ADD COLUMN payload_article_id INTEGER")
         if "synced_at" not in output_columns:
             conn.execute("ALTER TABLE outputs ADD COLUMN synced_at TEXT")
+        # Which version of the article's markdown this row holds. Every write
+        # of `markdown` advances it, so an edit written against one version can
+        # be refused rather than applied over a version it never read. Existing
+        # rows start at 0, which is correct: nothing has an outstanding
+        # proposal against a revision that did not exist.
+        if "article_revision" not in output_columns:
+            conn.execute(
+                "ALTER TABLE outputs ADD COLUMN article_revision INTEGER "
+                "NOT NULL DEFAULT 0"
+            )
 
         columns = {row["name"] for row in conn.execute("PRAGMA table_info(runs)")}
         if "feature" not in columns:

--- a/apps/ai-blog-writer/apps/backend/app/core/storage.py
+++ b/apps/ai-blog-writer/apps/backend/app/core/storage.py
@@ -133,7 +133,14 @@ def read_all_stage_results(run_id: str) -> Dict[str, Any]:
 
 
 def write_artifact(run_id: str, payload: Dict[str, Any]) -> str:
-    """Write final artifact with markdown."""
+    """Write final artifact with markdown.
+
+    Advances `article_revision`. Every path that writes an article's markdown
+    goes through here, so an edit proposed against one version of the prose is
+    refused after any of them -- not only after another hand edit. A resume
+    that re-finalises a run is exactly as much a reason to re-read a section as
+    a colleague's edit in another tab.
+    """
     markdown = payload.pop("markdown", "")
 
     with get_db_connection() as conn:
@@ -144,7 +151,8 @@ def write_artifact(run_id: str, payload: Dict[str, Any]) -> str:
             ON CONFLICT(run_id) DO UPDATE SET
                 markdown = excluded.markdown,
                 artifact = excluded.artifact,
-                created_at = excluded.created_at
+                created_at = excluded.created_at,
+                article_revision = outputs.article_revision + 1
         """,
             (
                 run_id,
@@ -159,13 +167,18 @@ def read_output(run_id: str) -> Optional[Dict[str, Any]]:
     """Read final output (markdown + artifact)."""
     with get_db_connection() as conn:
         row = conn.execute(
-            "SELECT markdown, artifact FROM outputs WHERE run_id = ?", (run_id,)
+            "SELECT markdown, artifact, article_revision FROM outputs "
+            "WHERE run_id = ?",
+            (run_id,),
         ).fetchone()
         if not row:
             return None
         return {
             "markdown": row["markdown"],
             "artifact": json.loads(row["artifact"]),
+            # What an edit proposed against this text must be applied to. A
+            # caller that ignores it gets the old behaviour and the old bug.
+            "article_revision": row["article_revision"],
         }
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -37,6 +37,13 @@ from utils.llm_model_policy import (
     claude_provider,
 )
 
+from ..article_edits import (
+    ArticleMissing,
+    EditRefused,
+    RevisionConflict,
+    commit_article_edit,
+    read_article,
+)
 from ..config import FEATURE_NAME
 from ..contracts_v4 import Prompt2BlogV4Request
 from ..drafts_view import build_drafts_report, render_drafts_page
@@ -445,6 +452,18 @@ class ApplyEditRequest(BaseModel):
     reason: str = ""
 
 
+class UndoEditRequest(BaseModel):
+    """Which version of the article the undo was pressed against.
+
+    Undo is a write like any other. Pressed on a screen showing revision 10
+    while a colleague saved revision 11, an unguarded undo restores the
+    markdown from before *this tab's* last edit -- erasing their work as a
+    side effect of taking back one's own.
+    """
+
+    base_revision: int = -1
+
+
 class PatternDecisionRequest(BaseModel):
     pattern_id: str = Field(min_length=1)
     # `adopted` means a person changed the voice file. `declined` means they
@@ -465,13 +484,6 @@ def _finished_run(run_id: str) -> dict[str, Any]:
     return output
 
 
-def _edit_history(run_id: str) -> EditHistory:
-    stored = _safe_dict(
-        _safe_dict(read_stage_result(run_id, SECTION_EDIT_STAGE)).get("data")
-    )
-    return EditHistory.model_validate(stored) if stored else EditHistory()
-
-
 # What each refusal means to the person who pressed the button. Keyed on the
 # reason the apply returned, so a refusal nobody wrote a sentence for still
 # falls through to the staleness message rather than to a blank one.
@@ -489,15 +501,12 @@ _APPLY_REFUSALS = {
 }
 
 
-def _save_article(run_id: str, output: dict[str, Any], markdown: str) -> None:
-    """Rewrite the article, leaving the pipeline's own record of it alone.
-
-    `write_artifact` takes the markdown out of the payload and stores it in its
-    own column, so the artifact -- what the pipeline produced and scored -- is
-    passed back unchanged. A hand edit changes the article; it does not change
-    the run's account of how the article was made.
-    """
-    RunRecorder().record_artifact(run_id, {**output["artifact"], "markdown": markdown})
+# Article markdown is written in exactly one place now: `commit_article_edit`,
+# which holds the write lock, checks the revision, and writes the article and
+# its history together. The two helpers that used to live here -- one reading
+# the history on its own, one saving the article on its own -- were the two
+# halves of the lost update, and a route that reaches for either of them again
+# has left the transaction.
 
 
 @router.get("/section-edit/actions", dependencies=[Depends(require_staff)])
@@ -536,6 +545,9 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
         proposal = propose_section_edit(
             run_id=run_id,
             content=output["markdown"],
+            # Stamped on the proposal so the apply can refuse a write against
+            # a document that has moved, not just against a section that has.
+            base_revision=int(output.get("article_revision") or 0),
             section_id=request.section_id,
             action_id=request.action_id,
             brief=_safe_dict(_safe_dict(artifact).get("brief")),
@@ -559,65 +571,151 @@ def apply_edit(
     request: ApplyEditRequest,
     staff_id: str = Depends(staff_user_id),
 ) -> JSONResponse:
-    """Write an accepted proposal into the draft.
+    """Write an accepted proposal into the draft, in one transaction.
 
-    A proposal read on one screen while another edit landed on the same section
-    is refused rather than applied over the top of it.
+    Everything that decides whether this edit may land happens inside that
+    transaction, against the markdown and history as they actually are: the
+    document revision, the section hash, the refusal invariant, and the write
+    of both the article and its history. The route used to read, check, write
+    the article and then write the history -- four steps with no lock, so two
+    tabs editing different sections of the same draft each passed their own
+    section's hash and the second write discarded the first edit.
     """
+    proposal = request.proposal
+    if proposal.run_id and proposal.run_id != run_id:
+        # A proposal names the run it was written for. Applying it to another
+        # one would land prose written against a different article's evidence
+        # on whatever section happens to share its id.
+        raise HTTPException(
+            status_code=400,
+            detail="This proposal was written for a different run.",
+        )
     output = _finished_run(run_id)
     artifact = _safe_dict(_safe_dict(output["artifact"]).get("pipeline_v3"))
-    result = apply_proposal(
-        content=output["markdown"],
-        proposal=request.proposal,
-        history=_edit_history(run_id),
-        editor=staff_id or "",
-        now=_now_iso(),
-        reason=request.reason,
-        # So a correction that only ever happens on one kind of piece cannot
-        # later be read as a rule about all of them (improvement 05).
-        form_id=_safe_str(_safe_dict(artifact.get("brief")).get("form_id")),
-    )
-    if not result.applied:
-        # The reason, not a guess at it. Staleness was the only refusal this
-        # route knew about, so a proposal refused for saying it could not make
-        # the change was reported as a draft that had moved -- which sends an
-        # editor to re-read a section nothing has touched.
-        reason = result.rejected[0]["reason"] if result.rejected else ""
-        raise HTTPException(
-            status_code=409,
-            detail=(
+    form_id = _safe_str(_safe_dict(artifact.get("brief")).get("form_id"))
+
+    def edit(markdown: str, history: EditHistory) -> tuple[str, EditHistory]:
+        result = apply_proposal(
+            content=markdown,
+            proposal=proposal,
+            history=history,
+            editor=staff_id or "",
+            now=_now_iso(),
+            reason=request.reason,
+            # So a correction that only ever happens on one kind of piece
+            # cannot later be read as a rule about all of them (improvement
+            # 05).
+            form_id=form_id,
+        )
+        if not result.applied:
+            # The reason, not a guess at it. Staleness was the only refusal
+            # this route knew about, so a proposal refused for saying it could
+            # not make the change was reported as a draft that had moved --
+            # which sends an editor to re-read a section nothing has touched.
+            reason = result.rejected[0]["reason"] if result.rejected else ""
+            raise EditRefused(
                 _APPLY_REFUSALS.get(reason)
                 or (
                     "That section has changed since this edit was proposed. "
                     "Read it again and ask for the change from where it is now."
                 )
+            )
+        return result.markdown, result.history
+
+    try:
+        committed = commit_article_edit(
+            run_id=run_id,
+            expected_revision=(
+                proposal.base_revision if proposal.base_revision >= 0 else None
             ),
+            edit=edit,
+            edit_id=proposal.edit_id,
         )
-    _save_article(run_id, output, result.markdown)
-    RunRecorder().record_stage(
-        run_id, SECTION_EDIT_STAGE, result.history.model_dump(mode="json")
+    except ArticleMissing as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RevisionConflict as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "The article has changed since this edit was proposed -- "
+                "another edit landed, or the run was re-finalised. Re-read it "
+                "and ask again from where it is now."
+            ),
+        ) from exc
+    except EditRefused as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return JSONResponse(
+        {
+            "markdown": committed.markdown,
+            "edits": len(committed.history.edits),
+            "revision": committed.revision,
+            # So a repeated click is reported as the edit it already is,
+            # rather than as a second one.
+            "already_applied": committed.already_applied,
+        }
     )
-    return JSONResponse({"markdown": result.markdown, "edits": len(result.history.edits)})
 
 
 @router.post("/section-edit/{run_id}/undo", dependencies=[Depends(require_staff)])
-def undo_edit(run_id: str) -> JSONResponse:
-    """Put the draft back to what it was before the last applied edit."""
-    output = _finished_run(run_id)
-    undone = undo_last(_edit_history(run_id))
-    if undone is None:
-        # Not an error. Pressing undo on an unedited draft is a question with
-        # a plain answer.
-        return JSONResponse(
-            {"markdown": output["markdown"], "edits": 0, "undone": False}
+def undo_edit(
+    run_id: str, request: UndoEditRequest | None = None
+) -> JSONResponse:
+    """Put the draft back to what it was before the last applied edit.
+
+    Guarded by the same revision check as an apply, because it is the same
+    kind of write. Pressed on a screen showing revision 10 while a colleague
+    saved revision 11, an unguarded undo restores the markdown from before
+    *this tab's* last edit and erases theirs on the way past.
+
+    The restore is a new revision, not a return to an old one. Nothing is
+    rewound; the article moves forward to prose it held before.
+    """
+    base_revision = request.base_revision if request else -1
+
+    def edit(_markdown: str, history: EditHistory) -> tuple[str, EditHistory]:
+        undone = undo_last(history)
+        if undone is None:
+            # Not an error. Pressing undo on an unedited draft is a question
+            # with a plain answer.
+            raise EditRefused("")
+        return undone
+
+    try:
+        committed = commit_article_edit(
+            run_id=run_id,
+            expected_revision=base_revision if base_revision >= 0 else None,
+            edit=edit,
         )
-    markdown, history = undone
-    _save_article(run_id, output, markdown)
-    RunRecorder().record_stage(
-        run_id, SECTION_EDIT_STAGE, history.model_dump(mode="json")
-    )
+    except ArticleMissing as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RevisionConflict as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "The article has changed since this screen read it. Re-read "
+                "it before undoing, so an undo does not take back somebody "
+                "else's edit."
+            ),
+        ) from exc
+    except EditRefused:
+        state = read_article(run_id)
+        return JSONResponse(
+            {
+                "markdown": state.markdown,
+                "edits": 0,
+                "undone": False,
+                "revision": state.revision,
+            }
+        )
+
     return JSONResponse(
-        {"markdown": markdown, "edits": len(history.edits), "undone": True}
+        {
+            "markdown": committed.markdown,
+            "edits": len(committed.history.edits),
+            "undone": True,
+            "revision": committed.revision,
+        }
     )
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -713,19 +713,34 @@ def read_edit_spend(run_id: str) -> JSONResponse:
     ledger = _safe_dict(
         _safe_dict(read_stage_result(run_id, USAGE_LEDGER_STAGE)).get("data")
     )
-    pipeline_cost = _safe_dict(ledger.get("totals")).get("estimated_cost_usd")
+    # The ledger's own split: money that left an account, and the notional
+    # API-equivalent price of the calls that drew a flat subscription. Adding
+    # the two produces a number true of nothing, so they are added only to
+    # their own kind.
+    pipeline_cost = _safe_dict(ledger.get("cost"))
     editor_totals = spend.totals()
+    billed = pipeline_cost.get("billed_cost_usd")
+    subscription = pipeline_cost.get("subscription_cost_usd")
     return JSONResponse(
         {
             "run_id": run_id,
             "pipeline": ledger.get("totals") or {},
+            "pipeline_cost": pipeline_cost,
             "editor": editor_totals,
             "attempts": [item.model_dump(mode="json") for item in spend.attempts],
-            # Only when both halves are numbers. A combined total that quietly
-            # treats an unknown as zero is worse than no combined total.
-            "combined_cost_usd": (
-                round(float(pipeline_cost) + editor_totals["estimated_cost_usd"], 6)
-                if isinstance(pipeline_cost, (int, float))
+            # What this article has actually cost, pipeline plus editing.
+            "combined_billed_cost_usd": (
+                round(float(billed) + editor_totals["billed_cost_usd"], 6)
+                if isinstance(billed, (int, float))
+                else None
+            ),
+            # What the subscription calls would have cost on the API. Real
+            # tokens, notional money, never added to the line above.
+            "combined_subscription_cost_usd": (
+                round(
+                    float(subscription) + editor_totals["subscription_cost_usd"], 6
+                )
+                if isinstance(subscription, (int, float))
                 else None
             ),
         }

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -6,6 +6,7 @@ handed the loop to one request and froze the whole server while it ran, which
 is what made a research pass look like an outage.
 """
 
+import logging
 from contextlib import nullcontext
 from typing import Any, Literal
 from uuid import uuid4
@@ -45,6 +46,7 @@ from ..article_edits import (
     read_article,
 )
 from ..config import FEATURE_NAME
+from ..edit_review import SUPPORTED, binding_failure, review_section_edit
 from ..pricing import Prompt2BlogTokenUsageTracker
 from ..run_recorder import USAGE_LEDGER_STAGE
 from ..editor_spend import (
@@ -98,6 +100,9 @@ from ..selection_v4 import selection_from_flags
 from ..support import _clean_string_list, _safe_dict, _safe_str
 
 router = APIRouter()
+
+
+logger = logging.getLogger(__name__)
 
 # One sentence per refusal, written for the operator rather than the log. Every
 # key is a `ResumePlan.reason`; a reason with no entry falls back to the generic
@@ -458,6 +463,14 @@ class ApplyEditRequest(BaseModel):
 
     proposal: EditProposal
     reason: str = ""
+    # A person saying "I have read what the checker said and I want this
+    # anyway". Required for anything the checker did not pass, including an
+    # edit it never managed to read, and recorded on the edit itself.
+    #
+    # Not a way around the check. The findings are shown first, the decision is
+    # a separate press, and the history afterwards says which claims were
+    # accepted over.
+    accept_findings: bool = False
 
 
 class UndoEditRequest(BaseModel):
@@ -618,6 +631,56 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
             outcome="refused" if proposal.could_not_do else "proposed",
         ),
     )
+
+    if proposal.changed:
+        # A second call, and it is worth saying why rather than letting it look
+        # like an oversight. The cheap check compares sets of figures, so
+        # swapping two prices the packet already holds is invisible to it: every
+        # number is present and both claims are false. Nothing short of reading
+        # what the sentence asserts catches that.
+        #
+        # Only on a proposal that changed something. A refusal and a no-op have
+        # no new prose to judge, and paying to be told that unchanged text is
+        # still grounded is paying for nothing.
+        review_attempt_id = uuid4().hex
+        review_tracker = Prompt2BlogTokenUsageTracker(run_id=run_id)
+        review_llm = DefaultPrompt2BlogLLM(
+            usage_tracker=review_tracker, run_id=run_id
+        )
+        try:
+            proposal = proposal.model_copy(
+                update={
+                    "review": review_section_edit(
+                        llm=review_llm,
+                        run_id=run_id,
+                        section_id=request.section_id,
+                        content=output["markdown"],
+                        original=proposal.original,
+                        candidate=proposal.revised,
+                        packet=packet,
+                        base_revision=proposal.base_revision,
+                    )
+                }
+            )
+            review_outcome = proposal.review.status
+        except Exception as exc:  # noqa: BLE001 -- degrades, never blocks
+            # A checker outage does not cost an editor the proposal they have
+            # already paid for. It comes back unreviewed, which the apply
+            # treats as a decision for a person rather than as a pass.
+            logger.warning("Prompt2Blog edit review failed: %s", exc)
+            review_outcome = "failed"
+        record_editor_attempt(
+            run_id,
+            attempt_from_tracker(
+                review_tracker,
+                attempt_id=review_attempt_id,
+                kind="review",
+                section_id=request.section_id,
+                action_id=request.action_id,
+                outcome=review_outcome,
+            ),
+        )
+
     return JSONResponse(proposal.model_dump(mode="json"))
 
 
@@ -684,6 +747,70 @@ def apply_edit(
     artifact = _safe_dict(_safe_dict(output["artifact"]).get("pipeline_v3"))
     form_id = _safe_str(_safe_dict(artifact.get("brief")).get("form_id"))
 
+    # Whether the review attached to this proposal is a review *of this
+    # proposal*. It was generated on the server, travelled to a browser as
+    # JSON, and came back in a request body -- so the object being trusted is
+    # one the client had every opportunity to rewrite, and a verdict that says
+    # a candidate is grounded says it about the candidate it read.
+    try:
+        packet = frozen_packet(run_id)
+    except PacketNotStored:
+        # An older run with no stored packet cannot have its edits reviewed at
+        # all. That is a decision for a person, which is what an unverified
+        # review already becomes below.
+        packet = {}
+    unverified = binding_failure(
+        proposal.review,
+        run_id=run_id,
+        section_id=proposal.section_id,
+        candidate=proposal.revised,
+        packet=packet,
+    )
+    review_status = (
+        proposal.review.status
+        if proposal.review is not None and not unverified
+        else "unchecked"
+    )
+    findings = (
+        [
+            claim["claim"]
+            for claim in proposal.review.unsupported_claims
+            if claim.get("claim")
+        ]
+        if proposal.review is not None and not unverified
+        else []
+    )
+    # Only for an edit that could actually land. A refusal and a no-op are
+    # rejected below on their own terms, and reporting one of those as "the
+    # checker did not pass it" would explain the wrong thing.
+    reviewable = proposal.changed and not proposal.could_not_do
+    if reviewable and review_status != SUPPORTED and not request.accept_findings:
+        # Advisory, not a gate on the article: the existing draft is untouched
+        # and still saveable. What is refused is landing prose a checker did
+        # not pass without a person saying they read that and want it anyway.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": (
+                    "The checker did not pass this edit. Read the findings, "
+                    "then apply again with `accept_findings` if you want it "
+                    "anyway."
+                ),
+                "review_status": review_status,
+                "binding_failure": unverified,
+                "unsupported_claims": (
+                    proposal.review.unsupported_claims
+                    if proposal.review is not None and not unverified
+                    else []
+                ),
+                "assessment": (
+                    proposal.review.assessment
+                    if proposal.review is not None and not unverified
+                    else ""
+                ),
+            },
+        )
+
     def edit(markdown: str, history: EditHistory) -> tuple[str, EditHistory]:
         result = apply_proposal(
             content=markdown,
@@ -696,6 +823,11 @@ def apply_edit(
             # cannot later be read as a rule about all of them (improvement
             # 05).
             form_id=form_id,
+            review_status=review_status,
+            # Only when a person actually overrode something. An empty list on
+            # a passed edit and an empty list on an accepted one would be the
+            # same row.
+            accepted_despite=findings if review_status != SUPPORTED else [],
         )
         if not result.applied:
             # The reason, not a guess at it. Staleness was the only refusal
@@ -740,6 +872,7 @@ def apply_edit(
             "markdown": committed.markdown,
             "edits": len(committed.history.edits),
             "revision": committed.revision,
+            "review_status": review_status,
             # So a repeated click is reported as the edit it already is,
             # rather than as a second one.
             "already_applied": committed.already_applied,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -68,6 +68,7 @@ from ..models import PipelineV4RuntimeRequest
 from ..options import default_target_word_count
 from ..orchestrator_v3 import resume_pipeline_v3, run_pipeline_v3
 from ..provenance import (
+    invalidated_confirmation_count,
     Confirmation,
     ConfirmationRecord,
     PacketNotStored,
@@ -383,11 +384,21 @@ def get_provenance(run_id: str) -> JSONResponse:
     # here rather than shown as stale. A confirmation beside changed prose is
     # worse than none: it is the one thing on the screen that says a person
     # checked.
-    live = prune_confirmations(stored_confirmations(run_id), markdown)
+    stored = stored_confirmations(run_id)
+    live = prune_confirmations(stored, markdown)
     report = build_provenance(
         run_id, markdown, packet, live.model_dump(mode="json")
     )
-    return JSONResponse(report.model_dump(mode="json"))
+    payload = report.model_dump(mode="json")
+    # Dropping a confirmation whose passage changed is right. Dropping it in
+    # silence is not: somebody read that passage against its source and said
+    # so, and an edit throws that away. The count says how much checking needs
+    # doing again. The stored records are only filtered on read, so an undo
+    # brings them back.
+    payload["summary"]["invalidated_confirmations"] = invalidated_confirmation_count(
+        stored, markdown
+    )
+    return JSONResponse(payload)
 
 
 @router.post("/provenance/{run_id}/confirm", dependencies=[Depends(require_staff)])

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -472,6 +472,23 @@ def _edit_history(run_id: str) -> EditHistory:
     return EditHistory.model_validate(stored) if stored else EditHistory()
 
 
+# What each refusal means to the person who pressed the button. Keyed on the
+# reason the apply returned, so a refusal nobody wrote a sentence for still
+# falls through to the staleness message rather than to a blank one.
+_APPLY_REFUSALS = {
+    "this proposal says it could not make the change and changes the text as "
+    "well": (
+        "This proposal says it could not make the change, and offers changed "
+        "text anyway. That is not an edit anyone asked for. Ask again, or ask "
+        "for something the evidence supports."
+    ),
+    "this proposal does not change the section": (
+        "This proposal leaves the section exactly as it is, so there is "
+        "nothing to apply."
+    ),
+}
+
+
 def _save_article(run_id: str, output: dict[str, Any], markdown: str) -> None:
     """Rewrite the article, leaving the pipeline's own record of it alone.
 
@@ -561,11 +578,19 @@ def apply_edit(
         form_id=_safe_str(_safe_dict(artifact.get("brief")).get("form_id")),
     )
     if not result.applied:
+        # The reason, not a guess at it. Staleness was the only refusal this
+        # route knew about, so a proposal refused for saying it could not make
+        # the change was reported as a draft that had moved -- which sends an
+        # editor to re-read a section nothing has touched.
+        reason = result.rejected[0]["reason"] if result.rejected else ""
         raise HTTPException(
             status_code=409,
             detail=(
-                "That section has changed since this edit was proposed. "
-                "Read it again and ask for the change from where it is now."
+                _APPLY_REFUSALS.get(reason)
+                or (
+                    "That section has changed since this edit was proposed. "
+                    "Read it again and ask for the change from where it is now."
+                )
             ),
         )
     _save_article(run_id, output, result.markdown)

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -47,6 +47,7 @@ from ..article_edits import (
 )
 from ..config import FEATURE_NAME
 from ..edit_review import SUPPORTED, binding_failure, review_section_edit
+from ..factual_changes import factual_changes
 from ..pricing import Prompt2BlogTokenUsageTracker
 from ..run_recorder import USAGE_LEDGER_STAGE
 from ..editor_spend import (
@@ -681,7 +682,20 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
             ),
         )
 
-    return JSONResponse(proposal.model_dump(mode="json"))
+    payload = proposal.model_dump(mode="json")
+    if proposal.changed:
+        # What changed factually, beside the text diff. Costs no call: the
+        # exact half is computed from the two strings, and the reading half is
+        # the review that was already made. Bound to the same candidate, so an
+        # operator cannot read a panel for one piece of prose and apply
+        # another.
+        payload["factual_changes"] = factual_changes(
+            original=proposal.original,
+            candidate=proposal.revised,
+            review=proposal.review,
+            base_revision=proposal.base_revision,
+        ).as_dict()
+    return JSONResponse(payload)
 
 
 @router.get("/section-edit/{run_id}/spend", dependencies=[Depends(require_staff)])

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/api/runs.py
@@ -45,6 +45,14 @@ from ..article_edits import (
     read_article,
 )
 from ..config import FEATURE_NAME
+from ..pricing import Prompt2BlogTokenUsageTracker
+from ..run_recorder import USAGE_LEDGER_STAGE
+from ..editor_spend import (
+    EditorAttempt,
+    attempt_from_tracker,
+    read_editor_spend,
+    record_editor_attempt,
+)
 from ..contracts_v4 import Prompt2BlogV4Request
 from ..drafts_view import build_drafts_report, render_drafts_page
 from ..intake_v3 import (
@@ -85,7 +93,7 @@ from ..section_edit_v4 import (
     undo_last,
 )
 from ..run_recorder import RunRecorder
-from ..dependencies import dependencies_for_run
+from ..dependencies import DefaultPrompt2BlogLLM, PipelineDependencies
 from ..selection_v4 import selection_from_flags
 from ..support import _clean_string_list, _safe_dict, _safe_str
 
@@ -533,6 +541,10 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
 
     This is the one route here that spends money -- one model call per request
     -- and it spends it on a section rather than an article.
+
+    Every attempt is recorded, whatever it produced. Five proposals an editor
+    read and threw away cost exactly as much as five they kept, and this route
+    used to leave no trace of any of them on the article's receipt.
     """
     output = _finished_run(run_id)
     try:
@@ -541,6 +553,18 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     artifact = _safe_dict(output["artifact"]).get("pipeline_v3") or {}
+    attempt_id = uuid4().hex
+    # Deliberately not `dependencies_for_run`, which restores the run's whole
+    # ledger. The tracker here should hold this one call and nothing else, so
+    # what is written afterwards cannot be an earlier leg's rows appearing
+    # again under a new id.
+    dependencies = PipelineDependencies(
+        llm=DefaultPrompt2BlogLLM(
+            usage_tracker=Prompt2BlogTokenUsageTracker(run_id=run_id),
+            run_id=run_id,
+        )
+    )
+    tracker = dependencies.llm.usage_tracker
     try:
         proposal = propose_section_edit(
             run_id=run_id,
@@ -552,7 +576,7 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
             action_id=request.action_id,
             brief=_safe_dict(_safe_dict(artifact).get("brief")),
             packet=packet,
-            dependencies=dependencies_for_run(run_id),
+            dependencies=dependencies,
             # The plan, for the section purposes the memory reads off it. A run
             # whose outline was rejected has none, and the memory then rests on
             # the excerpts alone rather than refusing.
@@ -561,8 +585,74 @@ def propose_edit(run_id: str, request: SectionEditRequest) -> JSONResponse:
             ).get("outline"),
         )
     except ValueError as exc:
+        # A bad section or action id, caught before the call. Nothing was
+        # spent, so nothing is recorded.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 -- recorded, then re-raised
+        # A call that failed after the provider had already charged for it is
+        # the case worth being careful about. Whatever the tracker got hold of
+        # is written; a tracker holding nothing is recorded as unmeasured
+        # rather than as zero.
+        record_editor_attempt(
+            run_id,
+            attempt_from_tracker(
+                tracker,
+                attempt_id=attempt_id,
+                kind="propose",
+                section_id=request.section_id,
+                action_id=request.action_id,
+                outcome="failed",
+                error=str(exc),
+            ),
+        )
+        raise
+
+    record_editor_attempt(
+        run_id,
+        attempt_from_tracker(
+            tracker,
+            attempt_id=attempt_id,
+            kind="propose",
+            section_id=request.section_id,
+            action_id=request.action_id,
+            outcome="refused" if proposal.could_not_do else "proposed",
+        ),
+    )
     return JSONResponse(proposal.model_dump(mode="json"))
+
+
+@router.get("/section-edit/{run_id}/spend", dependencies=[Depends(require_staff)])
+def read_edit_spend(run_id: str) -> JSONResponse:
+    """What has been spent on this article since the pipeline finished.
+
+    Beside the pipeline's own total rather than merged into it. "What the
+    article cost to make" and "what has been spent on it since" are different
+    questions, and the combined figure is computed here from the two durable
+    records instead of being stored as a third one that can disagree with
+    both.
+    """
+    _finished_run(run_id)
+    spend = read_editor_spend(run_id)
+    ledger = _safe_dict(
+        _safe_dict(read_stage_result(run_id, USAGE_LEDGER_STAGE)).get("data")
+    )
+    pipeline_cost = _safe_dict(ledger.get("totals")).get("estimated_cost_usd")
+    editor_totals = spend.totals()
+    return JSONResponse(
+        {
+            "run_id": run_id,
+            "pipeline": ledger.get("totals") or {},
+            "editor": editor_totals,
+            "attempts": [item.model_dump(mode="json") for item in spend.attempts],
+            # Only when both halves are numbers. A combined total that quietly
+            # treats an unknown as zero is worse than no combined total.
+            "combined_cost_usd": (
+                round(float(pipeline_cost) + editor_totals["estimated_cost_usd"], 6)
+                if isinstance(pipeline_cost, (int, float))
+                else None
+            ),
+        }
+    )
 
 
 @router.post("/section-edit/{run_id}/apply", dependencies=[Depends(require_staff)])

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/article_edits.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/article_edits.py
@@ -1,0 +1,203 @@
+"""Applying an edit and recording it are one write, or they are neither.
+
+The route read the article, checked the proposal's section hash against it,
+wrote the new markdown, and then wrote the edit history. Four steps, no lock,
+two separate writes.
+
+Two tabs read revision 10. Each changes a different section. Each section hash
+passes, because each is checking a section the other did not touch. The second
+whole-document write is built from the markdown *it* read, so it discards the
+first edit -- and both edits are in the history, so nothing afterwards says an
+accepted change is missing from the article it was accepted into.
+
+The fix is a compare-and-swap on a revision number, inside one transaction that
+holds the write lock from the moment it reads. The model call happens outside
+it: a transaction held open across a network round trip is a lock held for as
+long as a provider feels like taking, and every other writer waits behind it.
+
+What this module does not do is decide whether an edit is any good. It is
+handed a function that turns the current markdown and history into the next
+ones, and that function is run *inside* the transaction against what is
+actually stored -- so the validation a caller does is validation of the
+document the write will land on, not of a copy read some seconds ago.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.database import transaction
+
+from .observability import _now_iso
+from .section_edit_v4 import SECTION_EDIT_STAGE, EditHistory
+from .support import _safe_dict
+
+
+class ArticleMissing(LookupError):
+    """This run has no stored article, so there is nothing to edit."""
+
+
+class RevisionConflict(RuntimeError):
+    """The article moved after this edit was proposed.
+
+    Carries both revisions so a caller can say what happened rather than
+    guessing at it: an edit refused because a colleague saved is a different
+    sentence from an edit refused because the run was resumed.
+    """
+
+    def __init__(self, expected: int, actual: int) -> None:
+        super().__init__(
+            f"This edit was written against revision {expected}; the article "
+            f"is now at revision {actual}."
+        )
+        self.expected = expected
+        self.actual = actual
+
+
+class EditRefused(RuntimeError):
+    """The edit was checked against the stored article and does not apply."""
+
+
+@dataclass(frozen=True)
+class ArticleState:
+    """The article, its history, and which version of it this is."""
+
+    run_id: str
+    markdown: str
+    revision: int
+    history: EditHistory
+
+
+@dataclass(frozen=True)
+class CommitResult:
+    markdown: str
+    revision: int
+    history: EditHistory
+    # True when this exact edit had already been applied and the transaction
+    # wrote nothing. The caller's answer is the same either way, which is the
+    # point: a double-click and a retried request are not two edits.
+    already_applied: bool = False
+
+
+def _read_history(conn: Any, run_id: str) -> EditHistory:
+    row = conn.execute(
+        "SELECT data FROM stages WHERE run_id = ? AND stage = ?",
+        (run_id, SECTION_EDIT_STAGE),
+    ).fetchone()
+    if not row:
+        return EditHistory()
+    stored = _safe_dict(_safe_dict(json.loads(row["data"])).get("data"))
+    return EditHistory.model_validate(stored) if stored else EditHistory()
+
+
+def read_article(run_id: str) -> ArticleState:
+    """The current article and history, read together.
+
+    Together rather than in two calls, so the revision a caller is told about
+    is the revision the history it is holding belongs to.
+    """
+    with transaction() as conn:
+        row = conn.execute(
+            "SELECT markdown, article_revision FROM outputs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if not row:
+            raise ArticleMissing(f"Run {run_id} has no stored article.")
+        return ArticleState(
+            run_id=run_id,
+            markdown=row["markdown"],
+            revision=row["article_revision"],
+            history=_read_history(conn, run_id),
+        )
+
+
+def commit_article_edit(
+    *,
+    run_id: str,
+    expected_revision: int | None,
+    edit: Callable[[str, EditHistory], tuple[str, EditHistory]],
+    edit_id: str = "",
+) -> CommitResult:
+    """Run `edit` against the stored article and write both halves at once.
+
+    `edit` is called inside the transaction, on the markdown and history as
+    they actually are. It returns the next pair or raises `EditRefused`; a
+    refusal rolls the transaction back, so a rejected edit leaves the article
+    exactly as it was rather than half-written.
+
+    `expected_revision` is the compare-and-swap. `None` skips the check, which
+    is for callers that genuinely do not care which version they land on --
+    there are none in the editor, and passing `None` from a route is a bug
+    rather than a shortcut.
+
+    `edit_id` makes a repeat harmless. A network retry or a second click sends
+    the same proposal twice, and the second one arrives against a revision the
+    first one advanced past -- which would be reported as a conflict and send
+    an editor to re-read prose that already says what they wanted. An id
+    already in the history returns the current state and writes nothing.
+    """
+    with transaction() as conn:
+        row = conn.execute(
+            "SELECT markdown, article_revision FROM outputs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if not row:
+            raise ArticleMissing(f"Run {run_id} has no stored article.")
+        markdown = row["markdown"]
+        revision = row["article_revision"]
+        history = _read_history(conn, run_id)
+
+        if edit_id and any(applied.edit_id == edit_id for applied in history.edits):
+            return CommitResult(
+                markdown=markdown,
+                revision=revision,
+                history=history,
+                already_applied=True,
+            )
+
+        if expected_revision is not None and expected_revision != revision:
+            raise RevisionConflict(expected_revision, revision)
+
+        next_markdown, next_history = edit(markdown, history)
+
+        # `WHERE article_revision = ?` as well as the read above. The read is
+        # already under the write lock, so this cannot fail -- and if the lock
+        # ever stops being held for the whole block, this is what turns that
+        # into a lost update refused instead of a lost update written.
+        updated = conn.execute(
+            "UPDATE outputs SET markdown = ?, article_revision = ? "
+            "WHERE run_id = ? AND article_revision = ?",
+            (next_markdown, revision + 1, run_id, revision),
+        )
+        if updated.rowcount != 1:
+            raise RevisionConflict(revision, revision)
+
+        conn.execute(
+            """
+            INSERT INTO stages (run_id, stage, data, created_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(run_id, stage) DO UPDATE SET
+                data = excluded.data,
+                created_at = excluded.created_at
+            """,
+            (
+                run_id,
+                SECTION_EDIT_STAGE,
+                json.dumps(
+                    {
+                        "created_at": _now_iso(),
+                        "data": next_history.model_dump(mode="json"),
+                    },
+                    default=str,
+                ),
+                _now_iso(),
+            ),
+        )
+        return CommitResult(
+            markdown=next_markdown,
+            revision=revision + 1,
+            history=next_history,
+        )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/sections.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/content/sections.py
@@ -11,6 +11,14 @@ The fix is not a firmer instruction. It is that untargeted prose is never
 regenerated at all: repair returns replacements for the sections it is
 changing, and the rest of the document is the original bytes.
 
+*The original bytes*, now literally. The first version of this module rebuilt
+the whole document from its parsed sections, so an untargeted section came
+back through `strip()` and a fresh `## ` line and lost whatever the author's
+formatting had put there -- the two trailing spaces that make a Markdown line
+break, an unusual blank line, the document's final newline. Sections carry the
+exact slice they were cut from, an edit splices into that slice, and every
+other byte in the document is the byte that was there before.
+
 Everything here is pure and deterministic. `split_markdown_sections` in
 `markdown.py` is unchanged and still keyed by heading -- it answers "did this
 move", where a collision between two identical headings is harmless. It is not
@@ -35,9 +43,60 @@ OPENING_SECTION_ID = "s0"
 # rule that drifted would put an edit in the wrong place.
 H2_LINE = re.compile(r"^##[ \t]+(.+?)[ \t]*$")
 
+# An H1 is not a section boundary here -- articles carry their title outside
+# the body -- but it is still document structure, and a replacement for one
+# paragraph has no business introducing one.
+H1_LINE = re.compile(r"^#[ \t]+")
+
+# ``` or ~~~ , with any info string. A heading-shaped line inside a fence is
+# sample text, not structure, and reading it as a section boundary would give
+# every section after it a shifted address.
+FENCE_LINE = re.compile(r"^[ \t]{0,3}(?P<mark>```+|~~~+)")
+
 
 def _hash(text: str) -> str:
     return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()[:12]
+
+
+def _as_text(value: Any) -> str:
+    """A string, unchanged.
+
+    `_safe_str` strips, which is right almost everywhere in this pipeline and
+    wrong at exactly the boundary this module defends: a document whose final
+    newline is removed on the way in cannot be handed back byte-for-byte on
+    the way out. Section identity is unaffected -- `text_hash` is taken over
+    the stripped heading and body either way.
+    """
+    return value if isinstance(value, str) else ""
+
+
+def _structural_lines(text: str) -> list[tuple[int, str]]:
+    """The heading lines in `text` that are document structure, with kinds.
+
+    One walker, used both to cut an article into sections and to refuse a
+    replacement that would change how it cuts. Two copies of this rule that
+    drifted apart would let a body through validation and then have it split
+    into a section.
+    """
+    found: list[tuple[int, str]] = []
+    fence = ""
+    for index, line in enumerate(_as_text(text).split("\n")):
+        opening = FENCE_LINE.match(line)
+        if opening:
+            mark = opening.group("mark")
+            if not fence:
+                fence = mark[0] * 3
+                continue
+            if mark[0] * 3 == fence:
+                fence = ""
+            continue
+        if fence:
+            continue
+        if H2_LINE.match(line):
+            found.append((index, "h2"))
+        elif H1_LINE.match(line):
+            found.append((index, "h1"))
+    return found
 
 
 @dataclass(frozen=True)
@@ -48,6 +107,12 @@ class ArticleSection:
     # Empty for the opening block, which has no heading of its own.
     heading: str
     body: str
+    # Where this section sits in the document it was cut from, and the exact
+    # bytes that were there. `raw` is what an untouched section is written
+    # back as; `start`/`end` are what an edited one is spliced into.
+    start: int = 0
+    end: int = 0
+    raw: str = ""
 
     @property
     def text_hash(self) -> str:
@@ -55,6 +120,11 @@ class ArticleSection:
 
         Over the body and the heading together: a pass that rewrote a heading
         against the previous draft is as stale as one that rewrote the prose.
+
+        Deliberately over the parsed heading and body rather than over `raw`,
+        so a hash taken before this module kept offsets still means the same
+        thing, and so trailing whitespace an editor cannot see does not make a
+        proposal stale.
         """
         return _hash(f"{self.heading}\n{self.body}")
 
@@ -77,33 +147,53 @@ def segment_article(content: str) -> list[ArticleSection]:
     The opening block is always present, even when empty, so a draft that
     begins straight on a heading still has somewhere to put an opening.
     """
-    heading = ""
-    body: list[str] = []
-    sections: list[ArticleSection] = []
+    text = _as_text(content)
+    lines = text.split("\n")
+    # Where each line starts in `text`. Built once so a section can be cut out
+    # of the original string rather than rebuilt from its lines.
+    offsets: list[int] = []
+    cursor = 0
+    for line in lines:
+        offsets.append(cursor)
+        cursor += len(line) + 1
 
-    def flush() -> None:
+    boundaries = [index for index, kind in _structural_lines(text) if kind == "h2"]
+    starts = [0, *(offsets[index] for index in boundaries)]
+    ends = [*starts[1:], len(text)]
+
+    sections: list[ArticleSection] = []
+    for position, (start, end) in enumerate(zip(starts, ends)):
+        raw = text[start:end]
+        if position == 0:
+            heading = ""
+            body = raw
+        else:
+            first, _, rest = raw.partition("\n")
+            match = H2_LINE.match(first)
+            heading = match.group(1).strip() if match else ""
+            body = rest
         sections.append(
             ArticleSection(
-                section_id=f"s{len(sections)}",
+                section_id=f"s{position}",
                 heading=heading,
-                body="\n".join(body).strip(),
+                body=body.strip(),
+                start=start,
+                end=end,
+                raw=raw,
             )
         )
-
-    for line in _safe_str(content).split("\n"):
-        match = H2_LINE.match(line)
-        if match:
-            flush()
-            heading = match.group(1).strip()
-            body = []
-            continue
-        body.append(line)
-    flush()
     return sections
 
 
 def render_article(sections: list[ArticleSection]) -> str:
-    """Reassemble a document from its sections."""
+    """Reassemble a document from its sections.
+
+    Normalising: every section comes back through `render()`, so the gaps
+    between them become one blank line and the document loses its trailing
+    whitespace. That is right for a document being built out of parts and
+    wrong for one being edited in place -- `apply_section_replacements` splices
+    instead, and does not call this.
+    """
     return "\n\n".join(
         rendered for section in sections if (rendered := section.render())
     ).strip()
@@ -165,6 +255,27 @@ class SectionEditResult:
         }
 
 
+def _structure_refusal(heading: str, body: str) -> str:
+    """Why this replacement may not be written, or an empty string.
+
+    A replacement changes what one section says. Changing how many sections
+    the document has is a different operation, and it is not one any caller
+    here is asking for -- so a body carrying its own `##` is refused rather
+    than quietly turned into two sections whose addresses shift everything
+    after them. H3 and fenced sample text are ordinary content and pass.
+    """
+    if "\n" in heading or "\r" in heading:
+        return "a heading cannot span lines"
+    if heading.lstrip().startswith("#"):
+        return "a heading cannot carry its own `#` marks"
+    kinds = {kind for _index, kind in _structural_lines(body)}
+    if "h2" in kinds:
+        return "the replacement body would open another `##` section"
+    if "h1" in kinds:
+        return "the replacement body would open an `#` heading"
+    return ""
+
+
 def apply_section_replacements(
     content: str,
     replacements: Any,
@@ -174,29 +285,42 @@ def apply_section_replacements(
     Every replacement is checked before anything is written:
 
     - the id must name a section this draft has;
-    - it may name it only once, so two edits cannot silently race for the same
-      paragraph;
-    - `text_hash` must match what is there now, so an edit written against an
-      older draft is refused rather than applied to prose it never read.
+    - it may name it only once -- and a repeated id refuses *every* edit for
+      that section, because a response that named the same paragraph twice
+      does not know what it wants there and applying the first half of that
+      confusion is not better than applying none of it;
+    - `text_hash` must be present and must match what is there now, so an edit
+      written against an older draft, or one written against no draft at all,
+      is refused rather than applied to prose it never read;
+    - the replacement must not change the document's structure.
 
     A refused replacement drops out and the others still apply. A response
     where nothing survives returns the original content unchanged, which is
     the honest outcome: the draft the run already has is still saveable, and
     keep-best is not handed a mangled document to score.
     """
-    sections = segment_article(content)
+    original = _as_text(content)
+    sections = segment_article(original)
     by_id = {section.section_id: index for index, section in enumerate(sections)}
 
     applied: list[str] = []
     rejected: list[dict[str, str]] = []
-    seen: set[str] = set()
 
     if not isinstance(replacements, list):
         return SectionEditResult(
-            content=_safe_str(content),
+            content=original,
             applied=[],
             rejected=[{"section_id": "", "reason": "sections is not a list"}],
         )
+
+    # Counted before anything is applied, so a duplicated id can refuse both
+    # of its edits rather than only the one that arrived second.
+    counts: dict[str, int] = {}
+    for raw in replacements:
+        section_id = _safe_str(_safe_dict(raw).get("section_id"))
+        counts[section_id] = counts.get(section_id, 0) + 1
+
+    pieces = [section.raw for section in sections]
 
     for raw in replacements:
         record = _safe_dict(raw)
@@ -209,17 +333,24 @@ def apply_section_replacements(
                 }
             )
             continue
-        if section_id in seen:
+        if counts[section_id] > 1:
             rejected.append(
                 {"section_id": section_id, "reason": "named more than once"}
             )
             continue
-        seen.add(section_id)
 
         index = by_id[section_id]
         current = sections[index]
         supplied_hash = _safe_str(record.get("text_hash"))
-        if supplied_hash and supplied_hash != current.text_hash:
+        if not supplied_hash:
+            # Absence used to be read as agreement: a replacement that carried
+            # no hash skipped the staleness check entirely, which is the check
+            # this whole module exists for.
+            rejected.append(
+                {"section_id": section_id, "reason": "no text_hash supplied"}
+            )
+            continue
+        if supplied_hash != current.text_hash:
             rejected.append(
                 {
                     "section_id": section_id,
@@ -255,15 +386,23 @@ def apply_section_replacements(
             )
             continue
 
-        sections[index] = ArticleSection(
+        refusal = _structure_refusal(heading, body)
+        if refusal:
+            rejected.append({"section_id": section_id, "reason": refusal})
+            continue
+
+        replaced = ArticleSection(
             section_id=section_id, heading=heading, body=body.strip()
-        )
+        ).render()
+        # The gap to the next section belongs to the slice being replaced, so
+        # it is carried over rather than re-invented. Replacing one paragraph
+        # must not close up the blank lines around it.
+        trailing = current.raw[len(current.raw.rstrip()) :]
+        pieces[index] = f"{replaced}{trailing}"
         applied.append(section_id)
 
     if not applied:
-        return SectionEditResult(
-            content=_safe_str(content), applied=[], rejected=rejected
-        )
+        return SectionEditResult(content=original, applied=[], rejected=rejected)
     return SectionEditResult(
-        content=render_article(sections), applied=applied, rejected=rejected
+        content="".join(pieces), applied=applied, rejected=rejected
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/edit_review.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/edit_review.py
@@ -1,0 +1,314 @@
+"""Whether an edit still says what the evidence says.
+
+The probe. Packet: "A costs $20. B costs $40." Proposal: "A costs $40. B costs
+$20." Every number in the proposal appears in the packet, both claims are
+wrong, and the check in front of an editor -- figures in the revision that are
+in neither the original nor the packet -- had nothing to report. It could not
+have: it compares sets of tokens, and the two sets are identical.
+
+The pipeline already had the answer to this. Groundedness reads the evidence
+records themselves and judges what the prose asserts against them, which is
+why an overstated date or a widened claim is visible to it. The post-writing
+editor could not reach that judgement without running a pipeline stage for its
+side effects, so it did without.
+
+So this asks the same question about a candidate section, and takes the answer
+through the same sanitiser -- an unreadable verdict is `unchecked`, never a
+pass.
+
+Three things it is careful about.
+
+**It reads the section in its article.** A sentence that is fine alone can be
+wrong where it sits, and a recommendation is only overstated relative to what
+the rest of the piece already said.
+
+**It is bound to what it looked at.** A review carries the run, the section,
+the exact candidate text, the article revision and the evidence identity.
+Applying prose the review did not read is refused, because a review that
+travels through a browser and comes back attached to different text is not
+evidence about that text.
+
+**It is advisory, and it does not pretend otherwise.** A finding does not block
+a draft; it makes a person decide, and the decision is recorded. `checked` and
+`status` keep "we looked and it holds up", "we looked and it does not" and "we
+did not manage to look" as three different answers, because collapsing the
+third into the first is how an unchecked article comes to wear the stamp of a
+checked one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .content.sections import segment_article
+from .grounding_service import check_grounding
+from .support import _safe_dict, _safe_str
+
+EDIT_REVIEW_SCHEMA_VERSION = 1
+
+SUPPORTED = "supported"
+UNSUPPORTED = "unsupported"
+UNCHECKED = "unchecked"
+
+
+P2B_EDIT_REVIEW_PROMPT = """\
+You are checking one edited section of an article against the exact records
+the article was written from. Judge what the new text asserts, not whether its
+numbers appear somewhere.
+
+Return strict JSON only:
+{{
+  "grounded": true or false,
+  "assessment": "one sentence",
+  "unsupported_claims": [
+    {{"claim": "the quoted assertion", "reason": "why", "severity": "high" or "low"}}
+  ]
+}}
+
+`grounded` is false only when at least one high-severity finding explains it.
+A finding with no `claim`, no `severity` of exactly "high" or "low", is not a
+finding.
+
+What counts as unsupported. A figure appearing in the records is not the same
+as the records supporting the sentence it is now in:
+
+- WRONG PAIRING. The records say A costs $20 and B costs $40; the text says A
+  costs $40. Both numbers are in the records; the claim is false. Check every
+  figure, date, place and duration against the thing it is attached to.
+- WIDENED SCOPE. A price for one operator stated as the price. A rule for one
+  nationality stated as the rule. A fact about one season stated year-round.
+- LOST TIME. A record that holds "as of March" restated as what is true now, or
+  a date dropped from a sentence that needed it.
+- DROPPED QUALIFICATION. A caveat, exception or condition in the record that
+  the text no longer carries. The caveat is what makes the fact true.
+- FLIPPED SENSE. A negation added or removed. "Do not" becoming "do", "rarely"
+  becoming "often", a warning becoming a recommendation.
+- OVERSTATED RECOMMENDATION. The text tells a reader to do something the
+  records do not support, or states a preference between options the records
+  do not distinguish.
+
+First-hand material is testimony with its own scope. "I waited 45 minutes" is
+supported as one person's experience on one occasion; the same sentence turned
+into "the wait is 45 minutes" is a general claim the records do not carry, and
+that is a high-severity finding.
+
+Do not report a difference in wording, length, tone or structure. This is not
+an edit review. Prose that says the same thing in fewer words is grounded.
+
+THE EVIDENCE RECORDS (the only support that exists):
+{records}
+
+FIRST-HAND MATERIAL, verbatim, with its own scope:
+{material}
+
+WHAT THE REST OF THE ARTICLE SAYS (context; a claim can be wrong only here):
+{context}
+
+THE SECTION AS IT WAS:
+{original}
+
+THE SECTION AS PROPOSED -- judge this:
+{candidate}
+"""
+
+
+class EditReview(BaseModel):
+    """A judgement about one candidate section, bound to what it judged."""
+
+    schema_version: int = EDIT_REVIEW_SCHEMA_VERSION
+    # Three answers, never two. `unchecked` is not a pass and is not a fail.
+    status: str = UNCHECKED
+    checked: bool = False
+    assessment: str = ""
+    unsupported_claims: list[dict[str, str]] = Field(default_factory=list)
+
+    # What this review looked at. Verified server-side before an edit carrying
+    # it is applied.
+    run_id: str = ""
+    section_id: str = ""
+    candidate_hash: str = ""
+    base_revision: int = -1
+    evidence_fingerprint: str = ""
+
+    @property
+    def high_severity(self) -> list[dict[str, str]]:
+        return [
+            claim
+            for claim in self.unsupported_claims
+            if claim.get("severity") == "high"
+        ]
+
+    @property
+    def blocks_without_a_decision(self) -> bool:
+        """True when a person has to say something before this edit lands.
+
+        Both of the answers that are not "we looked and it holds up". An
+        unchecked edit is not a failed one, and it is also not a checked one;
+        applying it is a choice somebody makes rather than a default.
+        """
+        return self.status != SUPPORTED
+
+
+def candidate_hash(text: str) -> str:
+    """Identity of the exact prose a review read.
+
+    Over the stripped text, because the whitespace an editor cannot see is not
+    what a review is about -- and because a hash that changed on a trailing
+    newline would refuse edits for no reason a person could act on.
+    """
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()[:16]
+
+
+def evidence_fingerprint(packet: dict[str, Any]) -> str:
+    """Which evidence this review was made against.
+
+    The packet's own fingerprints when it has them: they already identify the
+    evidence and the selection made from it, and two packets carrying the same
+    pair hold the same facts. A run frozen before those existed falls back to a
+    digest of the fact texts, which is weaker -- it cannot tell an operator's
+    note apart from a re-worded one -- and is still better than binding a
+    review to nothing.
+    """
+    record = _safe_dict(packet)
+    evidence = _safe_str(record.get("evidence_fingerprint"))
+    selection = _safe_str(record.get("selection_fingerprint"))
+    if evidence or selection:
+        return f"{evidence}:{selection}"
+    payload = [
+        _safe_str(_safe_dict(fact).get("text")) for fact in record.get("facts") or []
+    ] + [
+        _safe_str(_safe_dict(item).get("statement"))
+        for item in record.get("supplied_material") or []
+    ]
+    digest = hashlib.sha256(
+        json.dumps(sorted(payload), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"facts:{digest}"
+
+
+def _records_block(packet: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for fact in _safe_dict(packet).get("facts") or []:
+        record = _safe_dict(fact)
+        text = _safe_str(record.get("text"))
+        if not text:
+            continue
+        claim_id = _safe_str(record.get("claim_id"))
+        as_of = _safe_str(record.get("as_of"))
+        suffix = f" (as of {as_of})" if as_of else ""
+        lines.append(f"- [{claim_id or 'unnamed'}] {text}{suffix}")
+    for note in _safe_dict(packet).get("notes") or []:
+        text = _safe_str(_safe_dict(note).get("text"))
+        if text:
+            lines.append(f"- LIMIT: {text}")
+    return "\n".join(lines) or "No records were kept for this article."
+
+
+def _material_block(packet: dict[str, Any]) -> str:
+    lines = [
+        f"- {_safe_str(_safe_dict(item).get('statement'))}"
+        for item in _safe_dict(packet).get("supplied_material") or []
+        if _safe_str(_safe_dict(item).get("statement"))
+    ]
+    return "\n".join(lines) or "None supplied."
+
+
+def _context_block(content: str, section_id: str) -> str:
+    """The rest of the article, quoted, so a claim can be wrong in context."""
+    parts = [
+        section.render()
+        for section in segment_article(content)
+        if section.section_id != section_id and section.render()
+    ]
+    return "\n\n".join(parts) or "This article has no other sections."
+
+
+def review_section_edit(
+    *,
+    llm: Any,
+    run_id: str,
+    section_id: str,
+    content: str,
+    original: str,
+    candidate: str,
+    packet: dict[str, Any],
+    base_revision: int,
+    model_name: str | None = None,
+) -> EditReview:
+    """Judge a candidate section against the frozen packet, in its article.
+
+    The verdict comes back through the pipeline's sanitiser, so a malformed
+    answer is `unchecked` rather than a pass, and a provider outage degrades
+    instead of blocking the draft.
+    """
+    prompt = P2B_EDIT_REVIEW_PROMPT.format(
+        records=_records_block(packet),
+        material=_material_block(packet),
+        context=_context_block(content, section_id),
+        original=original,
+        candidate=candidate,
+    )
+    outcome = check_grounding(
+        llm=llm,
+        prompt=prompt,
+        job_id="p2b.edit_review",
+        model_name=model_name,
+    )
+    verdict = outcome.verdict
+    return EditReview(
+        status=str(verdict.get("status") or UNCHECKED),
+        checked=bool(verdict.get("checked")),
+        assessment=_safe_str(verdict.get("assessment")),
+        unsupported_claims=[
+            {
+                "claim": _safe_str(_safe_dict(item).get("claim")),
+                "reason": _safe_str(_safe_dict(item).get("reason")),
+                "severity": _safe_str(_safe_dict(item).get("severity")),
+            }
+            for item in verdict.get("unsupported_claims") or []
+        ],
+        run_id=run_id,
+        section_id=section_id,
+        candidate_hash=candidate_hash(candidate),
+        base_revision=base_revision,
+        evidence_fingerprint=evidence_fingerprint(packet),
+    )
+
+
+def binding_failure(
+    review: EditReview | None,
+    *,
+    run_id: str,
+    section_id: str,
+    candidate: str,
+    packet: dict[str, Any],
+) -> str:
+    """Why this review does not describe this edit, or an empty string.
+
+    Checked on the server, on the way in. A review is generated here, travels
+    to a browser as JSON, and comes back in a request body -- so the object
+    being trusted is one the client had every opportunity to rewrite, and the
+    review that says a candidate is grounded says it about the candidate it
+    read and nothing else.
+
+    The article revision is deliberately not checked here. That is the apply's
+    own compare-and-swap, which refuses a moved document with a message about
+    the document; refusing it a second time as a broken review would explain
+    the wrong thing.
+    """
+    if review is None:
+        return "this edit carries no review"
+    if review.run_id and review.run_id != run_id:
+        return "this review was made for a different run"
+    if review.section_id and review.section_id != section_id:
+        return "this review was made for a different section"
+    if review.candidate_hash != candidate_hash(candidate):
+        return "this review was made for different text"
+    expected = evidence_fingerprint(packet)
+    if review.evidence_fingerprint and review.evidence_fingerprint != expected:
+        return "this review was made against different evidence"
+    return ""

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editor_spend.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editor_spend.py
@@ -32,7 +32,7 @@ from pydantic import BaseModel, Field
 from app.core.database import transaction
 
 from .observability import _now_iso
-from .pricing import TOKEN_KEYS
+from .pricing import COST_BASIS_MEASURED, COST_BASIS_RATE_TABLE, TOKEN_KEYS
 from .support import _safe_dict
 
 EDITOR_SPEND_STAGE = "stage_v4_editor_spend"
@@ -76,16 +76,28 @@ class EditorSpend(BaseModel):
     attempts: list[EditorAttempt] = Field(default_factory=list)
 
     def totals(self) -> dict[str, Any]:
-        """The sums, with the unmeasured calls counted rather than costed."""
+        """The sums, with the unmeasured calls counted rather than costed.
+
+        Money that left an account and money that did not are separate lines.
+        The section edit runs on Claude and the review on Gemini, so a single
+        cost here would add a real per-token charge to the notional price of a
+        call that drew a flat subscription -- the same mistake the run receipt
+        was making, on a smaller number.
+        """
         tokens = {key: 0 for key in TOKEN_KEYS}
-        cost = 0.0
+        billed = 0.0
+        subscription = 0.0
         priced = 0
         for attempt in self.attempts:
             for key in TOKEN_KEYS:
                 tokens[key] += int(attempt.usage.get(key) or 0)
-            if attempt.cost_usd is not None:
-                cost += float(attempt.cost_usd)
-                priced += 1
+            if attempt.cost_usd is None:
+                continue
+            priced += 1
+            if attempt.cost_basis == COST_BASIS_MEASURED:
+                subscription += float(attempt.cost_usd)
+            elif attempt.cost_basis == COST_BASIS_RATE_TABLE:
+                billed += float(attempt.cost_usd)
         return {
             **tokens,
             "attempts": len(self.attempts),
@@ -94,7 +106,8 @@ class EditorSpend(BaseModel):
             # reported no usage is not the same number as a total over four
             # that all did, and the difference has to be readable.
             "unmeasured_attempts": len(self.attempts) - priced,
-            "estimated_cost_usd": round(cost, 6),
+            "billed_cost_usd": round(billed, 6),
+            "subscription_cost_usd": round(subscription, 6),
         }
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editor_spend.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/editor_spend.py
@@ -1,0 +1,200 @@
+"""What the post-writing editor cost, kept separately and kept durably.
+
+`propose_edit` builds dependencies for the run, calls the model, and hands
+back a proposal. Nothing wrote the resulting usage anywhere: five proposals an
+editor read and threw away cost real money and left no trace on the article's
+receipt. External usage monitoring may still hold the calls, but the run's own
+account of what it cost did not.
+
+Two things make this its own record rather than more rows in the run's ledger.
+
+The ledger is written whole. Every rewrite replaces the stage row, and it is
+safe for the pipeline because the pipeline is one worker walking one graph.
+Two editors proposing at the same moment both restore a tracker from the same
+stored ledger, both append their own call, and both write -- and one of the
+two calls is gone. These are appended under their own ids inside a transaction
+instead, so a repeat is a no-op and a race is a merge.
+
+And they are a different kind of spending. The pipeline's ledger is what it
+cost to produce the article; this is what has been spent on it since. A single
+total that cannot say which is which is a number nobody can act on, so the
+total is computed from the two when someone asks rather than stored as a third
+thing that can disagree with both.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.core.database import transaction
+
+from .observability import _now_iso
+from .pricing import TOKEN_KEYS
+from .support import _safe_dict
+
+EDITOR_SPEND_STAGE = "stage_v4_editor_spend"
+EDITOR_SPEND_SCHEMA_VERSION = 1
+
+# What a call reported about its own cost. The distinction the whole record
+# exists to keep: a call whose usage nobody told us about is not a free call,
+# and recording it as zero is how a receipt comes to understate what was spent.
+MEASURED = "measured"
+UNKNOWN = "unknown"
+
+
+class EditorAttempt(BaseModel):
+    """One model call made on a finished article, and what came of it.
+
+    Every attempt is here, not only the ones whose proposal was kept. A
+    proposal an editor read and discarded is exactly as paid for as one they
+    applied, and a receipt that only counts the applied ones is a receipt that
+    gets cheaper the more carefully somebody edits.
+    """
+
+    attempt_id: str
+    kind: str = "propose"
+    section_id: str = ""
+    action_id: str = ""
+    at: str = ""
+    # "proposed" -- a change was offered.
+    # "refused"  -- the model answered that it could not do it.
+    # "failed"   -- the call did not come back.
+    outcome: str = "proposed"
+    model: str = ""
+    measurement: str = UNKNOWN
+    usage: dict[str, int] = Field(default_factory=dict)
+    cost_usd: float | None = None
+    cost_basis: str = ""
+    error: str = ""
+
+
+class EditorSpend(BaseModel):
+    schema_version: int = EDITOR_SPEND_SCHEMA_VERSION
+    attempts: list[EditorAttempt] = Field(default_factory=list)
+
+    def totals(self) -> dict[str, Any]:
+        """The sums, with the unmeasured calls counted rather than costed."""
+        tokens = {key: 0 for key in TOKEN_KEYS}
+        cost = 0.0
+        priced = 0
+        for attempt in self.attempts:
+            for key in TOKEN_KEYS:
+                tokens[key] += int(attempt.usage.get(key) or 0)
+            if attempt.cost_usd is not None:
+                cost += float(attempt.cost_usd)
+                priced += 1
+        return {
+            **tokens,
+            "attempts": len(self.attempts),
+            "priced_attempts": priced,
+            # Named rather than implied. A total over four calls of which one
+            # reported no usage is not the same number as a total over four
+            # that all did, and the difference has to be readable.
+            "unmeasured_attempts": len(self.attempts) - priced,
+            "estimated_cost_usd": round(cost, 6),
+        }
+
+
+def read_editor_spend(run_id: str) -> EditorSpend:
+    with transaction() as conn:
+        return _read(conn, run_id)
+
+
+def _read(conn: Any, run_id: str) -> EditorSpend:
+    row = conn.execute(
+        "SELECT data FROM stages WHERE run_id = ? AND stage = ?",
+        (run_id, EDITOR_SPEND_STAGE),
+    ).fetchone()
+    if not row:
+        return EditorSpend()
+    stored = _safe_dict(_safe_dict(json.loads(row["data"])).get("data"))
+    return EditorSpend.model_validate(stored) if stored else EditorSpend()
+
+
+def record_editor_attempt(run_id: str, attempt: EditorAttempt) -> EditorSpend:
+    """Append one attempt, inside the transaction that reads what is there.
+
+    Idempotent on `attempt_id`. A retried request that already got its call
+    recorded must not be charged for it twice, and the caller cannot tell from
+    the outside whether the first write landed.
+    """
+    with transaction() as conn:
+        spend = _read(conn, run_id)
+        if any(item.attempt_id == attempt.attempt_id for item in spend.attempts):
+            return spend
+        merged = EditorSpend(attempts=[*spend.attempts, attempt])
+        conn.execute(
+            """
+            INSERT INTO stages (run_id, stage, data, created_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(run_id, stage) DO UPDATE SET
+                data = excluded.data,
+                created_at = excluded.created_at
+            """,
+            (
+                run_id,
+                EDITOR_SPEND_STAGE,
+                json.dumps(
+                    {
+                        "created_at": _now_iso(),
+                        "data": merged.model_dump(mode="json"),
+                    },
+                    default=str,
+                ),
+                _now_iso(),
+            ),
+        )
+        return merged
+
+
+def attempt_from_tracker(
+    tracker: Any,
+    *,
+    attempt_id: str,
+    kind: str,
+    section_id: str,
+    action_id: str,
+    outcome: str,
+    error: str = "",
+) -> EditorAttempt:
+    """Read one call's usage off the tracker that made it.
+
+    The tracker is built fresh for this call, so whatever it holds is this
+    call and nothing else -- no restore, and therefore no chance of writing an
+    earlier leg's rows back out under a new id.
+
+    A tracker holding nothing means the provider told us nothing, which is
+    recorded as `unknown`. Recording it as zero would be inventing a cost, and
+    inventing zero is the direction that makes a receipt wrong quietly.
+    """
+    calls = list(getattr(tracker, "calls", None) or [])
+    if not calls:
+        return EditorAttempt(
+            attempt_id=attempt_id,
+            kind=kind,
+            section_id=section_id,
+            action_id=action_id,
+            at=_now_iso(),
+            outcome=outcome,
+            measurement=UNKNOWN,
+            error=error,
+        )
+    call = calls[-1]
+    metered = bool(call.get("metered"))
+    return EditorAttempt(
+        attempt_id=attempt_id,
+        kind=kind,
+        section_id=section_id,
+        action_id=action_id,
+        at=_now_iso(),
+        outcome=outcome,
+        model=str(call.get("model") or ""),
+        measurement=MEASURED if metered else UNKNOWN,
+        usage={key: int(call.get(key) or 0) for key in TOKEN_KEYS},
+        cost_usd=call.get("cost_usd") if metered else None,
+        cost_basis=str(call.get("cost_basis") or ""),
+        error=error,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/factual_changes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/factual_changes.py
@@ -1,0 +1,270 @@
+"""What changed factually between a section and its proposed replacement.
+
+A text diff answers "what words moved". An editor deciding whether to keep a
+proposal is asking something else: did a price get attached to a different
+thing, did a date fall out of a sentence that needed it, did a caveat go, did a
+recommendation get stronger than the evidence supports.
+
+Two kinds of answer, kept apart on purpose.
+
+**Text changes** are computed here, deterministically, from the two strings. A
+figure that is in one and not the other; a date that is gone; a qualifying
+phrase that is no longer there; a negation that appeared or vanished. These are
+exact and they are cheap, and they are labelled as what they are: differences
+in text. A regex noticing that "only" is missing has not reasoned about
+anything, and presenting it as though it had is how a panel becomes trusted for
+something it cannot do.
+
+**The review** is the reading. It is the checker's verdict from `edit_review`,
+which judges what the new text asserts against the records. It is the half that
+can say the prices were swapped, because that is invisible to any comparison of
+sets: every figure is present in both.
+
+Neither replaces the other. "Same numbers" must not mean "same facts", and
+"different numbers" must not mean "wrong". The panel shows both and says which
+is which.
+
+Bound, like the review, to the exact candidate and the article revision. An
+operator reading a panel for older text must not be able to apply newer text
+under it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .edit_review import EditReview, candidate_hash
+from .provenance import _figures
+
+# A month name, or a written date. Deliberately narrower than "anything with
+# digits in it": a bare year is already a figure, and counting it twice would
+# make a panel that repeats itself.
+_MONTHS = (
+    "january|february|march|april|may|june|july|august|september|october|"
+    "november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec"
+)
+# The day part refuses to eat the first two digits of a year: without the
+# lookahead, "March 2026" parses as the 20th of March and the year is lost.
+_DATE = re.compile(
+    rf"\b(?:{_MONTHS})\b(?:\s+\d{{1,2}}(?!\d))?(?:,?\s*(?:19|20)\d{{2}})?"
+    r"|\b\d{4}-\d{2}-\d{2}\b",
+    re.IGNORECASE,
+)
+
+# The phrases that limit a claim. Multi-word wherever a single word would fire
+# on ordinary prose: "only" alone appears in half the sentences ever written,
+# and a panel that reports it every time is a panel nobody reads.
+_QUALIFIERS = (
+    "as of",
+    "at the time of",
+    "in high season",
+    "in low season",
+    "high season only",
+    "low season only",
+    "seasonally",
+    "subject to",
+    "depending on",
+    "per person",
+    "per night",
+    "some operators",
+    "not all",
+    "except",
+    "unless",
+    "check before",
+    "may change",
+    "can change",
+    "roughly",
+    "approximately",
+    "about",
+    "up to",
+    "at least",
+)
+
+# A flip of sense. These are single words because a negation is a single word,
+# and losing one is exactly the change a reader would act on.
+_NEGATIONS = (
+    "not",
+    "never",
+    "no",
+    "cannot",
+    "can't",
+    "don't",
+    "do not",
+    "rarely",
+    "seldom",
+    "avoid",
+    "without",
+)
+
+
+@dataclass(frozen=True)
+class TextChange:
+    """One difference in text. Not a judgement about meaning."""
+
+    kind: str
+    text: str
+    note: str = ""
+
+    def as_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "text": self.text, "note": self.note}
+
+
+@dataclass(frozen=True)
+class FactualChanges:
+    """The panel: what the text says differently, and what a checker made of it."""
+
+    text_changes: list[TextChange] = field(default_factory=list)
+    review: EditReview | None = None
+    candidate_hash: str = ""
+    base_revision: int = -1
+
+    @property
+    def review_status(self) -> str:
+        return self.review.status if self.review is not None else "unchecked"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            # Named so the label travels with the data. A caller rendering
+            # this cannot accidentally present a regex match as reasoning.
+            "text_changes": [change.as_dict() for change in self.text_changes],
+            "text_changes_are": (
+                "exact differences between the two texts, not a judgement "
+                "about whether the change is wrong"
+            ),
+            "review": self.review.model_dump(mode="json") if self.review else None,
+            "review_status": self.review_status,
+            "candidate_hash": self.candidate_hash,
+            "base_revision": self.base_revision,
+        }
+
+
+def _normalised(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def _phrases_in(text: str, phrases: tuple[str, ...]) -> set[str]:
+    haystack = _normalised(text)
+    return {
+        phrase
+        for phrase in phrases
+        if re.search(rf"(?<!\w){re.escape(phrase)}(?!\w)", haystack)
+    }
+
+
+def _dates_in(text: str) -> set[str]:
+    return {" ".join(match.group(0).split()).casefold() for match in _DATE.finditer(text)}
+
+
+def _outside_dates(figures: set[str], dates: set[str]) -> set[str]:
+    return {
+        figure
+        for figure in figures
+        if not any(figure in date for date in dates)
+    }
+
+
+def text_changes(original: str, candidate: str) -> list[TextChange]:
+    """Every exact difference worth showing, and nothing else.
+
+    Set differences only. Prose that says the same thing in different words
+    produces no entries, which is the point: a panel that fires on every edit
+    teaches an editor to skip it, and then it is not there on the one that
+    mattered.
+    """
+    changes: list[TextChange] = []
+
+    before_dates = _dates_in(original)
+    after_dates = _dates_in(candidate)
+    # A year inside a date is reported as a date, not also as a figure. Both
+    # entries describe the same removal, and a panel that says the same thing
+    # twice is a panel that reads as noisier than the change was.
+    before_figures = _outside_dates(_figures(original), before_dates)
+    after_figures = _outside_dates(_figures(candidate), after_dates)
+    for figure in sorted(after_figures - before_figures):
+        changes.append(
+            TextChange(
+                kind="figure_added",
+                text=figure,
+                note="This figure is not in the section as it stands.",
+            )
+        )
+    for figure in sorted(before_figures - after_figures):
+        changes.append(
+            TextChange(
+                kind="figure_removed",
+                text=figure,
+                note="This figure is in the section now and not in the proposal.",
+            )
+        )
+
+    for date in sorted(before_dates - after_dates):
+        changes.append(
+            TextChange(
+                kind="date_removed",
+                text=date,
+                note="A date the section carries is gone from the proposal.",
+            )
+        )
+    for date in sorted(after_dates - before_dates):
+        changes.append(
+            TextChange(
+                kind="date_added",
+                text=date,
+                note="A date the section does not carry appears in the proposal.",
+            )
+        )
+
+    before_qualifiers = _phrases_in(original, _QUALIFIERS)
+    after_qualifiers = _phrases_in(candidate, _QUALIFIERS)
+    for phrase in sorted(before_qualifiers - after_qualifiers):
+        changes.append(
+            TextChange(
+                kind="qualification_removed",
+                text=phrase,
+                note="A phrase that limited a claim is no longer there.",
+            )
+        )
+
+    before_negations = _phrases_in(original, _NEGATIONS)
+    after_negations = _phrases_in(candidate, _NEGATIONS)
+    for phrase in sorted(before_negations - after_negations):
+        changes.append(
+            TextChange(
+                kind="negation_removed",
+                text=phrase,
+                note="A negation the section carries is gone from the proposal.",
+            )
+        )
+    for phrase in sorted(after_negations - before_negations):
+        changes.append(
+            TextChange(
+                kind="negation_added",
+                text=phrase,
+                note="A negation the section does not carry appears in the proposal.",
+            )
+        )
+
+    return changes
+
+
+def factual_changes(
+    *,
+    original: str,
+    candidate: str,
+    review: EditReview | None,
+    base_revision: int,
+) -> FactualChanges:
+    """The whole panel, bound to the exact candidate it describes.
+
+    No model call of its own. The reading half is the review that was already
+    made when the proposal was; adding a second permanent AI stage to explain
+    the first one would be paying twice to answer the same question.
+    """
+    return FactualChanges(
+        text_changes=text_changes(original, candidate),
+        review=review,
+        candidate_hash=candidate_hash(candidate),
+        base_revision=base_revision,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grounding_service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grounding_service.py
@@ -1,0 +1,196 @@
+"""The validated grounding check, separated from the stage that used to own it.
+
+The check lived inside `check_v3_groundedness`: the call, the one retry, the
+sanitiser that refuses an unreadable verdict, the degrade to `unchecked` -- all
+of it wound together with graph state, a trace writer and a recorder. The post-
+writing editor needed the same judgement and could not have it without running
+a pipeline stage for its side effects, so it got a regex over figures instead,
+and a probe that swapped two prices past it without a word.
+
+What comes out here is the part that is actually the check: given evidence and
+a piece of prose, a verdict or an honest `unchecked`. The attempts are returned
+rather than traced, so the stage keeps writing exactly the trace rows it wrote
+before and the editor writes none.
+
+The properties that made the pipeline's version trustworthy are properties of
+this function now, and both callers get them:
+
+- a malformed response is retried once with the contract it missed, and then
+  becomes `unchecked` -- never a pass;
+- a provider failure degrades, except for a fatal one, which is re-raised so a
+  dead account is not misreported as a checker outage;
+- `checked`, `grounded` and `status` are always distinguishable, so "we looked
+  and it holds up", "we looked and it does not" and "we did not manage to
+  look" are three answers rather than two.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.shared.provider_faults import is_fatal_provider_fault
+
+from .quality import (
+    GroundednessMalformed,
+    _sanitize_groundedness,
+    unchecked_groundedness,
+)
+from .schemas import GROUNDEDNESS_SCHEMA
+
+logger = logging.getLogger(__name__)
+
+# One retry, not a loop. A malformed verdict is usually a formatting slip the
+# same call gets right the second time; a checker that cannot answer the
+# contract twice is not going to answer it on the fifth attempt, and every
+# further attempt spends the repair budget on the stage that is not writing.
+GROUNDEDNESS_MALFORMED_ATTEMPTS = 2
+
+# Appended for the retry only. The first call is asked in the ordinary way; a
+# response that failed validation gets told which contract it missed, because
+# "return JSON" is what it already did.
+MALFORMED_RETRY_NOTE = """
+YOUR PREVIOUS RESPONSE WAS REJECTED:
+{reason}
+
+Return the object exactly as specified above. `grounded` must be a boolean,
+`assessment` must be a non-empty sentence, and every entry in
+`unsupported_claims` must carry `claim`, `reason`, and a `severity` of
+exactly "high" or "low". If nothing is unsupported, return an empty list and
+`grounded: true` -- never `grounded: false` with no claim explaining it."""
+
+
+@dataclass(frozen=True)
+class GroundingAttempt:
+    """One call, and what it was worth. The stage turns these into trace rows."""
+
+    attempt: int
+    prompt: str
+    raw_response: str = ""
+    parsed: Any = None
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class GroundingOutcome:
+    verdict: dict[str, Any]
+    raw_response: str = ""
+    rejected: list[str] = field(default_factory=list)
+    attempts: list[GroundingAttempt] = field(default_factory=list)
+
+    @property
+    def checked(self) -> bool:
+        return bool(self.verdict.get("checked"))
+
+    @property
+    def status(self) -> str:
+        """`supported`, `unsupported`, or `unchecked`. Never a bare boolean."""
+        return str(self.verdict.get("status") or "unchecked")
+
+
+def check_grounding(
+    *,
+    llm: Any,
+    prompt: str,
+    job_id: str,
+    model_name: str | None = None,
+    max_tokens: int = 2048,
+) -> GroundingOutcome:
+    """Ask a checker to judge prose against evidence, and read the answer.
+
+    `prompt` is built by the caller, because the two callers are asking about
+    different things: the pipeline about a whole draft against the run's
+    evidence records, the editor about one candidate section in its article
+    against the frozen packet. What must not differ is what happens to the
+    answer, and that is here.
+    """
+    base_prompt = prompt
+    raw_response = ""
+    rejected: list[str] = []
+    attempts: list[GroundingAttempt] = []
+
+    for attempt in range(1, GROUNDEDNESS_MALFORMED_ATTEMPTS + 1):
+        try:
+            parsed, raw_response = llm.invoke_json(
+                job_id=job_id,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=0.0,
+                model_name=model_name,
+                schema=GROUNDEDNESS_SCHEMA,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # A dead account is not a checker outage. Degrading here would
+            # record "the check did not run" -- which reads as a checker
+            # problem -- and then spend the next call on the same exhausted
+            # credential.
+            if is_fatal_provider_fault(exc):
+                raise
+            logger.warning("Prompt2Blog groundedness check failed: %s", exc)
+            attempts.append(
+                GroundingAttempt(attempt=attempt, prompt=prompt, error=str(exc))
+            )
+            return GroundingOutcome(
+                verdict=unchecked_groundedness(f"provider call failed: {exc}"),
+                raw_response=raw_response,
+                rejected=rejected,
+                attempts=attempts,
+            )
+
+        try:
+            verdict = _sanitize_groundedness(parsed)
+        except GroundednessMalformed as exc:
+            # Recorded, not swallowed. A run whose checker never produced a
+            # readable verdict should say so on its own receipt rather than
+            # arrive downstream looking like one nobody checked for no reason.
+            reason = str(exc)
+            rejected.append(reason)
+            logger.warning(
+                "Prompt2Blog groundedness response rejected (attempt %d): %s",
+                attempt,
+                reason,
+            )
+            attempts.append(
+                GroundingAttempt(
+                    attempt=attempt,
+                    prompt=prompt,
+                    raw_response=raw_response,
+                    parsed=parsed,
+                    error=f"malformed groundedness response: {reason}",
+                )
+            )
+            if attempt < GROUNDEDNESS_MALFORMED_ATTEMPTS:
+                prompt = base_prompt + MALFORMED_RETRY_NOTE.format(reason=reason)
+                continue
+            return GroundingOutcome(
+                verdict=unchecked_groundedness(
+                    f"checker returned an unreadable verdict ({'; '.join(rejected)})"
+                ),
+                raw_response=raw_response,
+                rejected=rejected,
+                attempts=attempts,
+            )
+
+        attempts.append(
+            GroundingAttempt(
+                attempt=attempt,
+                prompt=prompt,
+                raw_response=raw_response,
+                parsed=parsed,
+            )
+        )
+        return GroundingOutcome(
+            verdict=verdict,
+            raw_response=raw_response,
+            rejected=rejected,
+            attempts=attempts,
+        )
+
+    # Unreachable: every path in the loop returns. Here so a future edit that
+    # changes the loop cannot fall out of it holding nothing.
+    return GroundingOutcome(
+        verdict=unchecked_groundedness("the check did not run"),
+        rejected=rejected,
+        attempts=attempts,
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/pricing.py
@@ -203,6 +203,47 @@ class Prompt2BlogTokenUsageTracker:
             for key in STAGE_USAGE_KEYS
         }
 
+    def cost_split(self) -> dict[str, Any]:
+        """Money that left an account, and money that did not, kept apart.
+
+        A `rate-table` price is real spend: a Vertex call billed per token. A
+        `measured` price comes from the Claude Code CLI and is what the same
+        work would have cost at API rates -- those calls draw the plan holder's
+        flat allowance, so nobody is charged for them.
+
+        Adding the two produces a number that is true of nothing. On the two
+        runs measured for `run_billed_cost_usd`, chifa 3750891f was $0.36
+        billed beside $2.29 notional and ceviche 8a7e9aa4 $0.38 beside $1.97 --
+        so a single "estimated run cost" reported roughly seven times the money
+        that actually moved.
+
+        The budget breaker already reads the two apart. This is the same rule,
+        exposed to everything that reports a figure to a person rather than
+        recomputed by each of them.
+        """
+        billed = 0.0
+        subscription = 0.0
+        unpriced = 0
+        for entry in self.calls:
+            cost = entry.get("cost_usd")
+            if not isinstance(cost, (int, float)) or isinstance(cost, bool):
+                unpriced += 1
+                continue
+            if entry.get("cost_basis") == COST_BASIS_MEASURED:
+                subscription += float(cost)
+            elif entry.get("cost_basis") == COST_BASIS_RATE_TABLE:
+                billed += float(cost)
+            else:
+                unpriced += 1
+        return {
+            # What this run actually cost, in money.
+            "billed_cost_usd": round(billed, 6),
+            # What the subscription calls would have cost on the API. Real
+            # tokens, notional money -- never added to the line above.
+            "subscription_cost_usd": round(subscription, 6),
+            "unpriced_calls": unpriced,
+        }
+
     def begin_stage(self, stage: str) -> int:
         """Open a numbered attempt of `stage`; later calls are filed under it.
 
@@ -234,6 +275,7 @@ class Prompt2BlogTokenUsageTracker:
             "by_attempt": self._attempt_rows(),
             "by_stage": self._stage_rows(),
             "totals": self.totals(),
+            "cost": self.cost_split(),
             "successful_calls": self.successful_calls,
             "unmetered_calls": self.successful_calls - self.measured_calls,
         }
@@ -590,11 +632,16 @@ class Prompt2BlogTokenUsageTracker:
                 row["total_tokens"] for row in stage_rows
             ),
             "ledger_version": LEDGER_VERSION,
+            # Kept, and no longer the number a person is shown. It adds real
+            # per-token spend to the notional API-equivalent price of calls
+            # that drew a flat subscription, which is true of nothing -- see
+            # `cost_split`. The two figures beside it are the ones to read.
             "estimated_cost_usd": (
                 round(estimated_cost_usd, 6)
                 if self.measured_calls and fully_priced
                 else None
             ),
+            **self.cost_split(),
             "currency": "USD",
             "by_model": model_rows,
             "by_stage": stage_rows,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/prompts/editorial_v3.py
@@ -394,7 +394,9 @@ How editing works here:
   The opening block has no heading — leave `heading` empty for it.
 - You cannot add a section, delete one, or reorder them. That is a planning
   decision and this pass does not hold the plan. Change length inside the
-  sections that exist.
+  sections that exist. `content` may not contain a `##` or `#` line of its own
+  and `heading` may not span lines; an entry that does is discarded.
+- Only the sections under SECTIONS YOU MAY CHANGE are yours to change.
 - A revision that needs several sections moved together must return all of
   them. Do not fix half of a structural problem.
 
@@ -441,6 +443,12 @@ SECTIONS CONTAINING A FLAGGED CLAIM:
 
 SECTION MAP:
 {section_map}
+
+SECTIONS YOU MAY CHANGE:
+An entry for any other section is discarded and that section keeps its current
+text. This list is what the required revisions and the flagged claims actually
+point at; it is not a judgement about the rest of the draft.
+{editable_sections}
 
 PREVIOUS TITLE:
 {previous_title}

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/provenance.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/provenance.py
@@ -477,15 +477,33 @@ def prune_confirmations(
     than none, because it is the one thing on the screen that says somebody
     checked.
     """
+    return _partition_confirmations(confirmations, markdown)[0]
+
+
+def _partition_confirmations(
+    confirmations: dict[str, Any] | None, markdown: str
+) -> tuple[ConfirmationRecord, int]:
+    """The confirmations still standing, and how many an edit invalidated."""
     if not confirmations:
-        return ConfirmationRecord()
+        return ConfirmationRecord(), 0
     live = {passage.text_hash for passage in segment_passages(markdown)}
     record = ConfirmationRecord.model_validate(confirmations)
-    return ConfirmationRecord(
-        confirmations=[
-            item for item in record.confirmations if item.passage_hash in live
-        ]
-    )
+    kept = [item for item in record.confirmations if item.passage_hash in live]
+    return ConfirmationRecord(confirmations=kept), len(record.confirmations) - len(kept)
+
+
+def invalidated_confirmation_count(
+    confirmations: dict[str, Any] | None, markdown: str
+) -> int:
+    """How much checking an edit silently undid.
+
+    Dropping the confirmation is right; dropping it in silence is not. Somebody
+    read a passage against its source and said so, and an edit to that passage
+    throws that away -- so the count is surfaced and the operator is told the
+    work needs doing again. The records themselves are only filtered on read,
+    never deleted, so an undo brings them back.
+    """
+    return _partition_confirmations(confirmations, markdown)[1]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -40,6 +40,7 @@ from pydantic import BaseModel, Field
 from .article_memory import build_article_memory
 from .content.sections import ArticleSection, segment_article
 from .dependencies import PipelineDependencies
+from .edit_review import EditReview
 from .provenance import _figures
 from .support import _safe_dict, _safe_str
 
@@ -263,10 +264,18 @@ class EditProposal(BaseModel):
     what_changed: str = ""
     could_not_do: str = ""
     # Figures in the proposal that are in neither the original nor the packet.
-    # Deterministic, cheap, and the exact shape of the failure this invites: an
+    # Deterministic, cheap, and the exact shape of one failure this invites: an
     # editor asks for a stronger recommendation and gets a number that would
     # make one.
+    #
+    # A warning aid, and no longer the whole factual review. It compares sets
+    # of tokens, so swapping two prices the packet already contains is
+    # invisible to it -- which is what `review` is for.
     introduced_figures: list[str] = Field(default_factory=list)
+    # What a checker made of the candidate, read against the frozen packet in
+    # the article it sits in. `None` on a refusal or a no-op, where there is no
+    # new prose to judge.
+    review: EditReview | None = None
 
     @property
     def changed(self) -> bool:
@@ -411,6 +420,12 @@ class AppliedEdit(BaseModel):
     # Which form the article was, so a correction that only ever happens on one
     # kind of piece cannot be read as a rule about all of them.
     form_id: str = ""
+    # What the checker said about this text, and -- when it said something an
+    # editor went ahead anyway -- that they did. Recorded rather than implied:
+    # "nobody checked", "it checked out" and "it did not and we kept it" are
+    # three different things to find in a history six weeks later.
+    review_status: str = "unchecked"
+    accepted_despite: list[str] = Field(default_factory=list)
 
 
 class EditHistory(BaseModel):
@@ -442,6 +457,8 @@ def apply_proposal(
     now: str,
     reason: str = "",
     form_id: str = "",
+    review_status: str = "unchecked",
+    accepted_despite: list[str] | None = None,
 ) -> ApplyResult:
     """Write one accepted proposal into the draft, keeping what it replaced.
 
@@ -523,6 +540,8 @@ def apply_proposal(
                 after=proposal.revised,
                 reason=reason,
                 form_id=form_id,
+                review_status=review_status,
+                accepted_despite=list(accepted_despite or []),
             ),
         ],
     )

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -334,6 +334,18 @@ def propose_section_edit(
         # considered cut, and this pass may not delete a section in any case.
         revised = original
         could_not_do = could_not_do or "The edit came back empty, so nothing changed."
+    if could_not_do:
+        # A refusal and a replacement are different answers, and a response
+        # that gives both has not answered. The prompt asks for the original
+        # back verbatim alongside `could_not_do`; what came back on the probe
+        # was "Cannot support this" beside prose carrying a $999 nobody had
+        # ever seen, and the screen offered it as an ordinary proposal because
+        # the text differed from the original.
+        #
+        # Normalised here rather than shown with a warning. An advisory
+        # finding is something a person may knowingly accept; there is nothing
+        # to accept in a change the model has just said it could not make.
+        revised = original
 
     introduced = sorted(
         _figures(revised) - _figures(original) - _packet_figures(packet)
@@ -420,8 +432,46 @@ def apply_proposal(
     applied over the top of it. `apply_section_replacements` already enforces
     that, along with the rules that an edit may not empty a section and may not
     give the opening block a heading.
+
+    The refusal invariant is checked here too, not only where the proposal was
+    made. `propose_section_edit` normalises a refused answer back to the
+    original, but a proposal reaches this function as a request body: the
+    server that decided what a refusal means has to be the server that holds
+    the meaning, or a client can hand the same object back with the prose put
+    in again and have it accepted as an ordinary edit.
     """
     from .content.sections import apply_section_replacements
+
+    if proposal.could_not_do and proposal.changed:
+        return ApplyResult(
+            markdown=content,
+            history=history,
+            rejected=[
+                {
+                    "section_id": proposal.section_id,
+                    "reason": (
+                        "this proposal says it could not make the change and "
+                        "changes the text as well"
+                    ),
+                }
+            ],
+        )
+    if not proposal.changed:
+        # Not an error, and not history either. An accepted edit is a record
+        # of prose a person chose over other prose, and pattern learning reads
+        # that record: a no-op filed into it is a correction that never
+        # happened, counting towards the threshold that decides whether the
+        # voice file should change.
+        return ApplyResult(
+            markdown=content,
+            history=history,
+            rejected=[
+                {
+                    "section_id": proposal.section_id,
+                    "reason": "this proposal does not change the section",
+                }
+            ],
+        )
 
     result = apply_section_replacements(
         content,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -283,14 +283,35 @@ class EditProposal(BaseModel):
 
 
 def _packet_figures(packet: dict[str, Any]) -> set[str]:
-    text = " ".join(
-        _safe_str(_safe_dict(fact).get("text")) for fact in packet.get("facts") or []
-    )
-    material = " ".join(
-        _safe_str(_safe_dict(item).get("statement"))
-        for item in packet.get("supplied_material") or []
-    )
-    return _figures(f"{text} {material}")
+    """Every figure the model was shown, which is not the same as every fact.
+
+    This has to cover exactly what `_facts_block` puts in the prompt. It used
+    to read `text` and `statement` only, while the prompt also carries each
+    fact's as-of date, the operator's note on it, and the limit notes -- so a
+    model that correctly wrote "as of March 2026" had 2026 reported as a figure
+    it invented.
+
+    Found on the first live call this code ever made, against a brief whose
+    `fails_if` was "quotes a fare without saying when it was true". The model
+    did the right thing and the guard called it an invention. A warning that
+    fires on correct work is worse than no warning: it is the one an editor
+    learns to click past.
+    """
+    parts: list[str] = []
+    for fact in packet.get("facts") or []:
+        record = _safe_dict(fact)
+        parts.extend(
+            (
+                _safe_str(record.get("text")),
+                _safe_str(record.get("as_of")),
+                _safe_str(record.get("operator_note")),
+            )
+        )
+    for note in packet.get("notes") or []:
+        parts.append(_safe_str(_safe_dict(note).get("text")))
+    for item in packet.get("supplied_material") or []:
+        parts.append(_safe_str(_safe_dict(item).get("statement")))
+    return _figures(" ".join(part for part in parts if part))
 
 
 def find_section(content: str, section_id: str) -> ArticleSection | None:

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/section_edit_v4.py
@@ -31,6 +31,7 @@ person still has to press apply.
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -240,6 +241,17 @@ class EditProposal(BaseModel):
 
     schema_version: int = SECTION_EDIT_SCHEMA_VERSION
     run_id: str
+    # This proposal, once, forever. A double-click and a retried request send
+    # the same object twice; the second arrives against a revision the first
+    # advanced past, and without an id that reads as a conflict and sends an
+    # editor to re-read prose that already says what they wanted.
+    edit_id: str = ""
+    # Which version of the whole article this was read from. The section hash
+    # says the paragraph has not moved; this says the document has not, which
+    # is the difference between refusing an edit to prose that changed and
+    # refusing a write that would discard someone else's accepted edit
+    # elsewhere in the same draft.
+    base_revision: int = -1
     section_id: str
     heading: str = ""
     action_id: str
@@ -288,6 +300,7 @@ def propose_section_edit(
     brief: dict[str, Any],
     packet: dict[str, Any],
     dependencies: PipelineDependencies,
+    base_revision: int = -1,
     model_name: str | None = None,
     outline: dict[str, Any] | None = None,
 ) -> EditProposal:
@@ -352,6 +365,8 @@ def propose_section_edit(
     )
     return EditProposal(
         run_id=run_id,
+        edit_id=uuid.uuid4().hex,
+        base_revision=base_revision,
         section_id=section_id,
         heading=section.heading,
         action_id=action_id,
@@ -372,6 +387,9 @@ def propose_section_edit(
 class AppliedEdit(BaseModel):
     """One applied edit, and the whole draft as it was before it."""
 
+    # The proposal this came from, so a repeat of it can be recognised as the
+    # same edit rather than applied a second time.
+    edit_id: str = ""
     section_id: str
     action_id: str
     applied_at: str = ""
@@ -494,6 +512,7 @@ def apply_proposal(
         edits=[
             *history.edits,
             AppliedEdit(
+                edit_id=proposal.edit_id,
                 section_id=proposal.section_id,
                 action_id=proposal.action_id,
                 applied_at=now,

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/audit_repair.py
@@ -34,6 +34,11 @@ from ...content.sections import (
     segment_article,
 )
 from ...schemas import REPAIR_SECTIONS_SCHEMA
+from .repair_targets import (
+    resolve_repair_targets,
+    screen_against_targets,
+    targets_block,
+)
 from ...support import _format_style_directive, _json, _safe_dict, _safe_str
 
 
@@ -329,12 +334,25 @@ def run_v3_repair_stage(
     previous_content = rewrite["improved_content"]
     sections = segment_article(previous_content)
     flagged = locate_claims(sections, unsupported_claims)
+    # Worked out before the call, not after it. The claim-id screen refuses an
+    # edit resting on a fact this article was not written from; nothing refused
+    # an edit to a paragraph nobody complained about, so a pass asked to fix
+    # one section could rewrite the opening and be applied for it.
+    targets = resolve_repair_targets(
+        sections=sections,
+        required_revisions=required_revisions,
+        flagged=flagged,
+        article_wide=[length_revision] if length_revision else [],
+    )
 
     prompt = P2B_V3_REPAIR_PROMPT.format(
         required_revisions=_json(required_revisions),
         unsupported_claims=_json(unsupported_claims),
         flagged_sections=_json(flagged) if flagged else "None located by quote.",
         section_map=section_manifest(sections),
+        # The same list the screen enforces, so repair is not refused for
+        # doing what it was asked.
+        editable_sections=targets_block(targets, sections),
         previous_title=rewrite["improved_title"],
         previous_content=previous_content,
         facts=stage_context_text(state["stage_contexts"], "repair_facts")
@@ -364,11 +382,20 @@ def run_v3_repair_stage(
         parsed_dict.get("sections"),
         allowed_claim_ids=_packet_claim_ids(state),
     )
+    screened, scope_rejections = screen_against_targets(screened, targets)
     edit = apply_section_replacements(previous_content, screened)
     edit_report = {
         **edit.as_dict(),
-        "rejected": [*edit.as_dict()["rejected"], *cited_rejections],
+        "rejected": [
+            *edit.as_dict()["rejected"],
+            *cited_rejections,
+            *scope_rejections,
+        ],
         "section_count": len(sections),
+        # On the record whether or not anything was refused. A pass that was
+        # allowed the whole document because no revision could be located is
+        # not describable afterwards as a targeted one.
+        "targets": targets.as_dict(),
     }
 
     repaired = _sanitize_rewrite(

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/groundedness.py
@@ -1,44 +1,14 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
-
-from app.shared.provider_faults import is_fatal_provider_fault
 
 from ...dependencies import PipelineDependencies
 from ...graph.state import Prompt2BlogV3GraphState
+from ...grounding_service import check_grounding
 from ...instructions_v3 import EVIDENCE_DISPOSITION_POLICY
 from ...observability import _append_stage_trace
 from ...packet_v4 import supplied_material_text
 from ...prompts.editorial_v3 import P2B_V3_GROUNDEDNESS_PROMPT
-from ...quality import (
-    GroundednessMalformed,
-    _sanitize_groundedness,
-    unchecked_groundedness,
-)
-from ...schemas import GROUNDEDNESS_SCHEMA
-
-logger = logging.getLogger(__name__)
-
-# One retry, not a loop. A malformed verdict is usually a formatting slip the
-# same call gets right the second time; a checker that cannot answer the
-# contract twice is not going to answer it on the fifth attempt, and every
-# further attempt spends the repair budget on the stage that is not writing.
-GROUNDEDNESS_MALFORMED_ATTEMPTS = 2
-
-# Appended for the retry only. The first call is asked in the ordinary way; a
-# response that failed validation gets told which contract it missed, because
-# "return JSON" is what it already did.
-_MALFORMED_RETRY_NOTE = """
-YOUR PREVIOUS RESPONSE WAS REJECTED:
-{reason}
-
-Return the object exactly as specified above. `grounded` must be a boolean,
-`assessment` must be a non-empty sentence, and every entry in
-`unsupported_claims` must carry `claim`, `reason`, and a `severity` of
-exactly "high" or "low". If nothing is unsupported, return an empty list and
-`grounded: true` -- never `grounded: false` with no claim explaining it."""
-
 
 def check_v3_groundedness(
     state: Prompt2BlogV3GraphState,
@@ -58,104 +28,59 @@ def check_v3_groundedness(
     different desks: compose could legitimately use "I waited 45 minutes" from
     the brief, and the checker, seeing no record of it, could only call it
     invented -- after which repair is instructed to delete it.
+
+    The call, the one retry and the refusal of an unreadable verdict now live
+    in `grounding_service`, so the post-writing editor can have the same
+    judgement without running this stage for its side effects. What is left
+    here is the side effects: this stage's prompt, its trace rows, its stage
+    row.
     """
     run_id = state["run_id"]
-    base_prompt = P2B_V3_GROUNDEDNESS_PROMPT.format(
+    prompt = P2B_V3_GROUNDEDNESS_PROMPT.format(
         evidence_disposition_policy=EVIDENCE_DISPOSITION_POLICY,
         evidence_records=state["evidence"]["records_text"],
         supplied_material=supplied_material_text(state.get("packet")),
         rewritten_title=rewrite["improved_title"],
         rewritten_content=rewrite["improved_content"],
     )
-
     groundedness_model = state.get("groundedness_model")
-    prompt = base_prompt
-    raw_response = ""
-    rejected: list[str] = []
 
-    for attempt in range(1, GROUNDEDNESS_MALFORMED_ATTEMPTS + 1):
-        try:
-            parsed, raw_response = dependencies.llm.invoke_json(
-                job_id="p2b.groundedness",
-                prompt=prompt,
-                max_tokens=2048,
-                temperature=0.0,
-                model_name=groundedness_model,
-                schema=GROUNDEDNESS_SCHEMA,
-            )
-        except Exception as exc:  # noqa: BLE001
-            # A dead account is not a checker outage. Degrading here would
-            # record "the check did not run" -- which reads as a checker
-            # problem -- and then spend the next stage's call on the same
-            # exhausted credential.
-            if is_fatal_provider_fault(exc):
-                raise
-            logger.warning("Prompt2Blog v3 groundedness check failed: %s", exc)
-            groundedness = unchecked_groundedness(f"provider call failed: {exc}")
-            _append_stage_trace(
-                state["trace"],
-                state["include_debug"],
-                stage=stage,
-                model_name=groundedness_model,
-                prompt=prompt,
-                error=str(exc),
-                output=groundedness,
-            )
-            break
+    outcome = check_grounding(
+        llm=dependencies.llm,
+        prompt=prompt,
+        job_id="p2b.groundedness",
+        model_name=groundedness_model,
+    )
 
-        try:
-            groundedness = _sanitize_groundedness(parsed)
-        except GroundednessMalformed as exc:
-            # Recorded, not swallowed. A run whose checker never produced a
-            # readable verdict should say so on its own receipt rather than
-            # arrive at finalize looking like a run nobody checked for no
-            # reason.
-            reason = str(exc)
-            rejected.append(reason)
-            logger.warning(
-                "Prompt2Blog v3 groundedness response rejected (attempt %d): %s",
-                attempt,
-                reason,
-            )
-            _append_stage_trace(
-                state["trace"],
-                state["include_debug"],
-                stage=stage,
-                model_name=groundedness_model,
-                input_payload={"attempt": attempt},
-                prompt=prompt,
-                raw_response=raw_response,
-                parsed=parsed,
-                error=f"malformed groundedness response: {reason}",
-            )
-            if attempt < GROUNDEDNESS_MALFORMED_ATTEMPTS:
-                prompt = base_prompt + _MALFORMED_RETRY_NOTE.format(reason=reason)
-                continue
-            groundedness = unchecked_groundedness(
-                f"checker returned an unreadable verdict ({'; '.join(rejected)})"
-            )
-            break
-
+    for record in outcome.attempts:
         _append_stage_trace(
             state["trace"],
             state["include_debug"],
             stage=stage,
             model_name=groundedness_model,
-            input_payload={"attempt": attempt},
-            prompt=prompt,
-            raw_response=raw_response,
-            parsed=parsed,
-            output=groundedness,
+            input_payload=(
+                {"attempt": record.attempt} if record.raw_response or record.parsed
+                else None
+            ),
+            prompt=record.prompt,
+            raw_response=record.raw_response or None,
+            parsed=record.parsed,
+            error=record.error or None,
+            output=(
+                outcome.verdict
+                if record is outcome.attempts[-1] and not record.error
+                else None
+            ),
         )
-        break
 
-    if rejected:
-        groundedness = {**groundedness, "rejected_responses": rejected}
+    groundedness = outcome.verdict
+    if outcome.rejected:
+        groundedness = {**groundedness, "rejected_responses": outcome.rejected}
 
     dependencies.recorder.record_stage(
         run_id,
         stage,
-        {"groundedness": groundedness, "raw_response": raw_response},
+        {"groundedness": groundedness, "raw_response": outcome.raw_response},
     )
     return groundedness
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/repair_targets.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/stages/v3/repair_targets.py
@@ -1,0 +1,214 @@
+"""Which sections repair is allowed to touch, decided before it is asked.
+
+Finding: `_screen_section_edits` refuses an edit that cites a fact outside the
+packet, and that is the only thing it refuses. Scope was left entirely to the
+prompt -- "change length inside the sections that exist", "resolve each
+required revision directly" -- and a pass that came back with a rewritten
+opening nobody complained about had its edit applied, because the opening's id
+was real and its hash was current.
+
+So the targets are worked out first, from what the audit and the grounding
+check actually named, and enforced in code afterwards. The prompt is told the
+same list, so repair is not being refused for doing what it was asked.
+
+Everything here is deterministic. Resolving a revision to a section by asking
+a model would be a second call on the stage that already costs the most, and
+it would put the scope decision back inside a response nobody can check.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from ...content.sections import ArticleSection
+from ...support import _safe_str
+
+# A revision quoting the draft is the common case and the reliable one: the
+# auditor is told to quote the sentence it objects to, and a quote can be
+# looked up rather than interpreted.
+_QUOTED = re.compile(r"[\"“”'‘’]([^\"“”\n]{8,200})[\"“”'‘’]")
+
+
+
+@dataclass(frozen=True)
+class RepairTargets:
+    """The sections repair may change, and how that was decided."""
+
+    allowed: frozenset[str]
+    # "targeted" -- every revision resolved to named sections.
+    # "article_wide" -- a revision that legitimately covers the whole draft.
+    # "unresolved" -- nothing resolved, so the scope is not known.
+    scope: str
+    resolved: dict[str, list[str]] = field(default_factory=dict)
+    unresolved: list[str] = field(default_factory=list)
+
+    def permits(self, section_id: str) -> bool:
+        return section_id in self.allowed
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "scope": self.scope,
+            "allowed_section_ids": sorted(self.allowed),
+            "resolved_revisions": {
+                revision: list(ids) for revision, ids in self.resolved.items()
+            },
+            "unresolved_revisions": list(self.unresolved),
+        }
+
+
+def _normalise(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def _sections_named_by(
+    revision: str, sections: list[ArticleSection]
+) -> list[str]:
+    """The sections a revision points at, by quoted prose or by heading."""
+    text = _normalise(revision)
+    found: list[str] = []
+    quotes = [_normalise(match.group(1)) for match in _QUOTED.finditer(revision)]
+    for section in sections:
+        haystack = _normalise(f"{section.heading} {section.body}")
+        heading = _normalise(section.heading)
+        hit = any(quote and quote in haystack for quote in quotes)
+        # A heading has to be worth matching on. "Getting there" names a
+        # section; a two-letter heading would match half the sentences in the
+        # language and hand repair the whole document.
+        if not hit and len(heading) >= 6 and heading in text:
+            hit = True
+        if hit:
+            found.append(section.section_id)
+    return found
+
+
+def resolve_repair_targets(
+    *,
+    sections: list[ArticleSection],
+    required_revisions: list[str],
+    flagged: dict[str, list[str]],
+    article_wide: list[str] | None = None,
+) -> RepairTargets:
+    """Work out which sections this repair pass is for.
+
+    `article_wide` names the revisions the caller already knows cover the whole
+    draft -- in practice the length instruction, which this pipeline computes
+    itself from the counts that failed the check. Passed in rather than
+    recognised from its wording: the one revision whose meaning the code is
+    certain of is the one the code wrote, and matching an auditor's prose for
+    words like "throughout" would be guessing about the rest.
+
+    `flagged` is what `locate_claims` found: sections holding a claim the
+    grounding check called unsupported. Those are targets by definition -- the
+    policy is to delete the assertion, and the section holding it is where.
+
+    When nothing resolves, every section is allowed and the scope is recorded
+    as `unresolved`. That is a deliberate choice over refusing the pass: an
+    audit can raise a real problem with the whole draft -- it never answers
+    what the reader came for -- that no quote and no heading will locate, and
+    a repair that refuses those is a repair that only ever fixes the easy half.
+    What it must not do is happen quietly, so the reason is on the run's
+    record and the pass is not describable afterwards as targeted.
+    """
+    every = frozenset(section.section_id for section in sections)
+    allowed: set[str] = set(flagged)
+    resolved: dict[str, list[str]] = {
+        section_id: ["a claim the grounding check refused"]
+        for section_id in sorted(flagged)
+    }
+    unresolved: list[str] = []
+    wide = {_normalise(item) for item in (article_wide or []) if _safe_str(item)}
+    covers_everything = False
+
+    for revision in required_revisions:
+        text = _safe_str(revision)
+        if not text:
+            continue
+        if _normalise(text) in wide:
+            covers_everything = True
+            resolved[text] = sorted(every)
+            continue
+        named = _sections_named_by(text, sections)
+        if named:
+            allowed.update(named)
+            resolved[text] = named
+        else:
+            unresolved.append(text)
+
+    if covers_everything:
+        return RepairTargets(
+            allowed=every,
+            scope="article_wide",
+            resolved=resolved,
+            unresolved=unresolved,
+        )
+    if allowed:
+        return RepairTargets(
+            allowed=frozenset(allowed),
+            scope="targeted",
+            resolved=resolved,
+            unresolved=unresolved,
+        )
+    return RepairTargets(
+        allowed=every,
+        scope="unresolved",
+        resolved=resolved,
+        unresolved=unresolved,
+    )
+
+
+def screen_against_targets(
+    raw_sections: Any, targets: RepairTargets
+) -> tuple[Any, list[dict[str, str]]]:
+    """Drop edits to sections this pass was not for.
+
+    Runs beside the claim-id screen rather than replacing it. They refuse
+    different things: that one refuses an edit resting on a fact the article
+    was not written from, this one refuses an edit to a paragraph nobody
+    complained about, and an edit can be either without being the other.
+    """
+    if not isinstance(raw_sections, list):
+        return raw_sections, []
+    kept: list[Any] = []
+    rejected: list[dict[str, str]] = []
+    for raw in raw_sections:
+        section_id = _safe_str(
+            raw.get("section_id") if isinstance(raw, dict) else ""
+        )
+        if not targets.permits(section_id):
+            rejected.append(
+                {
+                    "section_id": section_id or "(missing)",
+                    "reason": (
+                        "outside the sections this repair was for "
+                        f"({targets.scope})"
+                    ),
+                }
+            )
+            continue
+        kept.append(raw)
+    return kept, rejected
+
+
+def targets_block(targets: RepairTargets, sections: list[ArticleSection]) -> str:
+    """What repair is told it may change, in the words of the section map."""
+    if targets.scope == "article_wide":
+        return (
+            "Every section. A required revision changes the whole draft's "
+            "length, which cannot be done inside one paragraph."
+        )
+    if targets.scope == "unresolved":
+        return (
+            "Every section. No revision named a particular one, so the scope "
+            "of this pass could not be narrowed -- change as little as the "
+            "revisions allow."
+        )
+    headings = {
+        section.section_id: section.heading or "(opening)" for section in sections
+    }
+    lines = [
+        f"- {section_id} {headings.get(section_id, '')}".rstrip()
+        for section_id in sorted(targets.allowed)
+    ]
+    return "\n".join(lines) or "- (none)"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_article_edits_atomic.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_article_edits_atomic.py
@@ -1,0 +1,305 @@
+"""Applying an edit and recording it are one write, or they are neither.
+
+Every test here runs against a real SQLite file in a temporary directory, and
+the concurrency ones use two separate connections through two threads with a
+barrier between them -- because the bug being fixed is invisible to a single
+in-process caller. An in-process lock would pass a test written that way and
+still lose an edit between two workers.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+
+import pytest
+
+from app.core.database import get_db_connection
+from app.core.storage import read_output, write_artifact
+from app.features.prompt2blog.article_edits import (
+    ArticleMissing,
+    EditRefused,
+    RevisionConflict,
+    commit_article_edit,
+    read_article,
+)
+from app.features.prompt2blog.section_edit_v4 import (
+    SECTION_EDIT_STAGE,
+    AppliedEdit,
+    EditHistory,
+)
+
+ARTICLE = (
+    "The direct answer.\n\n"
+    "## Prices\n\nA costs $20.\n\n"
+    "## Getting there\n\nThe bus runs hourly.\n"
+)
+
+
+@pytest.fixture
+def run(isolated_db):
+    """A finished run with an article, on a temporary database."""
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO runs (run_id, feature, status, stage, created_at, "
+            "updated_at) VALUES (?, 'prompt2blog', 'completed', 'complete', "
+            "'now', 'now')",
+            ("run-1",),
+        )
+    write_artifact("run-1", {"pipeline_v3": {}, "markdown": ARTICLE})
+    return "run-1"
+
+
+def _replace(section: str, text: str):
+    """An edit that rewrites one section and files it, as the route's does."""
+
+    def edit(markdown: str, history: EditHistory) -> tuple[str, EditHistory]:
+        if section not in markdown:
+            raise EditRefused(f"{section} is not in this draft")
+        return (
+            markdown.replace(section, text),
+            EditHistory(
+                original_markdown=history.original_markdown or markdown,
+                edits=[
+                    *history.edits,
+                    AppliedEdit(section_id="s1", action_id="shorten", previous_markdown=markdown),
+                ],
+            ),
+        )
+
+    return edit
+
+
+def _stored_history(run_id: str) -> dict:
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT data FROM stages WHERE run_id = ? AND stage = ?",
+            (run_id, SECTION_EDIT_STAGE),
+        ).fetchone()
+    return json.loads(row["data"])["data"] if row else {}
+
+
+def test_a_first_edit_advances_the_revision(run):
+    state = read_article(run)
+    assert state.revision == 0
+
+    result = commit_article_edit(
+        run_id=run,
+        expected_revision=0,
+        edit=_replace("A costs $20.", "A is $20."),
+    )
+
+    assert result.revision == 1
+    assert "A is $20." in result.markdown
+    assert read_article(run).revision == 1
+    assert len(_stored_history(run)["edits"]) == 1
+
+
+def test_an_edit_against_an_old_revision_is_refused(run):
+    commit_article_edit(
+        run_id=run,
+        expected_revision=0,
+        edit=_replace("A costs $20.", "A is $20."),
+    )
+
+    with pytest.raises(RevisionConflict) as raised:
+        commit_article_edit(
+            run_id=run,
+            expected_revision=0,
+            edit=_replace("The bus runs hourly.", "Buses run hourly."),
+        )
+
+    assert raised.value.expected == 0
+    assert raised.value.actual == 1
+    # And the refusal wrote nothing.
+    assert "Buses run hourly." not in read_article(run).markdown
+
+
+def test_two_writers_on_the_same_revision_do_not_lose_an_edit(run):
+    """The lost update, reproduced with two connections and a barrier.
+
+    Both threads read revision 0 and edit different sections, so each one's
+    section hash would pass against the draft it read. Without the write lock
+    held across the read, the second write is built from stale markdown and
+    discards the first edit.
+    """
+    started = threading.Barrier(2)
+    outcomes: dict[str, object] = {}
+
+    def attempt(name: str, edit) -> None:
+        started.wait(timeout=5)
+        try:
+            outcomes[name] = commit_article_edit(
+                run_id=run, expected_revision=0, edit=edit
+            )
+        except BaseException as exc:  # noqa: BLE001 -- recorded, then asserted
+            outcomes[name] = exc
+
+    threads = [
+        threading.Thread(
+            target=attempt, args=("a", _replace("A costs $20.", "A is $20."))
+        ),
+        threading.Thread(
+            target=attempt,
+            args=("b", _replace("The bus runs hourly.", "Buses run hourly.")),
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+
+    kinds = sorted(type(value).__name__ for value in outcomes.values())
+    assert kinds == ["CommitResult", "RevisionConflict"]
+
+    final = read_article(run)
+    assert final.revision == 1
+    # Whichever one won is entirely there, and the loser wrote nothing at all.
+    won_a = "A is $20." in final.markdown
+    assert won_a != ("Buses run hourly." in final.markdown)
+    if won_a:
+        assert "The bus runs hourly." in final.markdown
+    else:
+        assert "A costs $20." in final.markdown
+    assert len(_stored_history(run)["edits"]) == 1
+
+
+def test_a_refused_edit_leaves_neither_half_written(run):
+    """The article and the history roll back together."""
+
+    def edit(markdown: str, history: EditHistory):
+        raise EditRefused("nope")
+
+    with pytest.raises(EditRefused):
+        commit_article_edit(run_id=run, expected_revision=0, edit=edit)
+
+    state = read_article(run)
+    assert state.markdown == ARTICLE
+    assert state.revision == 0
+    assert _stored_history(run) == {}
+
+
+def test_a_failure_after_the_article_write_rolls_the_article_back(run):
+    """Simulated between the two writes, which is where they used to split.
+
+    The history write is the second statement in the transaction. A failure
+    there used to leave an article carrying an edit its history has no record
+    of; now it leaves the article as it was.
+    """
+
+    def edit(markdown: str, history: EditHistory):
+        return markdown.replace("A costs $20.", "A is $20."), _Unserialisable()
+
+    with pytest.raises(TypeError):
+        commit_article_edit(run_id=run, expected_revision=0, edit=edit)
+
+    state = read_article(run)
+    assert state.markdown == ARTICLE
+    assert state.revision == 0
+    assert _stored_history(run) == {}
+
+
+class _Unserialisable:
+    """Stands in for the history write failing, whatever the reason."""
+
+    edits: list = []
+
+    def model_dump(self, **_kwargs):
+        raise TypeError("history could not be written")
+
+
+def test_the_same_edit_applied_twice_lands_once(run):
+    """A double-click and a retried request are not two edits.
+
+    Without this the second arrives against the revision the first advanced
+    past and is reported as a conflict, which sends an editor to re-read prose
+    that already says what they wanted.
+    """
+
+    def edit(markdown: str, history: EditHistory) -> tuple[str, EditHistory]:
+        return (
+            markdown.replace("A costs $20.", "A is $20."),
+            EditHistory(
+                original_markdown=markdown,
+                edits=[
+                    *history.edits,
+                    AppliedEdit(edit_id="edit-9", section_id="s1", action_id="shorten"),
+                ],
+            ),
+        )
+
+    first = commit_article_edit(
+        run_id=run, expected_revision=0, edit=edit, edit_id="edit-9"
+    )
+    second = commit_article_edit(
+        run_id=run, expected_revision=0, edit=edit, edit_id="edit-9"
+    )
+
+    assert first.already_applied is False
+    assert second.already_applied is True
+    assert second.revision == first.revision == 1
+    assert len(_stored_history(run)["edits"]) == 1
+
+
+def test_a_run_with_no_article_is_a_missing_article_not_a_crash(isolated_db):
+    with pytest.raises(ArticleMissing):
+        read_article("never-ran")
+
+
+def test_a_pipeline_write_also_advances_the_revision(run):
+    """Every path that writes markdown, not only a hand edit.
+
+    A resume that re-finalises a run is exactly as much a reason to re-read a
+    section as a colleague's edit in another tab, and an edit proposed before
+    it must not land on the article it produced.
+    """
+    write_artifact(run, {"pipeline_v3": {}, "markdown": "A wholly new draft.\n"})
+
+    assert read_output(run)["article_revision"] == 1
+    with pytest.raises(RevisionConflict):
+        commit_article_edit(
+            run_id=run,
+            expected_revision=0,
+            edit=_replace("A costs $20.", "A is $20."),
+        )
+
+
+def test_the_write_lock_is_held_across_the_read(isolated_db, run):
+    """The property the whole module rests on, asserted directly.
+
+    A second connection trying to write while `commit_article_edit` is between
+    its read and its write must not get in. With a deferred transaction it
+    would; with `BEGIN IMMEDIATE` it waits, and a one-millisecond busy timeout
+    turns waiting into a visible error this test can assert on.
+    """
+    blocked: list[str] = []
+    inside = threading.Event()
+    release = threading.Event()
+
+    def edit(markdown: str, history: EditHistory):
+        inside.set()
+        release.wait(timeout=5)
+        return markdown, EditHistory()
+
+    def intrude() -> None:
+        inside.wait(timeout=5)
+        other = sqlite3.connect(str(isolated_db), timeout=0.001)
+        try:
+            other.execute("BEGIN IMMEDIATE")
+            other.execute("UPDATE outputs SET markdown = 'stolen'")
+            other.execute("COMMIT")
+            blocked.append("got in")
+        except sqlite3.OperationalError as exc:
+            blocked.append(str(exc))
+        finally:
+            other.close()
+            release.set()
+
+    thread = threading.Thread(target=intrude)
+    thread.start()
+    commit_article_edit(run_id=run, expected_revision=0, edit=edit)
+    thread.join(timeout=10)
+
+    assert blocked and "locked" in blocked[0]
+    assert "stolen" not in read_article(run).markdown

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_confirmations_after_edit.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_confirmations_after_edit.py
@@ -1,0 +1,126 @@
+"""What a hand edit does to the checking a person already did.
+
+Dropping a confirmation whose passage changed is right and stays: it is the
+one thing on the provenance screen that says a human read this against its
+source, and keeping it beside prose that has since moved would be worse than
+having none.
+
+Dropping it in silence is the part that was wrong.
+"""
+
+from __future__ import annotations
+
+from app.core import write_artifact, write_status
+from app.features.prompt2blog.provenance import (
+    invalidated_confirmation_count,
+    prune_confirmations,
+    segment_passages,
+)
+from tests.prompt2blog_test_support import response_payload
+
+ARTICLE = (
+    "The direct answer.\n\n"
+    "## Prices\n\nA costs $20.\n\n"
+    "## Getting there\n\nThe bus runs hourly.\n"
+)
+EDITED = ARTICLE.replace("A costs $20.", "A is $20.")
+
+
+def _confirmations(markdown: str, *hashes: str) -> dict:
+    return {
+        "confirmations": [
+            {
+                "passage_hash": passage_hash,
+                "source_kind": "claim",
+                "source_id": "c1",
+                "reviewer": "staff-1",
+                "confirmed_at": "2026-09-07T00:00:00Z",
+            }
+            for passage_hash in hashes
+        ]
+    }
+
+
+def _hash_of(markdown: str, needle: str) -> str:
+    return next(
+        passage.text_hash
+        for passage in segment_passages(markdown)
+        if needle in passage.text
+    )
+
+
+def test_an_edit_invalidates_the_confirmation_on_that_passage():
+    stored = _confirmations(ARTICLE, _hash_of(ARTICLE, "A costs $20."))
+
+    assert len(prune_confirmations(stored, ARTICLE).confirmations) == 1
+    assert invalidated_confirmation_count(stored, ARTICLE) == 0
+
+    assert prune_confirmations(stored, EDITED).confirmations == []
+    assert invalidated_confirmation_count(stored, EDITED) == 1
+
+
+def test_confirmations_on_untouched_passages_survive():
+    stored = _confirmations(
+        ARTICLE,
+        _hash_of(ARTICLE, "A costs $20."),
+        _hash_of(ARTICLE, "The bus runs hourly."),
+    )
+
+    live = prune_confirmations(stored, EDITED)
+
+    assert len(live.confirmations) == 1
+    assert invalidated_confirmation_count(stored, EDITED) == 1
+
+
+def test_an_undo_brings_the_confirmation_back():
+    """They are filtered on read, never deleted, so restoring the prose
+    restores the checking that was done against it."""
+    stored = _confirmations(ARTICLE, _hash_of(ARTICLE, "A costs $20."))
+
+    assert invalidated_confirmation_count(stored, EDITED) == 1
+    assert invalidated_confirmation_count(stored, ARTICLE) == 0
+    assert len(prune_confirmations(stored, ARTICLE).confirmations) == 1
+
+
+def test_the_route_reports_how_much_checking_an_edit_undid(isolated_db):
+    from app.features.prompt2blog.api import runs as runs_api
+    from app.features.prompt2blog.run_recorder import RunRecorder
+    from app.features.prompt2blog.provenance import PROVENANCE_STAGE
+
+    write_status(
+        "r-conf",
+        {
+            "run_id": "r-conf",
+            "state": "completed",
+            "stage": "complete",
+            "error": None,
+            "updated_at": "2026-09-07T00:00:00Z",
+        },
+        feature="prompt2blog",
+    )
+    write_artifact(
+        "r-conf", {"markdown": ARTICLE, "pipeline_v3": {"run_id": "r-conf"}}
+    )
+    from app.core import write_stage_result
+
+    write_stage_result(
+        "r-conf",
+        "pipeline_input_v3",
+        {"data": {"packet": {"facts": [{"claim_id": "c1", "text": "A costs $20."}]}}},
+    )
+    RunRecorder().record_stage(
+        "r-conf",
+        PROVENANCE_STAGE,
+        _confirmations(ARTICLE, _hash_of(ARTICLE, "A costs $20.")),
+    )
+
+    clean = response_payload(runs_api.get_provenance("r-conf"))
+    assert clean["summary"]["invalidated_confirmations"] == 0
+
+    # The article is edited, exactly as a hand edit would leave it.
+    write_artifact(
+        "r-conf", {"markdown": EDITED, "pipeline_v3": {"run_id": "r-conf"}}
+    )
+    after = response_payload(runs_api.get_provenance("r-conf"))
+
+    assert after["summary"]["invalidated_confirmations"] == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_cost_split.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_cost_split.py
@@ -1,0 +1,119 @@
+"""Money that left an account, kept apart from money that did not.
+
+Claude runs on the flat Claude Code subscription. The CLI reports what each
+call would have cost at API rates, and that figure was being added straight
+into the run's headline cost beside real per-token Vertex spend. On the two
+runs already measured in this repo -- chifa 3750891f at $0.36 billed beside
+$2.29 notional, ceviche 8a7e9aa4 at $0.38 beside $1.97 -- the receipt reported
+roughly seven times the money that actually moved.
+
+The budget breaker (`run_billed_cost_usd`) always read the two apart. Nothing
+that reported a figure to a person did.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.editor_spend import EditorAttempt, EditorSpend
+from app.features.prompt2blog.pricing import (
+    COST_BASIS_MEASURED,
+    COST_BASIS_RATE_TABLE,
+    Prompt2BlogTokenUsageTracker,
+    run_billed_cost_usd,
+)
+
+VERTEX_USAGE = {"input_tokens": 1000, "output_tokens": 500, "total_tokens": 1500}
+
+
+class _Llm:
+    def __init__(self, tracker):
+        self.usage_tracker = tracker
+
+
+def _run_with_both_kinds() -> Prompt2BlogTokenUsageTracker:
+    tracker = Prompt2BlogTokenUsageTracker(run_id="run-1")
+    tracker.begin_stage("p2b.audit")
+    tracker.record("gemini-2.5-flash", VERTEX_USAGE)
+    tracker.begin_stage("p2b.compose")
+    # What a subscription call looks like: the CLI reports its own price, and
+    # the tracker files it as `measured`.
+    tracker.record(
+        "claude-sonnet-5-medium",
+        {**VERTEX_USAGE, "measured_cost_usd": 2.29},
+    )
+    return tracker
+
+
+def test_a_subscription_call_is_not_added_to_billed_spend():
+    split = _run_with_both_kinds().cost_split()
+
+    assert split["subscription_cost_usd"] == 2.29
+    assert 0 < split["billed_cost_usd"] < 0.01
+    assert split["billed_cost_usd"] != split["subscription_cost_usd"]
+
+
+def test_the_split_agrees_with_the_budget_breaker():
+    """One rule, not two. The breaker was already right; this is the same
+    answer, exposed where a person reads it."""
+    tracker = _run_with_both_kinds()
+
+    assert tracker.cost_split()["billed_cost_usd"] == round(
+        run_billed_cost_usd(_Llm(tracker)), 6
+    )
+
+
+def test_the_run_summary_publishes_both_figures():
+    summary = _run_with_both_kinds().summary(
+        stack_id=None, worker_model=None, writing_model=None, audit_model=None
+    )
+
+    assert summary["subscription_cost_usd"] == 2.29
+    assert summary["billed_cost_usd"] < 0.01
+    # The old mixed field survives for runs recorded before the split, and is
+    # visibly the sum of two things that should not be summed.
+    assert summary["estimated_cost_usd"] > summary["billed_cost_usd"]
+
+
+def test_the_ledger_carries_the_split_too():
+    ledger = _run_with_both_kinds().ledger()
+
+    assert ledger["cost"]["subscription_cost_usd"] == 2.29
+    assert ledger["cost"]["unpriced_calls"] == 0
+
+
+def test_a_call_nobody_priced_is_counted_not_costed():
+    tracker = Prompt2BlogTokenUsageTracker(run_id="run-1")
+    tracker.begin_stage("p2b.compose")
+    tracker.record("some-unknown-model", VERTEX_USAGE)
+
+    split = tracker.cost_split()
+    assert split["billed_cost_usd"] == 0.0
+    assert split["subscription_cost_usd"] == 0.0
+    assert split["unpriced_calls"] == 1
+
+
+def test_editor_spend_splits_the_same_way():
+    """The section edit runs on Claude and its review on Gemini, so a single
+    editor total would make the same mistake on a smaller number."""
+    spend = EditorSpend(
+        attempts=[
+            EditorAttempt(
+                attempt_id="a1",
+                kind="propose",
+                cost_usd=0.08,
+                cost_basis=COST_BASIS_MEASURED,
+            ),
+            EditorAttempt(
+                attempt_id="a2",
+                kind="review",
+                cost_usd=0.002,
+                cost_basis=COST_BASIS_RATE_TABLE,
+            ),
+            EditorAttempt(attempt_id="a3", kind="propose"),
+        ]
+    )
+
+    totals = spend.totals()
+    assert totals["subscription_cost_usd"] == 0.08
+    assert totals["billed_cost_usd"] == 0.002
+    assert totals["priced_attempts"] == 2
+    assert totals["unmeasured_attempts"] == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_refusal.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_refusal.py
@@ -1,0 +1,204 @@
+"""A refusal is an unchanged proposal, on both sides of the wire.
+
+The probe: a response carrying both `could_not_do` ("Cannot support this") and
+changed prose containing a $999 that appears nowhere in the packet. The screen
+offered it as an ordinary proposal, because the only thing enabling "Use this"
+was that the text differed from the original, and applying it worked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.features.prompt2blog.content.sections import segment_article
+from app.features.prompt2blog.section_edit_v4 import (
+    EditHistory,
+    EditProposal,
+    apply_proposal,
+    propose_section_edit,
+)
+
+ARTICLE = (
+    "The direct answer.\n\n"
+    "## Prices\n\n"
+    "A costs $20. B costs $40.\n"
+)
+BRIEF = {"seed": "What to pay", "reader": {"primary_reader": "A first visitor"}}
+PACKET = {"facts": [{"text": "A costs $20."}, {"text": "B costs $40."}]}
+
+
+class _FakeLLM:
+    """A checkerless stand-in. Real model quality is not what these assert."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.calls = 0
+
+    def invoke_json(self, **_kwargs: Any) -> tuple[dict[str, Any], str]:
+        self.calls += 1
+        return self.response, "{}"
+
+
+class _FakeDependencies:
+    def __init__(self, llm: _FakeLLM) -> None:
+        self.llm = llm
+
+
+def _propose(response: dict[str, Any]) -> EditProposal:
+    return propose_section_edit(
+        run_id="run-1",
+        content=ARTICLE,
+        section_id="s1",
+        action_id="clarify_recommendation",
+        brief=BRIEF,
+        packet=PACKET,
+        dependencies=_FakeDependencies(_FakeLLM(response)),
+    )
+
+
+def _section_hash(section_id: str = "s1") -> str:
+    return next(
+        section.text_hash
+        for section in segment_article(ARTICLE)
+        if section.section_id == section_id
+    )
+
+
+def test_a_refusal_carrying_changed_text_comes_back_unchanged():
+    proposal = _propose(
+        {
+            "revised": "## Prices\n\nA costs $999 and is the clear winner.",
+            "could_not_do": "The facts do not support choosing between them.",
+            "what_changed": "Named a winner.",
+        }
+    )
+
+    assert proposal.could_not_do == (
+        "The facts do not support choosing between them."
+    )
+    assert proposal.revised.strip() == proposal.original.strip()
+    assert proposal.changed is False
+    assert "$999" not in proposal.revised
+
+
+def test_an_ordinary_edit_is_untouched_by_the_invariant():
+    proposal = _propose(
+        {
+            "revised": "## Prices\n\nA costs $20; B costs $40.",
+            "could_not_do": "",
+            "what_changed": "Joined two sentences.",
+        }
+    )
+
+    assert proposal.changed is True
+    assert proposal.could_not_do == ""
+
+
+def test_a_warning_only_proposal_is_still_offered():
+    """Advisory and refused are different, and stay different.
+
+    An introduced figure is something a person may look at, decide they know
+    where it came from, and keep. A refusal is not.
+    """
+    proposal = _propose(
+        {
+            "revised": "## Prices\n\nA costs $20. B costs $40. Budget $75 a day.",
+            "could_not_do": "",
+            "what_changed": "Added a daily budget.",
+        }
+    )
+
+    assert proposal.introduced_figures == ["$75"]
+    assert proposal.changed is True
+    assert proposal.could_not_do == ""
+
+
+def test_a_tampered_refusal_cannot_be_applied_directly():
+    """The client is not where this invariant lives.
+
+    A proposal reaches the apply route as a request body, so the normalisation
+    done when it was proposed proves nothing about the object that comes back.
+    """
+    tampered = EditProposal(
+        run_id="run-1",
+        section_id="s1",
+        heading="Prices",
+        action_id="clarify_recommendation",
+        text_hash=_section_hash(),
+        original="## Prices\n\nA costs $20. B costs $40.",
+        revised="## Prices\n\nA costs $999 and is the clear winner.",
+        could_not_do="The facts do not support choosing between them.",
+        introduced_figures=["$999"],
+    )
+
+    result = apply_proposal(
+        content=ARTICLE,
+        proposal=tampered,
+        history=EditHistory(),
+        editor="staff-1",
+        now="2026-09-07T00:00:00Z",
+    )
+
+    assert result.applied is False
+    assert result.markdown == ARTICLE
+    assert result.history.edits == []
+    assert result.rejected[0]["reason"] == (
+        "this proposal says it could not make the change and changes the text "
+        "as well"
+    )
+
+
+def test_a_no_op_proposal_makes_no_history():
+    """Pattern learning reads accepted edits, and counts them.
+
+    A no-op filed as an accepted edit is a correction that never happened,
+    counting towards a threshold that decides whether the voice file changes.
+    """
+    unchanged = EditProposal(
+        run_id="run-1",
+        section_id="s1",
+        heading="Prices",
+        action_id="shorten",
+        text_hash=_section_hash(),
+        original="## Prices\n\nA costs $20. B costs $40.",
+        revised="## Prices\n\nA costs $20. B costs $40.",
+    )
+
+    result = apply_proposal(
+        content=ARTICLE,
+        proposal=unchanged,
+        history=EditHistory(),
+        editor="staff-1",
+        now="2026-09-07T00:00:00Z",
+    )
+
+    assert result.applied is False
+    assert result.markdown == ARTICLE
+    assert result.history.edits == []
+    assert result.rejected[0]["reason"] == "this proposal does not change the section"
+
+
+def test_a_real_edit_still_applies_and_is_recorded():
+    proposal = EditProposal(
+        run_id="run-1",
+        section_id="s1",
+        heading="Prices",
+        action_id="shorten",
+        text_hash=_section_hash(),
+        original="## Prices\n\nA costs $20. B costs $40.",
+        revised="## Prices\n\nA costs $20; B costs $40.",
+        what_changed="Joined two sentences.",
+    )
+
+    result = apply_proposal(
+        content=ARTICLE,
+        proposal=proposal,
+        history=EditHistory(),
+        editor="staff-1",
+        now="2026-09-07T00:00:00Z",
+    )
+
+    assert result.applied is True
+    assert "A costs $20; B costs $40." in result.markdown
+    assert result.history.original_markdown == ARTICLE
+    assert len(result.history.edits) == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_review.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_review.py
@@ -1,0 +1,259 @@
+"""Whether an edit still says what the evidence says.
+
+The probe that started this. Packet: "A costs $20. B costs $40." Proposal: "A
+costs $40. B costs $20." Every number in the proposal is in the packet, both
+claims are wrong, and the introduced-figure check reported nothing -- it
+compares sets of tokens, and the two sets are identical.
+
+The checker is a controlled fixture throughout. These assert what the code does
+with a verdict, not that a real model produces the right one; no claim about
+real model quality follows from any of them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.prompt2blog.edit_review import (
+    SUPPORTED,
+    UNCHECKED,
+    UNSUPPORTED,
+    EditReview,
+    binding_failure,
+    candidate_hash,
+    evidence_fingerprint,
+    review_section_edit,
+)
+
+ARTICLE = (
+    "The direct answer.\n\n"
+    "## Prices\n\nA costs $20. B costs $40.\n\n"
+    "## Getting there\n\nThe bus runs hourly.\n"
+)
+PACKET = {
+    "evidence_fingerprint": "ev-1",
+    "selection_fingerprint": "sel-1",
+    "facts": [
+        {"claim_id": "c1", "text": "A costs $20.", "as_of": "March 2026"},
+        {"claim_id": "c2", "text": "B costs $40."},
+    ],
+    "notes": [{"text": "Prices are for the high season only."}],
+    "supplied_material": [{"kind": "visit", "statement": "I waited 45 minutes."}],
+}
+
+
+class _Checker:
+    """A checker that answers with whatever the test decided it should."""
+
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.prompts: list[str] = []
+
+    def invoke_json(self, *, job_id, prompt, **_kwargs):
+        self.prompts.append(prompt)
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response, "{}"
+
+
+def _review(response: Any, candidate: str = "## Prices\n\nA costs $40.") -> EditReview:
+    return review_section_edit(
+        llm=_Checker(response),
+        run_id="run-1",
+        section_id="s1",
+        content=ARTICLE,
+        original="## Prices\n\nA costs $20. B costs $40.",
+        candidate=candidate,
+        packet=PACKET,
+        base_revision=3,
+    )
+
+
+def test_swapped_prices_are_reported_as_unsupported():
+    """The probe. Every figure is in the packet and the claim is still false."""
+    review = _review(
+        {
+            "grounded": False,
+            "assessment": "The prices are attached to the wrong things.",
+            "unsupported_claims": [
+                {
+                    "claim": "A costs $40",
+                    "reason": "The record says A costs $20 and B costs $40.",
+                    "severity": "high",
+                }
+            ],
+        },
+        candidate="## Prices\n\nA costs $40. B costs $20.",
+    )
+
+    assert review.status == UNSUPPORTED
+    assert review.checked is True
+    assert review.blocks_without_a_decision is True
+    assert review.high_severity[0]["claim"] == "A costs $40"
+
+
+def test_a_grounded_edit_passes():
+    review = _review(
+        {
+            "grounded": True,
+            "assessment": "Every figure matches the record it comes from.",
+            "unsupported_claims": [],
+        }
+    )
+
+    assert review.status == SUPPORTED
+    assert review.checked is True
+    assert review.blocks_without_a_decision is False
+
+
+def test_a_malformed_verdict_is_unchecked_and_never_a_pass():
+    """Absence read as agreement is the failure this whole path exists to avoid."""
+    review = _review({"grounded": "yes", "assessment": "", "unsupported_claims": []})
+
+    assert review.status == UNCHECKED
+    assert review.checked is False
+    # And unchecked is not a fail either -- it is a decision for a person.
+    assert review.blocks_without_a_decision is True
+
+
+def test_a_provider_failure_degrades_rather_than_blocking():
+    review = _review(RuntimeError("the checker is down"))
+
+    assert review.status == UNCHECKED
+    assert review.checked is False
+    assert "provider call failed" in review.assessment
+
+
+def test_the_checker_reads_the_section_in_its_article():
+    """A claim can be wrong only in context, and a recommendation is only
+    overstated relative to what the article already said."""
+    checker = _Checker(
+        {"grounded": True, "assessment": "Fine.", "unsupported_claims": []}
+    )
+    review_section_edit(
+        llm=checker,
+        run_id="run-1",
+        section_id="s1",
+        content=ARTICLE,
+        original="## Prices\n\nA costs $20. B costs $40.",
+        candidate="## Prices\n\nA is the cheaper one.",
+        packet=PACKET,
+        base_revision=0,
+    )
+
+    prompt = checker.prompts[0]
+    assert "## Getting there" in prompt
+    # The section being judged is not repeated into its own context block.
+    assert prompt.count("The bus runs hourly.") == 1
+    assert "I waited 45 minutes." in prompt
+    assert "Prices are for the high season only." in prompt
+    assert "as of March 2026" in prompt
+
+
+def test_first_hand_material_is_named_as_testimony_with_its_own_scope():
+    """The prompt has to say what makes "I waited 45 minutes" different from
+    "the wait is 45 minutes", or the checker has no basis to separate them."""
+    checker = _Checker(
+        {"grounded": True, "assessment": "Fine.", "unsupported_claims": []}
+    )
+    review_section_edit(
+        llm=checker,
+        run_id="run-1",
+        section_id="s1",
+        content=ARTICLE,
+        original="## Prices\n\nA costs $20.",
+        candidate="## Prices\n\nThe wait is 45 minutes.",
+        packet=PACKET,
+        base_revision=0,
+    )
+
+    prompt = checker.prompts[0]
+    assert "testimony with its own scope" in prompt
+    assert "the wait is 45 minutes" in prompt.lower()
+
+
+def test_a_review_is_bound_to_what_it_read():
+    review = _review(
+        {"grounded": True, "assessment": "Fine.", "unsupported_claims": []}
+    )
+
+    assert review.run_id == "run-1"
+    assert review.section_id == "s1"
+    assert review.base_revision == 3
+    assert review.candidate_hash == candidate_hash("## Prices\n\nA costs $40.")
+    assert review.evidence_fingerprint == "ev-1:sel-1"
+
+
+# ---------------------------------------------------------------------------
+# The binding, checked on the way back in
+# ---------------------------------------------------------------------------
+
+
+def _bound(**overrides) -> EditReview:
+    fields = {
+        "status": SUPPORTED,
+        "checked": True,
+        "run_id": "run-1",
+        "section_id": "s1",
+        "candidate_hash": candidate_hash("## Prices\n\nA is $20."),
+        "base_revision": 3,
+        "evidence_fingerprint": "ev-1:sel-1",
+    }
+    fields.update(overrides)
+    return EditReview(**fields)
+
+
+def _failure(review, candidate: str = "## Prices\n\nA is $20.") -> str:
+    return binding_failure(
+        review,
+        run_id="run-1",
+        section_id="s1",
+        candidate=candidate,
+        packet=PACKET,
+    )
+
+
+def test_a_matching_review_binds():
+    assert _failure(_bound()) == ""
+
+
+def test_client_modified_text_cannot_inherit_a_successful_review():
+    """The whole reason the binding exists.
+
+    The review was generated on the server, went to a browser as JSON, and came
+    back in a request body. A verdict that says a candidate is grounded says it
+    about the candidate it read.
+    """
+    assert _failure(_bound(), "## Prices\n\nA is $999.") == (
+        "this review was made for different text"
+    )
+
+
+def test_a_review_from_another_run_or_section_does_not_bind():
+    assert _failure(_bound(run_id="run-2")) == (
+        "this review was made for a different run"
+    )
+    assert _failure(_bound(section_id="s2")) == (
+        "this review was made for a different section"
+    )
+
+
+def test_a_review_made_against_other_evidence_does_not_bind():
+    assert _failure(_bound(evidence_fingerprint="ev-9:sel-9")) == (
+        "this review was made against different evidence"
+    )
+
+
+def test_no_review_at_all_is_a_binding_failure_not_a_pass():
+    assert _failure(None) == "this edit carries no review"
+
+
+def test_a_run_with_no_fingerprints_still_gets_an_evidence_identity():
+    """Weaker than the fingerprints, and better than binding to nothing."""
+    legacy = {"facts": [{"text": "A costs $20."}]}
+    first = evidence_fingerprint(legacy)
+    assert first.startswith("facts:")
+    assert first == evidence_fingerprint({"facts": [{"text": "A costs $20."}]})
+    assert first != evidence_fingerprint({"facts": [{"text": "A costs $25."}]})

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
@@ -224,3 +224,131 @@ def test_undo_on_an_unedited_draft_is_a_plain_answer_not_an_error(isolated_db):
     assert payload["edits"] == 0
     assert payload["revision"] == 0
     assert payload["markdown"] == ARTICLE
+
+
+# ---------------------------------------------------------------------------
+# What the route spends
+# ---------------------------------------------------------------------------
+
+
+def _seed_packet(run_id: str) -> None:
+    from app.core import write_stage_result
+
+    write_stage_result(
+        run_id,
+        "pipeline_input_v3",
+        {"data": {"packet": {"facts": [{"text": "A costs $20."}]}}},
+    )
+
+
+def _stub_llm(monkeypatch, response: dict, usage: dict | None) -> None:
+    """Replace the provider call, keeping the tracker the route built.
+
+    The tracker is what the spend record is read off, so a double that skipped
+    it would prove nothing about the thing being tested.
+    """
+    from app.features.prompt2blog.dependencies import DefaultPrompt2BlogLLM
+
+    def invoke_json(self, *, job_id, prompt, **kwargs):
+        if usage is not None:
+            self.usage_tracker.begin_stage(job_id)
+            self.usage_tracker.record("gemini-2.5-flash", usage)
+        return response, "{}"
+
+    monkeypatch.setattr(DefaultPrompt2BlogLLM, "invoke_json", invoke_json)
+
+
+def _propose(run_id: str, action_id: str = "shorten"):
+    from app.features.prompt2blog.api import runs as runs_api
+
+    return runs_api.propose_edit(
+        run_id,
+        runs_api.SectionEditRequest(section_id="s1", action_id=action_id),
+    )
+
+
+USAGE = {"input_tokens": 1200, "output_tokens": 400, "total_tokens": 1600}
+
+
+def test_a_discarded_proposal_is_still_on_the_receipt(isolated_db, monkeypatch):
+    from app.features.prompt2blog.api import runs as runs_api
+    from app.features.prompt2blog.editor_spend import read_editor_spend
+
+    _seed("r-spend")
+    _seed_packet("r-spend")
+    _stub_llm(
+        monkeypatch, {"revised": "## Prices\n\nA is $20.", "could_not_do": ""}, USAGE
+    )
+
+    response_payload(_propose("r-spend"))
+    # And thrown away: nothing is applied.
+
+    spend = read_editor_spend("r-spend")
+    assert len(spend.attempts) == 1
+    assert spend.attempts[0].outcome == "proposed"
+    assert spend.totals()["input_tokens"] == 1200
+
+    payload = response_payload(runs_api.read_edit_spend("r-spend"))
+    assert payload["editor"]["attempts"] == 1
+    assert payload["editor"]["input_tokens"] == 1200
+
+
+def test_a_refused_proposal_is_recorded_as_refused(isolated_db, monkeypatch):
+    from app.features.prompt2blog.editor_spend import read_editor_spend
+
+    _seed("r-refused")
+    _seed_packet("r-refused")
+    _stub_llm(
+        monkeypatch,
+        {
+            "revised": "## Prices\n\nA is the winner.",
+            "could_not_do": "The facts do not support choosing.",
+        },
+        USAGE,
+    )
+
+    response_payload(_propose("r-refused", "clarify_recommendation"))
+
+    spend = read_editor_spend("r-refused")
+    assert spend.attempts[0].outcome == "refused"
+    assert spend.totals()["input_tokens"] == 1200
+
+
+def test_a_failed_call_is_recorded_and_the_article_survives(isolated_db, monkeypatch):
+    from app.features.prompt2blog.dependencies import DefaultPrompt2BlogLLM
+    from app.features.prompt2blog.editor_spend import read_editor_spend
+
+    _seed("r-failed")
+    _seed_packet("r-failed")
+
+    def explode(self, *, job_id, prompt, **kwargs):
+        raise RuntimeError("provider timed out")
+
+    monkeypatch.setattr(DefaultPrompt2BlogLLM, "invoke_json", explode)
+
+    with pytest.raises(RuntimeError):
+        _propose("r-failed")
+
+    spend = read_editor_spend("r-failed")
+    assert spend.attempts[0].outcome == "failed"
+    assert spend.attempts[0].measurement == "unknown"
+    assert spend.totals()["unmeasured_attempts"] == 1
+    # The article is untouched and still saveable.
+    assert read_article("r-failed").markdown == ARTICLE
+
+
+def test_applying_a_proposal_does_not_charge_for_it_again(isolated_db, monkeypatch):
+    from app.features.prompt2blog.editor_spend import read_editor_spend
+
+    _seed("r-apply")
+    _seed_packet("r-apply")
+    _stub_llm(
+        monkeypatch, {"revised": "## Prices\n\nA is $20.", "could_not_do": ""}, USAGE
+    )
+
+    proposed = response_payload(_propose("r-apply"))
+    before = read_editor_spend("r-apply").totals()
+
+    _apply("r-apply", EditProposal.model_validate(proposed))
+
+    assert read_editor_spend("r-apply").totals() == before

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
@@ -561,3 +561,54 @@ def test_a_refusal_is_still_reported_as_a_refusal(isolated_db, monkeypatch):
     assert "could not make the change" not in str(raised.value.detail) or True
     assert raised.value.status_code == 409
     assert read_article("r-ref2").markdown == ARTICLE
+
+
+def test_the_proposal_carries_a_factual_change_panel(isolated_db, monkeypatch):
+    """Bound to the candidate, so an operator cannot read a panel for one piece
+    of prose and apply another."""
+    from app.features.prompt2blog.edit_review import candidate_hash
+
+    _seed(
+        "r-panel",
+        "The direct answer.\n\n"
+        "## Prices\n\nA costs $20 as of March 2026.\n\n"
+        "## Getting there\n\nThe bus runs hourly.\n",
+    )
+    _seed_packet("r-panel")
+    _stub_llm(
+        monkeypatch,
+        {"revised": "## Prices\n\nA costs $20.", "could_not_do": ""},
+        USAGE,
+    )
+
+    payload = response_payload(_propose("r-panel"))
+
+    panel = payload["factual_changes"]
+    assert panel["candidate_hash"] == candidate_hash(payload["revised"])
+    assert panel["base_revision"] == payload["base_revision"]
+    assert panel["review_status"] == "supported"
+    # The as-of date left the sentence. Shortening removed a limit that changes
+    # what a reader should do, and that is exactly what the panel is for.
+    assert {change["kind"] for change in panel["text_changes"]} == {
+        "date_removed",
+        "qualification_removed",
+    }
+    assert "not a judgement" in panel["text_changes_are"]
+
+
+def test_a_refusal_carries_no_panel(isolated_db, monkeypatch):
+    """Nothing changed, so there is nothing factual to explain."""
+    _seed("r-nopanel")
+    _seed_packet("r-nopanel")
+    _stub_llm(
+        monkeypatch,
+        {
+            "revised": "## Prices\n\nA is the winner.",
+            "could_not_do": "The facts do not support choosing.",
+        },
+        USAGE,
+    )
+
+    payload = response_payload(_propose("r-nopanel"))
+
+    assert "factual_changes" not in payload

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
@@ -61,12 +61,25 @@ def _proposal(run_id: str, section_id: str = "s1", **overrides) -> EditProposal:
     return EditProposal(**fields)
 
 
-def _apply(run_id: str, proposal: EditProposal, reason: str = ""):
+def _apply(
+    run_id: str,
+    proposal: EditProposal,
+    reason: str = "",
+    accept_findings: bool = True,
+):
+    """Apply, accepting the checker's findings by default.
+
+    These tests are about revisions, refusals and history. The review gate has
+    its own tests below; defaulting to accepted here keeps every other test
+    from having to mock a checker to assert something unrelated to one.
+    """
     from app.features.prompt2blog.api import runs as runs_api
 
     return runs_api.apply_edit(
         run_id,
-        runs_api.ApplyEditRequest(proposal=proposal, reason=reason),
+        runs_api.ApplyEditRequest(
+            proposal=proposal, reason=reason, accept_findings=accept_findings
+        ),
         staff_id="staff-1",
     )
 
@@ -241,11 +254,22 @@ def _seed_packet(run_id: str) -> None:
     )
 
 
-def _stub_llm(monkeypatch, response: dict, usage: dict | None) -> None:
+GROUNDED = {
+    "grounded": True,
+    "assessment": "Every figure matches the record it comes from.",
+    "unsupported_claims": [],
+}
+
+
+def _stub_llm(
+    monkeypatch, response: dict, usage: dict | None, review: dict | None = GROUNDED
+) -> None:
     """Replace the provider call, keeping the tracker the route built.
 
     The tracker is what the spend record is read off, so a double that skipped
-    it would prove nothing about the thing being tested.
+    it would prove nothing about the thing being tested. Answers are keyed by
+    job, because the route makes two different calls and a single canned reply
+    would hand the checker an edit response and get `unchecked` for free.
     """
     from app.features.prompt2blog.dependencies import DefaultPrompt2BlogLLM
 
@@ -253,6 +277,10 @@ def _stub_llm(monkeypatch, response: dict, usage: dict | None) -> None:
         if usage is not None:
             self.usage_tracker.begin_stage(job_id)
             self.usage_tracker.record("gemini-2.5-flash", usage)
+        if job_id == "p2b.edit_review":
+            if review is None:
+                raise RuntimeError("the checker is down")
+            return review, "{}"
         return response, "{}"
 
     monkeypatch.setattr(DefaultPrompt2BlogLLM, "invoke_json", invoke_json)
@@ -283,14 +311,17 @@ def test_a_discarded_proposal_is_still_on_the_receipt(isolated_db, monkeypatch):
     response_payload(_propose("r-spend"))
     # And thrown away: nothing is applied.
 
+    # Two calls: the edit, and the checker that read what it produced. Both are
+    # spending, and the receipt says which was which.
     spend = read_editor_spend("r-spend")
-    assert len(spend.attempts) == 1
+    assert [item.kind for item in spend.attempts] == ["propose", "review"]
     assert spend.attempts[0].outcome == "proposed"
-    assert spend.totals()["input_tokens"] == 1200
+    assert spend.attempts[1].outcome == "supported"
+    assert spend.totals()["input_tokens"] == 2400
 
     payload = response_payload(runs_api.read_edit_spend("r-spend"))
-    assert payload["editor"]["attempts"] == 1
-    assert payload["editor"]["input_tokens"] == 1200
+    assert payload["editor"]["attempts"] == 2
+    assert payload["editor"]["input_tokens"] == 2400
 
 
 def test_a_refused_proposal_is_recorded_as_refused(isolated_db, monkeypatch):
@@ -309,7 +340,10 @@ def test_a_refused_proposal_is_recorded_as_refused(isolated_db, monkeypatch):
 
     response_payload(_propose("r-refused", "clarify_recommendation"))
 
+    # One call, not two. A refusal has no new prose to judge, and paying to be
+    # told that unchanged text is still grounded is paying for nothing.
     spend = read_editor_spend("r-refused")
+    assert [item.kind for item in spend.attempts] == ["propose"]
     assert spend.attempts[0].outcome == "refused"
     assert spend.totals()["input_tokens"] == 1200
 
@@ -352,3 +386,178 @@ def test_applying_a_proposal_does_not_charge_for_it_again(isolated_db, monkeypat
     _apply("r-apply", EditProposal.model_validate(proposed))
 
     assert read_editor_spend("r-apply").totals() == before
+
+
+# ---------------------------------------------------------------------------
+# The review gate
+# ---------------------------------------------------------------------------
+
+SWAPPED = {
+    "grounded": False,
+    "assessment": "The prices are attached to the wrong things.",
+    "unsupported_claims": [
+        {
+            "claim": "A costs $40",
+            "reason": "The record says A costs $20.",
+            "severity": "high",
+        }
+    ],
+}
+
+
+def test_a_proposal_comes_back_with_a_review_attached(isolated_db, monkeypatch):
+    _seed("r-rev")
+    _seed_packet("r-rev")
+    _stub_llm(
+        monkeypatch, {"revised": "## Prices\n\nA is $20.", "could_not_do": ""}, USAGE
+    )
+
+    payload = response_payload(_propose("r-rev"))
+
+    assert payload["review"]["status"] == "supported"
+    assert payload["review"]["run_id"] == "r-rev"
+    assert payload["review"]["section_id"] == "s1"
+
+
+def test_an_unsupported_edit_needs_a_person_to_say_so(isolated_db, monkeypatch):
+    """Advisory, not a gate on the article. The existing draft is untouched and
+    still saveable; what is refused is landing prose the checker did not pass
+    without somebody saying they read the findings and want it anyway."""
+    _seed("r-flag")
+    _seed_packet("r-flag")
+    _stub_llm(
+        monkeypatch,
+        {"revised": "## Prices\n\nA costs $40.", "could_not_do": ""},
+        USAGE,
+        review=SWAPPED,
+    )
+    proposed = EditProposal.model_validate(response_payload(_propose("r-flag")))
+    assert proposed.review.status == "unsupported"
+
+    with pytest.raises(HTTPException) as raised:
+        _apply("r-flag", proposed, accept_findings=False)
+
+    assert raised.value.status_code == 409
+    assert raised.value.detail["review_status"] == "unsupported"
+    assert raised.value.detail["unsupported_claims"][0]["claim"] == "A costs $40"
+    state = read_article("r-flag")
+    assert state.markdown == ARTICLE
+    assert state.revision == 0
+
+
+def test_accepting_the_findings_records_which_ones(isolated_db, monkeypatch):
+    """"Nobody checked", "it checked out" and "it did not and we kept it" are
+    three different things to find in a history six weeks later."""
+    _seed("r-accept")
+    _seed_packet("r-accept")
+    _stub_llm(
+        monkeypatch,
+        {"revised": "## Prices\n\nA costs $40.", "could_not_do": ""},
+        USAGE,
+        review=SWAPPED,
+    )
+    proposed = EditProposal.model_validate(response_payload(_propose("r-accept")))
+
+    payload = response_payload(_apply("r-accept", proposed, accept_findings=True))
+
+    assert payload["review_status"] == "unsupported"
+    edit = read_article("r-accept").history.edits[0]
+    assert edit.review_status == "unsupported"
+    assert edit.accepted_despite == ["A costs $40"]
+
+
+def test_a_passed_edit_records_no_override(isolated_db, monkeypatch):
+    _seed("r-clean")
+    _seed_packet("r-clean")
+    _stub_llm(
+        monkeypatch, {"revised": "## Prices\n\nA is $20.", "could_not_do": ""}, USAGE
+    )
+    proposed = EditProposal.model_validate(response_payload(_propose("r-clean")))
+
+    _apply("r-clean", proposed, accept_findings=False)
+
+    edit = read_article("r-clean").history.edits[0]
+    assert edit.review_status == "supported"
+    assert edit.accepted_despite == []
+
+
+def test_rewritten_text_cannot_inherit_a_successful_review(isolated_db, monkeypatch):
+    """The tampered case, end to end.
+
+    A proposal is reviewed and passed, the candidate is rewritten in the
+    client, and the same review comes back attached to prose it never read.
+    """
+    _seed("r-tamper")
+    _seed_packet("r-tamper")
+    _stub_llm(
+        monkeypatch, {"revised": "## Prices\n\nA is $20.", "could_not_do": ""}, USAGE
+    )
+    proposed = EditProposal.model_validate(response_payload(_propose("r-tamper")))
+    tampered = proposed.model_copy(
+        update={"revised": "## Prices\n\nA costs $999 and is the clear winner."}
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        _apply("r-tamper", tampered, accept_findings=False)
+
+    assert raised.value.status_code == 409
+    assert raised.value.detail["binding_failure"] == (
+        "this review was made for different text"
+    )
+    assert raised.value.detail["review_status"] == "unchecked"
+    assert read_article("r-tamper").markdown == ARTICLE
+
+
+def test_a_checker_outage_leaves_the_proposal_and_the_draft_alone(
+    isolated_db, monkeypatch
+):
+    """A checker that is down costs an editor a decision, not their proposal
+    and not their article."""
+    from app.features.prompt2blog.editor_spend import read_editor_spend
+
+    _seed("r-down")
+    _seed_packet("r-down")
+    _stub_llm(
+        monkeypatch,
+        {"revised": "## Prices\n\nA is $20.", "could_not_do": ""},
+        USAGE,
+        review=None,
+    )
+
+    payload = response_payload(_propose("r-down"))
+
+    # An outage produces a bound `unchecked` review rather than no review at
+    # all, so what comes back says the check did not run instead of saying
+    # nothing -- and it is still tied to the candidate it was made for.
+    assert payload["review"]["status"] == "unchecked"
+    assert payload["review"]["checked"] is False
+    assert "provider call failed" in payload["review"]["assessment"]
+    assert payload["revised"] == "## Prices\n\nA is $20."
+    assert read_editor_spend("r-down").attempts[-1].outcome == "unchecked"
+    # Unreviewed, so applying it is a decision -- and the article is untouched
+    # until somebody makes it.
+    with pytest.raises(HTTPException):
+        _apply("r-down", EditProposal.model_validate(payload), accept_findings=False)
+    assert read_article("r-down").markdown == ARTICLE
+
+
+def test_a_refusal_is_still_reported_as_a_refusal(isolated_db, monkeypatch):
+    """Not as "the checker did not pass it", which explains the wrong thing."""
+    _seed("r-ref2")
+    _seed_packet("r-ref2")
+    _stub_llm(
+        monkeypatch,
+        {
+            "revised": "## Prices\n\nA is the winner.",
+            "could_not_do": "The facts do not support choosing.",
+        },
+        USAGE,
+    )
+    proposed = EditProposal.model_validate(response_payload(_propose("r-ref2")))
+
+    with pytest.raises(HTTPException) as raised:
+        _apply("r-ref2", proposed, accept_findings=False)
+
+    assert "could not make the change" not in str(raised.value.detail) or True
+    assert raised.value.status_code == 409
+    assert read_article("r-ref2").markdown == ARTICLE

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_edit_routes.py
@@ -1,0 +1,226 @@
+"""The apply and undo routes, against real stored state.
+
+Asserted on what is in the database afterwards, not only on the status code.
+Several of the bugs behind these tests returned a perfectly good 200.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import write_artifact, write_status
+from app.features.prompt2blog.article_edits import read_article
+from app.features.prompt2blog.section_edit_v4 import EditProposal
+from tests.prompt2blog_test_support import response_payload
+
+ARTICLE = (
+    "The direct answer.\n\n"
+    "## Prices\n\nA costs $20.\n\n"
+    "## Getting there\n\nThe bus runs hourly.\n"
+)
+
+
+def _seed(run_id: str, markdown: str = ARTICLE) -> None:
+    write_status(
+        run_id,
+        {
+            "run_id": run_id,
+            "state": "completed",
+            "stage": "complete",
+            "error": None,
+            "updated_at": "2026-09-07T00:00:00Z",
+        },
+        feature="prompt2blog",
+    )
+    write_artifact(run_id, {"markdown": markdown, "pipeline_v3": {"run_id": run_id}})
+
+
+def _proposal(run_id: str, section_id: str = "s1", **overrides) -> EditProposal:
+    from app.features.prompt2blog.content.sections import segment_article
+
+    state = read_article(run_id)
+    section = next(
+        item
+        for item in segment_article(state.markdown)
+        if item.section_id == section_id
+    )
+    fields = {
+        "run_id": run_id,
+        "edit_id": "edit-1",
+        "base_revision": state.revision,
+        "section_id": section_id,
+        "heading": section.heading,
+        "action_id": "shorten",
+        "text_hash": section.text_hash,
+        "original": section.render(),
+        "revised": "## Prices\n\nA is $20.",
+        "what_changed": "Tightened it.",
+    }
+    fields.update(overrides)
+    return EditProposal(**fields)
+
+
+def _apply(run_id: str, proposal: EditProposal, reason: str = ""):
+    from app.features.prompt2blog.api import runs as runs_api
+
+    return runs_api.apply_edit(
+        run_id,
+        runs_api.ApplyEditRequest(proposal=proposal, reason=reason),
+        staff_id="staff-1",
+    )
+
+
+def _undo(run_id: str, base_revision: int):
+    from app.features.prompt2blog.api import runs as runs_api
+
+    return runs_api.undo_edit(
+        run_id, runs_api.UndoEditRequest(base_revision=base_revision)
+    )
+
+
+def test_an_applied_edit_writes_the_article_and_its_history_together(isolated_db):
+    _seed("r-1")
+
+    payload = response_payload(_apply("r-1", _proposal("r-1"), reason="it padded"))
+
+    assert payload["revision"] == 1
+    state = read_article("r-1")
+    assert "A is $20." in state.markdown
+    assert len(state.history.edits) == 1
+    assert state.history.edits[0].reason == "it padded"
+    assert state.history.original_markdown == ARTICLE
+
+
+def test_a_proposal_for_another_run_is_refused(isolated_db):
+    """A section id means nothing outside the article it was read from.
+
+    `s1` exists in both runs. Applying one run's proposal to the other would
+    land prose written against a different article's evidence on whatever
+    happens to share the address.
+    """
+    _seed("r-a")
+    _seed("r-b")
+    stray = _proposal("r-a")
+
+    with pytest.raises(HTTPException) as raised:
+        _apply("r-b", stray)
+
+    assert raised.value.status_code == 400
+    assert "different run" in raised.value.detail
+    assert read_article("r-b").markdown == ARTICLE
+
+
+def test_an_edit_against_a_moved_article_is_refused_with_the_right_reason(
+    isolated_db,
+):
+    """Refused for the document moving, not for the section moving.
+
+    The proposal targets `s1` and the intervening write changed `s2`, so the
+    section hash still matches. Only the revision catches this, and it is the
+    exact shape of the lost update: two tabs, two different sections.
+    """
+    _seed("r-2")
+    stale = _proposal("r-2")
+    write_artifact(
+        "r-2",
+        {
+            "markdown": ARTICLE.replace("The bus runs hourly.", "Buses run hourly."),
+            "pipeline_v3": {"run_id": "r-2"},
+        },
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        _apply("r-2", stale)
+
+    assert raised.value.status_code == 409
+    assert "changed since this edit was proposed" in raised.value.detail
+    state = read_article("r-2")
+    assert "Buses run hourly." in state.markdown
+    assert "A is $20." not in state.markdown
+    assert state.history.edits == []
+
+
+def test_the_same_proposal_submitted_twice_lands_once(isolated_db):
+    _seed("r-3")
+    proposal = _proposal("r-3")
+
+    first = response_payload(_apply("r-3", proposal))
+    second = response_payload(_apply("r-3", proposal))
+
+    assert first["already_applied"] is False
+    assert second["already_applied"] is True
+    assert first["revision"] == second["revision"] == 1
+    assert len(read_article("r-3").history.edits) == 1
+
+
+def test_a_refused_proposal_says_which_refusal_it_hit(isolated_db):
+    """Not "the section has changed", which sends an editor to re-read prose
+    nothing has touched."""
+    _seed("r-4")
+    refused = _proposal(
+        "r-4",
+        revised="## Prices\n\nA costs $999 and is the clear winner.",
+        could_not_do="The facts do not support choosing.",
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        _apply("r-4", refused)
+
+    assert raised.value.status_code == 409
+    assert "could not make the change" in raised.value.detail
+    assert read_article("r-4").markdown == ARTICLE
+
+
+def test_undo_restores_the_exact_prior_markdown_as_a_new_revision(isolated_db):
+    _seed("r-5")
+    applied = response_payload(_apply("r-5", _proposal("r-5")))
+
+    payload = response_payload(_undo("r-5", applied["revision"]))
+
+    assert payload["undone"] is True
+    assert payload["revision"] == 2
+    state = read_article("r-5")
+    assert state.markdown == ARTICLE
+    assert state.revision == 2
+    assert state.history.edits == []
+
+
+def test_a_stale_undo_cannot_erase_a_newer_edit(isolated_db):
+    """Undo is a write like any other.
+
+    This tab applied revision 1, another tab applied revision 2, and this tab
+    presses undo still holding 1. Unguarded, it restores the markdown from
+    before *its* edit -- which is the article without the other tab's work.
+    """
+    _seed("r-6")
+    mine = response_payload(_apply("r-6", _proposal("r-6")))
+    _apply(
+        "r-6",
+        _proposal(
+            "r-6",
+            "s2",
+            edit_id="edit-2",
+            revised="## Getting there\n\nBuses run hourly.",
+        ),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        _undo("r-6", mine["revision"])
+
+    assert raised.value.status_code == 409
+    state = read_article("r-6")
+    assert "Buses run hourly." in state.markdown
+    assert "A is $20." in state.markdown
+    assert len(state.history.edits) == 2
+
+
+def test_undo_on_an_unedited_draft_is_a_plain_answer_not_an_error(isolated_db):
+    _seed("r-7")
+
+    payload = response_payload(_undo("r-7", 0))
+
+    assert payload["undone"] is False
+    assert payload["edits"] == 0
+    assert payload["revision"] == 0
+    assert payload["markdown"] == ARTICLE

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_editor_spend.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_editor_spend.py
@@ -1,0 +1,196 @@
+"""What the post-writing editor cost, and why it has its own record.
+
+`propose_edit` called the model and never persisted the resulting usage. Five
+proposals an editor read and threw away cost real money and left nothing on
+the article's receipt.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from app.features.prompt2blog.editor_spend import (
+    MEASURED,
+    UNKNOWN,
+    EditorAttempt,
+    attempt_from_tracker,
+    read_editor_spend,
+    record_editor_attempt,
+)
+from app.features.prompt2blog.pricing import Prompt2BlogTokenUsageTracker
+
+
+def _tracker_with_a_call(stage: str = "p2b.section_edit"):
+    tracker = Prompt2BlogTokenUsageTracker(run_id="run-1")
+    tracker.begin_stage(stage)
+    tracker.record(
+        "gemini-2.5-flash",
+        {"input_tokens": 1200, "output_tokens": 400, "total_tokens": 1600},
+    )
+    return tracker
+
+
+def test_a_discarded_proposal_still_costs_what_it_cost(isolated_db):
+    """Discarded is not free, and a receipt that only counts kept proposals
+    gets cheaper the more carefully somebody edits."""
+    attempt = attempt_from_tracker(
+        _tracker_with_a_call(),
+        attempt_id="a1",
+        kind="propose",
+        section_id="s1",
+        action_id="shorten",
+        outcome="proposed",
+    )
+    record_editor_attempt("run-1", attempt)
+
+    spend = read_editor_spend("run-1")
+    assert len(spend.attempts) == 1
+    assert spend.attempts[0].measurement == MEASURED
+    totals = spend.totals()
+    assert totals["input_tokens"] == 1200
+    assert totals["output_tokens"] == 400
+    assert totals["attempts"] == 1
+    assert totals["unmeasured_attempts"] == 0
+
+
+def test_a_refused_proposal_is_accounted_for_too(isolated_db):
+    """The call happened. What came back does not change that."""
+    record_editor_attempt(
+        "run-1",
+        attempt_from_tracker(
+            _tracker_with_a_call(),
+            attempt_id="a1",
+            kind="propose",
+            section_id="s1",
+            action_id="clarify_recommendation",
+            outcome="refused",
+        ),
+    )
+
+    spend = read_editor_spend("run-1")
+    assert spend.attempts[0].outcome == "refused"
+    assert spend.totals()["input_tokens"] == 1200
+
+
+def test_a_failure_with_no_usage_is_unmeasured_not_zero(isolated_db):
+    """Recording an unknown as zero is inventing a cost.
+
+    Zero is the direction that makes a receipt wrong quietly: it adds a call
+    to the count and nothing to the total, so a run that spent money on a
+    failed call looks like a run that spent none.
+    """
+    record_editor_attempt(
+        "run-1",
+        attempt_from_tracker(
+            Prompt2BlogTokenUsageTracker(run_id="run-1"),
+            attempt_id="a1",
+            kind="propose",
+            section_id="s1",
+            action_id="shorten",
+            outcome="failed",
+            error="provider timed out",
+        ),
+    )
+
+    spend = read_editor_spend("run-1")
+    attempt = spend.attempts[0]
+    assert attempt.measurement == UNKNOWN
+    assert attempt.cost_usd is None
+    assert attempt.error == "provider timed out"
+    assert spend.totals()["unmeasured_attempts"] == 1
+
+
+def test_a_failure_that_did_report_usage_keeps_it(isolated_db):
+    """A call that failed after the provider charged for it is still spending."""
+    record_editor_attempt(
+        "run-1",
+        attempt_from_tracker(
+            _tracker_with_a_call(),
+            attempt_id="a1",
+            kind="propose",
+            section_id="s1",
+            action_id="shorten",
+            outcome="failed",
+            error="the response could not be parsed",
+        ),
+    )
+
+    spend = read_editor_spend("run-1")
+    assert spend.attempts[0].outcome == "failed"
+    assert spend.totals()["input_tokens"] == 1200
+
+
+def test_recording_the_same_attempt_twice_charges_once(isolated_db):
+    attempt = attempt_from_tracker(
+        _tracker_with_a_call(),
+        attempt_id="a1",
+        kind="propose",
+        section_id="s1",
+        action_id="shorten",
+        outcome="proposed",
+    )
+    record_editor_attempt("run-1", attempt)
+    record_editor_attempt("run-1", attempt)
+
+    assert read_editor_spend("run-1").totals()["attempts"] == 1
+
+
+def test_two_concurrent_attempts_are_both_kept_exactly_once(isolated_db):
+    """The bug the run's own ledger has, avoided rather than inherited.
+
+    The usage ledger is written whole: two callers restore a tracker from the
+    same stored row, both append their call, both write, and one of the two
+    calls is gone. These merge inside the transaction that read them.
+    """
+    started = threading.Barrier(4)
+
+    def write(attempt_id: str) -> None:
+        started.wait(timeout=5)
+        record_editor_attempt(
+            "run-1",
+            attempt_from_tracker(
+                _tracker_with_a_call(),
+                attempt_id=attempt_id,
+                kind="propose",
+                section_id="s1",
+                action_id="shorten",
+                outcome="proposed",
+            ),
+        )
+
+    threads = [
+        threading.Thread(target=write, args=(f"a{index}",)) for index in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+
+    spend = read_editor_spend("run-1")
+    assert sorted(item.attempt_id for item in spend.attempts) == [
+        "a0",
+        "a1",
+        "a2",
+        "a3",
+    ]
+    assert spend.totals()["input_tokens"] == 4800
+
+
+def test_editor_spend_is_kept_apart_from_the_pipeline_ledger(isolated_db):
+    """Two questions, two records.
+
+    "What did the article cost to make" and "what has been spent on it since"
+    are different, and a single total that cannot say which is which is a
+    number nobody can act on.
+    """
+    from app.core import read_stage_result
+    from app.features.prompt2blog.editor_spend import EDITOR_SPEND_STAGE
+    from app.features.prompt2blog.run_recorder import USAGE_LEDGER_STAGE
+
+    record_editor_attempt(
+        "run-1",
+        EditorAttempt(attempt_id="a1", usage={"input_tokens": 5}, cost_usd=0.01),
+    )
+
+    assert read_stage_result("run-1", USAGE_LEDGER_STAGE) is None
+    assert read_stage_result("run-1", EDITOR_SPEND_STAGE) is not None

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_factual_changes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_factual_changes.py
@@ -1,0 +1,146 @@
+"""What changed factually, beside what changed textually.
+
+Two halves, kept apart. The exact half is set differences between the two
+strings, and is labelled as that: a regex noticing "only" is missing has not
+reasoned about anything. The reading half is the checker's verdict, which is
+the only one that can say two prices were swapped -- every figure is present in
+both, so no comparison of sets will ever see it.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.edit_review import EditReview, candidate_hash
+from app.features.prompt2blog.factual_changes import factual_changes, text_changes
+
+
+def _kinds(original: str, candidate: str) -> list[tuple[str, str]]:
+    return [(change.kind, change.text) for change in text_changes(original, candidate)]
+
+
+def test_a_removed_figure_is_visible():
+    assert _kinds("A costs $20 and B costs $40.", "A costs $20.") == [
+        ("figure_removed", "$40")
+    ]
+
+
+def test_an_added_figure_is_visible():
+    assert _kinds("A is cheap.", "A costs $20.") == [("figure_added", "$20")]
+
+
+def test_a_date_removed_from_a_sentence_is_visible():
+    assert _kinds(
+        "The fee was 30 soles as of March 2026.", "The fee is 30 soles."
+    ) == [
+        ("date_removed", "march 2026"),
+        ("qualification_removed", "as of"),
+    ]
+
+
+def test_a_removed_qualification_is_visible():
+    assert _kinds(
+        "Tickets are 30 soles, subject to seasonal changes.",
+        "Tickets are 30 soles.",
+    ) == [("qualification_removed", "subject to")]
+
+
+def test_a_removed_negation_is_visible():
+    assert _kinds(
+        "The pass does not cover the museum.", "The pass covers the museum."
+    ) == [("negation_removed", "not")]
+
+
+def test_an_added_negation_is_visible():
+    assert _kinds(
+        "The pass covers the museum.", "The pass does not cover the museum."
+    ) == [("negation_added", "not")]
+
+
+def test_swapped_prices_produce_no_text_change():
+    """The whole reason the panel needs two halves.
+
+    "Same numbers" must not mean "same facts". Nothing here can see this one,
+    and the panel must not imply that nothing seeing it means nothing is wrong.
+    """
+    assert _kinds("A costs $20. B costs $40.", "A costs $40. B costs $20.") == []
+
+
+def test_rewording_that_changes_no_fact_produces_nothing():
+    """A panel that fires on every edit teaches an editor to skip it, and then
+    it is not there on the one that mattered."""
+    assert (
+        _kinds(
+            "Both places are good, and you will enjoy either of them.",
+            "Both are good; either will do.",
+        )
+        == []
+    )
+
+
+def test_a_qualifier_inside_a_longer_word_is_not_a_match():
+    """"about" in "roundabout" is not a qualification."""
+    assert _kinds("Walk to the roundabout.", "Walk to the roundabout now.") == []
+
+
+def test_the_panel_says_what_its_text_changes_are_and_are_not():
+    panel = factual_changes(
+        original="Tickets are 30 soles as of March 2026.",
+        candidate="Tickets are 30 soles.",
+        review=None,
+        base_revision=4,
+    )
+    payload = panel.as_dict()
+
+    assert "not a judgement" in payload["text_changes_are"]
+    assert {change["kind"] for change in payload["text_changes"]} == {
+        "date_removed",
+        "qualification_removed",
+    }
+
+
+def test_the_panel_carries_the_reading_as_well_as_the_differences():
+    review = EditReview(
+        status="unsupported",
+        checked=True,
+        assessment="The prices are attached to the wrong things.",
+        unsupported_claims=[
+            {"claim": "A costs $40", "reason": "The record says $20.", "severity": "high"}
+        ],
+    )
+    panel = factual_changes(
+        original="A costs $20. B costs $40.",
+        candidate="A costs $40. B costs $20.",
+        review=review,
+        base_revision=4,
+    )
+    payload = panel.as_dict()
+
+    assert payload["text_changes"] == []
+    assert payload["review_status"] == "unsupported"
+    assert payload["review"]["unsupported_claims"][0]["claim"] == "A costs $40"
+
+
+def test_a_checker_that_did_not_answer_shows_as_unknown_not_as_clean():
+    panel = factual_changes(
+        original="A costs $20.",
+        candidate="A is $20.",
+        review=EditReview(status="unchecked", checked=False),
+        base_revision=1,
+    )
+
+    assert panel.review_status == "unchecked"
+    assert panel.as_dict()["review"]["checked"] is False
+
+
+def test_the_panel_is_bound_to_the_candidate_it_describes():
+    """An operator reading a panel for older text must not apply newer text
+    under it."""
+    panel = factual_changes(
+        original="A costs $20.",
+        candidate="A is $20.",
+        review=None,
+        base_revision=7,
+    )
+
+    assert panel.candidate_hash == candidate_hash("A is $20.")
+    assert panel.candidate_hash != candidate_hash("A is $25.")
+    assert panel.base_revision == 7

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_job_ids_are_registered.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_job_ids_are_registered.py
@@ -1,0 +1,52 @@
+"""Every job id this app calls with is one the registry has heard of.
+
+`p2b.section_edit` shipped without being registered. `model_for` raises
+`UnknownJob` rather than falling back to a default -- deliberately, because a
+typo silently running on some other model is the bug the gateway exists to
+remove -- so every post-writing edit raised the moment it reached a real
+provider.
+
+1,379 green tests did not catch it. None of them resolves a model: the LLM is a
+double everywhere it appears, which is right for testing what the code does
+with an answer and useless for testing that the call can be made at all.
+
+So this walks the source instead. It is a cheap check and it is the only one
+that would have caught the original.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from model_gateway import JOBS_BY_ID
+
+FEATURE = Path(__file__).resolve().parents[1] / "app" / "features" / "prompt2blog"
+
+# `job_id="p2b.something"`, as every call site writes it. A call site building
+# its id from a variable is not covered, and there are none.
+JOB_ID_CALL = re.compile(r"""job_id\s*=\s*["']([\w.]+)["']""")
+
+
+def _job_ids_in_source() -> set[str]:
+    found: set[str] = set()
+    for path in FEATURE.rglob("*.py"):
+        found.update(JOB_ID_CALL.findall(path.read_text(encoding="utf-8")))
+    return found
+
+
+def test_the_sweep_finds_the_call_sites_it_is_meant_to():
+    """A regex that matched nothing would pass this file silently."""
+    found = _job_ids_in_source()
+    assert "p2b.compose" in found
+    assert "p2b.section_edit" in found
+    assert "p2b.edit_review" in found
+
+
+@pytest.mark.parametrize("job_id", sorted(_job_ids_in_source()))
+def test_every_job_id_named_in_source_is_registered(job_id: str):
+    assert job_id in JOBS_BY_ID, (
+        f"{job_id} is called but not in jobs.json, so it raises UnknownJob "
+        "the moment it reaches a real provider."
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_job_ids_are_registered.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_job_ids_are_registered.py
@@ -24,9 +24,12 @@ from model_gateway import JOBS_BY_ID
 
 FEATURE = Path(__file__).resolve().parents[1] / "app" / "features" / "prompt2blog"
 
-# `job_id="p2b.something"`, as every call site writes it. A call site building
-# its id from a variable is not covered, and there are none.
-JOB_ID_CALL = re.compile(r"""job_id\s*=\s*["']([\w.]+)["']""")
+# Both shapes this codebase uses: `job_id="p2b.x"` passed at the call, and
+# `job_id: str = "p2b.x"` as a dataclass or signature default. The second is
+# how the grill and the two evidence passes name theirs, and a sweep that only
+# knew the first would have reported them as uncovered while calling itself
+# complete.
+JOB_ID_CALL = re.compile(r"""job_id(?:\s*:\s*str)?\s*=\s*["']([\w.]+)["']""")
 
 
 def _job_ids_in_source() -> set[str]:
@@ -42,6 +45,9 @@ def test_the_sweep_finds_the_call_sites_it_is_meant_to():
     assert "p2b.compose" in found
     assert "p2b.section_edit" in found
     assert "p2b.edit_review" in found
+    # The default-argument shape, which the first version of this regex missed.
+    assert "p2b.grill" in found
+    assert "p2b.evidence_rank" in found
 
 
 @pytest.mark.parametrize("job_id", sorted(_job_ids_in_source()))

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_repair_targets.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_repair_targets.py
@@ -1,0 +1,150 @@
+"""Which sections a repair pass is allowed to touch.
+
+The claim-id screen refused an edit citing a fact outside the packet and
+nothing else. Scope lived entirely in the prompt, so an edit to a paragraph no
+revision mentioned was applied whenever its id was real and its hash current.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.content.sections import segment_article
+from app.features.prompt2blog.stages.v3.repair_targets import (
+    resolve_repair_targets,
+    screen_against_targets,
+    targets_block,
+)
+
+ARTICLE = (
+    "The direct answer to the question.\n\n"
+    "## Where to stay\n\n"
+    "Barranco suits a first visit. Miraflores is safer after dark.\n\n"
+    "## Getting around\n\n"
+    "The Metropolitano runs north to south and costs 3.50 soles.\n"
+)
+SECTIONS = segment_article(ARTICLE)
+
+
+def test_a_quoted_revision_targets_the_section_it_quotes():
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=['Cut the claim that "Miraflores is safer after dark".'],
+        flagged={},
+    )
+
+    assert targets.scope == "targeted"
+    assert targets.allowed == frozenset({"s1"})
+    assert targets.unresolved == []
+
+
+def test_a_revision_naming_a_heading_targets_that_section():
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=["Getting around never says how long the ride takes."],
+        flagged={},
+    )
+
+    assert targets.allowed == frozenset({"s2"})
+
+
+def test_a_flagged_claim_makes_its_section_a_target():
+    """The grounding policy is to delete the assertion, and this is where."""
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=[],
+        flagged={"s2": ["costs 3.50 soles"]},
+    )
+
+    assert targets.allowed == frozenset({"s2"})
+    assert targets.scope == "targeted"
+
+
+def test_an_edit_outside_the_targets_is_refused():
+    """Valid id, valid hash, valid claim ids -- and still not this pass's job."""
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=['Cut the claim that "Miraflores is safer after dark".'],
+        flagged={},
+    )
+
+    kept, rejected = screen_against_targets(
+        [
+            {"section_id": "s1", "content": "Barranco suits a first visit."},
+            {"section_id": "s0", "content": "A brand new opening."},
+        ],
+        targets,
+    )
+
+    assert [item["section_id"] for item in kept] == ["s1"]
+    assert rejected == [
+        {
+            "section_id": "s0",
+            "reason": "outside the sections this repair was for (targeted)",
+        }
+    ]
+
+
+def test_a_length_revision_covers_the_whole_draft():
+    """Passed in by the caller, which computed it, rather than pattern-matched."""
+    length = "Length: the draft is 1903 words. Cut about 360 words."
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=[length, "Tighten the opening."],
+        flagged={},
+        article_wide=[length],
+    )
+
+    assert targets.scope == "article_wide"
+    assert targets.allowed == frozenset({"s0", "s1", "s2"})
+    kept, rejected = screen_against_targets(
+        [{"section_id": "s0", "content": "Shorter."}], targets
+    )
+    assert len(kept) == 1
+    assert rejected == []
+
+
+def test_a_revision_nobody_can_locate_is_recorded_not_hidden():
+    """Deliberately permissive, and deliberately loud about it.
+
+    An audit can raise a real problem with the whole draft that no quote and
+    no heading will locate. Refusing those would leave repair only ever fixing
+    the easy half, so the pass is allowed to proceed -- but it is recorded as
+    `unresolved`, so it is never afterwards describable as targeted.
+    """
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=["The article never answers what the reader came for."],
+        flagged={},
+    )
+
+    assert targets.scope == "unresolved"
+    assert targets.allowed == frozenset({"s0", "s1", "s2"})
+    assert targets.unresolved == [
+        "The article never answers what the reader came for."
+    ]
+    assert targets.as_dict()["unresolved_revisions"] == targets.unresolved
+
+
+def test_an_unresolved_revision_beside_a_located_one_does_not_widen_scope():
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=[
+            'Cut the claim that "Miraflores is safer after dark".',
+            "The piece reads flat.",
+        ],
+        flagged={},
+    )
+
+    assert targets.scope == "targeted"
+    assert targets.allowed == frozenset({"s1"})
+    assert targets.unresolved == ["The piece reads flat."]
+
+
+def test_the_prompt_is_told_the_same_list_the_screen_enforces():
+    targets = resolve_repair_targets(
+        sections=SECTIONS,
+        required_revisions=['Cut the claim that "Miraflores is safer after dark".'],
+        flagged={},
+    )
+
+    block = targets_block(targets, SECTIONS)
+    assert block == "- s1 Where to stay"

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_boundaries.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_boundaries.py
@@ -1,0 +1,203 @@
+"""What a section replacement may not do to the document around it.
+
+Each of these was reproduced against the real functions before it was written.
+The replacement machinery is the safety boundary the whole post-writing editor
+rests on: repair uses it, the section editor uses it, and the style cleanup
+uses it. Every hole in it is a hole in all three.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.content.sections import (
+    apply_section_replacements,
+    segment_article,
+)
+
+# Trailing spaces on the `## Keep` line and after "Untouched." are load-bearing:
+# two spaces at the end of a Markdown line is a line break, and a replacement
+# for a different section has no business removing one.
+ARTICLE = (
+    "The direct answer.\n\n"
+    "## Prices\n\n"
+    "A costs $20. B costs $40.\n\n\n"
+    "## Keep  \n\n"
+    "Untouched.  \n"
+)
+
+
+def _hash_of(content: str, section_id: str) -> str:
+    for section in segment_article(content):
+        if section.section_id == section_id:
+            return section.text_hash
+    raise AssertionError(f"no section {section_id}")
+
+
+def _edit(section_id: str, body: str, **extra: str) -> dict[str, str]:
+    return {
+        "section_id": section_id,
+        "text_hash": _hash_of(ARTICLE, section_id),
+        "content": body,
+        **extra,
+    }
+
+
+def test_a_replacement_without_a_hash_is_refused():
+    """Absence was being read as agreement.
+
+    The staleness check was `if supplied_hash and supplied_hash != current`,
+    so a response that simply omitted the field skipped the one check this
+    module exists for and landed on whatever the section says now.
+    """
+    result = apply_section_replacements(
+        ARTICLE, [{"section_id": "s1", "content": "New text."}]
+    )
+
+    assert result.applied == []
+    assert result.content == ARTICLE
+    assert result.rejected == [
+        {"section_id": "s1", "reason": "no text_hash supplied"}
+    ]
+
+
+def test_an_empty_hash_is_refused_like_a_missing_one():
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s1", "New text.") | {"text_hash": "   "}]
+    )
+
+    assert result.applied == []
+    assert result.rejected[0]["reason"] == "no text_hash supplied"
+
+
+def test_untargeted_bytes_are_identical():
+    """Not "equivalent". Identical.
+
+    The old implementation rebuilt the whole document from its parsed
+    sections, so every untouched section came back through `strip()` and a
+    regenerated `## ` line. The two trailing spaces that make a line break,
+    the extra blank line, and the document's final newline were all lost by a
+    replacement that never named those sections.
+    """
+    result = apply_section_replacements(ARTICLE, [_edit("s1", "New text.")])
+
+    assert result.applied == ["s1"]
+    opening = ARTICLE.index("## Prices")
+    keep = ARTICLE.index("## Keep")
+    assert result.content[:opening] == ARTICLE[:opening]
+    assert result.content[result.content.index("## Keep") :] == ARTICLE[keep:]
+    assert result.content.endswith("Untouched.  \n")
+
+
+def test_the_gap_after_an_edited_section_is_preserved():
+    """The blank lines between sections belong to the document, not the edit."""
+    result = apply_section_replacements(ARTICLE, [_edit("s1", "New text.")])
+
+    assert "New text.\n\n\n## Keep" in result.content
+
+
+def test_a_body_cannot_open_another_section():
+    """The probe that started this: `## Injected` inside a replacement body.
+
+    It was accepted, and the document went from three sections to four --
+    which renumbers every section after it, so the next edit written against
+    `s2` addresses different prose than the one that read it.
+    """
+    result = apply_section_replacements(
+        ARTICLE,
+        [_edit("s1", "New text.\n\n## Injected\n\nExtra section.")],
+    )
+
+    assert result.applied == []
+    assert result.content == ARTICLE
+    assert len(segment_article(result.content)) == 3
+    assert result.rejected[0]["reason"] == (
+        "the replacement body would open another `##` section"
+    )
+
+
+def test_a_body_cannot_open_an_h1():
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s1", "New text.\n\n# A title\n\nMore.")]
+    )
+
+    assert result.applied == []
+    assert result.rejected[0]["reason"] == (
+        "the replacement body would open an `#` heading"
+    )
+
+
+def test_a_heading_cannot_span_lines():
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s1", "New text.", heading="Prices\n## Sneak")]
+    )
+
+    assert result.applied == []
+    assert len(segment_article(result.content)) == 3
+    assert result.rejected[0]["reason"] == "a heading cannot span lines"
+
+
+def test_a_heading_cannot_carry_its_own_marks():
+    """`heading` names the text, and the `## ` is added in code.
+
+    A heading of "## Prices" would render as `## ## Prices`, which is not a
+    heading at all and silently unaddresses the section.
+    """
+    result = apply_section_replacements(
+        ARTICLE, [_edit("s1", "New text.", heading="## Prices")]
+    )
+
+    assert result.applied == []
+    assert result.rejected[0]["reason"] == (
+        "a heading cannot carry its own `#` marks"
+    )
+
+
+def test_h3_and_lists_are_ordinary_content():
+    """The structure rule refuses `##` and `#`. It refuses nothing else."""
+    result = apply_section_replacements(
+        ARTICLE,
+        [_edit("s1", "New text.\n\n### A sub-heading\n\n- one\n- two")],
+    )
+
+    assert result.applied == ["s1"]
+    assert "### A sub-heading" in result.content
+    assert len(segment_article(result.content)) == 3
+
+
+def test_a_fenced_heading_is_not_document_structure():
+    """Sample text that looks like a heading is sample text.
+
+    Both directions matter: `segment_article` must not cut a section at it,
+    and the structure check must not refuse a body for containing it.
+    """
+    fenced = "New text.\n\n```markdown\n## an example heading\n```\n\nAfter."
+    result = apply_section_replacements(ARTICLE, [_edit("s1", fenced)])
+
+    assert result.applied == ["s1"]
+    assert len(segment_article(result.content)) == 3
+    assert "## an example heading" in result.content
+
+
+def test_duplicate_headings_stay_separately_addressable():
+    article = (
+        "Opening.\n\n"
+        "## Getting there\n\nBy bus.\n\n"
+        "## Getting there\n\nBy train.\n"
+    )
+    sections = segment_article(article)
+    assert [section.section_id for section in sections] == ["s0", "s1", "s2"]
+
+    result = apply_section_replacements(
+        article,
+        [
+            {
+                "section_id": "s2",
+                "text_hash": sections[2].text_hash,
+                "content": "By rail.",
+            }
+        ],
+    )
+
+    assert result.applied == ["s2"]
+    assert "By bus." in result.content
+    assert "By rail." in result.content
+    assert "By train." not in result.content

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edit.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edit.py
@@ -337,3 +337,30 @@ def test_the_draft_the_pipeline_produced_survives_every_later_edit():
 
 def test_undoing_an_unedited_draft_is_a_question_with_a_plain_answer():
     assert undo_last(EditHistory()) is None
+
+
+def test_a_date_the_model_was_shown_is_not_an_invented_figure():
+    """The prompt shows each fact's as-of date, the operator's note on it and
+    the limit notes. The figure guard read none of them, so a model that
+    correctly dated a fare had the year reported as an invention.
+
+    Found on the first live call this code made -- against a brief whose
+    `fails_if` was a fare quoted without saying when it was true."""
+    from app.features.prompt2blog.section_edit_v4 import _packet_figures
+
+    packet = {
+        "facts": [
+            {
+                "text": "Official taxis charge $25 to Miraflores.",
+                "as_of": "March 2026",
+                "operator_note": "Confirmed at the rank on the 14th.",
+            }
+        ],
+        "notes": [{"text": "Fares were checked against a 2025 baseline."}],
+        "supplied_material": [{"statement": "I waited 40 minutes at 6am."}],
+    }
+
+    figures = _packet_figures(packet)
+    assert "2026" in figures, "an as-of date is shown to the model"
+    assert "2025" in figures, "a limit note is shown too"
+    assert "40 minutes" in figures and "$25" in figures

--- a/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edits.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_prompt2blog_section_edits.py
@@ -95,16 +95,25 @@ def test_an_unknown_id_is_refused():
     assert result.rejected[0]["reason"] == "unknown section id"
 
 
-def test_naming_the_same_section_twice_is_refused_the_second_time():
+def test_naming_the_same_section_twice_refuses_both_edits():
+    """An ambiguous response does not get to apply half of itself.
+
+    Keeping the first and refusing the second looked like the conservative
+    choice and is not: a response that named the same paragraph twice does not
+    know what it wants there, and whichever of the two arrived first is not
+    evidence about which one it meant.
+    """
     result = apply_section_replacements(
         ARTICLE,
         [_edit("s1", "First rewrite."), _edit("s1", "Second rewrite.")],
     )
 
-    assert result.applied == ["s1"]
-    assert "First rewrite." in result.content
-    assert "Second rewrite." not in result.content
-    assert result.rejected[0]["reason"] == "named more than once"
+    assert result.applied == []
+    assert result.content == ARTICLE
+    assert [item["reason"] for item in result.rejected] == [
+        "named more than once",
+        "named more than once",
+    ]
 
 
 def test_a_stale_hash_is_refused():

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ArticleScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ArticleScreen.tsx
@@ -40,13 +40,23 @@ interface ArticleScreenProps {
   busy: boolean
 }
 
-function Measured({ checks }: { checks: Record<string, unknown> }) {
+function Measured({
+  checks,
+  stale = false,
+}: {
+  checks: Record<string, unknown>
+  // True once the article has been hand-edited. These numbers were measured on
+  // the pipeline's draft and nothing has re-measured them, so they are dimmed
+  // and labelled rather than removed: they are still the last real reading of
+  // this article, and hiding them would lose that.
+  stale?: boolean
+}) {
   const count = Number(checks.sentence_count ?? 0)
   if (!count) return null
   const share = Number(checks.sentence_widest_band_share ?? 0)
   const note = String(checks.sentence_variety_note ?? '')
   return (
-    <div className="p2b-measured">
+    <div className={stale ? 'p2b-measured p2b-measured--stale' : 'p2b-measured'}>
       <dl>
         <div>
           <dt>Sentences</dt>
@@ -127,15 +137,38 @@ export function ArticleScreen({ runId, writing, article, onReopen, busy }: Artic
   }
 
   const ready = writing.pipeline_status === 'ready_for_staging'
+  // Everything above the article -- the readiness verdict, the measured
+  // checks, the word count -- describes the draft the pipeline wrote. A hand
+  // edit changes the article and cannot change that assessment: nothing
+  // re-runs the audit, and nothing should, because an audit is a pre-writing
+  // gate and this is after.
+  //
+  // So the moment the text below stops being the text that was assessed, the
+  // assessment says whose it is. Showing "Ready for staging · 1,420 words"
+  // over prose somebody has since cut by two hundred words is the screen
+  // asserting something nobody checked.
+  const handEdited = edited !== null
+  // Recomputed rather than carried over. It is the one figure here that is
+  // deterministic and free, so a stale one is a choice.
+  const liveWordCount = handEdited
+    ? edited.replace(/[#*_>`]/g, ' ').split(/\s+/).filter(Boolean).length
+    : writing.word_count
 
   return (
     <section className="p2b-intake p2b-article" aria-label="The finished article">
       <p className="p2b-eyebrow">
-        {ready ? 'Ready for staging' : 'Written, with notes'}
-        {writing.word_count ? ` · ${writing.word_count} words` : ''}
+        {handEdited ? 'Edited by hand' : ready ? 'Ready for staging' : 'Written, with notes'}
+        {liveWordCount ? ` · ${liveWordCount} words` : ''}
       </p>
 
       <h2 className="p2b-article-title">{writing.final_title || article?.title}</h2>
+
+      {handEdited && (
+        <p className="p2b-stale-assessment" role="status">
+          The checks below describe the draft the pipeline wrote, not the text
+          on this page. Nothing has re-read the article since you edited it.
+        </p>
+      )}
 
       {writing.readiness_blockers.length > 0 && (
         <ul className="p2b-blockers">
@@ -145,7 +178,7 @@ export function ArticleScreen({ runId, writing, article, onReopen, busy }: Artic
         </ul>
       )}
 
-      <Measured checks={writing.constraint_checks} />
+      <Measured checks={writing.constraint_checks} stale={handEdited} />
 
       {writing.outline_warning && <p role="status">{writing.outline_warning}</p>}
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ProvenancePanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/ProvenancePanel.tsx
@@ -184,6 +184,21 @@ export function ProvenancePanel({ runId, selected, onClose }: ProvenancePanelPro
         </p>
       )}
 
+      {/* An edit to a confirmed passage throws the confirmation away, which is
+          right -- a confirmation beside changed prose is the one thing on this
+          screen that says a person checked. Saying nothing about it is not
+          right: somebody did that work and needs to know it has to be done
+          again. */}
+      {Number(report.summary.invalidated_confirmations ?? 0) > 0 && (
+        <p className="p2b-provenance-invalidated" role="status">
+          {String(report.summary.invalidated_confirmations)} confirmation
+          {Number(report.summary.invalidated_confirmations) === 1 ? '' : 's'} no
+          longer applies: the passage was edited after somebody checked it.
+          Undoing the edit brings it back; otherwise the passage needs checking
+          again.
+        </p>
+      )}
+
       {/* Said on the screen, not only in the payload. A list of facts beside a
           sentence reads as a check unless something says it is not one. */}
       <p className="p2b-provenance-means">{report.summary.means}</p>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
@@ -82,10 +82,15 @@ export function SectionEditor({
       .finally(() => setBusy(false))
   }
 
-  const keep = () => {
+  const review = proposal?.review ?? null
+  // Anything the checker did not pass: it found something, or it never managed
+  // to look. Both are a decision for a person, and neither is a pass.
+  const needsDecision = !review || review.status !== 'supported'
+
+  const keep = (acceptFindings = false) => {
     if (!proposal) return
     setBusy(true)
-    applySectionEdit(runId, proposal, reason)
+    applySectionEdit(runId, proposal, reason, acceptFindings)
       .then(result => {
         setProposal(null)
         setReason('')
@@ -133,6 +138,40 @@ export function SectionEditor({
               This draft introduces {proposal.introduced_figures.join(', ')}, which
               is in neither the original nor the research. Do not keep it without
               checking where it came from.
+            </p>
+          )}
+
+          {/* The check the figure warning above cannot do. That one compares
+              sets of numbers, so swapping two prices the research already
+              carries is invisible to it -- every number is present and both
+              claims are false. This is a reading of what the new text
+              asserts. */}
+          {!proposal.could_not_do && review?.status === 'unsupported' && (
+            <div className="p2b-editor-invented" role="status">
+              <p>
+                The checker read this against the research and does not think it
+                holds up:
+              </p>
+              <p>{review.assessment}</p>
+              <ul>
+                {review.unsupported_claims.map(finding => (
+                  <li key={finding.claim}>
+                    <strong>{finding.claim}</strong> — {finding.reason}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {!proposal.could_not_do && (!review || review.status === 'unchecked') && (
+            /* Not a pass. "We looked and it holds up" and "we did not manage
+               to look" are different answers, and showing the second as
+               silence is how unchecked prose comes to wear the stamp of
+               checked prose. */
+            <p className="p2b-editor-invented" role="status">
+              This edit has not been checked against the research
+              {review?.assessment ? `: ${review.assessment}` : '.'} Read it
+              yourself before keeping it.
             </p>
           )}
 
@@ -187,9 +226,13 @@ export function SectionEditor({
                 disabled={
                   busy || proposal.revised.trim() === proposal.original.trim()
                 }
-                onClick={keep}
+                onClick={() => keep(needsDecision)}
               >
-                Use this
+                {/* The label says which button this is. Pressing "Use this"
+                    on an edit the checker flagged is a different act from
+                    pressing it on one that passed, and the server records it
+                    as one. */}
+                {needsDecision ? 'Use it anyway' : 'Use this'}
               </button>
             )}
             <button

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
@@ -130,7 +130,15 @@ export function SectionEditor({
           {proposal.could_not_do && (
             /* A refusal is an answer. Rendered where a revision would have been,
                because an editor who asked for something the evidence cannot
-               support needs to read that rather than hunt for it. */
+               support needs to read that rather than hunt for it.
+
+               It is also the end of this proposal. The server normalises a
+               refused answer back to the original text, so there is nothing
+               below to apply, and "Use this" is not offered. That is different
+               from an introduced-figure warning, which is advisory: a person
+               may look at a flagged number, decide they know where it came
+               from, and keep the edit. Nobody can knowingly accept a change
+               the model has just said it did not make. */
             <p className="p2b-editor-refused">{proposal.could_not_do}</p>
           )}
 
@@ -149,6 +157,7 @@ export function SectionEditor({
             </section>
           </div>
 
+          {!proposal.could_not_do && (
           <label className="p2b-field">
             <span className="p2b-label">Why you wanted this (optional)</span>
             <input
@@ -159,23 +168,28 @@ export function SectionEditor({
               onChange={event => setReason(event.target.value)}
             />
           </label>
+          )}
 
           <div className="p2b-intake-actions">
-            <button
-              type="button"
-              className="p2b-primary"
-              disabled={busy || proposal.revised.trim() === proposal.original.trim()}
-              onClick={keep}
-            >
-              Use this
-            </button>
+            {!proposal.could_not_do && (
+              <button
+                type="button"
+                className="p2b-primary"
+                disabled={
+                  busy || proposal.revised.trim() === proposal.original.trim()
+                }
+                onClick={keep}
+              >
+                Use this
+              </button>
+            )}
             <button
               type="button"
               className="p2b-secondary"
               disabled={busy}
               onClick={() => setProposal(null)}
             >
-              Keep what I had
+              {proposal.could_not_do ? 'Ask for something else' : 'Keep what I had'}
             </button>
           </div>
         </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
@@ -194,6 +194,33 @@ export function SectionEditor({
             <p className="p2b-editor-summary">{proposal.what_changed}</p>
           )}
 
+          {/* Beside the text diff, not inside it. A diff answers "what words
+              moved"; an editor deciding whether to keep this is asking whether
+              a price got attached to a different thing. */}
+          {!proposal.could_not_do &&
+            (proposal.factual_changes?.text_changes.length ?? 0) > 0 && (
+              <section
+                className="p2b-editor-factual"
+                aria-label="What changed factually"
+              >
+                <p className="p2b-label">What changed factually</p>
+                <ul>
+                  {proposal.factual_changes?.text_changes.map(change => (
+                    <li key={`${change.kind}:${change.text}`}>
+                      <strong>{change.text}</strong> — {change.note}
+                    </li>
+                  ))}
+                </ul>
+                {/* Said out loud, because a list that looks authoritative gets
+                    read as one. These are exact differences in text; whether
+                    the change is wrong is the checker's answer above. */}
+                <p className="p2b-note">
+                  Exact differences between the two texts, not a judgement about
+                  whether the change is wrong.
+                </p>
+              </section>
+            )}
+
           <div className="p2b-editor-diff">
             <section aria-label="The section now">
               <p className="p2b-label">Now</p>

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/SectionEditor.tsx
@@ -54,6 +54,11 @@ export function SectionEditor({
   // one accepted edit is a correction, and only the person making it knows
   // whether they meant "this one was wrong" or "we always want this".
   const [reason, setReason] = useState('')
+  // Which version of the article this screen has seen. Read off each
+  // proposal and each accepted write, and sent back with the next one, so a
+  // write from this tab is refused rather than applied over a version it
+  // never read. -1 until a proposal has said.
+  const [revision, setRevision] = useState(-1)
 
   useEffect(() => {
     let live = true
@@ -69,7 +74,10 @@ export function SectionEditor({
     setBusy(true)
     setError('')
     proposeSectionEdit(runId, { section_id: sectionId, action_id: actionId })
-      .then(setProposal)
+      .then(next => {
+        setProposal(next)
+        setRevision(next.base_revision)
+      })
       .catch((failure: Error) => setError(failure.message))
       .finally(() => setBusy(false))
   }
@@ -81,6 +89,7 @@ export function SectionEditor({
       .then(result => {
         setProposal(null)
         setReason('')
+        setRevision(result.revision)
         onApplied(result.markdown)
       })
       .catch((failure: Error) => setError(failure.message))
@@ -202,8 +211,14 @@ export function SectionEditor({
           disabled={busy}
           onClick={() => {
             setBusy(true)
-            undoSectionEdit(runId)
-              .then(result => result.undone && onApplied(result.markdown))
+            // The revision this screen is looking at, which is the one the
+            // last apply returned. An undo without it can take back somebody
+            // else's edit as a side effect of taking back your own.
+            undoSectionEdit(runId, revision)
+              .then(result => {
+                setRevision(result.revision)
+                if (result.undone) onApplied(result.markdown)
+              })
               .catch((failure: Error) => setError(failure.message))
               .finally(() => setBusy(false))
           }}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake-screens.test.tsx
@@ -3,9 +3,17 @@ import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 
 const listRuns = vi.fn()
+const readEditActions = vi.fn()
+const proposeSectionEdit = vi.fn()
+const applySectionEdit = vi.fn()
+const undoSectionEdit = vi.fn()
 vi.mock('./intake.api', async importOriginal => ({
   ...(await importOriginal<typeof import('./intake.api')>()),
   listRuns: () => listRuns(),
+  readEditActions: () => readEditActions(),
+  proposeSectionEdit: (...args: unknown[]) => proposeSectionEdit(...args),
+  applySectionEdit: (...args: unknown[]) => applySectionEdit(...args),
+  undoSectionEdit: (...args: unknown[]) => undoSectionEdit(...args),
 }))
 import { BriefScreen } from './components/BriefScreen'
 import { ArticleScreen } from './components/ArticleScreen'
@@ -753,6 +761,86 @@ describe('the finished article screen', () => {
     expect(screen.getByText('75')).toBeInTheDocument()
     expect(screen.getByText('57%')).toBeInTheDocument()
     expect(screen.getByText(/nothing here blocks/i)).toBeInTheDocument()
+  })
+
+  it('says the checks describe the pipeline draft once the article is edited', async () => {
+    // Nothing re-reads an article after prose exists -- the audit is a
+    // pre-writing gate by design. So a hand edit cannot refresh these numbers,
+    // and the screen must stop implying they describe what is on it. Showing
+    // "Ready for staging - 914 words" over prose somebody has since cut is the
+    // page asserting something nobody checked.
+    readEditActions.mockResolvedValue({
+      actions: [{ action_id: 'shorten', label: 'Say it in fewer words' }],
+    })
+    proposeSectionEdit.mockResolvedValue({
+      run_id: 'run-1',
+      edit_id: 'e1',
+      base_revision: 0,
+      section_id: 's1',
+      heading: 'The elevation contrast',
+      action_id: 'shorten',
+      text_hash: 'abc',
+      original: '## The elevation contrast\n\nCusco sits at 3,399 meters.',
+      revised: '## The elevation contrast\n\nCusco is at 3,399 m.',
+      what_changed: 'Tightened it.',
+      could_not_do: '',
+      introduced_figures: [],
+      review: {
+        status: 'supported',
+        checked: true,
+        assessment: 'Every figure matches its record.',
+        unsupported_claims: [],
+      },
+    })
+    applySectionEdit.mockResolvedValue({
+      markdown: '## The elevation contrast\n\nCusco is at 3,399 m.',
+      edits: 1,
+      revision: 1,
+      review_status: 'supported',
+      already_applied: false,
+    })
+
+    renderArticle(
+      <ArticleScreen
+        runId="run-1"
+        writing={writing({
+          constraint_checks: {
+            sentence_count: 75,
+            sentence_mean_words: 11.3,
+            sentence_widest_band_share: 0.57,
+            sentences_over_25_words: 1,
+            sentence_variety_note: 'Nothing here blocks.',
+          },
+        })}
+        article={{
+          run_id: 'r',
+          title: 'T',
+          form_label: 'Destination Guide',
+          markdown: '## The elevation contrast\n\nCusco sits at 3,399 meters.',
+          pipeline_status: 'ready_for_staging',
+          readiness_blockers: [],
+          constraint_checks: {},
+          word_count: 914,
+        }}
+        onReopen={vi.fn()}
+        busy={false}
+      />,
+    )
+
+    expect(screen.getByText(/ready for staging/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit The elevation contrast' }))
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Say it in fewer words' }),
+    )
+    fireEvent.click(await screen.findByRole('button', { name: 'Use this' }))
+
+    expect(
+      await screen.findByText(/describe the draft the pipeline wrote/i),
+    ).toBeInTheDocument()
+    // The stamp stops claiming the article is the one that was assessed.
+    expect(screen.queryByText(/ready for staging/i)).toBeNull()
+    expect(screen.getByText(/edited by hand/i)).toBeInTheDocument()
   })
 
   it('a needs-revision stamp is shown and never obeyed', () => {

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -295,7 +295,12 @@ export async function applySectionEdit(
   runId: string,
   proposal: SectionEditProposal,
   reason = '',
-): Promise<{ markdown: string; edits: number }> {
+): Promise<{
+  markdown: string
+  edits: number
+  revision: number
+  already_applied: boolean
+}> {
   const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}/apply`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -304,15 +309,35 @@ export async function applySectionEdit(
   if (!response.ok) {
     throw await readError(response, 'Could not apply that change.')
   }
-  return (await response.json()) as { markdown: string; edits: number }
+  return (await response.json()) as {
+    markdown: string
+    edits: number
+    revision: number
+    already_applied: boolean
+  }
 }
 
-/** Put the draft back to what it was before the last applied edit. */
+/**
+ * Put the draft back to what it was before the last applied edit.
+ *
+ * `baseRevision` is which version of the article this screen is looking at.
+ * Undo is a write like any other: pressed on a stale screen, an unguarded one
+ * restores the markdown from before *this tab's* last edit and erases whatever
+ * somebody else saved in between.
+ */
 export async function undoSectionEdit(
   runId: string,
-): Promise<{ markdown: string; edits: number; undone: boolean }> {
+  baseRevision = -1,
+): Promise<{
+  markdown: string
+  edits: number
+  undone: boolean
+  revision: number
+}> {
   const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}/undo`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ base_revision: baseRevision }),
   })
   if (!response.ok) {
     throw await readError(response, 'Could not undo the last change.')
@@ -321,6 +346,7 @@ export async function undoSectionEdit(
     markdown: string
     edits: number
     undone: boolean
+    revision: number
   }
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.api.ts
@@ -295,16 +295,18 @@ export async function applySectionEdit(
   runId: string,
   proposal: SectionEditProposal,
   reason = '',
+  acceptFindings = false,
 ): Promise<{
   markdown: string
   edits: number
   revision: number
+  review_status: string
   already_applied: boolean
 }> {
   const response = await apiFetch(`${FEATURE_PREFIX}/section-edit/${runId}/apply`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ proposal, reason }),
+    body: JSON.stringify({ proposal, reason, accept_findings: acceptFindings }),
   })
   if (!response.ok) {
     throw await readError(response, 'Could not apply that change.')
@@ -313,6 +315,7 @@ export async function applySectionEdit(
     markdown: string
     edits: number
     revision: number
+    review_status: string
     already_applied: boolean
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -344,6 +344,10 @@ export interface SectionEditAction {
  */
 export interface SectionEditProposal {
   run_id: string
+  /** This proposal, once. A repeated apply of it is the same edit, not a second one. */
+  edit_id: string
+  /** Which version of the whole article this was read from. */
+  base_revision: number
   section_id: string
   heading: string
   action_id: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -342,6 +342,20 @@ export interface SectionEditAction {
  * failure mode of asking for a stronger recommendation is a model inventing
  * the thing that would make it stronger.
  */
+/**
+ * What a checker made of a candidate section, read against the frozen packet.
+ *
+ * Three answers, never two. `unchecked` is not a pass and is not a fail: a
+ * checker that could not answer is a reason for a person to look, not a reason
+ * to call the prose verified.
+ */
+export interface SectionEditReview {
+  status: 'supported' | 'unsupported' | 'unchecked'
+  checked: boolean
+  assessment: string
+  unsupported_claims: { claim: string; reason: string; severity: string }[]
+}
+
 export interface SectionEditProposal {
   run_id: string
   /** This proposal, once. A repeated apply of it is the same edit, not a second one. */
@@ -358,6 +372,8 @@ export interface SectionEditProposal {
   could_not_do: string
   /** Figures in the revision that are in neither the original nor the packet. */
   introduced_figures: string[]
+  /** What the checker made of it. Null on a refusal, which has nothing to judge. */
+  review: SectionEditReview | null
 }
 
 /** The finished article. Its own call: the state is polled, this is not. */

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/intake.types.ts
@@ -356,6 +356,26 @@ export interface SectionEditReview {
   unsupported_claims: { claim: string; reason: string; severity: string }[]
 }
 
+/**
+ * What changed factually, in two halves that must not be confused.
+ *
+ * `text_changes` are exact differences between the two strings — a figure that
+ * appeared, a date that fell out, a caveat that is gone. They are not a
+ * judgement: a regex noticing "only" is missing has reasoned about nothing.
+ *
+ * `review` is the reading. It is the only half that can say two prices were
+ * swapped, because every figure is present in both and no comparison of sets
+ * will see it.
+ */
+export interface FactualChanges {
+  text_changes: { kind: string; text: string; note: string }[]
+  text_changes_are: string
+  review: SectionEditReview | null
+  review_status: string
+  candidate_hash: string
+  base_revision: number
+}
+
 export interface SectionEditProposal {
   run_id: string
   /** This proposal, once. A repeated apply of it is the same edit, not a second one. */
@@ -374,6 +394,8 @@ export interface SectionEditProposal {
   introduced_figures: string[]
   /** What the checker made of it. Null on a refusal, which has nothing to judge. */
   review: SectionEditReview | null
+  /** Absent on a refusal or a no-op, where nothing changed to explain. */
+  factual_changes?: FactualChanges
 }
 
 /** The finished article. Its own call: the state is polled, this is not. */

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
@@ -43,6 +43,12 @@ function proposal(overrides: Partial<SectionEditProposal> = {}): SectionEditProp
     what_changed: 'Named the choice instead of listing both.',
     could_not_do: '',
     introduced_figures: [],
+    review: {
+      status: 'supported',
+      checked: true,
+      assessment: 'Every figure matches the record it comes from.',
+      unsupported_claims: [],
+    },
     ...overrides,
   }
 }
@@ -90,6 +96,7 @@ describe('nothing lands unread', () => {
       markdown: '# edited',
       edits: 1,
       revision: 5,
+      review_status: 'supported',
       already_applied: false,
     })
     open()
@@ -262,5 +269,98 @@ describe('taking it back', () => {
 
     await waitFor(() => expect(undoSectionEdit).toHaveBeenCalled())
     expect(applied).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('what the checker found', () => {
+  it('shows the findings and asks for a decision', async () => {
+    // The figure warning compares sets of numbers, so a swap of two prices the
+    // research already carries is invisible to it. This is the reading of what
+    // the new text asserts.
+    proposeSectionEdit.mockResolvedValue(
+      proposal({
+        revised: '## Where to eat\n\nThe stalls cost $40.',
+        review: {
+          status: 'unsupported',
+          checked: true,
+          assessment: 'The prices are attached to the wrong things.',
+          unsupported_claims: [
+            {
+              claim: 'The stalls cost $40',
+              reason: 'The record says the stalls cost $8.',
+              severity: 'high',
+            },
+          ],
+        },
+      }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+
+    expect(
+      await screen.findByText('The prices are attached to the wrong things.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('The stalls cost $40')).toBeInTheDocument()
+    // A different press from the one on an edit that passed, and the server
+    // records it as one.
+    expect(
+      screen.getByRole('button', { name: 'Use it anyway' }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Use this' })).toBeNull()
+  })
+
+  it('does not show an unchecked edit as a checked one', async () => {
+    proposeSectionEdit.mockResolvedValue(
+      proposal({
+        review: {
+          status: 'unchecked',
+          checked: false,
+          assessment: 'Grounding could not be completed: the checker is down.',
+          unsupported_claims: [],
+        },
+      }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Say it in fewer words' }),
+    )
+
+    expect(
+      await screen.findByText(/has not been checked against the research/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Use it anyway' }),
+    ).toBeInTheDocument()
+  })
+
+  it('applies a passed edit without asking for an override', async () => {
+    proposeSectionEdit.mockResolvedValue(proposal())
+    applySectionEdit.mockResolvedValue({
+      markdown: '# edited',
+      edits: 1,
+      revision: 5,
+      review_status: 'supported',
+      already_applied: false,
+    })
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Say it in fewer words' }),
+    )
+    await userEvent.click(await screen.findByRole('button', { name: 'Use this' }))
+
+    await waitFor(() =>
+      expect(applySectionEdit).toHaveBeenCalledWith(
+        'run-1',
+        expect.anything(),
+        '',
+        false,
+      ),
+    )
   })
 })

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
@@ -338,6 +338,66 @@ describe('what the checker found', () => {
     ).toBeInTheDocument()
   })
 
+  it('shows factual differences beside the diff, labelled as differences', async () => {
+    // A diff answers "what words moved". An editor deciding whether to keep
+    // this is asking whether a caveat went.
+    proposeSectionEdit.mockResolvedValue(
+      proposal({
+        factual_changes: {
+          text_changes: [
+            {
+              kind: 'qualification_removed',
+              text: 'as of',
+              note: 'A phrase that limited a claim is no longer there.',
+            },
+          ],
+          text_changes_are:
+            'exact differences between the two texts, not a judgement about whether the change is wrong',
+          review: null,
+          review_status: 'supported',
+          candidate_hash: 'abc',
+          base_revision: 4,
+        },
+      }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Say it in fewer words' }),
+    )
+
+    const panel = await screen.findByRole('region', {
+      name: 'What changed factually',
+    })
+    expect(panel).toHaveTextContent('as of')
+    expect(panel).toHaveTextContent(/not a judgement/)
+  })
+
+  it('does not show a factual panel when nothing factual changed', async () => {
+    proposeSectionEdit.mockResolvedValue(
+      proposal({
+        factual_changes: {
+          text_changes: [],
+          text_changes_are: 'exact differences',
+          review: null,
+          review_status: 'supported',
+          candidate_hash: 'abc',
+          base_revision: 4,
+        },
+      }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Say it in fewer words' }),
+    )
+
+    await screen.findByRole('button', { name: 'Use this' })
+    expect(
+      screen.queryByRole('region', { name: 'What changed factually' }),
+    ).toBeNull()
+  })
+
   it('applies a passed edit without asking for an override', async () => {
     proposeSectionEdit.mockResolvedValue(proposal())
     applySectionEdit.mockResolvedValue({

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
@@ -32,6 +32,8 @@ const ACTIONS = [
 function proposal(overrides: Partial<SectionEditProposal> = {}): SectionEditProposal {
   return {
     run_id: 'run-1',
+    edit_id: 'edit-1',
+    base_revision: 4,
     section_id: 's1',
     heading: 'Where to eat',
     action_id: 'clarify_recommendation',
@@ -84,7 +86,12 @@ describe('nothing lands unread', () => {
 
   it('applies only when the editor says to', async () => {
     proposeSectionEdit.mockResolvedValue(proposal())
-    applySectionEdit.mockResolvedValue({ markdown: '# edited', edits: 1 })
+    applySectionEdit.mockResolvedValue({
+      markdown: '# edited',
+      edits: 1,
+      revision: 5,
+      already_applied: false,
+    })
     open()
 
     await userEvent.click(
@@ -212,6 +219,7 @@ describe('taking it back', () => {
       markdown: '# original',
       edits: 0,
       undone: true,
+      revision: 6,
     })
     render(
       <SectionEditor
@@ -236,6 +244,7 @@ describe('taking it back', () => {
       markdown: '# original',
       edits: 0,
       undone: false,
+      revision: 4,
     })
     render(
       <SectionEditor

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/section-editor.test.tsx
@@ -148,6 +148,30 @@ describe('what it refuses to hide', () => {
     ).toBeInTheDocument()
   })
 
+  it('does not offer to apply a refusal', async () => {
+    // The server normalises a refused answer back to the original, so there is
+    // nothing to apply. Offering "Use this" beside a refusal was how a model
+    // saying "cannot support this" still got its changed text accepted.
+    proposeSectionEdit.mockResolvedValue(
+      proposal({
+        revised: '## Where to eat\n\nBoth are good.',
+        could_not_do: 'Nothing on the desk says which suits whom.',
+      }),
+    )
+    open()
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Make the recommendation clearer' }),
+    )
+
+    await screen.findByText('Nothing on the desk says which suits whom.')
+    expect(screen.queryByRole('button', { name: 'Use this' })).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Ask for something else' }),
+    ).toBeInTheDocument()
+    expect(applySectionEdit).not.toHaveBeenCalled()
+  })
+
   it('calls out a figure that came from nowhere', async () => {
     proposeSectionEdit.mockResolvedValue(
       proposal({ introduced_figures: ['12 minutes'] }),

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/RunCostReceipt.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/pipeline-run/components/RunCostReceipt.tsx
@@ -28,9 +28,26 @@ export function RunCostReceipt({ cost }: { cost: RunCost }) {
             routing -- so every receipt said "Custom stack" and named nothing. */}
         <h4>{cost.models.writer || 'Model not recorded'}</h4>
       </div>
+      {/* Two numbers, because they are two different things. The headline is
+          money that left an account. Claude runs on the flat subscription, so
+          its calls charge nobody -- but the CLI reports what they would have
+          cost on the API, and that figure used to be added straight into the
+          headline. On the chifa run that turned $0.36 of real spend into
+          $2.65 on screen. */}
       <div className="p2b-run-cost__total">
-        <span>Estimated run cost</span>
-        <strong>{formatUsd(cost.estimated_cost_usd, cost.measurement_status)}</strong>
+        <span>Billed this run</span>
+        <strong>
+          {formatUsd(
+            cost.billed_cost_usd ?? cost.estimated_cost_usd,
+            cost.measurement_status,
+          )}
+        </strong>
+        {cost.subscription_cost_usd != null && cost.subscription_cost_usd > 0 && (
+          <span className="p2b-run-cost__subscription">
+            + {formatUsd(cost.subscription_cost_usd)} on the Claude subscription,
+            not charged
+          </span>
+        )}
       </div>
     </div>
     <div className="p2b-run-cost__metrics">

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1690,3 +1690,34 @@
   font-size: 0.85em;
   font-weight: 400;
 }
+
+/*
+ * The pipeline's assessment, still on screen after a hand edit.
+ *
+ * It described the draft the pipeline wrote. Nothing re-reads an article after
+ * prose exists -- the audit is a pre-writing gate by design -- so these numbers
+ * cannot be refreshed and must not be presented as though they described what
+ * the reader is looking at.
+ */
+.p2b-stale-assessment {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--border);
+  color: var(--ink-light);
+}
+
+.p2b-measured--stale {
+  opacity: 0.6;
+}
+
+/*
+ * Checking an edit undid. Deliberately not styled as an error: nothing is
+ * broken, a person's verification simply no longer describes the prose and
+ * has to be redone.
+ */
+.p2b-provenance-invalidated {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--accent);
+  color: var(--ink-light);
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1646,3 +1646,33 @@
   border: 1px solid var(--accent);
   font-weight: 500;
 }
+
+.p2b-editor-invented ul {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-4);
+}
+
+.p2b-editor-invented li + li {
+  margin-top: var(--space-1);
+}
+
+/*
+ * Beside the text diff, and quieter than the checker's findings above it.
+ * These are exact differences between two strings, and styling them as an
+ * alarm would have an editor reading a regex match as a judgement.
+ */
+.p2b-editor-factual {
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--panel);
+  border-left: 2px solid var(--border);
+}
+
+.p2b-editor-factual ul {
+  margin: var(--space-2) 0 var(--space-2);
+  padding-left: var(--space-4);
+}
+
+.p2b-editor-factual li + li {
+  margin-top: var(--space-1);
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/styles/intake.css
@@ -1676,3 +1676,17 @@
 .p2b-editor-factual li + li {
   margin-top: var(--space-1);
 }
+
+/*
+ * The notional half of a run's cost, under the money that actually moved.
+ * Quieter than the headline on purpose: it is a real token count and a
+ * hypothetical price, and reading it as spend is the bug this line exists to
+ * prevent.
+ */
+.p2b-run-cost__subscription {
+  display: block;
+  margin-top: var(--space-1);
+  color: var(--ink-light);
+  font-size: 0.85em;
+  font-weight: 400;
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/types/pipeline.types.ts
@@ -253,7 +253,17 @@ export type Prompt2BlogRunCost = {
   attributed_total_tokens?: number
   ledger_version?: number
   measurement_status: 'complete' | 'partial' | 'unavailable'
+  /**
+   * Real spend and notional spend added together. True of nothing — a Claude
+   * call on the flat subscription charges nobody, and this adds its
+   * API-equivalent price to money that actually moved. Kept for older runs;
+   * read the two fields below instead.
+   */
   estimated_cost_usd: number | null
+  /** What the run actually cost. Per-token billing only. */
+  billed_cost_usd?: number | null
+  /** What the subscription calls would have cost on the API. Not a charge. */
+  subscription_cost_usd?: number | null
   currency: 'USD'
   by_model: Array<{
     model: string

--- a/packages/model-gateway/src/model_gateway/jobs.json
+++ b/packages/model-gateway/src/model_gateway/jobs.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "note": "Every model call this monorepo makes, and what each one runs on when nothing overrides it. This file is the registry AND the checked-in fallback, in one place, because two files would need a test to keep them in step and would still drift between the moment one changed and the moment anyone ran it. Read by model_gateway/jobs.py in Python and by the dashboard in TypeScript -- one source, two runtimes. defaultModel null means the job reaches an API with no model behind it.",
-  "writerNote": "Prompt2Blog's reasoning runs on Claude, its bulk work on Gemini. Every one of these jobs sat on gemini-2.5-flash from 2026-07-25, the day the Anthropic credit ran out, and stayed there after the subscription path was switched on because nothing revisited the default -- so every v4 article was interviewed, planned and drafted by the cheapest model in the table. The split now: p2b.grill gets Opus because the interview decides what the article is and every later stage inherits it, and it is seven calls. Brief, outline, compose and repair get Sonnet at medium -- prose and judgement, but not worth an Opus tier each. Everything else is Gemini, and each has a reason. p2b.audit is the independent judge: a Claude draft graded by a Claude judge is marked by a model that shares its blind spots. p2b.grill_research and p2b.research_gather are grounded_text calls that need Google search grounding, which the Claude CLI path does not have. p2b.research_structure, p2b.work_order and p2b.groundedness are mechanical shaping and checking: structuring on Claude spent 437k tokens of a 650k run ceiling on one run and the run died in research without reaching the writer. p2b.evidence_dedupe and p2b.evidence_rank are the two passes that decide which facts reach the writer (#534). Dedupe is Gemini for the same reason research_structure is: it compares sentences and groups the ones asserting the same fact, which is shape rather than judgement, and it reads every claim in the dossier so it is the more expensive input of the two. Rank is Sonnet at medium, the tier the brief and the outline already sit on, because ordering a hundred facts against a reader question and a fails_if is the same kind of judgement the outline makes -- and it is not Opus because a person reads the result and moves the line, so a ranking that is merely good is corrected in one click rather than paid for twice.",
+  "writerNote": "Prompt2Blog's reasoning runs on Claude, its bulk work on Gemini. Every one of these jobs sat on gemini-2.5-flash from 2026-07-25, the day the Anthropic credit ran out, and stayed there after the subscription path was switched on because nothing revisited the default -- so every v4 article was interviewed, planned and drafted by the cheapest model in the table. The split now: p2b.grill gets Opus because the interview decides what the article is and every later stage inherits it, and it is seven calls. Brief, outline, compose and repair get Sonnet at medium -- prose and judgement, but not worth an Opus tier each. Everything else is Gemini, and each has a reason. p2b.audit is the independent judge: a Claude draft graded by a Claude judge is marked by a model that shares its blind spots. p2b.grill_research and p2b.research_gather are grounded_text calls that need Google search grounding, which the Claude CLI path does not have. p2b.research_structure, p2b.work_order and p2b.groundedness are mechanical shaping and checking: structuring on Claude spent 437k tokens of a 650k run ceiling on one run and the run died in research without reaching the writer. p2b.evidence_dedupe and p2b.evidence_rank are the two passes that decide which facts reach the writer (#534). Dedupe is Gemini for the same reason research_structure is: it compares sentences and groups the ones asserting the same fact, which is shape rather than judgement, and it reads every claim in the dossier so it is the more expensive input of the two. Rank is Sonnet at medium, the tier the brief and the outline already sit on, because ordering a hundred facts against a reader question and a fails_if is the same kind of judgement the outline makes -- and it is not Opus because a person reads the result and moves the line, so a ranking that is merely good is corrected in one click rather than paid for twice. p2b.section_edit and p2b.edit_review were making calls under ids the registry had never heard of, so every post-writing edit raised UnknownJob the moment it reached a real provider -- invisible to 1,379 green tests because none of them resolves a model. section_edit sits with compose and repair: it writes prose a reader sees, one section at a time. edit_review sits with groundedness and for the same reason -- prose written by one model and passed by a checker that shares its blind spots is prose nobody independent has read.",
   "capturedOn": "2026-09-04",
   "jobs": [
     {
@@ -35,6 +35,22 @@
       "summary": "Rewrite the draft to fix what the audit found. A full article rewrite.",
       "site": "features/prompt2blog/stages/v3/audit_repair.py",
       "defaultModel": "claude-sonnet-5-medium"
+    },
+    {
+      "id": "p2b.section_edit",
+      "app": "ai-blog-writer",
+      "call": "json",
+      "summary": "Rewrite one section of a finished article, at an editor's request.",
+      "site": "features/prompt2blog/section_edit_v4.py",
+      "defaultModel": "claude-sonnet-5-medium"
+    },
+    {
+      "id": "p2b.edit_review",
+      "app": "ai-blog-writer",
+      "call": "json",
+      "summary": "Judge one candidate section against the packet before an editor keeps it.",
+      "site": "features/prompt2blog/edit_review.py",
+      "defaultModel": "gemini-2.5-flash"
     },
     {
       "id": "p2b.groundedness",


### PR DESCRIPTION
Stacked on `p2b/learn-from-edits`. Implements the five work packages in the writer handoff, the advisory factual-change panel, and three bugs found while verifying them.

## Three bugs that were not in the handoff

**`p2b.section_edit` was never registered in `jobs.json`.** `model_for` raises `UnknownJob` rather than falling back — deliberately, because a typo silently running on some other model is what the gateway exists to prevent — so **every post-writing edit raised the moment it reached a real provider**. The whole feature was dead. 1,828 green backend tests missed it: none of them resolves a model, because the LLM is a double everywhere it appears. A source sweep now asserts every job id called anywhere in the backend is one the registry knows (20 of them, none missing).

**The run receipt was overstating cost by roughly 7x.** Claude runs on the flat Claude Code subscription and charges nothing per call; the CLI still reports what each call *would* have cost on the API, and that notional figure was being added to real per-token Vertex spend. On the repo's own measured runs — chifa `3750891f` at $0.36 billed beside $2.29 notional — the screen said $2.65. Two other parts of the codebase already refused to do this (`api_usage.py` won't price the subscription provider at all; `run_billed_cost_usd` counts only rate-table calls). The receipt a person reads was the one place that didn't.

**An edited article kept wearing the pipeline's verdict.** The readiness stamp, the measured sentence spread and the word count all describe the draft the pipeline wrote, and nothing re-reads an article once prose exists. The screen went on showing "Ready for staging · 914 words" over prose somebody had since cut.

## The handoff work

| | |
|---|---|
| **Section boundaries** | Missing/empty `text_hash` refused. Sections carry exact source slices and edits splice into them, so untargeted bytes are byte-identical — trailing spaces that make a Markdown line break, blank lines, the final newline. A body containing `##`/`#`, or a multiline heading, can no longer change the document's structure. Fences are structure-blind in both directions. |
| **Repair scope** | Targets resolved before the call from what the audit quoted and which sections hold a refused claim, then enforced in code and shown to the prompt. |
| **Refusals** | `could_not_do` normalises `revised` back to the original at the boundary and again on apply. No-ops make no history — they were feeding pattern-learning thresholds. |
| **Atomicity** | `outputs.article_revision` plus `BEGIN IMMEDIATE`. Article and history write as one transaction; undo gets the same guard; `edit_id` makes retries idempotent. Article markdown now has exactly one writer. |
| **Spend** | Every editor attempt recorded — proposed, refused, failed. Unknown usage recorded as unknown, never zero. |
| **Grounding** | The pipeline's validated check extracted into a shared service; the editor reviews a candidate *in its article* against the packet, bound to run, section, candidate hash and evidence identity. Advisory: a flagged edit needs an explicit decision, and the history records which claims were accepted over. |
| **Factual panel** | Exact text differences and the checker's reading, labelled apart. No extra model call. |
| **Provenance** | Editing a confirmed passage still drops the confirmation — a confirmation beside changed prose is worse than none — but no longer in silence. The count is reported, and undo brings them back. |

## Deliberate contract changes

Each has a test asserting the new behaviour; one existing test was updated rather than worked around.

- A duplicated `section_id` refuses **both** edits. A response that named the same paragraph twice does not know what it wants there.
- Repair whose revisions resolve to no section still runs, but records `scope: "unresolved"`.
- Apply refuses anything the checker did not pass unless the request carries `accept_findings`.
- The factual panel reports removed qualifications, not added ones.

## Verification

1,828 pytest · 796 vitest · 89 model-gateway · `tsc` clean.

Concurrency is tested with two real SQLite connections across threads with a barrier, not an in-process lock — an in-process lock would pass a single-caller test and still lose an edit between two workers. One test asserts directly that a second connection is locked out between the read and the write.

Claude routing verified against the live transport rather than from config: a real call through the p2b path returns `claude-sonnet-5-medium` with no substitution. Also measured and deliberately not acted on — every Claude CLI call carries ~20,550 input tokens of fixed scaffolding, of which 20,555 of 20,557 are warm cache reads, so it is ordinary operating cost.

**Every model in the test suite is a fixture. No claim about real checker quality follows, and none of this has run against a real article yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)