### PR TITLE
feat(listicle): the search order is the thing that runs

### DIFF
--- a/apps/ai-blog-writer/.claude/launch.json
+++ b/apps/ai-blog-writer/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "abw",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "dev:local"],
+      "port": 3003
+    }
+  ]
+}

--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -449,6 +449,18 @@ evidence. Every sighting survives a merge.
 Boundary rule: a merge that conflicts on district or on a bracketed qualifier
 does not happen; the rows stand side by side as possible duplicates.
 
+### Marker Resolution
+Definition: what one interview marker is worth once every turn that answered
+it has been read. `restated` (a later answer said everything the earlier one
+said), `combined` (two answers said different things and both are used) or
+`replaced` (a marker that only ever takes one value was answered twice).
+Mechanism: `spec.resolve_answer`. The bar and the cut accumulate; the kind,
+the place and the angles replace, because the picker sends the whole selection
+and un-ticking a box is already the explicit replace.
+Boundary rule: last-write-wins is not a resolution. A marker answered twice is
+resolved from the answers, and the resolution reaches the order as an
+`answer_note` the operator can act on.
+
 ### Search Attempt
 Definition: one angle's search as it stands — `not_started`, `running`,
 `completed`, `failed` or `interrupted` — with the request fingerprint it was

--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -480,6 +480,16 @@ Boundary rule: an angle is identified across runs by its SHAPE, not its
 wording. The model rewrites the sentence every run. An operator's own angle has
 no shape, so it matches on exact wording or not at all.
 
+### Cut Check
+Definition: the two moments something asks "does this break what the operator
+barred" -- once over the approved angles, before the searches run, and once
+over the returned places, after.
+Mechanism: `cut_review`, one JSON call each, on a request that is already
+spending. Rows are identified to the model by NUMBER, never by name.
+Boundary rule: both only FLAG. Nothing is removed, reworded or reordered.
+Unchecked is not clean: `conflicts_checked` and `cut_checked` say whether
+anything looked, separately from what it found.
+
 ### Search Attempt
 Definition: one angle's search as it stands — `not_started`, `running`,
 `completed`, `failed` or `interrupted` — with the request fingerprint it was

--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -461,6 +461,25 @@ Boundary rule: last-write-wins is not a resolution. A marker answered twice is
 resolved from the answers, and the resolution reaches the order as an
 `answer_note` the operator can act on.
 
+### Contribution
+Definition: what one search bought — how many places it returned, how many of
+those the other searches also returned, and how many nothing else found.
+Mechanism: computed against the finished pool (never accumulated as searches
+land, so ordering cannot change it), written onto the attempt after every
+batch, and rewritten after a retry because a retry changes the pool.
+Boundary rule: reported, never acted on. A search with nothing exclusive may be
+the coverage everything else is being checked against; no angle is dropped,
+reordered or discouraged by its history.
+
+### Subject
+Definition: kind and place, folded — what two runs must share before one run's
+contribution says anything about the other's. The count, the bar and the cut
+change what a search asks for; none of them changes whether a shape finds
+places nobody else finds.
+Boundary rule: an angle is identified across runs by its SHAPE, not its
+wording. The model rewrites the sentence every run. An operator's own angle has
+no shape, so it matches on exact wording or not at all.
+
 ### Search Attempt
 Definition: one angle's search as it stands — `not_started`, `running`,
 `completed`, `failed` or `interrupted` — with the request fingerprint it was

--- a/apps/ai-blog-writer/CONTEXT.md
+++ b/apps/ai-blog-writer/CONTEXT.md
@@ -409,6 +409,53 @@ Do not confuse with: the v3 `questurian-default` brand-voice file, which was a r
 - **SQLite for run storage** because runs are local-only and replayable; not a multi-tenant store.
 - → **Suggest ADR**: the LexicalJSON ↔ Payload sync protocol has no formal spec; this is hard-to-reverse and crosses a context boundary.
 
+## Listicle Pipeline (search order)
+
+The newer pipeline under `app/features/listicle_pipeline`, distinct from the
+`editor_assist` listicle blurb pipeline whose vocabulary is above. It runs an
+interview, executes the searches it settles on, and pools candidate places.
+Decisions in [ADR 0037](./docs/adr/0037-the-search-order-is-the-source-of-truth.md).
+
+### Search Order
+Definition: the agreement in the form the searches run from — kind, place,
+target count, standard, exclusions, and the selected angles. Built once at
+agreement, versioned, stored. The displayed summary is generated from it.
+Boundary rule: nothing downstream re-reads the interview transcript. The count
+that is shown and the count that is executed are one field.
+
+### Angle
+Definition: one reason a place is on the list, and one literal web search.
+Carries a stable id, the shape it was written from, its role, the wording the
+operator approved, and whether they edited it.
+Boundary rule: an angle is a route into the pool, never a requirement. What
+every place must satisfy lives on the order and is composed into every search.
+
+### Shape
+Definition: the pattern an angle is written from, with the topic left blank.
+Declares its `core` meaning separately from the `instruction` given to the
+model, the subjects it applies to, its discovery role, and the shapes it tends
+to return the same places as.
+Boundary rule: overlap is explained, never enforced.
+
+### Discovery Role
+Definition: what an angle is for — `broad`, `distinctive` or `specific` — and
+therefore how many places it may be asked for.
+Mechanism: `search.role_allowances` spreads the overshoot across the roles. A
+`specific` angle may succeed with one result and is never asked to fill a quota.
+
+### Sighting
+Definition: one row exactly as one search returned it — angle, name, district,
+evidence. Every sighting survives a merge.
+Boundary rule: a merge that conflicts on district or on a bracketed qualifier
+does not happen; the rows stand side by side as possible duplicates.
+
+### Search Attempt
+Definition: one angle's search as it stands — `not_started`, `running`,
+`completed`, `failed` or `interrupted` — with the request fingerprint it was
+made under.
+Boundary rule: `interrupted` is not `failed`. Nobody knows whether the provider
+answered, and retrying may be charged again.
+
 ## AI Guidance
 
 When working in this context:

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
@@ -405,9 +405,13 @@ def list_shapes(_staff=Depends(require_staff)):
 
 def _order_view(order) -> dict[str, Any]:
     """The order as the screen reads it."""
+    from .runner import prior_contribution
     from .spec import planned_capacity, summary_of
 
     capacity = planned_capacity(order)
+    # What each of these searches bought last time, before this time is paid
+    # for. Empty on the first run about a subject, which is most of them.
+    history = prior_contribution(order)
     return {
         "run_id": order.run_id,
         "revision": order.revision,
@@ -444,6 +448,10 @@ def _order_view(order) -> dict[str, Any]:
                 "wanted": angle.wanted,
                 "edited": angle.edited,
                 "custom": angle.custom,
+                # Said before the search runs, and never acted on: no angle is
+                # dropped or reordered because of it. Two runs is a fact about
+                # two runs.
+                "last_time": history.get(angle.angle_id, ""),
             }
             for angle in order.angles
         ],

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
@@ -20,7 +20,7 @@ from ..prompt2blog.contracts_v4 import GrillState
 from ..prompt2blog.dependencies import DefaultPrompt2BlogLLM
 from ..prompt2blog.grill_v4 import GrillDependencies, GrillUnusableResponse
 from . import service
-from .shapes import SHAPES
+from .shapes import SHAPES, SHAPES_BY_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -31,12 +31,65 @@ class StartRequest(BaseModel):
     seed: str = Field(min_length=1, max_length=400)
 
 
+class AngleSelection(BaseModel):
+    """One line of the answer, as the screen knows it.
+
+    Sent beside the text rather than instead of it. The transcript keeps what
+    the operator wrote, because that is what the interview agreed to; this is
+    what the screen knows and the text cannot carry -- which menu entry the
+    line came from, whether it was changed, whether they wrote it themselves.
+    """
+
+    text: str = Field(min_length=1, max_length=600)
+    angle_id: str = Field(default="", max_length=64)
+    shape_key: str = Field(default="", max_length=64)
+    group: str = Field(default="", max_length=64)
+    role: str = Field(default="", max_length=32)
+    edited: bool = False
+    custom: bool = False
+
+
 class AnswerRequest(BaseModel):
     run_id: str = Field(min_length=1)
     answer: str = Field(min_length=1, max_length=4000)
+    # Empty for every question but the angle one, which is answered by
+    # choosing.
+    selections: list[AngleSelection] = Field(default_factory=list, max_length=60)
 
 
-def _search_call(prompt: str) -> tuple[str, list[str], int | None]:
+class AngleEdit(BaseModel):
+    angle_id: str = Field(default="", max_length=64)
+    text: str = Field(min_length=1, max_length=600)
+    shape_key: str = Field(default="", max_length=64)
+    group: str = Field(default="", max_length=64)
+    role: str = Field(default="", max_length=32)
+    edited: bool = False
+    custom: bool = False
+
+
+class ReviseOrderRequest(BaseModel):
+    """A correction to the agreement, which becomes a new revision.
+
+    Both fields optional: correcting the count is by far the most common
+    correction and should not require restating the angles.
+    """
+
+    target_count: int | None = Field(default=None, ge=1, le=200)
+    angles: list[AngleEdit] | None = None
+
+
+class SearchRequest(BaseModel):
+    """Which searches to run, and whether stored work may be reused.
+
+    `angle_ids` empty means the whole order. `reuse` false is the deliberate
+    full refresh: the operator wants new research and knows it costs.
+    """
+
+    angle_ids: list[str] = Field(default_factory=list, max_length=40)
+    reuse: bool = True
+
+
+def _search_call(prompt: str) -> tuple[str, list[str], int | None, list[str]]:
     """The web, asked exactly what the search runner wrote.
 
     Deliberately NOT the grill's `research`: that one wraps whatever it is
@@ -68,7 +121,17 @@ def _search_call(prompt: str) -> tuple[str, list[str], int | None]:
         # recorded as "nothing published for this angle", which is a different
         # and much more misleading finding.
         raise RuntimeError("The grounded search returned nothing.")
-    return result.text, list(result.source_urls), result.total_tokens
+    # Four elements, not three. The fourth is the publications behind the
+    # answer: every URL above is a Google redirect that names nothing, so
+    # without this the run cannot say whether a search told to work in the
+    # local language actually reached local press. Callers that send three are
+    # still read correctly -- see `search._search_once`.
+    return (
+        result.text,
+        list(result.source_urls),
+        result.total_tokens,
+        list(getattr(result, "source_titles", []) or []),
+    )
 
 
 def _base_dependencies() -> GrillDependencies:
@@ -139,16 +202,43 @@ def _view(state: GrillState) -> dict[str, Any]:
             # when it does not, so this single field is what decides the input
             # control.
             "options": [
-                {"text": o.text, "recommended": o.recommended, "group": o.group}
+                {
+                    "text": o.text,
+                    "recommended": o.recommended,
+                    # From the catalogue whenever the shape is known, never
+                    # from the model. A live run sent the shape's LABEL on one
+                    # turn and its KEY on the next, and since the screen groups
+                    # by this field, every option landed in a group of one and
+                    # the "these two overlap" warning could never fire.
+                    "group": (
+                        SHAPES_BY_KEY[o.shape].theme
+                        if o.shape in SHAPES_BY_KEY
+                        else o.group
+                    ),
+                    # The catalogue entry this was written from, and the job it
+                    # is for. Sent so the picker can hand them back with the
+                    # answer -- an edited line that loses its shape key is a
+                    # line the order has to guess about.
+                    "shape": o.shape,
+                    "role": o.role,
+                }
                 for o in state.pending.options
             ],
         },
     }
 
 
-def _handle(action, *args):
+def _handle(action, *args, **kwargs):
+    """Run one interview action and render the interview.
+
+    Interview actions only. A search is not an interview turn and its result is
+    not a `GrillState`, and passing one through here is what made every
+    successful search raise on the way out: `_view` read `.run_id` off a dict
+    and the operator was told the search had failed when it had worked and been
+    stored. `_report` is the search side of the same boundary.
+    """
     try:
-        return _view(action(*args))
+        return _view(action(*args, **kwargs))
     except LookupError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
     except GrillUnusableResponse as error:
@@ -168,7 +258,13 @@ def start_listicle_grill(req: StartRequest, _staff=Depends(require_staff)):
 
 @router.post("/grill/answer")
 def answer_listicle_grill(req: AnswerRequest, _staff=Depends(require_staff)):
-    return _handle(service.answer, req.run_id, req.answer, _base_dependencies())
+    return _handle(
+        service.answer,
+        req.run_id,
+        req.answer,
+        _base_dependencies(),
+        [selection.model_dump() for selection in req.selections],
+    )
 
 
 @router.post("/grill/reopen")
@@ -184,20 +280,84 @@ def get_listicle_grill(run_id: str, _staff=Depends(require_staff)):
     return _view(state)
 
 
+def _report(action, *args, **kwargs) -> dict[str, Any]:
+    """Run one search action and return its own payload.
+
+    Separate from `_handle` on purpose, and this separation is the whole fix
+    for the first of the six confirmed faults. A search result is not an
+    interview and must not be rendered as one; the error handling is shared
+    because a missing run and an unagreed order mean the same thing on either
+    side of the boundary.
+    """
+    try:
+        return action(*args, **kwargs)
+    except LookupError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+
+@router.get("/order/{run_id}")
+def get_listicle_order(run_id: str, _staff=Depends(require_staff)):
+    """The agreement in the form the searches actually run from.
+
+    Read by the screen so the operator sees the count that will be used rather
+    than the count a sentence appeared to say. The two disagreed on the only
+    real run there has been.
+    """
+    found = service.order(run_id)
+    if found is None:
+        raise HTTPException(
+            status_code=404,
+            detail="This interview has not agreed a search order yet.",
+        )
+    return _order_view(found)
+
+
+@router.post("/order/{run_id}")
+def revise_listicle_order(
+    run_id: str, req: ReviseOrderRequest, _staff=Depends(require_staff)
+):
+    """Correct the agreement. The correction becomes a new revision."""
+    revised = _report(
+        service.revise_order,
+        run_id,
+        target_count=req.target_count,
+        angles=None if req.angles is None else [a.model_dump() for a in req.angles],
+    )
+    return _order_view(revised)
+
+
 @router.post("/search/{run_id}")
-def run_listicle_search(run_id: str, _staff=Depends(require_staff)):
-    """Run the agreed search order.
+def run_listicle_search(
+    run_id: str,
+    req: SearchRequest | None = None,
+    _staff=Depends(require_staff),
+):
+    """Run the agreed search order, or the part of it that was asked for.
 
     Minutes of work and real tokens, so it is a POST the operator asks for and
     never something a screen does on its own when it loads.
     """
-    return _handle(service.search, run_id, _search_call)
+    body = req or SearchRequest()
+    return _report(
+        service.search,
+        run_id,
+        _search_call,
+        only=body.angle_ids or None,
+        reuse=body.reuse,
+    )
 
 
 @router.get("/search/{run_id}")
 def get_listicle_search(run_id: str, _staff=Depends(require_staff)):
-    """What a previous run of the search order found, if it has been run."""
-    found = service.results(run_id)
+    """What this run knows, without running anything.
+
+    A read, never a search. It reports progress as well as results, so a page
+    reopened while a batch is still going shows what has finished rather than
+    offering to start the batch again.
+    """
+    found = service.progress(run_id)
     if found is None:
         raise HTTPException(
             status_code=404, detail="This search order has not been run yet."
@@ -216,11 +376,62 @@ def list_shapes(_staff=Depends(require_staff)):
     return {
         "shapes": [
             {
-                "key": s.key,
-                "label": s.label,
-                "instruction": s.instruction,
-                "collides_with": s.collides_with,
+                "key": shape.key,
+                "label": shape.label,
+                "core": shape.core,
+                "instruction": shape.instruction,
+                "theme": shape.theme,
+                # Which shapes tend to return the same places. A note the
+                # screen explains, never a rule it enforces -- award-listed and
+                # expensive are the same places in some cities and not others,
+                # and the operator is the one who knows which.
+                "overlaps_with": list(shape.overlaps_with),
+                "applies_to": list(shape.applies_to),
+                "role": shape.role,
             }
-            for s in SHAPES
+            for shape in SHAPES
         ]
+    }
+
+
+def _order_view(order) -> dict[str, Any]:
+    """The order as the screen reads it."""
+    from .spec import planned_capacity, summary_of
+
+    capacity = planned_capacity(order)
+    return {
+        "run_id": order.run_id,
+        "revision": order.revision,
+        "kind": order.kind,
+        "place": order.place,
+        "target_count": order.target_count,
+        "standard": order.standard,
+        "exclusions": order.exclusions,
+        # Where the number came from, and whether anyone should look at it
+        # again. A count read out of an ambiguous answer is still used -- the
+        # run is not stuck -- and it is never presented as settled.
+        "count_source": order.count_source,
+        "count_ambiguous": order.count_ambiguous,
+        "count_note": order.count_note,
+        "capacity": capacity,
+        "capacity_warning": (
+            f"These {len(order.angles)} searches ask for {capacity} places in "
+            f"total, which may not fill a list of {order.target_count}."
+            if capacity < order.target_count
+            else ""
+        ),
+        "summary": summary_of(order),
+        "angles": [
+            {
+                "angle_id": angle.angle_id,
+                "text": angle.text,
+                "shape_key": angle.shape_key,
+                "group": angle.group,
+                "role": angle.role,
+                "wanted": angle.wanted,
+                "edited": angle.edited,
+                "custom": angle.custom,
+            }
+            for angle in order.angles
+        ],
     }

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
@@ -141,6 +141,41 @@ def _search_call(prompt: str) -> tuple[str, list[str], int | None, list[str]]:
     )
 
 
+def _review_call(job_id: str, prompt: str, tool_name: str, schema: dict) -> Any:
+    """One schema-shaped judgement about text already written down.
+
+    JSON rather than a forced tool call, and that is not a style preference.
+    The forced-tool version was built first and failed against real data on two
+    of four attempts with `finish_reason: MALFORMED_FUNCTION_CALL` -- Gemini
+    emitting `print(default_api.record_barred_places(...))` as source text
+    instead of calling the tool. The JSON inside was complete and correct every
+    time; only the transport was wrong. `candidates_token_count: 0` in the
+    failures rules out a length problem, so raising the cap does not fix it.
+
+    `tool_name` is still taken so the two callers read the same, and because a
+    provider that does enforce tools can use it later without changing them.
+
+    Not grounded: neither question needs the web. The angle check reads the
+    order, and the candidate check reads evidence the searches already brought
+    back -- which is the whole reason it costs one call instead of forty.
+    """
+    from ..prompt2blog.llm import _invoke_json_llm
+
+    from .cut_review import REVIEW_MAX_TOKENS
+
+    parsed, _raw = _invoke_json_llm(
+        prompt=prompt,
+        max_tokens=REVIEW_MAX_TOKENS,
+        # A judgement, not a composition. Nothing here should vary run to run
+        # more than the question already makes it.
+        temperature=0.0,
+        model_name=None,
+        schema=schema,
+        job_id=job_id,
+    )
+    return parsed or {}
+
+
 def _base_dependencies() -> GrillDependencies:
     """The live model and the one path in this app that reaches the web."""
     from ..prompt2blog.api.intake import _grounded_call
@@ -271,6 +306,9 @@ def answer_listicle_grill(req: AnswerRequest, _staff=Depends(require_staff)):
         req.answer,
         _base_dependencies(),
         [selection.model_dump() for selection in req.selections],
+        # Runs only on the turn that agrees, which is already a paid call.
+        # Every later read of the order is a GET and stays free.
+        _review_call,
     )
 
 
@@ -333,6 +371,9 @@ def revise_listicle_order(
         angles=None if req.angles is None else [a.model_dump() for a in req.angles],
         standard=req.standard,
         exclusions=req.exclusions,
+        # Changing the angles or the cut is when the two can start disagreeing,
+        # so the question is asked again on the correction that caused it.
+        review=_review_call,
     )
     return _order_view(revised)
 
@@ -355,6 +396,8 @@ def run_listicle_search(
         _search_call,
         only=body.angle_ids or None,
         reuse=body.reuse,
+        # One call over the finished pool, on the batch that paid for it.
+        review=_review_call,
     )
 
 
@@ -430,6 +473,19 @@ def _order_view(order) -> dict[str, Any]:
         # it. The screen shows these next to the value they are about, because
         # a combined cut is the safe reading rather than the certain one.
         "answer_notes": list(order.answer_notes),
+        # Approved searches that look like they will return places the same
+        # order bars. Said before the money is spent; nothing is removed.
+        # `conflicts_checked` false means nobody looked, which is not the same
+        # as looked and found nothing.
+        "conflicts_checked": order.conflicts_checked,
+        "angle_conflicts": [
+            {
+                "angle_id": conflict.angle_id,
+                "angle_text": conflict.angle_text,
+                "why": conflict.why,
+            }
+            for conflict in order.angle_conflicts
+        ],
         "capacity": capacity,
         "capacity_warning": (
             f"These {len(order.angles)} searches ask for {capacity} places in "

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/api.py
@@ -70,12 +70,19 @@ class AngleEdit(BaseModel):
 class ReviseOrderRequest(BaseModel):
     """A correction to the agreement, which becomes a new revision.
 
-    Both fields optional: correcting the count is by far the most common
+    Every field optional: correcting the count is by far the most common
     correction and should not require restating the angles.
+
+    `standard` and `exclusions` are here because either can have been assembled
+    from more than one answer, and an assembled value has to be arguable. An
+    empty string is a real correction -- it means there is no bar, or nothing
+    is barred -- so absent and empty are not the same thing.
     """
 
     target_count: int | None = Field(default=None, ge=1, le=200)
     angles: list[AngleEdit] | None = None
+    standard: str | None = Field(default=None, max_length=2000)
+    exclusions: str | None = Field(default=None, max_length=2000)
 
 
 class SearchRequest(BaseModel):
@@ -324,6 +331,8 @@ def revise_listicle_order(
         run_id,
         target_count=req.target_count,
         angles=None if req.angles is None else [a.model_dump() for a in req.angles],
+        standard=req.standard,
+        exclusions=req.exclusions,
     )
     return _order_view(revised)
 
@@ -413,6 +422,10 @@ def _order_view(order) -> dict[str, Any]:
         "count_source": order.count_source,
         "count_ambiguous": order.count_ambiguous,
         "count_note": order.count_note,
+        # Every marker the interview answered twice, and what was done about
+        # it. The screen shows these next to the value they are about, because
+        # a combined cut is the safe reading rather than the certain one.
+        "answer_notes": list(order.answer_notes),
         "capacity": capacity,
         "capacity_warning": (
             f"These {len(order.angles)} searches ask for {capacity} places in "

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
@@ -75,6 +75,28 @@ class SelectedAngle(ListicleModel):
     custom: bool = False
 
 
+class AngleConflict(ListicleModel):
+    """One approved search that looks like it will return barred places.
+
+    Run 33fca394 approved "Nikkei cevicherias doing Japanese-Peruvian
+    preparations" alongside a cut reading "no places where ceviche is not the
+    primary offering". Those two disagree, and the disagreement was visible in
+    the order before a penny was spent. Nobody looked, so the search ran: 8 of
+    its 10 places were barred by the same order that bought it -- one of seven
+    paid searches, spent almost entirely on results the operator had already
+    said they did not want.
+
+    A warning and nothing else. The angle is not removed, reworded or
+    reordered: an operator who wants Nikkei places that genuinely lead with
+    ceviche is asking for something coherent, and only they know that.
+    """
+
+    angle_id: str = Field(min_length=1)
+    angle_text: str = ""
+    # Why these two read as fighting, in a sentence a person can disagree with.
+    why: str = Field(min_length=1)
+
+
 class SearchOrder(ListicleModel):
     """The agreement, in the form the searches run from.
 
@@ -106,6 +128,14 @@ class SearchOrder(ListicleModel):
     # resolution is now a decision, and a decision has to be visible or it is
     # just the old silence with more code behind it.
     answer_notes: list[str] = Field(default_factory=list)
+    # Angles that read as fighting the cut, found before the searches run.
+    angle_conflicts: list[AngleConflict] = Field(default_factory=list)
+    # Whether anything has actually looked. False is not "no conflicts found" --
+    # it is "nobody checked", which is the state every order stored before this
+    # existed is in, and the state of any order built on a path that is not
+    # allowed to spend. The screen has to be able to tell those apart, because
+    # "we looked and it is fine" and "we never looked" are different claims.
+    conflicts_checked: bool = False
 
     def fingerprint(self) -> str:
         """What has to match for a stored result to still be this order's.

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
@@ -161,6 +161,13 @@ class SearchAttempt(ListicleModel):
     role: str = "broad"
     wanted: int = 0
     request_fingerprint: str = ""
+    # Which catalogue shape ran, and what it ran about. The wording is rewritten
+    # by the model on every run, so the text cannot identify "this search" from
+    # one run to the next and the shape can. `subject` scopes that identity:
+    # what the `hours` shape does for cevicherias in Lima says nothing about
+    # what it does for bookshops in Buenos Aires.
+    shape_key: str = ""
+    subject: str = ""
     state: str = "not_started"
     rows: int = 0
     sources: int = 0
@@ -170,6 +177,16 @@ class SearchAttempt(ListicleModel):
     # "did this search reach Spanish-language sources" is a question about one
     # search, and the run-level answer is the union of these.
     source_titles: list[str] = Field(default_factory=list)
+    # What this search contributed, against the pool as it stood when the batch
+    # finished. Recorded rather than only computed, because the whole point is
+    # to be able to say what an angle did LAST time before paying for it again
+    # -- and a number that only exists while a run is on screen cannot do that.
+    # Rewritten after every batch: retrying one angle changes the pool, and so
+    # changes what every other angle turns out to have contributed.
+    found: int = 0
+    shared: int = 0
+    exclusive: int = 0
+    contribution_recorded: bool = False
     sightings: list[dict] = Field(default_factory=list)
     started_at: str = ""
     finished_at: str = ""

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
@@ -1,4 +1,4 @@
-"""What a listicle interview has to settle before it may agree.
+"""What a listicle interview has to settle, and what it settles into.
 
 The article grill settles a vision: what the piece is for, who reads it, what
 would make it a failure. This settles a specification: what kind of place,
@@ -10,9 +10,20 @@ The two are not interchangeable and neither is a mode of the other -- an
 article is judged on whether it reads well, which was never provable; a list
 is judged on whether every item is real, current and earns its place, which
 is checkable.
+
+The records below are the second half of that. An interview that has agreed is
+prose plus a transcript, and prose is the wrong thing to execute: the first
+real run agreed on twenty items and searched for forty, because the number was
+read back out of a sentence. The order is what the searches actually run from,
+it is written down once, and every result files against the revision it was
+run under.
 """
 
 from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, ConfigDict, Field
 
 # (marker, the field it fills on the spec, how it is said to a person)
 LISTICLE_MARKERS: tuple[tuple[str, str, str], ...] = (
@@ -25,3 +36,133 @@ LISTICLE_MARKERS: tuple[tuple[str, str, str], ...] = (
 )
 
 LISTICLE_MARKER_KEYS: tuple[str, ...] = tuple(m for m, _, _ in LISTICLE_MARKERS)
+
+# The three jobs an angle can do. Named here as well as in `search` because
+# the order is what carries them; `search` is what spends against them.
+ANGLE_ROLES: tuple[str, ...] = ("broad", "distinctive", "specific")
+
+
+class ListicleModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SelectedAngle(ListicleModel):
+    """One approved search, with its identity kept.
+
+    `angle_id` is stable across revisions of an order so an attempt, a retry
+    and a result all point at the same search. `text` is the wording the
+    operator approved, stored exactly -- including a narrowing they wrote
+    deliberately, which is theirs and is not repaired.
+
+    `edited` is what makes the catalogue's opinion about this angle
+    provisional. A line the operator rewrote may no longer mean what its shape
+    meant, so the overlap guidance that came with the shape is shown as
+    uncertain rather than asserted.
+    """
+
+    angle_id: str = Field(min_length=1)
+    text: str = Field(min_length=1)
+    shape_key: str = ""
+    group: str = ""
+    role: str = "broad"
+    # What this angle is asked for. Filled when the order is built, from the
+    # role and the target; kept on the record so a stored result can be
+    # compared against what was actually requested.
+    wanted: int = 0
+    edited: bool = False
+    # Set when the angle was written by the operator rather than chosen from
+    # the menu. Never repaired, never re-grouped.
+    custom: bool = False
+
+
+class SearchOrder(ListicleModel):
+    """The agreement, in the form the searches run from.
+
+    This is the source of truth the plan of 2026-09-08 asked for. The displayed
+    summary is derived from it and the searches are executed from it, so the
+    two cannot disagree -- which they did, in the only real run there has been.
+    """
+
+    run_id: str = Field(min_length=1)
+    revision: int = 1
+    kind: str = ""
+    place: str = ""
+    target_count: int = 20
+    standard: str = ""
+    exclusions: str = ""
+    angles: list[SelectedAngle] = Field(default_factory=list)
+    # How the count was settled, and whether anyone should look at it again.
+    # An interview that answered "20, not 40" is unambiguous; one that answered
+    # "somewhere between 20 and 40" is not, and the difference must reach the
+    # screen rather than being resolved by whichever number happened to be
+    # larger.
+    count_source: str = "default"
+    count_ambiguous: bool = False
+    count_note: str = ""
+
+    def fingerprint(self) -> str:
+        """What has to match for a stored result to still be this order's.
+
+        Angle wording, the shared requirements, the place and the kind. Change
+        any of them and the request a stored result answered is not the request
+        this order makes, so the result is not reused.
+        """
+        material = "␟".join(
+            [
+                self.kind.strip(),
+                self.place.strip(),
+                self.standard.strip(),
+                self.exclusions.strip(),
+            ]
+        )
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+    def angle_fingerprint(self, angle: SelectedAngle) -> str:
+        """What has to match for one angle's stored result to still be current."""
+        material = "␟".join(
+            [self.fingerprint(), angle.text.strip(), str(angle.wanted)]
+        )
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+# The states one angle's search can be in. `interrupted` is the one that gets
+# forgotten: a request that was sent and whose answer never arrived is not a
+# search that did not happen, and retrying it may cost a second time.
+ATTEMPT_STATES: tuple[str, ...] = (
+    "not_started",
+    "running",
+    "completed",
+    "failed",
+    "interrupted",
+)
+
+
+class SearchAttempt(ListicleModel):
+    """One angle's search, as it stands.
+
+    Stored per angle rather than per order so a batch that fails on its sixth
+    search keeps the five that worked. The request is recorded alongside the
+    result because reuse is decided by whether the request still matches, and
+    reconstructing an old request from a conversation is exactly the guessing
+    this pipeline is trying to stop doing.
+    """
+
+    run_id: str = Field(min_length=1)
+    revision: int = 1
+    angle_id: str = Field(min_length=1)
+    angle_text: str = ""
+    role: str = "broad"
+    wanted: int = 0
+    request_fingerprint: str = ""
+    state: str = "not_started"
+    rows: int = 0
+    sources: int = 0
+    reason: str = ""
+    source_urls: list[str] = Field(default_factory=list)
+    # Which publications answered, by name. Recorded per attempt because
+    # "did this search reach Spanish-language sources" is a question about one
+    # search, and the run-level answer is the union of these.
+    source_titles: list[str] = Field(default_factory=list)
+    sightings: list[dict] = Field(default_factory=list)
+    started_at: str = ""
+    finished_at: str = ""

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/contracts.py
@@ -99,6 +99,13 @@ class SearchOrder(ListicleModel):
     count_source: str = "default"
     count_ambiguous: bool = False
     count_note: str = ""
+    # Markers the interview answered more than once, and what was done about
+    # it. A repeat used to be resolved by taking the last answer and saying
+    # nothing, which is how an additive follow-up about the cut could delete
+    # three quarters of it and leave a run that looked entirely normal. The
+    # resolution is now a decision, and a decision has to be visible or it is
+    # just the old silence with more code behind it.
+    answer_notes: list[str] = Field(default_factory=list)
 
     def fingerprint(self) -> str:
         """What has to match for a stored result to still be this order's.

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/cut_review.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/cut_review.py
@@ -1,0 +1,322 @@
+"""Does this break what the operator said to leave out?
+
+The same question asked at two moments, because the cut fails in two different
+ways and only one of them is recoverable.
+
+**Before the searches run.** An angle can contradict the cut. Run 33fca394
+approved "Nikkei cevicherias doing Japanese-Peruvian preparations" while its
+cut read "no places where ceviche is not the primary offering". Those disagree,
+and they disagreed in the order, on screen, before anything was bought. Nobody
+looked, so the search ran and returned Maido, Osaka Nikkei, Toshi, Hanzo,
+Nikko, Tomo and Shizen: 8 of its 10 places barred by the same order that paid
+for them. One of seven searches, spent on results already ruled out.
+
+**After they run.** A place can break the cut whichever angle found it. The
+rule is composed into every search prompt and the model does not reliably obey
+it -- that was tried, and the eight above are what it produced. More prompt
+text is not the answer.
+
+What makes the second check cheap is that nothing new has to be looked up. The
+search already wrote down why it returned each place, and for several of these
+the evidence gives it away by itself:
+
+    Maido         "top Nikkei restaurant, offers ceviche"
+    Osaka Nikkei  "Nikkei cuisine, offers ceviche"
+    Toshi         "Japanese and Nikkei food"
+
+"Offers ceviche" is the cut, stated. So this reads what is already stored and
+judges the whole list in one call, rather than researching forty places to
+rediscover what the first search said.
+
+Both checks FLAG. Neither removes anything, and no verdict here is final:
+Maido plainly breaks that cut, and a Nikkei place whose signature really is
+ceviche plainly might not. The operator knows the city; this only makes sure
+they are looking at the question.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Callable
+
+from .contracts import AngleConflict, SearchOrder
+
+logger = logging.getLogger(__name__)
+
+# Room for a verdict on every candidate, with the reasons.
+#
+# This was 2048 and a real call against 43 candidates died on it:
+# `finish_reason: MALFORMED_FUNCTION_CALL`, with the truncated text showing the
+# model part-way through its list. Gemini does not report an over-long tool
+# call as a length problem -- it reports a malformed one, which reads like a
+# schema fault and is not.
+REVIEW_MAX_TOKENS = 8192
+
+# How many candidates go into one review call. Well above a real run -- 43 in
+# the largest so far -- so a normal list is judged as a whole, against the pool
+# it is actually in, rather than in batches that cannot see each other.
+MAX_CANDIDATES_REVIEWED = 120
+
+CONFLICT_TOOL = "record_angle_conflicts"
+CANDIDATE_TOOL = "record_barred_places"
+
+CONFLICT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "conflicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "angle_id": {"type": "string"},
+                    "why": {"type": "string"},
+                },
+                "required": ["angle_id", "why"],
+            },
+        }
+    },
+    "required": ["conflicts"],
+}
+
+CANDIDATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "barred": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    # The row's number, not its name. A real call answered with
+                    # "Chez Wong (La Victoria)" -- it had copied back the line
+                    # exactly as printed, district and all, which matched no
+                    # candidate and would have silently dropped every finding.
+                    # A number cannot be mangled by how the prompt formats a
+                    # line.
+                    "number": {"type": "integer"},
+                    "name": {"type": "string"},
+                    "why": {"type": "string"},
+                    # "clear" or "arguable". Kept as a plain string rather than
+                    # an enum because a value outside the two is treated as
+                    # `arguable` anyway -- see `_confidence`.
+                    "confidence": {"type": "string"},
+                },
+                "required": ["number", "name", "why", "confidence"],
+            },
+        }
+    },
+    "required": ["barred"],
+}
+
+
+def build_conflict_prompt(order: SearchOrder) -> str:
+    """Ask whether any approved search is hunting for barred places."""
+    angles = "\n".join(
+        f"- {angle.angle_id}: {angle.text}" for angle in order.angles
+    )
+    return f"""An operator is building a list of {order.kind or "places"} in {order.place or "a city"}.
+
+They said to leave these out, no matter how good the place is:
+
+{order.exclusions}
+
+These are the searches they approved:
+
+{angles}
+
+Name any search that is likely to return places the operator just barred.
+
+A real example of what this is for: a list of cevicherias whose cut said "no
+places where ceviche is not the primary offering", with an approved search for
+"Nikkei cevicherias doing Japanese-Peruvian preparations". Most Nikkei
+restaurants are Japanese-Peruvian restaurants that serve ceviche among many
+things, so that search mostly returns barred places. It did: 8 of the 10 it
+found were barred.
+
+Only name a search where the clash is likely, not merely possible. Nearly any
+search can return one bad result; that is not what this is asking. Say nothing
+about a search that is fine.
+
+For each one, give its id and one plain sentence saying why the two disagree.
+Address the operator. Do not suggest replacement wording -- they will decide
+what to do."""
+
+
+def build_candidate_prompt(order: SearchOrder, candidates: list[dict]) -> str:
+    """Ask which returned places break the cut, from evidence already stored."""
+    lines = []
+    for index, candidate in enumerate(candidates[:MAX_CANDIDATES_REVIEWED], start=1):
+        evidence = "; ".join(
+            str(sighting.get("evidence", "")).strip()
+            for sighting in candidate.get("sightings", [])
+            if str(sighting.get("evidence", "")).strip()
+        )
+        district = str(candidate.get("district", "")).strip()
+        where = f" -- {district}" if district else ""
+        lines.append(
+            f"{index}. {candidate.get('name', '')}{where} -- "
+            f"{evidence or 'no evidence recorded'}"
+        )
+    listing = "\n".join(lines)
+
+    return f"""An operator is building a list of {order.kind or "places"} in {order.place or "a city"}.
+
+They said to leave these out, no matter how good the place is:
+
+{order.exclusions}
+
+These places came back from the searches. After each one is what the search
+itself said about it:
+
+{listing}
+
+List only the places you have a positive reason to think break one of those
+rules. Say nothing about the rest. Most of this list is expected to be fine --
+it came from searches built to satisfy the same order.
+
+Flag a place only when something POSITIVELY indicates it belongs to a barred
+category. Evidence that is merely thin, vague or silent is not an indication:
+a row that says nothing either way stays off your list.
+
+What counts as positive: the evidence names the place as belonging to the
+excluded category -- "Nikkei restaurant", "inside the hotel", "branch of" --
+or you independently know it does.
+
+What does NOT count, and has caused wrong flags before:
+
+- Evidence about the DISH itself, or about how the place sources or prepares
+  it. "Buys daily from artisanal fishermen" is a reason it belongs on the
+  list, not a reason to bar it.
+- Being a restaurant rather than a stall, being expensive, or being
+  well-regarded. None of those is an exclusion unless the operator said so.
+- A place widely known for the thing this list is about. A famous specialist
+  is the opposite of what such a rule excludes.
+
+Mark each one `clear` or `arguable`:
+
+- `clear` -- only when the evidence line ITSELF states the barred fact, so the
+  operator can see it without leaving the screen.
+- `arguable` -- everything else you flag, including anything resting on your
+  own knowledge rather than on the evidence shown.
+
+If you cannot point at the words that make it barred, it is `arguable`.
+
+Give the row's number, its name, and one plain sentence saying which rule it
+breaks. Copy the number exactly; it is what identifies the row."""
+
+
+def _fold(text: str) -> str:
+    """A name reduced to what two spellings of it have in common."""
+    return re.sub(r"[^a-z0-9]+", " ", str(text).lower()).strip()
+
+
+def _confidence(raw: str) -> str:
+    """`clear` only when it was actually said. Everything else is arguable.
+
+    The safe direction: `arguable` asks the operator to look, `clear` tells
+    them not to bother. A value the model invented gets the reading that costs
+    less if it is wrong.
+    """
+    return "clear" if str(raw).strip().lower() == "clear" else "arguable"
+
+
+def review_order(
+    order: SearchOrder,
+    review: Callable[[str, str, str, dict], Any],
+) -> list[AngleConflict]:
+    """Which approved searches look like they will return barred places.
+
+    `review` is injected rather than imported so that this module runs in a
+    test without a network, the same way `search` takes its `research`.
+
+    An order with no cut has nothing to contradict, and an order with no angles
+    has nothing to check. Both return empty without a call: this is the one
+    check that runs on the path to spending money, and it should not spend to
+    learn that there was nothing to ask about.
+    """
+    if not order.exclusions.strip() or not order.angles:
+        return []
+
+    try:
+        payload = review(
+            "listicle.cut_review",
+            build_conflict_prompt(order),
+            CONFLICT_TOOL,
+            CONFLICT_SCHEMA,
+        )
+    except Exception:
+        # A failed check is not a finding. The order stands and says nobody
+        # looked, which is true and is what `conflicts_checked` is for.
+        logger.warning("The angle/cut conflict check failed", exc_info=True)
+        raise
+
+    by_id = {angle.angle_id: angle for angle in order.angles}
+    found: list[AngleConflict] = []
+    for entry in (payload or {}).get("conflicts", []) or []:
+        angle_id = str(entry.get("angle_id", "")).strip()
+        why = str(entry.get("why", "")).strip()
+        angle = by_id.get(angle_id)
+        # An id nothing offered is not a finding about this order. Dropped
+        # rather than shown against a made-up angle.
+        if angle is None or not why:
+            continue
+        found.append(
+            AngleConflict(angle_id=angle_id, angle_text=angle.text, why=why)
+        )
+    return found
+
+
+def review_candidates(
+    order: SearchOrder,
+    candidates: list[dict],
+    review: Callable[[str, str, str, dict], Any],
+) -> dict[str, dict[str, str]]:
+    """Which returned places break the cut, keyed by the name they came back as.
+
+    One call for the whole list. Nothing is looked up: the evidence each search
+    already wrote is what this reads.
+    """
+    if not order.exclusions.strip() or not candidates:
+        return {}
+
+    payload = review(
+        "listicle.cut_review",
+        build_candidate_prompt(order, candidates),
+        CANDIDATE_TOOL,
+        CANDIDATE_SCHEMA,
+    )
+
+    reviewed = candidates[:MAX_CANDIDATES_REVIEWED]
+    flags: dict[str, dict[str, str]] = {}
+    for entry in (payload or {}).get("barred", []) or []:
+        why = str(entry.get("why", "")).strip()
+        if not why:
+            continue
+        try:
+            number = int(entry.get("number"))
+        except (TypeError, ValueError):
+            continue
+        # The listing is one-based, as printed.
+        if not 1 <= number <= len(reviewed):
+            continue
+        candidate = reviewed[number - 1]
+        actual = str(candidate.get("name", "")).strip()
+        if not actual:
+            continue
+        # The name is a cross-check, not the key. A number that points at a
+        # different restaurant from the one the model named is an off-by-one,
+        # and acting on it would flag an innocent place while the real one goes
+        # unflagged -- worse than dropping the finding. Compared loosely
+        # because the model may echo the row's district along with its name.
+        named = str(entry.get("name", "")).strip().lower()
+        if named and _fold(actual) not in _fold(named) and _fold(named) not in _fold(actual):
+            logger.warning(
+                "Cut review said row %s was %r, but row %s is %r; dropped",
+                number, entry.get("name"), number, actual,
+            )
+            continue
+        flags[actual] = {
+            "why": why,
+            "confidence": _confidence(entry.get("confidence", "")),
+        }
+    return flags

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/cut_review.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/cut_review.py
@@ -315,8 +315,25 @@ def review_candidates(
                 number, entry.get("name"), number, actual,
             )
             continue
+        confidence = _confidence(entry.get("confidence", ""))
+        # The same name can appear on more than one row: a pair the merge
+        # refused to join because their districts disagreed is two candidates
+        # with one name, and the model judges each row separately. Run
+        # 33fca394 has three such pairs, and one of them came back barred for
+        # two different reasons -- Nikkei on one row, chain on the other.
+        # Last-write-wins threw one of those away without saying so, so both
+        # are kept, at the stronger of the two readings.
+        existing = flags.get(actual)
+        if existing is None:
+            flags[actual] = {"why": why, "confidence": confidence}
+            continue
+        reasons = existing["why"]
+        if _fold(why) not in _fold(reasons):
+            reasons = f"{reasons} {why}"
         flags[actual] = {
-            "why": why,
-            "confidence": _confidence(entry.get("confidence", "")),
+            "why": reasons,
+            "confidence": "clear"
+            if "clear" in (existing["confidence"], confidence)
+            else "arguable",
         }
     return flags

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/cut_review.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/cut_review.py
@@ -153,8 +153,19 @@ def build_candidate_prompt(order: SearchOrder, candidates: list[dict]) -> str:
         )
         district = str(candidate.get("district", "")).strip()
         where = f" -- {district}" if district else ""
+        # Rows this pipeline could not prove are separate places. Said out
+        # loud, because without it the model reads two rows of one restaurant
+        # as two branches: a real run flagged Chez Wong and El Verídico de
+        # Fidel as chains on exactly that reasoning, and neither is a chain --
+        # each is one famous place whose district two searches recorded
+        # differently.
+        twin = (
+            " [may be the same place as another row here]"
+            if candidate.get("possible_duplicates")
+            else ""
+        )
         lines.append(
-            f"{index}. {candidate.get('name', '')}{where} -- "
+            f"{index}. {candidate.get('name', '')}{where}{twin} -- "
             f"{evidence or 'no evidence recorded'}"
         )
     listing = "\n".join(lines)
@@ -187,6 +198,11 @@ What does NOT count, and has caused wrong flags before:
 - Evidence about the DISH itself, or about how the place sources or prepares
   it. "Buys daily from artisanal fishermen" is a reason it belongs on the
   list, not a reason to bar it.
+- Two rows with the same name in different districts. This list is pooled from
+  several searches and often holds one place twice, which is why some rows are
+  marked as possibly the same place. That is a record-keeping artefact, NOT
+  evidence of a chain. Do not call something a chain because it appears twice
+  here; say so only if you know it genuinely has many branches.
 - Being a restaurant rather than a stall, being expensive, or being
   well-regarded. None of those is an exclusion unless the operator said so.
 - A place widely known for the thing this list is about. A famous specialist

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/evaluation.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/evaluation.py
@@ -1,0 +1,217 @@
+"""The commissions the angle system is judged on, and how a case is scored.
+
+The plan of 2026-09-08 asks for a small, varied set of cases rather than more
+of what already exists. Every interview this pipeline has ever run -- all six
+of them -- was about Lima cevicherias, and the database copied for the audit
+had no saved search results at all. Six interviews about one dish in one city
+are not a baseline for a catalogue that has to serve bars and hotels.
+
+Two halves, deliberately separated:
+
+**What can be checked without spending anything.** Whether a hotel commission
+is offered hotel dimensions, whether a narrow requirement survives into every
+search, whether an order of narrow angles admits it may not fill the list.
+These are properties of the catalogue and the order, they are checked by the
+test suite, and they need no model and no network.
+
+**What cannot.** Whether the angles find better places. That needs real
+searches against real money, and the plan is explicit that it must not be run
+until identity handling and result recording are trustworthy -- otherwise the
+measurements are measuring the bug. `scripts/listicle_angle_comparison.py`
+runs it, refuses to run without an explicit spend acknowledgement, and has not
+been run.
+
+Nothing in this module claims a case has been evaluated. It says what the case
+is and what would count as passing it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Case:
+    """One commission, and what a good answer to it looks like.
+
+    `must_offer` and `must_not_offer` are catalogue keys, checkable in code.
+    `must_survive` are requirements that have to reach every search whatever
+    angle found the place -- also checkable in code, because the requirements
+    are composed into the prompt rather than written into the angles.
+
+    `judged_by` is the part a person has to read. It is written down so the
+    criteria are fixed before any paid run, rather than chosen afterwards to
+    flatter whichever result came back.
+    """
+
+    key: str
+    seed: str
+    kind: str
+    subject: str
+    target_count: int
+    standard: str = ""
+    exclusions: str = ""
+    must_offer: tuple[str, ...] = ()
+    must_not_offer: tuple[str, ...] = ()
+    must_survive: tuple[str, ...] = ()
+    judged_by: tuple[str, ...] = ()
+    note: str = ""
+
+
+CASES: tuple[Case, ...] = (
+    Case(
+        key="broad-restaurants",
+        seed="The 30 best restaurants in Lima",
+        kind="restaurants",
+        subject="restaurants",
+        target_count=30,
+        standard="written about by someone other than the restaurant",
+        must_offer=("institution", "cheap", "regional-tradition", "informal"),
+        judged_by=(
+            "Does the mix reach past the same six prestigious names every "
+            "list in the city already has?",
+            "How many of the returned places appear on no international list?",
+        ),
+    ),
+    Case(
+        key="specialist-restaurants",
+        seed="The 20 best cevicherias in Lima",
+        kind="cevicherias",
+        subject="restaurants",
+        target_count=20,
+        exclusions="general restaurants where ceviche is one line on the menu",
+        must_offer=("regional-tradition", "producer-links", "hours"),
+        must_survive=("general restaurants where ceviche is one line on the menu",),
+        judged_by=(
+            "Do the angles add variety without drifting off the specialty?",
+            "Does the exclusion hold in every search, or only in the one that "
+            "mentions it?",
+        ),
+        note=(
+            "The only commission this pipeline has real history with. The first "
+            "run's Nikkei search returned four general restaurants because "
+            "nothing carried the exclusion out of the interview."
+        ),
+    ),
+    Case(
+        key="broad-bars",
+        seed="The 25 best bars in Lima",
+        kind="bars",
+        subject="bars",
+        target_count=25,
+        must_offer=("drink-specialty", "local-drinking", "service-format", "setting"),
+        must_not_offer=("informal", "regional-tradition"),
+        judged_by=(
+            "Are price, format, setting and local drinking traditions treated "
+            "as different things rather than four words for 'good bar'?",
+        ),
+    ),
+    Case(
+        key="narrow-bars",
+        seed="The 15 best rooftop bars in Lima",
+        kind="rooftop bars",
+        subject="bars",
+        target_count=15,
+        standard="an actual roof terrace open to guests",
+        must_survive=("an actual roof terrace open to guests",),
+        judged_by=(
+            "Does every returned place actually have a roof terrace?",
+            "Does any angle spend itself restating 'rooftop', which every "
+            "search already carries?",
+        ),
+    ),
+    Case(
+        key="broad-hotels",
+        seed="The 30 best hotels in Lima",
+        kind="hotels",
+        subject="hotels",
+        target_count=30,
+        must_offer=("lodging-format", "building-character", "transport-access"),
+        must_not_offer=("informal", "crossed", "hours"),
+        judged_by=(
+            "Does the catalogue reach for lodging dimensions, or for the "
+            "restaurant ones with the nouns changed?",
+        ),
+    ),
+    Case(
+        key="narrow-hotels",
+        seed="20 independent hotels in Lima suitable for longer stays",
+        kind="independent hotels",
+        subject="hotels",
+        target_count=20,
+        standard="independently owned, and set up for stays of a week or more",
+        exclusions="chains and international groups",
+        must_offer=("long-stay", "lodging-format"),
+        must_survive=(
+            "independently owned, and set up for stays of a week or more",
+            "chains and international groups",
+        ),
+        judged_by=(
+            "Do independence and long-stay survive every search, or does one "
+            "optional angle carry the whole commission?",
+        ),
+        note="The worked example in the plan of 2026-09-08.",
+    ),
+    Case(
+        key="sparse-location",
+        seed="The 20 best cevicherias in Huaraz",
+        kind="cevicherias",
+        subject="restaurants",
+        target_count=20,
+        judged_by=(
+            "Does the system accept a genuinely small pool and report the "
+            "shortfall, or invent volume to reach the number?",
+            "Does the interview warn about the count before the searches run?",
+        ),
+        note=(
+            "A mountain city three hundred kilometres from the sea. The right "
+            "answer is a short list and a warning."
+        ),
+    ),
+    Case(
+        key="operator-edited",
+        seed="The 20 best cevicherias in Lima",
+        kind="cevicherias",
+        subject="restaurants",
+        target_count=20,
+        judged_by=(
+            "Is a narrowing the operator wrote on purpose still in the search "
+            "that runs, word for word?",
+            "Is an angle they wrote themselves treated as theirs rather than "
+            "re-filed under the nearest catalogue shape?",
+        ),
+        note=(
+            "Run by editing two lines in the picker before approving. The "
+            "system must explain the likely effect on breadth and not repair "
+            "the intent."
+        ),
+    ),
+)
+
+CASES_BY_KEY: dict[str, Case] = {case.key: case for case in CASES}
+
+
+# What has to be reported, separately, whenever a comparison is run. Listed
+# here so a run cannot quietly report only the flattering half.
+REPORTED_OUTCOMES: tuple[tuple[str, str], ...] = (
+    ("eligibility", "how many checked candidates fit the requirements and the angle"),
+    ("coverage", "how many suitable distinct venues the whole pool holds, and what is missing"),
+    ("contribution", "which angles supply otherwise-missed candidates, and what they share"),
+    ("identity_errors", "false merges and unresolved duplicates, counted separately"),
+    ("wording_drift", "unrequested restrictions added, and requirements silently broadened"),
+    ("operator_effort", "edits, confusing choices, repeated questions, recovery actions"),
+    ("spend", "input and output usage, provider cost where available, latency, retries"),
+)
+
+
+@dataclass
+class CaseReport:
+    """One case's result. Every field starts empty and stays empty until a run
+    fills it: an unmeasured outcome must read as unmeasured, not as zero."""
+
+    case_key: str
+    outcomes: dict[str, str] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+
+    def unreported(self) -> list[str]:
+        return [name for name, _ in REPORTED_OUTCOMES if name not in self.outcomes]

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/prompts.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/prompts.py
@@ -4,6 +4,28 @@ The loop, the retry, the lookup budget, the pushback and the stop condition
 all come from `prompt2blog.grill_v4` unchanged. This file is the only thing
 that makes the interview about a list, which is why it is the only thing that
 had to be written.
+
+Three changes from the improvement plan of 2026-09-08:
+
+**The requirements come before the menu.** A requirement applies to every place
+on the list; an angle is one route into the places that already satisfy it.
+"Rooftop bars in Lima" already requires a rooftop, and a second rooftop angle
+adds no route -- while a family-friendly commission whose family requirement is
+demoted to one optional angle has quietly stopped being the list that was
+commissioned.
+
+**The catalogue belongs to the subject, and only arrives when it is needed.**
+A hotel commission was being shown market stalls and cuisine fusions because
+the catalogue was written for restaurants and shown to everything. It is now
+filtered, and it is only spelled out in full on the turn that can use it --
+which is the turn after `count` is settled, since the prompt already refuses to
+ask about angles before then.
+
+**Overlap is explained, not forbidden.** Four shapes shared a `prestige` group
+and at most one could be chosen. Award-listed and expensive are not the same
+places in most cities, and family-run and longstanding often are while sharing
+no group at all. The catalogue now says which pairs tend to collide and the
+operator decides.
 """
 
 from __future__ import annotations
@@ -11,7 +33,50 @@ from __future__ import annotations
 from ..prompt2blog.contracts_v4 import GrillState
 from ..prompt2blog.grill_v4 import _lookups_left, _marker_status, _transcript
 from .contracts import LISTICLE_MARKERS
-from .shapes import collision_groups, shape_menu
+from .shapes import (
+    angle_count_guidance,
+    overlap_notes,
+    roles_note,
+    shape_menu,
+    shapes_for,
+    subject_of,
+)
+from .spec import count_from, kind_from
+
+
+def _catalogue_block(state: GrillState) -> str:
+    """The catalogue, in as much detail as this turn can use.
+
+    Spelled out once `count` is settled, because that is the first turn on
+    which `angles` may be asked at all. Before then the model needs to know
+    what exists -- so that it does not settle a count the catalogue cannot
+    serve -- and does not need three hundred lines of wording rules it is
+    forbidden to act on yet.
+    """
+    subject = subject_of(kind_from(state))
+    available = shapes_for(subject)
+    named = subject or "no specialised subject; the shared catalogue only"
+
+    if "count" not in state.markers_covered:
+        labels = ", ".join(shape.key for shape in available)
+        return f"""THE SHAPE CATALOGUE ({named}), in outline. You will be shown it in full
+once the count is settled, which is the earliest you may ask about angles:
+{labels}"""
+
+    return f"""THE SHAPE CATALOGUE ({named}). These are the only shapes this commission
+gets. A shape not listed here does not apply to this subject -- do not reach
+for one, and do not invent a category so that the catalogue has something to
+offer:
+{shape_menu(subject)}
+
+PAIRS THAT TEND TO RETURN THE SAME PLACES (a warning, not a rule -- you may
+choose both if you can say why this city is different):
+{overlap_notes(subject) or "- none in this catalogue"}
+
+WHAT AN ANGLE IS FOR (`role`, one per angle):
+{roles_note()}
+
+{angle_count_guidance(count_from(state))}"""
 
 
 def build_listicle_turn_prompt(state: GrillState) -> str:
@@ -44,6 +109,14 @@ promises nothing about method and you must NEVER treat it as a stated
 criterion. The title usually carries the kind of place, the location and the
 count, and nothing else.
 
+Everything ELSE the title says is a REQUIREMENT, and requirements are not
+angles. "Rooftop bars in Lima" requires a rooftop of every place on the list.
+"Independent hotels" bars the chains. "Family-friendly hotels" requires
+somewhere a family can actually stay. Carry those into `bar` and `cut` where
+they belong, and never demote one into an optional angle -- a list that only
+checks its own title in one of six searches is not the list that was
+commissioned.
+
 WHAT YOU ALREADY LOOKED UP (never ask about anything in here):
 {state.research_digest or "Nothing; you could not look anything up."}
 
@@ -64,13 +137,14 @@ listed as missing above, and the markers have an order:
     angles               LAST, and never before `count` is covered
 
 `angles` is last because it is built FROM the others: the number of angles
-comes from the count, and their wording comes from the kind and the place. A
-live run asked about angles on turn four with the count still unsettled,
-learned the count two turns later, and had to ask the whole angle question
-again -- the most expensive question in the interview, asked twice. If every marker is covered, you are done -- say so and
-write the consensus. A live run asked the same `count` question twice in a row
-because it chose a marker it had already settled, and an interview that repeats
-itself is not one.
+comes from the count, their wording comes from the kind and the place, and what
+every place must satisfy comes from `bar` and `cut`. A live run asked about
+angles on turn four with the count still unsettled, learned the count two turns
+later, and had to ask the whole angle question again -- the most expensive
+question in the interview, asked twice. If every marker is covered, you are
+done -- say so and write the consensus. A live run asked the same `count`
+question twice in a row because it chose a marker it had already settled, and
+an interview that repeats itself is not one.
 
 If a marker is plainly answered by the title and you have nothing to warn them
 about, do NOT spend a turn confirming it: put it straight into
@@ -117,13 +191,23 @@ Now the part that matters.
   anyway. A number that reality cannot fill is the most expensive mistake this
   interview can make, because every later search inherits it.
 
+  Put the number you are recommending in `recommendation` as a plain number, on
+  its own or at the start. "Yes" is a normal answer to this question and the
+  number it agrees to has to be readable from what you proposed.
+
 - `bar` is what earns a place, beyond the angle that found it -- awards, local
   critics, customer reviews, what locals say, or their own judgement. Ask it
-  plainly and do not accept "the best", which is the question restated.
+  plainly and do not accept "the best", which is the question restated. Fold in
+  any requirement the title stated: if they asked for independent hotels,
+  independence is part of the bar or part of the cut, not an angle.
 
 - `cut` is what is barred no matter how good it is -- chains, delivery-only,
   hotel restaurants, anywhere they simply refuse to send a reader. People find
   this easier to answer than the bar, so it is a good question to ask second.
+
+  `bar` and `cut` are attached to EVERY search that runs, whatever angle found
+  the place. So they are worth getting right once, and worth never repeating
+  inside an angle.
 
 - `angles` is the search order itself, and it is the question this whole
   interview exists to reach.
@@ -133,38 +217,35 @@ Now the part that matters.
   will find nine. So the list is filled from several angles at once, each
   searched separately.
 
-  Roughly SEVEN items per angle. Work out the number of angles from the count
-  they settled on: about 40 items wants 6 angles, about 24 wants 4, about 15
-  wants 3, 8 or fewer wants 2.
-
-  That is how many to RECOMMEND. It is not a quota to hold them to. If they
-  send back more angles than you suggested, or fewer, that is their answer and
-  the marker is settled -- take it and move on. A live run recommended six,
-  was given seven, and asked the whole question again to get back to six; an
-  interview that re-asks a question it has already been answered is broken,
-  and more angles than planned is not a problem in the first place.
+  An angle must add a distinct ROUTE into the places that already satisfy the
+  requirements. It is not a restatement of the commission: for "rooftop bars",
+  "bars with rooftop terraces" is the commission with different words and one
+  wasted search. Ask yourself what each angle finds that the others would miss,
+  and if the answer is "nothing", it is not an angle.
 
   You do not invent angles freely and you do not pick finished ones off a
   list. You choose SHAPES from the catalogue below and write each one's version
   for THIS topic.
 
-THE SHAPE CATALOGUE:
-{shape_menu()}
+{_catalogue_block(state)}
 
   Rules for writing an angle from a shape, in order of how badly each one bites:
 
-  ADD NOTHING THE SHAPE DID NOT ASK FOR. The shape sets how tight the search
-  is. Every extra condition you volunteer empties it. Asked for "opened in the
-  last year" a previous run wrote "opened in the last 1-3 years AND has
-  significant buzz" and found one place instead of eight. No "AND". No quality
-  clause. No number of years where the shape says "decades".
+  ADD NOTHING THE SHAPE DID NOT ASK FOR. The shape's `means` line is the whole
+  condition. Every extra condition you volunteer empties the search. Asked for
+  "opened in the last year" a previous run wrote "opened in the last 1-3 years
+  AND has significant buzz" and found one place instead of eight. No "AND". No
+  quality clause. No number of years where the shape says "decades". No
+  requirement that a specialist sells nothing else.
 
-  NEVER CHOOSE TWO SHAPES FROM THE SAME GROUP. Shapes in a group return the
-  same places for the same reason. These are the groups:
-{collision_groups()}
-  A previous run picked three prestige-shaped angles and all three returned the
-  same three restaurants; a third of the list was wasted. At most one per
-  group. Everything outside a group may be combined freely.
+  DO NOT REPEAT THE REQUIREMENTS. `bar` and `cut` are attached to every search
+  already. An angle that restates them spends a search on a filter that was
+  going to be applied anyway.
+
+  SAY WHAT THE ANGLE IS FOR. Every option carries a `role`. Be honest about it:
+  an angle that can only ever return one or two places is `specific`, and
+  labelling it `broad` is how it gets asked for twelve and answers with twelve,
+  nine of which do not belong.
 
   MAKE IT SPECIFIC TO THE TOPIC. This is the whole reason you write the angle
   instead of reading it. "Tiny plain places where the food is the whole point"
@@ -173,38 +254,44 @@ THE SHAPE CATALOGUE:
   looked up: the local words, the local formats, the local neighbourhoods.
 
   WRITE IT AS A SEARCH, NOT A LABEL. It is sent to a web search almost
-  verbatim. "Hidden gem" is a label. "Unmarked huariques serving ceviche that
-  locals know by word of mouth" is a search. It must include the kind of place
-  and be a plain description of what to look for.
+  verbatim. "Hidden gem" is a label. "Huariques Lima residents recommend that
+  the visitor guides miss" is a search. It must include the kind of place and
+  be a plain description of what to look for. Never describe a place as having
+  no online presence: a web search cannot find what you have just called
+  unfindable.
 
   When and only when you ask about `angles`, fill `options` with a MENU, not
-  just your picks. Each entry is `{{text, recommended, group}}`:
+  just your picks. Each entry is `{{text, recommended, group, shape, role}}`:
 
     text         the finished search line, standing alone -- no numbering, no
                  shape name, no commentary
     recommended  true for the ones you are proposing, false for the rest
-    group        the shape's collision group, or "" if it has none
+    shape        the catalogue key you wrote it from, or "" if it is your own
+    group        the shape's theme, or "" -- a label, not a rule
+    role         broad, distinctive or specific
 
   The menu has three parts, and all three go in the same list:
 
-    1. YOUR PICKS, `recommended` true. As many as the count needs.
+    1. YOUR PICKS, `recommended` true. As many as the count needs. Two or three
+       `broad` ones at most; the rest earn their place by finding something the
+       broad ones miss.
 
-    2. EVERY OTHER SHAPE IN THE CATALOGUE, `recommended` false, each written
-       for this topic exactly as carefully as your picks. This is the part
-       that makes the question answerable: an operator shown only the six you
-       chose has nothing to swap in, and a shape written badly because it was
-       not going to be chosen is a trap for whoever ticks it.
+    2. EVERY OTHER SHAPE IN THIS COMMISSION'S CATALOGUE, `recommended` false,
+       each written for this topic exactly as carefully as your picks. This is
+       the part that makes the question answerable: an operator shown only the
+       six you chose has nothing to swap in, and a shape written badly because
+       it was not going to be chosen is a trap for whoever ticks it.
 
        Skip a shape only when it genuinely does not exist for this topic, and
        skip it silently.
 
-    3. ANGLES THE CATALOGUE HAS NO SHAPE FOR, `recommended` false, `group` "".
-       Up to four. These are the reasons a place makes THIS list that no
-       general pattern could have anticipated -- what you know about this
-       topic in this city that a catalogue written for restaurants, bars,
-       hotels and sights could never contain. Ceviche in Lima has places by
-       the fishing landings serving what came off the boat that morning;
-       nothing in the catalogue is that. Find that kind of thing.
+    3. ANGLES THE CATALOGUE HAS NO SHAPE FOR, `recommended` false, `shape` "",
+       `group` "". Up to four. These are the reasons a place makes THIS list
+       that no general pattern could have anticipated -- what you know about
+       this topic in this city that a catalogue written for restaurants, bars
+       and hotels could never contain. Ceviche in Lima has places by the
+       fishing landings serving what came off the boat that morning; nothing in
+       the catalogue is that. Find that kind of thing.
 
        They obey every other rule: one idea, no "AND", searchable, worded as
        a search. Do not restate a shape you have already written under a new
@@ -233,8 +320,10 @@ THE SHAPE CATALOGUE:
   true.
 
   `consensus` is the search order read back plainly -- the kind of place, the
-  location, the number of items, what earns a place, what is barred, how many
-  each search should aim to return, and then every angle on its own line
-  exactly as it will be searched. They should
-  be able to read it and know exactly what is about to be looked for.
+  location, the number of items, what earns a place, what is barred, and then
+  every angle on its own line exactly as it will be searched. They should be
+  able to read it and know exactly what is about to be looked for. Do not work
+  out how many results each search should ask for; that is decided from the
+  count and the roles after you agree, and an arithmetic you do here is one
+  more thing that can disagree with what actually runs.
 """

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
@@ -425,6 +425,11 @@ def assemble(order: SearchOrder) -> dict:
 
     uncertain = sum(1 for c in candidates if c.possible_duplicates)
     capacity = planned_capacity(order)
+    # None means nobody has checked this revision against the cut; `{}` means
+    # something checked and barred nothing. The screen says which, because
+    # "we looked and it is fine" and "we never looked" are different claims.
+    stored_review = store.load_cut_review(order.run_id, order.revision)
+    barred = stored_review or {}
     payload = {
         "run_id": order.run_id,
         "revision": order.revision,
@@ -444,6 +449,13 @@ def assemble(order: SearchOrder) -> dict:
         # Said rather than left to be worked out from a table. Roughly two of
         # seven searches in run 33fca394 returned no place the others missed,
         # and nothing anywhere said so.
+        # Whether anything has judged this revision's places against the cut,
+        # and what it said. Separate from the flags themselves so an unchecked
+        # run does not read as a clean one.
+        "cut_checked": stored_review is not None,
+        "barred_count": sum(
+            1 for c in candidates if barred.get(c.name, {}).get("why")
+        ),
         "empty_handed": [
             row["angle_id"]
             for row in angle_rows
@@ -476,6 +488,11 @@ def assemble(order: SearchOrder) -> dict:
                 "found_by": list(c.found_by),
                 "overlap": c.overlap,
                 "possible_duplicates": list(c.possible_duplicates),
+                # What the cut check said about this place, if anything has
+                # looked. Read from storage rather than recomputed: judging
+                # costs a model call, and drawing a screen must not.
+                "barred": barred.get(c.name, {}).get("why", ""),
+                "barred_confidence": barred.get(c.name, {}).get("confidence", ""),
                 "sightings": [
                     {
                         "angle": s.angle,

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
@@ -1,0 +1,371 @@
+"""Running a search order once, and recovering from the half of it that failed.
+
+The version this replaced ran six searches inside one HTTP request and stored
+what came back as a single blob. Three things followed from that, all of them
+bad and all of them seen on the only real run there has been:
+
+- a failure on the sixth search threw away the five that had worked;
+- a reload had no way to ask what had already been done, so the only way back
+  to a run was to pay for it again;
+- and a re-run replaced the stored results wholesale, so the last good version
+  was gone the moment a worse one finished.
+
+So the unit of work here is one angle, not one order. Each is claimed, run and
+stored on its own. A batch is a loop over that, and a retry is the same loop
+with a shorter list.
+
+What this can promise: successful work survives; a second click does not start
+a second batch; a stale result is never shown as current.
+
+What it cannot promise: that a request whose answer never arrived was not
+already processed and charged for. An interrupted attempt is labelled as
+interrupted rather than as failed, and retrying it may cost again. Saying so is
+the honest version; a green tick would not be.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from .contracts import SearchAttempt, SearchOrder
+from . import store
+from .search import (
+    AngleRequest,
+    Candidate,
+    Sighting,
+    contribution_of,
+    pool_sightings,
+    run_one_angle,
+)
+from .spec import planned_capacity
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _request_for(order: SearchOrder, angle) -> AngleRequest:
+    return AngleRequest(
+        angle_id=angle.angle_id,
+        text=angle.text,
+        role=angle.role,
+        wanted=angle.wanted,
+        shape_key=angle.shape_key,
+        group=angle.group,
+        edited=angle.edited,
+    )
+
+
+def reusable_attempt(
+    order: SearchOrder, angle, attempts: list[SearchAttempt]
+) -> SearchAttempt | None:
+    """A stored result that still answers the request this order makes.
+
+    Matched on the request rather than on the angle's name. Change the place,
+    the exclusions, the standard or the wording and the stored rows answered a
+    different question -- they may still be true and they are no longer this
+    order's evidence, so they are not silently carried forward.
+    """
+    fingerprint = order.angle_fingerprint(angle)
+    matching = [
+        attempt
+        for attempt in attempts
+        if attempt.angle_id == angle.angle_id
+        and attempt.state == "completed"
+        and attempt.request_fingerprint == fingerprint
+    ]
+    if not matching:
+        return None
+    return max(matching, key=lambda a: (a.revision, a.finished_at))
+
+
+def _sightings_of(attempt: SearchAttempt) -> list[Sighting]:
+    return [
+        Sighting(
+            angle=row.get("angle", attempt.angle_text),
+            angle_id=row.get("angle_id", attempt.angle_id),
+            name=row.get("name", ""),
+            district=row.get("district", ""),
+            evidence=row.get("evidence", ""),
+        )
+        for row in attempt.sightings
+        if row.get("name")
+    ]
+
+
+def run_order(
+    order: SearchOrder,
+    research,
+    *,
+    only: list[str] | None = None,
+    reuse: bool = True,
+) -> dict:
+    """Run the angles that need running, and assemble what the run now knows.
+
+    `only` names the angles to run; everything else is read from storage. That
+    is what makes a retry precise -- the operator re-runs the one search that
+    timed out and pays for one search.
+
+    `reuse` off is the deliberate full refresh: the operator wants new
+    research, knows it costs, and asked for it.
+    """
+    stored = {a.angle_id: a for a in _latest_by_angle(store.load_attempts(order.run_id))}
+    wanted_ids = set(only) if only is not None else None
+
+    for angle in order.angles:
+        request = _request_for(order, angle)
+        fingerprint = order.angle_fingerprint(angle)
+        should_run = wanted_ids is None or angle.angle_id in wanted_ids
+        if should_run and reuse:
+            existing = reusable_attempt(order, angle, list(stored.values()))
+            if existing is not None:
+                # Re-filed under this revision so the assembled view is a view
+                # of one revision, while `gathered_at` still says when the work
+                # was actually done.
+                carried = existing.model_copy(
+                    update={"revision": order.revision, "wanted": angle.wanted}
+                )
+                store.save_attempt(carried)
+                stored[angle.angle_id] = carried
+                continue
+        if not should_run:
+            continue
+
+        running = SearchAttempt(
+            run_id=order.run_id,
+            revision=order.revision,
+            angle_id=angle.angle_id,
+            angle_text=angle.text,
+            role=angle.role,
+            wanted=angle.wanted,
+            request_fingerprint=fingerprint,
+            state="running",
+            started_at=_now(),
+        )
+        store.save_attempt(running)
+        stored[angle.angle_id] = running
+
+        result, sightings = run_one_angle(
+            request,
+            kind=order.kind,
+            place=order.place,
+            exclusions=order.exclusions,
+            standard=order.standard,
+            research=research,
+        )
+        finished = running.model_copy(
+            update={
+                "state": "failed" if result.failed else "completed",
+                "rows": result.rows,
+                "sources": result.sources,
+                "reason": result.reason,
+                "source_urls": result.source_urls,
+                "source_titles": result.source_titles,
+                "sightings": [
+                    {
+                        "angle": s.angle,
+                        "angle_id": s.angle_id,
+                        "name": s.name,
+                        "district": s.district,
+                        "evidence": s.evidence,
+                    }
+                    for s in sightings
+                ],
+                "finished_at": _now(),
+            }
+        )
+        # Saved the moment it finishes rather than when the batch does. This is
+        # the whole reason a failure on the sixth search no longer costs the
+        # five that worked.
+        store.save_attempt(finished)
+        stored[angle.angle_id] = finished
+
+    return assemble(order)
+
+
+def _latest_by_angle(attempts: list[SearchAttempt]) -> list[SearchAttempt]:
+    best: dict[str, SearchAttempt] = {}
+    for attempt in attempts:
+        current = best.get(attempt.angle_id)
+        if current is None or (attempt.revision, attempt.finished_at) >= (
+            current.revision,
+            current.finished_at,
+        ):
+            best[attempt.angle_id] = attempt
+    return list(best.values())
+
+
+def _current_attempts(order: SearchOrder) -> dict[str, SearchAttempt]:
+    """The attempt that speaks for each angle right now.
+
+    This revision's attempt when there is one, because that is the live work
+    -- running, failed or finished. Otherwise a completed attempt from an
+    earlier revision whose request fingerprint still matches, which is the
+    reuse rule stated once: a stored result belongs to a request, not to a
+    revision number.
+
+    Reading it this way is what stops a corrected count blanking the screen. An
+    order revised to fix one angle leaves five angles asking exactly what they
+    asked before, and their results are still answers to their questions.
+    """
+    stored = store.load_attempts(order.run_id)
+    chosen: dict[str, SearchAttempt] = {}
+    for angle in order.angles:
+        mine = [
+            a
+            for a in stored
+            if a.angle_id == angle.angle_id and a.revision == order.revision
+        ]
+        if mine:
+            chosen[angle.angle_id] = max(mine, key=lambda a: a.finished_at)
+            continue
+        fingerprint = order.angle_fingerprint(angle)
+        reusable = [
+            a
+            for a in stored
+            if a.angle_id == angle.angle_id
+            and a.state == "completed"
+            and a.request_fingerprint == fingerprint
+        ]
+        if reusable:
+            chosen[angle.angle_id] = max(
+                reusable, key=lambda a: (a.revision, a.finished_at)
+            )
+    return chosen
+
+
+def _state_of(attempt: SearchAttempt | None, running: bool) -> str:
+    if attempt is None:
+        return "not_started"
+    if attempt.state == "running" and not running:
+        # The process that claimed it is gone. Not "failed": nobody knows
+        # whether the provider answered, and retrying may be charged again.
+        return "interrupted"
+    return attempt.state
+
+
+def assemble(order: SearchOrder) -> dict:
+    """What the run knows right now, whether or not anything is still running.
+
+    Read rather than computed as the searches go, so the numbers do not depend
+    on the order the angles finished in. Contribution in particular is
+    calculated against the finished pool: the first angle to return a place
+    does not collect credit for it, and reordering the searches cannot change
+    what the table says.
+    """
+    running = store.batch_is_running(order.run_id)
+    by_angle = _current_attempts(order)
+
+    sightings: list[Sighting] = []
+    for angle in order.angles:
+        attempt = by_angle.get(angle.angle_id)
+        if attempt is not None and attempt.state == "completed":
+            sightings.extend(_sightings_of(attempt))
+    candidates: list[Candidate] = sorted(
+        pool_sightings(sightings), key=lambda c: (-c.overlap, c.name.lower())
+    )
+
+    angle_rows = []
+    for angle in order.angles:
+        attempt = by_angle.get(angle.angle_id)
+        state = _state_of(attempt, running)
+        found, shared, exclusive = contribution_of(candidates, angle.text)
+        angle_rows.append(
+            {
+                "angle_id": angle.angle_id,
+                "angle": angle.text,
+                "shape": angle.shape_key,
+                "group": angle.group,
+                "role": angle.role,
+                "wanted": angle.wanted,
+                "edited": angle.edited,
+                "custom": angle.custom,
+                "state": state,
+                # Kept for the screen that has always read these.
+                "failed": state in {"failed", "interrupted"},
+                "rows": attempt.rows if attempt else 0,
+                "sources": attempt.sources if attempt else 0,
+                "reason": (
+                    attempt.reason
+                    if attempt
+                    else "this search has not been run yet"
+                )
+                if state != "interrupted"
+                else "it never came back; re-running it may be charged again",
+                # Repeated discovery, reported as itself. Not a ranking: a
+                # search with few exclusive names may be carrying the coverage
+                # everything else is being checked against.
+                "found": found,
+                "shared": shared,
+                "exclusive": exclusive,
+                "gathered_at": attempt.finished_at if attempt else "",
+                "sources_named": list(attempt.source_titles) if attempt else [],
+                "reused": bool(
+                    attempt
+                    and attempt.state == "completed"
+                    and attempt.revision != order.revision
+                ),
+            }
+        )
+
+    uncertain = sum(1 for c in candidates if c.possible_duplicates)
+    capacity = planned_capacity(order)
+    payload = {
+        "run_id": order.run_id,
+        "revision": order.revision,
+        "target": order.target_count,
+        "found": len(candidates),
+        "shortfall": max(0, order.target_count - len(candidates)),
+        "rows_returned": sum(row["rows"] for row in angle_rows),
+        "running": running,
+        "complete": all(
+            row["state"] == "completed" for row in angle_rows
+        ) and bool(angle_rows),
+        # Said plainly rather than left to be worked out. A distinct count is
+        # provisional while any two rows might be one venue, and a screen that
+        # prints one number implies a certainty this step has not got.
+        "uncertain_identity": uncertain,
+        "capacity": capacity,
+        "capacity_warning": (
+            f"These {len(order.angles)} searches ask for {capacity} places in "
+            f"total, which may not fill a list of {order.target_count}. Add an "
+            "angle, or take the shorter list."
+            if capacity < order.target_count
+            else ""
+        ),
+        "order": {
+            "kind": order.kind,
+            "place": order.place,
+            "target_count": order.target_count,
+            "standard": order.standard,
+            "exclusions": order.exclusions,
+            "count_source": order.count_source,
+            "count_ambiguous": order.count_ambiguous,
+            "count_note": order.count_note,
+        },
+        "angles": angle_rows,
+        "candidates": [
+            {
+                "name": c.name,
+                "district": c.district,
+                "evidence": c.evidence,
+                "found_by": list(c.found_by),
+                "overlap": c.overlap,
+                "possible_duplicates": list(c.possible_duplicates),
+                "sightings": [
+                    {
+                        "angle": s.angle,
+                        "name": s.name,
+                        "district": s.district,
+                        "evidence": s.evidence,
+                    }
+                    for s in c.sightings
+                ],
+            }
+            for c in candidates
+        ],
+    }
+    return payload

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
@@ -345,6 +345,7 @@ def assemble(order: SearchOrder) -> dict:
             "count_source": order.count_source,
             "count_ambiguous": order.count_ambiguous,
             "count_note": order.count_note,
+            "answer_notes": list(order.answer_notes),
         },
         "angles": angle_rows,
         "candidates": [

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/runner.py
@@ -142,6 +142,8 @@ def run_order(
             role=angle.role,
             wanted=angle.wanted,
             request_fingerprint=fingerprint,
+            shape_key=angle.shape_key,
+            subject=subject_of(order),
             state="running",
             started_at=_now(),
         )
@@ -183,7 +185,117 @@ def run_order(
         store.save_attempt(finished)
         stored[angle.angle_id] = finished
 
+    # The pool is only final once the batch is. Contribution is written back
+    # here rather than at the moment each search lands, because what a search
+    # contributed depends on what every other search returned.
+    record_contribution(order)
     return assemble(order)
+
+
+def prior_contribution(order: SearchOrder) -> dict[str, str]:
+    """What each angle bought the last time it ran, said before it runs again.
+
+    The open item this answers: in run 33fca394 the `purist` angle returned ten
+    rows for one place nothing else found, and `hours` returned six rows for
+    none. Roughly two of seven searches bought nothing, nothing noticed, and
+    the numbers only existed after the money was spent.
+
+    An angle is identified across runs by its SHAPE, not its wording -- the
+    model rewrites the sentence every run -- and only within the same subject.
+    An angle the operator wrote themselves has no shape to look up, so it is
+    matched on its exact wording or not at all.
+
+    Said, and nothing more. No angle is dropped, reordered or discouraged: two
+    runs is a fact about two runs, and this pipeline has two.
+    """
+    subject = subject_of(order)
+    history = store.completed_attempts_for(subject, exclude_run=order.run_id)
+    if not history:
+        return {}
+
+    by_shape: dict[str, list[SearchAttempt]] = {}
+    by_text: dict[str, list[SearchAttempt]] = {}
+    for attempt in history:
+        if attempt.shape_key:
+            by_shape.setdefault(attempt.shape_key, []).append(attempt)
+        if attempt.angle_text:
+            by_text.setdefault(attempt.angle_text.strip().lower(), []).append(attempt)
+
+    notes: dict[str, str] = {}
+    for angle in order.angles:
+        earlier = (
+            by_shape.get(angle.shape_key)
+            if angle.shape_key
+            else by_text.get(angle.text.strip().lower())
+        )
+        if not earlier:
+            continue
+        runs = len({attempt.run_id for attempt in earlier})
+        rows = sum(attempt.rows for attempt in earlier)
+        exclusive = sum(attempt.exclusive for attempt in earlier)
+        when = "the last time this search ran here" if runs == 1 else (
+            f"across the {runs} times this search has run here"
+        )
+        earned = (
+            "no place the other searches missed"
+            if exclusive == 0
+            else f"{exclusive} place{'' if exclusive == 1 else 's'} nothing else found"
+        )
+        notes[angle.angle_id] = (
+            f"{when.capitalize()} it returned {rows} "
+            f"row{'' if rows == 1 else 's'} and {earned}."
+        )
+    return notes
+
+
+def subject_of(order: SearchOrder) -> str:
+    """What a run is about, in the form two runs can be compared on.
+
+    Kind and place only. The count, the bar and the cut all change what a
+    search is asked for, and none of them changes whether "the `hours` shape
+    finds cevicherias in Lima nobody else finds".
+    """
+    return f"{order.kind.strip().lower()}|{order.place.strip().lower()}"
+
+
+def record_contribution(order: SearchOrder) -> None:
+    """Write each angle's contribution onto its stored attempt.
+
+    Contribution is computed against the finished pool, so it cannot be written
+    when a search lands -- the searches after it will change it. It is written
+    once the batch is done, and rewritten after every later batch: retrying one
+    angle changes the pool and therefore changes what the other six turn out to
+    have contributed.
+
+    This is what makes the number outlive the run. Until it was stored, an
+    angle that bought nothing was visible on one screen, for one run, after the
+    money was already spent.
+    """
+    by_angle = _current_attempts(order)
+    sightings: list[Sighting] = []
+    for angle in order.angles:
+        attempt = by_angle.get(angle.angle_id)
+        if attempt is not None and attempt.state == "completed":
+            sightings.extend(_sightings_of(attempt))
+    candidates = pool_sightings(sightings)
+
+    for angle in order.angles:
+        attempt = by_angle.get(angle.angle_id)
+        if attempt is None or attempt.state != "completed":
+            continue
+        found, shared, exclusive = contribution_of(candidates, angle.text)
+        store.save_attempt(
+            attempt.model_copy(
+                update={
+                    "found": found,
+                    "shared": shared,
+                    "exclusive": exclusive,
+                    "contribution_recorded": True,
+                    "shape_key": attempt.shape_key or angle.shape_key,
+                    "subject": attempt.subject or subject_of(order),
+                }
+            )
+        )
 
 
 def _latest_by_angle(attempts: list[SearchAttempt]) -> list[SearchAttempt]:
@@ -329,6 +441,14 @@ def assemble(order: SearchOrder) -> dict:
         # prints one number implies a certainty this step has not got.
         "uncertain_identity": uncertain,
         "capacity": capacity,
+        # Said rather than left to be worked out from a table. Roughly two of
+        # seven searches in run 33fca394 returned no place the others missed,
+        # and nothing anywhere said so.
+        "empty_handed": [
+            row["angle_id"]
+            for row in angle_rows
+            if row["state"] == "completed" and row["exclusive"] == 0
+        ],
         "capacity_warning": (
             f"These {len(order.angles)} searches ask for {capacity} places in "
             f"total, which may not fill a list of {order.target_count}. Add an "

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/search.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/search.py
@@ -18,9 +18,21 @@ it, so each angle is asked for enough that the pooled total clears the target
 with the overlap already priced in.
 
 **It keeps the overlap.** A place found by four angles is not four rows to be
-thinned to one -- it is the strongest thing on the list, and `found_by` is
-where ranking comes from later. Deduplication merges the rows and keeps the
-count.
+thinned to one. The rows merge, every original sighting is kept, and how many
+angles found a place is reported as what it is -- repeated discovery, not a
+verdict on quality.
+
+Two rules were added after the plan of 2026-09-08:
+
+**Angles do not all carry the same load.** "Affordable hotels" can supply a
+dozen; "the place credited with inventing the dish" supplies one, and asking it
+for a dozen is asking it to invent eleven. Each angle carries a discovery role
+and gets an allowance from it.
+
+**A merge that is not certain does not happen.** The Centro branch and the
+airport branch are two businesses; two bars inside one hotel are two
+businesses. Showing a possible duplicate costs a glance. Silently folding two
+venues into one loses a venue and nobody can see that it happened.
 """
 
 from __future__ import annotations
@@ -47,6 +59,29 @@ MIN_PER_ANGLE = 6
 SEARCH_TIMEOUT_SECONDS = 180
 SEARCH_MAX_TOKENS = 4_096
 SEARCH_ATTEMPTS = 3
+
+# The three jobs an angle can be doing, and what each may be asked for.
+#
+# These are requests, not forecasts. Nobody has measured how many places a
+# "specific discovery" angle really returns, and the numbers below are a
+# bounded, explainable starting point to be tuned against comparison runs --
+# not a yield model derived from six interviews.
+BROAD = "broad"
+DISTINCTIVE = "distinctive"
+SPECIFIC = "specific"
+ROLES: tuple[str, ...] = (BROAD, DISTINCTIVE, SPECIFIC)
+
+# Share of the per-angle ask each role carries, and the bounds it is held
+# between. A broad angle carries a full share; a specific-discovery angle is
+# never pressured to fill a quota it cannot fill honestly.
+_ROLE_SHARE = {BROAD: 1.0, DISTINCTIVE: 0.7, SPECIFIC: 0.25}
+_ROLE_FLOOR = {BROAD: MIN_PER_ANGLE, DISTINCTIVE: 4, SPECIFIC: 1}
+_ROLE_CEILING = {BROAD: MAX_PER_ANGLE, DISTINCTIVE: 12, SPECIFIC: 5}
+
+
+def _share(role: str) -> float:
+    return _ROLE_SHARE.get(role, _ROLE_SHARE[DISTINCTIVE])
+
 
 # Rows that name a container of places rather than one place. The searches
 # return these in good faith -- "Surquillo Market (stalls)" is a fair answer to
@@ -76,13 +111,45 @@ _NOISE_WORDS = {
     "del", "don", "dona", "the", "and", "y",
 }
 
+# A list marker, and nothing longer. The version this replaced stripped every
+# leading digit and every leading full stop, which turned "1900 Hotel" into
+# "Hotel" and a numbered row for "Bodega 1884" into "Bodega". A year in a bar's
+# name is common and the damage was silent: the row survived under a name that
+# does not exist, so nothing downstream could resolve it.
+_LIST_MARKER = re.compile(r"^\s*(?:[-*•·–—]+|\(?\d{1,2}\s*[.)\]]|#\d{1,2})\s+")
+
+
+def role_allowances(target_items: int, roles: list[str]) -> list[int]:
+    """How many places each angle in an order is asked for.
+
+    The overshoot is spread across the roles rather than divided equally: an
+    order of one broad angle and four specific ones must not ask the four for
+    the same number the broad one gets, because they cannot supply it and the
+    ask is what makes a search pad its answer.
+    """
+    if not roles:
+        return []
+    weight = sum(_share(role) for role in roles) or 1.0
+    per_unit = (target_items * OVERSHOOT) / weight
+    allowances = []
+    for role in roles:
+        raw = round(per_unit * _share(role))
+        floor = _ROLE_FLOOR.get(role, _ROLE_FLOOR[DISTINCTIVE])
+        ceiling = _ROLE_CEILING.get(role, _ROLE_CEILING[DISTINCTIVE])
+        allowances.append(max(floor, min(ceiling, raw)))
+    return allowances
+
 
 def per_angle_ask(target_items: int, angle_count: int) -> int:
-    """How many places to ask one search for."""
+    """How many places to ask one search for, when every angle is broad.
+
+    Kept as the plain case of `role_allowances`: an order whose roles are not
+    known yet is an order of broad searches, which is what the pipeline did
+    before roles existed.
+    """
     if angle_count <= 0:
         return 0
-    raw = round((target_items * OVERSHOOT) / angle_count)
-    return max(MIN_PER_ANGLE, min(MAX_PER_ANGLE, raw))
+    return role_allowances(target_items, [BROAD] * angle_count)[0]
 
 
 def name_tokens(name: str) -> list[str]:
@@ -91,12 +158,28 @@ def name_tokens(name: str) -> list[str]:
     A parenthetical is dropped before anything else. Searches qualify a name
     with what the row is about -- "Gran Hotel Bolívar (Bar Catedral)", "Hotel B
     (Rooftop bar)" -- and that qualifier is the row's reason, not part of the
-    business's name.
+    business's name. It is not thrown away: `qualifier_tokens` reads it back,
+    because two rows qualified differently may be two different businesses
+    inside one building.
     """
     without_aside = re.sub(r"\([^)]*\)", " ", name)
     folded = unicodedata.normalize("NFKD", without_aside.lower())
     folded = "".join(c for c in folded if not unicodedata.combining(c))
     return [w for w in re.findall(r"[a-z0-9]+", folded) if w not in _NOISE_WORDS]
+
+
+def qualifier_tokens(name: str) -> set[str]:
+    """What a name says about itself in brackets, or after a branch separator.
+
+    "Tanta (Larcomar)" and "Tanta (San Isidro)" are two restaurants. "Gran
+    Hotel Bolívar (Bar Catedral)" and "Gran Hotel Bolívar (Bar Maury)" are two
+    bars. Both pairs share every distinguishing word in the name itself, so the
+    only thing that can keep them apart is this.
+    """
+    asides = " ".join(re.findall(r"\(([^)]*)\)", name))
+    folded = unicodedata.normalize("NFKD", asides.lower())
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return {w for w in re.findall(r"[a-z0-9]+", folded) if w not in _NOISE_WORDS}
 
 
 def normalise_name(name: str) -> str:
@@ -111,6 +194,12 @@ def normalise_name(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", folded)
 
 
+def _district_key(district: str) -> str:
+    folded = unicodedata.normalize("NFKD", district.lower())
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", "", folded)
+
+
 # How many distinguishing words a shorter name needs before it may be treated
 # as the same place as a longer one that contains it.
 #
@@ -119,46 +208,60 @@ def normalise_name(name: str) -> str:
 _CONTAINMENT_MIN_TOKENS = 2
 
 
-def merge_contained(candidates: list["Candidate"]) -> list["Candidate"]:
-    """Fold a place named twice at different lengths into one entry.
+def _districts_conflict(a: str, b: str) -> bool:
+    """Two rows that name different districts are two branches until proven not.
 
-    Exact-key pooling catches "La Mar" and "La Mar Cebichería" because the
-    noise words fall away. It does not catch a name qualified by where it is:
-    "Bar Inglés at the Country Club Hotel" and "Bar Inglés del Country Club"
-    are one bar and share no normalised key.
-
-    Searching in the local language made this worse rather than better, which
-    is the point -- more sources means more spellings of the same place, and an
-    undetected duplicate does not merely pad the list, it splits an entry's
-    overlap in half and drops it down the ranking.
-
-    The name kept is the one carrying the most distinguishing words, and on a
-    tie the shorter string -- because a tie means the difference was a
-    parenthetical, and "Hotel B" is the bar's name where "Hotel B (Rooftop
-    bar)" is a search's note about why it turned up. `found_by` absorbs the
-    other spelling's, so a place found under two names is correctly counted as
-    found twice.
+    A chain with a branch in Centro and a branch at the airport is two entries
+    on a list and two different addresses. Merging them keeps one and loses the
+    other, and the loss is invisible: the surviving row looks like an ordinary
+    candidate.
     """
-    ordered = sorted(
-        candidates, key=lambda c: (-len(name_tokens(c.name)), len(c.name))
-    )
-    kept: list[Candidate] = []
-    for candidate in ordered:
-        tokens = set(name_tokens(candidate.name))
-        host = None
-        if len(tokens) >= _CONTAINMENT_MIN_TOKENS:
-            host = next(
-                (k for k in kept if tokens <= set(name_tokens(k.name))), None
-            )
-        if host is None:
-            kept.append(candidate)
-            continue
-        for angle in candidate.found_by:
-            if angle not in host.found_by:
-                host.found_by.append(angle)
-        if candidate.district and not host.district:
-            host.district = candidate.district
-    return kept
+    left, right = _district_key(a), _district_key(b)
+    if not left or not right:
+        return False
+    return left != right and left not in right and right not in left
+
+
+def _qualifiers_conflict(a: str, b: str) -> bool:
+    """Two rows qualified differently name two things inside one building."""
+    left, right = qualifier_tokens(a), qualifier_tokens(b)
+    if not left or not right:
+        # One row is unqualified. "Hotel B" and "Hotel B (Rooftop bar)" in a
+        # search for bars are the same bar written two ways, and refusing that
+        # merge would split the overlap of a place two angles agreed on.
+        return False
+    return left.isdisjoint(right)
+
+
+def may_merge(a: "Candidate", b: "Candidate") -> bool:
+    """Whether two rows are certainly the same business.
+
+    Deliberately asymmetric in what it costs to be wrong. A duplicate left
+    standing is a row the operator glances at and dismisses. A false merge
+    deletes a real venue, and there is nothing on the screen to notice.
+    """
+    if _districts_conflict(a.district, b.district):
+        return False
+    if _qualifiers_conflict(a.name, b.name):
+        return False
+    return True
+
+
+@dataclass
+class Sighting:
+    """One row exactly as one search returned it.
+
+    Kept per candidate rather than collapsed into a single evidence sentence.
+    Two angles finding the same place found it for two different reasons, and
+    the reasons are what a person needs to check whether the merge was right --
+    which the previous version discarded at the moment it mattered most.
+    """
+
+    angle: str
+    angle_id: str
+    name: str
+    district: str
+    evidence: str
 
 
 @dataclass
@@ -169,10 +272,35 @@ class Candidate:
     district: str
     evidence: str
     found_by: list[str] = field(default_factory=list)
+    sightings: list[Sighting] = field(default_factory=list)
+    # Rows that look like this place but were not merged into it, because a
+    # district or a bracketed qualifier said they might be somewhere else.
+    # Shown rather than resolved: this step cannot tell a second branch from a
+    # second spelling, and pretending otherwise is how a venue disappears.
+    possible_duplicates: list[str] = field(default_factory=list)
 
     @property
     def overlap(self) -> int:
         return len(self.found_by)
+
+
+@dataclass
+class AngleRequest:
+    """One angle as it is actually sent, with its identity attached.
+
+    The wording alone is not enough to file a result against: two revisions of
+    an order can carry the same sentence, and an edited angle carries a
+    sentence no shape ever wrote. The id travels with the request so a stored
+    result belongs to a search rather than to a string.
+    """
+
+    angle_id: str
+    text: str
+    role: str = BROAD
+    wanted: int = 0
+    shape_key: str = ""
+    group: str = ""
+    edited: bool = False
 
 
 @dataclass
@@ -189,6 +317,14 @@ class AngleResult:
     sources: int
     failed: bool = False
     reason: str = ""
+    angle_id: str = ""
+    role: str = BROAD
+    wanted: int = 0
+    source_urls: list[str] = field(default_factory=list)
+    # The publications, by name. `source_urls` are Google redirects and
+    # identify nothing; these are what say whether a search written to run in
+    # the local language actually reached local press.
+    source_titles: list[str] = field(default_factory=list)
 
 
 def build_search_prompt(
@@ -199,6 +335,7 @@ def build_search_prompt(
     exclusions: str,
     standard: str,
     wanted: int,
+    role: str = BROAD,
 ) -> str:
     """What one angle is sent to the web as.
 
@@ -207,14 +344,34 @@ def build_search_prompt(
     restaurants where ceviche is one line on the menu" and the Nikkei search
     returned four of exactly that, because nothing carried the bar from the
     interview to the search.
+
+    They are composed here, from the order, rather than written into the angle.
+    An angle is one route into the eligible pool; the requirements apply to
+    every place however it was found, so an operator editing an angle cannot
+    accidentally drop the commission's own conditions.
     """
+    # A specific-discovery angle asked to "keep going until you have twelve"
+    # will invent twelve. Saying plainly that a short honest answer is a good
+    # answer is the only thing standing between a narrow angle and padding.
+    if role == SPECIFIC:
+        effort = (
+            f"Find up to {wanted}. This is a narrow angle and there may only be "
+            "one or two. Returning one real place is a good answer; do not pad "
+            "the list with places that only loosely fit."
+        )
+    else:
+        effort = (
+            f"Find {wanted}. Keep going until you have {wanted} or have genuinely "
+            "run out -- listing four when eight exist is the failure mode here, "
+            "and a place you are reasonably confident about belongs on the list. "
+            "Breadth first: this is a shortlist someone will check, not a final "
+            "answer."
+        )
+
     return f"""List real, currently open {kind} in {place} that match this description:
 {angle}
 
-Find {wanted}. Keep going until you have {wanted} or have genuinely run out --
-listing four when eight exist is the failure mode here, and a place you are
-reasonably confident about belongs on the list. Breadth first: this is a
-shortlist someone will check, not a final answer.
+{effort}
 
 Search in the local language of {place} as well as in English, and say so to
 yourself before you start: run the query the way a resident would type it.
@@ -228,14 +385,28 @@ Every entry must be ONE named business a reader could walk into. Not a market,
 a street or a district -- if the answer is "the stalls in X market", name the
 individual stalls or leave it out.
 
-{f"Leave out: {exclusions}" if exclusions else ""}
+{f"Every place must satisfy this no matter which description found it: {standard}" if standard else ""}
 
-{f"Prefer places that meet this standard, but do not drop a well-known place for want of a citation: {standard}" if standard else ""}
+{f"Leave out, no matter how good: {exclusions}" if exclusions else ""}
 
 Write ONLY the list. One place per line, in exactly this format:
 NAME | DISTRICT | evidence in under ten words
 
+If a business has a branch qualifier -- a district, a street, a room inside a
+hotel -- keep it in brackets after the name. Two branches are two entries.
+
 No preamble, no numbering, no closing line."""
+
+
+def strip_list_marker(line: str) -> str:
+    """Remove a list marker without removing the name.
+
+    Bounded on purpose. Anything that strips leading digits freely eats the
+    year out of "Bodega Piselli 1915" the moment it starts a line, and a name
+    damaged this way is not recoverable further down -- nothing knows what was
+    taken off.
+    """
+    return _LIST_MARKER.sub("", line, count=1).strip().strip("*_ ").strip()
 
 
 def parse_rows(text: str) -> list[tuple[str, str, str]]:
@@ -250,7 +421,7 @@ def parse_rows(text: str) -> list[tuple[str, str, str]]:
         if "|" not in line:
             continue
         parts = [part.strip() for part in line.split("|")]
-        name = re.sub(r"^[\-\*•\d\.\)\s]+", "", parts[0]).strip().strip("*_ ")
+        name = strip_list_marker(parts[0])
         if not name or name.lower() in {"name", "place", "business", "restaurant"}:
             continue
         if _NOT_A_BUSINESS.search(name):
@@ -262,13 +433,273 @@ def parse_rows(text: str) -> list[tuple[str, str, str]]:
     return rows
 
 
-def _search_once(prompt: str, research) -> tuple[str, list[str]]:
-    digest, urls, _tokens = research(prompt)
-    return digest, urls
+def merge_contained(candidates: list[Candidate]) -> list[Candidate]:
+    """Fold a place named twice at different lengths into one entry.
+
+    Exact-key pooling catches "La Mar" and "La Mar Cebichería" because the
+    noise words fall away. It does not catch a name qualified by where it is:
+    "Bar Inglés at the Country Club Hotel" and "Bar Inglés del Country Club"
+    are one bar and share no normalised key.
+
+    Searching in the local language made this worse rather than better, which
+    is the point -- more sources means more spellings of the same place, and an
+    undetected duplicate does not merely pad the list, it splits an entry's
+    overlap in half and drops it down the ranking.
+
+    The name kept is the one carrying the most distinguishing words, and on a
+    tie the shorter string -- because a tie means the difference was a
+    parenthetical, and "Hotel B" is the bar's name where "Hotel B (Rooftop
+    bar)" is a search's note about why it turned up. `found_by` and every
+    original sighting absorb the other spelling's.
+
+    A containment that `may_merge` refuses is recorded on both rows instead of
+    performed. The screen can then show two entries and say they might be one,
+    which is the honest reading -- this step cannot tell a second branch from a
+    second spelling.
+    """
+    ordered = sorted(
+        candidates, key=lambda c: (-len(name_tokens(c.name)), len(c.name))
+    )
+    kept: list[Candidate] = []
+    for candidate in ordered:
+        tokens = set(name_tokens(candidate.name))
+        host = None
+        blocked: list[Candidate] = []
+        if len(tokens) >= _CONTAINMENT_MIN_TOKENS:
+            for other in kept:
+                if not tokens <= set(name_tokens(other.name)):
+                    continue
+                if may_merge(other, candidate):
+                    host = other
+                    break
+                blocked.append(other)
+        if host is None:
+            for other in blocked:
+                if candidate.name not in other.possible_duplicates:
+                    other.possible_duplicates.append(candidate.name)
+                if other.name not in candidate.possible_duplicates:
+                    candidate.possible_duplicates.append(other.name)
+            kept.append(candidate)
+            continue
+        _absorb(host, candidate)
+    return kept
+
+
+def _absorb(host: Candidate, other: Candidate) -> None:
+    for angle in other.found_by:
+        if angle not in host.found_by:
+            host.found_by.append(angle)
+    host.sightings.extend(other.sightings)
+    for name in other.possible_duplicates:
+        if name not in host.possible_duplicates:
+            host.possible_duplicates.append(name)
+    if other.district and not host.district:
+        host.district = other.district
+    if not host.evidence and other.evidence:
+        host.evidence = other.evidence
+
+
+def pool_sightings(sightings: list[Sighting]) -> list[Candidate]:
+    """Every row every angle returned, gathered into places.
+
+    Two passes, and both of them conservative. Exact-key pooling first, which
+    is the safe case -- the same name written two lengths. Containment second,
+    which is the case that can be wrong, and every merge there has to survive
+    `may_merge`.
+    """
+    pool: list[Candidate] = []
+    by_key: dict[str, list[Candidate]] = {}
+    for sighting in sightings:
+        key = normalise_name(sighting.name)
+        if not key:
+            continue
+        host = next(
+            (
+                candidate
+                for candidate in by_key.get(key, [])
+                if may_merge(
+                    candidate,
+                    Candidate(
+                        name=sighting.name,
+                        district=sighting.district,
+                        evidence=sighting.evidence,
+                    ),
+                )
+            ),
+            None,
+        )
+        if host is None:
+            fresh = Candidate(
+                name=sighting.name,
+                district=sighting.district,
+                evidence=sighting.evidence,
+                found_by=[sighting.angle],
+                sightings=[sighting],
+            )
+            for sibling in by_key.get(key, []):
+                if sighting.name not in sibling.possible_duplicates:
+                    sibling.possible_duplicates.append(sighting.name)
+                if sibling.name not in fresh.possible_duplicates:
+                    fresh.possible_duplicates.append(sibling.name)
+            by_key.setdefault(key, []).append(fresh)
+            pool.append(fresh)
+            continue
+        if sighting.angle not in host.found_by:
+            host.found_by.append(sighting.angle)
+        host.sightings.append(sighting)
+        # Keep the longer name and fill a district the first row lacked:
+        # "La Mar" and "La Mar Cebichería" are one place, and the fuller name
+        # is the one worth printing.
+        if len(sighting.name) > len(host.name):
+            host.name = sighting.name
+        if sighting.district and not host.district:
+            host.district = sighting.district
+        if not host.evidence and sighting.evidence:
+            host.evidence = sighting.evidence
+    return merge_contained(pool)
+
+
+def contribution_of(
+    candidates: list[Candidate], angle: str
+) -> tuple[int, int, int]:
+    """(found, shared, only this one) for one angle, against the whole pool.
+
+    Calculated from the finished pool rather than accumulated as the searches
+    run, so the first angle to return a place does not collect credit for it
+    and reordering the searches cannot change the numbers.
+    """
+    found = [c for c in candidates if angle in c.found_by]
+    exclusive = [c for c in found if len(c.found_by) == 1]
+    return len(found), len(found) - len(exclusive), len(exclusive)
+
+
+def _search_once(prompt: str, research) -> tuple[str, list[str], list[str]]:
+    """Whatever the research callable returned, read tolerantly.
+
+    Three elements is the long-standing shape and every test still sends it.
+    A fourth, when it is there, is the list of publications behind the answer:
+    the URLs are opaque Google redirects, so without this nothing stored can
+    say where a search actually looked -- which is the first question anyone
+    asks of a search written to run in the local language.
+    """
+    found = research(prompt)
+    digest = found[0]
+    urls = list(found[1] or [])
+    titles = list(found[3] or []) if len(found) > 3 else []
+    return digest, urls, titles
+
+
+def run_one_angle(
+    request: AngleRequest,
+    *,
+    kind: str,
+    place: str,
+    exclusions: str = "",
+    standard: str = "",
+    research=None,
+) -> tuple[AngleResult, list[Sighting]]:
+    """One angle, run and read. The unit that is stored and retried.
+
+    Separated from the batch so a failure is one search to run again rather
+    than an order to run again. Six searches cost real money and minutes, and
+    the version this replaced threw five good ones away when the sixth timed
+    out.
+    """
+    if research is None:  # pragma: no cover -- wiring error, not a runtime one
+        raise ValueError("run_one_angle needs a research callable")
+
+    prompt = build_search_prompt(
+        request.text,
+        kind=kind,
+        place=place,
+        exclusions=exclusions,
+        standard=standard,
+        wanted=request.wanted,
+        role=request.role,
+    )
+    text, urls, titles, failure = "", [], [], ""
+    for attempt in range(SEARCH_ATTEMPTS):
+        try:
+            text, urls, titles = _search_once(prompt, research)
+            failure = ""
+            break
+        except Exception as exc:  # pragma: no cover -- network dependent
+            failure = f"{type(exc).__name__}"
+            logger.warning(
+                "Angle search failed (attempt %s) for %r: %s",
+                attempt + 1,
+                request.text,
+                exc,
+            )
+
+    rows = parse_rows(text)
+    # Three different things look identical as a zero on the screen, and
+    # only one of them is worth re-running:
+    #
+    #   the search never ran          -> a fact about the network
+    #   it ran and said nothing       -> a fact about the model or the quota
+    #   it answered but named nobody  -> a fact about the angle
+    #
+    # The first real run labelled all three "nothing published for this
+    # angle", which sent the operator looking for a better angle when the
+    # actual problem was a 60-second timeout.
+    if failure:
+        reason = failure
+    elif rows:
+        reason = ""
+    elif not text.strip():
+        reason = "the search came back empty"
+    else:
+        reason = "the search answered but named no places"
+
+    sightings = [
+        Sighting(
+            angle=request.text,
+            angle_id=request.angle_id,
+            name=name,
+            district=district,
+            evidence=evidence,
+        )
+        for name, district, evidence in rows
+    ]
+    result = AngleResult(
+        angle=request.text,
+        rows=len(rows),
+        sources=len(urls),
+        failed=bool(failure),
+        reason=reason,
+        angle_id=request.angle_id,
+        role=request.role,
+        wanted=request.wanted,
+        source_urls=list(urls),
+        source_titles=list(titles),
+    )
+    return result, sightings
+
+
+def requests_for(
+    angles: list[str] | list[AngleRequest], target_items: int
+) -> list[AngleRequest]:
+    """Plain angle lines read as an order of broad searches.
+
+    The compatibility path. An order built by `spec.build_search_order` already
+    carries roles and ids; a bare list of lines is what the pipeline had before
+    it did, and what a test that only cares about pooling still passes.
+    """
+    if angles and isinstance(angles[0], AngleRequest):
+        return list(angles)  # type: ignore[arg-type]
+    lines = [str(a) for a in angles]
+    allowances = role_allowances(target_items, [BROAD] * len(lines))
+    return [
+        AngleRequest(
+            angle_id=f"a{index + 1}", text=text, role=BROAD, wanted=allowances[index]
+        )
+        for index, text in enumerate(lines)
+    ]
 
 
 def run_search_order(
-    angles: list[str],
+    angles: list[str] | list[AngleRequest],
     *,
     kind: str,
     place: str,
@@ -289,80 +720,22 @@ def run_search_order(
     if research is None:  # pragma: no cover -- wiring error, not a runtime one
         raise ValueError("run_search_order needs a research callable")
 
-    wanted = per_angle_ask(target_items, len(angles))
-    pool: dict[str, Candidate] = {}
+    requests = requests_for(angles, target_items)
     results: list[AngleResult] = []
-
-    for angle in angles:
-        prompt = build_search_prompt(
-            angle,
+    sightings: list[Sighting] = []
+    for request in requests:
+        result, found = run_one_angle(
+            request,
             kind=kind,
             place=place,
             exclusions=exclusions,
             standard=standard,
-            wanted=wanted,
+            research=research,
         )
-        text, urls, failure = "", [], ""
-        for attempt in range(SEARCH_ATTEMPTS):
-            try:
-                text, urls = _search_once(prompt, research)
-                failure = ""
-                break
-            except Exception as exc:  # pragma: no cover -- network dependent
-                failure = f"{type(exc).__name__}"
-                logger.warning(
-                    "Angle search failed (attempt %s) for %r: %s", attempt + 1, angle, exc
-                )
+        results.append(result)
+        sightings.extend(found)
 
-        rows = parse_rows(text)
-        # Three different things look identical as a zero on the screen, and
-        # only one of them is worth re-running:
-        #
-        #   the search never ran          -> a fact about the network
-        #   it ran and said nothing       -> a fact about the model or the quota
-        #   it answered but named nobody  -> a fact about the angle
-        #
-        # The first real run labelled all three "nothing published for this
-        # angle", which sent the operator looking for a better angle when the
-        # actual problem was a 60-second timeout.
-        if failure:
-            reason = failure
-        elif rows:
-            reason = ""
-        elif not text.strip():
-            reason = "the search came back empty"
-        else:
-            reason = "the search answered but named no places"
-        results.append(
-            AngleResult(
-                angle=angle,
-                rows=len(rows),
-                sources=len(urls),
-                failed=bool(failure),
-                reason=reason,
-            )
-        )
-
-        for name, district, evidence in rows:
-            key = normalise_name(name)
-            if not key:
-                continue
-            existing = pool.get(key)
-            if existing is None:
-                pool[key] = Candidate(
-                    name=name, district=district, evidence=evidence, found_by=[angle]
-                )
-                continue
-            if angle not in existing.found_by:
-                existing.found_by.append(angle)
-            # Keep the longer name and fill a district the first row lacked:
-            # "La Mar" and "La Mar Cebichería" are one place, and the fuller
-            # name is the one worth printing.
-            if len(name) > len(existing.name):
-                existing.name = name
-            if district and not existing.district:
-                existing.district = district
-
-    merged = merge_contained(list(pool.values()))
-    candidates = sorted(merged, key=lambda c: (-c.overlap, c.name.lower()))
+    candidates = sorted(
+        pool_sightings(sightings), key=lambda c: (-c.overlap, c.name.lower())
+    )
     return candidates, results

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -140,6 +140,8 @@ def revise_order(
     *,
     target_count: int | None = None,
     angles: list[dict] | None = None,
+    standard: str | None = None,
+    exclusions: str | None = None,
 ) -> SearchOrder:
     """Correct the agreement, at a new revision.
 
@@ -162,6 +164,18 @@ def revise_order(
         updated.count_source = "corrected by operator"
         updated.count_ambiguous = False
         updated.count_note = ""
+    # The bar and the cut can be typed out here because they may have been
+    # assembled from two answers rather than given once. A combined value is
+    # the safe reading and not necessarily the right one -- it keeps a rule the
+    # operator may have meant to drop -- so the only honest way to combine is
+    # to leave a way to disagree. Correcting one clears its note: it was a
+    # question about an inference, and there is no longer an inference.
+    if standard is not None:
+        updated.standard = standard.strip()
+        updated.answer_notes = spec.drop_note_for(updated.answer_notes, "bar")
+    if exclusions is not None:
+        updated.exclusions = exclusions.strip()
+        updated.answer_notes = spec.drop_note_for(updated.answer_notes, "cut")
     if angles is not None:
         if not angles:
             raise ValueError("An order with no searches in it cannot be run.")
@@ -359,6 +373,7 @@ def _upgrade_legacy(stored: dict, current: "SearchOrder") -> dict:
             "count_source": current.count_source,
             "count_ambiguous": current.count_ambiguous,
             "count_note": current.count_note,
+            "answer_notes": list(current.answer_notes),
         },
         "angles": angles,
         "candidates": candidates,

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -363,6 +363,7 @@ def _upgrade_legacy(stored: dict, current: "SearchOrder") -> dict:
         "complete": not any(row["failed"] for row in angles),
         "uncertain_identity": 0,
         "capacity": 0,
+        "empty_handed": [],
         "capacity_warning": "",
         "order": {
             "kind": current.kind,

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -402,10 +402,18 @@ def build_profile(
     """Open this place's profile, anchor it, and gather what has been said.
 
     Deliberately not called by the search step. A profile is worth building for
-    a candidate that survives, and which candidates survive is what the gate --
-    not yet built -- decides. Wiring this into the pipeline before that gate
-    exists would research every row returned, including the ones the gate is
-    there to throw away.
+    a candidate that survives, and wiring this in would research every row
+    returned -- around forty on a real run -- including the ones that are there
+    to be thrown away.
+
+    `gate.assess` exists and is tested, but it answers one question: is enough
+    published about this place to write about it. It does not answer whether
+    the place breaks the cut, and the two are not the same question. Run
+    33fca394 returned eight Nikkei and Japanese restaurants against an explicit
+    "no places where ceviche is not the primary offering", and every one of
+    them is written about constantly -- so a wired gate would have passed all
+    eight. Checking the cut is a separate judgement about each place, and it is
+    not built.
 
     Running it twice on the same place is safe and is the normal case: the
     profile is found rather than created, claims already held are not added

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -25,19 +25,28 @@ from ..prompt2blog.grill_v4 import (
     reopen_grill,
     start_grill,
 )
-from . import spec, store
-from .contracts import LISTICLE_MARKER_KEYS
+from . import runner, spec, store
+from .contracts import LISTICLE_MARKER_KEYS, SearchOrder
 from .prompts import build_listicle_turn_prompt
-from .search import run_search_order
 
 logger = logging.getLogger(__name__)
 
 
 def _dependencies(base: GrillDependencies) -> GrillDependencies:
-    """The article grill's dependencies, pointed at the listicle prompt."""
+    """The article grill's dependencies, pointed at the listicle prompt.
+
+    `job_id` is carried through, and that is the entire fix for a real bug:
+    this function used to build a fresh `GrillDependencies` and take the
+    default, so every listicle interview reported itself as `p2b.grill`. The
+    caller was already setting `listicle.grill` and it was being dropped one
+    line later -- which meant the usage dashboard attributed listicle spend to
+    Prompt2Blog, and the model gateway answered for the wrong job when someone
+    changed the listicle grill's model.
+    """
     return GrillDependencies(
         llm=base.llm,
         research=base.research,
+        job_id=base.job_id,
         model_name=base.model_name,
         build_prompt=build_listicle_turn_prompt,
     )
@@ -55,12 +64,31 @@ def start(seed: str, base: GrillDependencies) -> GrillState:
     return state
 
 
-def answer(run_id: str, text: str, base: GrillDependencies) -> GrillState:
+def answer(
+    run_id: str,
+    text: str,
+    base: GrillDependencies,
+    selections: list[dict] | None = None,
+) -> GrillState:
+    """One turn, plus whatever structure the screen knew about the answer.
+
+    `selections` is the angle picker's own record of what was ticked, edited or
+    written. The transcript still stores the operator's text verbatim, because
+    that is what the interview agreed to; the records are stored beside it so
+    the order does not have to reconstruct a shape from a sentence.
+    """
     state = store.load(run_id)
     if state is None:
         raise LookupError(f"No listicle interview with id {run_id}")
+    if selections:
+        store.save_selections(run_id, selections)
     state = answer_grill(state, text, _dependencies(base))
     store.save(state)
+    if state.status == "agreed":
+        # Written down at the moment of agreement, so what the screen shows
+        # next and what the searches run from are one object rather than two
+        # readings of a paragraph.
+        _ensure_order(state)
     return state
 
 
@@ -78,13 +106,124 @@ def get(run_id: str) -> GrillState | None:
     return store.load(run_id)
 
 
-def search(run_id: str, research) -> dict:
+def _ensure_order(state: GrillState) -> SearchOrder:
+    """The agreed order, built once and kept.
+
+    Rebuilt only when there is none. An order that already exists may have been
+    corrected by the operator, and regenerating it from the transcript would
+    silently undo that correction -- which is the same class of bug as reading
+    the count out of prose, one layer up.
+    """
+    existing = store.load_order(state.run_id)
+    if existing is not None:
+        return existing
+    order = spec.build_search_order(
+        state, revision=1, selections=store.load_selections(state.run_id)
+    )
+    store.save_order(order)
+    return order
+
+
+def order(run_id: str) -> SearchOrder | None:
+    """The order as it stands, built from the interview if it has agreed."""
+    existing = store.load_order(run_id)
+    if existing is not None:
+        return existing
+    state = store.load(run_id)
+    if state is None or state.status != "agreed":
+        return None
+    return _ensure_order(state)
+
+
+def revise_order(
+    run_id: str,
+    *,
+    target_count: int | None = None,
+    angles: list[dict] | None = None,
+) -> SearchOrder:
+    """Correct the agreement, at a new revision.
+
+    A correction is not an edit in place. Results already gathered answered the
+    previous request, and the only way to say so honestly is for the previous
+    request to still exist -- so a revision is added rather than the old one
+    overwritten, and every stored result is re-checked against the new request
+    before it is shown as current.
+    """
+    current = order(run_id)
+    if current is None:
+        raise LookupError(f"No agreed search order for run {run_id}")
+
+    updated = current.model_copy(deep=True)
+    updated.revision = store.next_revision(run_id)
+    if target_count is not None:
+        if not 1 <= target_count <= 200:
+            raise ValueError("A list length has to be between 1 and 200.")
+        updated.target_count = target_count
+        updated.count_source = "corrected by operator"
+        updated.count_ambiguous = False
+        updated.count_note = ""
+    if angles is not None:
+        if not angles:
+            raise ValueError("An order with no searches in it cannot be run.")
+        from .contracts import SelectedAngle
+
+        rebuilt: list[SelectedAngle] = []
+        for index, entry in enumerate(angles):
+            text = str(entry.get("text", "")).strip()
+            if not text:
+                continue
+            previous = next(
+                (a for a in current.angles if a.angle_id == entry.get("angle_id")),
+                None,
+            )
+            shape_key = str(entry.get("shape_key", "") or (previous.shape_key if previous else ""))
+            rebuilt.append(
+                SelectedAngle(
+                    angle_id=str(entry.get("angle_id") or f"a{index + 1}"),
+                    text=text,
+                    shape_key=shape_key,
+                    group=str(entry.get("group", "") or (previous.group if previous else "")),
+                    role=str(entry.get("role") or (previous.role if previous else "broad")),
+                    # An angle whose wording changed is an angle whose stored
+                    # result no longer answers it. Marked here so the
+                    # fingerprint changes and the reuse check refuses it.
+                    edited=bool(entry.get("edited"))
+                    or (previous is not None and previous.text != text),
+                    custom=bool(entry.get("custom")) or not shape_key,
+                )
+            )
+        if not rebuilt:
+            raise ValueError("An order with no searches in it cannot be run.")
+        updated.angles = rebuilt
+
+    from .search import role_allowances
+
+    allowances = role_allowances(
+        updated.target_count, [a.role for a in updated.angles]
+    )
+    for angle, allowance in zip(updated.angles, allowances):
+        angle.wanted = allowance
+
+    store.save_order(updated)
+    return updated
+
+
+def search(
+    run_id: str,
+    research,
+    *,
+    only: list[str] | None = None,
+    reuse: bool = True,
+) -> dict:
     """Run the agreed search order and pool what comes back.
 
     Refuses to run before the interview has agreed. A half-settled order is
     missing the angles, and searching without them is six searches for whatever
     the seed happened to say -- which is the single-search failure the split
     exists to avoid, at six times the cost.
+
+    `only` runs a named subset, which is how a retry costs one search rather
+    than six. `reuse=False` is the deliberate full refresh.
     """
     state = store.load(run_id)
     if state is None:
@@ -95,56 +234,143 @@ def search(run_id: str, research) -> dict:
             "nothing to search for."
         )
 
-    angles = spec.angles_from(state)
-    if not angles:
+    current = _ensure_order(state)
+    if not current.angles:
         raise ValueError("The agreed interview carries no angles to search.")
 
-    target = spec.count_from(state)
-    candidates, results = run_search_order(
-        angles,
-        kind=spec.kind_from(state),
-        place=spec.place_from(state),
-        target_items=target,
-        exclusions=spec.exclusions_from(state),
-        standard=spec.standard_from(state),
-        research=research,
-    )
-    payload = {
-        "run_id": run_id,
-        "target": target,
-        # Said plainly rather than left to be worked out from the list length.
-        # Whether the order filled the list is the only question this step was
-        # built to answer.
-        "found": len(candidates),
-        "shortfall": max(0, target - len(candidates)),
-        "rows_returned": sum(result.rows for result in results),
-        "angles": [
-            {
-                "angle": r.angle,
-                "rows": r.rows,
-                "sources": r.sources,
-                "failed": r.failed,
-                "reason": r.reason,
-            }
-            for r in results
-        ],
-        "candidates": [
-            {
-                "name": c.name,
-                "district": c.district,
-                "evidence": c.evidence,
-                "found_by": list(c.found_by),
-                "overlap": c.overlap,
-            }
-            for c in candidates
-        ],
-    }
+    if not store.claim_batch(run_id, current.revision):
+        raise ValueError(
+            "These searches are already running for this order. Wait for them "
+            "rather than starting a second set."
+        )
+    try:
+        payload = runner.run_order(current, research, only=only, reuse=reuse)
+    finally:
+        # Released whatever happened, so a failed batch does not lock the run
+        # out of the retry that is the point of storing attempts separately.
+        store.release_batch(run_id)
     store.save_results(run_id, payload)
     return payload
 
 
+def progress(run_id: str) -> dict | None:
+    """What the run knows, without running anything.
+
+    This is what a reopened page reads. It never searches: opening a screen is
+    not a decision to spend, and the version this replaced had no way to tell
+    "nothing stored" from "not read yet", so a reload looked like a run that
+    had never happened.
+    """
+    current = order(run_id)
+    if current is None:
+        # No agreed order, which for a run with stored results means one from
+        # before orders were recorded. Read through the same upgrade so the
+        # screen never receives a payload with fields missing.
+        stored = store.load_results(run_id)
+        if stored is None:
+            return None
+        return _upgrade_legacy(
+            stored,
+            SearchOrder(
+                run_id=run_id,
+                revision=0,
+                target_count=max(1, int(stored.get("target") or 20)),
+            ),
+        )
+    assembled = runner.assemble(current)
+    if assembled["rows_returned"] == 0 and not any(
+        row["state"] != "not_started" for row in assembled["angles"]
+    ):
+        # Nothing has been run under this order. An older blob may still exist
+        # from before attempts were stored per angle, and it is a real result.
+        legacy = store.load_results(run_id)
+        if legacy is not None and legacy.get("candidates"):
+            return _upgrade_legacy(legacy, current)
+        return None
+    return assembled
+
+
+def _upgrade_legacy(stored: dict, current: "SearchOrder") -> dict:
+    """An old stored result, read into the shape the screen now expects.
+
+    Runs from before work was recorded per angle are real results and they open.
+    What they cannot do is name their searches -- there are no attempts behind
+    them -- so every field the new screen reads is filled with the honest
+    default rather than left missing. A missing field is not a smaller version
+    of a result; it is a crash on a page the operator opened expecting their
+    research.
+    """
+    candidates = [
+        {
+            "name": row.get("name", ""),
+            "district": row.get("district", ""),
+            "evidence": row.get("evidence", ""),
+            "found_by": list(row.get("found_by", [])),
+            "overlap": row.get("overlap", len(row.get("found_by", []))),
+            # Neither was recorded at the time. Empty is the truthful answer:
+            # nothing was checked, rather than nothing was found.
+            "possible_duplicates": [],
+            "sightings": [],
+        }
+        for row in stored.get("candidates", [])
+    ]
+    angles = [
+        {
+            "angle_id": row.get("angle_id", ""),
+            "angle": row.get("angle", ""),
+            "shape": "",
+            "group": "",
+            "role": "broad",
+            "wanted": 0,
+            "edited": False,
+            "custom": False,
+            "state": "failed" if row.get("failed") else "completed",
+            "failed": bool(row.get("failed")),
+            "rows": row.get("rows", 0),
+            "sources": row.get("sources", 0),
+            "reason": row.get("reason", ""),
+            "found": 0,
+            "shared": 0,
+            "exclusive": 0,
+            "gathered_at": "",
+            "reused": False,
+        }
+        for row in stored.get("angles", [])
+    ]
+    target = stored.get("target", current.target_count)
+    return {
+        "run_id": current.run_id,
+        "revision": stored.get("revision", 0),
+        "target": target,
+        "found": stored.get("found", len(candidates)),
+        "shortfall": stored.get("shortfall", max(0, target - len(candidates))),
+        "rows_returned": stored.get("rows_returned", 0),
+        "running": False,
+        "complete": not any(row["failed"] for row in angles),
+        "uncertain_identity": 0,
+        "capacity": 0,
+        "capacity_warning": "",
+        "order": {
+            "kind": current.kind,
+            "place": current.place,
+            "target_count": target,
+            "standard": current.standard,
+            "exclusions": current.exclusions,
+            "count_source": current.count_source,
+            "count_ambiguous": current.count_ambiguous,
+            "count_note": current.count_note,
+        },
+        "angles": angles,
+        "candidates": candidates,
+        # Read by the screen, which then says individual searches cannot be
+        # re-run from here rather than offering a button that would do nothing.
+        "legacy": True,
+    }
+
+
 def results(run_id: str) -> dict | None:
-    return store.load_results(run_id)
+    """What a previous run found, assembled fresh from the stored attempts."""
+    return progress(run_id)
 
 
 def build_profile(

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/service.py
@@ -25,7 +25,7 @@ from ..prompt2blog.grill_v4 import (
     reopen_grill,
     start_grill,
 )
-from . import runner, spec, store
+from . import cut_review, runner, spec, store
 from .contracts import LISTICLE_MARKER_KEYS, SearchOrder
 from .prompts import build_listicle_turn_prompt
 
@@ -69,6 +69,7 @@ def answer(
     text: str,
     base: GrillDependencies,
     selections: list[dict] | None = None,
+    review=None,
 ) -> GrillState:
     """One turn, plus whatever structure the screen knew about the answer.
 
@@ -87,8 +88,10 @@ def answer(
     if state.status == "agreed":
         # Written down at the moment of agreement, so what the screen shows
         # next and what the searches run from are one object rather than two
-        # readings of a paragraph.
-        _ensure_order(state)
+        # readings of a paragraph. This is also the one moment the cut check
+        # may run: the turn is already a paid call, and every later read of the
+        # order is a GET that must stay free.
+        _ensure_order(state, review)
     return state
 
 
@@ -106,13 +109,20 @@ def get(run_id: str) -> GrillState | None:
     return store.load(run_id)
 
 
-def _ensure_order(state: GrillState) -> SearchOrder:
+def _ensure_order(state: GrillState, review=None) -> SearchOrder:
     """The agreed order, built once and kept.
 
     Rebuilt only when there is none. An order that already exists may have been
     corrected by the operator, and regenerating it from the transcript would
     silently undo that correction -- which is the same class of bug as reading
     the count out of prose, one layer up.
+
+    `review` is the cut check, and it is a parameter rather than an import
+    because this function is reached from two kinds of caller. Answering a turn
+    is a POST that is already spending on the model, and that is where the check
+    belongs. Opening the order screen is a GET, and a GET must not spend --
+    reopening a run without buying anything is the whole point of addressing
+    runs by id. Called without it, the order is built unchecked and says so.
     """
     existing = store.load_order(state.run_id)
     if existing is not None:
@@ -120,8 +130,27 @@ def _ensure_order(state: GrillState) -> SearchOrder:
     order = spec.build_search_order(
         state, revision=1, selections=store.load_selections(state.run_id)
     )
+    _apply_conflicts(order, review)
     store.save_order(order)
     return order
+
+
+def _apply_conflicts(order: SearchOrder, review) -> None:
+    """Ask whether any approved search fights the cut, if anyone may ask.
+
+    A check that fails is not a finding. `conflicts_checked` stays false and
+    the screen says nobody looked, which is true -- the alternative is an order
+    that reads as cleared because a model call timed out.
+    """
+    if review is None:
+        return
+    try:
+        order.angle_conflicts = cut_review.review_order(order, review)
+        order.conflicts_checked = True
+    except Exception:
+        logger.warning(
+            "The cut check did not run for %s; the order says so", order.run_id
+        )
 
 
 def order(run_id: str) -> SearchOrder | None:
@@ -142,6 +171,7 @@ def revise_order(
     angles: list[dict] | None = None,
     standard: str | None = None,
     exclusions: str | None = None,
+    review=None,
 ) -> SearchOrder:
     """Correct the agreement, at a new revision.
 
@@ -218,6 +248,15 @@ def revise_order(
     for angle, allowance in zip(updated.angles, allowances):
         angle.wanted = allowance
 
+    # Changing the angles or the cut is exactly the moment the two can start
+    # disagreeing, so the old verdict is not an answer about the new order.
+    # Cleared either way; re-asked only when the caller is a path allowed to
+    # spend, and left honestly unchecked when it is not.
+    if angles is not None or exclusions is not None:
+        updated.angle_conflicts = []
+        updated.conflicts_checked = False
+        _apply_conflicts(updated, review)
+
     store.save_order(updated)
     return updated
 
@@ -228,6 +267,7 @@ def search(
     *,
     only: list[str] | None = None,
     reuse: bool = True,
+    review=None,
 ) -> dict:
     """Run the agreed search order and pool what comes back.
 
@@ -264,7 +304,33 @@ def search(
         # out of the retry that is the point of storing attempts separately.
         store.release_batch(run_id)
     store.save_results(run_id, payload)
-    return payload
+    _review_candidates(current, payload, review)
+    return runner.assemble(current)
+
+
+def _review_candidates(order: SearchOrder, payload: dict, review) -> None:
+    """Judge what came back against the cut, once, on the batch that bought it.
+
+    One call for the whole list, reading evidence the searches already wrote.
+    Nothing is looked up: that is the difference between this and researching
+    forty places to rediscover what the first search said.
+
+    Like the order check, a failure is not a finding -- nothing is stored, and
+    a run with no stored review says nobody looked rather than nothing was
+    barred.
+    """
+    if review is None:
+        return
+    try:
+        flags = cut_review.review_candidates(
+            order, payload.get("candidates", []), review
+        )
+    except Exception:
+        logger.warning(
+            "The cut check did not run over %s's candidates", order.run_id
+        )
+        return
+    store.save_cut_review(order.run_id, order.revision, flags)
 
 
 def progress(run_id: str) -> dict | None:
@@ -363,6 +429,8 @@ def _upgrade_legacy(stored: dict, current: "SearchOrder") -> dict:
         "complete": not any(row["failed"] for row in angles),
         "uncertain_identity": 0,
         "capacity": 0,
+        "cut_checked": False,
+        "barred_count": 0,
         "empty_handed": [],
         "capacity_warning": "",
         "order": {

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/shapes.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/shapes.py
@@ -1,4 +1,5 @@
-"""The shapes an angle can take, and how many a list needs.
+"""The shapes an angle can take, which ones belong to a subject, and how many
+a list needs.
 
 An *angle* is one reason a place is on the list, and one search. A *shape* is
 the pattern behind it, with the topic left blank.
@@ -21,219 +22,551 @@ choose AND word its own angles for Lima restaurants, gemini-2.5-flash:
   "Experiential Dining" all returned Central, Maido and Astrid y Gastón. 49
   rows collapsed into 30 places.
 
-Hand-picked angles on the same model, same city, same day: 53 rows, 42 distinct
-places, from five searches instead of eight.
+Three things changed on 2026-09-08, from the improvement plan:
 
-A shape fixes both. It sets the tightness, so there is no blank to bolt an
-extra condition onto; and it belongs to a `collides_with` group, so the three
-angles that are all "the prestigious one" can no longer be chosen together.
+**The catalogue belongs to the subject.** A hotel list was being offered
+market-stall and cuisine-fusion angles, because the catalogue was written for
+restaurants and shown to everything. Every shape now says what it applies to,
+and subjects bring their own.
 
-The groups are the second failure written down. `prestige` exists because
-world-renowned, luxury, award-winning and tasting-menu return the same handful
-of restaurants in every city on earth. One of them is the strongest thing on a
-list. Three of them is a third of the list wasted.
+**The wording stopped over-tightening itself.** "Known for one thing and little
+else" excludes a specialist with a broad menu. "No sign, no listing" asks the
+web to find something the shape has just declared unfindable. The prompt could
+not prevent over-tightening while the catalogue was asking for it.
+
+**Groups became explanations, not prohibitions.** `cheap`, `informal` and
+`lesser-known` were one group and are not one idea -- a cheap neighbourhood bar
+and an expensive hidden one are both real and both worth searching for. What
+survives is a per-shape note about which other shapes tend to return the same
+places, said to the operator and to the model, and enforced by neither.
+
+**An angle carries a job.** "Affordable hotels" can supply a dozen; "the place
+credited with inventing the dish" supplies one. They were being asked for the
+same number, and the narrow one answered by padding.
 """
 
 from __future__ import annotations
+
+import re
+
+# Discovery roles. What an angle is for, and therefore what it may be asked
+# for. Defined in `search`, named here because a shape is where the role is
+# decided.
+BROAD = "broad"
+DISTINCTIVE = "distinctive"
+SPECIFIC = "specific"
+
+# The subjects the catalogue knows something extra about. A subject it does not
+# know keeps every shared shape and gets no invented category.
+RESTAURANTS = "restaurants"
+BARS = "bars"
+HOTELS = "hotels"
+SUBJECTS: tuple[str, ...] = (RESTAURANTS, BARS, HOTELS)
+
+# What a `kind` has to say to be read as one of them. Matched on whole words
+# against the searchable noun the interview settled, in the local spelling as
+# well as English -- "cevicheria" is a restaurant and "cantina" is a bar.
+_SUBJECT_WORDS: dict[str, tuple[str, ...]] = {
+    RESTAURANTS: (
+        "restaurant", "restaurants", "restaurante", "restaurantes", "eatery",
+        "eateries", "cevicheria", "cevicherias", "cebicheria", "cebicherias",
+        "pizzeria", "pizzerias", "trattoria", "trattorias", "taqueria",
+        "taquerias", "bistro", "bistros", "diner", "diners", "cafe", "cafes",
+        "cafeteria", "cafeterias", "brasserie", "brasseries", "izakaya",
+        "steakhouse", "steakhouses", "bakery", "bakeries", "panaderia",
+        "marisqueria", "marisquerias", "chifa", "chifas", "picanteria",
+        "picanterias", "huarique", "huariques", "food", "dining", "brunch",
+    ),
+    BARS: (
+        "bar", "bars", "cocktail", "cocktails", "pub", "pubs", "taproom",
+        "taprooms", "brewery", "breweries", "cerveceria", "cervecerias",
+        "cantina", "cantinas", "speakeasy", "speakeasies", "wine", "winery",
+        "bodega", "bodegas", "nightclub", "nightclubs", "club", "clubs",
+        "pisco", "mezcaleria", "distillery", "distilleries",
+    ),
+    HOTELS: (
+        "hotel", "hotels", "hostel", "hostels", "hostal", "hostales", "inn",
+        "inns", "guesthouse", "guesthouses", "guest", "b&b", "bnb", "lodge",
+        "lodges", "resort", "resorts", "aparthotel", "aparthotels", "stay",
+        "stays", "accommodation", "accommodations", "posada", "posadas",
+    ),
+}
+
+
+def subject_of(kind: str) -> str:
+    """Which subject's catalogue a commission gets, or "" for none.
+
+    Returning "" is a real answer and the common one. A list of museums keeps
+    the shared shapes and the operator's own lines; it is not filed under
+    restaurants so that the catalogue has something to offer it, which is how
+    a hotel list was offered market stalls.
+    """
+    words = set(re.findall(r"[a-z&]+", kind.lower()))
+    # Longest match wins nothing here -- the subjects do not overlap in these
+    # words, and a `kind` that hits two of them ("hotel bars") is genuinely
+    # both. First in declaration order is the one it is filed under, and bars
+    # come before hotels for that phrase because the list is of bars.
+    for subject in (BARS, RESTAURANTS, HOTELS):
+        if words & set(_SUBJECT_WORDS[subject]):
+            return subject
+    return ""
 
 
 class Shape:
     """One pattern an angle can take.
 
-    `instruction` is addressed to the model and says what to write. `example`
-    shows the same shape instantiated for two unlike topics, because one
-    example reads as a template to copy and two read as a pattern to apply.
+    `core` is what the shape means, in as few words as it takes. `instruction`
+    is what the model is told to write. They are separate because the failure
+    they exist to prevent is a shape whose finished wording quietly says more
+    than the shape means -- and the only way to see that is to have the meaning
+    written down beside it.
+
+    `example` shows the same shape instantiated for two unlike topics, because
+    one example reads as a template to copy and two read as a pattern to apply.
+
+    `applies_to` is the subjects this shape belongs to. Empty means all of
+    them.
+
+    `overlaps_with` names shapes that tend to return the same places. It is
+    explained and never enforced: `award` and `luxury` overlap in some cities
+    and not in others, and the operator knows which city this is.
     """
 
-    __slots__ = ("key", "label", "instruction", "example", "collides_with")
+    __slots__ = (
+        "key", "label", "core", "instruction", "example",
+        "theme", "overlaps_with", "applies_to", "role",
+    )
 
     def __init__(
         self,
         key: str,
         label: str,
+        core: str,
         instruction: str,
         example: str,
-        collides_with: str = "",
+        *,
+        theme: str = "",
+        overlaps_with: tuple[str, ...] = (),
+        applies_to: tuple[str, ...] = (),
+        role: str = DISTINCTIVE,
     ) -> None:
         self.key = key
         self.label = label
+        self.core = core
         self.instruction = instruction
         self.example = example
-        # Shapes sharing a group return the same places for the same reason.
-        # At most one of a group may be chosen.
-        self.collides_with = collides_with
+        # A descriptive family, shown as a label. Not a rule: two shapes
+        # sharing a theme may both be worth searching.
+        self.theme = theme
+        self.overlaps_with = overlaps_with
+        self.applies_to = applies_to
+        self.role = role
+
+    def applies(self, subject: str) -> bool:
+        return not self.applies_to or subject in self.applies_to
 
     def __repr__(self) -> str:  # pragma: no cover -- diagnostics only
         return f"Shape({self.key!r})"
 
 
 SHAPES: tuple[Shape, ...] = (
-    # --- prestige: these four find the same short list in every city ---------
+    # --- shared: every subject gets these ------------------------------------
     Shape(
         "world-renowned",
         "World renowned",
+        "Known outside the country.",
         "The ones known outside the country. International lists, foreign press.",
         "ceviche: cevicherias that appear on world's-best restaurant lists | "
         "pizza: pizzerias written up in the international food press",
-        collides_with="prestige",
+        theme="prestige",
+        overlaps_with=("award", "luxury"),
     ),
     Shape(
         "luxury",
         "The splurge",
-        "The expensive end. What people book for an anniversary.",
+        "The expensive end.",
+        "The expensive end. What people book for an anniversary. Price is the"
+        " whole condition -- do not add a quality or reputation clause.",
         "ceviche: expensive cevicherias people save up for | "
         "hotels: the most expensive hotels in the city",
-        collides_with="prestige",
+        theme="price",
+        overlaps_with=("world-renowned",),
+        role=BROAD,
     ),
     Shape(
         "award",
         "Award listed",
         "Formally recognised by a guide, award or national body.",
+        "Formally recognised by a guide, award or national body. Name the kind"
+        " of recognition, not a level of fame.",
         "ceviche: cevicherias that have won a national restaurant award | "
         "pizza: AVPN-certified pizzerias",
-        collides_with="prestige",
+        theme="prestige",
+        overlaps_with=("world-renowned",),
     ),
-    Shape(
-        "the-experience",
-        "The set experience",
-        "Booked in advance, fixed format, you sit down for the whole thing.",
-        "ceviche: cevicherias serving a tasting menu | "
-        "bars: bars with a reservation-only cocktail programme",
-        collides_with="prestige",
-    ),
-    # --- heritage: the old one and the first one are usually one place -------
     Shape(
         "institution",
         "Local institution",
-        "Open for decades. Predates whatever is fashionable now. Say 'decades',"
-        " never a specific number of years -- a number empties the search.",
+        "Longstanding. Nothing about landmark status.",
+        "Open for decades. Say 'decades', never a specific number of years -- a"
+        " number empties the search. Do not add that it must be famous or a"
+        " landmark; being old is the whole condition.",
         "ceviche: cevicherias that have been open for decades | "
         "hotels: hotels that have been operating for decades",
-        collides_with="heritage",
+        theme="heritage",
+        overlaps_with=("family", "origin"),
+        role=BROAD,
     ),
     Shape(
         "origin",
         "Where it started",
+        "Credited with starting this locally.",
         "The place credited with starting this locally, or with one dish"
-        " everyone else now copies.",
+        " everyone else now copies. There may only be one or two, and one is a"
+        " good answer.",
         "ceviche: the cevicheria credited with starting Lima's ceviche boom | "
         "pizza: the pizzeria credited with inventing the local style",
-        collides_with="heritage",
+        theme="heritage",
+        overlaps_with=("institution",),
+        role=SPECIFIC,
     ),
-    # --- humble: cheap, hidden and informal are close but not the same -------
     Shape(
-        "hidden",
-        "Hard to find",
-        "No sign, no listing, someone's front room, known by word of mouth.",
-        "ceviche: unmarked huariques serving ceviche that locals know by word"
-        " of mouth | bars: unmarked bars behind another business",
-        collides_with="humble",
+        "lesser-known",
+        "Less visitor coverage",
+        "Written about locally, missing from visitor lists.",
+        "Written up in local sources but absent from the familiar visitor"
+        " lists. Do NOT say it has no sign, no listing or no online presence --"
+        " a search cannot find something described as unfindable.",
+        "ceviche: huariques Lima residents recommend that visitor guides miss |"
+        " bars: neighbourhood bars local press writes about and guidebooks do not",
+        theme="locality",
+        overlaps_with=("district",),
     ),
     Shape(
         "cheap",
         "Cheap and good",
+        "Very cheap, rated well anyway.",
         "Very cheap, and rated highly anyway. Price is the point.",
         "ceviche: very cheap cevicherias that people rate highly | "
         "hotels: very cheap places to stay that people rate highly",
-        collides_with="humble",
+        theme="price",
+        role=BROAD,
     ),
-    Shape(
-        "informal",
-        "Stall, counter or market",
-        "Not a restaurant. A stall, a counter, a stand, a spot in a market.",
-        "ceviche: ceviche stalls inside the city's markets | "
-        "pizza: pizza served by the slice from a counter",
-        collides_with="humble",
-    ),
-    # --- standalone: none of these answer each other -------------------------
     Shape(
         "new-wave",
         "Just opened",
-        "Opened in the last year. Nothing else -- no buzz clause, no quality"
-        " clause. Adding one is what found a single place instead of eight.",
+        "Opened inside an explicit recent window.",
+        "Opened recently, with the window said explicitly and counted back from"
+        " today's date -- 'opened since <year>' or 'opened in the last year'."
+        " Nothing else. No buzz clause, no quality clause. Adding one is what"
+        " found a single place instead of eight.",
         "ceviche: cevicherias that opened in the last year | "
         "hotels: hotels that opened in the last year",
-    ),
-    Shape(
-        "purist",
-        "The orthodox version",
-        "Does it the traditional way and refuses to vary it.",
-        "ceviche: cevicherias serving classic ceviche with no fusion | "
-        "pizza: pizzerias doing only wood-fired Neapolitan",
-    ),
-    Shape(
-        "crossed",
-        "Crossed with something else",
-        "The same thing put through another cuisine, culture or technique.",
-        "ceviche: nikkei cevicherias doing Japanese-Peruvian preparations | "
-        "pizza: pizzerias doing a non-Italian style",
+        theme="recency",
     ),
     Shape(
         "one-thing",
-        "Known for one thing",
-        "Famous for a single item and little else.",
+        "Signature specialty",
+        "Known especially for one item.",
+        "Known especially for a single item. Do NOT require that it sells"
+        " little else -- a specialist with a full menu is still a specialist.",
         "ceviche: places known above all for their leche de tigre | "
         "wings: places famous for one sauce",
+        theme="specialty",
     ),
     Shape(
         "insider",
         "Where the trade goes",
+        "Where people in this trade go themselves.",
         "Where people who work in this field eat, drink or stay themselves.",
         "ceviche: where Lima chefs say they eat ceviche on their days off | "
         "bars: where bartenders drink after their shift",
+        theme="locality",
     ),
     Shape(
         "family",
         "Family run",
+        "Run by one family.",
         "Run by one family, often across generations.",
         "ceviche: cevicherias run by the same family for more than one"
         " generation | hotels: guesthouses run by the family who own them",
+        theme="heritage",
+        overlaps_with=("institution",),
     ),
     Shape(
         "setting",
         "For the room or the view",
+        "Chosen for where you are, not what you get.",
         "Chosen for where you sit rather than what you get.",
         "ceviche: cevicherias people go to for the view of the sea | "
         "bars: rooftop bars people go to for what they can see",
-    ),
-    Shape(
-        "hours",
-        "Defined by when",
-        "Only exists at one time of day. Lunch only, late night, breakfast.",
-        "ceviche: lunch-only cevicherias that close when the fish runs out | "
-        "bars: places busiest after most bars have closed",
+        theme="setting",
+        role=BROAD,
     ),
     Shape(
         "district",
         "One neighbourhood's own",
-        "The place people in one specific district go to, that visitors miss.",
+        "Belongs to one named neighbourhood.",
+        "The place people in one specific district go to, that visitors miss."
+        " Name the district.",
         "ceviche: cevicherias that one Lima neighbourhood keeps to itself | "
         "hotels: places chosen for the street they are on",
+        theme="locality",
+        overlaps_with=("lesser-known",),
+        role=BROAD,
+    ),
+    # --- restaurants and bars ------------------------------------------------
+    Shape(
+        "the-experience",
+        "The set experience",
+        "Fixed format, booked ahead.",
+        "Booked in advance, fixed format, you sit down for the whole thing.",
+        "ceviche: cevicherias serving a tasting menu | "
+        "bars: bars with a reservation-only cocktail programme",
+        theme="prestige",
+        overlaps_with=("world-renowned",),
+        applies_to=(RESTAURANTS, BARS),
+    ),
+    Shape(
+        "purist",
+        "The orthodox version",
+        "Known for the traditional version.",
+        "Known for doing it the traditional way. Do NOT invent a refusal --"
+        " 'no fusion, no variations, nothing else on the menu' is a condition"
+        " the shape did not ask for and it empties the search.",
+        "ceviche: cevicherias known for classic Limeño ceviche | "
+        "pizza: pizzerias known for wood-fired Neapolitan",
+        theme="tradition",
+        applies_to=(RESTAURANTS, BARS),
+    ),
+    Shape(
+        "crossed",
+        "Crossed with something else",
+        "Put through another cuisine or culture.",
+        "The same thing put through another cuisine, culture or technique.",
+        "ceviche: nikkei cevicherias doing Japanese-Peruvian preparations | "
+        "pizza: pizzerias doing a non-Italian style",
+        theme="tradition",
+        applies_to=(RESTAURANTS, BARS),
+    ),
+    Shape(
+        "hours",
+        "Defined by when",
+        "Exists at one time of day.",
+        "Only exists at one time of day. Lunch only, late night, breakfast.",
+        "ceviche: lunch-only cevicherias that close when the fish runs out | "
+        "bars: places busiest after most bars have closed",
+        theme="format",
+        applies_to=(RESTAURANTS, BARS),
+    ),
+    # --- restaurants ---------------------------------------------------------
+    Shape(
+        "informal",
+        "Stall, counter or market",
+        "Not a sit-down restaurant.",
+        "Not a restaurant. A stall, a counter, a stand, a spot in a market."
+        " Name individual businesses, never the market itself.",
+        "ceviche: ceviche counters inside the city's markets | "
+        "pizza: pizza served by the slice from a counter",
+        theme="format",
+        applies_to=(RESTAURANTS,),
+    ),
+    Shape(
+        "regional-tradition",
+        "A region's own version",
+        "Cooks one region's version of it.",
+        "Cooks the version belonging to one region or tradition of the country."
+        " Name the region.",
+        "ceviche: cevicherias cooking the northern Piuran style | "
+        "pizza: pizzerias cooking the Roman style",
+        theme="tradition",
+        overlaps_with=("purist",),
+        applies_to=(RESTAURANTS,),
+    ),
+    Shape(
+        "producer-links",
+        "Close to the producer",
+        "Sources direct, and says so.",
+        "Buys direct from a named fisherman, farm, market or maker, and is"
+        " written about for it.",
+        "ceviche: cevicherias that buy direct from named Lima fishermen | "
+        "steak: steakhouses that name the ranch",
+        theme="sourcing",
+        applies_to=(RESTAURANTS,),
+        role=SPECIFIC,
+    ),
+    # --- bars ----------------------------------------------------------------
+    Shape(
+        "drink-specialty",
+        "Built around one drink",
+        "One drink or category is the point.",
+        "Built around one drink or one category of drink.",
+        "bars: pisco bars with the deepest macerado lists | "
+        "bars: bars built around natural wine",
+        theme="specialty",
+        overlaps_with=("one-thing",),
+        applies_to=(BARS,),
+    ),
+    Shape(
+        "live-music",
+        "Live music or performance",
+        "Live performance is the reason to go.",
+        "Live music or performance is the reason people go. Say what kind.",
+        "bars: bars with live criolla music most nights | "
+        "bars: jazz bars with a nightly set",
+        theme="format",
+        applies_to=(BARS,),
+    ),
+    Shape(
+        "dancing",
+        "Somewhere to dance",
+        "People go to dance.",
+        "People go to dance. Say what to.",
+        "bars: salsa bars with a full dance floor | "
+        "bars: cumbia venues that stay open late",
+        theme="format",
+        overlaps_with=("live-music",),
+        applies_to=(BARS,),
+    ),
+    Shape(
+        "service-format",
+        "How it serves you",
+        "The format of the service itself.",
+        "Defined by how it serves rather than what it pours -- standing only,"
+        " a counter, table service, a window onto the street.",
+        "bars: standing-only bars with a single counter | "
+        "bars: bars serving through a street window",
+        theme="format",
+        applies_to=(BARS,),
+    ),
+    Shape(
+        "local-drinking",
+        "A local drinking tradition",
+        "Belongs to how the city drinks.",
+        "Belongs to a drinking custom particular to this place. Name the"
+        " custom.",
+        "bars: bodegas-bar where Limeños drink standing among the shelves | "
+        "bars: pulquerías serving the old way",
+        theme="tradition",
+        applies_to=(BARS,),
+    ),
+    # --- hotels --------------------------------------------------------------
+    Shape(
+        "lodging-format",
+        "The kind of stay",
+        "The format of the lodging.",
+        "Defined by the kind of lodging rather than its price -- aparthotel,"
+        " guesthouse, hostel with private rooms, serviced flat. Name it.",
+        "hotels: aparthotels with self-catering kitchens | "
+        "hotels: guesthouses with fewer than ten rooms",
+        theme="format",
+        applies_to=(HOTELS,),
+        role=BROAD,
+    ),
+    Shape(
+        "building-character",
+        "The building itself",
+        "The building is the reason.",
+        "The building is the reason to stay -- a converted house, a period"
+        " façade, a piece of architecture people write about.",
+        "hotels: hotels in converted republican-era casonas | "
+        "hotels: hotels in buildings by a named architect",
+        theme="setting",
+        overlaps_with=("setting",),
+        applies_to=(HOTELS,),
+    ),
+    Shape(
+        "long-stay",
+        "Set up for longer stays",
+        "Built for weeks, not nights.",
+        "Set up for staying weeks rather than nights -- kitchens, laundry,"
+        " monthly rates, desks.",
+        "hotels: aparthotels with monthly rates and kitchens | "
+        "hotels: places advertising weekly and monthly stays",
+        theme="format",
+        overlaps_with=("lodging-format",),
+        applies_to=(HOTELS,),
+        role=BROAD,
+    ),
+    Shape(
+        "family-facilities",
+        "Set up for families",
+        "Facilities families need.",
+        "Set up for families -- family rooms, cots, a pool, somewhere for"
+        " children to be.",
+        "hotels: hotels with family rooms and a pool | "
+        "hotels: places that put a cot in the room at no charge",
+        theme="audience",
+        applies_to=(HOTELS,),
+    ),
+    Shape(
+        "transport-access",
+        "Where it is, for getting about",
+        "Placed for getting around.",
+        "Chosen for how easy it is to get in and out -- near a named station,"
+        " line, terminal or airport.",
+        "hotels: hotels within walking distance of the Metropolitano | "
+        "hotels: hotels ten minutes from the airport",
+        theme="locality",
+        overlaps_with=("district",),
+        applies_to=(HOTELS,),
     ),
 )
 
 SHAPES_BY_KEY: dict[str, Shape] = {shape.key: shape for shape in SHAPES}
 
 
-def shape_menu() -> str:
+def shapes_for(subject: str) -> tuple[Shape, ...]:
+    """The catalogue this commission actually gets."""
+    return tuple(shape for shape in SHAPES if shape.applies(subject))
+
+
+def shape_menu(subject: str = "") -> str:
     """The catalogue as the model is shown it."""
     lines: list[str] = []
-    for shape in SHAPES:
-        group = f"  [group: {shape.collides_with}]" if shape.collides_with else ""
-        lines.append(f"{shape.key} -- {shape.label}{group}")
+    for shape in shapes_for(subject):
+        lines.append(f"{shape.key} -- {shape.label}  [{shape.role}]")
+        lines.append(f"    means: {shape.core}")
         lines.append(f"    write: {shape.instruction}")
         lines.append(f"    e.g.  {shape.example}")
+        if shape.overlaps_with:
+            lines.append(
+                f"    tends to overlap: {', '.join(shape.overlaps_with)}"
+            )
     return "\n".join(lines)
 
 
-def collision_groups() -> str:
-    """The groups, named, so the rule can be stated rather than implied."""
-    groups: dict[str, list[str]] = {}
-    for shape in SHAPES:
-        if shape.collides_with:
-            groups.setdefault(shape.collides_with, []).append(shape.key)
-    return "\n".join(
-        f"- {name}: {', '.join(keys)}" for name, keys in sorted(groups.items())
+def overlap_notes(subject: str = "") -> str:
+    """Which pairs tend to return the same places, said once.
+
+    A note rather than a rule. The version this replaced put four shapes in one
+    `prestige` group and refused to let two of them be chosen together, which
+    is wrong in both directions: award-listed and expensive are different
+    places in most cities, and family-run and longstanding are often the same
+    ones while sitting in no shared group at all.
+    """
+    seen: set[tuple[str, str]] = set()
+    lines: list[str] = []
+    available = {shape.key for shape in shapes_for(subject)}
+    for shape in shapes_for(subject):
+        for other in shape.overlaps_with:
+            if other not in available:
+                continue
+            pair = tuple(sorted((shape.key, other)))
+            if pair in seen:
+                continue
+            seen.add(pair)
+            lines.append(f"- {pair[0]} and {pair[1]}")
+    return "\n".join(lines)
+
+
+def roles_note() -> str:
+    """What the three roles mean, for the model choosing them."""
+    return (
+        f"{BROAD}       -- supplies a large share of the list. Two or three at most.\n"
+        f"{DISTINCTIVE} -- a format, a locality or a specialty the broad searches miss.\n"
+        f"{SPECIFIC}    -- a handful of unusually relevant places. One result is a"
+        " good result; never asked to fill a quota."
     )
 
 
@@ -241,13 +574,23 @@ def suggested_angle_count(target_items: int) -> int:
     """How many angles a list of this length gets built from.
 
     Roughly seven items per angle. A short list wants few angles asked hard; a
-    long one cannot be filled from a handful and needs the spread. Capped at
-    the number of shapes that can actually be chosen together -- an angle with
-    no places behind it is a search that returns nothing and a slot that
-    becomes padding.
+    long one cannot be filled from a handful and needs the spread.
+
+    A starting heuristic and nothing more. It lives here, in code, so the
+    prompt stops carrying the same arithmetic written out as prose -- which is
+    how the two came to disagree.
     """
     if target_items <= 8:
         return 2
     if target_items <= 15:
         return 3
     return max(4, min(10, round(target_items / 7)))
+
+
+def angle_count_guidance(target_items: int) -> str:
+    """The recommendation, said as the model should read it."""
+    return (
+        f"For {target_items} items, recommend about {suggested_angle_count(target_items)}"
+        " angles. That is a recommendation, not a quota: more or fewer coming"
+        " back is their answer and settles the marker."
+    )

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/spec.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/spec.py
@@ -1,64 +1,253 @@
-"""Reading the search order back off a finished interview.
+"""Turning a finished interview into the order the searches run from.
 
 The grill's `consensus` is prose, written to be read by a person. It is the
 wrong thing to execute: a number parsed out of a sentence is a number that can
-be parsed wrong, and silently.
+be parsed wrong, and silently. The first real run agreed on twenty items,
+searched for forty, and nothing anywhere noticed.
 
-The answers themselves are structured enough. Every question declares the
-marker it settles, so the answer to `count` is the count and the answer to
-`angles` is the angle list, one per line -- which is exactly how the picker
-sends them and why the picker sends lines instead of a paragraph.
+The fix is not a better expression. `count_from` was already careful -- it
+skipped years, it bounded the range -- and it still took 40 out of "20, not
+40", because it took the largest plausible number it could see. No regular
+expression interprets "yes" either, and "yes" is the most common answer to a
+question that already carries its own recommendation.
+
+So the decision is resolved once, here, against what was actually proposed, and
+written down on a `SearchOrder`. What the screen shows and what the searches run
+are then the same object rather than two readings of the same paragraph.
 """
 
 from __future__ import annotations
 
 import re
+import unicodedata
+from dataclasses import dataclass
 
 from ..prompt2blog.contracts_v4 import GrillState
+from .contracts import SearchOrder, SelectedAngle
+from .contracts import ANGLE_ROLES
+from .search import BROAD, DISTINCTIVE, role_allowances
+from .shapes import SHAPES_BY_KEY
+
+# A list length. Small on purpose: this is what keeps a price, a year and a
+# street number out of the count.
+_MIN_COUNT = 3
+_MAX_COUNT = 200
+
+# "20, not 40" and "not 40, 20". Both were said in real interviews and both
+# used to resolve to 40.
+_CORRECTION_FIRST = re.compile(
+    r"\b(\d{1,3})\b[\s,;]*(?:not|instead of|rather than|and not)\s+\b\d{1,3}\b",
+    re.IGNORECASE,
+)
+_CORRECTION_SECOND = re.compile(
+    r"\bnot\s+\d{1,3}\b[\s,;]*(?:but\s+|make it\s+|use\s+)?\b(\d{1,3})\b",
+    re.IGNORECASE,
+)
+# A number that is a count rather than a price, a year or a percentage.
+_PLAIN_NUMBER = re.compile(r"(?<![\d$€£%.,/-])\b(\d{1,3})\b(?![\d%]|\s*(?:soles|usd|dollars|euros))")
+
+_LIST_MARKER = re.compile(r"^\s*(?:[-*•·–—]+|\(?\d{1,2}\s*[.)\]]|#\d{1,2})\s+")
 
 
-def _answer_for(state: GrillState, marker: str) -> str:
-    """The last thing said about one marker.
+@dataclass
+class CountDecision:
+    """How many items, and how sure the pipeline is that it read it right."""
+
+    value: int
+    source: str
+    ambiguous: bool = False
+    note: str = ""
+
+
+def _turn_for(state: GrillState, marker: str):
+    """The last exchange about one marker.
 
     Last rather than first: a marker asked about twice was asked again because
     something was wrong with the first answer.
     """
     for turn in reversed(state.turns):
         if turn.question.asks_about == marker:
-            return turn.answer.strip()
-    return ""
+            return turn
+    return None
 
 
-def angles_from(state: GrillState) -> list[str]:
-    """The agreed angles, one per line, in the order they were chosen."""
-    raw = _answer_for(state, "angles")
-    lines = [re.sub(r"^[\-\*•\d\.\)\s]+", "", line).strip() for line in raw.splitlines()]
-    return [line for line in lines if line]
+def _answer_for(state: GrillState, marker: str) -> str:
+    turn = _turn_for(state, marker)
+    return turn.answer.strip() if turn else ""
+
+
+def _counts_in(text: str) -> list[int]:
+    return [
+        n
+        for n in (int(m) for m in _PLAIN_NUMBER.findall(text))
+        if _MIN_COUNT <= n <= _MAX_COUNT
+    ]
+
+
+def resolve_count(state: GrillState, default: int = 20) -> CountDecision:
+    """How many items the list is aiming at, and where that came from.
+
+    Four cases, in the order they are trusted:
+
+    1. The answer corrects a number -- "20, not 40". The correction wins.
+    2. The answer carries exactly one number. That is the number.
+    3. The answer carries no number at all. "Yes, that's right" is a perfectly
+       good answer to "is 40 the number?", and the number it agrees to is the
+       recommendation the question arrived with -- not the largest number
+       anywhere in the transcript.
+    4. The answer carries several numbers and none of them is a correction.
+       This is genuinely ambiguous. A number is still chosen so the run is not
+       stuck, the first one because it is the conservative read, and the
+       decision is marked so the screen can ask.
+    """
+    turn = _turn_for(state, "count")
+    if turn is not None:
+        answer = turn.answer.strip()
+        for pattern in (_CORRECTION_FIRST, _CORRECTION_SECOND):
+            found = pattern.search(answer)
+            if found:
+                value = int(found.group(1))
+                if _MIN_COUNT <= value <= _MAX_COUNT:
+                    return CountDecision(value, "corrected")
+        numbers = _counts_in(answer)
+        if len(numbers) == 1:
+            return CountDecision(numbers[0], "answered")
+        if not numbers:
+            # They agreed to what was proposed. Read the proposal, not the
+            # transcript: the seed may carry a number the interview talked them
+            # out of, and taking that one silently reverses the conversation.
+            proposed = _counts_in(turn.question.recommendation) or _counts_in(
+                turn.question.ask
+            )
+            if proposed:
+                return CountDecision(proposed[0], "accepted")
+        if numbers:
+            return CountDecision(
+                numbers[0],
+                "answered",
+                ambiguous=True,
+                note=(
+                    "The answer mentioned "
+                    + ", ".join(str(n) for n in numbers)
+                    + ". Read as "
+                    + str(numbers[0])
+                    + " -- correct it if that is wrong."
+                ),
+            )
+
+    seed_numbers = _counts_in(state.seed)
+    if seed_numbers:
+        return CountDecision(
+            seed_numbers[0],
+            "seed",
+            ambiguous=len(seed_numbers) > 1,
+            note=(
+                "Read off the title; the interview never settled a number."
+                if len(seed_numbers) == 1
+                else "The title mentions several numbers and the interview settled none."
+            ),
+        )
+    return CountDecision(
+        default,
+        "default",
+        ambiguous=True,
+        note="Nothing in the interview or the title said how many.",
+    )
 
 
 def count_from(state: GrillState, default: int = 20) -> int:
-    """How many items the list is aiming at.
+    """The count alone, for callers that only need the number."""
+    return resolve_count(state, default).value
 
-    Read from the count answer, and from the seed when the interview settled
-    the count without anyone restating the number -- "Yes, that's right" is a
-    perfectly good answer to "is 40 the number?" and carries no number at all.
+
+def _clean_line(line: str) -> str:
+    return _LIST_MARKER.sub("", line, count=1).strip().strip("*_ ").strip()
+
+
+def angle_lines(state: GrillState) -> list[str]:
+    """The agreed angles, one per line, in the order they were chosen."""
+    raw = _answer_for(state, "angles")
+    return [
+        cleaned
+        for cleaned in (_clean_line(line) for line in raw.splitlines())
+        if cleaned
+    ]
+
+
+# Kept under its old name: `service` and the tests both call it, and the lines
+# are what they wanted.
+angles_from = angle_lines
+
+
+# What a headline puts around the searchable noun. Stripped, in this order,
+# when the interview never asked about `kind` -- which is the normal case and
+# the good one: the prompt tells it not to spend a turn confirming what the
+# operator just typed.
+_SEED_ARTICLE = re.compile(r"^\s*(?:the|a|an)\s+", re.IGNORECASE)
+_SEED_COUNT = re.compile(r"^\s*\d{1,3}\s+")
+_SEED_SUPERLATIVE = re.compile(
+    r"^\s*(?:best|top|greatest|finest|essential|ultimate|coolest|must[- ]visit|"
+    r"must[- ]try|unmissable|favourite|favorite)\s+",
+    re.IGNORECASE,
+)
+# What is left when a headline had no noun in it to begin with.
+_NOT_A_NOUN = {
+    "best", "top", "greatest", "finest", "essential", "ultimate", "coolest",
+    "the", "a", "an", "places", "place", "spots", "spot",
+}
+# Where the noun ends and the location begins.
+_SEED_LOCATION = re.compile(r"\s+(?:in|around|near|across|of)\s+", re.IGNORECASE)
+
+
+def searchable_kind(seed: str) -> str:
+    """The searchable noun inside a headline.
+
+    "The 40 best cevicherias in Lima" is a title, not a noun, and sending it as
+    one puts "40 best" into every search -- the SEO phrase the interview is
+    told never to treat as a criterion, pushed into the one place it cannot be
+    argued with. A real run on 2026-09-08 reached the search step with
+    `kind` set to the whole seed, because the interview had correctly declined
+    to spend a turn confirming a word the operator had already typed.
+
+    Leading count, article and superlative come off; everything from the first
+    location preposition is dropped. A seed that reduces to nothing keeps its
+    original text, because a wrong noun is better than no noun.
     """
-    for text in (_answer_for(state, "count"), state.seed):
-        numbers = [int(n) for n in re.findall(r"\b(\d{1,3})\b", text)]
-        # Ignore years and other incidental numbers; a list length is small.
-        plausible = [n for n in numbers if 3 <= n <= 200]
-        if plausible:
-            return max(plausible)
-    return default
+    text = seed.strip()
+    for _ in range(3):
+        # Twice around, because "The 40 best" and "The best 40" both occur and
+        # neither order can be assumed.
+        for pattern in (_SEED_ARTICLE, _SEED_COUNT, _SEED_SUPERLATIVE):
+            text = pattern.sub("", text, count=1)
+    head = _SEED_LOCATION.split(text, maxsplit=1)[0].strip(" ,.:;-")
+    # A head that is nothing but headline furniture is not a noun. "The 40
+    # best" reduces to "best", and searching for "best" is worse than searching
+    # for the title it came from.
+    if not head or head.lower() in _NOT_A_NOUN:
+        return seed.strip()
+    return head
 
 
 def kind_from(state: GrillState) -> str:
-    """The searchable noun. Falls back to the seed, which usually carries it."""
-    return _answer_for(state, "kind") or state.seed
+    """The searchable noun.
+
+    Falls back to the seed with its headline furniture removed, rather than to
+    the raw seed. Everything downstream searches with this word.
+    """
+    return _answer_for(state, "kind") or searchable_kind(state.seed)
 
 
 def place_from(state: GrillState) -> str:
-    return _answer_for(state, "place") or state.location or state.seed
+    """Where to search.
+
+    The seed is the last resort and is stripped the same way, so a run whose
+    location was never recorded searches "Lima" rather than the whole headline.
+    """
+    answered = _answer_for(state, "place") or state.location
+    if answered:
+        return answered
+    tail = _SEED_LOCATION.split(state.seed.strip(), maxsplit=1)
+    return (tail[1].strip(" ,.:;-") if len(tail) > 1 else state.seed).strip()
 
 
 def standard_from(state: GrillState) -> str:
@@ -67,3 +256,208 @@ def standard_from(state: GrillState) -> str:
 
 def exclusions_from(state: GrillState) -> str:
     return _answer_for(state, "cut")
+
+
+def _fold(text: str) -> str:
+    folded = unicodedata.normalize("NFKD", text.lower())
+    folded = "".join(c for c in folded if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9\s]+", " ", folded)).strip()
+
+
+def _words(text: str) -> set[str]:
+    return set(_fold(text).split())
+
+
+def _closest_option(line: str, options: list) -> tuple[object | None, bool]:
+    """The menu entry a line came from, and whether it was changed.
+
+    Exact first, which is the normal case -- the picker sends the option's own
+    text back. Then a similarity match, which is how an edited line keeps its
+    lineage: knowing that this was the `new-wave` option before the operator
+    narrowed it is worth having, as long as nothing then treats the shape's
+    opinion about overlap as still true. That is what `edited` is for.
+    """
+    folded = _fold(line)
+    for option in options:
+        if _fold(option.text) == folded:
+            return option, False
+    line_words = _words(line)
+    if not line_words:
+        return None, True
+    best, best_score = None, 0.0
+    for option in options:
+        option_words = _words(option.text)
+        if not option_words:
+            continue
+        shared = len(line_words & option_words)
+        score = shared / max(1, min(len(line_words), len(option_words)))
+        if score > best_score:
+            best, best_score = option, score
+    # Two thirds of the shorter line's words. Below that it is a different
+    # search that happens to be about the same city.
+    return (best, True) if best_score >= 0.66 else (None, True)
+
+
+def _role_for(shape_key: str, fallback: str = DISTINCTIVE) -> str:
+    shape = SHAPES_BY_KEY.get(shape_key)
+    return shape.role if shape else fallback
+
+
+def _checked_role(claimed: str, shape_key: str) -> str:
+    """The role this angle runs under.
+
+    A role the model chose is kept, because how hard to ask an angle is a
+    judgement about this topic in this city and the model is the one looking at
+    it. A role that is not one of the three is not a judgement, it is noise,
+    and the catalogue answers instead.
+    """
+    return claimed if claimed in ANGLE_ROLES else _role_for(shape_key)
+
+
+def _theme_for(shape_key: str, claimed: str) -> str:
+    """A shape's theme, from the catalogue rather than from the model.
+
+    The model was asked for the theme and sent the shape's LABEL on one turn
+    and its KEY on the next -- both real values, neither the theme. Since the
+    screen groups by this field to warn about two angles that collide, every
+    option landed in a group of one and the warning could never fire.
+
+    Code holds catalogue metadata; the model writes the wording. An angle whose
+    shape is unknown keeps whatever it was given, because there is nothing to
+    look up.
+    """
+    shape = SHAPES_BY_KEY.get(shape_key)
+    return shape.theme if shape else claimed
+
+
+def selected_angles(
+    state: GrillState, selections: list[dict] | None = None
+) -> list[SelectedAngle]:
+    """The approved searches, each still knowing what it is.
+
+    `selections` is what the picker sent alongside the answer: the option each
+    line came from, and whether it was edited. It is authoritative when it is
+    there, because the screen knows what the operator did and this module can
+    only infer it.
+
+    Without it -- an interview answered as plain text, or one from before the
+    picker sent anything -- the lines are matched back against the menu the
+    question offered. That inference is where `edited` comes from, and an
+    inferred lineage is exactly as provisional as it sounds.
+    """
+    lines = angle_lines(state)
+    turn = _turn_for(state, "angles")
+    options = list(turn.question.options) if turn else []
+    by_text = {}
+    for entry in selections or []:
+        text = str(entry.get("text", "")).strip()
+        if text:
+            by_text[_fold(text)] = entry
+
+    chosen: list[SelectedAngle] = []
+    for index, line in enumerate(lines):
+        entry = by_text.get(_fold(line))
+        if entry is not None:
+            shape_key = str(entry.get("shape_key", "") or "")
+            chosen.append(
+                SelectedAngle(
+                    angle_id=str(entry.get("angle_id") or f"a{index + 1}"),
+                    text=line,
+                    shape_key=shape_key,
+                    group=_theme_for(shape_key, str(entry.get("group", "") or "")),
+                    role=_checked_role(str(entry.get("role") or ""), shape_key),
+                    edited=bool(entry.get("edited")),
+                    custom=bool(entry.get("custom")) or not shape_key,
+                )
+            )
+            continue
+        option, edited = _closest_option(line, options)
+        shape_key = getattr(option, "shape", "") if option is not None else ""
+        chosen.append(
+            SelectedAngle(
+                angle_id=f"a{index + 1}",
+                text=line,
+                shape_key=shape_key,
+                group=_theme_for(
+                    shape_key,
+                    getattr(option, "group", "") if option is not None else "",
+                ),
+                role=_role_for(shape_key, BROAD if option is None else DISTINCTIVE),
+                edited=edited,
+                custom=option is None,
+            )
+        )
+    return chosen
+
+
+def build_search_order(
+    state: GrillState,
+    *,
+    revision: int = 1,
+    selections: list[dict] | None = None,
+    target_count: int | None = None,
+) -> SearchOrder:
+    """The whole agreement, written down once.
+
+    `target_count` overrides the resolved one. That is how a correction works:
+    the operator says twenty, the order is rewritten at a new revision, and
+    every stored result is checked against the new request rather than
+    presented as though it answered it.
+    """
+    decision = resolve_count(state)
+    angles = selected_angles(state, selections)
+    count = target_count if target_count is not None else decision.value
+    allowances = role_allowances(count, [angle.role for angle in angles])
+    for angle, allowance in zip(angles, allowances):
+        angle.wanted = allowance
+    return SearchOrder(
+        run_id=state.run_id,
+        revision=revision,
+        kind=kind_from(state),
+        place=place_from(state),
+        target_count=count,
+        standard=standard_from(state),
+        exclusions=exclusions_from(state),
+        angles=angles,
+        count_source="corrected by operator" if target_count is not None else decision.source,
+        count_ambiguous=False if target_count is not None else decision.ambiguous,
+        count_note="" if target_count is not None else decision.note,
+    )
+
+
+def planned_capacity(order: SearchOrder) -> int:
+    """How many places the order can ask for at all.
+
+    An order made entirely of narrow angles cannot fill a long list, and that
+    is worth saying before the money is spent rather than after. It is a
+    warning and nothing else: no search is added that the operator did not
+    approve.
+    """
+    return sum(angle.wanted for angle in order.angles)
+
+
+def summary_of(order: SearchOrder) -> str:
+    """The order read back plainly, derived from the order itself.
+
+    The summary the operator reads and the request the searches make now come
+    from one object, so the two cannot say different things -- which is the
+    whole fault this record was added to fix.
+    """
+    lines = [
+        f"{order.target_count} {order.kind or 'places'} in {order.place or 'the location'}.",
+    ]
+    if order.standard:
+        lines.append(f"Earns a place: {order.standard}")
+    if order.exclusions:
+        lines.append(f"Left out: {order.exclusions}")
+    lines.append("")
+    lines.append(f"{len(order.angles)} searches:")
+    for angle in order.angles:
+        note = []
+        if angle.role != BROAD:
+            note.append(angle.role)
+        note.append(f"asks for {angle.wanted}")
+        if angle.edited:
+            note.append("edited")
+        lines.append(f"  - {angle.text}  [{', '.join(note)}]")
+    return "\n".join(lines)

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/spec.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/spec.py
@@ -62,8 +62,10 @@ class CountDecision:
 def _turn_for(state: GrillState, marker: str):
     """The last exchange about one marker.
 
-    Last rather than first: a marker asked about twice was asked again because
-    something was wrong with the first answer.
+    Last rather than first for the things a repeat is *about* -- the question
+    that was asked, the menu it offered -- which is what `selected_angles` and
+    `resolve_count` read it for. What the marker is *worth* does not come from
+    here; see `resolve_answer`.
     """
     for turn in reversed(state.turns):
         if turn.question.asks_about == marker:
@@ -71,9 +73,179 @@ def _turn_for(state: GrillState, marker: str):
     return None
 
 
+def _turns_for(state: GrillState, marker: str) -> list:
+    """Every exchange about one marker, in the order they were asked."""
+    return [turn for turn in state.turns if turn.question.asks_about == marker]
+
+
+# Markers whose second answer adds to the first instead of replacing it.
+#
+# `bar` and `cut` are prose criteria, and the grill's repeat about them is an
+# additive follow-up: run 292e71e3 settled the cut, then asked "are there any
+# other types of establishments ... you would like to exclude?" and
+# recommended "No hotel restaurants." Taking the last answer there throws away
+# chains, delivery-only and ceviche-not-primary, and the run looks entirely
+# normal while searching under a quarter of the operator's exclusions.
+#
+# Everything else replaces, deliberately. `kind` and `place` are single nouns
+# and a second one is a correction. `angles` arrives from the picker as the
+# complete current selection, so un-ticking a box already IS the explicit
+# replace -- accumulating there would put back the angle the operator just
+# dropped, and each angle is a paid search. `count` is resolved on its own in
+# `resolve_count`, against the number that was proposed.
+_ACCUMULATING_MARKERS = frozenset({"bar", "cut"})
+
+# Where one criterion ends and the next begins. Deliberately generous: this
+# only ever decides whether a later answer already SAYS what an earlier one
+# said, and splitting too finely makes that test stricter, which errs towards
+# keeping both.
+_CLAUSE = re.compile(r"[\n;,.]+|\band\b|\bor\b|\balso\b|\bplus\b", re.IGNORECASE)
+# Words that carry no criterion. "no chains" and "chains" have to match, or a
+# restated exclusion list reads as a new one and every rule is stored twice.
+_NOT_CONTENT = frozenset(
+    {
+        "the", "a", "an", "any", "all", "no", "not", "none", "nor", "but",
+        "and", "or", "also", "plus", "with", "without", "for", "from", "of",
+        "in", "on", "at", "to", "by", "as", "is", "are", "was", "were", "be",
+        "been", "it", "its", "that", "this", "these", "those", "where",
+        "which", "who", "what", "when", "than", "then", "there", "they",
+        "them", "would", "should", "like", "want", "wants", "other", "others",
+        "else", "more", "only", "just", "very", "really", "sure", "yes",
+    }
+)
+
+
+def _content_words(text: str) -> set[str]:
+    """The words in a phrase that say something about the world."""
+    return {
+        word
+        for word in _words(text)
+        if len(word) > 2 and word not in _NOT_CONTENT
+    }
+
+
+def _restates(earlier: str, later: str) -> bool:
+    """Does `later` already say everything `earlier` said?
+
+    This is the whole difference between a correction and an addition, and it
+    is decided from the two answers rather than from the question's wording,
+    because the wording is the model's and the answers are the operator's.
+
+    The test is deliberately strict: every clause of the earlier answer has to
+    survive whole in the later one. A partial overlap -- three rules restated
+    and a fourth quietly gone -- reads as an addition and both are kept, which
+    over-restricts a search rather than silently widening it. Of the two ways
+    to be wrong, only one is invisible.
+    """
+    later_words = _words(later)
+    clauses = [
+        content
+        for content in (_content_words(part) for part in _CLAUSE.split(earlier))
+        if content
+    ]
+    if not clauses:
+        # The earlier answer had nothing checkable in it -- "yes, that" and
+        # friends. Nothing to lose by taking the later one.
+        return True
+    return all(clause <= later_words for clause in clauses)
+
+
+@dataclass
+class AnswerDecision:
+    """What a marker is worth, and how more than one answer got there.
+
+    `source` is one of: `missing`, `single`, `restated` (a later answer said
+    everything the earlier one said, so the later one stands), `combined` (two
+    answers said different things and both are used) or `replaced` (a marker
+    that only ever takes one value was answered twice).
+    """
+
+    text: str
+    source: str
+    note: str = ""
+
+    @property
+    def revisited(self) -> bool:
+        """Was this marker answered more than once in a way worth showing?"""
+        return self.source in ("combined", "replaced")
+
+
+def _times(count: int) -> str:
+    return "twice" if count == 2 else f"{count} times"
+
+
+def _joined(parts: list[str]) -> str:
+    """Several answers read as one instruction.
+
+    Terminated, because these are pasted straight into a search prompt as one
+    line and "no chains no hotel restaurants" is a different sentence from
+    "no chains. No hotel restaurants."
+    """
+    return " ".join(
+        part if part.endswith((".", "!", "?")) else part + "."
+        for part in parts
+    )
+
+
+def resolve_answer(state: GrillState, marker: str) -> AnswerDecision:
+    """What one marker is worth, across every turn that answered it.
+
+    The bug this replaces: the value was read from the LAST turn that settled
+    a marker, so an additive follow-up silently deleted the earlier answer.
+    The run that hit it looked entirely normal.
+
+    Neither engine nor prompt can fix that. Refusing to show the repeated
+    question trades silent data loss for a stuck interview, and the engine
+    already retries once and then shows it anyway on purpose. So the decision
+    is made here, from the answers themselves, and it is written down.
+    """
+    answers = [
+        turn.answer.strip()
+        for turn in _turns_for(state, marker)
+        if turn.answer.strip()
+    ]
+    if not answers:
+        return AnswerDecision("", "missing")
+    if len(answers) == 1:
+        return AnswerDecision(answers[0], "single")
+
+    if marker not in _ACCUMULATING_MARKERS:
+        latest = answers[-1]
+        lost = [earlier for earlier in answers[:-1] if not _restates(earlier, latest)]
+        if not lost:
+            return AnswerDecision(latest, "restated")
+        return AnswerDecision(
+            latest,
+            "replaced",
+            note=(
+                f"This was answered {_times(len(answers))} and the last answer "
+                "is the one being used. The earlier one said: " + _joined(lost)
+            ),
+        )
+
+    kept: list[str] = []
+    for answer in answers:
+        if kept and _restates(_joined(kept), answer):
+            # They retyped the whole thing. Keeping both would say every rule
+            # twice; the later wording is theirs and is the one to keep.
+            kept = [answer]
+        else:
+            kept.append(answer)
+    if len(kept) == 1:
+        return AnswerDecision(kept[0], "restated")
+    return AnswerDecision(
+        _joined(kept),
+        "combined",
+        note=(
+            f"This was answered {_times(len(kept))} and every answer is being "
+            "used. Correct it here if one of them was meant to replace the "
+            "others."
+        ),
+    )
+
+
 def _answer_for(state: GrillState, marker: str) -> str:
-    turn = _turn_for(state, marker)
-    return turn.answer.strip() if turn else ""
+    return resolve_answer(state, marker).text
 
 
 def _counts_in(text: str) -> list[int]:
@@ -258,6 +430,47 @@ def exclusions_from(state: GrillState) -> str:
     return _answer_for(state, "cut")
 
 
+# How a revisited marker is said to a person. The marker keys are the
+# pipeline's; nobody wants to read "cut" on a screen.
+_MARKER_NAMES = {
+    "kind": "what kind of place",
+    "place": "where",
+    "count": "how many",
+    "bar": "what earns a place",
+    "cut": "what is left out",
+    "angles": "the angles",
+}
+
+
+def answer_notes(state: GrillState) -> list[str]:
+    """What to say about every marker the interview answered twice.
+
+    Empty for an interview that asked each thing once, which is the normal
+    case and the one worth staying quiet about.
+    """
+    notes: list[str] = []
+    for marker in _MARKER_NAMES:
+        if marker == "count":
+            # The count carries its own note, resolved against the number that
+            # was proposed rather than against the earlier answer's words.
+            continue
+        decision = resolve_answer(state, marker)
+        if decision.revisited and decision.note:
+            notes.append(f"{_MARKER_NAMES[marker].capitalize()}: {decision.note}")
+    return notes
+
+
+def drop_note_for(notes: list[str], marker: str) -> list[str]:
+    """The notes that still apply once the operator has corrected one marker.
+
+    A note about the cut is a question -- "both answers are being used, is that
+    what you meant?" -- and typing the cut out by hand answers it. Leaving it
+    on screen afterwards would ask again about a value nobody inferred.
+    """
+    prefix = f"{_MARKER_NAMES.get(marker, marker).capitalize()}:"
+    return [note for note in notes if not note.startswith(prefix)]
+
+
 def _fold(text: str) -> str:
     folded = unicodedata.normalize("NFKD", text.lower())
     folded = "".join(c for c in folded if not unicodedata.combining(c))
@@ -422,6 +635,7 @@ def build_search_order(
         count_source="corrected by operator" if target_count is not None else decision.source,
         count_ambiguous=False if target_count is not None else decision.ambiguous,
         count_note="" if target_count is not None else decision.note,
+        answer_notes=answer_notes(state),
     )
 
 
@@ -446,6 +660,11 @@ def summary_of(order: SearchOrder) -> str:
     lines = [
         f"{order.target_count} {order.kind or 'places'} in {order.place or 'the location'}.",
     ]
+    # First, because a run driven from the command line has no screen and this
+    # is the one thing on the order that is asking a question rather than
+    # stating a fact.
+    for note in order.answer_notes:
+        lines.append(f"! {note}")
     if order.standard:
         lines.append(f"Earns a place: {order.standard}")
     if order.exclusions:

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
@@ -81,6 +81,17 @@ CREATE TABLE IF NOT EXISTS listicle_angle_selections (
 )
 """
 
+_CUT_REVIEWS_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_cut_reviews (
+    run_id     TEXT NOT NULL,
+    revision   INTEGER NOT NULL,
+    payload    TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, revision)
+)
+"""
+
+
 _LOCKS_TABLE = """
 CREATE TABLE IF NOT EXISTS listicle_search_locks (
     run_id     TEXT PRIMARY KEY,
@@ -107,6 +118,7 @@ def ensure_tables() -> None:
         conn.execute(_ATTEMPTS_TABLE)
         conn.execute(_SELECTIONS_TABLE)
         conn.execute(_LOCKS_TABLE)
+        conn.execute(_CUT_REVIEWS_TABLE)
 
 
 def save(state: GrillState) -> None:
@@ -281,6 +293,39 @@ def load_attempts(run_id: str, revision: int | None = None) -> list[SearchAttemp
                 (run_id, revision),
             ).fetchall()
     return [SearchAttempt.model_validate(json.loads(row[0])) for row in rows]
+
+
+def save_cut_review(run_id: str, revision: int, flags: dict) -> None:
+    """What the cut check said about one revision's candidates.
+
+    Per revision, because a revised cut is a different question and the old
+    answer is not an answer to it. Stored rather than recomputed on read, for
+    the same reason every other result here is: opening a screen must not spend.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_cut_reviews (run_id, revision, payload) "
+            "VALUES (?, ?, ?) ON CONFLICT(run_id, revision) DO UPDATE SET "
+            "payload=excluded.payload, updated_at=datetime('now')",
+            (run_id, revision, json.dumps(flags)),
+        )
+
+
+def load_cut_review(run_id: str, revision: int) -> dict | None:
+    """The stored verdicts, or None when nothing has looked at this revision.
+
+    None and `{}` are different findings: nobody checked, versus checked and
+    nothing was barred. The screen says which.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT payload FROM listicle_cut_reviews "
+            "WHERE run_id = ? AND revision = ?",
+            (run_id, revision),
+        ).fetchone()
+    return None if row is None else json.loads(row[0])
 
 
 def completed_attempts_for(subject: str, *, exclude_run: str = "") -> list[SearchAttempt]:

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
@@ -1,19 +1,37 @@
-"""Where a listicle interview is kept between turns.
+"""Where a listicle run is kept between turns, and between searches.
 
 Persisted per turn rather than held in the browser, for the same reason the
 article grill is (ADR 0031): an abandoned interview is resumable, and a closed
 tab is not a lost run. The whole state goes in as JSON because it is a
 pydantic contract that will grow, and a column per field would have to be
 migrated every time a marker changes.
+
+Three tables were added on 2026-09-08, from the improvement plan:
+
+**The order.** What the interview settled, written down once and versioned. A
+revision exists so a corrected order cannot be answered by results gathered
+under the old one -- which is not a hypothetical: the only real run displayed
+one count and searched for another.
+
+**The attempts.** One row per angle per revision, so a batch that fails on its
+sixth search keeps the five that worked. Every one records the request it was
+made under, because reuse is decided by whether that request still matches.
+
+**The batch lock.** Two clicks on the same button should not run twelve
+searches. This prevents a duplicate start; it cannot promise that a provider
+did not process a request whose answer never arrived, and nothing here pretends
+otherwise.
 """
 
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 
 from app.core.database import get_db_connection
 
 from ..prompt2blog.contracts_v4 import GrillState
+from .contracts import SearchAttempt, SearchOrder
 
 _TABLE = """
 CREATE TABLE IF NOT EXISTS listicle_grills (
@@ -34,11 +52,61 @@ CREATE TABLE IF NOT EXISTS listicle_search_results (
 )
 """
 
+_ORDERS_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_search_orders (
+    run_id     TEXT NOT NULL,
+    revision   INTEGER NOT NULL,
+    payload    TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, revision)
+)
+"""
+
+_ATTEMPTS_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_search_attempts (
+    run_id     TEXT NOT NULL,
+    revision   INTEGER NOT NULL,
+    angle_id   TEXT NOT NULL,
+    payload    TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, revision, angle_id)
+)
+"""
+
+_SELECTIONS_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_angle_selections (
+    run_id     TEXT PRIMARY KEY,
+    payload    TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+_LOCKS_TABLE = """
+CREATE TABLE IF NOT EXISTS listicle_search_locks (
+    run_id     TEXT PRIMARY KEY,
+    revision   INTEGER NOT NULL,
+    started_at TEXT NOT NULL
+)
+"""
+
+# A batch that has been holding the lock for longer than this is presumed dead.
+# Long enough that a real six-search batch never trips it, short enough that a
+# crashed process does not wedge the run until someone edits the database.
+_LOCK_STALE_AFTER = timedelta(minutes=30)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
 
 def ensure_tables() -> None:
     with get_db_connection() as conn:
         conn.execute(_TABLE)
         conn.execute(_RESULTS_TABLE)
+        conn.execute(_ORDERS_TABLE)
+        conn.execute(_ATTEMPTS_TABLE)
+        conn.execute(_SELECTIONS_TABLE)
+        conn.execute(_LOCKS_TABLE)
 
 
 def save(state: GrillState) -> None:
@@ -70,6 +138,10 @@ def save_results(run_id: str, payload: dict) -> None:
     searches take minutes and cost real tokens; a screen that re-ran them on
     every reload would be unusable and expensive, and re-running is a decision
     the operator makes, not a side effect of looking.
+
+    Kept alongside the per-angle attempts rather than replaced by them. This is
+    the assembled view the screen reads, and it is also what every run stored
+    before attempts existed -- an old run still opens.
     """
     ensure_tables()
     with get_db_connection() as conn:
@@ -88,3 +160,186 @@ def load_results(run_id: str) -> dict | None:
             "SELECT payload FROM listicle_search_results WHERE run_id = ?", (run_id,)
         ).fetchone()
     return None if row is None else json.loads(row[0])
+
+
+# --- the order ------------------------------------------------------------
+
+
+def save_order(order: SearchOrder) -> None:
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_search_orders (run_id, revision, payload) "
+            "VALUES (?, ?, ?) ON CONFLICT(run_id, revision) DO UPDATE SET "
+            "payload=excluded.payload",
+            (order.run_id, order.revision, order.model_dump_json()),
+        )
+
+
+def load_order(run_id: str, revision: int | None = None) -> SearchOrder | None:
+    """The current order, or one named revision of it.
+
+    Older revisions are kept rather than overwritten. A result gathered under
+    revision one has to be readable as what it is -- an answer to a question
+    that is no longer being asked -- and that is not sayable if the question is
+    gone.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        if revision is None:
+            row = conn.execute(
+                "SELECT payload FROM listicle_search_orders WHERE run_id = ? "
+                "ORDER BY revision DESC LIMIT 1",
+                (run_id,),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT payload FROM listicle_search_orders "
+                "WHERE run_id = ? AND revision = ?",
+                (run_id, revision),
+            ).fetchone()
+    return None if row is None else SearchOrder.model_validate(json.loads(row[0]))
+
+
+def next_revision(run_id: str) -> int:
+    current = load_order(run_id)
+    return 1 if current is None else current.revision + 1
+
+
+# --- what the picker chose -------------------------------------------------
+
+
+def save_selections(run_id: str, selections: list[dict]) -> None:
+    """The angle records the screen sent, exactly as it sent them.
+
+    The screen knows what the operator did -- which menu entry a line came
+    from, whether they changed it, whether they wrote it themselves. Inferring
+    that back from the finished text is guesswork, and guessing is what this
+    whole record exists to stop.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_angle_selections (run_id, payload) VALUES (?, ?) "
+            "ON CONFLICT(run_id) DO UPDATE SET payload=excluded.payload, "
+            "updated_at=datetime('now')",
+            (run_id, json.dumps(selections, ensure_ascii=False)),
+        )
+
+
+def load_selections(run_id: str) -> list[dict]:
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT payload FROM listicle_angle_selections WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+    if row is None:
+        return []
+    found = json.loads(row[0])
+    return found if isinstance(found, list) else []
+
+
+# --- one angle's search ----------------------------------------------------
+
+
+def save_attempt(attempt: SearchAttempt) -> None:
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute(
+            "INSERT INTO listicle_search_attempts "
+            "(run_id, revision, angle_id, payload) VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(run_id, revision, angle_id) DO UPDATE SET "
+            "payload=excluded.payload, updated_at=datetime('now')",
+            (
+                attempt.run_id,
+                attempt.revision,
+                attempt.angle_id,
+                attempt.model_dump_json(),
+            ),
+        )
+
+
+def load_attempts(run_id: str, revision: int | None = None) -> list[SearchAttempt]:
+    """Every angle's search for one revision, in no particular order.
+
+    Across every revision when none is named, which is what a reuse check
+    wants: a result gathered two revisions ago still answers this revision's
+    request if the request did not change, and the fingerprint is what says so.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        if revision is None:
+            rows = conn.execute(
+                "SELECT payload FROM listicle_search_attempts WHERE run_id = ?",
+                (run_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT payload FROM listicle_search_attempts "
+                "WHERE run_id = ? AND revision = ?",
+                (run_id, revision),
+            ).fetchall()
+    return [SearchAttempt.model_validate(json.loads(row[0])) for row in rows]
+
+
+# --- not starting the same batch twice -------------------------------------
+
+
+def claim_batch(run_id: str, revision: int) -> bool:
+    """Take the run's search lock, or say it is already held.
+
+    What this can promise: two clicks do not start two batches, and a batch
+    whose process died does not hold the run forever.
+
+    What it cannot promise: that a provider did not already receive and charge
+    for a request whose answer never came back. Retrying an interrupted attempt
+    may spend a second time, and the screen says so rather than implying a
+    guarantee nothing can make.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT started_at FROM listicle_search_locks WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is not None:
+            try:
+                started = datetime.fromisoformat(row[0])
+            except ValueError:  # pragma: no cover -- corrupt row
+                started = datetime.now(timezone.utc) - _LOCK_STALE_AFTER
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) - started < _LOCK_STALE_AFTER:
+                return False
+        conn.execute(
+            "INSERT INTO listicle_search_locks (run_id, revision, started_at) "
+            "VALUES (?, ?, ?) ON CONFLICT(run_id) DO UPDATE SET "
+            "revision=excluded.revision, started_at=excluded.started_at",
+            (run_id, revision, _now()),
+        )
+    return True
+
+
+def release_batch(run_id: str) -> None:
+    ensure_tables()
+    with get_db_connection() as conn:
+        conn.execute("DELETE FROM listicle_search_locks WHERE run_id = ?", (run_id,))
+
+
+def batch_is_running(run_id: str) -> bool:
+    ensure_tables()
+    with get_db_connection() as conn:
+        row = conn.execute(
+            "SELECT started_at FROM listicle_search_locks WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+    if row is None:
+        return False
+    try:
+        started = datetime.fromisoformat(row[0])
+    except ValueError:  # pragma: no cover -- corrupt row
+        return False
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - started < _LOCK_STALE_AFTER

--- a/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/listicle_pipeline/store.py
@@ -283,6 +283,33 @@ def load_attempts(run_id: str, revision: int | None = None) -> list[SearchAttemp
     return [SearchAttempt.model_validate(json.loads(row[0])) for row in rows]
 
 
+def completed_attempts_for(subject: str, *, exclude_run: str = "") -> list[SearchAttempt]:
+    """Every finished search recorded for one subject, from any run.
+
+    The point of the whole record: what an angle bought last time is the only
+    thing anyone can know about what it will buy this time, and it has to be
+    readable before the search is paid for rather than after.
+
+    Scanned in Python rather than queried, because the fields live inside the
+    stored payload. That is fine at this size and would not be at a hundred
+    times it -- the fix then is a column, not a different answer.
+    """
+    ensure_tables()
+    with get_db_connection() as conn:
+        rows = conn.execute(
+            "SELECT payload FROM listicle_search_attempts"
+        ).fetchall()
+    attempts = [SearchAttempt.model_validate(json.loads(row[0])) for row in rows]
+    return [
+        attempt
+        for attempt in attempts
+        if attempt.subject == subject
+        and attempt.state == "completed"
+        and attempt.contribution_recorded
+        and attempt.run_id != exclude_run
+    ]
+
+
 # --- not starting the same batch twice -------------------------------------
 
 

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/contracts_v4.py
@@ -272,6 +272,15 @@ class GrillOption(V4ContractModel):
     text: str = Field(min_length=1)
     recommended: bool = False
     group: str = ""
+    # Which catalogue entry this option was written from, and what job it is
+    # meant to do. Both belong to the listicle grill, where an option is a
+    # search rather than a sentence: without the key, an option that the
+    # operator edits loses every fact the catalogue held about it, and the
+    # pipeline is back to inferring a shape from a rewritten sentence. Empty
+    # everywhere else, including the article grill, which does not use options
+    # at all.
+    shape: str = ""
+    role: str = ""
 
 
 class GrillQuestion(V4ContractModel):

--- a/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
+++ b/apps/ai-blog-writer/apps/backend/app/features/prompt2blog/grill_v4.py
@@ -120,6 +120,12 @@ NEXT_TURN_SCHEMA = require_non_empty({
                     "text": {"type": "string"},
                     "recommended": {"type": "boolean"},
                     "group": {"type": "string"},
+                    # Not required. The article grill sends no options at all,
+                    # and a listicle option that arrives without them is still
+                    # a usable search -- it just costs the pipeline the shape's
+                    # opinion about what it overlaps with.
+                    "shape": {"type": "string"},
+                    "role": {"type": "string"},
                 },
                 "required": ["text", "recommended"],
             },
@@ -479,12 +485,18 @@ def _options_from(raw: Any) -> list[GrillOption]:
     options: list[GrillOption] = []
     seen: set[str] = set()
     for item in raw:
+        shape, role = "", ""
         if isinstance(item, str):
             text, recommended, group = _safe_str(item), True, ""
         elif isinstance(item, dict):
             text = _safe_str(item.get("text")) or _safe_str(item.get("angle"))
             recommended = item.get("recommended") is True
             group = _safe_str(item.get("group"))
+            # Carried through rather than required. An option that arrives
+            # without them is still a search; it has just lost the catalogue's
+            # opinion about what it overlaps with and how hard to ask it.
+            shape = _safe_str(item.get("shape")) or _safe_str(item.get("shape_key"))
+            role = _safe_str(item.get("role"))
         else:
             continue
         # Duplicates are the failure this question exists to avoid: the same
@@ -493,7 +505,15 @@ def _options_from(raw: Any) -> list[GrillOption]:
         if not text or key in seen:
             continue
         seen.add(key)
-        options.append(GrillOption(text=text, recommended=recommended, group=group))
+        options.append(
+            GrillOption(
+                text=text,
+                recommended=recommended,
+                group=group,
+                shape=shape,
+                role=role,
+            )
+        )
     return options
 
 
@@ -587,6 +607,35 @@ class GrillUnusableResponse(RuntimeError):
         self.state = state
 
 
+class _WastedTurn(Exception):
+    """The grill asked a question it had already been answered.
+
+    Not an unusable reply -- the question is well formed and could be shown.
+    It is simply about a marker that is already settled, or about anything at
+    all when nothing is left to settle, and both of those cost an operator a
+    turn and a model call to learn nothing.
+
+    Worse than the waste: a marker's value is read from the LAST turn that
+    settled it, so a second, additive question about the same marker silently
+    replaces the first answer. A live listicle run on 2026-09-08 asked "what
+    else should be excluded?" after exclusions were settled; answering it
+    plainly would have thrown away the chains, delivery-only and
+    ceviche-not-primary rules and left "no hotel restaurants" as the entire
+    cut.
+
+    Carries the question anyway. One repeat is much better than a dead run, so
+    a retry that does not correct it is accepted rather than raised.
+    """
+
+    def __init__(self, before: GrillState, result: GrillState, why: str) -> None:
+        super().__init__(why)
+        # The state as the attempt left it, so a lookup already paid for is not
+        # bought again by the retry.
+        self.before = before
+        self.result = result
+        self.why = why
+
+
 def advance_grill(
     state: GrillState,
     dependencies: GrillDependencies,
@@ -605,9 +654,21 @@ def advance_grill(
     # Carried across attempts, so a lookup the first attempt paid for is not
     # bought again by the second.
     working = state
+    repeated: _WastedTurn | None = None
     for attempt in range(2):
         try:
             return _advance_once(working, dependencies)
+        except _WastedTurn as wasted:
+            # Retried once, for the same reason an unusable reply is: this is a
+            # flash model choosing one question, and it usually chooses a
+            # better one when asked again.
+            repeated = wasted
+            working = wasted.before
+            logger.warning(
+                "Grill re-asked a settled marker (attempt %s): %s",
+                attempt + 1,
+                wasted.why,
+            )
         except GrillUnusableResponse as error:
             attempts.append(error.raw)
             if error.state is not None:
@@ -617,6 +678,12 @@ def advance_grill(
                 attempt + 1,
                 error.raw[:500],
             )
+    if repeated is not None and not attempts:
+        # It repeated itself twice. Showing the question again wastes one turn;
+        # refusing to continue loses the whole interview, and the operator has
+        # no way to get past it.
+        logger.warning("Grill repeated itself twice; showing the question anyway")
+        return repeated.result
     raise GrillUnusableResponse("\n---\n".join(attempts), working)
 
 
@@ -684,7 +751,7 @@ def _advance_once(
     )
     if question is None:
         raise GrillUnusableResponse(raw or _json_or_repr(payload), state)
-    return state.model_copy(
+    asking = state.model_copy(
         update={
             "status": "asking",
             "pending": question,
@@ -692,6 +759,27 @@ def _advance_once(
             "location": location,
         }
     )
+
+    # The prompt says to ask about a marker that is still missing, and says it
+    # twice. A live run ignored it twice in six turns. A rule that is only
+    # written down is not enforced, so it is enforced here.
+    missing = [key for key in state.marker_keys if key not in covered]
+    # Claiming `done` and failing to say what was agreed is a different fault
+    # with a different remedy: the checklist is full, the playback is missing,
+    # and asking again is how the playback gets written. Retrying that as a
+    # repeated question would spend the budget refusing the one move that
+    # recovers it.
+    if not missing and payload.get("done") is not True:
+        raise _WastedTurn(
+            state, asking, "every marker is covered and it asked instead of agreeing"
+        )
+    if question.asks_about and question.asks_about in covered:
+        raise _WastedTurn(
+            state,
+            asking,
+            f"{question.asks_about} is settled while {', '.join(missing)} is not",
+        )
+    return asking
 
 
 def start_grill(

--- a/apps/ai-blog-writer/apps/backend/scripts/backfill_listicle_contribution.py
+++ b/apps/ai-blog-writer/apps/backend/scripts/backfill_listicle_contribution.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Write contribution onto listicle attempts that were stored before it existed.
+
+Contribution -- how many places a search returned, and how many of them nothing
+else found -- used to be computed when the results screen was drawn and thrown
+away with it. It is now recorded on the attempt, because the number is only
+worth anything if it can be read BEFORE the same search is paid for again.
+
+Runs stored before that change have the rows and the sightings but no
+contribution, so they cannot answer "what did this angle buy last time". This
+recomputes it for them. Nothing is fetched and nothing is spent: the pool is
+rebuilt from sightings that are already on disk.
+
+Safe to run more than once. It rewrites a derived number and touches nothing
+else.
+
+    cd apps/ai-blog-writer
+    set -a && . ./apps/backend/.env && set +a
+    export PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src
+    .venv/bin/python apps/backend/scripts/backfill_listicle_contribution.py --dry-run
+    .venv/bin/python apps/backend/scripts/backfill_listicle_contribution.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = Path(__file__).resolve().parents[3]
+for entry in (
+    ROOT,
+    REPO / "packages" / "shared" / "src",
+    REPO / "packages" / "utils" / "src",
+):
+    if str(entry) not in sys.path:
+        sys.path.insert(0, str(entry))
+
+
+def main(argv: list[str]) -> int:
+    from app.config import DB_PATH
+    from app.core.database import get_db_connection
+    from app.features.listicle_pipeline import runner, store
+
+    dry_run = "--dry-run" in argv
+    print(f"database: {DB_PATH}")
+
+    with get_db_connection() as conn:
+        run_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT DISTINCT run_id FROM listicle_search_orders ORDER BY run_id"
+            ).fetchall()
+        ]
+
+    for run_id in run_ids:
+        order = store.load_order(run_id)
+        if order is None:
+            print(f"{run_id}: no order, skipped")
+            continue
+        before = store.load_attempts(run_id)
+        pending = [a for a in before if a.state == "completed" and not a.contribution_recorded]
+        if not pending:
+            print(f"{run_id}: already recorded ({len(before)} attempts)")
+            continue
+        if dry_run:
+            print(f"{run_id}: would record {len(pending)} of {len(before)} attempts")
+            continue
+        runner.record_contribution(order)
+        after = sorted(store.load_attempts(run_id), key=lambda a: a.angle_id)
+        recorded = [
+            f"{a.angle_id} {a.rows}r/{a.exclusive}x"
+            for a in after
+            if a.contribution_recorded
+        ]
+        print(f"{run_id}: {', '.join(recorded)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/apps/ai-blog-writer/apps/backend/scripts/drive_listicle_run.py
+++ b/apps/ai-blog-writer/apps/backend/scripts/drive_listicle_run.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+"""Drive one real listicle run from the command line, a turn at a time.
+
+The same code the HTTP routes call -- `service` plus `api._base_dependencies()`
+-- with no server, no auth and no browser. This is how both real runs of
+2026-09-08 were driven, and it is the fastest way to exercise the pipeline
+against a live model.
+
+It spends real money: the seed lookup, every interview turn, and one grounded
+web search per angle. There is no confirmation prompt, because every command
+here is one the operator typed deliberately. `search` is the expensive one.
+
+    cd apps/ai-blog-writer
+    set -a && . ./apps/backend/.env && set +a
+    export PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src
+
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py \
+        start "The 40 best cevicherias in Lima"
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py \
+        answer <run_id> "the answer, written as a statement"
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py order <run_id>
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py search <run_id>
+
+Answering the angle question sends the picker's records alongside the text, as
+the screen does. Build them from `options` in the previous turn's output:
+
+    answer <run_id> "$(cat lines.txt)" "$(cat selections.json)"
+
+where `selections.json` is a list of
+`{text, angle_id, shape_key, group, role, edited, custom}`. `group` may be left
+empty -- the catalogue fills it, and a value from a model is not trusted.
+
+Two things to know before driving one:
+
+**Answer as a statement, never as a reply.** The answer is stored verbatim and
+reaches the searches as the operator's own words. "Yes, that" and "as you said"
+are recorded as the brief material, and they say nothing.
+
+**The recommendation is an answer, not part of the question.** It arrives in
+the operator's box for them to accept or correct. Read the question, decide
+what is true, and write that.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = Path(__file__).resolve().parents[3]
+for entry in (
+    ROOT,
+    REPO / "packages" / "shared" / "src",
+    REPO / "packages" / "utils" / "src",
+):
+    if str(entry) not in sys.path:
+        sys.path.insert(0, str(entry))
+
+
+def _deps():
+    import app.features.listicle_pipeline.api as api
+
+    return api._base_dependencies()
+
+
+def _wrap(text: str, indent: str = "    ") -> str:
+    out: list[str] = []
+    for para in str(text).split("\n"):
+        out.extend(
+            textwrap.wrap(para, 96, initial_indent=indent, subsequent_indent=indent)
+            or [indent.rstrip()]
+        )
+    return "\n".join(out)
+
+
+def show(state) -> None:
+    print(f"\nRUN {state.run_id}   status={state.status}")
+    print(f"covered: {', '.join(state.markers_covered) or '(none)'}")
+    missing = [k for k in state.marker_keys if k not in state.markers_covered]
+    print(f"missing: {', '.join(missing) or '(none)'}")
+    if state.lookups:
+        print(f"lookups so far: {state.lookups}")
+    if state.pending is not None:
+        pending = state.pending
+        print(f"\nASKS ABOUT: {pending.asks_about}")
+        print("QUESTION:")
+        print(_wrap(pending.ask))
+        if pending.pushback:
+            print("PUSHBACK:")
+            print(_wrap(pending.pushback))
+        # Printed as what it is: a proposed answer, not a second question.
+        print("ITS PROPOSED ANSWER (accept it or write your own):")
+        print(_wrap(pending.recommendation))
+        if pending.options:
+            print(f"\nOPTIONS ({len(pending.options)}):")
+            for option in pending.options:
+                flag = "PICKED" if option.recommended else "      "
+                print(
+                    f"  [{flag}] shape={option.shape or '-':<20} "
+                    f"role={option.role or '-':<12}"
+                )
+                print(_wrap(option.text, "           "))
+    if state.status == "agreed":
+        print("\nCONSENSUS:")
+        print(_wrap(state.consensus))
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    command = sys.argv[1]
+
+    from app.features.listicle_pipeline import service, spec
+
+    if command == "start":
+        state = service.start(sys.argv[2], _deps())
+        print("=== WHAT IT LOOKED UP BEFORE ASKING ANYTHING ===")
+        print(_wrap(state.research_digest[:3000] or "(nothing)"))
+        show(state)
+    elif command == "answer":
+        run_id, text = sys.argv[2], sys.argv[3]
+        selections = json.loads(sys.argv[4]) if len(sys.argv) > 4 else None
+        show(service.answer(run_id, text, _deps(), selections))
+    elif command == "show":
+        show(service.get(sys.argv[2]))
+    elif command == "digest":
+        print(service.get(sys.argv[2]).research_digest)
+    elif command == "order":
+        order = service.order(sys.argv[2])
+        if order is None:
+            print("This interview has not agreed a search order yet.")
+            return 1
+        print(spec.summary_of(order))
+        print(
+            f"\nplanned capacity: {spec.planned_capacity(order)} "
+            f"vs target {order.target_count}"
+        )
+        for angle in order.angles:
+            print(
+                f"  {angle.shape_key or '(custom)':<20} {angle.group or '-':<12} "
+                f"{angle.role:<12} asks {angle.wanted}"
+            )
+    elif command == "search":
+        import app.features.listicle_pipeline.api as api
+
+        only = sys.argv[3].split(",") if len(sys.argv) > 3 and sys.argv[3] else None
+        payload = service.search(sys.argv[2], api._search_call, only=only)
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    elif command == "report":
+        # The three numbers worth reading, without the whole payload.
+        found = service.progress(sys.argv[2])
+        if found is None:
+            print("Nothing has been searched for this run yet.")
+            return 1
+        print(
+            f"found {found['found']} of {found['target']} | "
+            f"shortfall {found['shortfall']} | rows {found['rows_returned']} | "
+            f"uncertain identity {found['uncertain_identity']}"
+        )
+        print(f"\n{'rows':>4} {'shared':>6} {'ONLY':>4}  {'role':<12} angle")
+        for angle in found["angles"]:
+            print(
+                f"{angle['rows']:>4} {angle['shared']:>6} {angle['exclusive']:>4}  "
+                f"{angle['role']:<12} {angle['angle'][:60]}"
+            )
+        named = sorted({t for a in found["angles"] for t in a.get("sources_named", [])})
+        print(f"\n{len(named)} publications: {', '.join(named)}")
+        print()
+        for index, candidate in enumerate(found["candidates"], 1):
+            duplicate = (
+                "  [dup? " + ", ".join(candidate["possible_duplicates"]) + "]"
+                if candidate["possible_duplicates"]
+                else ""
+            )
+            print(
+                f"{index:>3}. x{candidate['overlap']}  {candidate['name']} "
+                f"({candidate['district'] or '-'}){duplicate}"
+            )
+    else:
+        print(f"unknown command {command!r}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/ai-blog-writer/apps/backend/scripts/drive_listicle_run.py
+++ b/apps/ai-blog-writer/apps/backend/scripts/drive_listicle_run.py
@@ -65,6 +65,19 @@ def _deps():
     return api._base_dependencies()
 
 
+def _review():
+    """The cut check, as the routes pass it.
+
+    Without this the driver silently skips both halves of it and a run driven
+    here would look like a run whose order and candidates were clean, when in
+    fact nothing had looked. This script's whole claim is that it is the same
+    code the HTTP routes call.
+    """
+    import app.features.listicle_pipeline.api as api
+
+    return api._review_call
+
+
 def _wrap(text: str, indent: str = "    ") -> str:
     out: list[str] = []
     for para in str(text).split("\n"):
@@ -123,7 +136,7 @@ def main() -> int:
     elif command == "answer":
         run_id, text = sys.argv[2], sys.argv[3]
         selections = json.loads(sys.argv[4]) if len(sys.argv) > 4 else None
-        show(service.answer(run_id, text, _deps(), selections))
+        show(service.answer(run_id, text, _deps(), selections, _review()))
     elif command == "show":
         show(service.get(sys.argv[2]))
     elif command == "digest":
@@ -143,11 +156,24 @@ def main() -> int:
                 f"  {angle.shape_key or '(custom)':<20} {angle.group or '-':<12} "
                 f"{angle.role:<12} asks {angle.wanted}"
             )
+        # Whether anything looked, said separately from what it found: an
+        # unchecked order must not read as a cleared one.
+        if not order.conflicts_checked:
+            print("\nNOT CHECKED against the cut.")
+        elif order.angle_conflicts:
+            print(f"\n{len(order.angle_conflicts)} SEARCH(ES) FIGHT THE CUT:")
+            for conflict in order.angle_conflicts:
+                print(f"  {conflict.angle_text}")
+                print(_wrap(conflict.why, "      "))
+        else:
+            print("\nChecked against the cut; no search looks like it fights it.")
     elif command == "search":
         import app.features.listicle_pipeline.api as api
 
         only = sys.argv[3].split(",") if len(sys.argv) > 3 and sys.argv[3] else None
-        payload = service.search(sys.argv[2], api._search_call, only=only)
+        payload = service.search(
+            sys.argv[2], api._search_call, only=only, review=api._review_call
+        )
         print(json.dumps(payload, indent=2, ensure_ascii=False))
     elif command == "report":
         # The three numbers worth reading, without the whole payload.
@@ -169,16 +195,26 @@ def main() -> int:
         named = sorted({t for a in found["angles"] for t in a.get("sources_named", [])})
         print(f"\n{len(named)} publications: {', '.join(named)}")
         print()
+        if not found.get("cut_checked"):
+            print("The places below have NOT been checked against the cut.\n")
+        else:
+            print(
+                f"{found.get('barred_count', 0)} of {len(found['candidates'])} "
+                "look like places the cut barred (marked !).\n"
+            )
         for index, candidate in enumerate(found["candidates"], 1):
             duplicate = (
                 "  [dup? " + ", ".join(candidate["possible_duplicates"]) + "]"
                 if candidate["possible_duplicates"]
                 else ""
             )
+            barred = "!" if candidate.get("barred") else " "
             print(
-                f"{index:>3}. x{candidate['overlap']}  {candidate['name']} "
+                f"{barred}{index:>3}. x{candidate['overlap']}  {candidate['name']} "
                 f"({candidate['district'] or '-'}){duplicate}"
             )
+            if candidate.get("barred"):
+                print(_wrap(candidate["barred"], "        "))
     else:
         print(f"unknown command {command!r}")
         return 2

--- a/apps/ai-blog-writer/apps/backend/scripts/listicle_angle_comparison.py
+++ b/apps/ai-blog-writer/apps/backend/scripts/listicle_angle_comparison.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+"""Run one evaluation case's searches for real, under a stated spend cap.
+
+This is the paid half of the plan's phase 5, and it is a separate script rather
+than a route because nothing should be able to start it by accident. It buys
+one grounded search per angle per commission, against the same execution layer
+the pipeline uses.
+
+It refuses to run without `--i-know-this-costs-money`. That is not ceremony:
+the only path in this app that reaches the web is a live Gemini grounding call,
+this repository runs live Stripe on the same machine, and a script that quietly
+spends is the kind of thing that gets run at three in the morning by someone
+who wanted to see what it printed.
+
+Read before running:
+
+- The plan's own sequencing. Do not buy a quality comparison until identity
+  handling and result recording are trustworthy, because otherwise the
+  measurement measures the bug.
+- The adoption rule. Agree the numerical thresholds BEFORE the run. Thresholds
+  chosen afterwards are chosen to flatter whatever came back.
+- What this cannot establish: whether a returned place is real, currently open,
+  or worth writing about. Receiving a search result is not verification, and
+  this script reports discovery only.
+
+    PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src \
+        .venv/bin/python apps/backend/scripts/listicle_angle_comparison.py --list
+
+    PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src \
+        .venv/bin/python apps/backend/scripts/listicle_angle_comparison.py \
+        --case narrow-hotels --label after \
+        --angles "aparthotels in Lima with monthly rates and kitchens" \
+        --angles "hotels in Lima in converted republican-era casonas" \
+        --roles broad,distinctive \
+        --i-know-this-costs-money
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = Path(__file__).resolve().parents[3]
+# The same three entries `pyproject.toml` puts on pytest's path. `utils` is a
+# workspace package, not an installed one, and every import below dies without
+# it.
+for entry in (ROOT, REPO / "packages" / "shared" / "src", REPO / "packages" / "utils" / "src"):
+    if str(entry) not in sys.path:
+        sys.path.insert(0, str(entry))
+
+from app.features.listicle_pipeline.evaluation import (  # noqa: E402
+    CASES,
+    CASES_BY_KEY,
+    REPORTED_OUTCOMES,
+)
+from app.features.listicle_pipeline.search import (  # noqa: E402
+    AngleRequest,
+    contribution_of,
+    role_allowances,
+    run_search_order,
+)
+
+
+def _live_search(prompt: str) -> tuple[str, list[str], int | None]:
+    """The one path in this app that reaches the web, and the only spend here."""
+    from app.shared.model_calls import grounded_text
+    from app.features.listicle_pipeline.search import (
+        SEARCH_MAX_TOKENS,
+        SEARCH_TIMEOUT_SECONDS,
+    )
+
+    result = grounded_text(
+        "listicle.search",
+        prompt,
+        max_tokens=SEARCH_MAX_TOKENS,
+        timeout_seconds=SEARCH_TIMEOUT_SECONDS,
+        endpoint="generateContent:googleSearch",
+    )
+    if result is None:
+        raise RuntimeError("The grounded search returned nothing.")
+    return result.text, list(result.source_urls), result.total_tokens
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="Show the cases and stop.")
+    parser.add_argument("--case", help="Which evaluation case to run.")
+    parser.add_argument(
+        "--angles",
+        action="append",
+        default=[],
+        help="One angle, as it would be searched. Repeat per angle.",
+    )
+    parser.add_argument(
+        "--roles",
+        default="",
+        help="Comma-separated roles, one per angle. Defaults to all broad.",
+    )
+    parser.add_argument(
+        "--max-searches",
+        type=int,
+        default=8,
+        help="Hard cap on searches bought in one invocation.",
+    )
+    parser.add_argument(
+        "--label", default="", help="A word for this arm, e.g. 'before' or 'after'."
+    )
+    parser.add_argument(
+        "--i-know-this-costs-money",
+        action="store_true",
+        dest="confirmed",
+        help="Required. Every angle is one live grounded search.",
+    )
+    args = parser.parse_args()
+
+    if args.list or not args.case:
+        for case in CASES:
+            print(f"{case.key:22} {case.seed}")
+            for line in case.judged_by:
+                print(f"{'':22} - {line}")
+        return 0
+
+    case = CASES_BY_KEY.get(args.case)
+    if case is None:
+        print(f"No case called {args.case!r}.", file=sys.stderr)
+        return 2
+    if not args.angles:
+        print("Give at least one --angles.", file=sys.stderr)
+        return 2
+    if len(args.angles) > args.max_searches:
+        print(
+            f"{len(args.angles)} angles is above the cap of {args.max_searches}.",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.confirmed:
+        print(
+            f"This would buy {len(args.angles)} live grounded searches. "
+            "Re-run with --i-know-this-costs-money.",
+            file=sys.stderr,
+        )
+        return 1
+
+    roles = (
+        [r.strip() for r in args.roles.split(",") if r.strip()]
+        if args.roles
+        else ["broad"] * len(args.angles)
+    )
+    if len(roles) != len(args.angles):
+        print("One role per angle, or none at all.", file=sys.stderr)
+        return 2
+
+    allowances = role_allowances(case.target_count, roles)
+    requests = [
+        AngleRequest(
+            angle_id=f"a{index + 1}",
+            text=text,
+            role=roles[index],
+            wanted=allowances[index],
+        )
+        for index, text in enumerate(args.angles)
+    ]
+
+    candidates, results = run_search_order(
+        requests,
+        kind=case.kind,
+        place=case.seed.split(" in ")[-1] if " in " in case.seed else case.seed,
+        target_items=case.target_count,
+        exclusions=case.exclusions,
+        standard=case.standard,
+        research=_live_search,
+    )
+
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+    payload = {
+        "case": case.key,
+        "label": args.label,
+        "ran_at": stamp,
+        "target": case.target_count,
+        "found": len(candidates),
+        "shortfall": max(0, case.target_count - len(candidates)),
+        "uncertain_identity": sum(1 for c in candidates if c.possible_duplicates),
+        "angles": [
+            {
+                "angle": result.angle,
+                "role": result.role,
+                "wanted": result.wanted,
+                "rows": result.rows,
+                "sources": result.sources,
+                "failed": result.failed,
+                "reason": result.reason,
+                "found": contribution_of(candidates, result.angle)[0],
+                "shared": contribution_of(candidates, result.angle)[1],
+                "exclusive": contribution_of(candidates, result.angle)[2],
+            }
+            for result in results
+        ],
+        "candidates": [
+            {
+                "name": c.name,
+                "district": c.district,
+                "found_by": list(c.found_by),
+                "possible_duplicates": list(c.possible_duplicates),
+                "sightings": [
+                    {"angle": s.angle, "name": s.name, "evidence": s.evidence}
+                    for s in c.sightings
+                ],
+            }
+            for c in candidates
+        ],
+        # Recorded as unanswered rather than omitted. Every one of these has to
+        # be filled in by a person reading the run; a report that silently
+        # leaves out the unflattering half is not a report.
+        "outcomes_still_to_be_judged": {
+            name: reason
+            for name, reason in REPORTED_OUTCOMES
+            if name not in {"contribution", "spend"}
+        },
+        "judged_by": list(case.judged_by),
+    }
+
+    out = REPO / "docs" / "audits"
+    out.mkdir(parents=True, exist_ok=True)
+    name = f"listicle-angle-comparison-{case.key}-{args.label or 'run'}-{stamp}.json"
+    (out / name).write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"{len(candidates)} places from {len(results)} searches -> docs/audits/{name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/ai-blog-writer/apps/backend/scripts/listicle_angle_variance.py
+++ b/apps/ai-blog-writer/apps/backend/scripts/listicle_angle_variance.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Read what stored runs say about angle wording, and about run-to-run noise.
+
+Spends nothing. Reads the contribution already recorded on each attempt.
+
+This exists because of a claim that could not be checked without it: that the
+model over-tightens its own angle wording and it costs measurably. The evidence
+offered was one pair -- the `informal` angle, 9 words returning 11 places in one
+run and 12 words returning 6 in the next.
+
+The same two runs contain the control that pair needs. `institution` ran with
+IDENTICAL wording in both and moved 7 rows to 12, one exclusive place to six.
+If unchanged wording swings that far, one changed pair cannot be read as an
+effect of the change.
+
+So this prints both: the pairs, and the pairs whose wording did not change.
+The second group is the noise floor, and no comparison of the first group means
+anything until it is known.
+
+    cd apps/ai-blog-writer
+    set -a && . ./apps/backend/.env && set +a
+    export PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src
+    .venv/bin/python apps/backend/scripts/listicle_angle_variance.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = Path(__file__).resolve().parents[3]
+for entry in (
+    ROOT,
+    REPO / "packages" / "shared" / "src",
+    REPO / "packages" / "utils" / "src",
+):
+    if str(entry) not in sys.path:
+        sys.path.insert(0, str(entry))
+
+
+def main() -> int:
+    from app.core.database import get_db_connection
+    from app.features.listicle_pipeline import runner, store
+
+    with get_db_connection() as conn:
+        run_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT DISTINCT run_id FROM listicle_search_orders ORDER BY run_id"
+            ).fetchall()
+        ]
+
+    # Grouped by subject, because what a shape does for cevicherias in Lima
+    # says nothing about what it does for bookshops in Buenos Aires.
+    by_subject: dict[str, dict[str, list]] = {}
+    for run_id in run_ids:
+        order = store.load_order(run_id)
+        if order is None:
+            continue
+        subject = runner.subject_of(order)
+        for attempt in store.load_attempts(run_id):
+            if not (attempt.contribution_recorded and attempt.shape_key):
+                continue
+            by_subject.setdefault(subject, {}).setdefault(
+                attempt.shape_key, []
+            ).append(attempt)
+
+    for subject, shapes in sorted(by_subject.items()):
+        repeated = {k: v for k, v in shapes.items() if len(v) > 1}
+        if not repeated:
+            continue
+        print(f"\n{subject}")
+        print(f"  {'shape':16}{'words':>7}{'rows':>6}{'excl':>6}   runs")
+
+        unchanged: list[tuple[str, int, int]] = []
+        changed: list[tuple[str, int, int]] = []
+        for shape, attempts in sorted(repeated.items()):
+            lengths = {len(a.angle_text.split()) for a in attempts}
+            spread_rows = max(a.rows for a in attempts) - min(a.rows for a in attempts)
+            spread_excl = max(a.exclusive for a in attempts) - min(
+                a.exclusive for a in attempts
+            )
+            (unchanged if len(lengths) == 1 else changed).append(
+                (shape, spread_rows, spread_excl)
+            )
+            for a in sorted(attempts, key=lambda a: a.run_id):
+                print(
+                    f"  {shape:16}{len(a.angle_text.split()):7}{a.rows:6}"
+                    f"{a.exclusive:6}   {a.run_id}"
+                )
+
+        print()
+        if unchanged:
+            worst = max(unchanged, key=lambda r: r[2])
+            print(
+                f"  NOISE FLOOR: {len(unchanged)} shape(s) ran with the same "
+                f"wording twice. Widest swing: {worst[0]}, "
+                f"{worst[1]} rows and {worst[2]} exclusive places."
+            )
+        else:
+            print(
+                "  NOISE FLOOR: UNKNOWN. No shape ran twice with unchanged "
+                "wording, so nothing here separates wording from chance."
+            )
+        if changed:
+            worst = max(changed, key=lambda r: r[2])
+            print(
+                f"  REWORDED:    {len(changed)} shape(s) changed wording. "
+                f"Widest swing: {worst[0]}, "
+                f"{worst[1]} rows and {worst[2]} exclusive places."
+            )
+        print(
+            "\n  A reworded swing is only evidence about wording if it is "
+            "clearly larger\n  than the unchanged swing. Read the two numbers "
+            "above against each other."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/ai-blog-writer/apps/backend/tests/listicle_test_support.py
+++ b/apps/ai-blog-writer/apps/backend/tests/listicle_test_support.py
@@ -6,6 +6,8 @@ building one inline is thirty lines of contract before the test says anything.
 
 from __future__ import annotations
 
+import itertools
+
 from app.features.prompt2blog.contracts_v4 import (
     GrillOption,
     GrillQuestion,
@@ -13,6 +15,15 @@ from app.features.prompt2blog.contracts_v4 import (
     GrillTurn,
 )
 from app.features.listicle_pipeline.contracts import LISTICLE_MARKER_KEYS
+
+# `question_id` used to be `abs(hash(answer)) % 10_000`. Unique enough while
+# every test had at most one turn per marker, and a 1-in-10,000 flake the
+# moment one had two -- which the repeated-marker tests deliberately do.
+# `GrillState` requires question ids to be unique, so the collision surfaced as
+# a ValidationError in an unrelated test, once, on a hash seed that never came
+# back. Counted rather than hashed: nothing asserts on the value, and a test
+# helper has no business being probabilistic.
+_ISSUED = itertools.count(1)
 
 
 def turn(
@@ -25,7 +36,7 @@ def turn(
 ) -> GrillTurn:
     return GrillTurn(
         question=GrillQuestion(
-            question_id=f"q-{marker}-{abs(hash(answer)) % 10_000}",
+            question_id=f"q-{marker}-{next(_ISSUED)}",
             topic=marker,
             ask=ask or f"About {marker}?",
             recommendation=recommendation,

--- a/apps/ai-blog-writer/apps/backend/tests/listicle_test_support.py
+++ b/apps/ai-blog-writer/apps/backend/tests/listicle_test_support.py
@@ -1,0 +1,104 @@
+"""Building a listicle interview by hand, without a model or a network.
+
+Every test below the interview needs a `GrillState` that has agreed, and
+building one inline is thirty lines of contract before the test says anything.
+"""
+
+from __future__ import annotations
+
+from app.features.prompt2blog.contracts_v4 import (
+    GrillOption,
+    GrillQuestion,
+    GrillState,
+    GrillTurn,
+)
+from app.features.listicle_pipeline.contracts import LISTICLE_MARKER_KEYS
+
+
+def turn(
+    marker: str,
+    answer: str,
+    *,
+    ask: str = "",
+    recommendation: str = "-",
+    options: list[GrillOption] | None = None,
+) -> GrillTurn:
+    return GrillTurn(
+        question=GrillQuestion(
+            question_id=f"q-{marker}-{abs(hash(answer)) % 10_000}",
+            topic=marker,
+            ask=ask or f"About {marker}?",
+            recommendation=recommendation,
+            asks_about=marker,
+            options=options or [],
+        ),
+        answer=answer,
+    )
+
+
+def option(
+    text: str,
+    *,
+    recommended: bool = False,
+    group: str = "",
+    shape: str = "",
+    role: str = "",
+) -> GrillOption:
+    return GrillOption(
+        text=text, recommended=recommended, group=group, shape=shape, role=role
+    )
+
+
+def agreed_state(
+    *,
+    run_id: str = "run0001",
+    seed: str = "The 20 best cevicherias in Lima",
+    turns: list[GrillTurn] | None = None,
+    consensus: str = "Twenty cevicherias in Lima.",
+) -> GrillState:
+    """An interview that has settled every marker."""
+    return GrillState(
+        run_id=run_id,
+        seed=seed,
+        status="agreed",
+        consensus=consensus,
+        markers_covered=list(LISTICLE_MARKER_KEYS),
+        marker_keys=LISTICLE_MARKER_KEYS,
+        turns=turns or default_turns(),
+    )
+
+
+def default_turns() -> list[GrillTurn]:
+    return [
+        turn("kind", "cevicherias"),
+        turn("place", "Lima, Peru"),
+        turn("count", "20", recommendation="20"),
+        turn("bar", "written up by someone other than the place itself"),
+        turn("cut", "no chains, no delivery-only"),
+        turn(
+            "angles",
+            "cevicherias open for decades\nvery cheap cevicherias people rate highly",
+            options=[
+                option(
+                    "cevicherias open for decades",
+                    recommended=True,
+                    group="heritage",
+                    shape="institution",
+                    role="broad",
+                ),
+                option(
+                    "very cheap cevicherias people rate highly",
+                    recommended=True,
+                    group="price",
+                    shape="cheap",
+                    role="broad",
+                ),
+                option(
+                    "nikkei cevicherias doing Japanese-Peruvian preparations",
+                    group="tradition",
+                    shape="crossed",
+                    role="distinctive",
+                ),
+            ],
+        ),
+    ]

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_cut_review.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_cut_review.py
@@ -282,3 +282,69 @@ def test_nobody_checked_and_nothing_was_barred_are_different(isolated_db):
     assert store.load_cut_review(order.run_id, order.revision) is None
     store.save_cut_review(order.run_id, order.revision, {})
     assert store.load_cut_review(order.run_id, order.revision) == {}
+
+
+def _two_rows_one_name():
+    """A pair the merge refused to join, because their districts disagreed."""
+    return [
+        {
+            "name": "Hanzo",
+            "district": "Miraflores",
+            "sightings": [{"evidence": "Nikkei restaurant"}],
+        },
+        {
+            "name": "Hanzo",
+            "district": "San Isidro",
+            "sightings": [{"evidence": "second location"}],
+        },
+    ]
+
+
+def test_two_verdicts_about_one_name_are_both_kept():
+    """Last-write-wins threw one away silently. Run 33fca394 has three such
+    pairs, and one came back barred for two different reasons."""
+    flags = cut_review.review_candidates(
+        _order(exclusions="no chains, and no places where ceviche is not primary"),
+        _two_rows_one_name(),
+        _reviewer(
+            {
+                "barred": [
+                    {
+                        "number": 1,
+                        "name": "Hanzo",
+                        "why": "A Nikkei restaurant.",
+                        "confidence": "arguable",
+                    },
+                    {
+                        "number": 2,
+                        "name": "Hanzo",
+                        "why": "It has a second location.",
+                        "confidence": "clear",
+                    },
+                ]
+            }
+        ),
+    )
+    assert "Nikkei" in flags["Hanzo"]["why"]
+    assert "second location" in flags["Hanzo"]["why"]
+    # The stronger of the two readings, so a `clear` is not softened by an
+    # `arguable` that happened to arrive after it.
+    assert flags["Hanzo"]["confidence"] == "clear"
+
+
+def test_the_same_reason_twice_is_not_said_twice():
+    flags = cut_review.review_candidates(
+        _order(),
+        _two_rows_one_name(),
+        _reviewer(
+            {
+                "barred": [
+                    {"number": 1, "name": "Hanzo", "why": "A Nikkei restaurant.",
+                     "confidence": "arguable"},
+                    {"number": 2, "name": "Hanzo", "why": "A Nikkei restaurant.",
+                     "confidence": "arguable"},
+                ]
+            }
+        ),
+    )
+    assert flags["Hanzo"]["why"] == "A Nikkei restaurant."

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_cut_review.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_cut_review.py
@@ -1,0 +1,284 @@
+"""Catching what the cut said to leave out, before and after paying for it.
+
+Run 33fca394 approved an angle reading "Nikkei cevicherias doing
+Japanese-Peruvian preparations" while its cut read "no places where ceviche is
+not the primary offering". Those two disagree. Nothing said so, the search ran,
+and 8 of its 10 places were barred by the same order that bought them -- one of
+seven paid searches, spent entirely on results already ruled out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline import cut_review, service, store
+from app.features.listicle_pipeline.contracts import SearchOrder, SelectedAngle
+from tests.listicle_test_support import agreed_state
+
+
+def _order(**overrides) -> SearchOrder:
+    defaults = dict(
+        run_id="run0001",
+        kind="cevicherias",
+        place="Lima",
+        exclusions="no places where ceviche is not the primary offering",
+        angles=[
+            SelectedAngle(angle_id="a1", text="cevicherias open for decades"),
+            SelectedAngle(
+                angle_id="a2",
+                text="Nikkei cevicherias doing Japanese-Peruvian preparations",
+            ),
+        ],
+    )
+    defaults.update(overrides)
+    return SearchOrder(**defaults)
+
+
+def _reviewer(payload, *, seen=None):
+    def review(job_id, prompt, tool_name, schema):
+        if seen is not None:
+            seen.append((job_id, prompt, tool_name))
+        return payload
+
+    return review
+
+
+# Before the money is spent
+
+
+def test_an_angle_that_fights_the_cut_is_named():
+    conflicts = cut_review.review_order(
+        _order(),
+        _reviewer(
+            {
+                "conflicts": [
+                    {
+                        "angle_id": "a2",
+                        "why": "Most Nikkei restaurants serve ceviche among many dishes.",
+                    }
+                ]
+            }
+        ),
+    )
+    assert [c.angle_id for c in conflicts] == ["a2"]
+    # Carries the wording so the screen can show it against the right line.
+    assert "Nikkei" in conflicts[0].angle_text
+
+
+def test_an_angle_id_nobody_offered_is_not_a_finding():
+    """A verdict about an angle this order does not have is not about this
+    order. Dropped rather than shown against a made-up line."""
+    conflicts = cut_review.review_order(
+        _order(),
+        _reviewer({"conflicts": [{"angle_id": "a99", "why": "invented"}]}),
+    )
+    assert conflicts == []
+
+
+def test_an_order_with_no_cut_does_not_spend_to_learn_that():
+    seen: list = []
+    assert cut_review.review_order(_order(exclusions=""), _reviewer({}, seen=seen)) == []
+    assert seen == [], "nothing to contradict, so nothing should have been asked"
+
+
+def test_an_order_with_no_angles_does_not_spend_either():
+    seen: list = []
+    assert cut_review.review_order(_order(angles=[]), _reviewer({}, seen=seen)) == []
+    assert seen == []
+
+
+# After they come back
+
+
+def _candidates():
+    return [
+        {
+            "name": "Maido",
+            "district": "Miraflores",
+            "sightings": [{"evidence": "top Nikkei restaurant, offers ceviche"}],
+        },
+        {
+            "name": "Canta Rana",
+            "district": "Barranco",
+            "sightings": [{"evidence": "cevicheria open since the 1980s"}],
+        },
+    ]
+
+
+def test_a_returned_place_that_breaks_the_cut_is_flagged():
+    flags = cut_review.review_candidates(
+        _order(),
+        _candidates(),
+        _reviewer(
+            {
+                "barred": [
+                    {
+                        "number": 1,
+                        "name": "Maido",
+                        "why": "A Nikkei restaurant where ceviche is one dish of many.",
+                        "confidence": "clear",
+                    }
+                ]
+            }
+        ),
+    )
+    assert set(flags) == {"Maido"}
+    assert flags["Maido"]["confidence"] == "clear"
+
+
+def test_the_evidence_the_searches_wrote_is_what_gets_judged():
+    """The whole reason this costs one call instead of forty: nothing is
+    looked up. "offers ceviche" is already on disk."""
+    seen: list = []
+    cut_review.review_candidates(_order(), _candidates(), _reviewer({}, seen=seen))
+    prompt = seen[0][1]
+    assert "offers ceviche" in prompt
+    assert "cevicheria open since the 1980s" in prompt
+    assert "no places where ceviche is not the primary offering" in prompt
+
+
+@pytest.mark.parametrize("value", ["", "maybe", "CLEARLY", "yes", "definite"])
+def test_a_confidence_nobody_recognises_is_read_as_arguable(value):
+    """The safe direction. `arguable` asks the operator to look; `clear` tells
+    them not to bother, and a wrong `clear` costs a place that belonged."""
+    flags = cut_review.review_candidates(
+        _order(),
+        _candidates(),
+        _reviewer(
+            {
+                "barred": [
+                    {"number": 1, "name": "Maido", "why": "because", "confidence": value}
+                ]
+            }
+        ),
+    )
+    assert flags["Maido"]["confidence"] == "arguable"
+
+
+def test_the_row_number_identifies_the_place_not_its_name():
+    """A real call answered "Chez Wong (La Victoria)" -- it had copied the line
+    back exactly as printed, district and all. Keying on the name dropped every
+    finding silently. The number cannot be mangled by formatting."""
+    flags = cut_review.review_candidates(
+        _order(),
+        _candidates(),
+        _reviewer(
+            {
+                "barred": [
+                    {
+                        "number": 1,
+                        "name": "Maido (Miraflores)",
+                        "why": "ceviche is one dish of many",
+                        "confidence": "clear",
+                    }
+                ]
+            }
+        ),
+    )
+    assert set(flags) == {"Maido"}
+
+
+def test_the_listing_is_numbered_so_the_answer_can_point_at_a_row():
+    seen: list = []
+    cut_review.review_candidates(_order(), _candidates(), _reviewer({}, seen=seen))
+    prompt = seen[0][1]
+    assert "1. Maido" in prompt
+    assert "2. Canta Rana" in prompt
+
+
+@pytest.mark.parametrize("number", [0, 3, 99, -1, None, "two"])
+def test_a_row_number_that_is_not_a_row_is_dropped(number):
+    flags = cut_review.review_candidates(
+        _order(),
+        _candidates(),
+        _reviewer(
+            {"barred": [{"number": number, "name": "Maido", "why": "x",
+                         "confidence": "clear"}]}
+        ),
+    )
+    assert flags == {}
+
+
+def test_a_number_naming_a_different_place_is_dropped_as_an_off_by_one():
+    """Acting on it would flag an innocent place while the real one goes
+    unflagged -- worse than losing the finding."""
+    flags = cut_review.review_candidates(
+        _order(),
+        _candidates(),
+        _reviewer(
+            {
+                "barred": [
+                    {
+                        "number": 2,
+                        "name": "Maido",
+                        "why": "ceviche is one dish of many",
+                        "confidence": "clear",
+                    }
+                ]
+            }
+        ),
+    )
+    assert flags == {}, "row 2 is Canta Rana, so this verdict is not trustworthy"
+
+
+# Where it runs, and where it must not
+
+
+def test_agreeing_checks_the_order_because_that_turn_already_spends(isolated_db):
+    state = agreed_state()
+    store.save(state)
+    order = service._ensure_order(
+        state,
+        _reviewer({"conflicts": [{"angle_id": "a1", "why": "it fights the cut"}]}),
+    )
+    assert order.conflicts_checked is True
+    assert [c.why for c in order.angle_conflicts] == ["it fights the cut"]
+
+
+def test_opening_the_order_never_spends(isolated_db):
+    """Reopening a run without buying anything is the point of addressing runs
+    by id. An unchecked order says so rather than reading as cleared."""
+    state = agreed_state()
+    store.save(state)
+    order = service.order(state.run_id)
+    assert order is not None
+    assert order.conflicts_checked is False
+    assert order.angle_conflicts == []
+
+
+def test_a_check_that_fails_is_not_a_clean_bill(isolated_db):
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("the model timed out")
+
+    state = agreed_state()
+    store.save(state)
+    order = service._ensure_order(state, explode)
+    assert order.conflicts_checked is False, "a failure must not read as checked"
+    assert order.angle_conflicts == []
+
+
+def test_changing_the_cut_retires_the_old_verdict(isolated_db):
+    state = agreed_state()
+    store.save(state)
+    service._ensure_order(
+        state, _reviewer({"conflicts": [{"angle_id": "a1", "why": "stale"}]})
+    )
+
+    revised = service.revise_order(
+        state.run_id, exclusions="no chains at all", review=None
+    )
+    # The old answer was about a different question. Cleared, and honestly
+    # marked unchecked rather than silently carried forward.
+    assert revised.angle_conflicts == []
+    assert revised.conflicts_checked is False
+
+
+def test_nobody_checked_and_nothing_was_barred_are_different(isolated_db):
+    state = agreed_state()
+    store.save(state)
+    service._ensure_order(state, None)
+    order = service.order(state.run_id)
+
+    assert store.load_cut_review(order.run_id, order.revision) is None
+    store.save_cut_review(order.run_id, order.revision, {})
+    assert store.load_cut_review(order.run_id, order.revision) == {}

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_cut_review.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_cut_review.py
@@ -348,3 +348,39 @@ def test_the_same_reason_twice_is_not_said_twice():
         ),
     )
     assert flags["Hanzo"]["why"] == "A Nikkei restaurant."
+
+
+def test_an_unmerged_twin_is_marked_so_it_does_not_read_as_a_chain():
+    """A real run flagged Chez Wong and El Verídico de Fidel as chains because
+    each appeared as two unmerged rows in different districts. Neither is a
+    chain: it is one place whose district two searches recorded differently."""
+    seen: list = []
+    cut_review.review_candidates(
+        _order(exclusions="no chains"),
+        [
+            {
+                "name": "Chez Wong",
+                "district": "Lince",
+                "possible_duplicates": ["Chez Wong"],
+                "sightings": [{"evidence": "best ceviche in the world"}],
+            },
+            {
+                "name": "Chez Wong",
+                "district": "La Victoria",
+                "possible_duplicates": ["Chez Wong"],
+                "sightings": [{"evidence": "awarded on numerous occasions"}],
+            },
+        ],
+        _reviewer({}, seen=seen),
+    )
+    prompt = seen[0][1]
+    assert prompt.count("may be the same place as another row here") == 2
+    # Phrases chosen to sit inside one line: the prompt is wrapped.
+    assert "record-keeping artefact" in prompt
+    assert "Do not call something a chain because it appears twice" in prompt
+
+
+def test_a_row_with_no_twin_is_not_marked():
+    seen: list = []
+    cut_review.review_candidates(_order(), _candidates(), _reviewer({}, seen=seen))
+    assert "may be the same place" not in seen[0][1]

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_end_to_end.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_end_to_end.py
@@ -1,0 +1,225 @@
+"""One run, all the way through, against the real application.
+
+Every other listicle test checks one seam. This one walks the path an operator
+walks -- type a title, answer six questions, look at the order, correct the
+count, run the searches, lose one to a timeout, reopen the page, retry the one
+that failed -- through the app FastAPI actually serves, with the model and the
+web replaced and nothing else.
+
+It exists because five of the six confirmed faults were invisible to seam
+tests. Each seam was doing its own job correctly; the run was broken between
+them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.features.listicle_pipeline.api as listicle_api
+from app.features.prompt2blog.grill_v4 import GrillDependencies
+
+
+class ScriptedLLM:
+    """A model that walks one interview and then agrees."""
+
+    SCRIPT = [
+        ("kind", "Cevicherias.", []),
+        ("place", "Lima, Peru — the city, not one district.", []),
+        ("count", "20", []),
+        ("bar", "Written up by someone other than the place itself.", []),
+        ("cut", "No chains, no delivery-only.", []),
+        (
+            "angles",
+            "cevicherias open for decades\nvery cheap cevicherias people rate highly",
+            [
+                {
+                    "text": "cevicherias open for decades",
+                    "recommended": True,
+                    "group": "heritage",
+                    "shape": "institution",
+                    "role": "broad",
+                },
+                {
+                    "text": "very cheap cevicherias people rate highly",
+                    "recommended": True,
+                    "group": "price",
+                    "shape": "cheap",
+                    "role": "broad",
+                },
+                {
+                    "text": "the cevicheria credited with starting Lima's ceviche boom",
+                    "recommended": False,
+                    "group": "heritage",
+                    "shape": "origin",
+                    "role": "specific",
+                },
+            ],
+        ),
+    ]
+
+    def __init__(self) -> None:
+        self.turn = 0
+        self.jobs: list[str] = []
+
+    def invoke_json(self, *, prompt, model_name, schema, **kwargs):
+        self.jobs.append(kwargs.get("job_id", ""))
+        if self.turn >= len(self.SCRIPT):
+            return (
+                {
+                    "done": True,
+                    "ask": "",
+                    "recommendation": "",
+                    "consensus": "Twenty cevicherias in Lima, two searches.",
+                    "markers_covered": ["kind", "place", "count", "bar", "cut", "angles"],
+                    "asks_about": "",
+                    "options": [],
+                },
+                "fake-model",
+            )
+        marker, recommendation, options = self.SCRIPT[self.turn]
+        covered = [m for m, _, _ in self.SCRIPT[: self.turn]]
+        self.turn += 1
+        return (
+            {
+                "done": False,
+                "ask": f"About {marker}?",
+                "recommendation": recommendation,
+                "consensus": "",
+                "markers_covered": covered,
+                "asks_about": marker,
+                "options": options,
+            },
+            "fake-model",
+        )
+
+
+@pytest.fixture
+def client(isolated_db, monkeypatch):
+    from app.main import app
+
+    llm = ScriptedLLM()
+    state = {"fail_cheap": True, "calls": []}
+
+    def fake_search(prompt: str):
+        state["calls"].append(prompt)
+        if "cheap" in prompt:
+            if state["fail_cheap"]:
+                raise TimeoutError("read timed out")
+            return "Al Toke Pez | Surquillo | six stools", ["https://y.test"], 7
+        return (
+            "1. Canta Rana | Barranco | open since the 1980s\n"
+            "2. Bodega 1900 | Barranco | counter since 1900\n",
+            ["https://x.test"],
+            9,
+        )
+
+    monkeypatch.setattr(listicle_api, "_search_call", fake_search)
+    monkeypatch.setattr(
+        listicle_api,
+        "_base_dependencies",
+        lambda: GrillDependencies(
+            llm=llm,
+            research=lambda prompt: ("Lima has hundreds of cevicherias.", [], 100),
+            job_id="listicle.grill",
+        ),
+    )
+    with TestClient(app) as test_client:
+        test_client.llm = llm  # type: ignore[attr-defined]
+        test_client.search_state = state  # type: ignore[attr-defined]
+        yield test_client
+
+
+BASE = "/api/listicle-pipeline"
+
+
+def test_one_run_from_a_typed_title_to_a_retried_search(client):
+    # 1. The title. The run gets an id, and the id is what everything after
+    #    this is addressed by.
+    started = client.post(f"{BASE}/grill/start", json={"seed": "The 40 best cevicherias in Lima"})
+    assert started.status_code == 200
+    run_id = started.json()["run_id"]
+    assert started.json()["pending"]["ask"]
+
+    # 2. Six answers. The count one is answered by agreeing, which carries no
+    #    number -- the fault that made a twenty-item list search for forty.
+    answers = [
+        "Cevicherias.",
+        "Lima, Peru — the city, not one district.",
+        "Yes, that's right.",
+        "Written up by someone other than the place itself.",
+        "No chains, no delivery-only.",
+    ]
+    for text in answers:
+        reply = client.post(f"{BASE}/grill/answer", json={"run_id": run_id, "answer": text})
+        assert reply.status_code == 200, reply.text
+
+    # The angle question is answered by choosing, and the choice is sent as
+    # records rather than as a paragraph.
+    options = reply.json()["pending"]["options"]
+    assert options and options[0]["shape"] == "institution"
+    agreed = client.post(
+        f"{BASE}/grill/answer",
+        json={
+            "run_id": run_id,
+            "answer": "cevicherias open for decades\nvery cheap cevicherias people rate highly",
+            "selections": [
+                {
+                    "text": option["text"],
+                    "angle_id": f"a{index + 1}",
+                    "shape_key": option["shape"],
+                    "group": option["group"],
+                    "role": option["role"],
+                    "edited": False,
+                }
+                for index, option in enumerate(options[:2])
+            ],
+        },
+    )
+    assert agreed.status_code == 200
+    assert agreed.json()["status"] == "agreed"
+
+    # Every interview turn reported itself as the listicle grill, not as
+    # Prompt2Blog.
+    assert set(client.llm.jobs) == {"listicle.grill"}
+
+    # 3. The order. Twenty, because that is what the acceptance agreed to --
+    #    the forty in the title was the number the interview talked them out of.
+    order = client.get(f"{BASE}/order/{run_id}").json()
+    assert order["target_count"] == 20
+    assert order["count_source"] == "accepted"
+    assert [a["shape_key"] for a in order["angles"]] == ["institution", "cheap"]
+
+    # 4. A correction. New revision; the number the searches use follows it.
+    revised = client.post(f"{BASE}/order/{run_id}", json={"target_count": 24}).json()
+    assert revised["revision"] == 2 and revised["target_count"] == 24
+
+    # 5. The searches. One of them times out.
+    found = client.post(f"{BASE}/search/{run_id}").json()
+    assert found["found"] == 2
+    # A numbered row keeps the year in the name.
+    assert {c["name"] for c in found["candidates"]} == {"Canta Rana", "Bodega 1900"}
+    states = {row["angle"]: row["state"] for row in found["angles"]}
+    assert states["very cheap cevicherias people rate highly"] == "failed"
+
+    # 6. Reopening the page. It reads; it does not search.
+    before = len(client.search_state["calls"])
+    reopened = client.get(f"{BASE}/search/{run_id}").json()
+    assert reopened["found"] == 2
+    assert len(client.search_state["calls"]) == before
+
+    # 7. Retrying the one that failed costs one search, and the two places the
+    #    working search found are still there.
+    client.search_state["fail_cheap"] = False
+    failed = [row["angle_id"] for row in found["angles"] if row["state"] == "failed"]
+    after = client.post(
+        f"{BASE}/search/{run_id}", json={"angle_ids": failed, "reuse": False}
+    ).json()
+    assert len(client.search_state["calls"]) == before + 1
+    assert {c["name"] for c in after["candidates"]} == {
+        "Canta Rana",
+        "Bodega 1900",
+        "Al Toke Pez",
+    }
+    assert after["complete"] is True
+    assert after["shortfall"] == 21

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_evaluation.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_evaluation.py
@@ -1,0 +1,92 @@
+"""The evaluation cases, checked as far as they can be checked for nothing.
+
+Half of every case is a property of the catalogue and the order: which shapes a
+commission is offered, whether its stated requirements reach every search,
+whether an order that cannot fill a list says so. None of that needs a model.
+
+The other half -- whether the angles find better places -- needs real searches
+and real money, and the plan is explicit that it must not be bought until
+identity handling and result recording are trustworthy. These tests do not
+pretend to answer it, and the assertion at the bottom of this file is there so
+nobody later reads a green suite as evidence that they did.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline.evaluation import CASES, REPORTED_OUTCOMES, CaseReport
+from app.features.listicle_pipeline.search import build_search_prompt, role_allowances
+from app.features.listicle_pipeline.shapes import shapes_for, subject_of
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.key)
+def test_the_commission_is_filed_under_the_subject_it_belongs_to(case):
+    assert subject_of(case.kind) == case.subject
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.key)
+def test_the_catalogue_offers_what_this_subject_needs(case):
+    offered = {shape.key for shape in shapes_for(case.subject)}
+    assert set(case.must_offer) <= offered
+    assert not set(case.must_not_offer) & offered
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.key)
+def test_every_stated_requirement_reaches_every_search(case):
+    """A requirement applies to every place however it was found. It is
+    composed into the prompt from the order, so an operator editing an angle
+    cannot drop it and one angle cannot be left carrying the commission."""
+    for shape in shapes_for(case.subject)[:3]:
+        prompt = build_search_prompt(
+            f"{case.kind} that are {shape.core}",
+            kind=case.kind,
+            place="Lima, Peru",
+            exclusions=case.exclusions,
+            standard=case.standard,
+            wanted=8,
+            role=shape.role,
+        )
+        for requirement in case.must_survive:
+            assert requirement in prompt
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda c: c.key)
+def test_every_case_says_what_a_person_has_to_judge(case):
+    """Written down before any paid run. Criteria chosen afterwards are
+    criteria chosen to flatter whichever result came back."""
+    assert case.judged_by
+
+
+def test_an_order_of_broad_angles_can_reach_a_long_list():
+    assert sum(role_allowances(30, ["broad"] * 5)) >= 30
+
+
+def test_an_order_of_narrow_angles_cannot_and_the_numbers_say_so():
+    assert sum(role_allowances(30, ["specific"] * 5)) < 30
+
+
+def test_an_unreported_outcome_reads_as_unreported_rather_than_as_zero():
+    report = CaseReport(case_key="broad-hotels")
+    report.outcomes["coverage"] = "22 distinct venues"
+    assert "spend" in report.unreported()
+    assert len(report.unreported()) == len(REPORTED_OUTCOMES) - 1
+
+
+def test_no_comparison_has_been_run():
+    """The one thing this file must not be mistaken for.
+
+    A green suite says the mechanics behave. It says nothing about whether the
+    revised angle strategy finds better places, and the plan's own adoption
+    rule requires reviewed cases and a bounded live comparison for that. When
+    the first comparison is run, its results go in `docs/audits/` and this test
+    is replaced by one that points at them.
+    """
+    from pathlib import Path
+
+    audits = Path(__file__).resolve().parents[3] / "docs" / "audits"
+    existing = list(audits.glob("listicle-angle-comparison-*")) if audits.exists() else []
+    assert not existing, (
+        "A comparison has been recorded. Replace this test with one that reads "
+        "it, rather than leaving a test that asserts nothing was measured."
+    )

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_grill_identity.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_grill_identity.py
@@ -1,0 +1,218 @@
+"""Which job the listicle interview reports itself as.
+
+`api._base_dependencies` has always set `job_id="listicle.grill"`. `service`
+then built a fresh `GrillDependencies` from three of its fields and took the
+default for the rest, so the identity was dropped one line after it was set.
+Two things followed: the usage dashboard billed listicle interviews to
+Prompt2Blog, and the model gateway answered for `p2b.grill` when someone
+changed the listicle grill's model on the dashboard.
+
+Both callers are tested here because the engine is shared, and a listicle fix
+that moves Prompt2Blog's job identity is a worse bug than the one being fixed.
+"""
+
+from __future__ import annotations
+
+from app.features.listicle_pipeline import service
+from app.features.prompt2blog.grill_v4 import GrillDependencies, start_grill
+from app.features.prompt2blog.contracts_v4 import MARKER_KEYS
+
+
+class RecordingLLM:
+    """A model that walks forward one marker at a time.
+
+    It has to move: the engine now refuses a question about a marker that is
+    already settled, so a stub that asks the same thing forever is retried once
+    and then accepted, and the job ids it records stop being one per turn.
+    """
+
+    ORDER = ("kind", "place", "count", "bar", "cut", "angles")
+
+    def __init__(self) -> None:
+        self.jobs: list[str] = []
+        self.turn = 0
+
+    def invoke_json(self, *, prompt, model_name, schema, **kwargs):
+        self.jobs.append(kwargs.get("job_id", ""))
+        marker = self.ORDER[min(self.turn, len(self.ORDER) - 1)]
+        covered = list(self.ORDER[: self.turn])
+        self.turn += 1
+        return (
+            {
+                "done": False,
+                "ask": f"What about {marker}?",
+                "recommendation": "20",
+                "consensus": "",
+                "markers_covered": covered,
+                "asks_about": marker,
+                "options": [],
+            },
+            "fake-model",
+        )
+
+
+def _dependencies(llm, job_id):
+    return GrillDependencies(
+        llm=llm,
+        research=lambda prompt: ("", [], None),
+        job_id=job_id,
+    )
+
+
+def test_the_listicle_grill_reports_itself_as_the_listicle_grill(isolated_db):
+    llm = RecordingLLM()
+    state = service.start(
+        "The 20 best cevicherias in Lima", _dependencies(llm, "listicle.grill")
+    )
+    assert llm.jobs == ["listicle.grill"]
+
+    service.answer(state.run_id, "20", _dependencies(llm, "listicle.grill"))
+    assert llm.jobs == ["listicle.grill", "listicle.grill"]
+
+
+def test_prompt2blog_keeps_its_own_job_identity(isolated_db):
+    """The engine is shared. A listicle fix that moved this would be a worse
+    bug than the one it fixed."""
+    llm = RecordingLLM()
+    start_grill(
+        run_id="p2b-1",
+        seed="A guide to Lima's markets",
+        dependencies=_dependencies(llm, "p2b.grill"),
+        marker_keys=MARKER_KEYS,
+    )
+    assert llm.jobs == ["p2b.grill"]
+
+
+def test_the_default_is_still_prompt2blogs(isolated_db):
+    llm = RecordingLLM()
+    start_grill(
+        run_id="p2b-2",
+        seed="A guide to Lima's markets",
+        dependencies=GrillDependencies(
+            llm=llm, research=lambda prompt: ("", [], None)
+        ),
+        marker_keys=MARKER_KEYS,
+    )
+    assert llm.jobs == ["p2b.grill"]
+
+
+def test_no_usage_is_reported_by_these_tests(monkeypatch):
+    """Named rather than assumed. Three invented rows reached the real usage
+    dashboard once, and the fix was a fixture nobody can see from here."""
+    import os
+
+    assert not os.getenv("USAGE_MONITOR_URL")
+
+
+class RepeatingLLM:
+    """A model that asks about a marker it has already settled.
+
+    Exactly what a live run did twice in six turns on 2026-09-08: it settled
+    the exclusions, then asked "what else should be excluded?"; it settled the
+    angles, then asked for them again with every marker covered.
+    """
+
+    def __init__(self, *, repeats: int) -> None:
+        self.repeats = repeats
+        self.calls = 0
+
+    def invoke_json(self, *, prompt, model_name, schema, **kwargs):
+        self.calls += 1
+        if self.calls <= self.repeats:
+            # `cut` is settled and `angles` is not, so this question buys
+            # nothing.
+            return (
+                {
+                    "done": False,
+                    "ask": "Anything else you would like to exclude?",
+                    "recommendation": "No hotel restaurants.",
+                    "consensus": "",
+                    "markers_covered": ["kind", "place", "count", "bar", "cut"],
+                    "asks_about": "cut",
+                    "options": [],
+                },
+                "fake-model",
+            )
+        return (
+            {
+                "done": False,
+                "ask": "Which angles should the list be built from?",
+                "recommendation": "cevicherias open for decades",
+                "consensus": "",
+                "markers_covered": ["kind", "place", "count", "bar", "cut"],
+                "asks_about": "angles",
+                "options": [],
+            },
+            "fake-model",
+        )
+
+
+def test_a_question_about_a_settled_marker_is_retried_not_shown(isolated_db):
+    """A repeat costs an operator a turn to learn nothing -- and because a
+    marker is read from the LAST turn that settled it, answering the repeat
+    plainly replaces the earlier answer. The live run's second `cut` question
+    would have reduced four exclusions to one."""
+    llm = RepeatingLLM(repeats=1)
+    state = service.start("The 40 best cevicherias in Lima", _dependencies(llm, "listicle.grill"))
+    assert llm.calls == 2
+    assert state.pending is not None
+    assert state.pending.asks_about == "angles"
+
+
+def test_a_grill_that_repeats_itself_twice_is_shown_rather_than_killed(isolated_db):
+    """One wasted turn is much better than an interview the operator cannot
+    get past."""
+    llm = RepeatingLLM(repeats=99)
+    state = service.start("The 40 best cevicherias in Lima", _dependencies(llm, "listicle.grill"))
+    assert llm.calls == 2
+    assert state.status == "asking"
+    assert state.pending is not None
+    assert state.pending.asks_about == "cut"
+
+
+class DoneWithoutConsensusLLM:
+    """Claims done, says nothing, then writes the playback when asked again.
+
+    A different fault from a repeat, and the remedy is the opposite: asking
+    again is what recovers it, so the repeat guard must not eat the recovery.
+    """
+
+    MARKERS = ["kind", "place", "count", "bar", "cut", "angles"]
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def invoke_json(self, *, prompt, model_name, schema, **kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return (
+                {
+                    "done": True,
+                    "ask": "",
+                    "recommendation": "",
+                    "consensus": "",
+                    "markers_covered": self.MARKERS,
+                    "asks_about": "",
+                    "options": [],
+                },
+                "fake-model",
+            )
+        return (
+            {
+                "done": True,
+                "ask": "",
+                "recommendation": "",
+                "consensus": "Forty cevicherias in Lima.",
+                "markers_covered": self.MARKERS,
+                "asks_about": "",
+                "options": [],
+            },
+            "fake-model",
+        )
+
+
+def test_claiming_done_with_no_playback_is_still_allowed_to_ask_again(isolated_db):
+    llm = DoneWithoutConsensusLLM()
+    state = service.start("The 40 best cevicherias in Lima", _dependencies(llm, "listicle.grill"))
+    assert state.status == "agreed"
+    assert state.consensus == "Forty cevicherias in Lima."

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_order.py
@@ -274,3 +274,116 @@ def test_the_summary_reads_as_a_sentence_rather_than_a_doubled_headline():
     )
     summary = spec.summary_of(spec.build_search_order(state))
     assert summary.startswith("40 cevicherias in Lima.")
+
+
+# A marker answered twice
+#
+# Until 2026-09-08 a marker's value was read from the LAST turn that settled
+# it. Correct for a correction, silently destructive for the additive
+# follow-up the grill actually asks: run 292e71e3 settled the cut, then asked
+# "are there any other types of establishments ... you would like to exclude?"
+# and recommended "No hotel restaurants." Answering that plainly would have
+# left one rule out of four and searched under a quarter of the exclusions,
+# on a run that looked entirely normal.
+
+
+def _twice_about(marker: str, first: str, second: str):
+    turns = [t for t in default_turns() if t.question.asks_about != marker]
+    turns.append(turn(marker, first))
+    turns.append(turn(marker, second))
+    return agreed_state(turns=turns)
+
+
+def test_an_additive_follow_up_keeps_the_first_answer():
+    """The real failure, in the shape it really had."""
+    state = _twice_about(
+        "cut",
+        "No chains, no delivery-only kitchens, and no places where ceviche is "
+        "not the primary offering.",
+        "No hotel restaurants.",
+    )
+    decision = spec.resolve_answer(state, "cut")
+    assert decision.source == "combined"
+    for rule in ("chains", "delivery-only", "primary offering", "hotel restaurants"):
+        assert rule in decision.text
+
+
+def test_retyping_the_whole_list_does_not_store_it_twice():
+    """What the operator on 2026-09-08 actually did, having read the code.
+    The later answer says everything the earlier one said, so it stands
+    alone."""
+    state = _twice_about(
+        "cut",
+        "No chains, no delivery-only kitchens, and no places where ceviche is "
+        "not the primary offering.",
+        "No chains, no delivery-only kitchens, no places where ceviche is not "
+        "the primary offering, and no hotel restaurants.",
+    )
+    decision = spec.resolve_answer(state, "cut")
+    assert decision.source == "restated"
+    assert decision.text.count("chains") == 1
+    assert "hotel restaurants" in decision.text
+
+
+def test_a_partly_restated_answer_keeps_both_rather_than_guessing():
+    """Three rules restated and a fourth gone is ambiguous: dropped on
+    purpose, or forgotten. Both are kept, because over-restricting a search is
+    visible on the results and under-restricting it is not."""
+    state = _twice_about(
+        "cut", "no chains, no delivery-only kitchens", "no chains, no hotel bars"
+    )
+    decision = spec.resolve_answer(state, "cut")
+    assert decision.source == "combined"
+    assert "delivery-only" in decision.text
+
+
+def test_a_second_answer_about_the_bar_is_added_not_swapped_in():
+    state = _twice_about(
+        "bar", "written up by someone other than the place itself", "open on Sundays"
+    )
+    decision = spec.resolve_answer(state, "bar")
+    assert decision.source == "combined"
+    assert "written up" in decision.text and "Sundays" in decision.text
+
+
+def test_the_angles_are_replaced_because_the_picker_sends_the_whole_selection():
+    """Un-ticking a box is already an explicit replace. Accumulating here
+    would put back the angle the operator just dropped, and every angle is a
+    paid search."""
+    state = _twice_about("angles", "cevicherias open for decades", "nikkei cevicherias")
+    decision = spec.resolve_answer(state, "angles")
+    assert decision.source == "replaced"
+    assert decision.text == "nikkei cevicherias"
+    assert spec.angle_lines(state) == ["nikkei cevicherias"]
+
+
+def test_a_second_noun_replaces_the_first():
+    state = _twice_about("kind", "cevicherias", "seafood restaurants")
+    assert spec.kind_from(state) == "seafood restaurants"
+
+
+def test_a_marker_answered_once_says_nothing_about_being_answered_twice():
+    """The normal interview. Both real runs of 2026-09-08 produce no notes,
+    which is how this fix stays invisible when nothing repeated."""
+    order = spec.build_search_order(agreed_state())
+    assert order.answer_notes == []
+
+
+def test_a_combined_answer_reaches_the_order_and_says_so():
+    state = _twice_about(
+        "cut", "no chains, no delivery-only kitchens", "no hotel restaurants"
+    )
+    order = spec.build_search_order(state)
+    assert "chains" in order.exclusions and "hotel restaurants" in order.exclusions
+    assert any(note.startswith("What is left out:") for note in order.answer_notes)
+    # The operator reads this on a headless run, where there is no screen.
+    assert "What is left out:" in spec.summary_of(order)
+
+
+def test_correcting_a_combined_answer_clears_the_question_it_asked():
+    notes = [
+        "What is left out: This was answered twice and every answer is being used.",
+        "What earns a place: This was answered twice and every answer is being used.",
+    ]
+    remaining = spec.drop_note_for(notes, "cut")
+    assert remaining == [notes[1]]

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_order.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_order.py
@@ -1,0 +1,276 @@
+"""The agreement, and the number it was actually agreed on.
+
+The first real run displayed a search order for twenty items and searched for
+forty. Nothing was broken in the searching; the count was read back out of a
+sentence and the sentence contained both numbers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline import spec
+from app.features.listicle_pipeline.search import SPECIFIC, role_allowances
+from tests.listicle_test_support import agreed_state, default_turns, option, turn
+
+
+def _state_with_count(answer: str, *, recommendation: str = "20", seed: str | None = None):
+    turns = [t for t in default_turns() if t.question.asks_about != "count"]
+    turns.insert(2, turn("count", answer, recommendation=recommendation))
+    return agreed_state(
+        seed=seed or "The 40 best cevicherias in Lima", turns=turns
+    )
+
+
+def test_a_correction_is_read_as_the_correction():
+    """"20, not 40" used to resolve to 40, because the old reader took the
+    largest plausible number it could see."""
+    assert spec.resolve_count(_state_with_count("20, not 40")).value == 20
+
+
+def test_a_correction_written_the_other_way_round_reads_the_same():
+    assert spec.resolve_count(_state_with_count("not 40, 20")).value == 20
+
+
+def test_agreeing_without_saying_a_number_takes_the_number_proposed():
+    """"Yes, that's right" is a perfectly good answer to "is 20 the number?"
+    and carries no number at all. The old reader fell back to the seed, which
+    is where the number the interview had just argued them out of was."""
+    decision = spec.resolve_count(
+        _state_with_count("Yes, that's right", recommendation="20")
+    )
+    assert decision.value == 20
+    assert decision.source == "accepted"
+
+
+def test_accepting_the_draft_untouched_is_still_an_acceptance():
+    decision = spec.resolve_count(_state_with_count("20", recommendation="20"))
+    assert decision.value == 20
+
+
+def test_a_price_or_a_year_is_not_a_list_length():
+    decision = spec.resolve_count(
+        _state_with_count("Keep it to 20; nothing over 150 soles a head.")
+    )
+    assert decision.value == 20
+
+
+def test_an_ambiguous_answer_is_used_and_flagged_rather_than_guessed_at():
+    """A run that cannot proceed helps nobody, and a number chosen silently
+    from an ambiguous sentence is the fault this record exists to fix. It picks
+    the conservative reading and says it is unsure."""
+    decision = spec.resolve_count(_state_with_count("somewhere between 20 and 40"))
+    assert decision.value == 20
+    assert decision.ambiguous is True
+    assert "20" in decision.note and "40" in decision.note
+
+
+def test_the_summary_and_the_execution_read_the_same_number():
+    order = spec.build_search_order(_state_with_count("20, not 40"))
+    assert order.target_count == 20
+    assert "20 cevicherias" in spec.summary_of(order)
+
+
+def test_an_operator_correction_overrides_the_reading():
+    order = spec.build_search_order(
+        _state_with_count("somewhere between 20 and 40"), target_count=25
+    )
+    assert order.target_count == 25
+    assert order.count_ambiguous is False
+
+
+def test_each_angle_keeps_its_identity_and_its_shape():
+    order = spec.build_search_order(agreed_state())
+    assert [a.text for a in order.angles] == [
+        "cevicherias open for decades",
+        "very cheap cevicherias people rate highly",
+    ]
+    assert [a.shape_key for a in order.angles] == ["institution", "cheap"]
+    assert all(a.edited is False for a in order.angles)
+    assert len({a.angle_id for a in order.angles}) == 2
+
+
+def test_the_screens_own_record_of_what_was_chosen_wins():
+    """The picker knows which menu entry a line came from and whether the
+    operator changed it. Inferring that back out of the finished sentence is
+    guesswork, and this record is what stops the pipeline doing it."""
+    state = agreed_state()
+    order = spec.build_search_order(
+        state,
+        selections=[
+            {
+                "text": "cevicherias open for decades",
+                "angle_id": "picked-1",
+                "shape_key": "institution",
+                "group": "heritage",
+                "role": "broad",
+                "edited": False,
+            },
+            {
+                "text": "very cheap cevicherias people rate highly",
+                "angle_id": "picked-2",
+                "shape_key": "cheap",
+                "group": "price",
+                "role": "broad",
+                "edited": True,
+            },
+        ],
+    )
+    assert [a.angle_id for a in order.angles] == ["picked-1", "picked-2"]
+    assert order.angles[1].edited is True
+
+
+def test_an_edited_line_is_marked_as_edited_even_without_the_screens_record():
+    """An interview answered as plain text still has to say that a line no
+    longer matches the menu entry it came from -- the shape's opinion about
+    what this angle overlaps with is no longer known to be true."""
+    turns = [t for t in default_turns() if t.question.asks_about != "angles"]
+    turns.append(
+        turn(
+            "angles",
+            "cevicherias open for decades that are also famous",
+            options=[
+                option(
+                    "cevicherias open for decades",
+                    recommended=True,
+                    group="heritage",
+                    shape="institution",
+                )
+            ],
+        )
+    )
+    order = spec.build_search_order(agreed_state(turns=turns))
+    assert order.angles[0].edited is True
+    # The lineage is kept -- it is worth knowing where the line came from --
+    # and `edited` is what stops anything treating the shape's group as still
+    # describing it.
+    assert order.angles[0].shape_key == "institution"
+
+
+def test_an_angle_nobody_offered_is_recorded_as_the_operators_own():
+    turns = [t for t in default_turns() if t.question.asks_about != "angles"]
+    turns.append(
+        turn(
+            "angles",
+            "cevicherias beside the Chorrillos fishing landing",
+            options=[option("cevicherias open for decades", recommended=True)],
+        )
+    )
+    order = spec.build_search_order(agreed_state(turns=turns))
+    assert order.angles[0].custom is True
+    assert order.angles[0].shape_key == ""
+
+
+def test_numbering_in_a_typed_answer_does_not_eat_a_year():
+    """The same bounded-marker rule the search parser needed. "1. Bodega 1915"
+    loses the marker and keeps the year."""
+    turns = [t for t in default_turns() if t.question.asks_about != "angles"]
+    turns.append(turn("angles", "1. bars open since 1915\n2. rooftop bars"))
+    order = spec.build_search_order(agreed_state(turns=turns))
+    assert order.angles[0].text == "bars open since 1915"
+
+
+def test_a_narrow_angle_is_not_asked_for_a_broad_angles_number():
+    """"The place credited with inventing the dish" cannot supply twelve, and
+    asking it for twelve is asking it to invent eleven."""
+    broad, specific = role_allowances(40, ["broad", SPECIFIC])
+    assert specific < broad
+    assert specific <= 5
+
+
+def test_an_order_of_narrow_angles_says_it_may_not_fill_the_list():
+    """Said, not fixed. Adding a search the operator did not approve is the
+    behaviour this pipeline exists to avoid."""
+    turns = [t for t in default_turns() if t.question.asks_about != "angles"]
+    turns.append(
+        turn(
+            "angles",
+            "the cevicheria credited with starting the boom",
+            options=[
+                option(
+                    "the cevicheria credited with starting the boom",
+                    recommended=True,
+                    shape="origin",
+                )
+            ],
+        )
+    )
+    order = spec.build_search_order(agreed_state(turns=turns))
+    assert order.angles[0].role == SPECIFIC
+    assert spec.planned_capacity(order) < order.target_count
+
+
+@pytest.mark.parametrize("marker", ["kind", "place", "bar", "cut"])
+def test_every_agreed_field_reaches_the_order(marker):
+    order = spec.build_search_order(agreed_state())
+    assert getattr(
+        order,
+        {"kind": "kind", "place": "place", "bar": "standard", "cut": "exclusions"}[
+            marker
+        ],
+    )
+
+
+# --- what the first real run (292e71e3, 2026-09-08) exposed -----------------
+
+
+@pytest.mark.parametrize(
+    "seed, kind",
+    [
+        ("The 40 best cevicherias in Lima", "cevicherias"),
+        ("Top 20 rooftop bars in Lima", "rooftop bars"),
+        ("The best 15 pizzerias in Naples", "pizzerias"),
+        ("20 independent hotels in Lima suitable for longer stays", "independent hotels"),
+        ("Best cevicherias of Lima", "cevicherias"),
+        # Nothing to strip, and nothing stripped.
+        ("cevicherias", "cevicherias"),
+        # Reduces to nothing, so it keeps what it had: a wrong noun beats none.
+        ("The 40 best", "The 40 best"),
+    ],
+)
+def test_a_headline_is_reduced_to_the_noun_that_gets_searched(seed, kind):
+    """The interview is told not to spend a turn confirming a word the operator
+    already typed, so `kind` is usually covered without a turn -- and the
+    fallback was the whole seed. A real run reached the search step about to
+    ask the web for "The 40 best cevicherias in Lima in Lima", putting the SEO
+    phrase the interview must never treat as a criterion into all seven paid
+    searches."""
+    assert spec.searchable_kind(seed) == kind
+
+
+def test_a_marker_covered_without_a_turn_still_yields_a_searchable_noun():
+    """The real run's shape exactly: the interview settled kind, place and
+    count off the title without spending a turn on any of them."""
+    state = agreed_state(
+        seed="The 40 best cevicherias in Lima",
+        turns=[
+            t
+            for t in default_turns()
+            if t.question.asks_about not in {"kind", "place", "count"}
+        ],
+    )
+    order = spec.build_search_order(state)
+    assert order.kind == "cevicherias"
+    assert "best" not in order.kind
+    assert order.target_count == 40
+
+
+def test_the_place_falls_back_to_the_location_not_the_whole_headline():
+    turns = [
+        t for t in default_turns() if t.question.asks_about not in {"kind", "place"}
+    ]
+    state = agreed_state(seed="The 40 best cevicherias in Lima", turns=turns)
+    assert spec.place_from(state) == "Lima"
+
+
+def test_the_summary_reads_as_a_sentence_rather_than_a_doubled_headline():
+    state = agreed_state(
+        seed="The 40 best cevicherias in Lima",
+        turns=[
+            t
+            for t in default_turns()
+            if t.question.asks_about not in {"kind", "place", "count"}
+        ],
+    )
+    summary = spec.summary_of(spec.build_search_order(state))
+    assert summary.startswith("40 cevicherias in Lima.")

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_prompt.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_prompt.py
@@ -1,0 +1,135 @@
+"""What the interview is told, and when.
+
+Two of the plan's changes are only visible in the prompt: the requirements are
+named as requirements before any menu is written, and the catalogue is the
+subject's rather than the restaurant one shown to everything.
+"""
+
+from __future__ import annotations
+
+from app.features.listicle_pipeline.prompts import build_listicle_turn_prompt
+from app.features.prompt2blog.contracts_v4 import GrillQuestion, GrillState
+from app.features.listicle_pipeline.contracts import LISTICLE_MARKER_KEYS
+from tests.listicle_test_support import turn
+
+
+def _asking(seed: str, covered: list[str], turns=None) -> GrillState:
+    return GrillState(
+        run_id="prompt-1",
+        seed=seed,
+        status="asking",
+        markers_covered=covered,
+        marker_keys=LISTICLE_MARKER_KEYS,
+        turns=turns or [],
+        pending=GrillQuestion(
+            question_id="q1", topic="next", ask="What next?", recommendation="-"
+        ),
+    )
+
+
+def test_a_hotel_commission_is_not_shown_the_restaurant_catalogue():
+    state = _asking(
+        "20 independent hotels in Lima for longer stays",
+        ["kind", "place", "count"],
+        [turn("kind", "hotels"), turn("count", "20", recommendation="20")],
+    )
+    prompt = build_listicle_turn_prompt(state)
+    assert "lodging-format" in prompt
+    assert "long-stay" in prompt
+    # The two that were being offered to hotels, and are about food.
+    assert "regional-tradition" not in prompt
+    assert "informal --" not in prompt
+
+
+def test_a_bar_commission_gets_the_bar_dimensions():
+    state = _asking(
+        "The 15 best rooftop bars in Lima",
+        ["kind", "place", "count"],
+        [turn("kind", "rooftop bars"), turn("count", "15", recommendation="15")],
+    )
+    prompt = build_listicle_turn_prompt(state)
+    assert "drink-specialty" in prompt
+    assert "local-drinking" in prompt
+
+
+def test_the_full_catalogue_waits_until_the_count_is_settled():
+    """The turn that can act on it is the first turn after `count`, and the
+    prompt already refuses to ask about angles before then. Three hundred lines
+    of wording rules it is forbidden to use is input paid for and unread."""
+    early = build_listicle_turn_prompt(
+        _asking("20 rooftop bars in Lima", ["kind"], [turn("kind", "bars")])
+    )
+    assert "in outline" in early
+    assert "write:" not in early
+
+    late = build_listicle_turn_prompt(
+        _asking(
+            "20 rooftop bars in Lima",
+            ["kind", "place", "count"],
+            [turn("kind", "bars"), turn("count", "20", recommendation="20")],
+        )
+    )
+    assert "write:" in late
+    assert len(late) > len(early)
+
+
+def test_the_requirements_are_named_as_requirements_rather_than_angles():
+    prompt = build_listicle_turn_prompt(_asking("Rooftop bars in Lima", []))
+    assert "REQUIREMENT" in prompt
+    assert "never demote one into an optional angle" in prompt
+
+
+def test_an_angle_has_to_add_a_route_rather_than_restate_the_commission():
+    prompt = build_listicle_turn_prompt(
+        _asking(
+            "Rooftop bars in Lima",
+            ["kind", "place", "count"],
+            [turn("kind", "bars"), turn("count", "20", recommendation="20")],
+        )
+    )
+    assert "distinct ROUTE" in prompt
+    assert "not a restatement of the commission" in prompt
+
+
+def test_the_angle_arithmetic_is_not_written_out_twice():
+    """It lived in the prompt as prose and in `shapes` as code, and the two
+    came to disagree. The prose is gone and the number is interpolated."""
+    prompt = build_listicle_turn_prompt(
+        _asking(
+            "40 cevicherias in Lima",
+            ["kind", "place", "count"],
+            [turn("kind", "cevicherias"), turn("count", "40", recommendation="40")],
+        )
+    )
+    assert "about 40 items wants 6 angles" not in prompt
+    assert "recommend about 6" in prompt
+
+
+def test_overlap_is_offered_as_a_warning_not_a_prohibition():
+    prompt = build_listicle_turn_prompt(
+        _asking(
+            "20 cevicherias in Lima",
+            ["kind", "place", "count"],
+            [turn("kind", "cevicherias"), turn("count", "20", recommendation="20")],
+        )
+    )
+    assert "a warning, not a rule" in prompt
+    assert "NEVER CHOOSE TWO SHAPES FROM THE SAME GROUP" not in prompt
+
+
+def test_the_options_are_asked_for_with_their_shape_and_role():
+    prompt = build_listicle_turn_prompt(
+        _asking(
+            "20 cevicherias in Lima",
+            ["kind", "place", "count"],
+            [turn("kind", "cevicherias"), turn("count", "20", recommendation="20")],
+        )
+    )
+    assert "{text, recommended, group, shape, role}" in prompt
+
+
+def test_the_count_question_is_told_to_put_a_number_in_its_recommendation():
+    """Because "yes" is the most common answer to it, and the number the
+    acceptance agrees to has to be readable from what was proposed."""
+    prompt = build_listicle_turn_prompt(_asking("The best cevicherias in Lima", []))
+    assert "plain number" in prompt

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_recovery.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_recovery.py
@@ -378,3 +378,135 @@ def test_a_legacy_result_on_a_run_with_no_order_is_still_read_safely(isolated_db
     assert view["legacy"] is True
     assert view["target"] == 12
     assert view["candidates"][0]["sightings"] == []
+
+
+# What an angle bought, kept after the run that bought it
+#
+# Contribution -- how many places a search returned and how many of them
+# nothing else found -- was computed when the results screen was drawn and
+# thrown away with it. In run 33fca394 the `purist` angle returned ten rows for
+# one exclusive place and `hours` returned six for none: roughly two of seven
+# searches bought nothing, nothing noticed, and the numbers only existed after
+# the money was spent.
+
+
+def test_contribution_is_written_onto_the_attempt(run):
+    payload = service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s\nEl Mercado | Miraflores | a classic",
+            cheap="Canta Rana | Barranco | cheap and good",
+        ),
+    )
+    assert payload["found"] == 2
+
+    stored = {a.angle_id: a for a in store.load_attempts(run.run_id)}
+    decades = next(a for a in stored.values() if "decades" in a.angle_text)
+    cheap = next(a for a in stored.values() if "cheap" in a.angle_text)
+
+    assert decades.contribution_recorded and cheap.contribution_recorded
+    # `decades` found both; only El Mercado was its alone.
+    assert (decades.found, decades.shared, decades.exclusive) == (2, 1, 1)
+    # `cheap` found one place, and the other search found it too.
+    assert (cheap.found, cheap.shared, cheap.exclusive) == (1, 1, 0)
+
+
+def test_a_search_that_bought_nothing_exclusive_is_named(run):
+    payload = service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap="Canta Rana | Barranco | cheap and good",
+        ),
+    )
+    # Both found the same one place, so neither found anything the other
+    # missed. Said, rather than left to be worked out from a table.
+    assert len(payload["empty_handed"]) == 2
+
+
+def test_retrying_one_angle_rewrites_what_the_others_contributed(run):
+    """Contribution is a fact about the pool, so it cannot be frozen when a
+    search lands. Retrying one angle changes what every other angle turns out
+    to have contributed."""
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap=TimeoutError("read timed out"),
+        ),
+    )
+    before = next(
+        a for a in store.load_attempts(run.run_id) if "decades" in a.angle_text
+    )
+    assert before.exclusive == 1
+
+    order = store.load_order(run.run_id)
+    cheap_id = next(a.angle_id for a in order.angles if "cheap" in a.text)
+    service.search(
+        run.run_id,
+        _replies(cheap="Canta Rana | Barranco | cheap and good"),
+        only=[cheap_id],
+        reuse=False,
+    )
+
+    after = next(
+        a for a in store.load_attempts(run.run_id) if "decades" in a.angle_text
+    )
+    assert after.exclusive == 0, "the retry found the same place, so nothing is exclusive"
+
+
+def test_what_an_angle_bought_last_time_is_readable_before_paying_again(run):
+    from app.features.listicle_pipeline import runner
+
+    service.search(
+        run.run_id,
+        _replies(
+            decades=(
+                "Canta Rana | Barranco | open since the 1980s\n"
+                "El Mercado | Miraflores | a classic"
+            ),
+            cheap="Canta Rana | Barranco | cheap and good",
+        ),
+    )
+
+    # A second run about the same subject. The wording the model writes differs
+    # every time, so the shape is what identifies the search across runs.
+    second = agreed_state(run_id="run0002")
+    store.save(second)
+    order = service.order("run0002")
+    notes = runner.prior_contribution(order)
+
+    cheap_id = next(a.angle_id for a in order.angles if "cheap" in a.text)
+    assert "no place the other searches missed" in notes[cheap_id]
+    decades_id = next(a.angle_id for a in order.angles if "decades" in a.text)
+    assert "1 place nothing else found" in notes[decades_id]
+
+
+def test_a_different_subject_is_not_told_about_this_ones_history(run):
+    """What the `cheap` shape does for cevicherias in Lima says nothing about
+    what it does for bookshops in Buenos Aires."""
+    from app.features.listicle_pipeline import runner
+    from tests.listicle_test_support import default_turns, turn
+
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap="Canta Rana | Barranco | cheap and good",
+        ),
+    )
+
+    turns = [t for t in default_turns() if t.question.asks_about != "place"]
+    turns.insert(1, turn("place", "Buenos Aires, Argentina"))
+    elsewhere = agreed_state(run_id="run0003", turns=turns)
+    store.save(elsewhere)
+
+    assert runner.prior_contribution(service.order("run0003")) == {}
+
+
+def test_a_first_run_about_a_subject_is_told_nothing(isolated_db):
+    from app.features.listicle_pipeline import runner
+
+    state = agreed_state()
+    store.save(state)
+    assert runner.prior_contribution(service.order(state.run_id)) == {}

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_recovery.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_recovery.py
@@ -1,0 +1,380 @@
+"""Searching once, and recovering precisely from the half that failed.
+
+The version this replaced ran six searches inside one request and stored what
+came back as one blob. A failure on the sixth threw away the five that had
+worked, a reload could not tell "not run yet" from "not read yet", and a re-run
+replaced the last good version before the new one had finished.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline import service, store
+from tests.listicle_test_support import agreed_state
+
+
+@pytest.fixture
+def run(isolated_db):
+    state = agreed_state()
+    store.save(state)
+    return state
+
+
+def _replies(**by_marker):
+    """A research stub keyed on a word only one angle's prompt contains."""
+
+    def research(prompt: str):
+        for token, reply in by_marker.items():
+            if token in prompt:
+                if isinstance(reply, Exception):
+                    raise reply
+                return reply, ["https://example.test"], 10
+        raise AssertionError(f"unexpected prompt: {prompt[:120]}")
+
+    return research
+
+
+def test_a_failure_on_one_angle_keeps_every_other_angles_work(run):
+    research = _replies(
+        decades="Canta Rana | Barranco | open since the 1980s",
+        cheap=TimeoutError("read timed out"),
+    )
+    payload = service.search(run.run_id, research)
+
+    states = {row["angle"]: row["state"] for row in payload["angles"]}
+    assert states["cevicherias open for decades"] == "completed"
+    assert states["very cheap cevicherias people rate highly"] == "failed"
+    assert [c["name"] for c in payload["candidates"]] == ["Canta Rana"]
+
+
+def test_retrying_one_angle_runs_only_that_angle(run):
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap=TimeoutError("read timed out"),
+        ),
+    )
+
+    asked: list[str] = []
+
+    def research(prompt: str):
+        asked.append(prompt)
+        return "Al Toke Pez | Surquillo | counter", [], 5
+
+    order = service.order(run.run_id)
+    failed = [a.angle_id for a in order.angles if "cheap" in a.text]
+    payload = service.search(run.run_id, research, only=failed)
+
+    assert len(asked) == 1
+    assert "cheap" in asked[0]
+    # And the angle that already worked is still there, not re-run and not
+    # thrown away.
+    assert {c["name"] for c in payload["candidates"]} == {"Canta Rana", "Al Toke Pez"}
+
+
+def test_reopening_a_run_reads_the_results_rather_than_searching_again(run):
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+    again = service.progress(run.run_id)
+    assert again["found"] == 2
+    assert again["complete"] is True
+
+
+def test_an_unrun_order_reports_nothing_rather_than_an_empty_result(run):
+    assert service.progress(run.run_id) is None
+
+
+def test_a_second_start_on_a_running_order_is_refused(run):
+    store.claim_batch(run.run_id, 1)
+    with pytest.raises(ValueError, match="already running"):
+        service.search(run.run_id, _replies(decades="x | y | z"))
+
+
+def test_the_lock_is_released_even_when_the_batch_raises(run):
+    def research(prompt: str):
+        raise RuntimeError("the whole batch fell over")
+
+    # Every angle failing is not an exception -- a failed search is a recorded
+    # fact -- so the lock has to be released on the ordinary path too.
+    service.search(run.run_id, research)
+    assert store.batch_is_running(run.run_id) is False
+
+
+def test_stored_work_is_reused_when_the_request_has_not_changed(run):
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+
+    def refuse(prompt: str):
+        raise AssertionError("nothing should have been searched again")
+
+    payload = service.search(run.run_id, refuse)
+    assert payload["found"] == 2
+
+
+def test_changing_the_wording_invalidates_that_angles_stored_result(run):
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+    order = service.order(run.run_id)
+    edited = [
+        {"angle_id": a.angle_id, "text": a.text, "shape_key": a.shape_key, "role": a.role}
+        for a in order.angles
+    ]
+    edited[0]["text"] = "cevicherias open for decades in Callao"
+    service.revise_order(run.run_id, angles=edited)
+
+    asked: list[str] = []
+
+    def research(prompt: str):
+        asked.append(prompt)
+        return "Rovira | Callao | since 1907", [], 3
+
+    service.search(run.run_id, research)
+    assert len(asked) == 1
+    assert "Callao" in asked[0]
+
+
+def test_a_count_that_changes_what_each_search_asks_for_invalidates_reuse(run):
+    """The count decides how many each search asks for, so a correction that
+    changes the ask is a different request of every angle -- not the same
+    answers relabelled."""
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+    before = service.order(run.run_id)
+    revised = service.revise_order(run.run_id, target_count=6)
+    assert [a.wanted for a in revised.angles] != [a.wanted for a in before.angles]
+
+    asked: list[str] = []
+
+    def research(prompt: str):
+        asked.append(prompt)
+        return "Canta Rana | Barranco | since the 1980s", [], 3
+
+    service.search(run.run_id, research)
+    assert len(asked) == 2
+
+
+def test_a_correction_that_changes_no_request_does_not_re_buy_the_research(run):
+    """Reuse is decided by the request, not by the revision number. Both these
+    orders ask each search for the same fifteen places, so the stored answers
+    are still answers to the questions being asked -- and re-running them would
+    spend money to learn nothing."""
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+    before = service.order(run.run_id)
+    revised = service.revise_order(run.run_id, target_count=60)
+    assert [a.wanted for a in revised.angles] == [a.wanted for a in before.angles]
+
+    def refuse(prompt: str):
+        raise AssertionError("nothing should have been searched again")
+
+    payload = service.search(run.run_id, refuse)
+    assert payload["found"] == 2
+    assert payload["target"] == 60
+
+
+def test_a_stale_result_never_appears_as_the_current_revisions(run):
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+    order = service.order(run.run_id)
+    edited = [
+        {"angle_id": a.angle_id, "text": a.text, "shape_key": a.shape_key, "role": a.role}
+        for a in order.angles
+    ]
+    edited[0]["text"] = "cevicherias open for decades in Callao"
+    revised = service.revise_order(run.run_id, angles=edited)
+
+    view = service.progress(run.run_id)
+    assert view["revision"] == revised.revision
+    rows = {row["angle"]: row for row in view["angles"]}
+    assert rows["cevicherias open for decades in Callao"]["state"] == "not_started"
+    # The angle that did not change keeps its result, and says when it was
+    # gathered rather than implying it was gathered now.
+    kept = rows["very cheap cevicherias people rate highly"]
+    assert kept["state"] == "completed"
+    assert kept["gathered_at"]
+
+
+def test_a_full_refresh_is_a_deliberate_action_and_re_runs_everything(run):
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s",
+            cheap="Al Toke Pez | Surquillo | counter",
+        ),
+    )
+    asked: list[str] = []
+
+    def research(prompt: str):
+        asked.append(prompt)
+        return "Canta Rana | Barranco | since the 1980s", [], 3
+
+    service.search(run.run_id, research, reuse=False)
+    assert len(asked) == 2
+
+
+def test_an_interrupted_attempt_is_not_reported_as_a_failure(run):
+    """Nobody knows whether the provider answered, and retrying may be charged
+    a second time. Saying "failed" implies a certainty nothing here has."""
+    from app.features.listicle_pipeline.contracts import SearchAttempt
+
+    order = service.order(run.run_id)
+    store.save_attempt(
+        SearchAttempt(
+            run_id=run.run_id,
+            revision=order.revision,
+            angle_id=order.angles[0].angle_id,
+            angle_text=order.angles[0].text,
+            state="running",
+            started_at="2026-09-08T00:00:00+00:00",
+        )
+    )
+    view = service.progress(run.run_id)
+    row = next(r for r in view["angles"] if r["angle_id"] == order.angles[0].angle_id)
+    assert row["state"] == "interrupted"
+    assert "charged again" in row["reason"]
+    assert "failed" not in row["reason"]
+
+
+def test_an_unagreed_interview_refuses_to_search(isolated_db):
+    from app.features.prompt2blog.contracts_v4 import GrillQuestion, GrillState
+    from app.features.listicle_pipeline.contracts import LISTICLE_MARKER_KEYS
+
+    state = GrillState(
+        run_id="halfway",
+        seed="20 cevicherias in Lima",
+        status="asking",
+        marker_keys=LISTICLE_MARKER_KEYS,
+        pending=GrillQuestion(
+            question_id="q1", topic="count", ask="How many?", recommendation="20"
+        ),
+    )
+    store.save(state)
+    with pytest.raises(ValueError, match="not agreed"):
+        service.search("halfway", _replies())
+
+
+def test_a_missing_run_is_a_missing_run(isolated_db):
+    with pytest.raises(LookupError):
+        service.search("nope", _replies())
+
+
+def test_contribution_is_reported_without_calling_the_repeated_one_best(run):
+    payload = service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | since the 1980s\nEl Mercado | Miraflores | old",
+            cheap="El Mercado | Miraflores | cheap menu",
+        ),
+    )
+    rows = {row["angle"]: row for row in payload["angles"]}
+    decades = rows["cevicherias open for decades"]
+    assert (decades["found"], decades["shared"], decades["exclusive"]) == (2, 1, 1)
+    cheap = rows["very cheap cevicherias people rate highly"]
+    assert (cheap["found"], cheap["shared"], cheap["exclusive"]) == (1, 1, 0)
+
+
+def test_a_short_pool_says_so_without_adding_an_unapproved_search(run):
+    payload = service.search(
+        run.run_id, _replies(decades="Canta Rana | Barranco | x", cheap="")
+    )
+    assert payload["shortfall"] == 19
+    assert len(payload["angles"]) == 2
+
+
+def test_a_run_stored_before_attempts_existed_still_opens(run):
+    """Real results, from before work was recorded per angle. They open, and
+    every field the screen reads is filled with the honest default -- a missing
+    field is not a smaller result, it is a crash on a page the operator opened
+    expecting their research."""
+    store.save_results(
+        run.run_id,
+        {
+            "run_id": run.run_id,
+            "target": 20,
+            "found": 1,
+            "shortfall": 19,
+            "rows_returned": 1,
+            "angles": [
+                {
+                    "angle": "cevicherias open for decades",
+                    "rows": 1,
+                    "sources": 2,
+                    "failed": False,
+                    "reason": "",
+                }
+            ],
+            "candidates": [
+                {
+                    "name": "Canta Rana",
+                    "district": "Barranco",
+                    "evidence": "since the 1980s",
+                    "found_by": ["cevicherias open for decades"],
+                    "overlap": 1,
+                }
+            ],
+        },
+    )
+    view = service.progress(run.run_id)
+    assert view["legacy"] is True
+    assert view["found"] == 1
+    # The fields the new screen reads, present rather than missing.
+    assert view["candidates"][0]["possible_duplicates"] == []
+    assert view["candidates"][0]["sightings"] == []
+    assert view["angles"][0]["state"] == "completed"
+    assert view["uncertain_identity"] == 0
+    assert view["running"] is False
+
+
+def test_a_new_result_replaces_the_legacy_view_rather_than_sitting_beside_it(run):
+    store.save_results(run.run_id, {"candidates": [{"name": "Old", "found_by": []}]})
+    payload = service.search(
+        run.run_id,
+        _replies(decades="Canta Rana | Barranco | x", cheap="Al Toke Pez | Surquillo | y"),
+    )
+    assert payload.get("legacy") is not True
+    assert service.progress(run.run_id)["found"] == 2
+
+
+def test_a_legacy_result_on_a_run_with_no_order_is_still_read_safely(isolated_db):
+    """The oldest case: results stored before orders existed, on a run whose
+    interview cannot rebuild one."""
+    store.save_results(
+        "ancient",
+        {"target": 12, "candidates": [{"name": "Canta Rana", "found_by": ["a"]}]},
+    )
+    view = service.progress("ancient")
+    assert view["legacy"] is True
+    assert view["target"] == 12
+    assert view["candidates"][0]["sightings"] == []

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_recovery.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_recovery.py
@@ -510,3 +510,108 @@ def test_a_first_run_about_a_subject_is_told_nothing(isolated_db):
     state = agreed_state()
     store.save(state)
     assert runner.prior_contribution(service.order(state.run_id)) == {}
+
+
+# The cut, checked over what came back
+
+
+def _names_in(prompt: str) -> list[str]:
+    """The candidate names as the review prompt numbered them.
+
+    Read back out of the prompt rather than assumed, because the pool's order
+    is the runner's business and a test that hard-codes it would pass while
+    pointing at the wrong row.
+    """
+    names = []
+    for line in prompt.splitlines():
+        stripped = line.strip()
+        if stripped[:1].isdigit() and ". " in stripped:
+            names.append(stripped.split(". ", 1)[1].split(" -- ")[0].strip())
+    return names
+
+
+def test_the_cut_check_runs_on_the_batch_that_paid_for_it(run):
+    seen: list = []
+
+    def review(job_id, prompt, tool_name, schema):
+        seen.append(tool_name)
+        return {
+            "barred": [
+                {
+                    "number": next(
+                        i for i, c in enumerate(_names_in(prompt), start=1)
+                        if c == "Maido"
+                    ),
+                    "name": "Maido",
+                    "why": "Nikkei restaurant; ceviche is one dish of many.",
+                    "confidence": "clear",
+                }
+            ]
+        }
+
+    payload = service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap="Maido | Miraflores | top Nikkei restaurant, offers ceviche",
+        ),
+        review=review,
+    )
+
+    assert seen, "the cut check should run once the pool is final"
+    assert payload["cut_checked"] is True
+    assert payload["barred_count"] == 1
+    flagged = {c["name"]: c["barred"] for c in payload["candidates"] if c["barred"]}
+    assert "Maido" in flagged
+    assert "Canta Rana" not in flagged
+
+
+def test_a_run_nobody_checked_does_not_read_as_a_clean_one(run):
+    payload = service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap="Maido | Miraflores | offers ceviche",
+        ),
+    )
+    # No reviewer, so nothing looked. That is not the same as nothing barred.
+    assert payload["cut_checked"] is False
+    assert payload["barred_count"] == 0
+    assert all(c["barred"] == "" for c in payload["candidates"])
+
+
+def test_the_verdict_survives_a_reload_without_spending_again(run):
+    calls: list = []
+
+    def review(job_id, prompt, tool_name, schema):
+        calls.append(tool_name)
+        return {
+            "barred": [
+                {
+                    "number": next(
+                        i for i, c in enumerate(_names_in(prompt), start=1)
+                        if c == "Maido"
+                    ),
+                    "name": "Maido",
+                    "why": "ceviche is not primary",
+                    "confidence": "clear",
+                }
+            ]
+        }
+
+    service.search(
+        run.run_id,
+        _replies(
+            decades="Canta Rana | Barranco | open since the 1980s",
+            cheap="Maido | Miraflores | offers ceviche",
+        ),
+        review=review,
+    )
+    assert len(calls) == 1
+
+    # Opening the results again is a read. It must show the verdict and buy
+    # nothing.
+    reopened = service.progress(run.run_id)
+    assert len(calls) == 1, "reading a stored run must not re-judge it"
+    assert reopened["cut_checked"] is True
+    assert reopened["barred_count"] == 1

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_routes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_routes.py
@@ -1,0 +1,136 @@
+"""The HTTP boundary: what a search returns, and what a reopened run reads.
+
+The first of the six confirmed faults lived here and nowhere else. Every
+successful search was passed through the interview's view builder, which reads
+`.run_id` off a `GrillState`; a search returns a dict. So a search that worked,
+and whose results were already safely stored, was reported to the operator as a
+failure -- and the only way to see the results was to pay for them again.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.features.listicle_pipeline.api as listicle_api
+from app.features.listicle_pipeline import store
+from tests.listicle_test_support import agreed_state
+
+
+@pytest.fixture
+def client(isolated_db, monkeypatch):
+    def fake_search(prompt: str):
+        if "decades" in prompt:
+            return "Canta Rana | Barranco | open since the 1980s", ["https://x.test"], 9
+        return "Al Toke Pez | Surquillo | six stools", ["https://y.test"], 7
+
+    monkeypatch.setattr(listicle_api, "_search_call", fake_search)
+    app = FastAPI()
+    app.include_router(listicle_api.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def run(client):
+    state = agreed_state()
+    store.save(state)
+    return state
+
+
+def test_a_successful_search_comes_back_as_a_successful_search(client, run):
+    """The whole first fault, stated as a test. No network: the one path that
+    reaches the web is replaced above."""
+    response = client.post(f"/api/listicle-pipeline/search/{run.run_id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["found"] == 2
+    assert {c["name"] for c in body["candidates"]} == {"Canta Rana", "Al Toke Pez"}
+
+
+def test_the_results_can_be_read_back_afterwards(client, run):
+    client.post(f"/api/listicle-pipeline/search/{run.run_id}")
+    response = client.get(f"/api/listicle-pipeline/search/{run.run_id}")
+    assert response.status_code == 200
+    assert response.json()["found"] == 2
+
+
+def test_reading_before_anything_has_run_is_a_state_not_a_result(client, run):
+    response = client.get(f"/api/listicle-pipeline/search/{run.run_id}")
+    assert response.status_code == 404
+
+
+def test_a_missing_run_is_still_a_404(client):
+    assert client.post("/api/listicle-pipeline/search/nope").status_code == 404
+
+
+def test_an_unagreed_order_is_still_a_400(client, isolated_db):
+    from app.features.prompt2blog.contracts_v4 import GrillQuestion, GrillState
+    from app.features.listicle_pipeline.contracts import LISTICLE_MARKER_KEYS
+
+    store.save(
+        GrillState(
+            run_id="halfway",
+            seed="20 cevicherias in Lima",
+            status="asking",
+            marker_keys=LISTICLE_MARKER_KEYS,
+            pending=GrillQuestion(
+                question_id="q1", topic="count", ask="How many?", recommendation="20"
+            ),
+        )
+    )
+    response = client.post("/api/listicle-pipeline/search/halfway")
+    assert response.status_code == 400
+    assert "not agreed" in response.json()["detail"]
+
+
+def test_the_order_is_readable_and_says_where_its_count_came_from(client, run):
+    response = client.get(f"/api/listicle-pipeline/order/{run.run_id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["target_count"] == 20
+    assert body["count_source"] in {"answered", "accepted", "corrected"}
+    assert len(body["angles"]) == 2
+    assert body["summary"].startswith("20 cevicherias")
+
+
+def test_correcting_the_count_makes_a_new_revision(client, run):
+    client.get(f"/api/listicle-pipeline/order/{run.run_id}")
+    response = client.post(
+        f"/api/listicle-pipeline/order/{run.run_id}", json={"target_count": 12}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["target_count"] == 12
+    assert body["revision"] == 2
+
+
+def test_a_retry_names_the_angles_it_wants(client, run):
+    client.post(f"/api/listicle-pipeline/search/{run.run_id}")
+    order = client.get(f"/api/listicle-pipeline/order/{run.run_id}").json()
+    one = order["angles"][0]["angle_id"]
+    response = client.post(
+        f"/api/listicle-pipeline/search/{run.run_id}",
+        json={"angle_ids": [one], "reuse": False},
+    )
+    assert response.status_code == 200
+    assert response.json()["found"] == 2
+
+
+def test_the_shape_catalogue_says_what_each_shape_applies_to(client):
+    response = client.get("/api/listicle-pipeline/shapes")
+    assert response.status_code == 200
+    shapes = {s["key"]: s for s in response.json()["shapes"]}
+    assert shapes["informal"]["applies_to"] == ["restaurants"]
+    assert shapes["long-stay"]["applies_to"] == ["hotels"]
+    # Shared shapes apply to everything, said as an empty list rather than as
+    # every subject spelled out -- a new subject must not need this edited.
+    assert shapes["cheap"]["applies_to"] == []
+    assert "overlaps_with" in shapes["award"]
+
+
+def test_a_search_that_is_already_running_is_refused_rather_than_doubled(client, run):
+    store.claim_batch(run.run_id, 1)
+    response = client.post(f"/api/listicle-pipeline/search/{run.run_id}")
+    assert response.status_code == 400
+    assert "already running" in response.json()["detail"]

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_search.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_search.py
@@ -281,3 +281,197 @@ def test_two_places_that_merely_share_a_word_stay_apart(first, second):
 
 def test_a_parenthetical_is_the_rows_reason_not_part_of_the_name():
     assert name_tokens("Hotel B (Rooftop bar)") == name_tokens("Hotel B")
+
+
+# --- what the plan of 2026-09-08 changed ----------------------------------
+
+
+from app.features.listicle_pipeline.search import (  # noqa: E402
+    SPECIFIC,
+    AngleRequest,
+    Sighting,
+    build_search_prompt,
+    contribution_of,
+    pool_sightings,
+    role_allowances,
+    strip_list_marker,
+)
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        # The failure. Stripping every leading digit turned a real hotel into
+        # a common noun, and nothing downstream could tell it had happened.
+        ("1900 Hotel", "1900 Hotel"),
+        ("1. Bodega 1884", "Bodega 1884"),
+        ("2) Bar Piselli 1915", "Bar Piselli 1915"),
+        ("- Al Toke Pez", "Al Toke Pez"),
+        ("**La Mar**", "La Mar"),
+        ("400 Grados", "400 Grados"),
+        ("10. 1900 Hotel", "1900 Hotel"),
+    ],
+)
+def test_a_list_marker_goes_and_the_name_stays(line, expected):
+    assert strip_list_marker(line) == expected
+
+
+def test_a_numbered_row_keeps_the_year_in_the_name():
+    rows = parse_rows("1. Bodega 1900 | Barranco | open since 1900\n")
+    assert rows[0][0] == "Bodega 1900"
+
+
+def test_two_branches_of_one_business_stay_two_businesses():
+    """Merging them keeps one and loses the other, and the loss is invisible --
+    the surviving row looks like an ordinary candidate.
+
+    The rows are identical apart from the district, which is exactly the shape
+    a chain's two branches arrive in.
+    """
+    merged = pool_sightings(
+        [
+            Sighting(angle="a", angle_id="a1", name="Tanta", district="Centro", evidence=""),
+            Sighting(angle="b", angle_id="a2", name="Tanta", district="Miraflores", evidence=""),
+        ]
+    )
+    assert len(merged) == 2
+    # Not silently dropped either: the screen is told these might be one place.
+    assert all(c.possible_duplicates for c in merged)
+
+
+def test_a_branch_named_in_the_title_is_not_folded_into_the_shorter_name():
+    merged = merge_contained(
+        [
+            Candidate(name="Tanta Larcomar", district="Miraflores", evidence="", found_by=["a"]),
+            Candidate(name="Tanta Larcomar Centro", district="Centro", evidence="", found_by=["b"]),
+        ]
+    )
+    assert len(merged) == 2
+    assert all(c.possible_duplicates for c in merged)
+
+
+def test_two_bars_inside_one_hotel_stay_two_bars():
+    merged = merge_contained(
+        [
+            Candidate(
+                name="Gran Hotel Bolívar (Bar Catedral)",
+                district="",
+                evidence="",
+                found_by=["a"],
+            ),
+            Candidate(
+                name="Gran Hotel Bolívar (Bar Maury)",
+                district="",
+                evidence="",
+                found_by=["b"],
+            ),
+        ]
+    )
+    assert len(merged) == 2
+
+
+def test_a_hotel_and_its_only_named_bar_still_merge():
+    """One row qualified and one not, in a search for bars, is the same bar
+    written two ways -- and refusing that merge splits the overlap of a place
+    two angles agreed on."""
+    merged = merge_contained(
+        [
+            Candidate(name="Hotel B", district="", evidence="", found_by=["a"]),
+            Candidate(
+                name="Hotel B (Rooftop bar)", district="", evidence="", found_by=["b"]
+            ),
+        ]
+    )
+    assert len(merged) == 1
+
+
+def test_an_accent_variant_in_the_same_district_still_merges():
+    merged = pool_sightings(
+        [
+            Sighting(angle="a", angle_id="a1", name="Cevichería Nancy", district="Callao", evidence="x"),
+            Sighting(angle="b", angle_id="a2", name="Cevicheria Nancy", district="Callao", evidence="y"),
+        ]
+    )
+    assert len(merged) == 1
+    assert merged[0].overlap == 2
+
+
+def test_every_original_sighting_survives_a_merge():
+    """Keeping one evidence sentence and throwing the rest away is too thin to
+    check a merge with: two angles found this place for two different reasons
+    and the reasons are the only way to see whether it is one place."""
+    merged = pool_sightings(
+        [
+            Sighting(angle="awards", angle_id="a1", name="El Mercado", district="", evidence="on best-of lists"),
+            Sighting(angle="nikkei", angle_id="a2", name="El Mercado", district="Miraflores", evidence="Japanese-Peruvian"),
+        ]
+    )
+    assert len(merged) == 1
+    assert sorted(s.evidence for s in merged[0].sightings) == [
+        "Japanese-Peruvian",
+        "on best-of lists",
+    ]
+
+
+def test_contribution_does_not_depend_on_which_search_ran_first():
+    """The first angle to return a place used to collect it, so reordering the
+    searches changed the table."""
+    shared = [
+        Sighting(angle="a", angle_id="a1", name="El Mercado", district="", evidence=""),
+        Sighting(angle="b", angle_id="a2", name="El Mercado", district="", evidence=""),
+        Sighting(angle="b", angle_id="a2", name="Canta Rana", district="", evidence=""),
+    ]
+    forward = pool_sightings(shared)
+    backward = pool_sightings(list(reversed(shared)))
+    assert contribution_of(forward, "a") == contribution_of(backward, "a") == (1, 1, 0)
+    assert contribution_of(forward, "b") == contribution_of(backward, "b") == (2, 1, 1)
+
+
+def test_a_narrow_search_is_told_that_one_result_is_a_good_result():
+    prompt = build_search_prompt(
+        "the cevicheria credited with starting the boom",
+        kind="cevicherias",
+        place="Lima",
+        exclusions="",
+        standard="",
+        wanted=2,
+        role=SPECIFIC,
+    )
+    assert "do not pad" in prompt.lower()
+    assert "keep going until" not in prompt.lower()
+
+
+def test_the_requirements_are_composed_in_rather_than_written_into_the_angle():
+    prompt = build_search_prompt(
+        "rooftop bars with a view of the sea",
+        kind="bars",
+        place="Lima",
+        exclusions="no hotel chains",
+        standard="independently owned",
+        wanted=8,
+    )
+    assert "independently owned" in prompt
+    assert "no hotel chains" in prompt
+    assert "no matter which description found it" in prompt
+
+
+def test_allowances_are_bounded_and_add_up_to_more_than_the_target():
+    allowances = role_allowances(40, ["broad", "broad", "distinctive", SPECIFIC])
+    assert sum(allowances) >= 40
+    assert allowances[3] < allowances[0]
+
+
+def test_an_angle_request_carries_its_identity_through_the_result():
+    def research(prompt: str):
+        return "Al Toke Pez | Surquillo | counter", ["https://example.test"], 5
+
+    _, results = run_search_order(
+        [AngleRequest(angle_id="a7", text="counter ceviche", role="distinctive", wanted=6)],
+        kind="cevicherias",
+        place="Lima",
+        target_items=20,
+        research=research,
+    )
+    assert results[0].angle_id == "a7"
+    assert results[0].role == "distinctive"
+    assert results[0].wanted == 6

--- a/apps/ai-blog-writer/apps/backend/tests/test_listicle_shapes.py
+++ b/apps/ai-blog-writer/apps/backend/tests/test_listicle_shapes.py
@@ -1,0 +1,177 @@
+"""The catalogue: what a commission is offered, and what the wording asks for.
+
+Two faults from the plan of 2026-09-08 live here. A hotel commission was shown
+market stalls and cuisine fusions because one restaurant-shaped catalogue was
+shown to every subject. And the wording rules could not stop a search
+over-tightening while the catalogue itself was asking for it -- "known for one
+thing and little else" excludes a specialist with a full menu, and "no sign, no
+listing" asks the web to find something described as unfindable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.features.listicle_pipeline.shapes import (
+    SHAPES,
+    SHAPES_BY_KEY,
+    BROAD,
+    SPECIFIC,
+    overlap_notes,
+    shape_menu,
+    shapes_for,
+    subject_of,
+    suggested_angle_count,
+)
+
+
+@pytest.mark.parametrize(
+    "kind, subject",
+    [
+        ("cevicherias", "restaurants"),
+        ("pizzerias", "restaurants"),
+        ("rooftop bars", "bars"),
+        ("pisco bars", "bars"),
+        ("independent hotels", "hotels"),
+        ("hostels", "hotels"),
+        # A subject the catalogue knows nothing extra about keeps the shared
+        # shapes rather than being filed under one it does not belong to.
+        ("museums", ""),
+        ("surf breaks", ""),
+    ],
+)
+def test_the_subject_is_read_off_the_kind(kind, subject):
+    assert subject_of(kind) == subject
+
+
+def test_a_hotel_list_is_not_offered_market_stalls_or_cuisine_fusions():
+    keys = {shape.key for shape in shapes_for("hotels")}
+    assert "informal" not in keys
+    assert "crossed" not in keys
+    assert "regional-tradition" not in keys
+
+
+def test_a_hotel_list_is_offered_hotel_dimensions():
+    keys = {shape.key for shape in shapes_for("hotels")}
+    assert {"lodging-format", "long-stay", "building-character", "family-facilities"} <= keys
+
+
+def test_a_bar_list_is_offered_bar_dimensions():
+    keys = {shape.key for shape in shapes_for("bars")}
+    assert {"drink-specialty", "live-music", "dancing", "local-drinking"} <= keys
+    assert "informal" not in keys
+
+
+def test_an_unsupported_subject_keeps_the_shared_shapes():
+    keys = {shape.key for shape in shapes_for("")}
+    assert {"cheap", "luxury", "institution", "setting", "district"} <= keys
+    assert not any(shape.applies_to for shape in shapes_for(""))
+
+
+@pytest.mark.parametrize(
+    "key, banned",
+    [
+        # Every one of these was in the catalogue as a condition, and every one
+        # of them is a condition the shape does not mean. What the shape MEANS
+        # and the EXAMPLE searches are what reach a finished angle, so those
+        # are what must be clean; the instruction may still name the condition,
+        # because warning the writer off it is the opposite of asking for it.
+        ("one-thing", "little else"),
+        ("purist", "no fusion"),
+        ("lesser-known", "no listing"),
+        ("lesser-known", "no sign"),
+        ("institution", "landmark status unless"),
+        ("institution", "50+"),
+    ],
+)
+def test_the_catalogue_stopped_asking_for_the_over_tightening(key, banned):
+    shape = SHAPES_BY_KEY[key]
+    text = f"{shape.core} {shape.example}".lower()
+    assert banned not in text
+
+
+def test_a_shape_that_bans_something_says_so_as_a_prohibition_on_the_writer():
+    """Where the wording has to warn the model off a condition, it warns the
+    model rather than putting the condition in the search."""
+    assert "do not require" in SHAPES_BY_KEY["one-thing"].instruction.lower()
+    assert "do not say it has no" in SHAPES_BY_KEY["lesser-known"].instruction.lower()
+
+
+def test_the_recent_opening_window_is_explicit_and_anchored():
+    instruction = SHAPES_BY_KEY["new-wave"].instruction.lower()
+    assert "explicitly" in instruction
+    assert "today's date" in instruction
+
+
+def test_cheap_hidden_and_informal_are_no_longer_one_group():
+    """A cheap neighbourhood bar and an expensive hidden one are both real and
+    both worth searching for. They shared a group and at most one could be
+    chosen."""
+    notes = overlap_notes("")
+    assert "cheap and lesser-known" not in notes
+    assert "cheap and informal" not in notes
+
+
+def test_award_and_expensive_are_not_declared_duplicates():
+    assert "luxury" not in SHAPES_BY_KEY["award"].overlaps_with
+
+
+def test_an_overlap_the_old_groups_missed_is_now_stated():
+    """Family-run and longstanding are often the same places and shared no
+    group at all."""
+    assert "institution" in SHAPES_BY_KEY["family"].overlaps_with
+
+
+def test_no_shape_claims_to_collide_with_something_that_is_not_a_shape():
+    for shape in SHAPES:
+        for other in shape.overlaps_with:
+            assert other in SHAPES_BY_KEY, f"{shape.key} -> {other}"
+
+
+def test_every_shape_declares_a_role_it_can_actually_be_asked_for():
+    for shape in SHAPES:
+        assert shape.role in {BROAD, "distinctive", SPECIFIC}
+
+
+def test_the_narrow_shapes_are_labelled_narrow():
+    """"The place credited with starting it" cannot supply twelve, and the
+    allowance follows the role."""
+    assert SHAPES_BY_KEY["origin"].role == SPECIFIC
+
+
+def test_the_menu_a_commission_sees_carries_meaning_and_wording_separately():
+    menu = shape_menu("hotels")
+    assert "means:" in menu and "write:" in menu
+    assert "market" not in menu.lower()
+
+
+@pytest.mark.parametrize(
+    "target, expected", [(5, 2), (12, 3), (24, 4), (40, 6), (200, 10)]
+)
+def test_the_angle_count_heuristic_lives_in_code(target, expected):
+    """It was written out as arithmetic in the prompt as well, and the two came
+    to disagree."""
+    assert suggested_angle_count(target) == expected
+
+
+def test_a_shapes_theme_comes_from_the_catalogue_not_from_a_model():
+    """A live run sent the shape's LABEL as `group` on one turn and its KEY on
+    the next. Both are real values and neither is the theme, and since the
+    screen groups by this field to warn about colliding angles, every option
+    landed in a group of one and the warning could never fire."""
+    from app.features.listicle_pipeline.spec import _theme_for
+
+    assert _theme_for("institution", "Local institution") == "heritage"
+    assert _theme_for("institution", "institution") == "heritage"
+    assert _theme_for("cheap", "") == "price"
+    # An angle the catalogue has no shape for keeps what it was given: there is
+    # nothing to look up.
+    assert _theme_for("", "sourcing") == "sourcing"
+
+
+def test_a_role_that_is_not_a_role_falls_back_to_the_catalogue():
+    from app.features.listicle_pipeline.spec import _checked_role
+
+    assert _checked_role("specific", "institution") == "specific"
+    assert _checked_role("", "origin") == "specific"
+    assert _checked_role("enthusiastic", "origin") == "specific"

--- a/apps/ai-blog-writer/apps/frontend/.env.example
+++ b/apps/ai-blog-writer/apps/frontend/.env.example
@@ -10,3 +10,16 @@ VITE_SCHEMA_PUBLISHER_LOGO_URL=
 VITE_SCHEMA_DEFAULT_AUTHOR_NAME=
 VITE_SCHEMA_MEDIA_BASE_URL=https://cms.questurian.com
 VITE_FRONTEND_URL=
+
+# Skip the Payload login while developing locally.
+#
+# The credential this app uses is Payload's httpOnly cookie, so signing in
+# needs Payload running and reachable. It is not run on the machine this app is
+# developed on -- Questura is a live-only environment -- which left no way to
+# open a writer screen locally without hand-editing the auth guard.
+#
+# Set to "true" to get a local admin session instead. Fenced twice: this is
+# read only when Vite's DEV flag is set, which is a build-time literal, so the
+# branch does not exist in a production bundle at all. Absent from .env by
+# default; opted into per machine.
+VITE_DEV_OFFLINE_LOGIN=false

--- a/apps/ai-blog-writer/apps/frontend/src/App.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/App.tsx
@@ -89,8 +89,12 @@ export default function App() {
               {/* Itineraries Pipeline */}
               <Route path="itineraries-pipeline" element={<ItinerariesPipelinePage />} />
 
-              {/* Listicle Pipeline */}
+              {/* Listicle Pipeline. The run id is in the address so a run can
+                  be reopened, linked and bookmarked: the interview and the
+                  searches were always stored server-side, and the only thing
+                  missing was the operator's way back to them. */}
               <Route path="listicle-pipeline" element={<ListiclePipelinePage />} />
+              <Route path="listicle-pipeline/:runId" element={<ListiclePipelinePage />} />
 
               {/* Location Images */}
               <Route path="location-documents" element={<LocationDocumentsPage />} />

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/dev-session.test.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/dev-session.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+/**
+ * The bypass exists so nobody hand-edits `RequireAuth` to look at a screen.
+ * These tests are about the fence around it, not the convenience.
+ */
+
+async function loadWith(env: Record<string, unknown>) {
+  vi.resetModules()
+  vi.stubGlobal('import.meta', undefined)
+  // Vite replaces `import.meta.env.*` at build time; under vitest it is a real
+  // object, so the flags are set on it directly.
+  Object.assign(import.meta.env, env)
+  return await import('./dev-session')
+}
+
+const REAL_DEV = import.meta.env.DEV
+const REAL_MODE = import.meta.env.MODE
+const REAL_FLAG = import.meta.env.VITE_DEV_OFFLINE_LOGIN
+
+afterEach(() => {
+  Object.assign(import.meta.env, {
+    DEV: REAL_DEV,
+    MODE: REAL_MODE,
+    VITE_DEV_OFFLINE_LOGIN: REAL_FLAG,
+  })
+  vi.unstubAllGlobals()
+})
+
+describe('the offline development session', () => {
+  it('is nothing in a production build, even with the flag turned on', async () => {
+    // The fence that matters. `import.meta.env.DEV` is a build-time literal,
+    // so a production bundle cannot be talked into this by any env var.
+    const { offlineDevSession } = await loadWith({
+      DEV: false,
+      VITE_DEV_OFFLINE_LOGIN: 'true',
+    })
+    expect(offlineDevSession()).toBeNull()
+  })
+
+  it('is nothing in development unless it is explicitly asked for', async () => {
+    const { offlineDevSession } = await loadWith({
+      DEV: true,
+      MODE: 'development',
+      VITE_DEV_OFFLINE_LOGIN: undefined,
+    })
+    expect(offlineDevSession()).toBeNull()
+  })
+
+  it('is not switched on by a value that merely looks true', async () => {
+    for (const value of ['1', 'yes', 'TRUE', 'on', '']) {
+      const { offlineDevSession } = await loadWith({
+        DEV: true,
+      MODE: 'development',
+        VITE_DEV_OFFLINE_LOGIN: value,
+      })
+      expect(offlineDevSession(), `value ${JSON.stringify(value)}`).toBeNull()
+    }
+  })
+
+  it('is nothing under vitest, so no suite depends on a local .env', async () => {
+    // This is not hypothetical. Turning the flag on locally broke
+    // AuthProvider.test.tsx, which asserts a signed-out visitor reaches the
+    // login page.
+    const { offlineDevSession } = await loadWith({
+      DEV: true,
+      MODE: 'test',
+      VITE_DEV_OFFLINE_LOGIN: 'true',
+    })
+    expect(offlineDevSession()).toBeNull()
+  })
+
+  it('signs in a visibly fake user when every fence is down', async () => {
+    const { offlineDevSession } = await loadWith({
+      DEV: true,
+      MODE: 'development',
+      VITE_DEV_OFFLINE_LOGIN: 'true',
+    })
+    const session = offlineDevSession()
+    expect(session).not.toBeNull()
+    // Named so nobody reading a screenshot takes it for a real account.
+    expect(session?.user.email).toContain('localhost.invalid')
+    expect(session?.user.lastName).toContain('not a real login')
+    expect(session?.expiresAt).toBeGreaterThan(Date.now())
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/dev-session.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/dev-session.ts
@@ -1,0 +1,64 @@
+/**
+ * A signed-in session for local work, when there is nothing to sign in to.
+ *
+ * The credential this app uses is Payload's httpOnly `payload-token` cookie,
+ * so being logged in requires Payload to be running and reachable. It is not
+ * running on the machine this app is developed on and is not meant to be:
+ * Questura is a live-only environment. The practical effect was that nobody
+ * could open a writer screen locally without hand-editing `RequireAuth` and
+ * remembering to put it back — which was done twice in one session, and the
+ * second time only because the first was noticed.
+ *
+ * So the bypass is written down instead of improvised, and it is fenced twice:
+ *
+ * 1. `import.meta.env.DEV` is replaced with a literal at build time, so in a
+ *    production bundle this whole branch is `false` and the bundler removes
+ *    it. There is no flag anyone can set on a deployed build to switch it on.
+ * 2. `VITE_DEV_OFFLINE_LOGIN` must be set explicitly. It is absent from `.env`
+ *    and documented in `.env.example`, so it is opted into per machine rather
+ *    than inherited.
+ * 3. It is off under `vitest`. A suite whose result depends on whether the
+ *    person running it happens to have a flag in their own `.env` is not a
+ *    suite -- and this was not hypothetical: turning the flag on locally
+ *    immediately broke `AuthProvider.test.tsx`, which asserts that a signed-out
+ *    visitor is sent to the login page. A test that wants this behaviour asks
+ *    for it explicitly.
+ *
+ * All three, not any. The user it returns is named so that nobody reading a
+ * screenshot mistakes it for a real account.
+ *
+ * What it does NOT do is tell "Payload is unreachable" apart from "Payload says
+ * you are signed out" -- `hydratePayloadSession` returns null for both, and
+ * with the flag on either one produces the local session. That is exactly what
+ * the flag asks for, and it is why it may only ever be set by hand on a
+ * development machine.
+ */
+
+import type { AuthState } from './auth-context';
+
+// Far enough out that a long session never lapses mid-test; not infinite, so
+// the expiry path is still the same code everything else uses.
+const A_DAY = 24 * 60 * 60 * 1000;
+
+export function offlineDevSession(): AuthState | null {
+  if (!import.meta.env.DEV) return null;
+  if (import.meta.env.MODE === 'test') return null;
+  if (import.meta.env.VITE_DEV_OFFLINE_LOGIN !== 'true') return null;
+  return {
+    expiresAt: Date.now() + A_DAY,
+    user: {
+      id: 'dev-offline',
+      email: 'dev@localhost.invalid',
+      // Admin because the point is to reach every screen. This grants nothing:
+      // the backend decides what it will do, and its own staff check is a
+      // separate flag that is off by default in development.
+      role: 'admin',
+      firstName: 'Local',
+      lastName: 'Dev (not a real login)',
+    },
+  };
+}
+
+export function offlineDevSessionActive(): boolean {
+  return offlineDevSession() !== null;
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/auth/useAuthSessionState.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/auth/useAuthSessionState.ts
@@ -4,6 +4,7 @@ import { EXPIRY_BUFFER_MS } from './auth.constants';
 import { hasActiveSession } from './auth-state';
 import { clearPermissionsCache } from './usePermissions';
 import { getLiveAuthState, setLiveAuthState } from './auth-session-store';
+import { offlineDevSession } from './dev-session';
 import {
   checkPayloadHealth,
   hydratePayloadSession,
@@ -40,8 +41,14 @@ export function useAuthSessionState(): AuthContextValue {
         return;
       }
 
-      applyAuthState(nextState);
-      if (nextState) {
+      // Null covers both "Payload is unreachable" and "Payload says you are
+      // signed out", and the fallback does not tell them apart -- see
+      // `dev-session`. It returns null unless a development build has been
+      // explicitly told to stand in for a Payload that is not running.
+      const resolved = nextState ?? offlineDevSession();
+
+      applyAuthState(resolved);
+      if (resolved) {
         setIsConnected(true);
       }
       setIsRestoringSession(false);

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/angle-picker.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/angle-picker.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AnglePicker } from './components/AnglePicker'
+import type { ListicleGrillOption } from './types'
+
+/**
+ * The angle menu.
+ *
+ * What comes back from it is the search order, so what it sends matters more
+ * than what it shows. It used to send a paragraph, and everything downstream
+ * had to work out from a sentence which menu entry the line had been and
+ * whether the operator had changed it.
+ */
+
+function option(overrides: Partial<ListicleGrillOption> = {}): ListicleGrillOption {
+  return {
+    text: 'cevicherias open for decades',
+    recommended: true,
+    group: 'heritage',
+    shape: 'institution',
+    role: 'broad',
+    ...overrides,
+  }
+}
+
+describe('the angle menu', () => {
+  it('sends the records, not just the sentences', async () => {
+    const onSend = vi.fn()
+    render(
+      <AnglePicker
+        options={[option(), option({ text: 'very cheap cevicherias', shape: 'cheap', group: 'price' })]}
+        busy={false}
+        onSend={onSend}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: /use these/i }))
+
+    const [answer, selections] = onSend.mock.calls[0]
+    expect(answer).toBe('cevicherias open for decades\nvery cheap cevicherias')
+    expect(selections).toEqual([
+      expect.objectContaining({ shape_key: 'institution', role: 'broad', edited: false }),
+      expect.objectContaining({ shape_key: 'cheap', role: 'broad', edited: false }),
+    ])
+  })
+
+  it('marks a line the operator rewrote', async () => {
+    const onSend = vi.fn()
+    render(<AnglePicker options={[option()]} busy={false} onSend={onSend} />)
+
+    await userEvent.type(screen.getByRole('textbox'), ' in Callao')
+    await userEvent.click(screen.getByRole('button', { name: /use these/i }))
+
+    const [answer, selections] = onSend.mock.calls[0]
+    // Kept exactly as written. A narrowing the operator wrote on purpose is
+    // theirs, and this screen does not repair it.
+    expect(answer).toBe('cevicherias open for decades in Callao')
+    expect(selections[0].edited).toBe(true)
+  })
+
+  it('marks an angle nobody offered as the operator’s own', async () => {
+    const onSend = vi.fn()
+    render(<AnglePicker options={[option()]} busy={false} onSend={onSend} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /add an angle/i }))
+    const boxes = screen.getAllByRole('textbox')
+    await userEvent.type(boxes[boxes.length - 1], 'cevicherias by the fishing landings')
+    await userEvent.click(screen.getByRole('button', { name: /use these/i }))
+
+    const [, selections] = onSend.mock.calls[0]
+    expect(selections[1]).toEqual(
+      expect.objectContaining({ custom: true, shape_key: '' }),
+    )
+  })
+
+  it('explains an overlap rather than refusing it', async () => {
+    render(
+      <AnglePicker
+        options={[
+          option({ text: 'cevicherias open for decades', shape: 'institution' }),
+          option({ text: 'family-run cevicherias', shape: 'family' }),
+        ]}
+        busy={false}
+        onSend={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(/often return the same places/)
+    // Both stay ticked. The operator knows the city.
+    expect(screen.getByRole('button', { name: /use these/i })).toBeEnabled()
+    expect(screen.getByText('2 searches')).toBeInTheDocument()
+  })
+
+  it('does not assert a stale label on a line that was changed', async () => {
+    render(
+      <AnglePicker
+        options={[option(), option({ text: 'family-run cevicherias', shape: 'family' })]}
+        busy={false}
+        onSend={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(/heritage/)
+
+    await userEvent.type(screen.getAllByRole('textbox')[0], ' near the sea')
+    // The clash was between two `heritage` lines and one of them no longer
+    // reliably means what the catalogue said it meant.
+    expect(screen.getByRole('status')).toHaveTextContent(/has been edited/)
+  })
+
+  it('groups the alternatives so the menu reads as kinds of angle', () => {
+    render(
+      <AnglePicker
+        options={[
+          option(),
+          option({ text: 'very cheap cevicherias', recommended: false, group: 'price', shape: 'cheap' }),
+          option({ text: 'cevicherias by the fishing landings', recommended: false, group: '', shape: '' }),
+        ]}
+        busy={false}
+        onSend={vi.fn()}
+      />,
+    )
+    const headings = screen
+      .getAllByText(/^price$|^Specific to this list$/)
+      .filter(node => node.className.includes('lp-picker-theme-name'))
+    expect(headings.map(node => node.textContent)).toEqual([
+      'price',
+      'Specific to this list',
+    ])
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/api.ts
@@ -95,7 +95,12 @@ export async function loadOrder(runId: string): Promise<ListicleOrder | null> {
  *  gathered under the old one cannot be shown as answers to the new one. */
 export async function reviseOrder(
   runId: string,
-  patch: { target_count?: number; angles?: ListicleOrder['angles'] },
+  patch: {
+    target_count?: number
+    angles?: ListicleOrder['angles']
+    standard?: string
+    exclusions?: string
+  },
 ): Promise<ListicleOrder> {
   const response = await apiFetch(`${BASE}/order/${runId}`, {
     method: 'POST',

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/api.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/api.ts
@@ -1,5 +1,10 @@
 import { apiFetch } from '../../shared/api/client/apiFetch'
-import type { ListicleGrillState, ListicleSearchResults } from './types'
+import type {
+  ListicleAngleSelection,
+  ListicleGrillState,
+  ListicleOrder,
+  ListicleSearchResults,
+} from './types'
 
 /**
  * One call per move the operator can make.
@@ -28,6 +33,11 @@ async function readError(response: Response, fallback: string): Promise<Error> {
   return new Error(fallback)
 }
 
+/** A run that is not there. Distinguished so a screen can say "this run does
+ *  not exist" instead of "something went wrong", which are different problems
+ *  with different next steps. */
+export class NotFoundError extends Error {}
+
 async function call(
   path: string,
   init?: RequestInit,
@@ -37,7 +47,8 @@ async function call(
     headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
   })
   if (!response.ok) {
-    throw await readError(response, 'That turn could not be completed.')
+    const error = await readError(response, 'That turn could not be completed.')
+    throw response.status === 404 ? new NotFoundError(error.message) : error
   }
   return (await response.json()) as ListicleGrillState
 }
@@ -49,10 +60,14 @@ export function startGrill(seed: string): Promise<ListicleGrillState> {
   })
 }
 
-export function answerGrill(runId: string, answer: string): Promise<ListicleGrillState> {
+export function answerGrill(
+  runId: string,
+  answer: string,
+  selections: ListicleAngleSelection[] = [],
+): Promise<ListicleGrillState> {
   return call(`${BASE}/grill/answer`, {
     method: 'POST',
-    body: JSON.stringify({ run_id: runId, answer }),
+    body: JSON.stringify({ run_id: runId, answer, selections }),
   })
 }
 
@@ -62,14 +77,58 @@ export function loadGrill(runId: string): Promise<ListicleGrillState> {
 
 
 /**
- * Run the agreed search order, or read what a previous run found.
+ * The agreement, as the searches will run it.
+ *
+ * Read rather than derived from the consensus paragraph. What the operator sees
+ * and what the searches do now come from one record, which is the whole fix for
+ * a run that displayed twenty and searched for forty.
+ */
+export async function loadOrder(runId: string): Promise<ListicleOrder | null> {
+  const response = await apiFetch(`${BASE}/order/${runId}`)
+  // Not agreed yet is a state, not a failure.
+  if (response.status === 404) return null
+  if (!response.ok) throw await readError(response, 'The search order could not be read.')
+  return (await response.json()) as ListicleOrder
+}
+
+/** Correct the agreement. The correction becomes a new revision, so results
+ *  gathered under the old one cannot be shown as answers to the new one. */
+export async function reviseOrder(
+  runId: string,
+  patch: { target_count?: number; angles?: ListicleOrder['angles'] },
+): Promise<ListicleOrder> {
+  const response = await apiFetch(`${BASE}/order/${runId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  if (!response.ok) throw await readError(response, 'That correction was refused.')
+  return (await response.json()) as ListicleOrder
+}
+
+
+/**
+ * Run the agreed search order, or read what this run already knows.
  *
  * Running is minutes of grounded searching and real tokens, so it is only ever
  * something the operator asks for -- `loadSearch` is what a screen calls when
- * it opens.
+ * it opens, and it never searches.
+ *
+ * `angleIds` runs a named subset, which is how a retry costs one search rather
+ * than six. `reuse: false` is the deliberate full refresh.
  */
-export async function runSearch(runId: string): Promise<ListicleSearchResults> {
-  const response = await apiFetch(`${BASE}/search/${runId}`, { method: 'POST' })
+export async function runSearch(
+  runId: string,
+  options: { angleIds?: string[]; reuse?: boolean } = {},
+): Promise<ListicleSearchResults> {
+  const response = await apiFetch(`${BASE}/search/${runId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      angle_ids: options.angleIds ?? [],
+      reuse: options.reuse ?? true,
+    }),
+  })
   if (!response.ok) throw await readError(response, 'The search could not be run.')
   return (await response.json()) as ListicleSearchResults
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/AnglePicker.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/AnglePicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import type { ListicleGrillOption } from '../types'
+import type { ListicleAngleSelection, ListicleGrillOption } from '../types'
 
 /**
  * The angle question, answered by choosing rather than by writing.
@@ -21,16 +21,33 @@ import type { ListicleGrillOption } from '../types'
  * and a model that has just broken that rule will not notice it did. Someone
  * reading "opened in the last year AND has significant buzz" is the only check
  * there is.
+ *
+ * Two things changed with the plan of 2026-09-08. What is sent back is the
+ * records, not a paragraph -- so the order knows which menu entry each line
+ * came from and whether it was changed, instead of inferring it from a
+ * sentence. And a clash is explained rather than announced: `cheap` and
+ * `hidden` used to be one group of which at most one could be chosen, and an
+ * expensive hidden bar and a cheap neighbourhood one are both real.
  */
 
 export interface AnglePickerProps {
   options: ListicleGrillOption[]
   busy: boolean
-  onSend: (answer: string) => void
+  onSend: (answer: string, selections: ListicleAngleSelection[]) => void
 }
 
 interface Choice extends ListicleGrillOption {
   keep: boolean
+  /** The wording as it arrived. What "edited" is measured against. */
+  original: string
+}
+
+/** What each role means, said in the operator's terms rather than the
+ *  catalogue's. The number a search is asked for follows from it. */
+const ROLE_NOTE: Record<string, string> = {
+  broad: 'fills a lot of the list',
+  distinctive: 'finds what the broad searches miss',
+  specific: 'a handful of places; one is a good answer',
 }
 
 export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
@@ -39,22 +56,47 @@ export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
   // A new question replaces the list outright. Carrying edits across questions
   // would silently answer the new one with the old one's lines.
   useEffect(() => {
-    setChoices(options.map(option => ({ ...option, keep: option.recommended })))
+    setChoices(
+      options.map(option => ({
+        ...option,
+        keep: option.recommended,
+        original: option.text,
+      })),
+    )
   }, [options])
 
   const kept = choices.filter(choice => choice.keep && choice.text.trim())
   const answer = kept.map(choice => choice.text.trim()).join('\n')
 
-  // Two ticked angles from one group run two searches that come back with the
-  // same places. Said, not enforced: the operator knows the city, and this is
-  // a default rather than a law.
+  const selections: ListicleAngleSelection[] = kept.map((choice, index) => ({
+    text: choice.text.trim(),
+    angle_id: `a${index + 1}`,
+    shape_key: choice.shape,
+    group: choice.group,
+    role: choice.role,
+    // Measured against the wording that arrived, not guessed at afterwards.
+    // An edited line may no longer mean what its shape meant, and everything
+    // downstream treats the catalogue's opinion about it as provisional.
+    edited: choice.text.trim() !== choice.original.trim(),
+    custom: !choice.shape,
+  }))
+
+  // Two ticked angles that tend to return the same places. Explained, never
+  // enforced: the operator knows the city, and the pairs that actually collide
+  // vary by city -- award-listed and expensive are the same restaurants in some
+  // and nothing like each other in others.
   const clashes = useMemo(() => {
-    const counts = new Map<string, number>()
+    const byGroup = new Map<string, Choice[]>()
     for (const choice of kept) {
-      if (choice.group) counts.set(choice.group, (counts.get(choice.group) ?? 0) + 1)
+      if (!choice.group || choice.text.trim() !== choice.original.trim()) continue
+      byGroup.set(choice.group, [...(byGroup.get(choice.group) ?? []), choice])
     }
-    return [...counts].filter(([, count]) => count > 1).map(([group]) => group)
+    return [...byGroup].filter(([, group]) => group.length > 1)
   }, [kept])
+
+  // A line the operator rewrote. Worth saying once, because the theme label
+  // still shown beside it came from the wording it no longer has.
+  const editedCount = selections.filter(selection => selection.edited).length
 
   function update(index: number, patch: Partial<Choice>) {
     setChoices(current =>
@@ -63,6 +105,7 @@ export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
   }
 
   function row(choice: Choice, index: number) {
+    const changed = choice.text.trim() !== choice.original.trim()
     return (
       // Index-keyed on purpose: rows are edited in place and never reordered,
       // and the text itself changes as it is typed.
@@ -83,7 +126,28 @@ export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
           disabled={busy}
           onChange={event => update(index, { text: event.target.value })}
         />
-        {choice.group && <span className="lp-picker-group">{choice.group}</span>}
+        <span className="lp-picker-tags">
+          {choice.role && (
+            <span className="lp-picker-role" title={ROLE_NOTE[choice.role] ?? ''}>
+              {choice.role}
+            </span>
+          )}
+          {choice.group && (
+            <span
+              className={
+                changed ? 'lp-picker-group lp-picker-group-stale' : 'lp-picker-group'
+              }
+              title={
+                changed
+                  ? 'You changed this line, so this label describes the wording it used to have.'
+                  : undefined
+              }
+            >
+              {choice.group}
+              {changed ? '?' : ''}
+            </span>
+          )}
+        </span>
       </li>
     )
   }
@@ -92,30 +156,60 @@ export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
   const recommended = picks.filter(([choice]) => choice.recommended)
   const alternates = picks.filter(([choice]) => !choice.recommended)
 
+  // Alternatives grouped by their theme, so the menu reads as kinds of angle
+  // rather than as a long undifferentiated list. Ungrouped ones -- the
+  // catalogue has no shape for them -- go last under their own heading,
+  // because they are the ones nothing else could have suggested.
+  const alternateGroups = useMemo(() => {
+    const byTheme = new Map<string, (readonly [Choice, number])[]>()
+    for (const entry of alternates) {
+      const theme = entry[0].group || 'Specific to this list'
+      byTheme.set(theme, [...(byTheme.get(theme) ?? []), entry])
+    }
+    return [...byTheme].sort(([a], [b]) =>
+      a === 'Specific to this list' ? 1 : b === 'Specific to this list' ? -1 : a.localeCompare(b),
+    )
+  }, [alternates])
+
   return (
     <div className="lp-picker">
       <p className="lp-picker-hint">
         These are the searches. Untick what you don&apos;t want, edit the wording, or
-        take one from below.
+        take one from below. A line you edit is kept exactly as you write it.
       </p>
 
       <ul className="lp-picker-list">{recommended.map(([choice, index]) => row(choice, index))}</ul>
 
-      {alternates.length > 0 && (
+      {alternateGroups.length > 0 && (
         <>
           <p className="lp-picker-heading">
             Other angles for this list &mdash; tick any to add
           </p>
-          <ul className="lp-picker-list">
-            {alternates.map(([choice, index]) => row(choice, index))}
-          </ul>
+          {alternateGroups.map(([theme, entries]) => (
+            <div key={theme} className="lp-picker-theme">
+              <p className="lp-picker-theme-name">{theme}</p>
+              <ul className="lp-picker-list">
+                {entries.map(([choice, index]) => row(choice, index))}
+              </ul>
+            </div>
+          ))}
         </>
       )}
 
-      {clashes.length > 0 && (
-        <p className="lp-picker-warning" role="status">
-          Two ticked angles are both <strong>{clashes.join(' and ')}</strong>. They tend
-          to return the same places, so one of them is probably a wasted search.
+      {clashes.map(([group, members]) => (
+        <p key={group} className="lp-picker-warning" role="status">
+          {members.length} ticked angles are both <strong>{group}</strong>. Those often
+          return the same places, so one may be a wasted search &mdash; keep both if you
+          know this city separates them.
+        </p>
+      ))}
+
+      {editedCount > 0 && (
+        <p className="lp-picker-note" role="status">
+          {editedCount === 1 ? 'One line has' : `${editedCount} lines have`} been edited.
+          Your wording is used exactly as written; the labels beside{' '}
+          {editedCount === 1 ? 'it' : 'them'} describe what{' '}
+          {editedCount === 1 ? 'it' : 'they'} said before.
         </p>
       )}
 
@@ -127,19 +221,31 @@ export function AnglePicker({ options, busy, onSend }: AnglePickerProps) {
           onClick={() =>
             setChoices(current => [
               ...current,
-              { text: '', recommended: true, group: '', keep: true },
+              {
+                text: '',
+                recommended: true,
+                group: '',
+                shape: '',
+                role: 'distinctive',
+                keep: true,
+                original: '',
+              },
             ])
           }
         >
           Add an angle
         </button>
         <span className="lp-picker-count">
-          {/* The honest progress signal: roughly seven items come from each
-              search, so this number is what decides whether the list can reach
-              its target at all. */}
+          {/* The honest progress signal: how many separate searches this
+              order will run. How many places each one is asked for is worked
+              out from the count and the roles once the order is agreed. */}
           {kept.length} {kept.length === 1 ? 'search' : 'searches'}
         </span>
-        <button type="button" disabled={busy || !answer} onClick={() => onSend(answer)}>
+        <button
+          type="button"
+          disabled={busy || !answer}
+          onClick={() => onSend(answer, selections)}
+        >
           Use these
         </button>
       </div>

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/GrillScreen.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/GrillScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { AnglePicker } from './AnglePicker'
+import type { ListicleAngleSelection } from '../types'
 import type { ListicleGrillState } from '../types'
 
 /**
@@ -32,7 +33,10 @@ const MARKER_LABELS: Record<string, string> = {
 interface GrillScreenProps {
   state: ListicleGrillState
   busy: boolean
-  onAnswer: (text: string) => void
+  /** The second argument is the picker's own record of what was chosen: which
+   *  menu entry each line came from and whether it was edited. Empty for every
+   *  question answered by typing, which is all of them but one. */
+  onAnswer: (text: string, selections?: ListicleAngleSelection[]) => void
   onReset: () => void
 }
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
@@ -19,6 +19,7 @@ interface OrderPanelProps {
   order: ListicleOrder
   busy: boolean
   onCorrectCount: (target: number) => void
+  onCorrectRequirements: (patch: { standard?: string; exclusions?: string }) => void
 }
 
 const SOURCE_NOTE: Record<string, string> = {
@@ -30,14 +31,28 @@ const SOURCE_NOTE: Record<string, string> = {
   default: 'nothing said how many, so this is a default',
 }
 
-export function OrderPanel({ order, busy, onCorrectCount }: OrderPanelProps) {
+export function OrderPanel({
+  order,
+  busy,
+  onCorrectCount,
+  onCorrectRequirements,
+}: OrderPanelProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(String(order.target_count))
+  const [editingRequirements, setEditingRequirements] = useState(false)
+  const [standard, setStandard] = useState(order.standard)
+  const [exclusions, setExclusions] = useState(order.exclusions)
 
   useEffect(() => {
     setDraft(String(order.target_count))
     setEditing(false)
   }, [order.target_count, order.revision])
+
+  useEffect(() => {
+    setStandard(order.standard)
+    setExclusions(order.exclusions)
+    setEditingRequirements(false)
+  }, [order.standard, order.exclusions, order.revision])
 
   const parsed = Number.parseInt(draft, 10)
   const valid = Number.isFinite(parsed) && parsed >= 1 && parsed <= 200
@@ -110,24 +125,83 @@ export function OrderPanel({ order, busy, onCorrectCount }: OrderPanelProps) {
         </button>
       )}
 
-      <dl className="lp-order-requirements">
-        {order.standard && (
-          <>
-            <dt>Earns a place</dt>
-            <dd>{order.standard}</dd>
-          </>
-        )}
-        {order.exclusions && (
-          <>
-            <dt>Left out</dt>
-            <dd>{order.exclusions}</dd>
-          </>
-        )}
-      </dl>
-      {(order.standard || order.exclusions) && (
-        <p className="lp-muted lp-order-note">
-          Attached to every search, whichever angle finds the place.
+      {/* A marker the interview answered twice. The value was resolved from
+          the answers rather than by taking the last one, and the resolution is
+          said out loud: keeping both is the safe reading, not the certain one,
+          and the operator is the only one who knows which they meant. */}
+      {order.answer_notes.map(note => (
+        <p key={note} className="lp-order-warning" role="status">
+          {note}
         </p>
+      ))}
+
+      {editingRequirements ? (
+        <div className="lp-order-edit lp-order-edit-requirements">
+          <label htmlFor="lp-standard">What earns a place</label>
+          <textarea
+            id="lp-standard"
+            rows={3}
+            value={standard}
+            disabled={busy}
+            onChange={event => setStandard(event.target.value)}
+          />
+          <label htmlFor="lp-exclusions">What is left out</label>
+          <textarea
+            id="lp-exclusions"
+            rows={3}
+            value={exclusions}
+            disabled={busy}
+            onChange={event => setExclusions(event.target.value)}
+          />
+          <button
+            type="button"
+            disabled={
+              busy ||
+              (standard === order.standard && exclusions === order.exclusions)
+            }
+            onClick={() => onCorrectRequirements({ standard, exclusions })}
+          >
+            Use these
+          </button>
+          <button
+            type="button"
+            className="lp-secondary"
+            disabled={busy}
+            onClick={() => setEditingRequirements(false)}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <>
+          <dl className="lp-order-requirements">
+            {order.standard && (
+              <>
+                <dt>Earns a place</dt>
+                <dd>{order.standard}</dd>
+              </>
+            )}
+            {order.exclusions && (
+              <>
+                <dt>Left out</dt>
+                <dd>{order.exclusions}</dd>
+              </>
+            )}
+          </dl>
+          {(order.standard || order.exclusions) && (
+            <p className="lp-muted lp-order-note">
+              Attached to every search, whichever angle finds the place.
+            </p>
+          )}
+          <button
+            type="button"
+            className="lp-secondary lp-order-correct"
+            disabled={busy}
+            onClick={() => setEditingRequirements(true)}
+          >
+            Correct what earns a place, or what is left out
+          </button>
+        </>
       )}
 
       <ol className="lp-order-angles">

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react'
+import type { ListicleOrder } from '../types'
+
+/**
+ * The agreement, as the searches will actually run it.
+ *
+ * On screen because the alternative was believing a paragraph. The only real
+ * run of this pipeline displayed a search order for twenty items and searched
+ * for forty: the number had been read back out of a sentence, and there was
+ * nowhere in the interface that would have shown the disagreement.
+ *
+ * So the count is shown as a number, it says where it came from, and it can be
+ * corrected here. A correction makes a new revision rather than an edit in
+ * place, which is what lets the results screen say which stored searches still
+ * answer the question being asked.
+ */
+
+interface OrderPanelProps {
+  order: ListicleOrder
+  busy: boolean
+  onCorrectCount: (target: number) => void
+}
+
+const SOURCE_NOTE: Record<string, string> = {
+  answered: 'you said this',
+  corrected: 'you corrected this',
+  'corrected by operator': 'you corrected this',
+  accepted: 'you agreed to the number suggested',
+  seed: 'read off the title; the interview never settled it',
+  default: 'nothing said how many, so this is a default',
+}
+
+export function OrderPanel({ order, busy, onCorrectCount }: OrderPanelProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(String(order.target_count))
+
+  useEffect(() => {
+    setDraft(String(order.target_count))
+    setEditing(false)
+  }, [order.target_count, order.revision])
+
+  const parsed = Number.parseInt(draft, 10)
+  const valid = Number.isFinite(parsed) && parsed >= 1 && parsed <= 200
+
+  return (
+    <section className="lp-order" aria-label="The agreed search order">
+      <header className="lp-order-head">
+        <p className="lp-order-title">
+          The search order
+          {order.revision > 1 && (
+            <span className="lp-muted"> &middot; revision {order.revision}</span>
+          )}
+        </p>
+        <p className="lp-order-line">
+          <strong>{order.target_count}</strong> {order.kind || 'places'} in{' '}
+          {order.place || 'the location'}
+          <span className="lp-muted">
+            {' '}
+            &mdash; {SOURCE_NOTE[order.count_source] ?? order.count_source}
+          </span>
+        </p>
+      </header>
+
+      {/* An ambiguous answer is used so the run is not stuck, and never
+          presented as settled. The number is on screen and one click away from
+          being corrected, which is the difference between a guess and a guess
+          you can see. */}
+      {order.count_ambiguous && order.count_note && (
+        <p className="lp-order-warning" role="status">
+          {order.count_note}
+        </p>
+      )}
+
+      {editing ? (
+        <div className="lp-order-edit">
+          <label htmlFor="lp-target-count">How many items?</label>
+          <input
+            id="lp-target-count"
+            type="number"
+            min={1}
+            max={200}
+            value={draft}
+            disabled={busy}
+            onChange={event => setDraft(event.target.value)}
+          />
+          <button
+            type="button"
+            disabled={busy || !valid || parsed === order.target_count}
+            onClick={() => onCorrectCount(parsed)}
+          >
+            Use this number
+          </button>
+          <button
+            type="button"
+            className="lp-secondary"
+            disabled={busy}
+            onClick={() => setEditing(false)}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="lp-secondary lp-order-correct"
+          disabled={busy}
+          onClick={() => setEditing(true)}
+        >
+          Correct the number
+        </button>
+      )}
+
+      <dl className="lp-order-requirements">
+        {order.standard && (
+          <>
+            <dt>Earns a place</dt>
+            <dd>{order.standard}</dd>
+          </>
+        )}
+        {order.exclusions && (
+          <>
+            <dt>Left out</dt>
+            <dd>{order.exclusions}</dd>
+          </>
+        )}
+      </dl>
+      {(order.standard || order.exclusions) && (
+        <p className="lp-muted lp-order-note">
+          Attached to every search, whichever angle finds the place.
+        </p>
+      )}
+
+      <ol className="lp-order-angles">
+        {order.angles.map(angle => (
+          <li key={angle.angle_id} className="lp-order-angle">
+            <span className="lp-order-angle-text">{angle.text}</span>
+            <span className="lp-order-angle-tags">
+              <span className="lp-picker-role">{angle.role}</span>
+              <span className="lp-muted">asks for {angle.wanted}</span>
+              {angle.edited && <span className="lp-order-edited">your wording</span>}
+              {angle.custom && !angle.edited && (
+                <span className="lp-order-edited">your angle</span>
+              )}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {/* Said, and not fixed. Adding a search nobody approved is the behaviour
+          this whole record exists to prevent. */}
+      {order.capacity_warning && (
+        <p className="lp-order-warning" role="status">
+          {order.capacity_warning} Add an angle, or take the shorter list.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
@@ -54,6 +54,10 @@ export function OrderPanel({
     setEditingRequirements(false)
   }, [order.standard, order.exclusions, order.revision])
 
+  const conflictsByAngle = new Map(
+    (order.angle_conflicts ?? []).map(conflict => [conflict.angle_id, conflict.why]),
+  )
+
   const parsed = Number.parseInt(draft, 10)
   const valid = Number.isFinite(parsed) && parsed >= 1 && parsed <= 200
 
@@ -204,6 +208,14 @@ export function OrderPanel({
         </>
       )}
 
+      {/* Nobody looked is not the same as nothing found, and an order that
+          stays quiet about the difference reads as cleared. */}
+      {order.conflicts_checked === false && order.exclusions && (
+        <p className="lp-muted lp-order-note">
+          These searches have not been checked against what you left out.
+        </p>
+      )}
+
       <ol className="lp-order-angles">
         {order.angles.map(angle => (
           <li key={angle.angle_id} className="lp-order-angle">
@@ -225,6 +237,19 @@ export function OrderPanel({
             {angle.last_time && (
               <span className="lp-muted lp-order-angle-history">
                 {angle.last_time}
+              </span>
+            )}
+            {/* This search looks like it will return places the same order
+                bars. Run 33fca394 approved "Nikkei cevicherias" alongside a
+                cut reading "no places where ceviche is not the primary
+                offering"; 8 of that search's 10 results were barred by the
+                order that bought it. The disagreement was visible here,
+                before the money went. Said, not enforced: an operator who
+                wants Nikkei places that genuinely lead with ceviche is asking
+                for something coherent, and only they know that. */}
+            {conflictsByAngle.get(angle.angle_id) && (
+              <span className="lp-order-angle-conflict">
+                Fights what you left out: {conflictsByAngle.get(angle.angle_id)}
               </span>
             )}
           </li>

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/OrderPanel.tsx
@@ -216,6 +216,17 @@ export function OrderPanel({
                 <span className="lp-order-edited">your angle</span>
               )}
             </span>
+            {/* What this search bought last time, before this time is paid
+                for. In run 33fca394 two of the seven searches returned no
+                place the others missed, and the only place that was visible
+                was a table drawn after the money was gone. Nothing acts on
+                this: the operator knows the city, and two runs is a fact
+                about two runs. */}
+            {angle.last_time && (
+              <span className="lp-muted lp-order-angle-history">
+                {angle.last_time}
+              </span>
+            )}
           </li>
         ))}
       </ol>

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
@@ -44,6 +44,13 @@ export function SearchResults({ results, busy, onRun }: SearchResultsProps) {
     angle => angle.state === 'failed' || angle.state === 'interrupted',
   )
   const unrun = results.angles.filter(angle => angle.state === 'not_started')
+  // A finished search that returned no place the others missed. Every one of
+  // these was paid for. In run 33fca394 two of seven were like this and
+  // nothing anywhere said so — the numbers were in the table and the sentence
+  // was not.
+  const emptyHanded = results.angles.filter(
+    angle => angle.state === 'completed' && angle.exclusive === 0,
+  )
   // Deduplicated across every angle: the same paper cited by three searches is
   // one publication, not three.
   const sourcesNamed = [
@@ -71,6 +78,14 @@ export function SearchResults({ results, busy, onRun }: SearchResultsProps) {
             {results.uncertain_identity === 1 ? 'entry has' : 'entries have'} a
             possible duplicate beside {results.uncertain_identity === 1 ? 'it' : 'them'},
             so this count is provisional.
+          </p>
+        )}
+        {emptyHanded.length > 0 && (
+          <p className="lp-muted lp-results-sub">
+            {emptyHanded.length} of {results.angles.length} searches returned no
+            place the others missed. Not wasted by definition — a search with
+            nothing exclusive may be the coverage the rest are being checked
+            against — but each one was paid for.
           </p>
         )}
         {short && (

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
@@ -179,6 +179,25 @@ export function SearchResults({ results, busy, onRun }: SearchResultsProps) {
         </tbody>
       </table>
 
+      {/* The cut is composed into every search prompt and the model does not
+          reliably obey it. Run 33fca394 returned eight Nikkei and Japanese
+          restaurants against an explicit "no places where ceviche is not the
+          primary offering". Nothing here checks them, and a list presented
+          without saying so reads as though something did.
+
+          Not solved with more prompt text -- that was already tried and is
+          what produced the eight. Checking a place against the cut is a
+          judgement about that place, and it is not built. `gate.assess` does
+          not do it either: it weighs whether enough is published about a
+          place, and every one of those eight is written about constantly. */}
+      {results.order.exclusions && results.candidates.length > 0 && (
+        <p className="lp-results-unchecked" role="status">
+          Nothing below has been checked against what you left out. The rule
+          went to every search; whether a place breaks it is not something this
+          step decides.
+        </p>
+      )}
+
       <ol className="lp-candidates">
         {results.candidates.map(candidate => (
           <li key={`${candidate.name}-${candidate.district}`} className="lp-candidate">

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
@@ -1,27 +1,54 @@
-import type { ListicleSearchResults } from '../types'
+import type { ListicleAngleResult, ListicleSearchResults } from '../types'
 
 /**
  * What the searches found.
  *
- * The list is ordered by how many angles found each place, not alphabetically
- * and not by any score. A place three separate searches returned is the
- * strongest thing here, and that ordering is the only ranking the pipeline has
- * earned so far -- it comes out of the searches rather than out of a model
- * being asked which restaurant is best.
+ * The list is ordered by how many angles found each place. That is repeated
+ * discovery and it is reported as itself: a place three searches returned has
+ * been found three times, which is not the same as being the best one, and
+ * nothing here has checked whether any of them is worth writing about. Ranking
+ * belongs after evidence, and the evidence step is not built.
  *
  * The per-angle table is above the list on purpose. When the count falls short
  * the question is always "which search failed", and an angle that returned
- * nothing is the answer.
+ * nothing is the answer. Each row now says what the angle contributed as well
+ * as what it returned: how much of its haul other angles found too, and how
+ * much only it found. A search with few exclusive names is not thereby useless
+ * -- it may be the coverage everything else is being checked against.
  */
 
 interface SearchResultsProps {
   results: ListicleSearchResults
   busy: boolean
-  onRerun: () => void
+  /** Re-run some or all of the order. Named angles cost one search each. */
+  onRun: (options: { angleIds?: string[]; reuse?: boolean }) => void
 }
 
-export function SearchResults({ results, busy, onRerun }: SearchResultsProps) {
+const STATE_LABEL: Record<string, string> = {
+  not_started: 'not run yet',
+  running: 'running',
+  completed: '',
+  failed: 'failed',
+  interrupted: 'interrupted',
+}
+
+function angleNote(angle: ListicleAngleResult): string {
+  const label = STATE_LABEL[angle.state] ?? angle.state
+  if (angle.state === 'completed') return angle.reason
+  return angle.reason ? `${label} — ${angle.reason}` : label
+}
+
+export function SearchResults({ results, busy, onRun }: SearchResultsProps) {
   const short = results.shortfall > 0
+  const rerunnable = results.angles.filter(
+    angle => angle.state === 'failed' || angle.state === 'interrupted',
+  )
+  const unrun = results.angles.filter(angle => angle.state === 'not_started')
+  // Deduplicated across every angle: the same paper cited by three searches is
+  // one publication, not three.
+  const sourcesNamed = [
+    ...new Set(results.angles.flatMap(angle => angle.sources_named ?? [])),
+  ].sort()
 
   return (
     <section className="lp-results" aria-label="What the searches found">
@@ -32,26 +59,105 @@ export function SearchResults({ results, busy, onRerun }: SearchResultsProps) {
         </p>
         <p className="lp-muted lp-results-sub">
           {results.rows_returned} results across {results.angles.length} searches,{' '}
-          {results.rows_returned - results.found} of them the same place found twice
+          {Math.max(0, results.rows_returned - results.found)} of them the same place
+          found more than once
         </p>
+        {/* A distinct count is provisional while any two rows might be one
+            venue. Printing one number without saying so implies a certainty
+            this step has not got. */}
+        {results.uncertain_identity > 0 && (
+          <p className="lp-muted lp-results-sub">
+            {results.uncertain_identity}{' '}
+            {results.uncertain_identity === 1 ? 'entry has' : 'entries have'} a
+            possible duplicate beside {results.uncertain_identity === 1 ? 'it' : 'them'},
+            so this count is provisional.
+          </p>
+        )}
         {short && (
           <p className="lp-results-short" role="status">
             {results.shortfall} short. Add an angle, or take the shorter list.
           </p>
         )}
+        {results.capacity_warning && (
+          <p className="lp-results-short" role="status">
+            {results.capacity_warning}
+          </p>
+        )}
+        {results.running && (
+          <p className="lp-muted" role="status">
+            Searches are still running for this order. This is what has finished
+            so far.
+          </p>
+        )}
+        {results.legacy && (
+          <p className="lp-muted" role="status">
+            Stored before this pipeline recorded work per search, so individual
+            searches cannot be re-run from here.
+          </p>
+        )}
       </header>
 
+      {/* Where the searches actually looked. The citation URLs are opaque
+          Google redirects, so this list is the only thing that can answer
+          "did it read local sources or only the visitor guides". */}
+      {sourcesNamed.length > 0 && (
+        <details className="lp-sources">
+          <summary>
+            {sourcesNamed.length} publications behind these results
+          </summary>
+          <p className="lp-sources-list">{sourcesNamed.join(' · ')}</p>
+        </details>
+      )}
+
       <table className="lp-angle-table">
+        <thead>
+          <tr>
+            <th scope="col">Returned</th>
+            <th scope="col">Search</th>
+            <th scope="col">Shared</th>
+            <th scope="col">Only this</th>
+            <th scope="col" />
+          </tr>
+        </thead>
         <tbody>
           {results.angles.map(angle => (
-            <tr key={angle.angle} className={angle.failed ? 'lp-angle-failed' : undefined}>
+            <tr
+              key={angle.angle_id || angle.angle}
+              className={angle.failed ? 'lp-angle-failed' : undefined}
+            >
               <td className="lp-angle-count">{angle.rows}</td>
-              <td>{angle.angle}</td>
+              <td>
+                {angle.angle}
+                <span className="lp-angle-tags">
+                  <span className="lp-picker-role">{angle.role}</span>
+                  {angle.reused && angle.gathered_at && (
+                    <span className="lp-muted" title={angle.gathered_at}>
+                      reused from earlier research
+                    </span>
+                  )}
+                </span>
+              </td>
+              {/* Contribution, against the whole pool. Calculated after every
+                  search finished, so reordering them cannot change it. */}
+              <td className="lp-angle-count lp-muted">{angle.shared}</td>
+              <td className="lp-angle-count">{angle.exclusive}</td>
               <td className="lp-muted lp-angle-note">
                 {/* A search that broke and a search that found nothing are
                     different findings, and only one of them is worth
                     re-running. */}
-                {angle.failed ? `failed — ${angle.reason}` : angle.reason}
+                {angleNote(angle)}
+                {(angle.state === 'failed' ||
+                  angle.state === 'interrupted' ||
+                  angle.state === 'not_started') && (
+                  <button
+                    type="button"
+                    className="lp-link-button"
+                    disabled={busy}
+                    onClick={() => onRun({ angleIds: [angle.angle_id], reuse: false })}
+                  >
+                    run this one
+                  </button>
+                )}
               </td>
             </tr>
           ))}
@@ -60,7 +166,7 @@ export function SearchResults({ results, busy, onRerun }: SearchResultsProps) {
 
       <ol className="lp-candidates">
         {results.candidates.map(candidate => (
-          <li key={candidate.name} className="lp-candidate">
+          <li key={`${candidate.name}-${candidate.district}`} className="lp-candidate">
             <div className="lp-candidate-line">
               <span className="lp-candidate-name">{candidate.name}</span>
               {candidate.district && (
@@ -68,22 +174,77 @@ export function SearchResults({ results, busy, onRerun }: SearchResultsProps) {
               )}
               {candidate.overlap > 1 && (
                 <span className="lp-candidate-overlap" title={candidate.found_by.join('\n')}>
-                  found by {candidate.overlap}
+                  found by {candidate.overlap} searches
                 </span>
               )}
             </div>
             {candidate.evidence && (
               <p className="lp-candidate-evidence">{candidate.evidence}</p>
             )}
+            {/* Every row as a search returned it. Two angles found this place
+                for two different reasons, and the reasons are what a person
+                needs to check whether it is one place. */}
+            {candidate.sightings.length > 1 && (
+              <ul className="lp-candidate-sightings">
+                {candidate.sightings.map((sighting, index) => (
+                  <li key={index}>
+                    <span className="lp-muted">{sighting.angle}:</span> {sighting.name}
+                    {sighting.evidence ? ` — ${sighting.evidence}` : ''}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {/* Shown rather than resolved. This step cannot tell a second
+                branch from a second spelling, and folding them together loses
+                a venue with nothing on screen to notice. */}
+            {candidate.possible_duplicates.length > 0 && (
+              <p className="lp-candidate-duplicate">
+                Might be the same place as {candidate.possible_duplicates.join(', ')}.
+              </p>
+            )}
           </li>
         ))}
       </ol>
 
       <div className="lp-actions">
-        <button type="button" className="lp-secondary" onClick={onRerun} disabled={busy}>
-          {busy ? 'Searching…' : 'Run the searches again'}
+        {rerunnable.length > 0 && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() =>
+              onRun({ angleIds: rerunnable.map(angle => angle.angle_id), reuse: false })
+            }
+          >
+            {busy
+              ? 'Searching…'
+              : `Retry ${rerunnable.length} failed ${
+                  rerunnable.length === 1 ? 'search' : 'searches'
+                }`}
+          </button>
+        )}
+        {unrun.length > 0 && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onRun({})}
+          >
+            {busy ? 'Searching…' : `Run ${unrun.length} remaining`}
+          </button>
+        )}
+        <button
+          type="button"
+          className="lp-secondary"
+          onClick={() => onRun({ reuse: false })}
+          disabled={busy}
+        >
+          {busy ? 'Searching…' : 'Search everything again'}
         </button>
       </div>
+      <p className="lp-muted lp-results-sub">
+        Searching everything again buys new research for every angle. Retrying one
+        search costs one search &mdash; and a search that was interrupted may have
+        been charged already.
+      </p>
     </section>
   )
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/components/SearchResults.tsx
@@ -191,11 +191,19 @@ export function SearchResults({ results, busy, onRun }: SearchResultsProps) {
           not do it either: it weighs whether enough is published about a
           place, and every one of those eight is written about constantly. */}
       {results.order.exclusions && results.candidates.length > 0 && (
-        <p className="lp-results-unchecked" role="status">
-          Nothing below has been checked against what you left out. The rule
-          went to every search; whether a place breaks it is not something this
-          step decides.
-        </p>
+        results.cut_checked ? (
+          <p className="lp-results-unchecked" role="status">
+            {results.barred_count
+              ? `${results.barred_count} of these look like places you left out — marked below. Judged from what the searches themselves reported, not from a fresh look at each place, so check before dropping any.`
+              : 'Checked against what you left out; none of these looked barred. That is a reading of what the searches reported, not a verification of the places.'}
+          </p>
+        ) : (
+          <p className="lp-results-unchecked" role="status">
+            Nothing below has been checked against what you left out. The rule
+            went to every search; whether a place breaks it is not something
+            this step decides.
+          </p>
+        )
       )}
 
       <ol className="lp-candidates">
@@ -231,6 +239,28 @@ export function SearchResults({ results, busy, onRun }: SearchResultsProps) {
             {/* Shown rather than resolved. This step cannot tell a second
                 branch from a second spelling, and folding them together loses
                 a venue with nothing on screen to notice. */}
+            {/* Flagged, never removed.
+
+                Both levels read as "look at this", not as a verdict. Measured
+                on real data: which places get flagged is stable across runs,
+                but whether one comes back `clear` or `arguable` is not -- the
+                same 43 candidates produced 13/13/11 flags over three calls
+                with the split moving each time. The reason underneath is the
+                substance; the level is only a rough ordering. */}
+            {candidate.barred && (
+              <p
+                className={
+                  candidate.barred_confidence === 'clear'
+                    ? 'lp-candidate-barred'
+                    : 'lp-candidate-barred lp-candidate-barred-arguable'
+                }
+              >
+                {candidate.barred_confidence === 'clear'
+                  ? 'Looks like something you left out'
+                  : 'Might be something you left out'}
+                : {candidate.barred}
+              </p>
+            )}
             {candidate.possible_duplicates.length > 0 && (
               <p className="lp-candidate-duplicate">
                 Might be the same place as {candidate.possible_duplicates.join(', ')}.

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
@@ -370,6 +370,33 @@ describe('the agreed order on screen', () => {
     ).toBeInTheDocument()
   })
 
+  it('says the candidates were never checked against the cut', async () => {
+    // Run 33fca394 returned eight Nikkei and Japanese restaurants against an
+    // explicit "no places where ceviche is not the primary offering". A list
+    // presented without saying so reads as though something checked it.
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(
+      results({
+        order: {
+          kind: 'cevicherias',
+          place: 'Lima, Peru',
+          target_count: 20,
+          standard: '',
+          exclusions: 'no places where ceviche is not the primary offering',
+          count_source: 'answered',
+          count_ambiguous: false,
+          count_note: '',
+        },
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(
+      await screen.findByText(/has been checked against what you left out/),
+    ).toBeInTheDocument()
+  })
+
   it('says when the order cannot fill the list, without adding a search', async () => {
     loadGrill.mockResolvedValue(AGREED)
     loadOrder.mockResolvedValue(

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
@@ -84,6 +84,7 @@ function order(overrides: Partial<ListicleOrder> = {}): ListicleOrder {
     count_source: 'answered',
     count_ambiguous: false,
     count_note: '',
+    answer_notes: [],
     capacity: 30,
     capacity_warning: '',
     summary: '20 cevicherias in Lima, Peru.',
@@ -289,6 +290,52 @@ describe('the agreed order on screen', () => {
 
     await waitFor(() =>
       expect(reviseOrder).toHaveBeenCalledWith('abc123', { target_count: 12 }),
+    )
+    expect(await screen.findByText(/revision 2/)).toBeInTheDocument()
+  })
+
+  it('says when a marker was answered twice and both answers are being used', async () => {
+    // The fault of 2026-09-08: the cut was settled, then asked again
+    // additively, and the later answer silently replaced the earlier one. Both
+    // are kept now, and keeping both is a reading rather than a certainty, so
+    // it is on screen next to the value it produced.
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(
+      order({
+        exclusions: 'no chains, no delivery-only kitchens. No hotel restaurants.',
+        answer_notes: [
+          'What is left out: This was answered twice and every answer is being used. Correct it here if one of them was meant to replace the others.',
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(
+      await screen.findByText(/every answer is being used/),
+    ).toBeInTheDocument()
+  })
+
+  it('lets the cut be typed out, because a combined one may keep a rule they dropped', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order({ answer_notes: ['What is left out: ...'] }))
+    reviseOrder.mockResolvedValue(
+      order({ exclusions: 'no chains', revision: 2, answer_notes: [] }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /what is left out/i }),
+    )
+    const box = screen.getByLabelText(/what is left out/i)
+    await userEvent.clear(box)
+    await userEvent.type(box, 'no chains only')
+    await userEvent.click(screen.getByRole('button', { name: /use these/i }))
+
+    await waitFor(() =>
+      expect(reviseOrder).toHaveBeenCalledWith('abc123', {
+        standard: 'written up by someone other than the place',
+        exclusions: 'no chains only',
+      }),
     )
     expect(await screen.findByText(/revision 2/)).toBeInTheDocument()
   })

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
@@ -1,0 +1,437 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const startGrill = vi.fn()
+const answerGrill = vi.fn()
+const loadGrill = vi.fn()
+const loadOrder = vi.fn()
+const reviseOrder = vi.fn()
+const runSearch = vi.fn()
+const loadSearch = vi.fn()
+
+vi.mock('./api', async importOriginal => {
+  const actual = await importOriginal<typeof import('./api')>()
+  return {
+    ...actual,
+    startGrill: (...args: unknown[]) => startGrill(...args),
+    answerGrill: (...args: unknown[]) => answerGrill(...args),
+    loadGrill: (...args: unknown[]) => loadGrill(...args),
+    loadOrder: (...args: unknown[]) => loadOrder(...args),
+    reviseOrder: (...args: unknown[]) => reviseOrder(...args),
+    runSearch: (...args: unknown[]) => runSearch(...args),
+    loadSearch: (...args: unknown[]) => loadSearch(...args),
+  }
+})
+
+import { NotFoundError } from './api'
+import { ListiclePipelinePage } from './pages/ListiclePipelinePage'
+import type {
+  ListicleGrillState,
+  ListicleOrder,
+  ListicleSearchResults,
+} from './types'
+
+/**
+ * Getting back to a run.
+ *
+ * The interview and the searches were always stored on the server. What was
+ * not stored anywhere the operator could reach was the run id: it lived in one
+ * hook's memory, so a refresh landed on an empty seed box with a paid, agreed,
+ * searched run in the database and no route to it. These are the behaviours
+ * that fix costs money to get wrong.
+ */
+
+function grill(overrides: Partial<ListicleGrillState> = {}): ListicleGrillState {
+  return {
+    run_id: 'abc123',
+    seed: '20 cevicherias in Lima',
+    status: 'asking',
+    consensus: '',
+    markers_covered: ['kind'],
+    markers_missing: ['place', 'count', 'bar', 'cut', 'angles'],
+    lookups: [],
+    turns: [],
+    pending: {
+      question_id: 'q1',
+      ask: 'How many items?',
+      recommendation: '20',
+      pushback: '',
+      options: [],
+    },
+    ...overrides,
+  }
+}
+
+const AGREED = grill({
+  status: 'agreed',
+  consensus: 'Twenty cevicherias in Lima.',
+  markers_covered: ['kind', 'place', 'count', 'bar', 'cut', 'angles'],
+  markers_missing: [],
+  pending: null,
+})
+
+function order(overrides: Partial<ListicleOrder> = {}): ListicleOrder {
+  return {
+    run_id: 'abc123',
+    revision: 1,
+    kind: 'cevicherias',
+    place: 'Lima, Peru',
+    target_count: 20,
+    standard: 'written up by someone other than the place',
+    exclusions: 'no chains',
+    count_source: 'answered',
+    count_ambiguous: false,
+    count_note: '',
+    capacity: 30,
+    capacity_warning: '',
+    summary: '20 cevicherias in Lima, Peru.',
+    angles: [
+      {
+        angle_id: 'a1',
+        text: 'cevicherias open for decades',
+        shape_key: 'institution',
+        group: 'heritage',
+        role: 'broad',
+        wanted: 15,
+        edited: false,
+        custom: false,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function results(overrides: Partial<ListicleSearchResults> = {}): ListicleSearchResults {
+  return {
+    run_id: 'abc123',
+    revision: 1,
+    target: 20,
+    found: 1,
+    shortfall: 19,
+    rows_returned: 1,
+    running: false,
+    complete: true,
+    uncertain_identity: 0,
+    capacity: 30,
+    capacity_warning: '',
+    order: {
+      kind: 'cevicherias',
+      place: 'Lima, Peru',
+      target_count: 20,
+      standard: '',
+      exclusions: '',
+      count_source: 'answered',
+      count_ambiguous: false,
+      count_note: '',
+    },
+    angles: [
+      {
+        angle_id: 'a1',
+        angle: 'cevicherias open for decades',
+        shape: 'institution',
+        group: 'heritage',
+        role: 'broad',
+        wanted: 15,
+        edited: false,
+        custom: false,
+        state: 'completed',
+        rows: 1,
+        sources: 2,
+        failed: false,
+        reason: '',
+        found: 1,
+        shared: 0,
+        exclusive: 1,
+        gathered_at: '2026-09-08T10:00:00+00:00',
+        sources_named: ['elcomercio.pe', 'ohlalima.com'],
+        reused: false,
+      },
+    ],
+    candidates: [
+      {
+        name: 'Canta Rana',
+        district: 'Barranco',
+        evidence: 'open since the 1980s',
+        found_by: ['cevicherias open for decades'],
+        overlap: 1,
+        possible_duplicates: [],
+        sightings: [],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function ShowLocation() {
+  return <span data-testid="where">{useLocation().pathname}</span>
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <ShowLocation />
+      <Routes>
+        <Route path="/listicle-pipeline" element={<ListiclePipelinePage />} />
+        <Route path="/listicle-pipeline/:runId" element={<ListiclePipelinePage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  startGrill.mockReset()
+  answerGrill.mockReset()
+  loadGrill.mockReset()
+  loadOrder.mockReset().mockResolvedValue(null)
+  reviseOrder.mockReset()
+  runSearch.mockReset()
+  loadSearch.mockReset().mockResolvedValue(null)
+})
+
+describe('getting back to a run', () => {
+  it('puts a new run in the address bar', async () => {
+    startGrill.mockResolvedValue(grill())
+    renderAt('/listicle-pipeline')
+
+    await userEvent.type(
+      screen.getByRole('textbox'),
+      '20 cevicherias in Lima',
+    )
+    await userEvent.click(screen.getByRole('button', { name: /start|begin|go/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('where')).toHaveTextContent(
+        '/listicle-pipeline/abc123',
+      ),
+    )
+  })
+
+  it('opens the run named in the address rather than a blank seed box', async () => {
+    loadGrill.mockResolvedValue(grill())
+    renderAt('/listicle-pipeline/abc123')
+
+    await waitFor(() => expect(loadGrill).toHaveBeenCalledWith('abc123'))
+    expect(await screen.findByText(/How many items/)).toBeInTheDocument()
+  })
+
+  it('reads stored results instead of searching again', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(results())
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText('Canta Rana')).toBeInTheDocument()
+    // The whole point: opening a screen is not a decision to spend.
+    expect(runSearch).not.toHaveBeenCalled()
+  })
+
+  it('says a run does not exist rather than starting a new one', async () => {
+    loadGrill.mockRejectedValue(new NotFoundError('No such interview'))
+    renderAt('/listicle-pipeline/gone')
+
+    expect(await screen.findByText(/no run with the id/i)).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('a failed read is not reported as a run that was never searched', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockRejectedValue(new Error('The database is unreachable.'))
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The database is unreachable.',
+    )
+  })
+})
+
+describe('the agreed order on screen', () => {
+  it('shows the number that will actually be searched for', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order({ target_count: 20 }))
+    renderAt('/listicle-pipeline/abc123')
+
+    const panel = await screen.findByRole('region', {
+      name: /the agreed search order/i,
+    })
+    expect(panel).toHaveTextContent('20')
+    expect(panel).toHaveTextContent('cevicherias')
+  })
+
+  it('says when it is unsure how the number was read', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(
+      order({
+        count_ambiguous: true,
+        count_note: 'The answer mentioned 20, 40. Read as 20 -- correct it if that is wrong.',
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText(/Read as 20/)).toBeInTheDocument()
+  })
+
+  it('lets the number be corrected, and the correction makes a new revision', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    reviseOrder.mockResolvedValue(order({ target_count: 12, revision: 2 }))
+    renderAt('/listicle-pipeline/abc123')
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /correct the number/i }),
+    )
+    const box = screen.getByLabelText(/how many items/i)
+    await userEvent.clear(box)
+    await userEvent.type(box, '12')
+    await userEvent.click(screen.getByRole('button', { name: /use this number/i }))
+
+    await waitFor(() =>
+      expect(reviseOrder).toHaveBeenCalledWith('abc123', { target_count: 12 }),
+    )
+    expect(await screen.findByText(/revision 2/)).toBeInTheDocument()
+  })
+
+  it('says when the order cannot fill the list, without adding a search', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(
+      order({
+        capacity: 5,
+        capacity_warning:
+          'These 1 searches ask for 5 places in total, which may not fill a list of 20.',
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText(/may not fill a list of 20/)).toBeInTheDocument()
+    const panel = screen.getByRole('region', { name: /the agreed search order/i })
+    expect(panel.querySelectorAll('.lp-order-angle')).toHaveLength(1)
+  })
+})
+
+describe('recovering from a partial failure', () => {
+  it('keeps the searches that worked and offers to retry the one that did not', async () => {
+    const partial = results({
+      angles: [
+        results().angles[0],
+        {
+          ...results().angles[0],
+          angle_id: 'a2',
+          angle: 'very cheap cevicherias',
+          state: 'failed',
+          failed: true,
+          rows: 0,
+          reason: 'TimeoutError',
+          found: 0,
+          shared: 0,
+          exclusive: 0,
+        },
+      ],
+    })
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(partial)
+    runSearch.mockResolvedValue(results())
+    renderAt('/listicle-pipeline/abc123')
+
+    // The successful angle's results are still on screen.
+    expect(await screen.findByText('Canta Rana')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /retry 1 failed search/i }))
+    await waitFor(() =>
+      expect(runSearch).toHaveBeenCalledWith('abc123', {
+        angleIds: ['a2'],
+        reuse: false,
+      }),
+    )
+  })
+
+  it('names the publications the searches actually reached', async () => {
+    // The citation URLs Google returns are opaque redirects. Without these
+    // names nothing on the screen can say whether a search written to run in
+    // the local language read local press or stopped at the visitor guides.
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(results())
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText(/2 publications behind these results/)).toBeInTheDocument()
+    expect(screen.getByText(/elcomercio\.pe · ohlalima\.com/)).toBeInTheDocument()
+  })
+
+  it('says when a result was reused rather than gathered now', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(
+      results({ angles: [{ ...results().angles[0], reused: true }] }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText(/reused from earlier research/i)).toBeInTheDocument()
+  })
+
+  it('does not call an interrupted search a failed one', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(
+      results({
+        angles: [
+          {
+            ...results().angles[0],
+            state: 'interrupted',
+            failed: true,
+            reason: 'it never came back; re-running it may be charged again',
+          },
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    // Labelled as interrupted, not as failed: nobody knows whether the
+    // provider answered, and retrying may be charged a second time.
+    expect(
+      await screen.findByText(/^interrupted —/),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/may be charged again/)).toBeInTheDocument()
+  })
+
+  it('reports contribution without calling the most repeated place the best', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(
+      results({
+        candidates: [
+          {
+            ...results().candidates[0],
+            found_by: ['a', 'b', 'c'],
+            overlap: 3,
+          },
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText(/found by 3 searches/)).toBeInTheDocument()
+    expect(screen.queryByText(/strongest|best/i)).not.toBeInTheDocument()
+  })
+
+  it('shows a possible duplicate rather than folding two venues into one', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(
+      results({
+        uncertain_identity: 1,
+        candidates: [
+          { ...results().candidates[0], possible_duplicates: ['Canta Rana Centro'] },
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(
+      await screen.findByText(/Might be the same place as Canta Rana Centro/),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/this count is provisional/)).toBeInTheDocument()
+  })
+})

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
@@ -340,6 +340,36 @@ describe('the agreed order on screen', () => {
     expect(await screen.findByText(/revision 2/)).toBeInTheDocument()
   })
 
+  it('says what a search bought last time, before this time is paid for', async () => {
+    // Run 33fca394 spent two of seven searches on angles that returned no
+    // place the others missed. The numbers existed only on a table drawn after
+    // the money was gone.
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(
+      order({
+        angles: [
+          {
+            angle_id: 'a1',
+            text: 'cevicherias open for decades',
+            shape_key: 'institution',
+            group: 'heritage',
+            role: 'broad',
+            wanted: 15,
+            edited: false,
+            custom: false,
+            last_time:
+              'The last time this search ran here it returned 6 rows and no place the other searches missed.',
+          },
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(
+      await screen.findByText(/no place the other searches missed/),
+    ).toBeInTheDocument()
+  })
+
   it('says when the order cannot fill the list, without adding a search', async () => {
     loadGrill.mockResolvedValue(AGREED)
     loadOrder.mockResolvedValue(

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/listicle-resume.test.tsx
@@ -397,6 +397,81 @@ describe('the agreed order on screen', () => {
     ).toBeInTheDocument()
   })
 
+  it('warns that an approved search fights the cut, before it is paid for', async () => {
+    // Run 33fca394 approved "Nikkei cevicherias" alongside "no places where
+    // ceviche is not the primary offering". 8 of that search's 10 results were
+    // barred by the order that bought it.
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(
+      order({
+        conflicts_checked: true,
+        angle_conflicts: [
+          {
+            angle_id: 'a1',
+            angle_text: 'cevicherias open for decades',
+            why: 'Most Nikkei restaurants serve ceviche among many dishes.',
+          },
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(await screen.findByText(/Fights what you left out/)).toBeInTheDocument()
+  })
+
+  it('does not let an unchecked order read as a cleared one', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(
+      order({ conflicts_checked: false, exclusions: 'no chains' }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(
+      await screen.findByText(/have not been checked against what you left out/),
+    ).toBeInTheDocument()
+  })
+
+  it('marks a returned place that breaks the cut, without removing it', async () => {
+    loadGrill.mockResolvedValue(AGREED)
+    loadOrder.mockResolvedValue(order())
+    loadSearch.mockResolvedValue(
+      results({
+        cut_checked: true,
+        barred_count: 1,
+        order: {
+          kind: 'cevicherias',
+          place: 'Lima, Peru',
+          target_count: 20,
+          standard: '',
+          exclusions: 'no places where ceviche is not the primary offering',
+          count_source: 'answered',
+          count_ambiguous: false,
+          count_note: '',
+        },
+        candidates: [
+          {
+            name: 'Maido',
+            district: 'Miraflores',
+            evidence: 'top Nikkei restaurant, offers ceviche',
+            found_by: ['nikkei'],
+            overlap: 1,
+            possible_duplicates: [],
+            sightings: [],
+            barred: 'Ceviche is one dish of many here.',
+            barred_confidence: 'clear',
+          },
+        ],
+      }),
+    )
+    renderAt('/listicle-pipeline/abc123')
+
+    expect(
+      await screen.findByText(/Looks like something you left out/),
+    ).toBeInTheDocument()
+    // Flagged, never removed.
+    expect(screen.getByText('Maido')).toBeInTheDocument()
+  })
+
   it('says when the order cannot fill the list, without adding a search', async () => {
     loadGrill.mockResolvedValue(AGREED)
     loadOrder.mockResolvedValue(

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/pages/ListiclePipelinePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/pages/ListiclePipelinePage.tsx
@@ -132,6 +132,7 @@ export function ListiclePipelinePage() {
                 order={order}
                 busy={busy || searching}
                 onCorrectCount={grill.correctCount}
+                onCorrectRequirements={grill.correctRequirements}
               />
             )}
 

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/pages/ListiclePipelinePage.tsx
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/pages/ListiclePipelinePage.tsx
@@ -1,8 +1,10 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { GrillScreen } from '../components/GrillScreen'
+import { OrderPanel } from '../components/OrderPanel'
 import { SearchResults } from '../components/SearchResults'
 import { SeedScreen } from '../components/SeedScreen'
 import { useListicleGrill } from '../useListicleGrill'
+import { useEffect } from 'react'
 import '../styles.css'
 
 /**
@@ -14,17 +16,32 @@ import '../styles.css'
  * is real, current and earns its place against a stated standard, which is
  * checkable. Different definitions of success do not share a spine.
  *
- * Its own screen treatment is deliberate too — the operator should be able to
- * tell at a glance which one they are in.
+ * The run id is in the URL. That is what makes a run survivable: the interview
+ * and the searches were always stored on the server, and the only thing that
+ * was not was the operator's way back to them -- a refresh landed on an empty
+ * seed box with a paid, agreed, searched run in the database and no route to
+ * it. A link now reaches a run, and a reload reads it rather than starting
+ * again.
  *
- * Right now this is the shell and nothing else: no run, no server, no model,
- * no research. The grill walks a hardcoded placeholder script so the shape can
- * be looked at and argued with before anything is built underneath it.
+ * Nothing after the searches is built: there is no evidence check, no gate, no
+ * list. Said on the screen so nobody opening this mistakes a pool of
+ * candidates for a finished listicle.
  */
 
 export function ListiclePipelinePage() {
-  const grill = useListicleGrill()
-  const { state, results, busy, searching, error } = grill
+  const { runId } = useParams<{ runId: string }>()
+  const navigate = useNavigate()
+  const grill = useListicleGrill(runId ?? null)
+  const { state, order, results, busy, searching, loading, missing, error } = grill
+
+  // A run that has just been created gets its own address. Done here rather
+  // than inside the hook so the hook stays a data concern and the routing
+  // stays a page one.
+  useEffect(() => {
+    if (state && state.run_id !== runId) {
+      navigate(`/listicle-pipeline/${state.run_id}`, { replace: !runId })
+    }
+  }, [navigate, runId, state])
 
   return (
     <div className="lp-page">
@@ -47,10 +64,6 @@ export function ListiclePipelinePage() {
       </header>
 
       <main className="lp-container">
-        {/* The interview runs, and stops when the specification is full.
-            Nothing after it is built: there is no research, no gate, no list.
-            Said on the screen so nobody opening this mistakes an agreed
-            interview for a finished listicle. */}
         <p className="lp-scaffold-banner" role="status">
           <strong>Interview and search.</strong> The interview settles the search
           order and the searches return candidate places. Checking each one has
@@ -62,8 +75,8 @@ export function ListiclePipelinePage() {
             <span className="lp-step">
               {state.status === 'agreed' ? 'Settled' : 'A few questions'}
             </span>
-            {/* On screen so an interview can be returned to: it lives on the
-                run, not in this tab. */}
+            {/* On screen and in the address bar: an interview lives on the run,
+                not in this tab, and this link is how it is returned to. */}
             <span className="lp-run-id">run {state.run_id}</span>
           </div>
         )}
@@ -74,7 +87,30 @@ export function ListiclePipelinePage() {
           </p>
         )}
 
-        {state === null ? (
+        {/* Three states that used to look identical, and are not: reading an
+            existing run, a run that is not there, and no run at all. Offering
+            a fresh seed box while the third is still unknown is how an
+            operator starts a second interview for a run they already had. */}
+        {loading ? (
+          <p className="lp-muted" role="status">
+            Opening run {runId}…
+          </p>
+        ) : missing ? (
+          <div className="lp-actions">
+            <p className="lp-error" role="alert">
+              There is no run with the id <strong>{runId}</strong>.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                grill.reset()
+                navigate('/listicle-pipeline')
+              }}
+            >
+              Start a new list
+            </button>
+          </div>
+        ) : state === null ? (
           <SeedScreen busy={busy} onStart={grill.start} />
         ) : (
           <>
@@ -82,27 +118,47 @@ export function ListiclePipelinePage() {
               state={state}
               busy={busy}
               onAnswer={grill.answer}
-              onReset={grill.reset}
+              onReset={() => {
+                grill.reset()
+                navigate('/listicle-pipeline')
+              }}
             />
 
+            {/* The agreement, as a record rather than as a paragraph. On
+                screen before anything is spent, because the only real run of
+                this pipeline showed twenty and searched for forty. */}
+            {state.status === 'agreed' && order && (
+              <OrderPanel
+                order={order}
+                busy={busy || searching}
+                onCorrectCount={grill.correctCount}
+              />
+            )}
+
             {/* Offered only once the order is settled, and only as a button:
-                seven grounded searches take minutes and cost real tokens, so
+                several grounded searches take minutes and cost real tokens, so
                 nothing starts them except someone asking. */}
             {state.status === 'agreed' && results === null && (
               <div className="lp-actions lp-search-cta">
-                <button type="button" onClick={grill.search} disabled={searching}>
+                <button
+                  type="button"
+                  onClick={() => grill.search()}
+                  disabled={searching}
+                >
                   {searching ? 'Searching the web…' : 'Run the searches'}
                 </button>
                 {searching && (
                   <p className="lp-muted">
-                    One search per angle. This takes a few minutes.
+                    One search per angle. This takes a few minutes. Each one is
+                    saved as it finishes, so a failure part way through does not
+                    lose the rest.
                   </p>
                 )}
               </div>
             )}
 
             {results && (
-              <SearchResults results={results} busy={searching} onRerun={grill.search} />
+              <SearchResults results={results} busy={searching} onRun={grill.search} />
             )}
           </>
         )}

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
@@ -380,8 +380,28 @@
   color: var(--muted);
 }
 
-/* The collision group, sitting quietly at the end of the row. It only matters
-   when two of them are ticked, and then the warning below says so. */
+/* The theme label and the role, sitting quietly at the end of the row.
+   Descriptive, not a rule: two angles sharing a theme may both be worth
+   searching, and the warning below explains rather than forbids. */
+.lp-picker-tags {
+  align-self: center;
+  flex: none;
+  display: flex;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.lp-picker-role {
+  flex: none;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--lp-accent);
+  border: 1px solid var(--lp-accent);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.1rem 0.4rem;
+}
+
 .lp-picker-group {
   align-self: center;
   flex: none;
@@ -394,6 +414,26 @@
   padding: 0.1rem 0.4rem;
 }
 
+/* A label describing wording the line no longer has. Shown faded and with a
+   question mark rather than removed: where the angle came from is worth
+   knowing, and asserting it as still true is not. */
+.lp-picker-group-stale {
+  opacity: 0.55;
+  border-style: dashed;
+}
+
+.lp-picker-theme {
+  margin-top: var(--space-2);
+}
+
+.lp-picker-theme-name {
+  margin: 0 0 0.2rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
 .lp-picker-warning {
   margin: 0;
   padding: var(--space-2) var(--space-3);
@@ -401,6 +441,132 @@
   background: var(--lp-accent-soft);
   color: var(--ink);
   font-size: 0.875rem;
+}
+
+.lp-picker-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+/* ---------- the agreed order ---------- */
+
+/* On screen because the alternative was believing a paragraph. The one real
+   run of this pipeline displayed twenty and searched for forty. */
+.lp-order {
+  max-width: 46rem;
+  margin: var(--space-4) auto 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) clamp(var(--space-4), 4vw, var(--space-5));
+  box-shadow: 0 2px 16px var(--shadow-soft);
+}
+
+.lp-order-head {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.lp-order-title {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.lp-order-line {
+  margin: var(--space-1) 0 0;
+  color: var(--ink);
+  font-size: 1.05rem;
+}
+
+.lp-order-line strong {
+  font-size: 1.4rem;
+}
+
+.lp-order-warning {
+  margin: var(--space-2) 0;
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--lp-accent);
+  background: var(--lp-accent-soft);
+  font-size: 0.875rem;
+}
+
+.lp-order-edit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-2);
+  font-size: 0.875rem;
+}
+
+.lp-order-edit input {
+  width: 6rem;
+}
+
+.lp-order-correct {
+  margin-bottom: var(--space-2);
+}
+
+.lp-order-requirements {
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(6rem, auto) 1fr;
+  gap: 0.2rem var(--space-3);
+  font-size: 0.875rem;
+}
+
+.lp-order-requirements dt {
+  color: var(--muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.lp-order-requirements dd {
+  margin: 0;
+  color: var(--ink);
+}
+
+.lp-order-note {
+  margin: var(--space-1) 0 var(--space-3);
+  font-size: 0.75rem;
+}
+
+.lp-order-angles {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.lp-order-angle {
+  font-size: 0.875rem;
+  color: var(--ink);
+}
+
+.lp-order-angle-tags {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+}
+
+.lp-order-edited {
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.05rem 0.4rem;
 }
 
 /* ---------- what the searches found ---------- */
@@ -545,4 +711,88 @@
   color: var(--muted);
   font-size: 0.8125rem;
   line-height: 1.4;
+}
+
+
+/* ---------- retrying one search ---------- */
+
+/* A per-row action, because a retry costs one search and a full refresh costs
+   the whole order. Rendered as a link so it does not compete with the two
+   buttons at the foot of the table. */
+.lp-link-button {
+  background: none;
+  border: none;
+  padding: 0 0 0 0.4rem;
+  color: var(--lp-accent);
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.lp-link-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.lp-angle-table th {
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.lp-angle-tags {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+}
+
+/* Every row as a search returned it. Two angles found this place for two
+   different reasons, and the reasons are what a person needs to check whether
+   the merge was right. */
+.lp-candidate-sightings {
+  margin: 0.3rem 0 0;
+  padding-left: 1rem;
+  list-style: none;
+  border-left: 2px solid var(--border);
+  color: var(--muted);
+  font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+/* Shown rather than resolved. This step cannot tell a second branch from a
+   second spelling, and folding them together loses a venue silently. */
+.lp-candidate-duplicate {
+  margin: 0.3rem 0 0;
+  font-size: 0.75rem;
+  color: var(--lp-accent);
+}
+
+/* Where the searches actually looked. Collapsed by default: it is forty
+   domains and the answer it gives -- local press, or only visitor guides --
+   is a question people ask once and then stop asking. */
+.lp-sources {
+  margin-bottom: var(--space-4);
+  font-size: 0.8125rem;
+}
+
+.lp-sources summary {
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.lp-sources-list {
+  margin: var(--space-2) 0 0;
+  color: var(--muted);
+  line-height: 1.7;
+  word-break: break-word;
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
@@ -508,6 +508,23 @@
   width: 6rem;
 }
 
+/* The bar and the cut are sentences, not a number, so they wrap onto their own
+   full-width rows rather than sitting on the count's one line. */
+.lp-order-edit-requirements {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.lp-order-edit-requirements textarea {
+  width: 100%;
+  resize: vertical;
+  font: inherit;
+}
+
+.lp-order-edit-requirements button {
+  align-self: flex-start;
+}
+
 .lp-order-correct {
   margin-bottom: var(--space-2);
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
@@ -527,6 +527,16 @@
 
 /* What this search bought last time. Quiet: it is a fact offered, not a
    recommendation, and it must not outweigh the angle it sits under. */
+/* What was asked for and not verified. Reads as a caveat, not an alarm: the
+   candidates are real findings, they are simply not checked. */
+.lp-results-unchecked {
+  margin: var(--space-3) 0 var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--muted);
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+
 .lp-order-angle-history {
   display: block;
   margin-top: 0.15rem;

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
@@ -525,6 +525,14 @@
   align-self: flex-start;
 }
 
+/* What this search bought last time. Quiet: it is a fact offered, not a
+   recommendation, and it must not outweigh the angle it sits under. */
+.lp-order-angle-history {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+}
+
 .lp-order-correct {
   margin-bottom: var(--space-2);
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/styles/grill.css
@@ -537,6 +537,27 @@
   color: var(--muted);
 }
 
+/* An approved search that fights the cut. Louder than the history line under
+   it, because this one is about money not yet spent. */
+.lp-order-angle-conflict {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  color: var(--lp-accent);
+}
+
+/* A returned place that looks barred. `arguable` reads quieter than `clear`:
+   the operator is being asked to look, not told to delete. */
+.lp-candidate-barred {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--lp-accent);
+}
+
+.lp-candidate-barred-arguable {
+  color: var(--muted);
+}
+
 .lp-order-angle-history {
   display: block;
   margin-top: 0.15rem;

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
@@ -111,6 +111,10 @@ export interface ListicleOrder {
   count_source: string
   count_ambiguous: boolean
   count_note: string
+  /** One line per marker the interview answered more than once, saying what
+   *  was done about it. Empty for an interview that asked each thing once,
+   *  which is the normal case. */
+  answer_notes: string[]
   capacity: number
   capacity_warning: string
   summary: string
@@ -210,6 +214,7 @@ export interface ListicleSearchResults {
     count_source: string
     count_ambiguous: boolean
     count_note: string
+    answer_notes?: string[]
   }
   angles: ListicleAngleResult[]
   candidates: ListicleCandidate[]

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
@@ -34,9 +34,32 @@ export interface ListicleGrillOption {
   text: string
   /** Arrives ticked. The rest are the menu you can swap in. */
   recommended: boolean
-  /** Options sharing a group return the same places for the same reason.
-   *  Empty when the option answers to nothing else. */
+  /** A descriptive theme, shown as a label. Not a rule: two options sharing a
+   *  theme may both be worth searching, and the pair that actually collides is
+   *  named per option rather than per group. */
   group: string
+  /** Which catalogue entry this was written from. Sent back with the answer so
+   *  an edited line does not lose everything the catalogue knew about it. */
+  shape: string
+  /** What the search is for: broad, distinctive or specific. Decides how many
+   *  places it is asked for. */
+  role: string
+}
+
+/** One chosen line, as the screen knows it.
+ *
+ *  Sent alongside the answer text rather than instead of it. The transcript
+ *  keeps what the operator wrote, because that is what was agreed to; this
+ *  carries what the sentence cannot — which menu entry it came from, whether
+ *  it was edited, whether they wrote it themselves. */
+export interface ListicleAngleSelection {
+  text: string
+  angle_id?: string
+  shape_key?: string
+  group?: string
+  role?: string
+  edited?: boolean
+  custom?: boolean
 }
 
 export interface ListicleGrillState {
@@ -54,38 +77,143 @@ export interface ListicleGrillState {
 
 
 /**
+ * The agreement, in the form the searches actually run from.
+ *
+ * Read separately from the interview because the two used to be one paragraph
+ * with two readings: the screen showed a search order for twenty items and the
+ * searches ran for forty, and there was nowhere to look that would have said
+ * so.
+ */
+export interface ListicleOrderAngle {
+  angle_id: string
+  text: string
+  shape_key: string
+  group: string
+  role: string
+  /** How many places this search is asked for. Follows the role. */
+  wanted: number
+  /** The operator changed the wording. What the catalogue knew about this
+   *  angle is no longer known to be true of it. */
+  edited: boolean
+  custom: boolean
+}
+
+export interface ListicleOrder {
+  run_id: string
+  revision: number
+  kind: string
+  place: string
+  target_count: number
+  standard: string
+  exclusions: string
+  /** Where the number came from — answered, accepted, corrected, read off the
+   *  title, or a default. */
+  count_source: string
+  count_ambiguous: boolean
+  count_note: string
+  capacity: number
+  capacity_warning: string
+  summary: string
+  angles: ListicleOrderAngle[]
+}
+
+
+/**
  * What the search order found.
  *
  * `found` against `target` is the only question this step exists to answer, so
  * it arrives as a number rather than as something the screen counts for
  * itself.
  */
+export interface ListicleSighting {
+  angle: string
+  name: string
+  district: string
+  evidence: string
+}
+
 export interface ListicleCandidate {
   name: string
   district: string
   evidence: string
-  /** Every angle that returned this place. More than one is the ranking
-   *  signal: a place three searches agree on is the strongest on the list. */
+  /** Every angle that returned this place. Repeated discovery, reported as
+   *  itself — not a verdict that the most-repeated place is the best one. */
   found_by: string[]
   overlap: number
+  /** Rows that look like this place and were not merged into it, because a
+   *  district or a bracketed qualifier said they might be somewhere else. */
+  possible_duplicates: string[]
+  /** Every row exactly as a search returned it. Kept so a merge can be
+   *  checked: two angles found this place for two different reasons. */
+  sightings: ListicleSighting[]
 }
 
+export type ListicleAngleState =
+  | 'not_started'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'interrupted'
+
 export interface ListicleAngleResult {
+  angle_id: string
   angle: string
+  shape: string
+  group: string
+  role: string
+  wanted: number
+  edited: boolean
+  custom: boolean
+  state: ListicleAngleState
   rows: number
   sources: number
-  /** A search that never ran. Different from one that ran and found nothing,
-   *  and the screen must not present them as the same thing. */
+  /** A search that never came back. Different from one that ran and found
+   *  nothing, and the screen must not present them as the same thing. */
   failed: boolean
   reason: string
+  /** Contribution, against the whole pool: everything this angle found, how
+   *  much of it other angles found too, and what only this one found. */
+  found: number
+  shared: number
+  exclusive: number
+  gathered_at: string
+  /** The publications this search actually reached, by name. Every citation
+   *  URL Google returns is an opaque redirect, so without these there is no
+   *  way to tell whether a search written to run in the local language reached
+   *  local press or stopped at the visitor guides. */
+  sources_named: string[]
+  /** This result was gathered under an earlier revision of the order and still
+   *  answers the request being made. */
+  reused: boolean
 }
 
 export interface ListicleSearchResults {
   run_id: string
+  revision: number
   target: number
   found: number
   shortfall: number
   rows_returned: number
+  running: boolean
+  complete: boolean
+  /** How many candidates have a possible duplicate standing beside them. The
+   *  distinct count is provisional while this is above zero. */
+  uncertain_identity: number
+  capacity: number
+  capacity_warning: string
+  order: {
+    kind: string
+    place: string
+    target_count: number
+    standard: string
+    exclusions: string
+    count_source: string
+    count_ambiguous: boolean
+    count_note: string
+  }
   angles: ListicleAngleResult[]
   candidates: ListicleCandidate[]
+  /** A result stored before work was recorded per angle. Readable, and not
+   *  retryable at the angle level. */
+  legacy?: boolean
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
@@ -102,6 +102,13 @@ export interface ListicleOrderAngle {
   last_time?: string
 }
 
+export interface ListicleAngleConflict {
+  angle_id: string
+  angle_text: string
+  /** One plain sentence saying why this search and the cut disagree. */
+  why: string
+}
+
 export interface ListicleOrder {
   run_id: string
   revision: number
@@ -119,6 +126,12 @@ export interface ListicleOrder {
    *  was done about it. Empty for an interview that asked each thing once,
    *  which is the normal case. */
   answer_notes: string[]
+  /** Approved searches that look like they will return places this same order
+   *  bars. Found before anything is spent; nothing is removed. */
+  angle_conflicts?: ListicleAngleConflict[]
+  /** False means nobody looked — which is not the same as looked and found
+   *  nothing. Every order stored before this check existed is in that state. */
+  conflicts_checked?: boolean
   capacity: number
   capacity_warning: string
   summary: string
@@ -151,6 +164,11 @@ export interface ListicleCandidate {
   /** Rows that look like this place and were not merged into it, because a
    *  district or a bracketed qualifier said they might be somewhere else. */
   possible_duplicates: string[]
+  /** Why this place appears to break what the operator left out. Empty when it
+   *  does not, or when nothing has checked. */
+  barred?: string
+  /** 'clear' or 'arguable'. Anything unrecognised is read as 'arguable'. */
+  barred_confidence?: string
   /** Every row exactly as a search returned it. Kept so a merge can be
    *  checked: two angles found this place for two different reasons. */
   sightings: ListicleSighting[]
@@ -213,6 +231,10 @@ export interface ListicleSearchResults {
    *  fact about this run, not a verdict: a search with nothing exclusive may
    *  be the coverage everything else is being checked against. */
   empty_handed?: string[]
+  /** Whether anything judged this revision's places against the cut. False is
+   *  "nobody looked", not "nothing was barred". */
+  cut_checked?: boolean
+  barred_count?: number
   order: {
     kind: string
     place: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/types.ts
@@ -96,6 +96,10 @@ export interface ListicleOrderAngle {
    *  angle is no longer known to be true of it. */
   edited: boolean
   custom: boolean
+  /** What this search bought the last time it ran about the same subject —
+   *  before this time is paid for. Empty on a first run, which is most of
+   *  them. Said and never acted on: no angle is dropped because of it. */
+  last_time?: string
 }
 
 export interface ListicleOrder {
@@ -205,6 +209,10 @@ export interface ListicleSearchResults {
   uncertain_identity: number
   capacity: number
   capacity_warning: string
+  /** The searches that finished and returned no place the others missed. A
+   *  fact about this run, not a verdict: a search with nothing exclusive may
+   *  be the coverage everything else is being checked against. */
+  empty_handed?: string[]
   order: {
     kind: string
     place: string

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/useListicleGrill.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/useListicleGrill.ts
@@ -1,14 +1,33 @@
-import { useCallback, useEffect, useState } from 'react'
-import { answerGrill, loadSearch, runSearch, startGrill } from './api'
-import type { ListicleGrillState, ListicleSearchResults } from './types'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  NotFoundError,
+  answerGrill,
+  loadGrill,
+  loadOrder,
+  loadSearch,
+  reviseOrder,
+  runSearch,
+  startGrill,
+} from './api'
+import type {
+  ListicleAngleSelection,
+  ListicleGrillState,
+  ListicleOrder,
+  ListicleSearchResults,
+} from './types'
 
 /**
- * The listicle interview, driven by the server.
+ * The listicle interview, driven by the server and addressed by its run id.
  *
  * There is no local copy of the conversation: every move posts and replaces
  * the whole state with what came back. The interview lives on the run, so a
  * closed tab is not a lost interview -- the same reason the article grill
  * persists per turn rather than holding the thread in a browser.
+ *
+ * That was already true of the storage and was not true of the screen. The run
+ * id existed only in this hook's memory, so a refresh landed on an empty seed
+ * box with a paid, agreed, searched run sitting in the database and no way to
+ * reach it. The id is now in the URL and this hook loads whatever it is given.
  *
  * Each turn is a live model call and takes a few seconds, so `busy` is what
  * the screen disables itself on.
@@ -16,97 +35,223 @@ import type { ListicleGrillState, ListicleSearchResults } from './types'
 
 interface UseListicleGrill {
   state: ListicleGrillState | null
+  order: ListicleOrder | null
   results: ListicleSearchResults | null
   busy: boolean
   /** Set only while the searches are running. They take minutes where a grill
    *  turn takes seconds, and a screen that says "working" for both tells the
    *  operator nothing about how long to wait. */
   searching: boolean
+  /** Set while an existing run is being read. Distinct from `busy`: nothing is
+   *  being spent, and the screen must not offer to start a second interview
+   *  while it does not yet know whether this one exists. */
+  loading: boolean
+  /** The run in the URL is not there. A different problem from a failed read,
+   *  and it has a different next step. */
+  missing: boolean
   error: string | null
   start: (seed: string) => void
-  answer: (text: string) => void
-  search: () => void
+  answer: (text: string, selections?: ListicleAngleSelection[]) => void
+  search: (options?: { angleIds?: string[]; reuse?: boolean }) => void
+  correctCount: (target: number) => void
   reset: () => void
 }
 
-export function useListicleGrill(): UseListicleGrill {
+export function useListicleGrill(runId: string | null): UseListicleGrill {
   const [state, setState] = useState<ListicleGrillState | null>(null)
+  const [order, setOrder] = useState<ListicleOrder | null>(null)
   const [results, setResults] = useState<ListicleSearchResults | null>(null)
   const [busy, setBusy] = useState(false)
   const [searching, setSearching] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [missing, setMissing] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const run = useCallback(async (work: () => Promise<ListicleGrillState>) => {
-    setBusy(true)
-    setError(null)
-    try {
-      setState(await work())
-    } catch (caught) {
-      // Said on the screen rather than swallowed: a failed turn leaves the
-      // interview exactly where it was, and the operator has to be able to
-      // tell that from a turn that simply had nothing to ask.
-      setError(caught instanceof Error ? caught.message : 'That turn failed.')
-    } finally {
-      setBusy(false)
-    }
-  }, [])
+  // Which run this screen is currently showing. Read inside every async
+  // callback before it writes: switching runs while a slow read is in flight
+  // used to let the old run's answer land on the new run's screen, which is
+  // the one failure mode a resumable page adds that a disposable one never
+  // had.
+  const showing = useRef<string | null>(runId)
+  showing.current = runId
+
+  const run = useCallback(
+    async (id: string | null, work: () => Promise<ListicleGrillState>) => {
+      setBusy(true)
+      setError(null)
+      try {
+        const next = await work()
+        if (id !== null && showing.current !== id) return
+        setState(next)
+      } catch (caught) {
+        if (id !== null && showing.current !== id) return
+        // Said on the screen rather than swallowed: a failed turn leaves the
+        // interview exactly where it was, and the operator has to be able to
+        // tell that from a turn that simply had nothing to ask.
+        setError(caught instanceof Error ? caught.message : 'That turn failed.')
+      } finally {
+        setBusy(false)
+      }
+    },
+    [],
+  )
 
   const start = useCallback(
     (seed: string) => {
       if (!seed.trim()) return
-      void run(() => startGrill(seed.trim()))
+      void run(null, () => startGrill(seed.trim()))
     },
     [run],
   )
 
   const answer = useCallback(
-    (text: string) => {
-      const runId = state?.run_id
-      if (!runId || !text.trim()) return
-      void run(() => answerGrill(runId, text.trim()))
+    (text: string, selections: ListicleAngleSelection[] = []) => {
+      const id = state?.run_id
+      if (!id || !text.trim()) return
+      void run(id, () => answerGrill(id, text.trim(), selections))
     },
     [run, state?.run_id],
   )
 
-  // Running the order is minutes of grounded searching, so it is never done
-  // on a screen opening -- it looks for what a previous run stored first, and
-  // only searches when there is nothing there or the operator asks again.
-  const search = useCallback(() => {
-    const runId = state?.run_id
-    if (!runId || searching) return
-    setSearching(true)
+  // Reopening a run reads it. It never searches: opening a screen is not a
+  // decision to spend, and the version this replaced could not tell "never
+  // searched" from "not read yet" -- so a reload offered to buy the research
+  // again.
+  useEffect(() => {
+    if (!runId) {
+      setMissing(false)
+      return
+    }
+    if (state?.run_id === runId) return
+    let live = true
+    setLoading(true)
+    setMissing(false)
     setError(null)
+    setResults(null)
+    setOrder(null)
     void (async () => {
       try {
-        setResults(await runSearch(runId))
+        const found = await loadGrill(runId)
+        if (!live || showing.current !== runId) return
+        setState(found)
       } catch (caught) {
-        setError(caught instanceof Error ? caught.message : 'The search failed.')
+        if (!live || showing.current !== runId) return
+        if (caught instanceof NotFoundError) {
+          setMissing(true)
+        } else {
+          setError(
+            caught instanceof Error ? caught.message : 'That run could not be read.',
+          )
+        }
       } finally {
-        setSearching(false)
+        if (live) setLoading(false)
       }
     })()
-  }, [searching, state?.run_id])
+    return () => {
+      live = false
+    }
+  }, [runId, state?.run_id])
 
-  // An agreed interview may already have results behind it, from this session
-  // or another one. Read them before offering to spend on new ones.
+  // The agreement and whatever the searches have already found, read once the
+  // interview has settled. Both are reads and neither costs anything.
   useEffect(() => {
-    const runId = state?.run_id
-    if (!runId || state?.status !== 'agreed' || results) return
-    void loadSearch(runId)
-      .then(found => {
-        if (found) setResults(found)
-      })
-      .catch(() => {
-        // Nothing stored is the normal case, and it is not an error worth
-        // putting on the screen: the button to run them is right there.
-      })
-  }, [results, state?.run_id, state?.status])
+    const id = state?.run_id
+    if (!id || state?.status !== 'agreed') return
+    let live = true
+    void (async () => {
+      try {
+        const [found, stored] = await Promise.all([loadOrder(id), loadSearch(id)])
+        if (!live || showing.current !== id) return
+        setOrder(found)
+        if (stored) setResults(stored)
+      } catch (caught) {
+        if (!live || showing.current !== id) return
+        // A read that fails is not the same as nothing being there, and
+        // treating it as "never searched" is how an operator is invited to
+        // pay twice for the same research.
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : 'The stored results could not be read.',
+        )
+      }
+    })()
+    return () => {
+      live = false
+    }
+  }, [state?.run_id, state?.status])
+
+  const search = useCallback(
+    (options: { angleIds?: string[]; reuse?: boolean } = {}) => {
+      const id = state?.run_id
+      if (!id || searching) return
+      setSearching(true)
+      setError(null)
+      void (async () => {
+        try {
+          const found = await runSearch(id, options)
+          if (showing.current !== id) return
+          setResults(found)
+        } catch (caught) {
+          if (showing.current !== id) return
+          setError(caught instanceof Error ? caught.message : 'The search failed.')
+        } finally {
+          setSearching(false)
+        }
+      })()
+    },
+    [searching, state?.run_id],
+  )
+
+  const correctCount = useCallback(
+    (target: number) => {
+      const id = state?.run_id
+      if (!id) return
+      setError(null)
+      void (async () => {
+        try {
+          const revised = await reviseOrder(id, { target_count: target })
+          if (showing.current !== id) return
+          setOrder(revised)
+          // The results on screen answered the previous request. Re-read
+          // rather than left standing: some of them still answer this one and
+          // some of them do not, and the server is what knows which.
+          const stored = await loadSearch(id)
+          if (showing.current === id) setResults(stored)
+        } catch (caught) {
+          if (showing.current !== id) return
+          setError(
+            caught instanceof Error ? caught.message : 'That correction failed.',
+          )
+        }
+      })()
+    },
+    [state?.run_id],
+  )
 
   const reset = useCallback(() => {
     setState(null)
+    setOrder(null)
     setResults(null)
     setError(null)
+    setMissing(false)
   }, [])
 
-  return { state, results, busy, searching, error, start, answer, search, reset }
+  return {
+    state,
+    order,
+    results,
+    busy,
+    searching,
+    loading,
+    missing,
+    error,
+    start,
+    answer,
+    search,
+    correctCount,
+    reset,
+  }
 }
+
+export type { UseListicleGrill }

--- a/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/useListicleGrill.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/listiclePipeline/useListicleGrill.ts
@@ -54,6 +54,10 @@ interface UseListicleGrill {
   answer: (text: string, selections?: ListicleAngleSelection[]) => void
   search: (options?: { angleIds?: string[]; reuse?: boolean }) => void
   correctCount: (target: number) => void
+  /** The bar or the cut, typed out. Needed because either can have been
+   *  assembled from more than one answer, and an assembled value has to be
+   *  arguable. */
+  correctRequirements: (patch: { standard?: string; exclusions?: string }) => void
   reset: () => void
 }
 
@@ -203,14 +207,18 @@ export function useListicleGrill(runId: string | null): UseListicleGrill {
     [searching, state?.run_id],
   )
 
-  const correctCount = useCallback(
-    (target: number) => {
+  // One correction path, whatever is being corrected. The count, the bar and
+  // the cut all make a new revision and all invalidate stored results the same
+  // way, and a second copy of that sequence is a second place for the re-read
+  // to be forgotten.
+  const correctOrder = useCallback(
+    (patch: { target_count?: number; standard?: string; exclusions?: string }) => {
       const id = state?.run_id
       if (!id) return
       setError(null)
       void (async () => {
         try {
-          const revised = await reviseOrder(id, { target_count: target })
+          const revised = await reviseOrder(id, patch)
           if (showing.current !== id) return
           setOrder(revised)
           // The results on screen answered the previous request. Re-read
@@ -227,6 +235,11 @@ export function useListicleGrill(runId: string | null): UseListicleGrill {
       })()
     },
     [state?.run_id],
+  )
+
+  const correctCount = useCallback(
+    (target: number) => correctOrder({ target_count: target }),
+    [correctOrder],
   )
 
   const reset = useCallback(() => {
@@ -250,6 +263,7 @@ export function useListicleGrill(runId: string | null): UseListicleGrill {
     answer,
     search,
     correctCount,
+    correctRequirements: correctOrder,
     reset,
   }
 }

--- a/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/findings.ts
+++ b/apps/ai-blog-writer/apps/frontend/src/features/prompt2blog/intake/components/findings.ts
@@ -49,7 +49,9 @@ export function comparable(text: string): string {
     .replace(/[‘’ʼ]/g, "'")
     .replace(/[“”]/g, '"')
     .replace(/[–—]/g, '-')
-    .replace(/ /g, ' ')
+    // Written as the escape, not the character: a literal non-breaking space
+    // in source is invisible, and eslint refuses it for that reason.
+    .replace(/\u00a0/g, ' ')
     // Link text survives, the URL does not: the editor quotes what it read.
     .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
     .replace(/[*_`#>]/g, '')

--- a/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
+++ b/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
@@ -137,6 +137,16 @@ returned place is real, currently open, independently sourced or worth writing
 about, and repeated discovery is reported as repeated discovery rather than as
 a verdict on quality. The evidence step is not built.
 
+**Nor is a returned place checked against the cut.** The exclusions are
+composed into every search prompt, and that is necessary and not sufficient:
+run 33fca394 returned eight Nikkei and Japanese restaurants against an explicit
+"no places where ceviche is not the primary offering". `gate.assess` does not
+catch this and was never going to -- it weighs whether enough is published
+about a place, and all eight are written about constantly. Checking the cut is
+a separate per-place judgement, it needs evidence about the place rather than
+its name, and it does not exist. The screen says so rather than presenting the
+candidates as though something had checked them.
+
 Nor has the revised angle strategy been shown to find better places. The eight
 evaluation cases are in `app/features/listicle_pipeline/evaluation.py` with
 their criteria written down in advance; the paid comparison is

--- a/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
+++ b/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
@@ -82,6 +82,34 @@ and labelled as possible duplicates. Every original sighting survives, so the
 merge can be checked. The distinct count is reported as provisional whenever
 any pair is unresolved.
 
+**A marker answered twice is resolved, not overwritten.** The value used to be
+read from the last turn that settled a marker. That is right for a correction
+and silently destructive for the additive follow-up the grill actually asks:
+run `292e71e3` settled the cut, then asked "are there any other types of
+establishments ... you would like to exclude?" and recommended "No hotel
+restaurants." Answering that plainly would have left one rule out of four and
+searched under a quarter of the operator's exclusions, on a run that looked
+entirely normal from every screen.
+
+The engine is the wrong place to fix it. Refusing to show a repeated question
+trades silent data loss for a stuck interview, which is worse; the grill
+already retries once and then shows the question anyway, on purpose. So the
+resolution happens where the value is read. A later answer that says
+everything the earlier one said replaces it; one that says something different
+is added to it. The bar and the cut accumulate, because a follow-up about them
+is an increment. The kind, the place and the angles replace: the first two are
+single nouns, and the angle picker sends the operator's whole current
+selection, so un-ticking a box is already the explicit replace -- accumulating
+there would put back an angle they just dropped, and every angle is a paid
+search.
+
+Keeping both is the safe reading and not the certain one: it can hold on to a
+rule the operator meant to drop, which over-restricts a search visibly rather
+than widening it invisibly. Of the two ways to be wrong, only one leaves
+nothing to see. So the combination is said out loud on the order, and the bar
+and the cut became correctable there for the same reason the count already
+was: an inferred value has to be arguable.
+
 ## What this deliberately does not claim
 
 Receiving a search result is not verification. Nothing here establishes that a

--- a/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
+++ b/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
@@ -137,7 +137,48 @@ returned place is real, currently open, independently sourced or worth writing
 about, and repeated discovery is reported as repeated discovery rather than as
 a verdict on quality. The evidence step is not built.
 
-**Nor is a returned place checked against the cut.** The exclusions are
+**The cut is checked, twice, and both checks only flag.** Added 2026-09-09
+after the failure below was traced. An angle can contradict the cut, and that
+is visible in the order before anything is bought: run 33fca394 approved
+"Nikkei cevicherias doing Japanese-Peruvian preparations" against a cut reading
+"no places where ceviche is not the primary offering", and 8 of that search's
+10 places were barred by the same order that paid for it -- one of seven paid
+searches, spent on results already ruled out. So the order is checked at
+agreement, and the candidates are checked once the pool is final.
+
+The second check costs one call, not forty, because nothing is looked up: the
+searches already recorded why they returned each place, and "offers ceviche"
+is the cut stated. Both run only on a request that is already spending. Opening
+a screen never triggers either, and an order or a run that has not been checked
+says so -- `conflicts_checked` and `cut_checked` are false by default, because
+"nobody looked" and "looked and found nothing" are different claims.
+
+Measured against the real stored run rather than asserted:
+
+- The angle check flagged exactly the Nikkei angle, and only it, out of seven.
+- The candidate check caught all seven known violations on every attempt.
+- Which places get flagged is stable. Whether one comes back `clear` or
+  `arguable` is **not**: three calls over the same 43 candidates returned
+  13/13/11 flags with the split moving each time. So the screen words both
+  levels as "look at this" rather than as a verdict, and the reason underneath
+  is the substance.
+- One consistent false positive: Costanera 700, a well-known cevicheria, is
+  flagged because the evidence a search stored for it reads "shaped modern
+  Nikkei cuisine, offers ceviche". That is a faithful reading of a misleading
+  line, which is the honest limit of a check that reads what the searches
+  reported instead of looking the place up again.
+
+Forced tool calling was built first and abandoned: it failed on two of four
+real attempts with `MALFORMED_FUNCTION_CALL`, Gemini emitting
+`print(default_api.record_barred_places(...))` as source text. The JSON inside
+was correct every time and `candidates_token_count` was 0, so it was never a
+length problem and raising the cap did not help. The JSON path succeeded three
+times out of three. Rows are identified to the model by NUMBER, not by name --
+a real call answered "Chez Wong (La Victoria)", copying back the district the
+prompt had printed, which matched nothing and would have dropped every finding
+silently.
+
+**A returned place is still not verified against the cut.** The exclusions are
 composed into every search prompt, and that is necessary and not sufficient:
 run 33fca394 returned eight Nikkei and Japanese restaurants against an explicit
 "no places where ceviche is not the primary offering". `gate.assess` does not

--- a/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
+++ b/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
@@ -110,6 +110,26 @@ nothing to see. So the combination is said out loud on the order, and the bar
 and the cut became correctable there for the same reason the count already
 was: an inferred value has to be arguable.
 
+**What a search bought is recorded, and said before it is bought again.**
+Contribution was computed when the results screen was drawn and thrown away
+with it, so the only place an angle's worth ever existed was a table rendered
+after the money was spent. It is now written onto the attempt, which lets the
+order screen say what each search returned the last time it ran about the same
+subject.
+
+An angle is identified across runs by its shape rather than its wording,
+because the model rewrites the sentence every run, and only within the same
+subject -- kind and place. Contribution is recomputed and rewritten after every
+batch, since retrying one angle changes the pool and therefore changes what the
+others turn out to have contributed.
+
+It is said and nothing more. No angle is dropped, reordered or discouraged by
+its history: a search with nothing exclusive may be the coverage everything
+else is being checked against, and two runs is a fact about two runs. The
+results screen counts only searches with *zero* exclusive places, which is the
+defensible line -- "this one returned ten rows for one place" is a judgement,
+and the operator is the one who should make it.
+
 ## What this deliberately does not claim
 
 Receiving a search result is not verification. Nothing here establishes that a

--- a/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
+++ b/apps/ai-blog-writer/docs/adr/0037-the-search-order-is-the-source-of-truth.md
@@ -1,0 +1,113 @@
+# The search order is the source of truth
+
+## Context
+
+The listicle pipeline runs an interview, turns what it settles into a set of
+web searches, and pools the named places that come back. One real run existed
+when this was written -- 2026-09-04, Lima cevicherias -- and an audit of it
+found six confirmed faults and a catalogue built for one subject.
+
+The improvement plan is
+`~/.codex/visualizations/2026/09/08/01a082ef-f684-7cb0-b61f-635305a9dac1/listicle-pipeline-improvement-plan.html`.
+Its six faults, and what each one actually was:
+
+| fault | what it really was |
+|---|---|
+| every successful search reported as a failure | the search's result was passed through the interview's view builder, which reads `.run_id` off a `GrillState` |
+| no way back to a run | the run id lived in one React hook's memory; the interview and results were on the server all along |
+| the wrong count executed | the count was parsed out of a sentence, and "20, not 40" gave 40 because the reader took the largest plausible number |
+| venues merged that are not the same place | name similarity beat conflicting evidence: two branches, two bars in one hotel |
+| numeric names damaged | every leading digit was stripped as a list marker, so "1900 Hotel" became "Hotel" |
+| listicle spend billed to Prompt2Blog | `service` rebuilt `GrillDependencies` from three fields and took the default for `job_id` |
+
+Only the first is a coding slip. The rest are one shape of mistake: **a
+decision that was made, and then re-derived from prose instead of being kept.**
+
+The catalogue had the matching problem in the other direction. Four shapes
+shared a `prestige` group of which at most one could be chosen; `cheap`,
+`hidden` and `informal` shared a `humble` group. Award-listed and expensive are
+different restaurants in most cities. A cheap neighbourhood bar and an
+expensive hidden one are both real. Meanwhile family-run and longstanding are
+usually the same places and shared no group at all. And a hotel commission was
+offered market stalls and cuisine fusions, because one restaurant-shaped
+catalogue was shown to every subject.
+
+## Decision
+
+**The `SearchOrder` is what the searches run from, and what the screen shows.**
+Kind, place, target count, standard, exclusions, and the selected angles with
+their identities. Built once at agreement, versioned, stored. The displayed
+summary is generated from it. Nothing downstream re-reads the transcript.
+
+**A decision is resolved against what was proposed, not against the
+transcript.** An answer that carries no number is an acceptance of the
+recommendation the question arrived with. An answer that corrects one -- "20,
+not 40" -- is the correction. An answer carrying several numbers and no
+correction is ambiguous: a number is still chosen so the run is not stuck, the
+conservative one, and the order says it is unsure and offers to be corrected.
+
+**An angle keeps its identity.** A stable id, the shape it was written from,
+the role it plays, the wording the operator approved, and whether they changed
+it. The picker sends those records alongside the answer text; the transcript
+still stores what the operator wrote, because that is what was agreed to.
+
+**A correction makes a new revision.** Results gathered under the old one still
+exist and are re-checked against the new request by fingerprint. A stored
+result is reused when the request has not changed and re-bought when it has.
+
+**Work is stored per angle, not per batch.** A failure on the sixth search
+keeps the five that worked. A retry names its angles and costs one search each.
+A reload reads progress and never searches.
+
+**Overlap is explained, never enforced.** Hard collision groups are gone. Each
+shape names the shapes it tends to return the same places as, and the operator
+decides. An edited line's theme label is shown as uncertain, because it
+describes wording the line no longer has.
+
+**The catalogue belongs to the subject.** Shapes declare what they apply to;
+restaurants, bars and hotels bring their own dimensions; a subject the
+catalogue knows nothing about keeps the shared shapes and gets no invented
+category. The full catalogue reaches the model only once `count` is settled,
+which is the first turn on which angles may be asked about.
+
+**An angle carries a discovery role, and the role sets its allowance.** Broad
+angles carry the list. A specific-discovery angle may succeed with one result
+and is never pressured to fill a quota -- asking "the place credited with
+inventing the dish" for twelve is asking it to invent eleven. An order whose
+allowances cannot reach the target says so, and adds nothing nobody approved.
+
+**A merge that is not certain does not happen.** Conflicting districts and
+differing bracketed qualifiers block a merge; the rows are shown side by side
+and labelled as possible duplicates. Every original sighting survives, so the
+merge can be checked. The distinct count is reported as provisional whenever
+any pair is unresolved.
+
+## What this deliberately does not claim
+
+Receiving a search result is not verification. Nothing here establishes that a
+returned place is real, currently open, independently sourced or worth writing
+about, and repeated discovery is reported as repeated discovery rather than as
+a verdict on quality. The evidence step is not built.
+
+Nor has the revised angle strategy been shown to find better places. The eight
+evaluation cases are in `app/features/listicle_pipeline/evaluation.py` with
+their criteria written down in advance; the paid comparison is
+`scripts/listicle_angle_comparison.py`, it refuses to run without an explicit
+spend acknowledgement, and **it has not been run**. The plan's own sequencing
+says not to buy it until identity handling and result recording are
+trustworthy, because otherwise the measurement measures the bug.
+
+## Consequences
+
+- `GrillOption` gains optional `shape` and `role`. The article grill sends no
+  options at all and is unaffected; both callers are tested.
+- Runs stored before this exist and still open. Their per-angle work was never
+  recorded, so the assembled view falls back to the old stored blob and says
+  individual searches cannot be re-run from it.
+- Conservative matching will show more rows than the version it replaces. That
+  is the intended direction: a duplicate left standing costs a glance, and a
+  false merge deletes a venue with nothing on screen to notice.
+- The batch lock prevents a duplicate start. It cannot promise a provider did
+  not process a request whose answer never arrived, so an interrupted attempt
+  is labelled interrupted rather than failed and the screen says retrying it
+  may be charged again.

--- a/apps/ai-blog-writer/docs/plans/listicle-how-to-test.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-how-to-test.md
@@ -43,10 +43,23 @@ other search did. On `33fca394` the lunch-hours angle shows 0 — it was paid fo
 and bought nothing. There is a sentence above saying how many searches ended up
 like that.
 
-**The line above the list of places**: nothing has been checked against what
-you left out. That is true and it is the biggest gap in the pipeline — the
-searches returned eight Nikkei and Japanese restaurants on a list that said "no
-places where ceviche is not the primary offering". Nothing catches that yet.
+**Under the Nikkei search**, a line saying it fights what you left out. That
+search asked for Nikkei restaurants while the cut said "no places where ceviche
+is not the primary offering" — and 8 of its 10 results were barred by the same
+order that paid for it. You now see that before you spend.
+
+**The flagged places** in the list below, marked "Looks like something you left
+out" or "Might be". Nothing is removed; they are marked for you to judge.
+
+Two honest warnings about those flags:
+
+- The wording of the *level* is rough. Which places get flagged is stable
+  across runs; whether one says "Looks like" or "Might be" is not.
+- **Costanera 700 is a false positive.** It is a well-known cevicheria. It gets
+  flagged because the search stored "shaped modern Nikkei cuisine, offers
+  ceviche" against it. The check reads what the searches reported — it does not
+  look the place up again — so a misleading line becomes a wrong flag. Read the
+  reason, not just the flag.
 
 ## Start a new one — this spends money
 

--- a/apps/ai-blog-writer/docs/plans/listicle-how-to-test.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-how-to-test.md
@@ -1,0 +1,76 @@
+# Trying the listicle pipeline yourself
+
+Plain instructions. Nothing here spends money unless it says so.
+
+## Start it
+
+    cd apps/ai-blog-writer
+    pnpm run dev:local
+
+Two servers come up: the app on **http://localhost:3003** and its backend on
+4003. Leave that terminal running.
+
+You will not be asked to log in. The app normally signs in through Payload,
+which does not run on this machine, so a development-only switch stands in for
+it (`VITE_DEV_OFFLINE_LOGIN=true`, already set in `apps/frontend/.env`). The
+header will say "Payload Offline" — that is correct and nothing is wrong.
+
+That switch cannot reach a real build: it is fenced on Vite's `DEV` flag, which
+is a build-time literal, and a production build with the flag deliberately
+turned on was checked to contain no trace of it.
+
+## Look at a finished run — free
+
+Open one of the two real runs:
+
+- http://localhost:3003/listicle-pipeline/33fca394 — the clean one
+- http://localhost:3003/listicle-pipeline/292e71e3 — the earlier one
+
+Reading a stored run costs nothing. What to look at:
+
+**The search order**, near the top. The count, what earns a place, what is left
+out, and the seven searches. Under each search is a line saying what it
+returned the *last* time it ran — that is the new bit, and it is there so you
+can see a search is not worth buying before you buy it.
+
+**"Correct the number"** and **"Correct what earns a place, or what is left
+out"**. Both make a new revision rather than editing in place, so results
+already gathered still say which request they answered. Safe to click; costs
+nothing.
+
+**The results table.** `ONLY THIS` is how many places that search found that no
+other search did. On `33fca394` the lunch-hours angle shows 0 — it was paid for
+and bought nothing. There is a sentence above saying how many searches ended up
+like that.
+
+**The line above the list of places**: nothing has been checked against what
+you left out. That is true and it is the biggest gap in the pipeline — the
+searches returned eight Nikkei and Japanese restaurants on a list that said "no
+places where ceviche is not the primary offering". Nothing catches that yet.
+
+## Start a new one — this spends money
+
+From http://localhost:3003/listicle-pipeline. Type a title, answer the
+interview, approve the searches. Roughly one grounded web search per angle,
+about seven, plus the interview.
+
+Two rules when answering, both learned the hard way:
+
+- **Answer as a statement, not as a reply.** What you type is stored word for
+  word and reaches the searches as your own words. "Yes, that" says nothing.
+- **The suggestion in the box is a proposed answer, not part of the question.**
+  Read the question, decide what is true, write that.
+
+Nothing searches until you press the button. Opening a page never spends.
+
+## If something looks wrong
+
+The backend prints to the same terminal. Run state lives in
+`apps/ai-blog-writer/data/pipeline.db`; copy it before poking at it.
+
+These read stored runs and spend nothing:
+
+    set -a && . ./apps/backend/.env && set +a
+    export PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py report <run_id>
+    .venv/bin/python apps/backend/scripts/listicle_angle_variance.py

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -15,9 +15,15 @@ Vocabulary: the "Listicle Pipeline (search order)" section of `CONTEXT.md`.
 
 ## State right now
 
-**Committed and pushed.** Branch `listicle/search-order-rework`. Open as
-**PR #557** against `main`. First commit: 39 files, the rework itself. Second:
-the repeated-marker fix below.
+**Committed. Not yet pushed past the first commit.** Branch
+`listicle/search-order-rework`, open as **PR #557** against `main`.
+
+    fdfbcf73  the rework itself, 39 files          (pushed, on the PR)
+    1250ca61  a marker answered twice is resolved  (local)
+    580dad5f  the screen opened on a stored run    (local)
+    575b7f65  what a search bought is recorded     (local)
+    c3af7c3d  the screen stops implying the cut    (local)
+    3c538775  the over-tightening claim's control  (local)
 
 **This file only exists on that branch.** If you are reading a checkout of
 `main` you cannot see it, and you cannot see the code either:
@@ -30,7 +36,7 @@ staging CSS extraction. Nothing of it is mixed into this branch. Do not merge
 the two.
 
 Working tree is clean. Verification **on this branch alone**: 2264 backend
-tests, 874 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
+tests, 875 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
 in `listicle_pipeline/api.py` and `profiles.py`. (2249 / 871 at the first
 commit; the repeated-marker fix and the contribution record added the rest.)
 

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -35,16 +35,16 @@ The owner's unrelated Prompt2Blog work is committed separately on
 staging CSS extraction. Nothing of it is mixed into this branch. Do not merge
 the two.
 
-Working tree is clean. Verification **on this branch alone**: 2264 backend
-tests, 875 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
+Working tree is clean and **CI is green on all five checks**. Verification on
+this branch: 2264 backend tests, 880 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
 in `listicle_pipeline/api.py` and `profiles.py`. (2249 / 871 at the first
 commit; the repeated-marker fix and the contribution record added the rest.)
 
-eslint is clean **over `src/features/listiclePipeline`**. Over the whole
-frontend there is one error — a literal U+00A0 inside a regex in
-`prompt2blog/intake/components/findings.ts`, which arrived on `main` with
-commit 4bd7e813 and is nothing to do with this branch. Left alone here rather
-than folded in.
+eslint is clean over the whole frontend: 0 errors, 2 pre-existing warnings.
+The one error — a literal U+00A0 inside a regex in
+`prompt2blog/intake/components/findings.ts` — arrived on `main` with commit
+4bd7e813 and had nothing to do with this branch, but it was why every CI run
+here was red, so it is fixed (written as the escape instead).
 
 Those counts are lower than the 2263 / 876 quoted while the two branches shared
 a working tree, and the difference is not a regression: the owner's
@@ -165,6 +165,15 @@ repeated-marker question once and then shows it anyway, because a dead
 interview is worse than a repeat.
 
 ## Other open items, in order
+
+0. **Anyone can open the screen now.** `docs/plans/listicle-how-to-test.md` is
+   the plain-language version. `pnpm run dev:local`, then
+   `http://localhost:3003/listicle-pipeline/33fca394`. No login: the Payload
+   sign-in is stood in for by a dev-only session
+   (`VITE_DEV_OFFLINE_LOGIN=true`, already in `apps/frontend/.env`), fenced on
+   Vite's `DEV` literal and off under vitest. A production build made with the
+   flag deliberately ON was checked to contain no trace of it. Do not
+   hand-edit `RequireAuth` any more.
 
 1. **The screen has now been opened on stored runs; the interview has not.**
    Done 2026-09-09 against both stored runs, at `/listicle-pipeline/<run>` with

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -15,19 +15,52 @@ Vocabulary: the "Listicle Pipeline (search order)" section of `CONTEXT.md`.
 
 ## State right now
 
-**Everything below is uncommitted**, in a working tree that also holds
-unrelated Prompt2Blog edits belonging to the owner. Committing is the first
-thing to do, and only the listicle paths:
+**Committed and pushed.** Branch `listicle/search-order-rework`, one commit,
+39 files. Open as **PR #557** against `main`.
 
-    app/features/listicle_pipeline/    features/listiclePipeline/
-    app/features/prompt2blog/grill_v4.py      (repeat-marker guard)
-    app/features/prompt2blog/contracts_v4.py  (GrillOption.shape/role)
-    packages/utils/src/utils/google_grounding.py  (source titles)
-    apps/frontend/src/App.tsx  CONTEXT.md  docs/adr/0037-*.md
-    apps/backend/tests/test_listicle_*.py  tests/listicle_test_support.py
+**This file only exists on that branch.** If you are reading a checkout of
+`main` you cannot see it, and you cannot see the code either:
 
-Verification: 2263 backend tests, 876 frontend, tsc and eslint clean,
-flake8 clean apart from two pre-existing F401s in `api.py` and `profiles.py`.
+    git switch listicle/search-order-rework
+
+The owner's unrelated Prompt2Blog work is committed separately on
+`p2b/paste-an-article` (PR #558) — two commits, a paste-an-article path and a
+staging CSS extraction. Nothing of it is mixed into this branch. Do not merge
+the two.
+
+Working tree is clean. Verification **on this branch alone**: 2249 backend
+tests, 871 frontend, tsc and eslint clean, flake8 clean apart from two
+pre-existing F401s in `listicle_pipeline/api.py` and `profiles.py`.
+
+Those counts are lower than the 2263 / 876 quoted while the two branches shared
+a working tree, and the difference is not a regression: the owner's
+`test_prompt2blog_pasted_article.py` and its frontend tests live on
+`p2b/paste-an-article` and are not on this branch. `main` alone is 2084 / 855.
+
+## Driving a real run
+
+`apps/backend/scripts/drive_listicle_run.py` — the same code the HTTP routes
+call, with no server, auth or browser. Both runs below were driven with it.
+
+    cd apps/ai-blog-writer
+    set -a && . ./apps/backend/.env && set +a
+    export PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py start "<title>"
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py answer <run> "<answer>"
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py order <run>
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py search <run>
+    .venv/bin/python apps/backend/scripts/drive_listicle_run.py report <run>
+
+`report` reads a finished run and spends nothing. `search` is the expensive
+command: one grounded web search per angle.
+
+Two rules when answering, both learned the hard way:
+
+- **Answer as a statement, never as a reply.** The text is stored verbatim and
+  reaches the searches as the operator's own words. "Yes, that" says nothing.
+- **The recommendation is a proposed answer, not part of the question.** Read
+  the question, decide what is true, write that. Accept the proposal when it is
+  good; reword it when it is not, without referring to it.
 
 ## What was built (plan phases 1-4, plus half of 5)
 
@@ -49,11 +82,7 @@ From the improvement plan at
 
 ## Two real runs, both stored
 
-Driven headlessly through `service` + `api._base_dependencies()`; no server or
-auth needed. The driver is in the session scratchpad and is trivial to rewrite:
-`start` / `answer <run_id> <text> [selections_json]` / `order` / `search`.
-Source `apps/backend/.env` and set
-`PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src`.
+Both stored in the dev database and readable with `report` above.
 
 | run | questions | searches | rows | places | notes |
 |---|---:|---:|---:|---:|---|

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -36,7 +36,7 @@ staging CSS extraction. Nothing of it is mixed into this branch. Do not merge
 the two.
 
 Working tree is clean and **CI is green on all five checks**. Verification on
-this branch: 2264 backend tests, 880 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
+this branch: 2264 backend tests, 883 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
 in `listicle_pipeline/api.py` and `profiles.py`. (2249 / 871 at the first
 commit; the repeated-marker fix and the contribution record added the rest.)
 
@@ -229,28 +229,43 @@ interview is worse than a repeat.
    poor value but is not nothing — so the screen counts zero, and leaves "ten
    rows for one place" to the operator's judgement.
 
-3. **The `cut` reaches every search prompt and the model ignores it.**
-   Confirmed on the stored run, 2026-09-09: 8 of `33fca394`'s 43 candidates —
-   Hanzo (twice), Maido, Nikko, Osaka Nikkei, Shizen, Tomo, Toshi — are places
-   the cut explicitly barred.
+3. ~~**The `cut` reaches every search prompt and the model ignores it.**~~
+   **Done 2026-09-09.** Two checks, both flag-only, both on requests that were
+   already spending. Opening a screen still never spends.
 
-   **Correction to what this note used to say.** It said catching this was the
-   unbuilt evidence/gate step's job. That is wrong, and acting on it would have
-   wasted the work: `gate.assess` **is** built and tested, and it answers a
-   different question — is enough published about this place to write about it.
-   Every one of those eight is written about constantly, so a fully wired gate
-   would have passed all eight.
+   **Before the searches run**, the order is checked for angles that fight the
+   cut. This was the bigger finding: all 8 barred places in `33fca394` came
+   from ONE angle, "Nikkei cevicherias doing Japanese-Peruvian preparations",
+   approved alongside "no places where ceviche is not the primary offering".
+   8 of that angle's 10 places were barred by the order that bought it. Against
+   the real order the check flagged exactly that angle and only it, of seven.
 
-   Checking the cut is a separate per-place judgement that does not exist
-   anywhere. It cannot be done from a name; it needs evidence about the place,
-   which means `build_profile` running for every candidate — around forty paid
-   calls per run — plus a new verdict the gate does not currently have. That is
-   a real feature and a spending decision, so it was **not** built here.
+   **After they return**, the candidates are checked. One call, not forty:
+   nothing is looked up, because the searches already wrote why they returned
+   each place and "offers ceviche" is the cut stated.
 
-   What was done instead, because it costs nothing and the screen was lying by
-   omission: the results now say plainly that nothing below has been checked
-   against the cut. The rule still goes to every search. Do not reach for more
-   prompt text — that is what produced the eight.
+   The earlier note in this file said this was the gate's job. It was not, and
+   following it would have wasted the work -- see the ADR.
+
+   What the real runs showed, which the tests could not:
+
+   - Forced tool calling fails. Two of four attempts died with
+     `MALFORMED_FUNCTION_CALL` (Gemini writing `print(default_api...)` as
+     text). `candidates_token_count` was 0, so it was never length. The JSON
+     path went 3 for 3. **Do not "fix" this by raising max_tokens.**
+   - Rows are identified by NUMBER. A real call answered "Chez Wong (La
+     Victoria)" -- copying back the district the prompt printed -- which
+     matched no candidate and would have dropped every finding silently.
+   - All 7 known violations caught on every attempt.
+   - **The `clear`/`arguable` label is not stable.** Three calls over the same
+     43 candidates gave 13/13/11 flags with the split moving. Which places get
+     flagged is stable; how confidently is not. The screen words both as "look
+     at this" for that reason.
+   - One standing false positive: **Costanera 700**, a well-known cevicheria,
+     flagged because its stored evidence reads "shaped modern Nikkei cuisine,
+     offers ceviche". The check faithfully read a misleading line. That is the
+     honest limit of reading what the searches said instead of looking a place
+     up.
 
 4. **The over-tightening claim is NOT established, and the stored runs say
    why.** Checked 2026-09-09 with `scripts/listicle_angle_variance.py`

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -29,10 +29,16 @@ The owner's unrelated Prompt2Blog work is committed separately on
 staging CSS extraction. Nothing of it is mixed into this branch. Do not merge
 the two.
 
-Working tree is clean. Verification **on this branch alone**: 2258 backend
-tests, 873 frontend, tsc and eslint clean, flake8 clean apart from two
-pre-existing F401s in `listicle_pipeline/api.py` and `profiles.py`. (2249 / 871
-before the repeated-marker fix added its tests.)
+Working tree is clean. Verification **on this branch alone**: 2264 backend
+tests, 874 frontend, tsc clean, flake8 clean apart from two pre-existing F401s
+in `listicle_pipeline/api.py` and `profiles.py`. (2249 / 871 at the first
+commit; the repeated-marker fix and the contribution record added the rest.)
+
+eslint is clean **over `src/features/listiclePipeline`**. Over the whole
+frontend there is one error — a literal U+00A0 inside a regex in
+`prompt2blog/intake/components/findings.ts`, which arrived on `main` with
+commit 4bd7e813 and is nothing to do with this branch. Left alone here rather
+than folded in.
 
 Those counts are lower than the 2263 / 876 quoted while the two branches shared
 a working tree, and the difference is not a regression: the owner's
@@ -169,10 +175,35 @@ interview is worse than a repeat.
    temporary local edit to `RequireAuth` that was reverted immediately. Anyone
    repeating it has to do the same.
 
-2. **Angles that contribute nothing still cost a search.** In `33fca394`,
-   `purist` returned 10 rows for 1 unique place and `hours` returned 6 rows for
-   0. Roughly two of seven searches bought nothing. There is no mechanism that
-   notices this, and contribution is only visible after the money is spent.
+2. ~~**Angles that contribute nothing still cost a search.**~~ **Done
+   2026-09-09.** Contribution used to be computed when the results screen was
+   drawn and thrown away with it, so an angle's worth only ever existed after
+   the money was spent.
+
+   It is now recorded on the attempt (`found` / `shared` / `exclusive`), and
+   the order screen says what each search returned the last time it ran about
+   the same subject — *before* this time is paid for. An angle is matched
+   across runs by its SHAPE, not its wording: the model rewrites the sentence
+   every run. The results screen also names how many searches finished having
+   found no place the others missed, which nothing said before.
+
+   Recomputed after every batch, because retrying one angle changes the pool
+   and so changes what the other six turn out to have contributed.
+
+   Nothing acts on it. No angle is dropped, reordered or discouraged: two runs
+   is a fact about two runs.
+
+   Both stored runs were backfilled with
+   `scripts/backfill_listicle_contribution.py` (recomputes from sightings
+   already on disk; spends nothing; safe to re-run). Checked on the real data:
+   opening `33fca394` now shows six history lines on the order and "1 of 7
+   searches returned no place the others missed" on the results.
+
+   One correction to the note this replaces: it said "roughly two of seven"
+   bought nothing. Exactly one of the seven returned zero exclusive places
+   (`hours`). `purist` returned ten rows for one exclusive place, which is
+   poor value but is not nothing — so the screen counts zero, and leaves "ten
+   rows for one place" to the operator's judgement.
 
 3. **The `cut` reaches every search prompt and the model ignores it.** Run 2
    returned Maido, Osaka Nikkei, Hanzo (twice), Toshi, Nikko, Tomo and Shizen

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -1,0 +1,155 @@
+# Listicle pipeline — handoff, 2026-09-08
+
+Written for a fresh session. Read this before touching
+`app/features/listicle_pipeline` or `features/listiclePipeline`.
+
+## What this pipeline is
+
+An operator types a title. An interview (the "grill") settles six markers —
+kind, place, count, bar, cut, angles. Those become a **search order**. Each
+angle is one grounded web search. The pooled named places are candidates.
+Nothing after that is built: there is no evidence check, no gate, no article.
+
+Decisions: `docs/adr/0037-the-search-order-is-the-source-of-truth.md`.
+Vocabulary: the "Listicle Pipeline (search order)" section of `CONTEXT.md`.
+
+## State right now
+
+**Everything below is uncommitted**, in a working tree that also holds
+unrelated Prompt2Blog edits belonging to the owner. Committing is the first
+thing to do, and only the listicle paths:
+
+    app/features/listicle_pipeline/    features/listiclePipeline/
+    app/features/prompt2blog/grill_v4.py      (repeat-marker guard)
+    app/features/prompt2blog/contracts_v4.py  (GrillOption.shape/role)
+    packages/utils/src/utils/google_grounding.py  (source titles)
+    apps/frontend/src/App.tsx  CONTEXT.md  docs/adr/0037-*.md
+    apps/backend/tests/test_listicle_*.py  tests/listicle_test_support.py
+
+Verification: 2263 backend tests, 876 frontend, tsc and eslint clean,
+flake8 clean apart from two pre-existing F401s in `api.py` and `profiles.py`.
+
+## What was built (plan phases 1-4, plus half of 5)
+
+From the improvement plan at
+`~/.codex/visualizations/2026/09/08/01a082ef-f684-7cb0-b61f-635305a9dac1/listicle-pipeline-improvement-plan.html`.
+
+- Search results stop being rendered through the interview's view builder.
+- Runs are addressed by id in the URL and reopen without spending.
+- The count is resolved against what was proposed, stored, and correctable.
+- Conservative candidate matching; blocked merges shown as possible duplicates.
+- Bounded list-marker stripping, so `1900 Hotel` keeps its 1900.
+- `job_id` carried through, so listicle spend stops billing Prompt2Blog.
+- Per-angle durable attempts, reuse by request fingerprint, targeted retry.
+- Subject-aware shape catalogue; hard collision groups replaced by explained
+  overlap; discovery roles set each angle's allowance.
+- Eight evaluation cases with criteria fixed in advance
+  (`listicle_pipeline/evaluation.py`); the paid comparison script refuses to
+  run without `--i-know-this-costs-money` and **has never been run**.
+
+## Two real runs, both stored
+
+Driven headlessly through `service` + `api._base_dependencies()`; no server or
+auth needed. The driver is in the session scratchpad and is trivial to rewrite:
+`start` / `answer <run_id> <text> [selections_json]` / `order` / `search`.
+Source `apps/backend/.env` and set
+`PYTHONPATH=apps/backend:packages/shared/src:packages/utils/src`.
+
+| run | questions | searches | rows | places | notes |
+|---|---:|---:|---:|---:|---|
+| `292e71e3` | 5 (2 were repeats) | 7 | 62 | 47 | before the fixes below |
+| `33fca394` | 3 (no repeats) | 7 | 62 | 43 | clean, no intervention |
+
+Only **14 places appear in both runs**. Union is 76. The searches sample a
+pool much larger than 40 rather than enumerating it — pooling repeat runs of
+one order is the obvious untried lever.
+
+Everything runs on `gemini-2.5-flash` (`listicle.grill`,
+`listicle.grill_lookup`, `listicle.search` — all registered, all resolve).
+
+## THE ONE THING THAT MUST BE FIXED FIRST
+
+**A marker's value is read from the LAST turn that settled it, and a repeated
+question silently replaces the earlier answer.**
+
+`spec._answer_for` walks `reversed(state.turns)` and takes the first match.
+That is correct when a marker is genuinely corrected. It is wrong when the
+grill asks an *additive* follow-up, which run `292e71e3` did: after exclusions
+were settled it asked "anything else you would like to exclude?", recommending
+"No hotel restaurants."
+
+Answering that naturally would have made "No hotel restaurants" the entire cut
+and thrown away chains, delivery-only and ceviche-not-primary. The run would
+have looked completely normal and searched under one quarter of the operator's
+exclusions. It did not happen only because the operator that day had read the
+code and retyped the full list.
+
+`grill_v4._WastedTurn` now retries a repeated-marker question once, which makes
+the repeat much rarer — but on the second failure it **shows the question
+anyway** (deliberately: a dead interview is worse). So the path is still open.
+
+The fix is at the `spec` layer, not the engine: a marker answered twice needs
+either explicit accumulation or an explicit replace, not last-write-wins. Do
+not "fix" it by making the engine refuse — that trades silent data loss for a
+stuck interview.
+
+## Other open items, in order
+
+2. **The UI has never seen a live run.** Both runs were driven headlessly.
+   `AnglePicker` sending selections, `OrderPanel`'s count correction, the
+   per-angle retry buttons — all unit-tested, none exercised end to end in a
+   browser. Do this before trusting the screen.
+
+3. **Angles that contribute nothing still cost a search.** In `33fca394`,
+   `purist` returned 10 rows for 1 unique place and `hours` returned 6 rows for
+   0. Roughly two of seven searches bought nothing. There is no mechanism that
+   notices this, and contribution is only visible after the money is spent.
+
+4. **The `cut` reaches every search prompt and the model ignores it.** Run 2
+   returned Maido, Osaka Nikkei, Hanzo (twice), Toshi, Nikko, Tomo and Shizen
+   against an explicit "no places where ceviche is not the primary offering".
+   Composing the rule in is necessary and not sufficient. Catching it is the
+   unbuilt evidence/gate step's job — do not try to solve it with more prompt
+   text.
+
+5. **The model still over-tightens its own wording, and it costs measurably.**
+   Run 1's market angle was "ceviche counters inside the city's markets or
+   street stalls" → 11 rows, 11 unique. Run 2's was the same plus "not
+   traditional sit-down restaurants" → 6 rows, 4 unique. One comparison is not
+   proof, but it is the predicted direction and a large drop.
+
+6. **No paid angle comparison has been run.** `evaluation.py` holds the eight
+   cases and their criteria, fixed in advance on purpose.
+   `scripts/listicle_angle_comparison.py` runs one arm. Agree thresholds before
+   spending, not after.
+
+## Things that will bite you
+
+- `spec.searchable_kind` exists because the interview correctly declines to
+  ask about a marker the title already answers, which leaves no turn to read.
+  Any marker can be covered without a turn; check the fallback before trusting
+  a field.
+- `GrillOption.group` is filled from the catalogue in `api._view` and
+  `spec._theme_for`, never from the model. A live run sent the shape's label on
+  one turn, its key on the next, and nothing on a third. Code supplies
+  catalogue metadata; the model supplies wording.
+- The research callable returns a 3- or 4-tuple. `search._search_once` reads
+  both. Do not tighten it — every existing test sends three.
+- `source_urls` are opaque `vertexaisearch.cloud.google.com` redirects and
+  identify nothing. `source_titles` (added here) carry the real domains and are
+  what answers "did it read Spanish sources". It did: `ohlalima.com`,
+  `elcomercio.pe`, `larepublica.pe`, `infobae.com`, `gestion.pe`, `andina.pe`,
+  `mesa247.pe` among 40 publications in run 2.
+- Backend tests can write to the real dev database. Take the `isolated_db`
+  fixture for anything touching storage.
+- Adding a new exported name to `packages/utils` breaks the backend suite —
+  tests install a process-global `utils` stub. A new field on an existing
+  dataclass is fine; read it with `getattr(..., default)`.
+
+## What this pipeline does not claim
+
+Receiving a search result is not verification. Nothing establishes that a
+returned place is real, currently open, independently sourced or worth writing
+about. Repeated discovery is reported as repeated discovery, not as quality.
+A green test suite says the machinery behaves and says nothing about whether
+the angles find better places.

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -205,12 +205,28 @@ interview is worse than a repeat.
    poor value but is not nothing — so the screen counts zero, and leaves "ten
    rows for one place" to the operator's judgement.
 
-3. **The `cut` reaches every search prompt and the model ignores it.** Run 2
-   returned Maido, Osaka Nikkei, Hanzo (twice), Toshi, Nikko, Tomo and Shizen
-   against an explicit "no places where ceviche is not the primary offering".
-   Composing the rule in is necessary and not sufficient. Catching it is the
-   unbuilt evidence/gate step's job — do not try to solve it with more prompt
-   text.
+3. **The `cut` reaches every search prompt and the model ignores it.**
+   Confirmed on the stored run, 2026-09-09: 8 of `33fca394`'s 43 candidates —
+   Hanzo (twice), Maido, Nikko, Osaka Nikkei, Shizen, Tomo, Toshi — are places
+   the cut explicitly barred.
+
+   **Correction to what this note used to say.** It said catching this was the
+   unbuilt evidence/gate step's job. That is wrong, and acting on it would have
+   wasted the work: `gate.assess` **is** built and tested, and it answers a
+   different question — is enough published about this place to write about it.
+   Every one of those eight is written about constantly, so a fully wired gate
+   would have passed all eight.
+
+   Checking the cut is a separate per-place judgement that does not exist
+   anywhere. It cannot be done from a name; it needs evidence about the place,
+   which means `build_profile` running for every candidate — around forty paid
+   calls per run — plus a new verdict the gate does not currently have. That is
+   a real feature and a spending decision, so it was **not** built here.
+
+   What was done instead, because it costs nothing and the screen was lying by
+   omission: the results now say plainly that nothing below has been checked
+   against the cut. The rule still goes to every search. Do not reach for more
+   prompt text — that is what produced the eight.
 
 4. **The model still over-tightens its own wording, and it costs measurably.**
    Run 1's market angle was "ceviche counters inside the city's markets or

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -15,8 +15,9 @@ Vocabulary: the "Listicle Pipeline (search order)" section of `CONTEXT.md`.
 
 ## State right now
 
-**Committed and pushed.** Branch `listicle/search-order-rework`, one commit,
-39 files. Open as **PR #557** against `main`.
+**Committed and pushed.** Branch `listicle/search-order-rework`. Open as
+**PR #557** against `main`. First commit: 39 files, the rework itself. Second:
+the repeated-marker fix below.
 
 **This file only exists on that branch.** If you are reading a checkout of
 `main` you cannot see it, and you cannot see the code either:
@@ -28,9 +29,10 @@ The owner's unrelated Prompt2Blog work is committed separately on
 staging CSS extraction. Nothing of it is mixed into this branch. Do not merge
 the two.
 
-Working tree is clean. Verification **on this branch alone**: 2249 backend
-tests, 871 frontend, tsc and eslint clean, flake8 clean apart from two
-pre-existing F401s in `listicle_pipeline/api.py` and `profiles.py`.
+Working tree is clean. Verification **on this branch alone**: 2258 backend
+tests, 873 frontend, tsc and eslint clean, flake8 clean apart from two
+pre-existing F401s in `listicle_pipeline/api.py` and `profiles.py`. (2249 / 871
+before the repeated-marker fix added its tests.)
 
 Those counts are lower than the 2263 / 876 quoted while the two branches shared
 a working tree, and the difference is not a regression: the owner's
@@ -96,58 +98,78 @@ one order is the obvious untried lever.
 Everything runs on `gemini-2.5-flash` (`listicle.grill`,
 `listicle.grill_lookup`, `listicle.search` — all registered, all resolve).
 
-## THE ONE THING THAT MUST BE FIXED FIRST
+## The one thing that had to be fixed first -- fixed 2026-09-09
 
-**A marker's value is read from the LAST turn that settled it, and a repeated
-question silently replaces the earlier answer.**
+**A marker's value was read from the LAST turn that settled it, and a repeated
+question silently replaced the earlier answer.**
 
-`spec._answer_for` walks `reversed(state.turns)` and takes the first match.
-That is correct when a marker is genuinely corrected. It is wrong when the
-grill asks an *additive* follow-up, which run `292e71e3` did: after exclusions
-were settled it asked "anything else you would like to exclude?", recommending
-"No hotel restaurants."
+That was correct for a genuine correction and wrong for the *additive*
+follow-up the grill actually asks. Run `292e71e3` asked, after exclusions were
+settled, "are there any other types of establishments ... that you would like
+to exclude?", recommending "No hotel restaurants." Answering it naturally would
+have made that the entire cut and thrown away chains, delivery-only and
+ceviche-not-primary. The run would have looked completely normal. It did not
+happen only because the operator that day had read the code and retyped the
+full list.
 
-Answering that naturally would have made "No hotel restaurants" the entire cut
-and thrown away chains, delivery-only and ceviche-not-primary. The run would
-have looked completely normal and searched under one quarter of the operator's
-exclusions. It did not happen only because the operator that day had read the
-code and retyped the full list.
+`spec.resolve_answer` now reads every turn that answered a marker and decides
+between them, and the decision is written on the order rather than taken
+silently:
 
-`grill_v4._WastedTurn` now retries a repeated-marker question once, which makes
-the repeat much rarer — but on the second failure it **shows the question
-anyway** (deliberately: a dead interview is worse). So the path is still open.
+- A later answer that says everything the earlier one said **replaces** it
+  (`restated`). That is the retype, and it does not store the list twice.
+- A later answer that says something different is **added** to it (`combined`)
+  for the `bar` and the `cut`, which are the two markers a follow-up asks an
+  increment about.
+- `kind`, `place` and `angles` still take the last answer (`replaced`), on
+  purpose: the first two are single nouns, and the angle picker sends the whole
+  current selection, so un-ticking a box already is the explicit replace.
+  Accumulating there would put back an angle the operator just dropped, and
+  every angle is a paid search.
+- A *partial* restatement -- three rules repeated and a fourth gone -- is read
+  as an addition and both are kept. Over-restricting a search is visible on the
+  results; under-restricting it is not.
 
-The fix is at the `spec` layer, not the engine: a marker answered twice needs
-either explicit accumulation or an explicit replace, not last-write-wins. Do
-not "fix" it by making the engine refuse — that trades silent data loss for a
-stuck interview.
+Because keeping both can hold a rule they meant to drop, the combination is
+said on screen (`SearchOrder.answer_notes`) and the bar and the cut are now
+correctable there, the way the count already was. `service.revise_order` takes
+`standard` and `exclusions`; correcting one clears its note.
+
+Checked against both stored runs: neither changes (`292e71e3`'s cut resolves
+`restated`, `33fca394`'s is `single`), and neither produces a note. Replaying
+`292e71e3` with turn 2 answered naturally now keeps all four rules.
+
+The engine was deliberately left alone. `grill_v4._WastedTurn` still retries a
+repeated-marker question once and then shows it anyway, because a dead
+interview is worse than a repeat.
 
 ## Other open items, in order
 
-2. **The UI has never seen a live run.** Both runs were driven headlessly.
-   `AnglePicker` sending selections, `OrderPanel`'s count correction, the
-   per-angle retry buttons — all unit-tested, none exercised end to end in a
-   browser. Do this before trusting the screen.
+1. **The UI has never seen a live run.** Both runs were driven headlessly.
+   `AnglePicker` sending selections, `OrderPanel`'s count correction and its
+   new bar/cut correction, the per-angle retry buttons — all unit-tested, none
+   exercised end to end in a browser. Do this before trusting the screen. It is
+   now the top item, and the fix above added a control to that same panel.
 
-3. **Angles that contribute nothing still cost a search.** In `33fca394`,
+2. **Angles that contribute nothing still cost a search.** In `33fca394`,
    `purist` returned 10 rows for 1 unique place and `hours` returned 6 rows for
    0. Roughly two of seven searches bought nothing. There is no mechanism that
    notices this, and contribution is only visible after the money is spent.
 
-4. **The `cut` reaches every search prompt and the model ignores it.** Run 2
+3. **The `cut` reaches every search prompt and the model ignores it.** Run 2
    returned Maido, Osaka Nikkei, Hanzo (twice), Toshi, Nikko, Tomo and Shizen
    against an explicit "no places where ceviche is not the primary offering".
    Composing the rule in is necessary and not sufficient. Catching it is the
    unbuilt evidence/gate step's job — do not try to solve it with more prompt
    text.
 
-5. **The model still over-tightens its own wording, and it costs measurably.**
+4. **The model still over-tightens its own wording, and it costs measurably.**
    Run 1's market angle was "ceviche counters inside the city's markets or
    street stalls" → 11 rows, 11 unique. Run 2's was the same plus "not
    traditional sit-down restaurants" → 6 rows, 4 unique. One comparison is not
    proof, but it is the predicted direction and a large drop.
 
-6. **No paid angle comparison has been run.** `evaluation.py` holds the eight
+5. **No paid angle comparison has been run.** `evaluation.py` holds the eight
    cases and their criteria, fixed in advance on purpose.
    `scripts/listicle_angle_comparison.py` runs one arm. Agree thresholds before
    spending, not after.

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -145,11 +145,29 @@ interview is worse than a repeat.
 
 ## Other open items, in order
 
-1. **The UI has never seen a live run.** Both runs were driven headlessly.
-   `AnglePicker` sending selections, `OrderPanel`'s count correction and its
-   new bar/cut correction, the per-angle retry buttons — all unit-tested, none
-   exercised end to end in a browser. Do this before trusting the screen. It is
-   now the top item, and the fix above added a control to that same panel.
+1. **The screen has now been opened on stored runs; the interview has not.**
+   Done 2026-09-09 against both stored runs, at `/listicle-pipeline/<run>` with
+   the dev servers up (`pnpm run dev:local`, ports 4003/3003; `.claude/launch.json`
+   starts them). What was exercised for real:
+
+   - The order panel renders from a stored run. Every listicle call returned
+     200; the console's `ERR_CONNECTION_REFUSED` noise is Payload on :3000,
+     which does not run on this machine, and is unrelated.
+   - The repeated-marker note appears, and correcting the cut posted, made
+     revision 2, replaced the value and cleared the note.
+   - The results table draws, and its shared/only-this columns are where open
+     item 2 below is visible on screen: `purist` 10 rows for 1 unique, `hours`
+     6 rows for 0.
+   - The per-angle "run this one" and "Retry 1 failed search" controls render
+     for an interrupted angle, with the honest wording about being charged
+     again. **Not clicked** — clicking spends.
+
+   Two things the browser still has not seen, both because they need a live
+   interview and money: `AnglePicker` sending selections on a real turn, and a
+   retry actually running. The frontend requires a Payload staff session and
+   Payload does not run on this machine, so the check above was made with a
+   temporary local edit to `RequireAuth` that was reverted immediately. Anyone
+   repeating it has to do the same.
 
 2. **Angles that contribute nothing still cost a search.** In `33fca394`,
    `purist` returned 10 rows for 1 unique place and `hours` returned 6 rows for

--- a/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
+++ b/apps/ai-blog-writer/docs/plans/listicle-pipeline-handoff-2026-09-08.md
@@ -62,6 +62,15 @@ call, with no server, auth or browser. Both runs below were driven with it.
 `report` reads a finished run and spends nothing. `search` is the expensive
 command: one grounded web search per angle.
 
+Two more that spend nothing, both reading what is already stored:
+
+    .venv/bin/python apps/backend/scripts/listicle_angle_variance.py
+    .venv/bin/python apps/backend/scripts/backfill_listicle_contribution.py --dry-run
+
+`listicle_angle_variance.py` prints the wording-versus-noise table behind open
+item 4. `backfill_listicle_contribution.py` recomputes contribution for runs
+stored before it was recorded; both stored runs have already been done.
+
 Two rules when answering, both learned the hard way:
 
 - **Answer as a statement, never as a reply.** The text is stored verbatim and
@@ -228,16 +237,61 @@ interview is worse than a repeat.
    against the cut. The rule still goes to every search. Do not reach for more
    prompt text — that is what produced the eight.
 
-4. **The model still over-tightens its own wording, and it costs measurably.**
-   Run 1's market angle was "ceviche counters inside the city's markets or
-   street stalls" → 11 rows, 11 unique. Run 2's was the same plus "not
-   traditional sit-down restaurants" → 6 rows, 4 unique. One comparison is not
-   proof, but it is the predicted direction and a large drop.
+4. **The over-tightening claim is NOT established, and the stored runs say
+   why.** Checked 2026-09-09 with `scripts/listicle_angle_variance.py`
+   (spends nothing; reads the contribution now recorded on each attempt).
 
-5. **No paid angle comparison has been run.** `evaluation.py` holds the eight
-   cases and their criteria, fixed in advance on purpose.
-   `scripts/listicle_angle_comparison.py` runs one arm. Agree thresholds before
-   spending, not after.
+   The claim was that the model narrows its own wording and it costs
+   measurably, evidenced by the `informal` angle: 9 words returning 11 places
+   in run 1, 12 words returning 4 in run 2. That is a real drop. But the same
+   two runs contain the control it needs:
+
+   | | shapes | widest swing |
+   |---|---:|---|
+   | wording UNCHANGED between runs | 1 (`institution`) | 5 rows, 5 exclusive |
+   | wording REWORDED between runs | 5 | 5 rows, 7 exclusive |
+
+   `institution` ran with **identical wording** in both runs and moved 7 rows
+   to 12, one exclusive place to six. Unchanged wording swings almost as far as
+   the widest reworded pair, so nothing here separates wording from chance.
+
+   Of the five reworded pairs: three moved the predicted way, `lesser-known`
+   moved the opposite way (longer wording did *better*, 7 exclusive to 10), and
+   `producer-links` did not move at all.
+
+   **The noise floor has to be bought before the comparison is.** One case's
+   order re-run three times with wording held identical is about 21 grounded
+   searches. Until that number exists, the 8-case comparison in item 5 cannot
+   be read — it would measure noise and call it wording. This is also the
+   "pooling repeat runs" lever already flagged as obvious and untried, so it
+   buys two answers at once.
+
+5. **No paid angle comparison has been run, and it should not be the first
+   purchase.** `evaluation.py` holds the eight cases and their criteria, fixed
+   in advance on purpose. `scripts/listicle_angle_comparison.py` runs one arm
+   and refuses without `--i-know-this-costs-money`.
+
+   Cost, in the only unit that is certain — grounded searches, all on
+   `gemini-2.5-flash` (see `listicle.search` in the model gateway's
+   `jobs.json`); the per-search grounding rate is whatever the account's is:
+
+   - noise floor, 1 case × 7 angles × 3 repeats — **~21 searches**
+   - full comparison, 8 cases × 2 arms × ~7 angles — **~112 searches**, plus an
+     interview per arm
+
+   Thresholds have to be agreed before either, not after. Suggested, and not
+   yet approved by the owner:
+
+   - **Read the noise floor first.** Take the widest exclusive-place swing
+     across the three identical repeats. Call that N.
+   - A comparison arm counts as better only if it beats the other by **more
+     than N** exclusive places on the same case. On today's single data point
+     N would be 5, which is most of a seven-angle run — that is the honest
+     reading, and it is the argument for buying the repeats first.
+   - Report per case, never pooled. Eight cases with one run each is eight
+     anecdotes, and averaging them hides that.
+   - Discovery only. A returned place being real, open or worth writing about
+     is not what this measures and must not be claimed from it.
 
 ## Things that will bite you
 

--- a/apps/ai-blog-writer/packages/utils/src/utils/google_grounding.py
+++ b/apps/ai-blog-writer/packages/utils/src/utils/google_grounding.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import os
 import re
@@ -32,6 +32,11 @@ class GroundedGenerationResult:
     text: str
     source_urls: list[str]
     model_name: str
+    # Where the answer actually came from, by name. Every `source_urls` entry
+    # is a Google redirect that identifies nothing; the publication is in the
+    # grounding chunk's `title` beside it. Default empty so a caller built
+    # before this existed still constructs.
+    source_titles: list[str] = field(default_factory=list)
     # What the call cost, straight off the response. Without this a grounded
     # call is invisible to any caller that meters spend: this path is raw REST,
     # so it never passes through the LangChain adapters the token ledger
@@ -165,6 +170,55 @@ def _extract_urls_from_nested(value: Any) -> list[str]:
             if cleaned:
                 collected.append(cleaned)
     return collected
+
+
+def extract_grounded_source_titles(response: Any, max_titles: int = 24) -> list[str]:
+    """The publications behind a grounded answer, as their own names.
+
+    Google returns every citation as a `vertexaisearch.cloud.google.com`
+    redirect, so the URLs a caller stores say nothing about where the answer
+    came from. The domain lives in a sibling `title` on the same grounding
+    chunk, and it was being discarded.
+
+    That mattered the first time someone asked whether a search written to run
+    in the local language actually reached local sources. Nothing stored could
+    answer it: seventy-seven redirect URLs and no publication named among them.
+    """
+    if response is None:
+        return []
+
+    titles: list[str] = []
+    seen: set[str] = set()
+
+    def walk(value: Any) -> None:
+        if len(titles) >= max_titles:
+            return
+        if isinstance(value, dict):
+            # A grounding chunk is `{"web": {"uri": ..., "title": ...}}`, and
+            # `retrievedContext` carries the same pair. Matched on the shape
+            # rather than on a fixed path, because the REST and SDK responses
+            # nest them differently.
+            for key in ("web", "retrievedContext"):
+                nested = value.get(key)
+                if isinstance(nested, dict):
+                    title = nested.get("title")
+                    if isinstance(title, str) and title.strip():
+                        cleaned = title.strip()
+                        if cleaned not in seen:
+                            seen.add(cleaned)
+                            titles.append(cleaned)
+            for nested in value.values():
+                walk(nested)
+            return
+        if isinstance(value, list):
+            for nested in value:
+                walk(nested)
+
+    try:
+        walk(response if isinstance(response, dict) else response.to_dict())
+    except Exception:
+        pass
+    return titles[:max_titles]
 
 
 def extract_grounded_urls_from_response(response: Any, max_urls: int = 12) -> list[str]:
@@ -325,6 +379,7 @@ def invoke_google_grounded_text(
     return GroundedGenerationResult(
         text=_safe_text(response),
         source_urls=extract_grounded_urls_from_response(response),
+        source_titles=extract_grounded_source_titles(response),
         model_name=response.get("modelVersion", effective_model_name),
         input_tokens=input_tokens,
         output_tokens=output_tokens,

--- a/packages/model-gateway/src/model_gateway/jobs.json
+++ b/packages/model-gateway/src/model_gateway/jobs.json
@@ -181,6 +181,14 @@
       "defaultModel": "gemini-2.5-flash"
     },
     {
+      "id": "listicle.cut_review",
+      "app": "ai-blog-writer",
+      "call": "json",
+      "summary": "Judge angles and returned places against what the operator barred.",
+      "site": "features/listicle_pipeline/cut_review.py",
+      "defaultModel": "gemini-2.5-flash"
+    },
+    {
       "id": "listicle.grill",
       "app": "ai-blog-writer",
       "call": "json",


### PR DESCRIPTION
Six confirmed faults in the listicle pipeline, and one shape of mistake behind all of them: **a decision was made, then re-derived from prose instead of kept.**

The count was the clearest case. `"20, not 40"` resolved to **40**, because the reader took the largest plausible number it could see. `"Yes, that's right"` fell back to whatever number was in the title. So the agreement is now written down once, versioned, and both the displayed summary and the executed searches read the same record.

## The six faults

| Where | What it did | What it does now |
|---|---|---|
| Running a search | Every successful search was reported as a failure — the result was passed through the interview's view builder, which reads `.run_id` off a `GrillState`. Results were already saved; the only way to see them was to buy them again. | A search result comes back as a search result. |
| Getting back to a run | The run id lived in one browser tab's memory. A refresh landed on an empty box with a paid, finished run in the database and no route to it. | The id is in the URL. Reopening reads; it never searches. |
| How many items | Read out of a sentence, largest-number-wins. | Resolved against what was proposed, stored on the order, correctable at a new revision. |
| Two places, one row | Name similarity beat conflicting evidence. Two branches of a chain became one place; two bars in one hotel became one bar. | A conflicting district or bracketed qualifier blocks the merge. Both rows stand, labelled as possibly the same. Every original sighting survives. |
| Names with numbers | Every leading digit stripped as a list marker. `1900 Hotel` → `Hotel`, silently. | Only an actual marker goes. |
| Who pays | Listicle interviews billed themselves to `p2b.grill`. | `job_id` carried through. |

Plus: work is stored **per angle**, so a failure on the sixth search keeps the five that worked and a retry names its angles and costs one search each. The shape catalogue now belongs to the subject (a hotel list stops being offered market stalls). Hard collision groups are replaced by explained overlap. A discovery role sets each angle's allowance, so a narrow angle is not asked for twelve places it would have to invent.

## Found by running it, not by reading it

Two real runs (`292e71e3`, `33fca394`) against live Gemini. Four more faults surfaced that no test caught:

- **The interview re-asked settled markers twice in six turns.** The rule was written in the prompt and enforced nowhere. `_WastedTurn` now retries once and shows the question rather than killing the interview.
- **`kind` was the entire seed.** The interview correctly declines to spend a turn on a word the operator already typed, which leaves no turn to read — so every search was about to ask the web for *"The 40 best cevicherias in Lima in Lima"*, pushing an SEO phrase the interview must never treat as a criterion into seven paid searches.
- **`group` came back as a shape's label on one turn and its key on the next**, so the screen's overlap warning could never fire. Code supplies catalogue metadata now; the model supplies wording.
- **Grounded citations are opaque Google redirects.** `source_titles` carries the real publications — which is what answers whether a search told to work in the local language actually reached local press. It did: `ohlalima.com`, `elcomercio.pe`, `larepublica.pe`, `infobae.com`, `gestion.pe`, `andina.pe` among 40 publications in run 2.

## Deliberately not done

**No paid angle comparison has been run.** The eight evaluation cases and their judging criteria are fixed in advance in `evaluation.py`; the script that runs one refuses without `--i-know-this-costs-money`. A green suite says the machinery behaves and says nothing about whether the angles find better places.

## Known open, and first in the handoff

A marker is read from the **last** turn that settled it, so a repeated additive question still silently replaces the earlier answer. In run 1 the grill asked *"anything else to exclude?"* after exclusions were settled; answering that naturally would have reduced four exclusion rules to one, and the run would have looked completely normal. The repeat is now rare, but the overwrite path is open.

## Verification

2263 backend tests, 876 frontend, tsc / eslint / flake8 clean. The end-to-end test walks a whole run — title, answers, order, correction, searches, one timeout, reload, retry — through the real app with the model and the web replaced.

ADR `0037-the-search-order-is-the-source-of-truth.md`. Handoff for the next session: `docs/plans/listicle-pipeline-handoff-2026-09-08.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
